### PR TITLE
Fix CI: update behavior tests to use AddContextMessage

### DIFF
--- a/crates/tirea-agentos/src/runtime/wiring/behavior.rs
+++ b/crates/tirea-agentos/src/runtime/wiring/behavior.rs
@@ -273,7 +273,14 @@ mod tests {
             &self,
             _ctx: &ReadOnlyContext<'_>,
         ) -> ActionSet<BeforeInferenceAction> {
-            ActionSet::single(BeforeInferenceAction::AddSystemContext(self.text.clone()))
+            ActionSet::single(BeforeInferenceAction::AddContextMessage(
+                tirea_contract::runtime::inference::ContextMessage {
+                    key: self.id.to_string(),
+                    content: self.text.clone(),
+                    cooldown_turns: 0,
+                    target: Default::default(),
+                },
+            ))
         }
     }
 
@@ -286,7 +293,7 @@ mod tests {
             .into_vec()
             .into_iter()
             .filter_map(|a| match a {
-                BeforeInferenceAction::AddSystemContext(s) => Some(s),
+                BeforeInferenceAction::AddContextMessage(m) => Some(m.content),
                 _ => None,
             })
             .collect()


### PR DESCRIPTION
## Summary
- Replace removed `BeforeInferenceAction::AddSystemContext` variant with `AddContextMessage` in `OrderedBehavior` and `extract_texts` test helpers
- The `AddSystemContext` variant was renamed to `AddSessionContext` and later replaced by `AddContextMessage`, but these test helpers in `behavior.rs` were not updated

## Test plan
- [x] `cargo check --package tirea-agentos` passes
- [x] All 17 behavior wiring tests pass (`cargo test --package tirea-agentos --lib -- wiring`)

