### PR TITLE
✨ feat(runtime): track thinking tokens in token usage

### DIFF
--- a/crates/tirea-agentos/src/runtime/loop_runner/outcome.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/outcome.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 pub struct LoopUsage {
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
+    pub thinking_tokens: usize,
     pub total_tokens: usize,
 }
 

--- a/crates/tirea-agentos/src/runtime/loop_runner/run_state.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/run_state.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 /// Internal state tracked across run steps for loop stats/cancellation flows.
 pub(super) struct LoopRunState {
     pub(super) completed_steps: usize,
+    pub(super) total_thinking_tokens: usize,
     pub(super) total_input_tokens: usize,
     pub(super) total_output_tokens: usize,
     pub(super) llm_calls: usize,
@@ -28,6 +29,7 @@ impl LoopRunState {
     pub(super) fn new() -> Self {
         Self {
             completed_steps: 0,
+            total_thinking_tokens: 0,
             total_input_tokens: 0,
             total_output_tokens: 0,
             llm_calls: 0,
@@ -59,6 +61,7 @@ impl LoopRunState {
 
     pub(super) fn update_from_response(&mut self, result: &StreamResult) {
         if let Some(ref usage) = result.usage {
+            self.total_thinking_tokens += usage.thinking_tokens.unwrap_or(0) as usize;
             self.total_input_tokens += usage.prompt_tokens.unwrap_or(0) as usize;
             self.total_output_tokens += usage.completion_tokens.unwrap_or(0) as usize;
         }
@@ -95,6 +98,7 @@ impl LoopRunState {
             prompt_tokens: self.total_input_tokens,
             completion_tokens: self.total_output_tokens,
             total_tokens: self.total_input_tokens + self.total_output_tokens,
+            thinking_tokens: self.total_thinking_tokens,
         }
     }
 

--- a/crates/tirea-agentos/src/runtime/loop_runner/stream_runner.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/stream_runner.rs
@@ -133,6 +133,7 @@ fn stream_result_has_usage(result: &StreamResult) -> bool {
             || usage.total_tokens.is_some()
             || usage.cache_read_tokens.is_some()
             || usage.cache_creation_tokens.is_some()
+            || usage.thinking_tokens.is_some()
     })
 }
 

--- a/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/tests.rs
@@ -9434,15 +9434,18 @@ async fn test_run_state_tracks_token_usage() {
             prompt_tokens: Some(100),
             completion_tokens: Some(50),
             total_tokens: Some(150),
+            thinking_tokens: Some(20),
             ..Default::default()
         }),
         stop_reason: None,
     };
     state.update_from_response(&result);
+    assert_eq!(state.total_thinking_tokens, 20);
     assert_eq!(state.total_input_tokens, 100);
     assert_eq!(state.total_output_tokens, 50);
 
     state.update_from_response(&result);
+    assert_eq!(state.total_thinking_tokens, 40);
     assert_eq!(state.total_input_tokens, 200);
     assert_eq!(state.total_output_tokens, 100);
 }

--- a/crates/tirea-agentos/src/runtime/streaming.rs
+++ b/crates/tirea-agentos/src/runtime/streaming.rs
@@ -21,12 +21,19 @@ pub(crate) fn token_usage_from_genai(u: &Usage) -> TokenUsage {
         .prompt_tokens_details
         .as_ref()
         .map_or((None, None), |d| (d.cached_tokens, d.cache_creation_tokens));
+
+    let thinking_tokens = u
+        .completion_tokens_details
+        .as_ref()
+        .and_then(|d| d.reasoning_tokens);
+
     TokenUsage {
         prompt_tokens: u.prompt_tokens,
         completion_tokens: u.completion_tokens,
         total_tokens: u.total_tokens,
         cache_read_tokens: cache_read,
         cache_creation_tokens: cache_creation,
+        thinking_tokens,
     }
 }
 
