### PR TITLE
✨ feat(agentos): add model fallback chain support

### DIFF
--- a/crates/tirea-agentos-server/src/main.rs
+++ b/crates/tirea-agentos-server/src/main.rs
@@ -192,6 +192,7 @@ fn build_os(
             name: None,
             description: None,
             model: None,
+            model_fallbacks: None,
             system_prompt: String::new(),
             max_rounds: None,
             tool_execution_mode: ToolExecutionModeConfig::ParallelStreaming,

--- a/crates/tirea-agentos/src/composition/agent_definition.rs
+++ b/crates/tirea-agentos/src/composition/agent_definition.rs
@@ -12,14 +12,14 @@ use std::collections::HashMap;
 pub struct ModeOverlay {
     /// Override model identifier.
     pub model: Option<String>,
+    /// Override model fallbacks.
+    pub model_fallbacks: Option<Vec<String>>,
     /// Override system prompt.
     pub system_prompt: Option<String>,
     /// Override maximum rounds.
     pub max_rounds: Option<usize>,
     /// Override chat options.
     pub chat_options: Option<Option<ChatOptions>>,
-    /// Override fallback models.
-    pub fallback_models: Option<Vec<String>>,
     /// Override tool whitelist.
     pub allowed_tools: Option<Option<Vec<String>>>,
     /// Override tool blacklist.
@@ -55,6 +55,8 @@ pub struct AgentDefinition {
     pub description: Option<String>,
     /// Model identifier (e.g., "gpt-4", "claude-3-opus").
     pub model: String,
+    /// Fallback model ids used when the primary model fails.
+    pub model_fallbacks: Vec<String>,
     /// System prompt for the LLM.
     pub system_prompt: String,
     /// Maximum number of tool call rounds before stopping.
@@ -63,10 +65,6 @@ pub struct AgentDefinition {
     pub tool_execution_mode: ToolExecutionMode,
     /// Chat options for the LLM.
     pub chat_options: Option<ChatOptions>,
-    /// Fallback model ids used when the primary model fails.
-    ///
-    /// Evaluated in order after `model`.
-    pub fallback_models: Vec<String>,
     /// Retry policy for LLM inference failures.
     pub llm_retry_policy: LlmRetryPolicy,
     /// Behavior references resolved from AgentOS behavior registry.
@@ -98,6 +96,7 @@ impl Default for AgentDefinition {
             name: None,
             description: None,
             model: "gpt-4o-mini".to_string(),
+            model_fallbacks: Vec::new(),
             system_prompt: String::new(),
             max_rounds: 10,
             tool_execution_mode: ToolExecutionMode::ParallelStreaming,
@@ -107,7 +106,6 @@ impl Default for AgentDefinition {
                     .with_capture_reasoning_content(true)
                     .with_capture_tool_calls(true),
             ),
-            fallback_models: Vec::new(),
             llm_retry_policy: LlmRetryPolicy::default(),
             behavior_ids: Vec::new(),
             allowed_tools: None,
@@ -130,6 +128,7 @@ impl std::fmt::Debug for AgentDefinition {
             .field("name", &self.name)
             .field("description", &self.description)
             .field("model", &self.model)
+            .field("model_fallbacks", &self.model_fallbacks)
             .field(
                 "system_prompt",
                 &format!("[{} chars]", self.system_prompt.len()),
@@ -137,7 +136,6 @@ impl std::fmt::Debug for AgentDefinition {
             .field("max_rounds", &self.max_rounds)
             .field("tool_execution_mode", &self.tool_execution_mode)
             .field("chat_options", &self.chat_options)
-            .field("fallback_models", &self.fallback_models)
             .field("llm_retry_policy", &self.llm_retry_policy)
             .field("behavior_ids", &self.behavior_ids)
             .field("allowed_tools", &self.allowed_tools)
@@ -154,7 +152,64 @@ impl std::fmt::Debug for AgentDefinition {
 }
 
 impl AgentDefinition {
-    tirea_contract::impl_shared_agent_builder_methods!();
+    /// Create a new instance with the given model id.
+    pub fn new(model: impl Into<String>) -> Self {
+        Self {
+            model: model.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create a new instance with explicit id and model.
+    pub fn with_id(id: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            model: model.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set system prompt.
+    #[must_use]
+    pub fn with_system_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.system_prompt = prompt.into();
+        self
+    }
+
+    /// Set max rounds.
+    #[must_use]
+    pub fn with_max_rounds(mut self, max_rounds: usize) -> Self {
+        self.max_rounds = max_rounds;
+        self
+    }
+
+    /// Set chat options.
+    #[must_use]
+    pub fn with_chat_options(mut self, options: ChatOptions) -> Self {
+        self.chat_options = Some(options);
+        self
+    }
+
+    /// Set fallback model ids to try after the primary model.
+    #[must_use]
+    pub fn with_fallback_models(mut self, models: Vec<String>) -> Self {
+        self.model_fallbacks = models;
+        self
+    }
+
+    /// Add a single fallback model id.
+    #[must_use]
+    pub fn with_fallback_model(mut self, model: impl Into<String>) -> Self {
+        self.model_fallbacks.push(model.into());
+        self
+    }
+
+    /// Set LLM retry policy.
+    #[must_use]
+    pub fn with_llm_retry_policy(mut self, policy: LlmRetryPolicy) -> Self {
+        self.llm_retry_policy = policy;
+        self
+    }
 
     #[must_use]
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
@@ -276,6 +331,9 @@ impl AgentDefinition {
         if let Some(ref model) = overlay.model {
             self.model = model.clone();
         }
+        if let Some(ref models) = overlay.model_fallbacks {
+            self.model_fallbacks = models.clone();
+        }
         if let Some(ref prompt) = overlay.system_prompt {
             self.system_prompt = prompt.clone();
         }
@@ -284,9 +342,6 @@ impl AgentDefinition {
         }
         if let Some(ref opts) = overlay.chat_options {
             self.chat_options = opts.clone();
-        }
-        if let Some(ref models) = overlay.fallback_models {
-            self.fallback_models = models.clone();
         }
         if let Some(ref tools) = overlay.allowed_tools {
             self.allowed_tools = tools.clone();
@@ -321,7 +376,7 @@ mod tests {
 
         assert_eq!(normalized.model, "openai::gemini-2.5-flash");
         assert_eq!(
-            normalized.fallback_models,
+            normalized.model_fallbacks,
             vec!["gpt-4o-mini".to_string(), "claude-3-7-sonnet".to_string()]
         );
     }

--- a/crates/tirea-agentos/src/composition/config.rs
+++ b/crates/tirea-agentos/src/composition/config.rs
@@ -130,6 +130,9 @@ pub struct ModeOverlayConfig {
     /// Override model identifier.
     #[serde(default)]
     pub model: Option<String>,
+    /// Override model fallbacks.
+    #[serde(default)]
+    pub model_fallbacks: Option<Vec<String>>,
     /// Override system prompt.
     #[serde(default)]
     pub system_prompt: Option<String>,
@@ -142,6 +145,11 @@ impl ModeOverlayConfig {
     fn into_overlay(self, agent_id: &str) -> Result<ModeOverlay, AgentConfigError> {
         Ok(ModeOverlay {
             model: normalize_optional_field(agent_id, "mode.model", self.model)?,
+            model_fallbacks: normalize_optional_list(
+                agent_id,
+                "mode.model_fallbacks",
+                self.model_fallbacks,
+            )?,
             system_prompt: self.system_prompt,
             max_rounds: self.max_rounds,
             ..Default::default()
@@ -158,6 +166,8 @@ pub struct LocalAgentConfig {
     pub description: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
+    #[serde(default)]
+    pub model_fallbacks: Option<Vec<String>>,
     #[serde(default)]
     pub system_prompt: String,
     #[serde(default)]
@@ -179,6 +189,9 @@ impl LocalAgentConfig {
         let name = normalize_optional_text(self.name);
         let description = normalize_optional_text(self.description).unwrap_or_default();
         let model = normalize_optional_field(&id, "model", self.model)?;
+        let model_fallbacks =
+            normalize_optional_list(&id, "model_fallbacks", self.model_fallbacks)?
+                .unwrap_or_default();
         let behavior_ids = normalize_identifier_list(&id, "behavior_ids", self.behavior_ids)?;
 
         let mut definition = AgentDefinition {
@@ -193,6 +206,7 @@ impl LocalAgentConfig {
         if let Some(model) = model {
             definition.model = model;
         }
+        definition.model_fallbacks = model_fallbacks;
         if let Some(max_rounds) = self.max_rounds {
             definition.max_rounds = max_rounds;
         }
@@ -339,6 +353,17 @@ fn normalize_optional_field(
     }
 }
 
+fn normalize_optional_list(
+    agent_id: &str,
+    field: &'static str,
+    values: Option<Vec<String>>,
+) -> Result<Option<Vec<String>>, AgentConfigError> {
+    match values {
+        Some(values) => normalize_identifier_list(agent_id, field, values).map(Some),
+        None => Ok(None),
+    }
+}
+
 fn normalize_identifier_list(
     agent_id: &str,
     field: &'static str,
@@ -438,8 +463,12 @@ mod tests {
                 "agents": [{
                     "id": "coder",
                     "model": "claude-opus",
+                    "model_fallbacks": ["claude-instant"],
                     "modes": {
-                        "fast": { "model": "claude-haiku" },
+                        "fast": {
+                            "model": "claude-haiku",
+                            "model_fallbacks": ["claude-sonnet"]
+                        },
                         "deep": { "model": "claude-opus", "max_rounds": 50 }
                     }
                 }]
@@ -453,7 +482,12 @@ mod tests {
         assert_eq!(spec.id(), "coder");
         if let super::super::AgentDefinitionSpec::Local(def) = spec {
             assert_eq!(def.modes.len(), 2);
+            assert_eq!(def.model_fallbacks, vec!["claude-instant".to_string()]);
             assert_eq!(def.modes["fast"].model.as_deref(), Some("claude-haiku"));
+            assert_eq!(
+                def.modes["fast"].model_fallbacks.as_ref(),
+                Some(&vec!["claude-sonnet".to_string()])
+            );
             assert_eq!(def.modes["deep"].max_rounds, Some(50));
         } else {
             panic!("expected local agent spec");

--- a/crates/tirea-agentos/src/runtime/loop_runner/mod.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/mod.rs
@@ -316,6 +316,13 @@ impl LlmErrorClass {
     }
 }
 
+fn should_fallback_on_llm_error_class(error_class: LlmErrorClass) -> bool {
+    matches!(
+        error_class,
+        LlmErrorClass::RateLimit | LlmErrorClass::ServerUnavailable
+    )
+}
+
 fn classify_llm_error_message(message: &str) -> LlmErrorClass {
     let lower = message.to_ascii_lowercase();
     if ["429", "too many requests", "rate limit"]
@@ -779,6 +786,7 @@ where
                     let message = e.to_string();
                     last_llm_error =
                         format!("model='{model}' attempt={attempt}/{max_attempts}: {message}");
+                    let can_fallback_model = should_fallback_on_llm_error_class(error_class);
                     let can_retry_same_model =
                         retry_current_model && attempt < max_attempts && error_class.is_retryable();
                     tracing::warn!(
@@ -786,6 +794,7 @@ where
                         attempt = attempt,
                         max_attempts = max_attempts,
                         error_class = error_class.as_str(),
+                        fallbackable = can_fallback_model,
                         retryable = can_retry_same_model,
                         error = %message,
                         "LLM call failed"
@@ -814,6 +823,9 @@ where
                                 break 'models;
                             }
                         }
+                    }
+                    if !can_fallback_model {
+                        break 'models;
                     }
                     break;
                 }

--- a/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
@@ -5989,6 +5989,163 @@ async fn test_nonstream_uses_fallback_model_after_primary_failures() {
 }
 
 #[tokio::test]
+async fn test_nonstream_succeeds_without_using_fallbacks() {
+    let provider = Arc::new(MockChatProvider::new(vec![Ok(text_chat_response("ok"))]));
+    let config = BaseAgent::new("primary")
+        .with_fallback_models(vec!["fallback-a".to_string(), "fallback-b".to_string()])
+        .with_llm_retry_policy(LlmRetryPolicy {
+            max_attempts_per_model: 1,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+            retry_stream_start: true,
+            ..LlmRetryPolicy::default()
+        })
+        .with_llm_executor(provider.clone() as Arc<dyn LlmExecutor>);
+    let thread = Thread::new("test").with_message(Message::user("go"));
+    let run_ctx = RunContext::from_thread(&thread, tirea_contract::RunPolicy::default()).unwrap();
+
+    let outcome = run_loop(&config, HashMap::new(), run_ctx, None, None, None).await;
+
+    assert_eq!(outcome.termination, TerminationReason::NaturalEnd);
+    assert_eq!(outcome.response.as_deref(), Some("ok"));
+    assert_eq!(provider.seen_models(), vec!["primary".to_string()]);
+}
+
+#[tokio::test]
+async fn test_nonstream_uses_first_fallback_after_primary_service_unavailable() {
+    let provider = Arc::new(MockChatProvider::new(vec![
+        Err(genai::Error::Internal(
+            "503 service unavailable".to_string(),
+        )),
+        Ok(text_chat_response("ok")),
+    ]));
+    let config = BaseAgent::new("primary")
+        .with_fallback_models(vec!["fallback-a".to_string(), "fallback-b".to_string()])
+        .with_llm_retry_policy(LlmRetryPolicy {
+            max_attempts_per_model: 1,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+            retry_stream_start: true,
+            ..LlmRetryPolicy::default()
+        })
+        .with_llm_executor(provider.clone() as Arc<dyn LlmExecutor>);
+    let thread = Thread::new("test").with_message(Message::user("go"));
+    let run_ctx = RunContext::from_thread(&thread, tirea_contract::RunPolicy::default()).unwrap();
+    let outcome = run_loop(&config, HashMap::new(), run_ctx, None, None, None).await;
+    assert_eq!(outcome.termination, TerminationReason::NaturalEnd);
+    assert_eq!(outcome.response.as_deref(), Some("ok"));
+    assert_eq!(
+        provider.seen_models(),
+        vec!["primary".to_string(), "fallback-a".to_string(),]
+    );
+}
+
+#[tokio::test]
+async fn test_nonstream_does_not_fallback_for_non_fallbackable_errors() {
+    let provider = Arc::new(MockChatProvider::new(vec![
+        Err(genai::Error::Internal("401 unauthorized".to_string())),
+        Ok(text_chat_response("should not be used")),
+    ]));
+    let config = BaseAgent::new("primary")
+        .with_fallback_model("fallback")
+        .with_llm_retry_policy(LlmRetryPolicy {
+            max_attempts_per_model: 1,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+            retry_stream_start: true,
+            ..LlmRetryPolicy::default()
+        })
+        .with_llm_executor(provider.clone() as Arc<dyn LlmExecutor>);
+    let thread = Thread::new("test").with_message(Message::user("go"));
+    let run_ctx = RunContext::from_thread(&thread, tirea_contract::RunPolicy::default()).unwrap();
+    let outcome = run_loop(&config, HashMap::new(), run_ctx, None, None, None).await;
+    assert!(matches!(outcome.termination, TerminationReason::Error(_)));
+    assert!(
+        matches!(outcome.failure, Some(LoopFailure::Llm(message)) if message.contains("401 unauthorized"))
+    );
+    assert_eq!(provider.seen_models(), vec!["primary".to_string()]);
+}
+
+#[tokio::test]
+async fn test_nonstream_propagates_error_after_all_fallbacks_fail() {
+    let provider = Arc::new(MockChatProvider::new(vec![
+        Err(genai::Error::Internal(
+            "503 service unavailable".to_string(),
+        )),
+        Err(genai::Error::Internal(
+            "503 service unavailable".to_string(),
+        )),
+        Err(genai::Error::Internal(
+            "503 service unavailable".to_string(),
+        )),
+    ]));
+    let config = BaseAgent::new("primary")
+        .with_fallback_models(vec!["fallback-a".to_string(), "fallback-b".to_string()])
+        .with_llm_retry_policy(LlmRetryPolicy {
+            max_attempts_per_model: 1,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+            retry_stream_start: true,
+            ..LlmRetryPolicy::default()
+        })
+        .with_llm_executor(provider.clone() as Arc<dyn LlmExecutor>);
+    let thread = Thread::new("test").with_message(Message::user("go"));
+    let run_ctx = RunContext::from_thread(&thread, tirea_contract::RunPolicy::default()).unwrap();
+
+    let outcome = run_loop(&config, HashMap::new(), run_ctx, None, None, None).await;
+
+    assert!(matches!(outcome.termination, TerminationReason::Error(_)));
+    assert!(matches!(
+        outcome.failure,
+        Some(LoopFailure::Llm(message)) if message.contains("503 service unavailable")
+    ));
+    assert_eq!(
+        provider.seen_models(),
+        vec![
+            "primary".to_string(),
+            "fallback-a".to_string(),
+            "fallback-b".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_stream_tries_multiple_fallback_models_in_order() {
+    let provider = Arc::new(FailingStartProvider::new(2));
+    let config = BaseAgent::new("primary")
+        .with_fallback_models(vec!["fallback-a".to_string(), "fallback-b".to_string()])
+        .with_llm_retry_policy(LlmRetryPolicy {
+            max_attempts_per_model: 1,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 10,
+            retry_stream_start: true,
+            ..LlmRetryPolicy::default()
+        });
+    let thread = Thread::new("test").with_message(Message::user("go"));
+    let tools = HashMap::new();
+    let config = config.with_llm_executor(provider.clone() as Arc<dyn LlmExecutor>);
+    let run_ctx = RunContext::from_thread(&thread, tirea_contract::RunPolicy::default()).unwrap();
+    let stream = run_loop_stream(Arc::new(config), tools, run_ctx, None, None, None);
+    let events = collect_stream_events(stream).await;
+    assert_eq!(
+        extract_termination(&events),
+        Some(TerminationReason::NaturalEnd)
+    );
+    assert_eq!(
+        provider.seen_models(),
+        vec![
+            "primary".to_string(),
+            "fallback-a".to_string(),
+            "fallback-b".to_string(),
+        ]
+    );
+    assert_eq!(
+        extract_inference_model(&events),
+        Some("fallback-b".to_string())
+    );
+}
+
+#[tokio::test]
 async fn test_nonstream_retry_budget_exhaustion_stops_additional_attempts() {
     let provider = Arc::new(MockChatProvider::new(vec![
         Err(genai::Error::Internal("429 rate limit".to_string())),

--- a/crates/tirea-agentos/src/runtime/resolve.rs
+++ b/crates/tirea-agentos/src/runtime/resolve.rs
@@ -551,7 +551,7 @@ fn build_base_agent_from_definition(
         max_rounds: definition.max_rounds,
         tool_executor,
         chat_options: definition.chat_options,
-        fallback_models: definition.fallback_models,
+        fallback_models: definition.model_fallbacks,
         llm_retry_policy: definition.llm_retry_policy,
         behavior,
         lattice_registry: Arc::new(lattice_registry),
@@ -564,8 +564,8 @@ fn build_base_agent_from_definition(
 
 fn normalize_definition_models(mut definition: AgentDefinition) -> AgentDefinition {
     definition.model = definition.model.trim().to_string();
-    definition.fallback_models = definition
-        .fallback_models
+    definition.model_fallbacks = definition
+        .model_fallbacks
         .into_iter()
         .map(|model| model.trim().to_string())
         .filter(|model| !model.is_empty())


### PR DESCRIPTION
## Summary
- add `model_fallbacks` support to local agent config and mode overlays
- propagate configured fallback models into `AgentDefinition` and runtime resolution
- add fallback retry handling for retryable inference errors in `loop_runner`
- prevent fallback attempts for non-retryable errors
- add unit tests covering no-fallback success, fallback success, all-fallbacks-fail, and stream fallback order