### PR TITLE
fix(agentos): allow tool call ID reuse when provider retries from terminal state

### DIFF
--- a/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
@@ -3643,7 +3643,9 @@ fn test_execute_tools_with_config_denied_response_is_applied_via_tool_call_state
 }
 
 #[test]
-fn test_execute_tools_with_config_rejects_illegal_terminal_to_running_transition() {
+fn test_execute_tools_with_config_allows_terminal_id_reuse_for_provider_retry() {
+    // Some providers (e.g., Gemini) reuse the same tool call ID when retrying.
+    // A terminal (Succeeded/Failed) call ID should start a fresh lifecycle.
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
         let thread = Thread::with_initial_state(
@@ -3667,7 +3669,7 @@ fn test_execute_tools_with_config_rejects_illegal_terminal_to_running_transition
             tool_calls: vec![crate::contracts::thread::ToolCall::new(
                 "call_1",
                 "echo",
-                json!({"message": "should-fail"}),
+                json!({"message": "retry-attempt"}),
             )],
             usage: None,
             stop_reason: None,
@@ -3675,19 +3677,19 @@ fn test_execute_tools_with_config_rejects_illegal_terminal_to_running_transition
         let tools = tool_map([EchoTool]);
         let config = BaseAgent::new("gpt-4");
 
-        let err = execute_tools_with_config(thread, &result, &tools, &config)
+        let outcome = execute_tools_with_config(thread, &result, &tools, &config)
             .await
-            .expect_err("terminal->running transition should fail");
-        let AgentLoopError::StateError(message) = err else {
-            panic!("unexpected error variant");
-        };
-        assert!(
-            message.contains("invalid tool call status transition"),
-            "unexpected error message: {message}"
+            .expect("terminal ID reuse should succeed as a fresh lifecycle");
+        let thread = outcome.into_thread();
+        // The tool result message should be present (tool executed successfully)
+        assert_eq!(thread.messages.len(), 1);
+        assert_eq!(
+            thread.messages[0].role,
+            crate::contracts::thread::Role::Tool
         );
         assert!(
-            message.contains("Succeeded") && message.contains("Running"),
-            "error should include transition details: {message}"
+            thread.messages[0].content.contains("retry-attempt"),
+            "tool result should reflect the retried call arguments"
         );
     });
 }

--- a/crates/tirea-agentos/src/runtime/loop_runner/tool_exec.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/tool_exec.rs
@@ -167,6 +167,14 @@ fn persist_tool_call_status(
         | ToolCallStatus::Resuming => (current_resume_token, current_resume),
     };
 
+    // Some providers (e.g., Gemini) reuse the same tool call ID when retrying
+    // a failed call. Reset terminal state so the call starts a fresh lifecycle.
+    let current_state = if previous_status.is_terminal() && status == ToolCallStatus::Running {
+        None
+    } else {
+        current_state
+    };
+
     let Some(runtime_state) = transition_tool_call_state(
         current_state,
         ToolCallStateSeed {


### PR DESCRIPTION
## Summary
- Gemini reuses the same tool call ID when retrying a failed call. The state machine rejected `Failed -> Running` as an invalid terminal transition, causing a non-retryable `StateError` that aborted the task.
- Fix: in `persist_tool_call_status`, reset the state slot to `None` when a terminal-state ID is reused for execution, so `transition_tool_call_state` treats it as a fresh `New -> Running` lifecycle.
- The `ToolCallStatus` state machine itself is unchanged — terminal states remain terminal. The reset operates one layer above.

## Test plan
- [x] Updated existing test from expecting rejection to verifying successful fresh lifecycle on ID reuse
- [x] All 823 `tirea-agentos` lib tests pass
- [x] All `tirea-contract` and `tirea-state` tests pass