### PR TITLE
✨ feat(agentos): track per-run inference token totals

### DIFF
--- a/crates/tirea-agentos/src/runtime/loop_runner/mod.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/mod.rs
@@ -68,6 +68,7 @@ use crate::contracts::{AgentEvent, RunAction, TerminationReason, ToolCallDecisio
 use crate::engine::convert::{assistant_message, assistant_tool_calls, tool_response};
 use crate::runtime::activity::ActivityHub;
 
+use crate::runtime::loop_runner::state_commit::RunTokenTotals;
 use crate::runtime::streaming::StreamCollector;
 use async_stream::stream;
 use futures::{Stream, StreamExt};
@@ -1063,11 +1064,12 @@ async fn persist_run_termination(
     agent: &dyn Agent,
     run_identity: &RunIdentity,
     pending_delta_commit: &PendingDeltaCommitContext<'_>,
+    token_totals: RunTokenTotals,
 ) -> Result<(), AgentLoopError> {
     sync_run_lifecycle_for_termination_with_context(run_ctx, run_identity, termination)?;
     finalize_run_end(run_ctx, tool_descriptors, agent).await;
     pending_delta_commit
-        .commit_run_finished(run_ctx, termination)
+        .commit_run_finished(run_ctx, termination, token_totals)
         .await?;
     Ok(())
 }
@@ -1967,6 +1969,7 @@ pub async fn run_loop_with_context(
                 agent,
                 &run_identity,
                 &pending_delta_commit,
+                run_state.token_totals(),
             )
             .await
             {

--- a/crates/tirea-agentos/src/runtime/loop_runner/run_state.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/run_state.rs
@@ -1,5 +1,6 @@
 use super::outcome::{LoopStats, LoopUsage};
 use crate::contracts::runtime::StreamResult;
+use crate::runtime::loop_runner::state_commit::RunTokenTotals;
 use std::collections::VecDeque;
 use std::time::Instant;
 
@@ -39,6 +40,12 @@ impl LoopRunState {
             tool_call_history: VecDeque::new(),
             truncation_retries: 0,
             stream_event_retries: 0,
+        }
+    }
+    pub(super) fn token_totals(&self) -> RunTokenTotals {
+        RunTokenTotals {
+            input_tokens: self.total_input_tokens as u64,
+            output_tokens: self.total_output_tokens as u64,
         }
     }
 

--- a/crates/tirea-agentos/src/runtime/loop_runner/state_commit.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/state_commit.rs
@@ -21,6 +21,12 @@ impl ChannelStateCommitter {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct RunTokenTotals {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
 #[async_trait]
 impl StateCommitter for ChannelStateCommitter {
     async fn commit(
@@ -44,6 +50,7 @@ pub(super) async fn commit_pending_delta(
     state_committer: Option<&Arc<dyn StateCommitter>>,
     run_identity: &RunIdentity,
     termination: Option<&TerminationReason>,
+    token_totals: Option<RunTokenTotals>,
 ) -> Result<(), AgentLoopError> {
     let Some(committer) = state_committer else {
         return Ok(());
@@ -86,6 +93,7 @@ pub(super) async fn commit_pending_delta(
         let origin: RunOrigin = run_identity.origin;
         let parent_thread_id = None; // Already set on the initial changeset.
         let (status, termination_code, termination_detail) = map_termination(termination);
+        let token_totals = token_totals.unwrap_or_default();
         changeset.run_meta = Some(RunMeta {
             agent_id,
             origin,
@@ -94,6 +102,8 @@ pub(super) async fn commit_pending_delta(
             termination_code,
             termination_detail,
             source_mailbox_entry_id: None,
+            input_tokens: token_totals.input_tokens,
+            output_tokens: token_totals.output_tokens,
         });
     }
 
@@ -161,6 +171,7 @@ impl<'a> PendingDeltaCommitContext<'a> {
             self.state_committer,
             self.run_identity,
             None,
+            None,
         )
         .await
     }
@@ -169,6 +180,7 @@ impl<'a> PendingDeltaCommitContext<'a> {
         &self,
         run_ctx: &mut RunContext,
         termination: &TerminationReason,
+        token_totals: RunTokenTotals,
     ) -> Result<(), AgentLoopError> {
         commit_pending_delta(
             run_ctx,
@@ -177,6 +189,7 @@ impl<'a> PendingDeltaCommitContext<'a> {
             self.state_committer,
             self.run_identity,
             Some(termination),
+            Some(token_totals),
         )
         .await
     }

--- a/crates/tirea-agentos/src/runtime/loop_runner/stream_runner.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/stream_runner.rs
@@ -255,6 +255,7 @@ pub(super) fn run_stream(
                     agent.as_ref(),
                     &run_identity,
                     &pending_delta_commit,
+                    run_state.token_totals(),
                 )
                 .await
                 {
@@ -295,6 +296,7 @@ pub(super) fn run_stream(
                     agent.as_ref(),
                     &run_identity,
                     &pending_delta_commit,
+                    run_state.token_totals(),
                 )
                 .await
                 {

--- a/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
@@ -11012,6 +11012,7 @@ async fn test_commit_pending_delta_noops_when_empty() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -11037,6 +11038,7 @@ async fn test_commit_pending_delta_force_persists_empty() {
         true, // forced
         Some(&committer),
         &run_identity,
+        None,
         None,
     )
     .await
@@ -11072,6 +11074,7 @@ async fn test_commit_pending_delta_version_advancement() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -11090,6 +11093,7 @@ async fn test_commit_pending_delta_version_advancement() {
         false,
         Some(&committer),
         &run_identity,
+        None,
         None,
     )
     .await
@@ -11147,6 +11151,7 @@ async fn test_commit_pending_delta_precondition_exactness() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -11189,6 +11194,7 @@ async fn test_commit_pending_delta_error_propagation() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await;
 
@@ -11216,6 +11222,7 @@ async fn test_commit_pending_delta_no_committer() {
         false,
         None,
         &run_identity,
+        None,
         None,
     )
     .await
@@ -11247,6 +11254,7 @@ async fn test_consecutive_checkpoints_disjoint_deltas() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -11263,6 +11271,7 @@ async fn test_consecutive_checkpoints_disjoint_deltas() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -11278,6 +11287,7 @@ async fn test_consecutive_checkpoints_disjoint_deltas() {
         false,
         Some(&committer),
         &run_identity,
+        None,
         None,
     )
     .await
@@ -11328,6 +11338,7 @@ async fn test_run_end_checkpoint_captures_remaining() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -11359,6 +11370,7 @@ async fn test_all_deltas_consumed_final_checkpoint_empty() {
         Some(&committer),
         &run_identity,
         None,
+        None,
     )
     .await
     .unwrap();
@@ -11371,6 +11383,7 @@ async fn test_all_deltas_consumed_final_checkpoint_empty() {
         true,
         Some(&committer),
         &run_identity,
+        None,
         None,
     )
     .await

--- a/crates/tirea-agentos/src/runtime/run.rs
+++ b/crates/tirea-agentos/src/runtime/run.rs
@@ -342,6 +342,8 @@ impl AgentOs {
                 termination_code: None,
                 termination_detail: None,
                 source_mailbox_entry_id: request.source_mailbox_entry_id.clone(),
+                input_tokens: 0,
+                output_tokens: 0,
             });
         }
         let committed = agent_state_store

--- a/crates/tirea-agentos/src/runtime/tests.rs
+++ b/crates/tirea-agentos/src/runtime/tests.rs
@@ -4069,6 +4069,101 @@ async fn prepare_run_cleans_up_tool_call_scope_between_consecutive_runs() {
     );
 }
 
+#[tokio::test]
+async fn run_persists_token_totals_after_inference() {
+    use futures::StreamExt;
+    use genai::chat::{ChatStreamEvent, StreamChunk, StreamEnd, Usage};
+    use tirea_contract::storage::RunReader;
+    use tirea_store_adapters::MemoryStore;
+
+    #[derive(Debug)]
+    struct TokenUsageLlm;
+
+    #[async_trait]
+    impl crate::runtime::loop_runner::LlmExecutor for TokenUsageLlm {
+        async fn exec_chat_response(
+            &self,
+            _model: &str,
+            _chat_req: genai::chat::ChatRequest,
+            _options: Option<&genai::chat::ChatOptions>,
+        ) -> genai::Result<genai::chat::ChatResponse> {
+            unreachable!("streaming path only")
+        }
+
+        async fn exec_chat_stream_events(
+            &self,
+            _model: &str,
+            _chat_req: genai::chat::ChatRequest,
+            _options: Option<&genai::chat::ChatOptions>,
+        ) -> genai::Result<crate::runtime::loop_runner::LlmEventStream> {
+            Ok(Box::pin(futures::stream::iter(vec![
+                Ok(ChatStreamEvent::Start),
+                Ok(ChatStreamEvent::Chunk(StreamChunk {
+                    content: "ok".to_string(),
+                })),
+                Ok(ChatStreamEvent::End(StreamEnd {
+                    captured_usage: Some(Usage {
+                        prompt_tokens: Some(123),
+                        prompt_tokens_details: None,
+                        completion_tokens: Some(45),
+                        completion_tokens_details: None,
+                        total_tokens: Some(168),
+                    }),
+                    ..Default::default()
+                })),
+            ])))
+        }
+
+        fn name(&self) -> &'static str {
+            "token_usage_llm"
+        }
+    }
+
+    let storage = Arc::new(MemoryStore::new());
+    let os = AgentOs::builder()
+        .with_agent_spec(AgentDefinitionSpec::local_with_id(
+            "a1",
+            AgentDefinition::new("gpt-4o-mini"),
+        ))
+        .with_agent_state_store(storage.clone() as Arc<dyn crate::contracts::storage::ThreadStore>)
+        .build()
+        .unwrap();
+
+    let mut resolved = os.resolve("a1").unwrap();
+    resolved.agent = resolved.agent.with_llm_executor(
+        Arc::new(TokenUsageLlm) as Arc<dyn crate::runtime::loop_runner::LlmExecutor>
+    );
+
+    let prepared = os
+        .prepare_run(
+            RunRequest {
+                agent_id: "a1".to_string(),
+                thread_id: Some("t-token-usage".to_string()),
+                run_id: Some("run-token-usage".to_string()),
+                parent_run_id: None,
+                parent_thread_id: None,
+                resource_id: None,
+                origin: RunOrigin::default(),
+                state: None,
+                messages: vec![crate::contracts::thread::Message::user("go")],
+                initial_decisions: vec![],
+                source_mailbox_entry_id: None,
+            },
+            resolved,
+        )
+        .await
+        .unwrap();
+    let run = AgentOs::execute_prepared(prepared).unwrap();
+    let _events: Vec<_> = run.events.collect().await;
+
+    let record = RunReader::load_run(storage.as_ref(), "run-token-usage")
+        .await
+        .expect("load run")
+        .expect("run should exist");
+    assert_eq!(record.input_tokens, 123);
+    assert_eq!(record.output_tokens, 45);
+}
+
 // ── SystemWiring tests ───────────────────────────────────────────────────────
 
 /// A minimal test SystemWiring that contributes a tool and a behavior.

--- a/crates/tirea-contract/src/storage/run_types.rs
+++ b/crates/tirea-contract/src/storage/run_types.rs
@@ -48,6 +48,10 @@ pub struct RunRecord {
     pub source_mailbox_entry_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
 }
 
 impl RunRecord {
@@ -74,6 +78,8 @@ impl RunRecord {
             updated_at: now_ms,
             source_mailbox_entry_id: None,
             metadata: None,
+            input_tokens: 0,
+            output_tokens: 0,
         }
     }
 }

--- a/crates/tirea-contract/src/thread/changeset.rs
+++ b/crates/tirea-contract/src/thread/changeset.rs
@@ -40,6 +40,10 @@ pub struct RunMeta {
     pub termination_detail: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_mailbox_entry_id: Option<String>,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
 }
 
 /// An incremental change to a thread produced by a single step.

--- a/crates/tirea-store-adapters/src/file_run_store.rs
+++ b/crates/tirea-store-adapters/src/file_run_store.rs
@@ -123,6 +123,8 @@ mod tests {
             100,
         );
         record.updated_at = 120;
+        record.input_tokens = 123;
+        record.output_tokens = 45;
 
         store.upsert_run(&record).await.expect("upsert");
         let loaded = store
@@ -132,6 +134,8 @@ mod tests {
             .expect("exists");
         assert_eq!(loaded.thread_id, "thread-1");
         assert_eq!(loaded.updated_at, 120);
+        assert_eq!(loaded.input_tokens, 123);
+        assert_eq!(loaded.output_tokens, 45);
 
         let page = store.list_runs(&RunQuery::default()).await.expect("list");
         assert_eq!(page.total, 1);

--- a/crates/tirea-store-adapters/src/file_store.rs
+++ b/crates/tirea-store-adapters/src/file_store.rs
@@ -775,6 +775,8 @@ impl FileStore {
                         now,
                     )
                 });
+            record.input_tokens = meta.input_tokens;
+            record.output_tokens = meta.output_tokens;
             record.status = meta.status;
             record.agent_id.clone_from(&meta.agent_id);
             record.origin = meta.origin;

--- a/crates/tirea-store-adapters/src/memory_run_store.rs
+++ b/crates/tirea-store-adapters/src/memory_run_store.rs
@@ -66,7 +66,7 @@ mod tests {
     #[tokio::test]
     async fn upsert_load_and_list_runs() {
         let store = MemoryRunStore::new();
-        let r1 = RunRecord::new(
+        let mut r1 = RunRecord::new(
             "run-1",
             "thread-1",
             "",
@@ -74,6 +74,8 @@ mod tests {
             RunStatus::Running,
             1,
         );
+        r1.input_tokens = 123;
+        r1.output_tokens = 45;
         let r2 = RunRecord::new(
             "run-2",
             "thread-2",
@@ -91,6 +93,8 @@ mod tests {
             .expect("load")
             .expect("exists");
         assert_eq!(loaded.thread_id, "thread-1");
+        assert_eq!(loaded.input_tokens, 123);
+        assert_eq!(loaded.output_tokens, 45);
 
         let page = store
             .list_runs(&RunQuery {

--- a/crates/tirea-store-adapters/src/memory_store.rs
+++ b/crates/tirea-store-adapters/src/memory_store.rs
@@ -485,6 +485,8 @@ impl ThreadWriter for MemoryStore {
                         now,
                     )
                 });
+                record.input_tokens = meta.input_tokens;
+                record.output_tokens = meta.output_tokens;
                 record.status = meta.status;
                 record.agent_id.clone_from(&meta.agent_id);
                 record.origin = meta.origin;

--- a/crates/tirea-store-adapters/src/postgres_store.rs
+++ b/crates/tirea-store-adapters/src/postgres_store.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 #[cfg(feature = "postgres")]
 use sqlx::{Postgres, QueryBuilder};
+#[cfg(feature = "postgres")]
 use tirea_contract::storage::{
     paginate_mailbox_entries, Committed, MailboxEntry, MailboxEntryOrigin, MailboxInterrupt,
     MailboxPage, MailboxQuery, MailboxReader, MailboxState, MailboxStoreError, MailboxWriter,
@@ -60,105 +61,115 @@ impl PostgresStore {
 
     fn schema_statements(&self) -> Vec<String> {
         vec![
-            format!(
-                "CREATE TABLE IF NOT EXISTS {} (id TEXT PRIMARY KEY, data JSONB NOT NULL, updated_at TIMESTAMPTZ NOT NULL DEFAULT now())",
-                self.table
-            ),
-            format!(
-                "CREATE TABLE IF NOT EXISTS {} (seq BIGSERIAL PRIMARY KEY, session_id TEXT NOT NULL REFERENCES {}(id) ON DELETE CASCADE, message_id TEXT, run_id TEXT, step_index INTEGER, data JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL DEFAULT now())",
-                self.messages_table, self.table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_session_seq ON {} (session_id, seq)",
-                self.messages_table, self.messages_table
-            ),
-            format!(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_{}_message_id ON {} (message_id) WHERE message_id IS NOT NULL",
-                self.messages_table, self.messages_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_session_run ON {} (session_id, run_id) WHERE run_id IS NOT NULL",
-                self.messages_table, self.messages_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_resource_id ON {} ((data->>'resource_id')) WHERE data ? 'resource_id'",
-                self.table, self.table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_parent_thread_id ON {} ((data->>'parent_thread_id')) WHERE data ? 'parent_thread_id'",
-                self.table, self.table
-            ),
-            format!(
-                "CREATE TABLE IF NOT EXISTS {} (run_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, agent_id TEXT NOT NULL DEFAULT '', parent_run_id TEXT, parent_thread_id TEXT, origin TEXT NOT NULL, status TEXT NOT NULL, termination_code TEXT, termination_detail TEXT, created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL, source_mailbox_entry_id TEXT, metadata JSONB)",
-                self.runs_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_thread_id ON {} (thread_id)",
-                self.runs_table, self.runs_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_thread_active ON {} (thread_id, created_at DESC) WHERE status != 'done'",
-                self.runs_table, self.runs_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_parent_run_id ON {} (parent_run_id) WHERE parent_run_id IS NOT NULL",
-                self.runs_table, self.runs_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_status ON {} (status)",
-                self.runs_table, self.runs_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_termination_code ON {} (termination_code) WHERE termination_code IS NOT NULL",
-                self.runs_table, self.runs_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_origin ON {} (origin)",
-                self.runs_table, self.runs_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_created_at ON {} (created_at, run_id)",
-                self.runs_table, self.runs_table
-            ),
-            format!(
-                "CREATE TABLE IF NOT EXISTS {} (entry_id TEXT PRIMARY KEY, mailbox_id TEXT NOT NULL, origin TEXT NOT NULL DEFAULT 'external', sender_id TEXT, payload JSONB NOT NULL, priority SMALLINT NOT NULL DEFAULT 0, dedupe_key TEXT, generation BIGINT NOT NULL DEFAULT 0, status TEXT NOT NULL, available_at BIGINT NOT NULL, attempt_count INTEGER NOT NULL DEFAULT 0, last_error TEXT, claim_token TEXT, claimed_by TEXT, lease_until BIGINT, created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL)",
-                self.mailbox_table
-            ),
-            format!(
-                "CREATE TABLE IF NOT EXISTS {} (mailbox_id TEXT PRIMARY KEY, current_generation BIGINT NOT NULL DEFAULT 0, updated_at BIGINT NOT NULL)",
-                self.mailbox_threads_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_status_available ON {} (status, available_at, created_at)",
-                self.mailbox_table, self.mailbox_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_mailbox_status ON {} (mailbox_id, status, created_at)",
-                self.mailbox_table, self.mailbox_table
-            ),
-            format!(
-                "CREATE INDEX IF NOT EXISTS idx_{}_mailbox_origin_status ON {} (mailbox_id, origin, status, created_at)",
-                self.mailbox_table, self.mailbox_table
-            ),
-            format!(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_{}_mailbox_dedupe ON {} (mailbox_id, dedupe_key) WHERE dedupe_key IS NOT NULL",
-                self.mailbox_table, self.mailbox_table
-            ),
-            // Migration: add agent_id column to existing tables.
-            format!(
-                "ALTER TABLE {} ADD COLUMN IF NOT EXISTS agent_id TEXT NOT NULL DEFAULT ''",
-                self.runs_table
-            ),
-            format!(
-                "ALTER TABLE {} ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT 'external'",
-                self.mailbox_table
-            ),
-            // Enforce at most one non-terminal run per thread.
-            format!(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_{}_thread_active_unique ON {} (thread_id) WHERE status != 'done'",
-                self.runs_table, self.runs_table
-            ),
-        ]
+                    format!(
+                        "CREATE TABLE IF NOT EXISTS {} (id TEXT PRIMARY KEY, data JSONB NOT NULL, updated_at TIMESTAMPTZ NOT NULL DEFAULT now())",
+                        self.table
+                    ),
+                    format!(
+                        "CREATE TABLE IF NOT EXISTS {} (seq BIGSERIAL PRIMARY KEY, session_id TEXT NOT NULL REFERENCES {}(id) ON DELETE CASCADE, message_id TEXT, run_id TEXT, step_index INTEGER, data JSONB NOT NULL, created_at TIMESTAMPTZ NOT NULL DEFAULT now())",
+                        self.messages_table, self.table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_session_seq ON {} (session_id, seq)",
+                        self.messages_table, self.messages_table
+                    ),
+                    format!(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_{}_message_id ON {} (message_id) WHERE message_id IS NOT NULL",
+                        self.messages_table, self.messages_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_session_run ON {} (session_id, run_id) WHERE run_id IS NOT NULL",
+                        self.messages_table, self.messages_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_resource_id ON {} ((data->>'resource_id')) WHERE data ? 'resource_id'",
+                        self.table, self.table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_parent_thread_id ON {} ((data->>'parent_thread_id')) WHERE data ? 'parent_thread_id'",
+                        self.table, self.table
+                    ),
+                    format!(
+                        "CREATE TABLE IF NOT EXISTS {} (run_id TEXT PRIMARY KEY,thread_id TEXT NOT NULL,agent_id TEXT NOT NULL DEFAULT '',parent_run_id TEXT,parent_thread_id TEXT,origin TEXT NOT NULL,status TEXT NOT NULL,termination_code TEXT,termination_detail TEXT,created_at BIGINT NOT NULL,updated_at BIGINT NOT NULL,source_mailbox_entry_id TEXT,metadata JSONB,input_tokens BIGINT NOT NULL DEFAULT 0,output_tokens BIGINT NOT NULL DEFAULT 0)",
+                        self.runs_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_thread_id ON {} (thread_id)",
+                        self.runs_table, self.runs_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_thread_active ON {} (thread_id, created_at DESC) WHERE status != 'done'",
+                        self.runs_table, self.runs_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_parent_run_id ON {} (parent_run_id) WHERE parent_run_id IS NOT NULL",
+                        self.runs_table, self.runs_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_status ON {} (status)",
+                        self.runs_table, self.runs_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_termination_code ON {} (termination_code) WHERE termination_code IS NOT NULL",
+                        self.runs_table, self.runs_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_origin ON {} (origin)",
+                        self.runs_table, self.runs_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_created_at ON {} (created_at, run_id)",
+                        self.runs_table, self.runs_table
+                    ),
+                    format!(
+                        "CREATE TABLE IF NOT EXISTS {} (entry_id TEXT PRIMARY KEY, mailbox_id TEXT NOT NULL, origin TEXT NOT NULL DEFAULT 'external', sender_id TEXT, payload JSONB NOT NULL, priority SMALLINT NOT NULL DEFAULT 0, dedupe_key TEXT, generation BIGINT NOT NULL DEFAULT 0, status TEXT NOT NULL, available_at BIGINT NOT NULL, attempt_count INTEGER NOT NULL DEFAULT 0, last_error TEXT, claim_token TEXT, claimed_by TEXT, lease_until BIGINT, created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL)",
+                        self.mailbox_table
+                    ),
+                    format!(
+                        "CREATE TABLE IF NOT EXISTS {} (mailbox_id TEXT PRIMARY KEY, current_generation BIGINT NOT NULL DEFAULT 0, updated_at BIGINT NOT NULL)",
+                        self.mailbox_threads_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_status_available ON {} (status, available_at, created_at)",
+                        self.mailbox_table, self.mailbox_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_mailbox_status ON {} (mailbox_id, status, created_at)",
+                        self.mailbox_table, self.mailbox_table
+                    ),
+                    format!(
+                        "CREATE INDEX IF NOT EXISTS idx_{}_mailbox_origin_status ON {} (mailbox_id, origin, status, created_at)",
+                        self.mailbox_table, self.mailbox_table
+                    ),
+                    format!(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_{}_mailbox_dedupe ON {} (mailbox_id, dedupe_key) WHERE dedupe_key IS NOT NULL",
+                        self.mailbox_table, self.mailbox_table
+                    ),
+                    // Migration: add agent_id column to existing tables.
+                    format!(
+                        "ALTER TABLE {} ADD COLUMN IF NOT EXISTS agent_id TEXT NOT NULL DEFAULT ''",
+                        self.runs_table
+                    ),
+                    format!(
+                        "ALTER TABLE {} ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT 'external'",
+                        self.mailbox_table
+                    ),
+
+                    // Migration: add input_tokens and output_tokens columns to existing tables.
+                    format!(
+                        "ALTER TABLE {} ADD COLUMN IF NOT EXISTS input_tokens BIGINT NOT NULL DEFAULT 0",
+                        self.runs_table
+                    ),
+                    format!(
+                        "ALTER TABLE {} ADD COLUMN IF NOT EXISTS output_tokens BIGINT NOT NULL DEFAULT 0",
+                        self.runs_table
+                    ),
+                    // Enforce at most one non-terminal run per thread.
+                    format!(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_{}_thread_active_unique ON {} (thread_id) WHERE status != 'done'",
+                        self.runs_table, self.runs_table
+                    ),
+                ]
     }
 
     async fn ensure_schema_ready(&self) -> Result<(), sqlx::Error> {
@@ -1629,6 +1640,8 @@ type RunRowTuple = (
     i64,
     Option<String>,
     Option<serde_json::Value>,
+    i64,
+    i64,
 );
 
 #[cfg(feature = "postgres")]
@@ -1696,6 +1709,8 @@ impl PostgresStore {
             updated_at,
             source_mailbox_entry_id,
             metadata,
+            input_tokens,
+            output_tokens,
         ) = row;
         Ok(RunRecord {
             run_id,
@@ -1711,6 +1726,8 @@ impl PostgresStore {
             updated_at: Self::from_db_timestamp(updated_at, "updated_at")?,
             source_mailbox_entry_id,
             metadata,
+            input_tokens: Self::from_db_timestamp(input_tokens, "input_tokens")?,
+            output_tokens: Self::from_db_timestamp(output_tokens, "output_tokens")?,
         })
     }
 
@@ -1763,7 +1780,7 @@ impl RunReader for PostgresStore {
         self.ensure_run_schema_ready().await?;
 
         let sql = format!(
-            "SELECT run_id, thread_id, agent_id, parent_run_id, parent_thread_id, origin, status, termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata FROM {} WHERE run_id = $1",
+            "SELECT run_id, thread_id, agent_id, parent_run_id, parent_thread_id, origin, status, termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata,input_tokens,output_tokens FROM {} WHERE run_id = $1",
             self.runs_table
         );
         let row = sqlx::query_as::<_, RunRowTuple>(&sql)
@@ -1848,7 +1865,7 @@ impl RunReader for PostgresStore {
             .map_err(Self::run_sql_err)?;
 
         let mut data_qb = QueryBuilder::<Postgres>::new(format!(
-            "SELECT run_id, thread_id, agent_id, parent_run_id, parent_thread_id, origin, status, termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata FROM {}",
+            "SELECT run_id, thread_id, agent_id, parent_run_id, parent_thread_id, origin, status, termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata,input_tokens,output_tokens FROM {}",
             self.runs_table
         ));
         let mut has_where = false;
@@ -1951,7 +1968,7 @@ impl RunReader for PostgresStore {
 
         let sql = format!(
             "SELECT run_id, thread_id, agent_id, parent_run_id, parent_thread_id, origin, status, \
-             termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata \
+             termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata,input_tokens,output_tokens \
              FROM {} WHERE thread_id = $1 AND status != $2 \
              ORDER BY created_at DESC, updated_at DESC, run_id DESC LIMIT 1",
             self.runs_table
@@ -1974,16 +1991,18 @@ impl RunWriter for PostgresStore {
 
         let created_at = Self::to_db_timestamp(record.created_at, "created_at")?;
         let updated_at = Self::to_db_timestamp(record.updated_at, "updated_at")?;
+        let input_tokens = Self::to_db_timestamp(record.input_tokens, "input_tokens")?;
+        let output_tokens = Self::to_db_timestamp(record.output_tokens, "output_tokens")?;
         let sql = format!(
             "INSERT INTO {} (run_id, thread_id, agent_id, parent_run_id, parent_thread_id, origin, status, \
-             termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) \
+             termination_code, termination_detail, created_at, updated_at, source_mailbox_entry_id, metadata,input_tokens,output_tokens) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,$14,$15) \
              ON CONFLICT (run_id) DO UPDATE SET thread_id = EXCLUDED.thread_id, agent_id = EXCLUDED.agent_id, \
              parent_run_id = EXCLUDED.parent_run_id, parent_thread_id = EXCLUDED.parent_thread_id, \
              origin = EXCLUDED.origin, status = EXCLUDED.status, termination_code = EXCLUDED.termination_code, \
              termination_detail = EXCLUDED.termination_detail, created_at = EXCLUDED.created_at, \
              updated_at = EXCLUDED.updated_at, source_mailbox_entry_id = EXCLUDED.source_mailbox_entry_id, \
-             metadata = EXCLUDED.metadata",
+             metadata = EXCLUDED.metadata,input_tokens=EXCLUDED.input_tokens,output_tokens=EXCLUDED.output_tokens",
             self.runs_table
         );
         sqlx::query(&sql)
@@ -2000,6 +2019,8 @@ impl RunWriter for PostgresStore {
             .bind(updated_at)
             .bind(record.source_mailbox_entry_id.as_deref())
             .bind(&record.metadata)
+            .bind(input_tokens)
+            .bind(output_tokens)
             .execute(&self.pool)
             .await
             .map_err(Self::run_sql_err)?;

--- a/crates/tirea-store-adapters/tests/postgres_store.rs
+++ b/crates/tirea-store-adapters/tests/postgres_store.rs
@@ -121,6 +121,8 @@ async fn test_auto_initializes_schema_on_first_run_access() {
         100,
     );
     run.updated_at = 120;
+    run.input_tokens = 123;
+    run.output_tokens = 45;
 
     store
         .upsert_run(&run)
@@ -132,6 +134,8 @@ async fn test_auto_initializes_schema_on_first_run_access() {
         .expect("load run")
         .expect("run should exist");
     assert_eq!(loaded.thread_id, "thread-auto-init");
+    assert_eq!(loaded.input_tokens, 123);
+    assert_eq!(loaded.output_tokens, 45);
 
     let current = store
         .load_current_run("thread-auto-init")
@@ -139,6 +143,8 @@ async fn test_auto_initializes_schema_on_first_run_access() {
         .expect("load current run")
         .expect("current run should exist");
     assert_eq!(current.run_id, "run-auto-init");
+    assert_eq!(current.input_tokens, 123);
+    assert_eq!(current.output_tokens, 45);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add input/output token fields to run metadata and durable run records
- accumulate provider-reported usage across inference calls and persist totals when a run finishes
- update memory, file, and postgres stores plus tests to roundtrip the new token fields
## User-visible impact
Operators can inspect per-run input and output token totals from RunRecord for spend monitoring and usage display.
## Testing
- cargo test -p tirea-store-adapters -q
- cargo test -p tirea-agentos token_totals_after_inference