### PR TITLE
Rewrite README with user-centric framing and simplified structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Tirea
 
-**Build AI agents in Rust. Connect to any frontend. Scale to production.**
+**Type-safe AI agents that handle concurrent state without locks. One binary serves React, Next.js, and other agents over three protocols.**
 
-Define agents, tools, and state in Rust — then serve them to React, Next.js, CopilotKit, or other agents over AG-UI, AI SDK v6, A2A, and MCP from a single binary.
+Define agents, tools, and state in Rust — then serve them to any frontend over AG-UI, AI SDK v6, and A2A from a single binary. Connect to external tool servers via MCP.
 
 [![Crates.io](https://img.shields.io/crates/v/tirea.svg)](https://crates.io/crates/tirea)
 [![docs.rs](https://img.shields.io/docsrs/tirea)](https://docs.rs/tirea)
@@ -14,9 +14,110 @@ Define agents, tools, and state in Rust — then serve them to React, Next.js, C
   <img src="./docs/assets/demo.svg" alt="Tirea demo — tool call + LLM streaming" width="800">
 </p>
 
-## What you can build
+## 30-second mental model
 
-Build components — tools, plugins, agents — then assemble them into an `AgentOs`. The OS is a container; agents are composed from the components you register.
+1. **Tools** — typed functions your agent can call; JSON schema is generated from the struct
+2. **Agents** — each agent has a system prompt and a set of allowed tools/sub-agents; the LLM drives all orchestration through natural language — no DAGs or state machines like LangGraph/ADK
+3. **State** — typed, scoped (thread / run / tool_call), with CRDT fields for safe concurrent writes
+4. **Plugins** — lifecycle hooks for permissions, observability, context window, reminders, and more
+
+Your agent picks tools, calls them, reads and updates state, and repeats — all orchestrated by the runtime. Every state change is an immutable patch you can replay.
+
+## Why Tirea
+
+| What you get | How it works |
+|---|---|
+| **Ship one backend for every frontend** | Serve React (AI SDK v6), Next.js (AG-UI), and other agents (A2A) from the same binary. No separate deployments. Connect to external tool servers via MCP. |
+| **Let multiple agents write to the same state** | CRDT fields (`GSet`, `ORSet`, `GCounter`) merge concurrent writes automatically — you don't need locks, queues, or manual conflict resolution. |
+| **Scope state to its lifetime** | Mark state as Thread-scoped (persists across conversations), Run-scoped (reset each run), or ToolCall-scoped (gone after the tool finishes). No stale data leaks between runs. |
+| **Catch plugin wiring errors at compile time** | Plugins hook into 8 typed lifecycle phases. Wire a permission check to the wrong phase? The compiler tells you, not your users. |
+| **Replay any conversation to any point** | Every state change is an immutable patch. Replay them to reconstruct the exact state at any point — useful for debugging, auditing, and testing. |
+| **Run thousands of agents on minimal resources** | No GC pauses. ~170 KB RSS per agent run (10-turn conversation, mock LLM). 32 concurrent agents at ~1,000 runs/s. (`cargo bench --package tirea-agentos --bench runtime_throughput` to reproduce.) |
+
+### Feature comparison
+
+|  | Tirea | LangGraph | CrewAI | OpenAI Agents | Mastra | PydanticAI | Letta |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Language** | Rust | Python | Python | Python/TS | TypeScript | Python | Python |
+| **Multi-protocol server** | AG-UI · AI SDK · A2A | ◐ | ❌ | ❌ | ◐ | AG-UI | REST |
+| **Typed state** | ✅ derive macros | ◐ | ❌ | ❌ | ◐ | ◐ | ❌ |
+| **Concurrent state (CRDT)** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **State lifecycle scoping** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **State replay** | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Plugin lifecycle** | 8 typed phases | ❌ | ❌ | Guardrails | ❌ | ❌ | ❌ |
+| **Sub-agents** | ✅ | ✅ | ✅ | Handoffs | ◐ | ◐ | ✅ |
+| **MCP support** | ✅ | Adapter | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **Human-in-the-loop** | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| **Built-in general tools** | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+
+✅ = native  ◐ = partial  ❌ = not available
+
+## Quick start
+
+### Prerequisites
+
+- Rust toolchain from [`rust-toolchain.toml`](./rust-toolchain.toml)
+- For frontend demos: Node.js 20+ and npm
+- One model provider key (OpenAI, DeepSeek, Anthropic, etc.)
+
+### Full-stack demo in 60 seconds
+
+**React + AI SDK v6:**
+
+```bash
+git clone https://github.com/tirea-ai/tirea.git && cd tirea
+cd examples/ai-sdk-starter && npm install
+DEEPSEEK_API_KEY=<your-key> npm run dev
+# First run compiles the Rust agent (~1-2 min), then opens http://localhost:3001
+```
+
+**Next.js + CopilotKit:**
+
+```bash
+cd examples/copilotkit-starter && npm install
+cp .env.example .env.local
+DEEPSEEK_API_KEY=<your-key> npm run setup:agent && npm run dev
+# Open http://localhost:3000
+```
+
+### Server only
+
+```bash
+export OPENAI_API_KEY=<your-key>
+cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
+```
+
+## Usage
+
+### Architecture
+
+```mermaid
+graph LR
+    subgraph "Your frontends"
+        A["React app\n(AI SDK v6)"]
+        B["Next.js app\n(CopilotKit / AG-UI)"]
+        C["Another agent\n(A2A)"]
+    end
+
+    subgraph "tirea server (one binary)"
+        GW["Protocol gateway\nUI: AG-UI · AI SDK\nAgent: A2A"]
+        RT["Agent runtime\nLLM streaming · tool dispatch\nplugin lifecycle · context mgmt"]
+        EXT["Extensions\npermission · skills · MCP\nreminder · observability"]
+    end
+
+    subgraph "Storage (pick one)"
+        S1[(File)]
+        S2[(PostgreSQL)]
+    end
+
+    A & B --> GW
+    C --> GW
+    GW --> RT
+    RT --> EXT
+    RT --> S1 & S2
+```
+
+### Define tools, agents, and assemble
 
 ```rust
 // 1. Build tools — define args as a struct, schema is generated automatically
@@ -70,119 +171,11 @@ let os = AgentOsBuilder::new()
     .build()?;
 ```
 
-Tools are registered globally on the OS. Each agent defines its own access policy — which tools, skills, and sub-agents it can use via `allowed_*` / `excluded_*` lists. At resolve time, the runtime filters the global tool pool down to what each agent is permitted to access.
-
-Connect a React frontend with `useChat()`, a CopilotKit app via AG-UI, or another agent via A2A — no code changes needed.
-
-## What makes it different
-
-| What you get | Why it matters |
-|---|---|
-| **One server, four protocols** | UI protocols (AG-UI, AI SDK v6) and agent protocols (A2A, MCP) from the same binary. No separate deployments. |
-| **State that survives concurrency** | Multiple agents can write to the same state simultaneously. CRDT fields (`GSet`, `ORSet`, `GCounter`) merge automatically — no locks, no conflicts. |
-| **State scoped to its lifetime** | Mark state as Thread-scoped (persists forever), Run-scoped (reset each run), or ToolCall-scoped (gone after the tool finishes). No stale data leaking between runs. |
-| **Compile-time plugin safety** | Plugins hook into 8 lifecycle phases. Wire a permission check to the wrong phase? Compiler catches it. |
-| **Replay any conversation** | Every state change is an immutable patch. Replay them to reconstruct the exact state at any point. |
-| **Rust performance** | No GC pauses. ~170 KB RSS per agent run (10-turn conversation, mock LLM). 32 concurrent agents at ~1,000 runs/s. `cargo bench --package tirea-agentos --bench runtime_throughput` to reproduce. |
-
-## Feature comparison
-
-|  | Tirea | LangGraph | CrewAI | OpenAI Agents | Mastra | PydanticAI | Letta |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Language** | Rust | Python | Python | Python/TS | TypeScript | Python | Python |
-| **Multi-protocol server** | AG-UI · AI SDK · A2A · MCP | ❌ | ❌ | ❌ | ❌ | AG-UI | REST |
-| **Typed state** | ✅ derive macros | ◐ | ❌ | ❌ | ◐ | ◐ | ❌ |
-| **Concurrent state safety** | ✅ CRDT | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **State lifecycle scoping** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **State replay** | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **Plugin lifecycle** | 8 typed phases | ❌ | ❌ | Guardrails | ❌ | ❌ | ❌ |
-| **Sub-agents** | ✅ | ✅ | ✅ | Handoffs | ◐ | ◐ | ✅ |
-| **MCP support** | ✅ | Adapter | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **Human-in-the-loop** | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
-| **Built-in general tools** | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
-
-✅ = native  ◐ = partial  ❌ = not available
-
-## Quick start
-
-### Prerequisites
-
-- Rust toolchain from [`rust-toolchain.toml`](./rust-toolchain.toml)
-- For frontend demos: Node.js 20+ and npm
-- One model provider key (OpenAI, DeepSeek, Anthropic, etc.)
-
-### Full-stack demo in 60 seconds
-
-**React + AI SDK v6:**
-
-```bash
-git clone https://github.com/tirea-ai/tirea.git && cd tirea
-cd examples/ai-sdk-starter && npm install
-DEEPSEEK_API_KEY=<your-key> npm run dev
-# First run compiles the Rust agent (~1-2 min), then opens http://localhost:3001
-```
-
-**Next.js + CopilotKit:**
-
-```bash
-cd examples/copilotkit-starter && npm install
-cp .env.example .env.local
-DEEPSEEK_API_KEY=<your-key> npm run setup:agent && npm run dev
-# Open http://localhost:3000
-```
-
-### Server only
-
-```bash
-export OPENAI_API_KEY=<your-key>
-cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
-```
-
-## How it works
-
-```mermaid
-graph LR
-    subgraph "Your frontends"
-        A["React app\n(AI SDK v6)"]
-        B["Next.js app\n(CopilotKit / AG-UI)"]
-        C["Another agent\n(A2A)"]
-    end
-
-    subgraph "tirea server (one binary)"
-        GW["Protocol gateway\nUI: AG-UI · AI SDK\nAgent: A2A · MCP"]
-        RT["Agent runtime\nLLM streaming · tool dispatch\nplugin lifecycle · context mgmt"]
-        EXT["Extensions\npermission · skills · MCP\nreminder · observability"]
-    end
-
-    subgraph "Storage (pick one)"
-        S1[(File)]
-        S2[(PostgreSQL)]
-    end
-
-    A & B --> GW
-    C --> GW
-    GW --> RT
-    RT --> EXT
-    RT --> S1 & S2
-```
-
-## What you can do
+Tools are registered globally. Each agent controls its own access via `allowed_*` / `excluded_*` lists — the runtime filters the tool pool at resolve time.
 
 ### Connect to any frontend
 
-One backend serves multiple protocols from the same binary. No code changes between them:
-
-**UI protocols** — connect frontends to your agent:
-
-- **AG-UI** (CopilotKit) — shared state, frontend actions, generative UI, human-in-the-loop
-- **AI SDK v6** (Vercel) — `useChat()` streaming, canvas, thread history
-
-**Agent protocols** — connect agents to each other:
-
-- **A2A** — Google's agent-to-agent protocol; expose your agent as a peer service
-- **MCP** — connect to MCP servers; external tools appear as native tools
-
-**Endpoints** — start the server, then connect from any frontend:
+Start the server, then connect from React, Next.js, or another agent — no code changes between them:
 
 ```bash
 cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
@@ -192,8 +185,9 @@ cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
 |---|---|---|
 | AI SDK v6 | `POST /v1/ai-sdk/agents/:agent_id/runs` | React `useChat()` |
 | AG-UI | `POST /v1/ag-ui/agents/:agent_id/runs` | CopilotKit `<CopilotKit>` |
+| A2A | `POST /v1/a2a/agents/:agent_id/message:send` | Other agents |
 
-**React + AI SDK v6** — minimal frontend:
+**React + AI SDK v6:**
 
 ```typescript
 import { useChat } from "ai/react";
@@ -203,7 +197,7 @@ const { messages, input, handleSubmit } = useChat({
 });
 ```
 
-**Next.js + CopilotKit** — minimal frontend:
+**Next.js + CopilotKit:**
 
 ```typescript
 import { CopilotKit } from "@copilotkit/react-core";
@@ -260,59 +254,23 @@ Tirea ships with tools for sub-agents, background tasks, skills, UI rendering, a
 | **A2UI** (`a2ui` extension) | `render_a2ui` | Send declarative UI components to the frontend |
 | **MCP** (`mcp` feature) | *dynamic* | Tools from connected MCP servers appear as native tools |
 
-### Why plugins? Tools alone aren't enough
-
-A tool is just a function the LLM can call. But a bare tool doesn't work in practice:
-
-**The LLM doesn't know it exists.** The `agent_run` tool can launch sub-agents — but the LLM won't call it unless the system prompt lists which agents are available. That context injection isn't the tool's job. The `AgentToolsPlugin` handles it by injecting the agent catalog before each inference.
-
-The same pattern applies everywhere: `SkillDiscoveryPlugin` injects the skill catalog so the LLM knows which skills to activate. `BackgroundTasksPlugin` injects task status so the LLM knows which tasks are running. `A2uiPlugin` injects the UI schema so the LLM knows how to render components.
-
-**Cross-cutting concerns can't live in individual tools:**
-
-| Problem | Why tools can't solve it | Plugin solution |
-|---|---|---|
-| Permission gating | Each tool would re-implement auth | `PermissionPlugin` — one `before_tool_execute` hook for all tools |
-| Token budget | No single tool sees the full message history | `ContextPlugin` — truncates, summarizes, and caches across all messages |
-| Stop conditions | No tool knows when to stop the agent loop | `StopPolicyPlugin` — evaluates max rounds, timeout, budget after each inference |
-| Observability | Latency/token spans cross tool boundaries | `LLMMetryPlugin` — OpenTelemetry spans for the full LLM + tool pipeline |
-| Persistent reminders | Reminders survive across turns, not tied to one tool | `ReminderPlugin` — injects reminders before each inference |
-| Orphan recovery | Sub-agents can outlive their parent process | `AgentRecoveryPlugin` — detects and resumes orphaned runs on restart |
-
-This is why every built-in tool ships with a companion plugin. The tool provides the capability; the plugin wires it into the LLM's awareness and the runtime's lifecycle.
-
 ### Require approval before dangerous actions
 
-The built-in `PermissionPlugin` checks tool permissions via `PermissionPolicy` state (Allow/Deny/Ask per tool). Or write a custom plugin to gate any tool with full control over the suspension flow:
-
-```rust
-// In your plugin's before_tool_execute:
-async fn before_tool_execute(&self, ctx: &ReadOnlyContext<'_>)
-    -> ActionSet<BeforeToolExecuteAction>
-{
-    let tool_id = ctx.tool_name().unwrap_or_default();
-    let call_id = ctx.tool_call_id().unwrap_or_default();
-
-    if tool_id == "delete_account" {
-        let pending_id = format!("fc_{call_id}");
-        let tool_args = ctx.tool_args().cloned().unwrap_or_default();
-        let suspension = Suspension::new(&pending_id, "confirm_delete")
-            .with_message("Requires admin approval");
-        let pending = PendingToolCall::new(pending_id, "Confirm", tool_args);
-        ActionSet::single(BeforeToolExecuteAction::Suspend(
-            SuspendTicket::new(suspension, pending, ToolCallResumeMode::ReplayToolCall)
-        ))
-    } else {
-        ActionSet::empty()
-    }
-}
-```
-
-The frontend receives the suspension event with the pending call. When the user approves, the runtime replays the original tool call — this time bypassing the permission check.
+The built-in `PermissionPlugin` gates tool execution via Allow/Deny/Ask policies per tool. When a tool requires approval, the runtime suspends execution and sends the pending call to the frontend. When the user approves, the runtime replays the original tool call. See the [human-in-the-loop guide](https://tirea-ai.github.io/tirea/explanation/human-in-the-loop.html) for details.
 
 ### Multi-agent collaboration
 
-Multi-agent orchestration is a core capability. Register agents at build time — the runtime injects the agent catalog into the system prompt, and the orchestrator delegates via built-in tools:
+Tirea agents delegate through **natural-language orchestration**. You define each agent's identity and access policy, then register them in the agent registry; the LLM decides when to delegate, to whom, and how to combine results — no DAGs, no hand-coded state machines, no explicit routing logic.
+
+The runtime makes this work:
+- **Agent registry** — register agents at build time; the runtime renders the registry into the system prompt so the LLM always knows who it can delegate to
+- **Background execution with completion notifications** — sub-agents and tasks run in the background; the runtime injects their status after each tool call, so the LLM stays aware of what's running, what's finished, and what failed
+- **Foreground and background modes** — block until a sub-agent finishes, or run multiple sub-agents concurrently in the background and receive completion notifications when each one finishes
+- **Thread isolation** — each sub-agent runs in its own thread with independent state
+- **Orphan recovery** — if the parent process crashes, orphaned sub-agents are detected and resumed on restart
+- **Local + remote transparency** — in-process agents and remote A2A agents use the same `agent_run` interface; the orchestrator doesn't need to know the difference
+
+Register agents at build time:
 
 ```rust
 let orchestrator = AgentDefinition::with_id("orchestrator", "deepseek-chat")
@@ -334,27 +292,7 @@ let os = AgentOsBuilder::new()
     .build()?;
 ```
 
-**Delegation tools** — each sub-agent runs in its own isolated thread:
-
-- `agent_run` — launch by `agent_id` (foreground or background), or resume by `run_id`
-- `agent_stop` — cancel a running sub-agent (cascades to descendants)
-- `agent_output` — read a sub-agent's results from its thread
-
-**Supported patterns:**
-
-| Pattern | How it works |
-|---|---|
-| **Coordinator** | Orchestrator analyzes intent, routes to the right specialist |
-| **Pipeline** | Agents execute sequentially — each transforms the previous output |
-| **Parallel fan-out** | Orchestrator launches multiple agents concurrently, gathers results |
-| **Hierarchical** | Parent decomposes → children decompose further → recursive delegation |
-| **Generator-Critic** | Generator drafts, critic validates, generator revises in a loop |
-
-**Foreground vs background:** `agent_run(background=false)` blocks until the child finishes (progress streamed back). `agent_run(background=true)` returns immediately with a `run_id` — check status later with `agent_output`.
-
-**Local + remote agents:** Local agents run in-process. Remote agents communicate via A2A protocol over HTTP — same `agent_run` interface, transparent to the orchestrator.
-
-Agents must be pre-defined in the builder. Visibility is policy-enforced via `allowed_agents` / `excluded_agents`. Orphaned sub-agents are automatically recovered on restart. See the [multi-agent design patterns guide](https://tirea-ai.github.io/tirea/explanation/multi-agent-design-patterns.html) for details.
+See the [multi-agent design patterns guide](https://tirea-ai.github.io/tirea/explanation/multi-agent-design-patterns.html) for coordinator, pipeline, fan-out, and other patterns.
 
 ### Manage state across conversations
 
@@ -374,7 +312,7 @@ struct SearchProgress { /* ... */ }
 struct ToolWorkspace { /* ... */ }
 ```
 
-Fields marked `#[tirea(lattice)]` use CRDT types that merge automatically when multiple agents write concurrently — no locks needed.
+Fields marked `#[tirea(lattice)]` use CRDT types (conflict-free replicated data types) that merge automatically when multiple agents write concurrently — no locks needed.
 
 ### Persist conversations
 
@@ -439,12 +377,12 @@ model: "claude-sonnet-4-20250514".into(), // Anthropic
 
 ## Examples
 
-| Example | What it shows |
-|---|---|
-| [ai-sdk-starter](./examples/ai-sdk-starter/) | React + AI SDK v6 — chat, canvas, shared state |
-| [copilotkit-starter](./examples/copilotkit-starter/) | Next.js + CopilotKit — persisted threads, frontend actions |
-| [travel-ui](./examples/travel-ui/) | Map canvas + approval-gated trip planning |
-| [research-ui](./examples/research-ui/) | Resource collection + report writing with approval |
+| Example | What it shows | Best for |
+|---|---|---|
+| [ai-sdk-starter](./examples/ai-sdk-starter/) | React + AI SDK v6 — chat, canvas, shared state | Fastest start, minimal setup |
+| [copilotkit-starter](./examples/copilotkit-starter/) | Next.js + CopilotKit — persisted threads, frontend actions | Full-stack with persistence |
+| [travel-ui](./examples/travel-ui/) | Map canvas + approval-gated trip planning | Geospatial + human-in-the-loop |
+| [research-ui](./examples/research-ui/) | Resource collection + report writing with approval | Approval-gated workflows |
 
 ## Documentation
 

--- a/crates/tirea-extension-a2ui/Cargo.toml
+++ b/crates/tirea-extension-a2ui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tirea-extension-a2ui"
 version.workspace = true
 edition = "2021"
-description = "A2UI (Agent-to-UI) extension for tirea — declarative generative UI via tool-based rendering"
+description = "Render interactive UI components to the frontend via AG-UI protocol for tirea"
 license = "MIT OR Apache-2.0"
 repository.workspace = true
 

--- a/crates/tirea-extension-reminder/Cargo.toml
+++ b/crates/tirea-extension-reminder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tirea-extension-reminder"
 version.workspace = true
 edition = "2021"
-description = "System-reminder injection for persistent cross-turn context in tirea agents"
+description = "Persistent reminders that survive across agent turns for tirea"
 license = "MIT OR Apache-2.0"
 repository.workspace = true
 keywords = ["agent", "llm", "reminder", "context"]

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 # Tirea
 
-**用 Rust 构建 AI 智能体，连接任意前端，轻松部署到生产环境。**
+**类型安全的 AI 智能体，并发状态无需加锁。一个二进制文件通过三种协议服务 React、Next.js 和其他智能体。**
 
-用 Rust 定义智能体、工具和状态，然后通过单一二进制文件将它们通过 AG-UI、AI SDK v6、A2A 和 MCP 协议提供给 React、Next.js、CopilotKit 或其他智能体使用。
+用 Rust 定义智能体、工具和状态，然后通过 AG-UI、AI SDK v6 和 A2A 协议从单一二进制文件服务任意前端。通过 MCP 连接外部工具服务器。
 
 [![Crates.io](https://img.shields.io/crates/v/tirea.svg)](https://crates.io/crates/tirea)
 [![docs.rs](https://img.shields.io/docsrs/tirea)](https://docs.rs/tirea)
@@ -14,9 +14,110 @@
   <img src="./assets/demo.svg" alt="Tirea demo — 工具调用 + LLM 流式响应" width="800">
 </p>
 
-## 你能构建什么
+## 30 秒心智模型
 
-构建组件——工具、插件、智能体——然后将它们组装成一个 `AgentOs`。AgentOs 是一个容器，智能体由你注册的组件组合而成。
+1. **工具 (Tools)** — 类型化的函数，JSON Schema 从结构体自动生成
+2. **智能体 (Agents)** — 每个智能体拥有系统提示和允许使用的工具/子智能体；由 LLM 通过自然语言驱动所有编排——不需要像 LangGraph/ADK 那样编写 DAG 或状态机
+3. **状态 (State)** — 类型化、按作用域划分（thread / run / tool_call），CRDT 字段支持安全并发写入
+4. **插件 (Plugins)** — 生命周期钩子，用于权限控制、可观测性、上下文窗口、提醒等
+
+智能体选择工具、调用工具、读写状态、循环往复——全部由运行时编排。每次状态变更都是可回放的不可变补丁。
+
+## 为什么选择 Tirea
+
+| 特性 | 实现方式 |
+|---|---|
+| **一个后端服务所有前端** | 同一个二进制文件同时服务 React (AI SDK v6)、Next.js (AG-UI) 和其他智能体 (A2A)，无需单独部署。通过 MCP 连接外部工具服务器。 |
+| **让多个智能体写入同一状态** | CRDT 字段（`GSet`、`ORSet`、`GCounter`）自动合并并发写入——你不需要锁、队列或手动冲突解决。 |
+| **按生命周期划分状态作用域** | 将状态标记为 Thread 作用域（跨对话持久化）、Run 作用域（每次运行时重置）或 ToolCall 作用域（工具执行结束后销毁），避免过期数据泄漏。 |
+| **在编译期捕获插件接线错误** | 插件挂载到 8 个类型化生命周期阶段。将权限检查接到错误的阶段？编译器告诉你，而不是你的用户。 |
+| **回放任意对话到任意时间点** | 每次状态变更都是不可变补丁，可以重放以精确还原任意时间点的状态——用于调试、审计和测试。 |
+| **用最少资源运行数千个智能体** | 无 GC 停顿。每个 agent run 约 170 KB RSS（10 轮对话，mock LLM）。32 个并发智能体可达约 1,000 runs/s。（`cargo bench --package tirea-agentos --bench runtime_throughput` 可复现。） |
+
+### 功能对比
+
+|  | Tirea | LangGraph | CrewAI | OpenAI Agents | Mastra | PydanticAI | Letta |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **语言** | Rust | Python | Python | Python/TS | TypeScript | Python | Python |
+| **多协议服务器** | AG-UI · AI SDK · A2A | ◐ | ❌ | ❌ | ◐ | AG-UI | REST |
+| **类型化状态** | ✅ derive 宏 | ◐ | ❌ | ❌ | ◐ | ◐ | ❌ |
+| **并发状态 (CRDT)** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **状态生命周期作用域** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **状态回放** | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **插件生命周期** | 8 个类型化阶段 | ❌ | ❌ | Guardrails | ❌ | ❌ | ❌ |
+| **子智能体** | ✅ | ✅ | ✅ | Handoffs | ◐ | ◐ | ✅ |
+| **MCP 支持** | ✅ | Adapter | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **Human-in-the-loop** | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| **内置通用工具** | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+
+✅ = 原生支持  ◐ = 部分支持  ❌ = 不支持
+
+## 快速开始
+
+### 前置条件
+
+- 来自 [`rust-toolchain.toml`](../rust-toolchain.toml) 的 Rust 工具链
+- 前端演示需要：Node.js 20+ 和 npm
+- 任意一个模型提供商的 API Key（OpenAI、DeepSeek、Anthropic 等）
+
+### 60 秒内运行全栈演示
+
+**React + AI SDK v6：**
+
+```bash
+git clone https://github.com/tirea-ai/tirea.git && cd tirea
+cd examples/ai-sdk-starter && npm install
+DEEPSEEK_API_KEY=<your-key> npm run dev
+# 首次运行会编译 Rust agent（约 1-2 分钟），然后打开 http://localhost:3001
+```
+
+**Next.js + CopilotKit：**
+
+```bash
+cd examples/copilotkit-starter && npm install
+cp .env.example .env.local
+DEEPSEEK_API_KEY=<your-key> npm run setup:agent && npm run dev
+# Open http://localhost:3000
+```
+
+### 仅启动服务器
+
+```bash
+export OPENAI_API_KEY=<your-key>
+cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
+```
+
+## 使用方式
+
+### 架构
+
+```mermaid
+graph LR
+    subgraph "Your frontends"
+        A["React app\n(AI SDK v6)"]
+        B["Next.js app\n(CopilotKit / AG-UI)"]
+        C["Another agent\n(A2A)"]
+    end
+
+    subgraph "tirea server (one binary)"
+        GW["Protocol gateway\nUI: AG-UI · AI SDK\nAgent: A2A"]
+        RT["Agent runtime\nLLM streaming · tool dispatch\nplugin lifecycle · context mgmt"]
+        EXT["Extensions\npermission · skills · MCP\nreminder · observability"]
+    end
+
+    subgraph "Storage (pick one)"
+        S1[(File)]
+        S2[(PostgreSQL)]
+    end
+
+    A & B --> GW
+    C --> GW
+    GW --> RT
+    RT --> EXT
+    RT --> S1 & S2
+```
+
+### 定义工具、智能体并组装
 
 ```rust
 // 1. 构建工具 — 将参数定义为结构体，Schema 自动生成
@@ -70,119 +171,11 @@ let os = AgentOsBuilder::new()
     .build()?;
 ```
 
-工具在 AgentOs 上全局注册，每个智能体通过 `allowed_*` / `excluded_*` 列表定义自己的访问策略——决定可以使用哪些工具、技能和子智能体。运行时在解析时将全局工具池过滤为每个智能体有权访问的子集。
-
-通过 `useChat()` 连接 React 前端、通过 AG-UI 连接 CopilotKit 应用，或通过 A2A 连接另一个智能体——无需修改任何代码。
-
-## 与众不同之处
-
-| 特性 | 为什么重要 |
-|---|---|
-| **一个服务器，四种协议** | 同一个二进制文件同时提供 UI 协议（AG-UI、AI SDK v6）和智能体协议（A2A、MCP），无需单独部署。 |
-| **并发安全的状态** | 多个智能体可以同时写入同一状态。CRDT 字段（`GSet`、`ORSet`、`GCounter`）自动合并——无锁、无冲突。 |
-| **按生命周期划分的状态作用域** | 将状态标记为 Thread 作用域（永久持久化）、Run 作用域（每次运行时重置）或 ToolCall 作用域（工具执行结束后销毁），避免过期数据在多次运行间泄漏。 |
-| **编译期插件安全性** | 插件挂载到 8 个生命周期阶段。将权限检查接入错误的阶段？编译器直接报错。 |
-| **回放任意对话** | 每次状态变更都是不可变补丁，可以重放以精确还原任意时间点的状态。 |
-| **Rust 性能** | 无 GC 停顿，内存占用低，原生异步并发。 |
-
-## 功能对比
-
-|  | Tirea | LangGraph | CrewAI | OpenAI Agents | Mastra | PydanticAI | Letta |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **语言** | Rust | Python | Python | Python/TS | TypeScript | Python | Python |
-| **多协议服务器** | AG-UI · AI SDK · A2A · MCP | ❌ | ❌ | ❌ | ❌ | AG-UI | REST |
-| **类型化状态** | ✅ derive 宏 | ◐ | ❌ | ❌ | ◐ | ◐ | ❌ |
-| **并发状态安全** | ✅ CRDT | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **状态生命周期作用域** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **状态回放** | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| **插件生命周期** | 8 个类型化阶段 | ❌ | ❌ | Guardrails | ❌ | ❌ | ❌ |
-| **子智能体** | ✅ | ✅ | ✅ | Handoffs | ◐ | ◐ | ✅ |
-| **MCP 支持** | ✅ | Adapter | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **Human-in-the-loop** | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
-| **内置通用工具** | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
-
-✅ = 原生支持  ◐ = 部分支持  ❌ = 不支持
-
-## 快速开始
-
-### 前置条件
-
-- 来自 [`rust-toolchain.toml`](../rust-toolchain.toml) 的 Rust 工具链
-- 前端演示需要：Node.js 20+ 和 npm
-- 任意一个模型提供商的 API Key（OpenAI、DeepSeek、Anthropic 等）
-
-### 60 秒内运行全栈演示
-
-**React + AI SDK v6：**
-
-```bash
-git clone https://github.com/tirea-ai/tirea.git && cd tirea
-cd examples/ai-sdk-starter && npm install
-DEEPSEEK_API_KEY=<your-key> npm run dev
-# 首次运行会编译 Rust agent（约 1-2 分钟），然后打开 http://localhost:3001
-```
-
-**Next.js + CopilotKit：**
-
-```bash
-cd examples/copilotkit-starter && npm install
-cp .env.example .env.local
-DEEPSEEK_API_KEY=<your-key> npm run setup:agent && npm run dev
-# Open http://localhost:3000
-```
-
-### 仅启动服务器
-
-```bash
-export OPENAI_API_KEY=<your-key>
-cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
-```
-
-## 工作原理
-
-```mermaid
-graph LR
-    subgraph "Your frontends"
-        A["React app\n(AI SDK v6)"]
-        B["Next.js app\n(CopilotKit / AG-UI)"]
-        C["Another agent\n(A2A)"]
-    end
-
-    subgraph "tirea server (one binary)"
-        GW["Protocol gateway\nUI: AG-UI · AI SDK\nAgent: A2A · MCP"]
-        RT["Agent runtime\nLLM streaming · tool dispatch\nplugin lifecycle · context mgmt"]
-        EXT["Extensions\npermission · skills · MCP\nreminder · observability"]
-    end
-
-    subgraph "Storage (pick one)"
-        S1[(File)]
-        S2[(PostgreSQL)]
-    end
-
-    A & B --> GW
-    C --> GW
-    GW --> RT
-    RT --> EXT
-    RT --> S1 & S2
-```
-
-## 能做什么
+工具全局注册，每个智能体通过 `allowed_*` / `excluded_*` 列表控制自己的访问权限——运行时在解析时自动过滤。
 
 ### 连接任意前端
 
-一个后端从同一个二进制文件提供多种协议，切换时无需修改代码：
-
-**UI 协议** — 将前端连接到你的智能体：
-
-- **AG-UI**（CopilotKit）— 共享状态、前端操作、生成式 UI、human-in-the-loop
-- **AI SDK v6**（Vercel）— `useChat()` 流式传输、画布、对话历史
-
-**智能体协议** — 将智能体互联：
-
-- **A2A** — Google 的 agent-to-agent 协议，将你的智能体暴露为对等服务
-- **MCP** — 连接 MCP 服务器，外部工具以原生工具形式呈现
-
-**端点** — 启动服务器后，从任意前端连接：
+启动服务器，然后从 React、Next.js 或其他智能体连接——切换时无需修改代码：
 
 ```bash
 cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
@@ -192,8 +185,9 @@ cargo run --package tirea-agentos-server -- --http-addr 127.0.0.1:8080
 |---|---|---|
 | AI SDK v6 | `POST /v1/ai-sdk/agents/:agent_id/runs` | React `useChat()` |
 | AG-UI | `POST /v1/ag-ui/agents/:agent_id/runs` | CopilotKit `<CopilotKit>` |
+| A2A | `POST /v1/a2a/agents/:agent_id/message:send` | 其他智能体 |
 
-**React + AI SDK v6** — 极简前端：
+**React + AI SDK v6：**
 
 ```typescript
 import { useChat } from "ai/react";
@@ -203,7 +197,7 @@ const { messages, input, handleSubmit } = useChat({
 });
 ```
 
-**Next.js + CopilotKit** — 极简前端：
+**Next.js + CopilotKit：**
 
 ```typescript
 import { CopilotKit } from "@copilotkit/react-core";
@@ -260,59 +254,23 @@ Tirea 内置了用于子智能体、后台任务、技能、UI 渲染和 MCP 集
 | **A2UI**（`a2ui` 扩展） | `render_a2ui` | 向前端发送声明式 UI 组件 |
 | **MCP**（`mcp` feature） | *动态* | 来自已连接 MCP 服务器的工具以原生工具形式呈现 |
 
-### 为什么需要插件？仅靠工具还不够
-
-工具只是 LLM 可以调用的函数，但单纯的工具在实践中行不通。
-
-**LLM 不知道工具的存在。** `agent_run` 工具可以启动子智能体，但 LLM 不会去调用它，除非系统提示中列出了哪些智能体可用。这种上下文注入不是工具的职责，`AgentToolsPlugin` 通过在每次推理前注入智能体目录来解决这个问题。
-
-同样的模式随处可见：`SkillDiscoveryPlugin` 注入技能目录，让 LLM 知道可以激活哪些技能；`BackgroundTasksPlugin` 注入任务状态，让 LLM 了解哪些任务正在运行；`A2uiPlugin` 注入 UI Schema，让 LLM 知道如何渲染组件。
-
-**横切关注点无法在单个工具内解决：**
-
-| 问题 | 为何工具无法解决 | 插件方案 |
-|---|---|---|
-| 权限控制 | 每个工具都要重新实现鉴权 | `PermissionPlugin` — 对所有工具统一提供一个 `before_tool_execute` 钩子 |
-| Token 预算 | 单个工具无法看到完整的消息历史 | `ContextPlugin` — 跨所有消息进行截断、摘要和缓存 |
-| 停止条件 | 没有工具知道何时应该停止智能体循环 | `StopPolicyPlugin` — 在每次推理后评估最大轮次、超时和预算 |
-| 可观测性 | 延迟/Token 跨度跨越工具边界 | `LLMMetryPlugin` — 对完整的 LLM + 工具流水线生成 OpenTelemetry span |
-| 持久化提醒 | 提醒需要跨轮次存活，不依附于某个工具 | `ReminderPlugin` — 在每次推理前注入提醒 |
-| 孤儿恢复 | 子智能体可能在父进程退出后继续存在 | `AgentRecoveryPlugin` — 在重启时检测并恢复孤立的运行实例 |
-
-这就是每个内置工具都附带一个伴生插件的原因。工具提供能力，插件将其接入 LLM 的感知范围和运行时生命周期。
-
 ### 在危险操作前要求审批
 
-内置的 `PermissionPlugin` 通过 `PermissionPolicy` 状态（每个工具的 Allow/Deny/Ask 策略）检查工具权限。你也可以编写自定义插件，完全控制暂停流程来拦截任意工具：
-
-```rust
-// In your plugin's before_tool_execute:
-async fn before_tool_execute(&self, ctx: &ReadOnlyContext<'_>)
-    -> ActionSet<BeforeToolExecuteAction>
-{
-    let tool_id = ctx.tool_name().unwrap_or_default();
-    let call_id = ctx.tool_call_id().unwrap_or_default();
-
-    if tool_id == "delete_account" {
-        let pending_id = format!("fc_{call_id}");
-        let tool_args = ctx.tool_args().cloned().unwrap_or_default();
-        let suspension = Suspension::new(&pending_id, "confirm_delete")
-            .with_message("Requires admin approval");
-        let pending = PendingToolCall::new(pending_id, "Confirm", tool_args);
-        ActionSet::single(BeforeToolExecuteAction::Suspend(
-            SuspendTicket::new(suspension, pending, ToolCallResumeMode::ReplayToolCall)
-        ))
-    } else {
-        ActionSet::empty()
-    }
-}
-```
-
-前端会收到带有待处理调用的暂停事件。当用户批准后，运行时会重放原始工具调用——这次将跳过权限检查。
+内置的 `PermissionPlugin` 通过 Allow/Deny/Ask 策略控制每个工具的执行权限。当工具需要审批时，运行时暂停执行并将待处理的调用发送到前端。用户批准后，运行时重放原始工具调用。详见 [human-in-the-loop 指南](https://tirea-ai.github.io/tirea/explanation/human-in-the-loop.html)。
 
 ### 多智能体协作
 
-多智能体编排是核心能力。在构建时注册智能体——运行时将智能体目录注入系统提示，编排者通过内置工具进行委派：
+Tirea 智能体通过**自然语言编排**进行委派。你定义每个智能体的身份和访问策略，然后注册到智能体注册表；由 LLM 决定何时委派、委派给谁、以及如何组合结果——没有 DAG，没有手写状态机，没有显式路由逻辑。
+
+运行时让这一切成为可能：
+- **智能体注册表** — 在构建时注册智能体；运行时将注册表渲染到系统提示中，LLM 始终知道可以委派给谁
+- **后台执行与完成通知** — 子智能体和任务在后台运行；运行时在每次工具调用后注入它们的状态，LLM 始终了解哪些任务正在运行、已完成或已失败
+- **前台与后台模式** — 阻塞等待子智能体完成，或在后台并发运行多个子智能体并在每个完成时收到通知
+- **线程隔离** — 每个子智能体在独立线程中运行，状态互不干扰
+- **孤儿恢复** — 父进程崩溃后，孤立的子智能体会在重启时被检测并自动恢复
+- **本地与远程透明** — 进程内智能体和远程 A2A 智能体使用相同的 `agent_run` 接口，编排者无需区分
+
+在构建时注册智能体：
 
 ```rust
 let orchestrator = AgentDefinition::with_id("orchestrator", "deepseek-chat")
@@ -334,27 +292,7 @@ let os = AgentOsBuilder::new()
     .build()?;
 ```
 
-**委派工具** — 每个子智能体在自己独立的线程中运行：
-
-- `agent_run` — 通过 `agent_id` 启动（前台或后台），或通过 `run_id` 恢复
-- `agent_stop` — 取消正在运行的子智能体（级联至所有后代）
-- `agent_output` — 从子智能体的线程中读取其运行结果
-
-**支持的协作模式：**
-
-| 模式 | 工作方式 |
-|---|---|
-| **协调者** | 编排者分析意图，路由到合适的专家 |
-| **流水线** | 智能体顺序执行——每个智能体对前一个的输出进行转换 |
-| **并行扇出** | 编排者并发启动多个智能体，汇总结果 |
-| **层级式** | 父级分解任务 → 子级进一步分解 → 递归委派 |
-| **生成-批评** | 生成者起草，批评者验证，生成者在循环中修订 |
-
-**前台与后台：** `agent_run(background=false)` 阻塞直到子智能体完成（进度实时回传）。`agent_run(background=true)` 立即返回一个 `run_id`——稍后通过 `agent_output` 检查状态。
-
-**本地 + 远程智能体：** 本地智能体在进程内运行。远程智能体通过 A2A 协议经 HTTP 通信——对编排者透明，使用相同的 `agent_run` 接口。
-
-智能体必须在构建器中预先定义。可见性通过 `allowed_agents` / `excluded_agents` 进行策略控制。孤立的子智能体会在重启时自动恢复。详见[多智能体设计模式指南](https://tirea-ai.github.io/tirea/explanation/multi-agent-design-patterns.html)。
+详见[多智能体设计模式指南](https://tirea-ai.github.io/tirea/explanation/multi-agent-design-patterns.html)，了解协调者、流水线、并行扇出等模式。
 
 ### 跨对话管理状态
 
@@ -374,7 +312,7 @@ struct SearchProgress { /* ... */ }
 struct ToolWorkspace { /* ... */ }
 ```
 
-标记为 `#[tirea(lattice)]` 的字段使用 CRDT 类型，当多个智能体并发写入时自动合并——无需加锁。
+标记为 `#[tirea(lattice)]` 的字段使用 CRDT 类型（无冲突复制数据类型），当多个智能体并发写入时自动合并——无需加锁。
 
 ### 持久化对话
 
@@ -415,36 +353,36 @@ model: "claude-sonnet-4-20250514".into(), // Anthropic
 
 ## 适合使用 Tirea 的场景
 
-- 你希望用 **Rust 后端**构建具备编译期安全性的 AI 智能体
-- 你需要从一个服务器提供**多种前端协议**
-- 你的智能体需要**无需协调地并发共享状态**
-- 你需要**可审计的状态历史**和回放能力
-- 你面向**生产环境**构建——低内存占用、无 GC、支持数千个并发智能体
+- 希望用 **Rust 后端**构建具备编译期安全性的 AI 智能体
+- 需要从一个服务器提供**多种前端协议**
+- 多个智能体需要**无需协调地并发共享状态**
+- 需要**可审计的状态历史**和回放能力
+- 面向**生产环境**构建——低内存占用、无 GC、支持数千个并发智能体
 
 ## 不适合使用 Tirea 的场景
 
-- 你需要开箱即用的**文件/Shell/网页工具**——可以考虑 Dify、CrewAI
-- 你想要**可视化工作流构建器**——可以考虑 Dify、LangGraph Studio
-- 你偏好 **Python** 和快速原型开发——可以考虑 LangGraph、PydanticAI
-- 你需要 **LLM 管理的记忆**（由智能体决定记住什么）——可以考虑 Letta
+- 需要开箱即用的**文件/Shell/网页工具**——可以考虑 Dify、CrewAI
+- 想要**可视化工作流构建器**——可以考虑 Dify、LangGraph Studio
+- 偏好 **Python** 和快速原型开发——可以考虑 LangGraph、PydanticAI
+- 需要 **LLM 管理的记忆**（由智能体决定记住什么）——可以考虑 Letta
 
 ## 学习路径
 
 | 目标 | 从这里开始 | 然后 |
 |---|---|---|
-| 构建你的第一个智能体 | [First Agent 教程](https://tirea-ai.github.io/tirea/tutorials/first-agent.html) | [构建智能体指南](https://tirea-ai.github.io/tirea/how-to/build-an-agent.html) |
+| 构建第一个智能体 | [First Agent 教程](https://tirea-ai.github.io/tirea/tutorials/first-agent.html) | [构建智能体指南](https://tirea-ai.github.io/tirea/how-to/build-an-agent.html) |
 | 查看完整全栈应用 | [AI SDK starter](../examples/ai-sdk-starter/README.md) | [CopilotKit starter](../examples/copilotkit-starter/README.md) |
 | 探索 API | [API 参考](https://tirea-ai.github.io/tirea/reference/api.html) | `cargo doc --workspace --no-deps --open` |
 | 参与贡献 | [贡献指南](../CONTRIBUTING.md) | [能力矩阵](https://tirea-ai.github.io/tirea/reference/capability-matrix.html) |
 
 ## 示例
 
-| 示例 | 展示内容 |
-|---|---|
-| [ai-sdk-starter](../examples/ai-sdk-starter/) | React + AI SDK v6 — 聊天、画布、共享状态 |
-| [copilotkit-starter](../examples/copilotkit-starter/) | Next.js + CopilotKit — 持久化对话、前端操作 |
-| [travel-ui](../examples/travel-ui/) | 地图画布 + 需审批的行程规划 |
-| [research-ui](../examples/research-ui/) | 资源收集 + 需审批的报告撰写 |
+| 示例 | 展示内容 | 适合 |
+|---|---|---|
+| [ai-sdk-starter](../examples/ai-sdk-starter/) | React + AI SDK v6 — 聊天、画布、共享状态 | 最快上手，最少配置 |
+| [copilotkit-starter](../examples/copilotkit-starter/) | Next.js + CopilotKit — 持久化对话、前端操作 | 全栈 + 持久化 |
+| [travel-ui](../examples/travel-ui/) | 地图画布 + 需审批的行程规划 | 地理空间 + 人机交互 |
+| [research-ui](../examples/research-ui/) | 资源收集 + 需审批的报告撰写 | 审批控制工作流 |
 
 ## 文档
 

--- a/docs/book/src/explanation/multi-agent-design-patterns.md
+++ b/docs/book/src/explanation/multi-agent-design-patterns.md
@@ -1,6 +1,17 @@
 # Multi-Agent Design Patterns
 
-This page describes common multi-agent patterns and how they map to Tirea primitives.
+## Natural-language orchestration
+
+Tirea uses **natural-language orchestration** — the LLM decides when to delegate, to whom, and how to combine results. You define each agent's identity and access policy; the runtime handles everything else. There are no DAGs, no state machines, and no explicit routing code — unlike frameworks such as LangGraph or Google ADK where you wire agents into graphs and define transitions in code.
+
+This works because the runtime provides:
+- **Agent registry** — agents registered at build time are rendered into the system prompt, so the LLM always knows who it can delegate to
+- **Background execution with completion notifications** — sub-agents run in the background; the runtime injects their status after each tool call, keeping the LLM aware of what's running, finished, or failed
+- **Foreground and background modes** — block until a sub-agent finishes, or run multiple concurrently and receive completion notifications
+- **Thread isolation** — each sub-agent runs in its own thread with independent state
+- **Orphan recovery** — orphaned sub-agents are detected and resumed on restart
+
+## Patterns
 
 All patterns below are implemented with the same building blocks:
 
@@ -9,7 +20,7 @@ All patterns below are implemented with the same building blocks:
 - `SuspendTicket` for human-in-the-loop gating
 - System prompt engineering for control flow
 
-Tirea does not require dedicated workflow agent types. The LLM-driven loop plus delegation tools cover these patterns through prompt configuration.
+No dedicated workflow agent types are needed. The LLM-driven loop plus delegation tools cover these patterns through prompt configuration.
 
 ## Pattern Index
 

--- a/examples/copilotkit-starter/README.md
+++ b/examples/copilotkit-starter/README.md
@@ -1,4 +1,4 @@
-# with-tirea
+# CopilotKit Starter with Tirea
 
 Official-style CopilotKit starter for integrating with `tirea-agentos-server` over AG-UI.
 


### PR DESCRIPTION
## Summary
- Rewrite tagline and feature table from user perspective
- Add 30-second mental model section and natural-language orchestration description
- Simplify structure: merge fragmented sections into `Why Tirea` → `Quick start` → `Usage`
- Remove MCP from serving protocol list (internal tool integration, not a serving protocol)
- Fix feature comparison: LangGraph/Mastra multi-protocol ❌→◐
- Fix crate descriptions (tirea-extension-reminder, tirea-extension-a2ui)
- Add natural-language orchestration section to multi-agent design patterns guide
- Sync all changes between English and Chinese READMEs

## Test plan
- [ ] Verify all links in README resolve correctly
- [ ] Verify mermaid diagram renders on GitHub
- [ ] Verify Chinese README matches English structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)