### PR TITLE
✨ feat(agentos): add built-in read_file tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --locked
 
+  book-doctests:
+    name: Book Doctests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: Swatinem/rust-cache@v2
+      - run: bash scripts/test-book.sh
+
   ai-sdk-starter-build:
     # Build the frontend example to catch TypeScript errors
     name: AI SDK Starter Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "awaken-doctest"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "awaken",
+ "doc-comment",
+ "futures",
+ "genai",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "awaken-examples"
 version = "0.1.0"
 dependencies = [
@@ -993,6 +1008,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "dotenvy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/awaken-ext-deferred-tools",
     "crates/awaken-tool-pattern",
     "crates/awaken-server",
+    "crates/awaken-doctest",
     "examples",
     "examples/ai-sdk-starter/agent",
     "examples/copilotkit-starter/agent",

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "awaken-doctest"
+version.workspace = true
+edition.workspace = true
+description = "Compile-tests for book documentation code examples"
+license.workspace = true
+publish = false
+
+[dependencies]
+awaken = { version = "0.1.0", path = "../awaken", features = ["full"] }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
+genai = { workspace = true }
+schemars = { workspace = true }
+doc-comment = "0.3"
+
+[lints]
+workspace = true

--- a/crates/awaken-doctest/src/lib.rs
+++ b/crates/awaken-doctest/src/lib.rs
@@ -1,0 +1,89 @@
+//! Compile-tests for book documentation code examples.
+//!
+//! This crate uses `doc_comment::doctest!` to compile-test Rust code blocks
+//! in the mdbook documentation. Any `rust` or `rust,no_run` block in the
+//! included markdown files will be compiled (but not executed) as part of
+//! `cargo test -p awaken-doctest`.
+//!
+//! Code blocks tagged `rust,ignore` are skipped.
+//!
+//! To add a new doc file: add a `doctest!()` line below and convert its key
+//! code blocks from `rust,ignore` to `rust,no_run` (with hidden `# ` setup
+//! lines as needed).
+
+#[cfg(doctest)]
+mod book_tests {
+    use doc_comment::doctest;
+
+    // ── Introduction ───────────────────────────────────────────
+    doctest!("../../../docs/book/src/introduction.md");
+
+    // ── Tutorials ──────────────────────────────────────────────
+    doctest!("../../../docs/book/src/tutorials/first-agent.md");
+    doctest!("../../../docs/book/src/tutorials/first-tool.md");
+
+    // ── How-to guides ──────────────────────────────────────────
+    doctest!("../../../docs/book/src/how-to/add-a-plugin.md");
+    doctest!("../../../docs/book/src/how-to/add-a-tool.md");
+    doctest!("../../../docs/book/src/how-to/build-an-agent.md");
+    doctest!("../../../docs/book/src/how-to/configure-stop-policies.md");
+    doctest!("../../../docs/book/src/how-to/enable-observability.md");
+    doctest!("../../../docs/book/src/how-to/enable-tool-permission-hitl.md");
+    doctest!("../../../docs/book/src/how-to/expose-http-sse.md");
+    doctest!("../../../docs/book/src/how-to/integrate-ai-sdk-frontend.md");
+    doctest!("../../../docs/book/src/how-to/integrate-copilotkit-ag-ui.md");
+    doctest!("../../../docs/book/src/how-to/optimize-context-window.md");
+    doctest!("../../../docs/book/src/how-to/report-tool-progress.md");
+    doctest!("../../../docs/book/src/how-to/testing-strategy.md");
+    doctest!("../../../docs/book/src/how-to/use-agent-handoff.md");
+    doctest!("../../../docs/book/src/how-to/use-deferred-tools.md");
+    doctest!("../../../docs/book/src/how-to/use-file-store.md");
+    doctest!("../../../docs/book/src/how-to/use-generative-ui.md");
+    doctest!("../../../docs/book/src/how-to/use-mcp-tools.md");
+    doctest!("../../../docs/book/src/how-to/use-postgres-store.md");
+    doctest!("../../../docs/book/src/how-to/use-reminder-plugin.md");
+    doctest!("../../../docs/book/src/how-to/use-skills-subsystem.md");
+
+    // ── Reference ──────────────────────────────────────────────
+    doctest!("../../../docs/book/src/reference/cancellation.md");
+    doctest!("../../../docs/book/src/reference/config.md");
+    doctest!("../../../docs/book/src/reference/effects.md");
+    doctest!("../../../docs/book/src/reference/errors.md");
+    doctest!("../../../docs/book/src/reference/events.md");
+    doctest!("../../../docs/book/src/reference/http-api.md");
+    doctest!("../../../docs/book/src/reference/overview.md");
+    doctest!("../../../docs/book/src/reference/protocols/a2a.md");
+    doctest!("../../../docs/book/src/reference/protocols/ag-ui.md");
+    doctest!("../../../docs/book/src/reference/protocols/ai-sdk-v6.md");
+    doctest!("../../../docs/book/src/reference/scheduled-actions.md");
+    doctest!("../../../docs/book/src/reference/state-keys.md");
+    doctest!("../../../docs/book/src/reference/thread-model.md");
+    doctest!("../../../docs/book/src/reference/tool-execution-modes.md");
+    doctest!("../../../docs/book/src/reference/tool-trait.md");
+
+    // ── Explanation ────────────────────────────────────────────
+    doctest!("../../../docs/book/src/explanation/agent-resolution.md");
+    doctest!("../../../docs/book/src/explanation/architecture.md");
+    doctest!("../../../docs/book/src/explanation/design-tradeoffs.md");
+    doctest!("../../../docs/book/src/explanation/hitl-and-mailbox.md");
+    doctest!("../../../docs/book/src/explanation/multi-agent-patterns.md");
+    doctest!("../../../docs/book/src/explanation/plugin-internals.md");
+    doctest!("../../../docs/book/src/explanation/run-lifecycle-and-phases.md");
+    doctest!("../../../docs/book/src/explanation/state-and-snapshot-model.md");
+    doctest!("../../../docs/book/src/explanation/tool-and-plugin-boundary.md");
+
+    // ── Appendix ───────────────────────────────────────────────
+    doctest!("../../../docs/book/src/appendix/faq.md");
+    doctest!("../../../docs/book/src/appendix/glossary.md");
+    doctest!("../../../docs/book/src/appendix/migration-from-tirea.md");
+
+    // ── Chinese translations ───────────────────────────────────
+    doctest!("../../../docs/book/src/zh-CN/introduction.md");
+    doctest!("../../../docs/book/src/zh-CN/tutorials/first-agent.md");
+    doctest!("../../../docs/book/src/zh-CN/tutorials/first-tool.md");
+    doctest!("../../../docs/book/src/zh-CN/explanation/agent-resolution.md");
+    doctest!("../../../docs/book/src/zh-CN/explanation/architecture.md");
+    doctest!("../../../docs/book/src/zh-CN/explanation/plugin-internals.md");
+    doctest!("../../../docs/book/src/zh-CN/how-to/testing-strategy.md");
+    doctest!("../../../docs/book/src/zh-CN/how-to/use-deferred-tools.md");
+}

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -5,6 +5,9 @@ authors = ["Awaken Contributors"]
 language = "en"
 src = "src"
 
+[rust]
+edition = "2024"
+
 [build]
 build-dir = "../../target/book"
 

--- a/docs/book/src/how-to/add-a-plugin.md
+++ b/docs/book/src/how-to/add-a-plugin.md
@@ -11,11 +11,11 @@ Use this when you need to extend the agent lifecycle with state keys, phase hook
 
 1. Define a state key.
 
-```rust,ignore
-use awaken::{StateKey, KeyScope, MergeStrategy, StateError, JsonValue};
+```rust,no_run
+use awaken::{StateKey, MergeStrategy, StateError, JsonValue};
 use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AuditLog {
     pub entries: Vec<String>,
 }
@@ -85,7 +85,7 @@ impl Plugin for AuditPlugin {
 
         registrar.register_phase_hook(
             "audit",
-            Phase::AfterInference,
+            Phase::PostInference,
             AuditHook,
         )?;
 
@@ -98,23 +98,17 @@ impl Plugin for AuditPlugin {
 
 ```rust,ignore
 use std::sync::Arc;
-use awaken::engine::GenaiExecutor;
-use awaken::{AgentSpec, AgentRuntimeBuilder, ModelSpec};
+use awaken::{AgentSpec, AgentRuntimeBuilder};
 
 let spec = AgentSpec::new("assistant")
-    .with_model("claude-sonnet")
+    .with_model("anthropic/claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("audit");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_plugin("audit", Arc::new(AuditPlugin))
     .with_agent_spec(spec)
-    .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model("claude-sonnet", ModelSpec {
-        id: "claude-sonnet".into(),
-        provider: "anthropic".into(),
-        model: "claude-sonnet-4-20250514".into(),
-    })
+    .with_provider("anthropic", Arc::new(provider))
     .build()?;
 ```
 

--- a/docs/book/src/how-to/add-a-tool.md
+++ b/docs/book/src/how-to/add-a-tool.md
@@ -11,11 +11,15 @@ Use this when you need to expose a custom capability to the agent by implementin
 
 1. Implement the `Tool` trait.
 
-```rust,ignore
+```rust,no_run
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use awaken::contract::tool::{Tool, ToolCallContext, ToolDescriptor, ToolError, ToolResult, ToolOutput};
 
+# async fn fetch_weather(_city: &str) -> Result<String, ToolError> {
+#     Ok("Sunny, 22°C".to_string())
+# }
+#
 pub struct WeatherTool;
 
 #[async_trait]

--- a/docs/book/src/how-to/use-reminder-plugin.md
+++ b/docs/book/src/how-to/use-reminder-plugin.md
@@ -20,10 +20,8 @@ serde_json = "1"
 
 ```rust,ignore
 use std::sync::Arc;
-use awaken::engine::GenaiExecutor;
-use awaken::ext_reminder::{ReminderPlugin, ReminderRulesConfig};
-use awaken::registry_spec::{AgentSpec, ModelSpec};
 use awaken::{AgentRuntimeBuilder, Plugin};
+use awaken::ext_reminder::{ReminderPlugin, ReminderRulesConfig};
 
 let json = r#"{
     "rules": [
@@ -41,21 +39,8 @@ let json = r#"{
 let config = ReminderRulesConfig::from_str(json, Some("json"))
     .expect("failed to parse reminder config");
 let rules = config.into_rules().expect("invalid rules");
-let agent_spec = AgentSpec::new("my-agent")
-    .with_model("claude-sonnet")
-    .with_system_prompt("You are a helpful assistant.")
-    .with_hook_filter("reminder");
 
 let runtime = AgentRuntimeBuilder::new()
-    .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model(
-        "claude-sonnet",
-        ModelSpec {
-            id: "claude-sonnet".into(),
-            provider: "anthropic".into(),
-            model: "claude-3-7-sonnet-latest".into(),
-        },
-    )
     .with_agent_spec(agent_spec)
     .with_plugin("reminder", Arc::new(ReminderPlugin::new(rules)) as Arc<dyn Plugin>)
     .build()
@@ -201,7 +186,7 @@ let rules = config.into_rules().expect("invalid rules");
 use awaken::registry_spec::AgentSpec;
 
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("claude-sonnet")
+    .with_model("anthropic/claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("reminder");
 ```
@@ -213,7 +198,7 @@ The `with_hook_filter("reminder")` call activates the reminder plugin's phase ho
 1. Configure a rule matching a tool you can easily trigger (e.g. `"*"` with `"any"` output).
 2. Run the agent and invoke a tool.
 3. Inspect the prompt or enable `tracing` at debug level. You should see:
-   ```
+   ```text
    reminder rule matched, scheduling context message
    ```
 4. Confirm the context message appears in the agent's next inference prompt at the expected target location.

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -13,7 +13,6 @@ pub struct AgentSpec {
     pub max_rounds: usize,                          // default: 16
     pub max_continuation_retries: usize,            // default: 2
     pub context_policy: Option<ContextWindowPolicy>,
-    pub reasoning_effort: Option<ReasoningEffort>,
     pub plugin_ids: Vec<String>,
     pub active_hook_filter: HashSet<String>,
     pub allowed_tools: Option<Vec<String>>,
@@ -34,7 +33,6 @@ AgentSpec::new(id) -> Self
     .with_model(model) -> Self
     .with_system_prompt(prompt) -> Self
     .with_max_rounds(n) -> Self
-    .with_reasoning_effort(effort) -> Self
     .with_hook_filter(plugin_id) -> Self
     .with_config::<K>(config) -> Result<Self, StateError>
     .with_delegate(agent_id) -> Self
@@ -56,7 +54,8 @@ fn set_config<K: PluginConfigKey>(&mut self, config: K::Config) -> Result<(), St
 
 Controls context window management and auto-compaction.
 
-```rust,ignore
+```rust,no_run
+# #[derive(Default)] pub enum ContextCompactionMode { #[default] KeepRecentRawSuffix, CompactToSafeFrontier }
 pub struct ContextWindowPolicy {
     pub max_context_tokens: usize,          // default: 200_000
     pub max_output_tokens: usize,           // default: 16_384
@@ -70,7 +69,7 @@ pub struct ContextWindowPolicy {
 
 ### ContextCompactionMode
 
-```rust,ignore
+```rust,no_run
 pub enum ContextCompactionMode {
     KeepRecentRawSuffix,       // Keep N recent messages raw, compact the rest
     CompactToSafeFrontier,     // Compact everything up to safe frontier
@@ -83,7 +82,8 @@ Per-inference parameter override. All fields are `Option`; `None` means "use
 agent-level default". Multiple plugins can emit overrides; fields merge with
 last-wins semantics.
 
-```rust,ignore
+```rust,no_run
+# pub enum ReasoningEffort { None, Low, Medium, High, Max, Budget(u32) }
 pub struct InferenceOverride {
     pub model: Option<String>,
     pub fallback_models: Option<Vec<String>>,
@@ -103,7 +103,7 @@ fn merge(&mut self, other: InferenceOverride)
 
 ### ReasoningEffort
 
-```rust,ignore
+```rust,no_run
 pub enum ReasoningEffort {
     None,
     Low,
@@ -137,7 +137,6 @@ Configuration for agents running on external A2A servers.
 pub struct RemoteEndpoint {
     pub base_url: String,
     pub bearer_token: Option<String>,
-    pub agent_id: Option<String>,
     pub poll_interval_ms: u64,    // default: 2000
     pub timeout_ms: u64,          // default: 300_000
 }
@@ -272,12 +271,8 @@ pub struct CircuitBreakerConfig {
 | `observability` | Registers the observability plugin; emits traces and metrics |
 | `mcp` | Enables MCP tool bridge; tools from MCP servers are auto-registered |
 | `skills` | Enables the skills subsystem for reusable agent capabilities |
-| `reminder` | Registers the reminder plugin; injects context messages after tool execution based on pattern rules |
 | `server` | Builds the HTTP server with SSE streaming and protocol adapters |
 | `generative-ui` | Enables generative UI component streaming to frontends |
-
-The workspace also contains extension crates that are not currently exposed as
-facade feature flags on `awaken`. Today that includes `awaken-ext-deferred-tools`.
 
 ## Custom plugin configuration
 

--- a/docs/book/src/reference/errors.md
+++ b/docs/book/src/reference/errors.md
@@ -7,7 +7,8 @@ All error types use `thiserror` derives and implement `std::error::Error` +
 
 Errors from state management operations. Defined in `awaken-contract`.
 
-```rust,ignore
+```rust,no_run
+# use awaken::Phase;
 pub enum StateError {
     RevisionConflict { expected: u64, actual: u64 },
     MutationBaseRevisionMismatch { left: u64, right: u64 },
@@ -38,7 +39,7 @@ Errors returned from `Tool::validate_args` or `Tool::execute`. A `ToolError`
 aborts the tool call entirely (as opposed to `ToolResult::error`, which sends
 the failure back to the LLM).
 
-```rust,ignore
+```rust,no_run
 pub enum ToolError {
     InvalidArguments(String),
     ExecutionFailed(String),
@@ -54,7 +55,9 @@ pub enum ToolError {
 
 Errors from `AgentRuntimeBuilder::build()`.
 
-```rust,ignore
+```rust,no_run
+# use awaken::StateError;
+# struct DiscoveryError;
 pub enum BuildError {
     State(StateError),
     AgentRegistryConflict(String),
@@ -75,7 +78,8 @@ pub enum BuildError {
 
 Errors from agent runtime operations (resolving agents, starting runs).
 
-```rust,ignore
+```rust,no_run
+# use awaken::StateError;
 pub enum RuntimeError {
     State(StateError),
     ThreadAlreadyRunning { thread_id: String },
@@ -93,7 +97,7 @@ pub enum RuntimeError {
 
 Errors from the LLM execution layer.
 
-```rust,ignore
+```rust,no_run
 pub enum InferenceExecutionError {
     Provider(String),
     RateLimited(String),
@@ -108,7 +112,7 @@ pub enum InferenceExecutionError {
 
 Errors returned by `ThreadStore`, `RunStore`, and `ThreadRunStore` operations.
 
-```rust,ignore
+```rust,no_run
 pub enum StorageError {
     NotFound(String),
     AlreadyExists(String),
@@ -125,7 +129,8 @@ pub enum StorageError {
 Errors from the agent resolution pipeline (resolving `AgentSpec` to a runnable
 `ResolvedAgent`).
 
-```rust,ignore
+```rust,no_run
+# use awaken::StateError;
 pub enum ResolveError {
     AgentNotFound(String),
     ModelNotFound(String),
@@ -144,7 +149,7 @@ pub enum ResolveError {
 
 Controls behavior when encountering an unknown state key during deserialization.
 
-```rust,ignore
+```rust,no_run
 pub enum UnknownKeyPolicy {
     Error,
     Skip,

--- a/docs/book/src/reference/events.md
+++ b/docs/book/src/reference/events.md
@@ -27,6 +27,8 @@ pub enum AgentEvent {
 
     ReasoningDelta { delta: String },
 
+    ReasoningEncryptedValue { encrypted_value: String },
+
     ToolCallStart { id: String, name: String },
 
     ToolCallDelta { id: String, args_delta: String },
@@ -50,7 +52,7 @@ pub enum AgentEvent {
         delta: String,
     },
 
-    ReasoningEncryptedValue { encrypted_value: String },
+    ToolCallResumed { target_id: String, result: Value },
 
     MessagesSnapshot { messages: Vec<Value> },
 
@@ -66,8 +68,6 @@ pub enum AgentEvent {
         activity_type: String,
         patch: Vec<Value>,
     },
-
-    ToolCallResumed { target_id: String, result: Value },
 
     StepStart { message_id: String },
 
@@ -101,43 +101,45 @@ impl AgentEvent {
 }
 ```
 
-## SSE Wire Format
+## StreamEvent
 
-Events are sent over HTTP as Server-Sent Events. Each frame uses the SSE `id`
-field as a monotonically increasing sequence number for resumability:
-
-```
-id: {seq}
-data: {json}
-
-```
-
-Where `{json}` is the JSON-serialized `AgentEvent`. The sequence counter starts
-at 0 and increments by 1 for each event emitted within a run.
-
-The server also sends periodic keep-alive comment lines (`: heartbeat`) when the
-stream is idle to prevent client/proxy timeouts during long inference pauses.
-These comment lines carry no event data and must be ignored by clients.
-
-Implemented via `format_sse_data_with_id` in `awaken-server::http_sse`.
-
-## Run Inputs
-
-To push messages into a run, POST to `/v1/runs/{run_id}/inputs`. The request
-body is deserialized as `PushRunInputsPayload`:
+Wire-format envelope that wraps an `AgentEvent` with sequencing metadata.
+Sent over SSE as JSON.
 
 ```rust,ignore
-struct PushRunInputsPayload {
-    messages: Vec<RunMessage>,
-}
-
-struct RunMessage {
-    role: String,
-    content: String,
+pub struct StreamEvent {
+    /// Monotonically increasing sequence number within a run.
+    pub seq: u64,
+    /// ISO 8601 timestamp.
+    pub timestamp: String,
+    /// The wrapped agent event (flattened via #[serde(flatten)]).
+    pub event: AgentEvent,
 }
 ```
 
-At least one message is required. The server returns `202 Accepted` on success.
+### Constructor
+
+```rust,ignore
+fn new(seq: u64, timestamp: impl Into<String>, event: AgentEvent) -> Self
+```
+
+## RunInput
+
+Input to start or resume a run.
+
+```rust,ignore
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RunInput {
+    /// A new user message to process.
+    UserMessage { text: String },
+    /// Resume a suspended run with a decision.
+    ResumeDecision {
+        tool_call_id: String,
+        action: ResumeDecisionAction,
+        payload: Value,       // omitted when null
+    },
+}
+```
 
 ## RunOutput
 
@@ -149,14 +151,10 @@ pub type RunOutput = futures::stream::BoxStream<'static, AgentEvent>;
 
 ## TerminationReason
 
-Why a run terminated. Serialized with `#[serde(tag = "type", content = "value",
-rename_all = "snake_case")]`.
+Why a run terminated. Serialized as `{ "type": "...", "value": ... }`.
 
-- Unit variants (no payload) serialize as `{ "type": "natural_end" }` — no
-  `"value"` key is emitted.
-- Tuple variants serialize as `{ "type": "stopped", "value": { ... } }`.
-
-```rust,ignore
+```rust,no_run
+# pub struct StoppedReason { pub code: String, pub detail: Option<String> }
 pub enum TerminationReason {
     NaturalEnd,
     BehaviorRequested,
@@ -168,20 +166,9 @@ pub enum TerminationReason {
 }
 ```
 
-## StoppedReason
-
-Payload carried by `TerminationReason::Stopped`.
-
-```rust,ignore
-pub struct StoppedReason {
-    pub code: String,
-    pub detail: Option<String>,    // omitted when None
-}
-```
-
 ## ToolCallOutcome
 
-```rust,ignore
+```rust,no_run
 pub enum ToolCallOutcome {
     Succeeded,
     Failed,
@@ -189,25 +176,9 @@ pub enum ToolCallOutcome {
 }
 ```
 
-## ToolResult
-
-Result of a tool execution, carried in `ToolCallDone`. Defined in
-`awaken::contract::tool::ToolResult`.
-
-```rust,ignore
-pub struct ToolResult {
-    pub tool_name: String,
-    pub status: ToolStatus,        // "success" | "pending" | "error"
-    pub data: Value,
-    pub message: Option<String>,
-    pub suspension: Option<Box<SuspendTicket>>,   // omitted when None
-    pub metadata: HashMap<String, Value>,          // omitted when empty
-}
-```
-
 ## TokenUsage
 
-```rust,ignore
+```rust,no_run
 pub struct TokenUsage {
     pub prompt_tokens: Option<i32>,
     pub completion_tokens: Option<i32>,

--- a/docs/book/src/reference/protocols/ag-ui.md
+++ b/docs/book/src/reference/protocols/ag-ui.md
@@ -4,7 +4,7 @@ The AG-UI adapter translates Awaken's `AgentEvent` stream into the [AG-UI (Copil
 
 ## Endpoint
 
-```
+```text
 POST /v1/ag-ui/run
 ```
 
@@ -34,9 +34,6 @@ SSE stream (`text/event-stream`). Each frame is a JSON-encoded AG-UI `Event`.
 
 | Route | Method | Description |
 |-------|--------|-------------|
-| `/v1/ag-ui/threads/:thread_id/runs` | POST | Start a run scoped to a specific thread. |
-| `/v1/ag-ui/agents/:agent_id/runs` | POST | Start a run scoped to a specific agent. |
-| `/v1/ag-ui/threads/:thread_id/interrupt` | POST | Interrupt a running thread. |
 | `/v1/ag-ui/threads/:id/messages` | GET | Retrieve thread message history. |
 
 ## Event Mapping

--- a/docs/book/src/reference/protocols/ai-sdk-v6.md
+++ b/docs/book/src/reference/protocols/ai-sdk-v6.md
@@ -4,7 +4,7 @@ The AI SDK v6 adapter translates Awaken's internal `AgentEvent` stream into the 
 
 ## Endpoint
 
-```
+```text
 POST /v1/ai-sdk/chat
 ```
 
@@ -32,13 +32,9 @@ SSE stream (`text/event-stream`). Each line is a JSON-encoded `UIStreamEvent`.
 
 | Route | Method | Description |
 |-------|--------|-------------|
-| `/v1/ai-sdk/threads/:thread_id/runs` | POST | Start a thread-scoped run. |
-| `/v1/ai-sdk/agents/:agent_id/runs` | POST | Start an agent-scoped run. |
-| `/v1/ai-sdk/chat/:thread_id/stream` | GET | Reconnect to a thread's SSE stream. |
-| `/v1/ai-sdk/threads/:thread_id/stream` | GET | Alias for thread-based reconnect. |
-| `/v1/ai-sdk/threads/:thread_id/messages` | GET | Retrieve thread message history. |
-| `/v1/ai-sdk/threads/:thread_id/cancel` | POST | Cancel a thread. |
-| `/v1/ai-sdk/threads/:thread_id/interrupt` | POST | Interrupt a thread. |
+| `/v1/ai-sdk/streams/:run_id` | GET | Reconnect to an active run's SSE stream. |
+| `/v1/ai-sdk/runs/:run_id/stream` | GET | Alias for stream reconnect. |
+| `/v1/ai-sdk/threads/:id/messages` | GET | Retrieve thread message history. |
 
 ## Event Mapping
 

--- a/docs/book/src/tutorials/first-agent.md
+++ b/docs/book/src/tutorials/first-agent.md
@@ -26,7 +26,7 @@ export DEEPSEEK_API_KEY=<your-key>
 
 ## 1. Create `src/main.rs`
 
-```rust,ignore
+```rust,no_run
 use std::sync::Arc;
 use serde_json::{json, Value};
 use async_trait::async_trait;
@@ -35,7 +35,8 @@ use awaken::contract::message::Message;
 use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::engine::GenaiExecutor;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry_spec::AgentSpec;
+use awaken::registry::ModelEntry;
 use awaken::{AgentRuntimeBuilder, RunRequest};
 
 struct EchoTool;
@@ -72,10 +73,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_agent_spec(agent_spec)
         .with_tool("echo", Arc::new(EchoTool))
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model("gpt-4o-mini", ModelSpec {
-            id: "gpt-4o-mini".into(),
+        .with_model("gpt-4o-mini", ModelEntry {
             provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+            model_name: "gpt-4o-mini".into(),
         })
         .build()?;
 
@@ -126,10 +126,9 @@ let runtime = AgentRuntimeBuilder::new()
     .with_agent_spec(agent_spec)
     .with_tool("echo", Arc::new(EchoTool))
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model("gpt-4o-mini", ModelSpec {
-        id: "gpt-4o-mini".into(),
+    .with_model("gpt-4o-mini", ModelEntry {
         provider: "openai".into(),
-        model: "gpt-4o-mini".into(),
+        model_name: "gpt-4o-mini".into(),
     })
     .build()?;
 ```
@@ -163,3 +162,8 @@ Use the next page based on what you want:
 - Tool not selected: ensure the prompt explicitly asks to use `echo`.
 - No `RunFinish` event: check that `with_max_rounds` is set high enough for the model to complete.
 
+## Next
+
+- [First Tool](./first-tool.md)
+- [Events](../reference/events.md)
+- [Expose HTTP SSE](../how-to/expose-http-sse.md)

--- a/docs/book/src/tutorials/first-tool.md
+++ b/docs/book/src/tutorials/first-tool.md
@@ -24,9 +24,9 @@ serde_json = "1"
 
 A `StateKey` describes one named slot in the state map. It declares the value type, how updates are applied, and the lifetime scope.
 
-```rust,ignore
-use awaken::{StateKey, KeyScope, MergeStrategy};
-
+```rust,no_run
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+#
 /// Tracks how many times the greeting tool has been called.
 struct GreetCount;
 
@@ -42,6 +42,7 @@ impl StateKey for GreetCount {
         *value += update;
     }
 }
+# fn main() {}
 ```
 
 Key choices:
@@ -54,7 +55,18 @@ Key choices:
 
 The tool reads the current count via `ctx.state::<GreetCount>()` and returns a personalized greeting.
 
-```rust,ignore
+```rust,no_run
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+# struct GreetCount;
+# impl StateKey for GreetCount {
+#     const KEY: &'static str = "greet_count";
+#     const MERGE: MergeStrategy = MergeStrategy::Commutative;
+#     const SCOPE: KeyScope = KeyScope::Run;
+#     type Value = u32;
+#     type Update = u32;
+#     fn apply(value: &mut Self::Value, update: Self::Update) { *value += update; }
+# }
+use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use awaken::contract::tool::{Tool, ToolDescriptor, ToolResult, ToolOutput, ToolError, ToolCallContext};
@@ -98,43 +110,92 @@ impl Tool for GreetTool {
         })).into())
     }
 }
+# fn main() {}
 ```
 
 ## 3. Register the Tool
 
-```rust,ignore
-use std::sync::Arc;
-use awaken::engine::GenaiExecutor;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+```rust,no_run
+# use std::sync::Arc;
+# use async_trait::async_trait;
+# use serde_json::{json, Value};
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+# use awaken::contract::tool::{Tool, ToolDescriptor, ToolResult, ToolOutput, ToolError, ToolCallContext};
+# struct GreetCount;
+# impl StateKey for GreetCount {
+#     const KEY: &'static str = "greet_count";
+#     const MERGE: MergeStrategy = MergeStrategy::Commutative;
+#     const SCOPE: KeyScope = KeyScope::Run;
+#     type Value = u32;
+#     type Update = u32;
+#     fn apply(value: &mut Self::Value, update: Self::Update) { *value += update; }
+# }
+# struct GreetTool;
+# #[async_trait]
+# impl Tool for GreetTool {
+#     fn descriptor(&self) -> ToolDescriptor {
+#         ToolDescriptor::new("greet", "Greet", "Greet a user by name")
+#     }
+#     async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+#         Ok(ToolResult::success("greet", json!({})).into())
+#     }
+# }
+use awaken::registry_spec::AgentSpec;
 use awaken::AgentRuntimeBuilder;
 
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 let agent_spec = AgentSpec::new("assistant")
     .with_model("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant. Use the greet tool when asked.")
     .with_max_rounds(5);
 
 let runtime = AgentRuntimeBuilder::new()
-    .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
-        "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
-        },
-    )
     .with_agent_spec(agent_spec)
     .with_tool("greet", Arc::new(GreetTool))
     .build()?;
+# Ok(())
+# }
 ```
 
 ## 4. Run
 
-```rust,ignore
+```rust,no_run
+# use std::sync::Arc;
+# use async_trait::async_trait;
+# use serde_json::{json, Value};
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+# use awaken::contract::tool::{Tool, ToolDescriptor, ToolResult, ToolOutput, ToolError, ToolCallContext};
+# use awaken::registry_spec::AgentSpec;
+# use awaken::AgentRuntimeBuilder;
+# struct GreetCount;
+# impl StateKey for GreetCount {
+#     const KEY: &'static str = "greet_count";
+#     const MERGE: MergeStrategy = MergeStrategy::Commutative;
+#     const SCOPE: KeyScope = KeyScope::Run;
+#     type Value = u32;
+#     type Update = u32;
+#     fn apply(value: &mut Self::Value, update: Self::Update) { *value += update; }
+# }
+# struct GreetTool;
+# #[async_trait]
+# impl Tool for GreetTool {
+#     fn descriptor(&self) -> ToolDescriptor {
+#         ToolDescriptor::new("greet", "Greet", "Greet a user by name")
+#     }
+#     async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+#         Ok(ToolResult::success("greet", json!({})).into())
+#     }
+# }
 use awaken::contract::message::Message;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::RunRequest;
 
+# #[tokio::main]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let runtime = AgentRuntimeBuilder::new()
+#     .with_agent_spec(AgentSpec::new("assistant").with_model("gpt-4o-mini"))
+#     .with_tool("greet", Arc::new(GreetTool))
+#     .build()?;
 let request = RunRequest::new(
     "thread-1",
     vec![Message::user("Greet Alice")],
@@ -143,6 +204,8 @@ let request = RunRequest::new(
 
 let sink = Arc::new(VecEventSink::new());
 runtime.run(request, sink.clone()).await?;
+# Ok(())
+# }
 ```
 
 ## 5. Verify
@@ -188,4 +251,3 @@ The `StateKey` trait gives you type-safe, scoped state without raw JSON manipula
 - `StateError::KeyEncode` / `StateError::KeyDecode`: the `Value` type does not round-trip through JSON. Ensure `Serialize` and `Deserialize` are derived correctly.
 - `ToolError::InvalidArguments` not surfaced: `validate_args` is called before `execute` by the runtime. If you skip validation, bad input reaches `execute` and may panic on `.unwrap()`.
 - Scope mismatch: `KeyScope::Run` state is cleared between runs. If you expect persistence, use `KeyScope::Thread`.
-

--- a/docs/book/src/zh-CN/tutorials/first-agent.md
+++ b/docs/book/src/zh-CN/tutorials/first-agent.md
@@ -26,7 +26,7 @@ export DEEPSEEK_API_KEY=<your-key>
 
 ## 1. 创建 `src/main.rs`
 
-```rust,ignore
+```rust,no_run
 use std::sync::Arc;
 use serde_json::{json, Value};
 use async_trait::async_trait;
@@ -35,7 +35,8 @@ use awaken::contract::message::Message;
 use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::engine::GenaiExecutor;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry_spec::AgentSpec;
+use awaken::registry::ModelEntry;
 use awaken::{AgentRuntimeBuilder, RunRequest};
 
 struct EchoTool;
@@ -72,10 +73,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_agent_spec(agent_spec)
         .with_tool("echo", Arc::new(EchoTool))
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model("gpt-4o-mini", ModelSpec {
-            id: "gpt-4o-mini".into(),
+        .with_model("gpt-4o-mini", ModelEntry {
             provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+            model_name: "gpt-4o-mini".into(),
         })
         .build()?;
 
@@ -126,10 +126,9 @@ let runtime = AgentRuntimeBuilder::new()
     .with_agent_spec(agent_spec)
     .with_tool("echo", Arc::new(EchoTool))
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model("gpt-4o-mini", ModelSpec {
-        id: "gpt-4o-mini".into(),
+    .with_model("gpt-4o-mini", ModelEntry {
         provider: "openai".into(),
-        model: "gpt-4o-mini".into(),
+        model_name: "gpt-4o-mini".into(),
     })
     .build()?;
 ```
@@ -152,9 +151,9 @@ let events = sink.take();
 
 根据你的需求选择下一页：
 
-- 添加类型化状态和有状态工具：[第一个 Tool](./first-tool.md)
-- 了解事件如何映射到智能体循环：[事件参考](../reference/events.md)
-- 通过 HTTP 暴露智能体：[暴露 HTTP SSE](../how-to/expose-http-sse.md)
+- 添加类型化状态和有状态工具：[第一个 Tool](../../tutorials/first-tool.md)
+- 了解事件如何映射到智能体循环：[事件参考](../../reference/events.md)
+- 通过 HTTP 暴露智能体：[暴露 HTTP SSE](../../how-to/expose-http-sse.md)
 
 ## 常见错误
 
@@ -163,3 +162,8 @@ let events = sink.take();
 - 工具未被选中：确保提示词明确要求使用 `echo`。
 - 没有 `RunFinish` 事件：检查 `with_max_rounds` 设置是否足够高，以便模型完成执行。
 
+## 下一步
+
+- [第一个 Tool](../../tutorials/first-tool.md)
+- [事件参考](../../reference/events.md)
+- [暴露 HTTP SSE](../../how-to/expose-http-sse.md)

--- a/docs/book/src/zh-CN/tutorials/first-tool.md
+++ b/docs/book/src/zh-CN/tutorials/first-tool.md
@@ -2,14 +2,14 @@
 
 ## 目标
 
-实现一个在执行时从 `ToolCallContext` 读取类型化状态的 tool。
+实现一个在执行时从 `ToolCallContext` 读取类型化状态的工具。
 
-> **状态不是必需的。** 很多工具（API 调用、搜索、shell 命令）根本不需要状态；只要实现 `execute` 并返回 `ToolResult` 即可。
+> **状态是可选的。** 许多工具（API 调用、搜索、Shell 命令）不需要状态——只需实现 `execute` 并返回 `ToolResult` 即可。
 
 ## 前置条件
 
-- 先完成[第一个 Agent](./first-agent.md)
-- 复用那一页里的运行时依赖
+- 先完成 [第一个 Agent](./first-agent.md)。
+- 复用 [第一个 Agent](./first-agent.md) 中的运行时依赖。
 
 ```toml
 [dependencies]
@@ -20,14 +20,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ```
 
-## 1. 定义一个 `StateKey`
+## 1. 定义 `StateKey`
 
-`StateKey` 描述状态映射中的一个具名槽位，它声明值类型、更新方式和生命周期作用域。
+`StateKey` 描述状态映射中的一个命名槽位，声明值类型、更新策略和生命周期范围。
 
-```rust,ignore
-use awaken::{StateKey, KeyScope, MergeStrategy};
-
-/// 追踪问候工具被调用的次数。
+```rust,no_run
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+#
+/// 记录问候工具被调用的次数。
 struct GreetCount;
 
 impl StateKey for GreetCount {
@@ -42,19 +42,31 @@ impl StateKey for GreetCount {
         *value += update;
     }
 }
+# fn main() {}
 ```
 
-关键点：
+关键选项说明：
 
-- `KeyScope::Run`：每次 run 开始时重置；如果想跨 run 保留，就改成 `KeyScope::Thread`
-- `MergeStrategy::Commutative`：适合并发安全累加
-- `apply`：定义 `Update` 如何作用到当前值
+- `KeyScope::Run` — 状态在每次运行开始时重置。使用 `KeyScope::Thread` 可跨运行持久化。
+- `MergeStrategy::Commutative` — 并发更新安全。当只有一个写入方时使用 `Exclusive`。
+- `apply` 定义 `Update` 如何修改当前 `Value`，此处为递增。
 
 ## 2. 实现 Tool
 
-tool 通过 `ctx.state::<GreetCount>()` 读取当前计数，然后返回一个个性化问候。
+该工具通过 `ctx.state::<GreetCount>()` 读取当前计数并返回个性化问候。
 
-```rust,ignore
+```rust,no_run
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+# struct GreetCount;
+# impl StateKey for GreetCount {
+#     const KEY: &'static str = "greet_count";
+#     const MERGE: MergeStrategy = MergeStrategy::Commutative;
+#     const SCOPE: KeyScope = KeyScope::Run;
+#     type Value = u32;
+#     type Update = u32;
+#     fn apply(value: &mut Self::Value, update: Self::Update) { *value += update; }
+# }
+use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use awaken::contract::tool::{Tool, ToolDescriptor, ToolResult, ToolOutput, ToolError, ToolCallContext};
@@ -89,7 +101,7 @@ impl Tool for GreetTool {
     ) -> Result<ToolOutput, ToolError> {
         let name = args["name"].as_str().unwrap_or("world");
 
-        // 读取状态 -- 若该 key 尚未写入则返回 None。
+        // 读取状态——如果该键尚未设置则返回 None。
         let count = ctx.state::<GreetCount>().copied().unwrap_or(0);
 
         Ok(ToolResult::success("greet", json!({
@@ -98,43 +110,92 @@ impl Tool for GreetTool {
         })).into())
     }
 }
+# fn main() {}
 ```
 
 ## 3. 注册 Tool
 
-```rust,ignore
-use std::sync::Arc;
-use awaken::engine::GenaiExecutor;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+```rust,no_run
+# use std::sync::Arc;
+# use async_trait::async_trait;
+# use serde_json::{json, Value};
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+# use awaken::contract::tool::{Tool, ToolDescriptor, ToolResult, ToolOutput, ToolError, ToolCallContext};
+# struct GreetCount;
+# impl StateKey for GreetCount {
+#     const KEY: &'static str = "greet_count";
+#     const MERGE: MergeStrategy = MergeStrategy::Commutative;
+#     const SCOPE: KeyScope = KeyScope::Run;
+#     type Value = u32;
+#     type Update = u32;
+#     fn apply(value: &mut Self::Value, update: Self::Update) { *value += update; }
+# }
+# struct GreetTool;
+# #[async_trait]
+# impl Tool for GreetTool {
+#     fn descriptor(&self) -> ToolDescriptor {
+#         ToolDescriptor::new("greet", "Greet", "Greet a user by name")
+#     }
+#     async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+#         Ok(ToolResult::success("greet", json!({})).into())
+#     }
+# }
+use awaken::registry_spec::AgentSpec;
 use awaken::AgentRuntimeBuilder;
 
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 let agent_spec = AgentSpec::new("assistant")
     .with_model("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant. Use the greet tool when asked.")
     .with_max_rounds(5);
 
 let runtime = AgentRuntimeBuilder::new()
-    .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
-        "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
-        },
-    )
     .with_agent_spec(agent_spec)
     .with_tool("greet", Arc::new(GreetTool))
     .build()?;
+# Ok(())
+# }
 ```
 
 ## 4. 运行
 
-```rust,ignore
+```rust,no_run
+# use std::sync::Arc;
+# use async_trait::async_trait;
+# use serde_json::{json, Value};
+# use awaken::{StateKey, KeyScope, MergeStrategy};
+# use awaken::contract::tool::{Tool, ToolDescriptor, ToolResult, ToolOutput, ToolError, ToolCallContext};
+# use awaken::registry_spec::AgentSpec;
+# use awaken::AgentRuntimeBuilder;
+# struct GreetCount;
+# impl StateKey for GreetCount {
+#     const KEY: &'static str = "greet_count";
+#     const MERGE: MergeStrategy = MergeStrategy::Commutative;
+#     const SCOPE: KeyScope = KeyScope::Run;
+#     type Value = u32;
+#     type Update = u32;
+#     fn apply(value: &mut Self::Value, update: Self::Update) { *value += update; }
+# }
+# struct GreetTool;
+# #[async_trait]
+# impl Tool for GreetTool {
+#     fn descriptor(&self) -> ToolDescriptor {
+#         ToolDescriptor::new("greet", "Greet", "Greet a user by name")
+#     }
+#     async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+#         Ok(ToolResult::success("greet", json!({})).into())
+#     }
+# }
 use awaken::contract::message::Message;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::RunRequest;
 
+# #[tokio::main]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+# let runtime = AgentRuntimeBuilder::new()
+#     .with_agent_spec(AgentSpec::new("assistant").with_model("gpt-4o-mini"))
+#     .with_tool("greet", Arc::new(GreetTool))
+#     .build()?;
 let request = RunRequest::new(
     "thread-1",
     vec![Message::user("Greet Alice")],
@@ -143,11 +204,13 @@ let request = RunRequest::new(
 
 let sink = Arc::new(VecEventSink::new());
 runtime.run(request, sink.clone()).await?;
+# Ok(())
+# }
 ```
 
 ## 5. 验证
 
-检查事件流里是否出现了 `ToolCallDone`：
+检查收集到的事件中是否包含 `name == "greet"` 的 `ToolCallDone` 事件：
 
 ```rust,ignore
 use awaken::contract::event::AgentEvent;
@@ -160,30 +223,31 @@ let tool_done = events.iter().any(|e| matches!(
 println!("tool_call_done_seen: {}", tool_done);
 ```
 
-预期：
+预期结果：
 
 - `tool_call_done_seen: true`
-- `ToolCallDone.result` 中包含 `greeting` 和 `times_greeted`
+- `ToolCallDone` 中的 `result` 包含 `greeting` 和 `times_greeted` 字段。
 
-## 你刚刚创建了什么
+## 你创建了什么
 
-你完成了一个 tool，它：
+一个工具，它：
 
-1. 通过 `descriptor()` 声明 JSON Schema
-2. 通过 `validate_args()` 做参数校验
-3. 通过 `ctx.state::<K>()` 读取类型化状态
-4. 通过 `ToolResult::success()` 返回结构化 JSON
+1. 通过 `descriptor()` 声明参数的 JSON Schema。
+2. 通过 `validate_args()` 在执行前验证参数。
+3. 通过 `ctx.state::<K>()` 从快照读取类型化状态。
+4. 通过 `ToolResult::success()` 返回结构化 JSON。
 
-## 下一步读什么
+`StateKey` trait 提供了类型安全的、有范围的状态管理，无需手动操作原始 JSON。
 
-- 完整理解 tool 生命周期：[Tool Trait](../reference/tool-trait.md)
-- 学习如何在 phase 边界扩展行为：[Add a Plugin](../how-to/add-a-plugin.md)
-- 学习状态作用域：[State Keys](../reference/state-keys.md)
+## 下一步阅读
+
+- 了解完整工具生命周期：[Tool Trait](../../reference/tool-trait.md)
+- 添加跨运行管理状态的插件：[添加插件](../how-to/add-a-plugin.md)
+- 学习状态范围规则：[State Keys](../../reference/state-keys.md)
 
 ## 常见错误
 
-- `ctx.state::<K>()` 返回 `None`：这个 key 在当前 run 里还没写入
-- `StateError::KeyEncode` / `KeyDecode`：`Value` 类型不能正确序列化 / 反序列化
-- `ToolError::InvalidArguments` 没有出现：通常是你跳过了 `validate_args()` 逻辑
-- 作用域不匹配：如果希望跨多次 run 保持状态，需要用 `KeyScope::Thread`
-
+- `ctx.state::<K>()` 返回 `None`：该状态键在本次运行中尚未写入。对数值类型使用 `.unwrap_or_default()` 或 `.copied().unwrap_or(0)`。
+- `StateError::KeyEncode` / `StateError::KeyDecode`：`Value` 类型无法通过 JSON 往返序列化。确保正确派生了 `Serialize` 和 `Deserialize`。
+- `ToolError::InvalidArguments` 未被触发：运行时在 `execute` 之前调用 `validate_args`。如果跳过验证，错误输入将到达 `execute` 并可能在 `.unwrap()` 处崩溃。
+- 范围不匹配：`KeyScope::Run` 状态在运行之间被清除。如果需要持久化，使用 `KeyScope::Thread`。

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -19,6 +19,7 @@ cargo doc --workspace --no-deps --manifest-path "$WORKSPACE_ROOT/Cargo.toml"
 echo "==> Installing Mermaid support..."
 mdbook-mermaid install "$WORKSPACE_ROOT/docs/book"
 
+# Note: to test book code examples, use scripts/test-book.sh (build and test are separate)
 echo "==> Building mdBook..."
 mdbook build "$WORKSPACE_ROOT/docs/book"
 

--- a/scripts/test-book.sh
+++ b/scripts/test-book.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKSPACE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "Testing book code examples via awaken-doctest..."
+cargo test -p awaken-doctest --doc --manifest-path "$WORKSPACE_ROOT/Cargo.toml"


### PR DESCRIPTION
## Summary
- add the built-in `read_file` tool in `crates/tirea-agentos/src/builtin_tools/read_file.rs`
- export `read_file` from `crates/tirea-agentos/src/builtin_tools/mod.rs` and `crates/tirea-agentos/src/lib.rs`
- register `read_file` in the base tool registry in `crates/tirea-agentos/src/composition/builder.rs`
- enforce sandboxed path resolution and a 10 MiB file size limit for file reads
## Testing
- `cargo test -p tirea-agentos --lib builtin_tools::read_file`
- `cargo test -p tirea-agentos --lib build_registers_read_file_tool_by_default`
## Affected Crates
- `crates/tirea-agentos`
## Related
- closes https://github.com/tirea-ai/tirea/issues/7