@@ -337,6 +344,7 @@ mod tests {
     use crate::contracts::runtime::tool_call::ToolResult;
     use crate::contracts::AgentEvent;
     use crate::contracts::TerminationReason;
+    use genai::chat::CompletionTokensDetails;
     use serde_json::json;
 
     #[test]
@@ -1443,6 +1451,37 @@ mod tests {
         assert_eq!(usage.prompt_tokens, Some(10));
         assert_eq!(usage.completion_tokens, Some(20));
         assert_eq!(usage.total_tokens, Some(30));
+        assert_eq!(usage.thinking_tokens, None);
+    }
+
+    #[test]
+    fn test_stream_collector_end_event_captures_thinking_usage() {
+        let mut collector = StreamCollector::new();
+
+        let end = StreamEnd {
+            captured_usage: Some(Usage {
+                prompt_tokens: Some(10),
+                prompt_tokens_details: None,
+                completion_tokens: Some(20),
+                completion_tokens_details: Some(CompletionTokensDetails {
+                    accepted_prediction_tokens: None,
+                    rejected_prediction_tokens: None,
+                    reasoning_tokens: Some(10),
+                    audio_tokens: None,
+                }),
+                total_tokens: Some(30),
+            }),
+            ..Default::default()
+        };
+        collector.process(ChatStreamEvent::End(end));
+
+        let result = collector.finish(None);
+        assert!(result.usage.is_some());
+        let usage = result.usage.unwrap();
+        assert_eq!(usage.prompt_tokens, Some(10));
+        assert_eq!(usage.completion_tokens, Some(20));
+        assert_eq!(usage.total_tokens, Some(30));
+        assert_eq!(usage.thinking_tokens, Some(10));
     }
 
     #[test]

--- a/crates/tirea-contract/src/runtime/inference/response.rs
+++ b/crates/tirea-contract/src/runtime/inference/response.rs
@@ -32,6 +32,8 @@ pub struct TokenUsage {
     pub cache_read_tokens: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_creation_tokens: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_tokens: Option<i32>,
 }
 
 /// Result of stream collection used by runtime and plugin phase contracts.

--- a/crates/tirea-extension-observability/src/lib.rs
+++ b/crates/tirea-extension-observability/src/lib.rs
@@ -99,6 +99,7 @@ mod tests {
             total_tokens: Some(total),
             cache_read_tokens: None,
             cache_creation_tokens: None,
+            thinking_tokens: None,
         }
     }
 
@@ -109,6 +110,7 @@ mod tests {
             total_tokens: Some(total),
             cache_read_tokens: Some(cached),
             cache_creation_tokens: None,
+            thinking_tokens: None,
         }
     }
 
@@ -122,6 +124,7 @@ mod tests {
             finish_reasons: Vec::new(),
             error_type: None,
             error_class: None,
+            thinking_tokens: None,
             input_tokens: Some(10),
             output_tokens: Some(20),
             total_tokens: Some(30),
@@ -492,18 +495,37 @@ mod tests {
     #[test]
     fn test_extract_token_counts_some() {
         let u = usage(10, 20, 30);
-        let (i, o, t) = extract_token_counts(Some(&u));
+        let (i, o, t, thinking) = extract_token_counts(Some(&u));
         assert_eq!(i, Some(10));
         assert_eq!(o, Some(20));
         assert_eq!(t, Some(30));
+        assert_eq!(thinking, None);
+    }
+
+    #[test]
+    fn test_extract_token_counts_with_thinking() {
+        let u = TokenUsage {
+            prompt_tokens: Some(10),
+            completion_tokens: Some(20),
+            total_tokens: Some(30),
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+            thinking_tokens: Some(7),
+        };
+        let (i, o, t, thinking) = extract_token_counts(Some(&u));
+        assert_eq!(i, Some(10));
+        assert_eq!(o, Some(20));
+        assert_eq!(t, Some(30));
+        assert_eq!(thinking, Some(7));
     }
 
     #[test]
     fn test_extract_token_counts_none() {
-        let (i, o, t) = extract_token_counts(None);
+        let (i, o, t, thinking) = extract_token_counts(None);
         assert!(i.is_none());
         assert!(o.is_none());
         assert!(t.is_none());
+        assert!(thinking.is_none());
     }
 
     #[test]

--- a/crates/tirea-extension-observability/src/plugin.rs
+++ b/crates/tirea-extension-observability/src/plugin.rs
@@ -23,10 +23,15 @@ pub(super) fn lock_unpoison<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 
 pub(super) fn extract_token_counts(
     usage: Option<&TokenUsage>,
-) -> (Option<i32>, Option<i32>, Option<i32>) {
+) -> (Option<i32>, Option<i32>, Option<i32>, Option<i32>) {
     match usage {
-        Some(u) => (u.prompt_tokens, u.completion_tokens, u.total_tokens),
-        None => (None, None, None),
+        Some(u) => (
+            u.prompt_tokens,
+            u.completion_tokens,
+            u.total_tokens,
+            u.thinking_tokens,
+        ),
+        None => (None, None, None, None),
     }
 }
 
@@ -142,6 +147,7 @@ impl AgentBehavior for LLMMetryPlugin {
             "gen_ai.request.stop_sequences" = tracing::field::Empty,
             "gen_ai.response.model" = tracing::field::Empty,
             "gen_ai.response.id" = tracing::field::Empty,
+            "gen_ai.usage.thinking_tokens" = tracing::field::Empty,
             "gen_ai.usage.input_tokens" = tracing::field::Empty,
             "gen_ai.usage.output_tokens" = tracing::field::Empty,
             "gen_ai.response.finish_reasons" = tracing::field::Empty,
@@ -183,7 +189,8 @@ impl AgentBehavior for LLMMetryPlugin {
             .unwrap_or(0);
 
         let usage = ctx.response().and_then(|r| r.usage.as_ref());
-        let (input_tokens, output_tokens, total_tokens) = extract_token_counts(usage);
+        let (input_tokens, output_tokens, total_tokens, thinking_tokens) =
+            extract_token_counts(usage);
         let (cache_read_input_tokens, cache_creation_input_tokens) = extract_cache_tokens(usage);
         let error = ctx.inference_error().cloned();
 
@@ -201,6 +208,7 @@ impl AgentBehavior for LLMMetryPlugin {
             input_tokens,
             output_tokens,
             total_tokens,
+            thinking_tokens,
             cache_read_input_tokens,
             cache_creation_input_tokens,
             temperature: *lock_unpoison(&self.temperature),
@@ -211,6 +219,9 @@ impl AgentBehavior for LLMMetryPlugin {
         };
 
         if let Some(tracing_span) = lock_unpoison(&self.inference_tracing_span).take() {
+            if let Some(v) = span.thinking_tokens {
+                tracing_span.record("gen_ai.usage.thinking_tokens", v);
+            }
             if let Some(v) = span.input_tokens {
                 tracing_span.record("gen_ai.usage.input_tokens", v);
             }
@@ -321,6 +332,7 @@ impl AgentBehavior for LLMMetryPlugin {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .remove(&call_id_for_span);
+
         if let Some(tracing_span) = tracing_span {
             if let (Some(ref v), Some(ref msg)) = (&span.error_type, &error_message) {
                 tracing_span.record("error.type", v.as_str());

--- a/crates/tirea-extension-observability/src/spans.rs
+++ b/crates/tirea-extension-observability/src/spans.rs
@@ -19,6 +19,8 @@ pub struct GenAISpan {
     pub error_type: Option<String>,
     /// Classified error category (e.g. `rate_limit`, `timeout`).
     pub error_class: Option<String>,
+    /// OTel: `gen_ai.usage.thinking_tokens`.
+    pub thinking_tokens: Option<i32>,
     /// OTel: `gen_ai.usage.input_tokens`.
     pub input_tokens: Option<i32>,
     /// OTel: `gen_ai.usage.output_tokens`.


### PR DESCRIPTION
## Summary
- track thinking tokens in runtime token usage accounting
- map provider reasoning token usage into the runtime usage model
- aggregate thinking token totals across the runtime loop
- expose thinking token usage through observability spans and plugin output
## Testing
- \`cargo test -p tirea-agentos --lib\`
- \`cargo test -p tirea-extension-observability --lib\`
## Affected Crates
- \`crates/tirea-agentos\`
- \`crates/tirea-contract\`
- \`crates/tirea-extension-observability\`
## Related
- closes https://github.com/tirea-ai/tirea/issues/37"