### PR TITLE
🧹 fix(ci): stabilize docs, warnings, and example builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install mdBook
-        run: cargo install mdbook --locked --version 0.5.2
+        run: cargo install mdbook --locked --version 0.5.0
 
       - name: Install mdBook Mermaid
         run: cargo install mdbook-mermaid --locked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ cd examples/copilotkit-starter && npm install && npm run build
 ### Docs
 
 ```bash
-cargo install mdbook --locked --version 0.5.2
+cargo install mdbook --locked --version 0.5.0
 cargo install mdbook-mermaid --locked
 bash scripts/build-docs.sh
 ```
@@ -156,7 +156,7 @@ Example:
 Make sure both tools are installed:
 
 ```bash
-cargo install mdbook --locked --version 0.5.2
+cargo install mdbook --locked --version 0.5.0
 cargo install mdbook-mermaid --locked
 ```
 

--- a/crates/tirea-agentos-server/src/protocol/acp/stdio.rs
+++ b/crates/tirea-agentos-server/src/protocol/acp/stdio.rs
@@ -89,9 +89,9 @@ struct InitializeParams {
 #[serde(rename_all = "camelCase")]
 struct NewSessionParams {
     #[serde(default)]
-    cwd: Option<String>,
+    _cwd: Option<String>,
     #[serde(default)]
-    mcp_servers: Vec<Value>,
+    _mcp_servers: Vec<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -884,15 +884,15 @@ mod tests {
     fn parse_new_session_params() {
         let raw = json!({"cwd": "/home/user/project", "mcpServers": []});
         let params: NewSessionParams = serde_json::from_value(raw).unwrap();
-        assert_eq!(params.cwd.as_deref(), Some("/home/user/project"));
-        assert!(params.mcp_servers.is_empty());
+        assert_eq!(params._cwd.as_deref(), Some("/home/user/project"));
+        assert!(params._mcp_servers.is_empty());
     }
 
     #[test]
     fn parse_new_session_params_minimal() {
         let raw = json!({});
         let params: NewSessionParams = serde_json::from_value(raw).unwrap();
-        assert!(params.cwd.is_none());
+        assert!(params._cwd.is_none());
     }
 
     // -- session/prompt --

--- a/crates/tirea-agentos-server/src/transport/runtime_endpoint.rs
+++ b/crates/tirea-agentos-server/src/transport/runtime_endpoint.rs
@@ -4,7 +4,7 @@
 //!
 //! 1. `Run(request)` — starts execution via the injected run factory.
 //! 2. `Decision(d)` / `Cancel` — control messages managed by AgentOS
-//!    [`ThreadRunHandle`], not by this endpoint.
+//!    `ThreadRunHandle`, not by this endpoint.
 //!
 //! `close()` is transport-only and does **not** cancel the run.
 

--- a/crates/tirea-agentos/src/composition/agent_definition.rs
+++ b/crates/tirea-agentos/src/composition/agent_definition.rs
@@ -15,7 +15,7 @@ pub enum ToolExecutionMode {
 ///
 /// This is the orchestration-facing model and uses only registry references
 /// (`behavior_ids`, `stop_condition_ids`) and declarative specs.
-/// Before execution, AgentOS resolves it into loop-facing [`BaseAgent`].
+/// Before execution, AgentOS resolves it into a loop-facing base agent.
 #[derive(Clone)]
 pub struct AgentDefinition {
     /// Unique identifier for this agent.

--- a/crates/tirea-agentos/src/runtime/loop_runner/config.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/config.rs
@@ -433,9 +433,9 @@ impl BaseAgent {
         self
     }
 
-    /// Set static tool map (wraps in [`StaticStepToolProvider`]).
+    /// Set static tool map (wraps in `StaticStepToolProvider`).
     ///
-    /// Prefer passing tools directly to [`run_loop`] / [`run_loop_stream`];
+    /// Prefer passing tools directly to `run_loop` / `run_loop_stream`;
     /// use this only when you need to set tools via `step_tool_provider`.
     #[must_use]
     pub fn with_tools(self, tools: HashMap<String, Arc<dyn Tool>>) -> Self {

--- a/crates/tirea-agentos/src/runtime/loop_runner/outcome.rs
+++ b/crates/tirea-agentos/src/runtime/loop_runner/outcome.rs
@@ -101,7 +101,7 @@ where
         .collect()
 }
 
-/// Helper to create a tool map from Arc<dyn Tool>.
+/// Helper to create a tool map from `Arc<dyn Tool>`.
 pub fn tool_map_from_arc<I>(tools: I) -> HashMap<String, Arc<dyn Tool>>
 where
     I: IntoIterator<Item = Arc<dyn Tool>>,

--- a/crates/tirea-agentos/src/runtime/run.rs
+++ b/crates/tirea-agentos/src/runtime/run.rs
@@ -432,8 +432,8 @@ impl AgentOs {
     /// Resolve, prepare, and execute an agent run.
     ///
     /// This is the primary entry point. Callers that need to customize
-    /// the resolved wiring should use [`resolve`] + mutation + [`prepare_run`]
-    /// + [`execute_prepared`] instead.
+    /// the resolved wiring should use `resolve` + mutation + `prepare_run`
+    /// + `execute_prepared` instead.
     pub async fn run_stream(&self, request: RunRequest) -> Result<RunStream, AgentOsRunError> {
         let resolved = self.resolve(&request.agent_id)?;
         let prepared = self.prepare_run(request, resolved).await?;
@@ -444,7 +444,7 @@ impl AgentOs {
     ///
     /// When multiple agents are registered, `HandoffPlugin` handles dynamic
     /// agent switching within the run via `agent_handoff`. No termination or
-    /// re-resolution occurs — this method simply delegates to [`run_stream`].
+    /// re-resolution occurs — this method simply delegates to `run_stream`.
     #[cfg(feature = "handoff")]
     pub async fn run(&self, request: RunRequest) -> Result<RunStream, AgentOsRunError> {
         self.run_stream(request).await

--- a/crates/tirea-agentos/src/runtime/wiring/resolve.rs
+++ b/crates/tirea-agentos/src/runtime/wiring/resolve.rs
@@ -615,7 +615,6 @@ fn agent_overlay_from_definition(
                             G::High => ReasoningEffort::High,
                             G::Max => ReasoningEffort::Max,
                             G::Budget(n) => ReasoningEffort::Budget(*n),
-                            _ => ReasoningEffort::Max,
                         }
                     }),
                 )

--- a/crates/tirea-contract/src/runtime/inference/context.rs
+++ b/crates/tirea-contract/src/runtime/inference/context.rs
@@ -4,7 +4,7 @@ use crate::runtime::tool_call::ToolDescriptor;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/// Auto-compaction strategy used by [`ContextPlugin`].
+/// Auto-compaction strategy used by the context-window management behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ContextCompactionMode {
@@ -21,7 +21,7 @@ const fn default_compaction_raw_suffix_messages() -> usize {
 
 /// Context window management policy.
 ///
-/// Pure data struct used by [`ContextPlugin`] to configure context
+/// Pure data struct used by the context-window management behavior to configure context
 /// management. Lives in the contract layer so plugin crates can construct
 /// it without depending on `tirea-agentos`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,7 +35,7 @@ pub struct ContextWindowPolicy {
     /// Whether to enable prompt caching (Anthropic `cache_control: ephemeral`).
     pub enable_prompt_cache: bool,
     /// Token count threshold that triggers auto-compaction. `None` disables.
-    /// Used by ContextPlugin to decide when to compact history.
+    /// Used by the context-window management behavior to decide when to compact history.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub autocompact_threshold: Option<usize>,
     /// Auto-compaction strategy to use when `autocompact_threshold` is reached.

--- a/crates/tirea-contract/src/runtime/state/scope_registry.rs
+++ b/crates/tirea-contract/src/runtime/state/scope_registry.rs
@@ -6,12 +6,12 @@ use tirea_state::StateSpec;
 /// Registry mapping `StateSpec` types to their declared [`StateScope`] and path.
 ///
 /// Built once at agent construction by calling
-/// [`AgentBehavior::register_state_scopes`] on each behavior. The loop then
-/// uses [`resolve`] to determine the effective scope of any [`AnyStateAction`],
+/// `AgentBehavior::register_state_scopes` on each behavior. The loop then
+/// uses `resolve` to determine the effective scope of any [`AnyStateAction`],
 /// overriding the action-carried default when a registered type provides a
 /// canonical scope.
 ///
-/// Also exposes [`run_scoped_paths`] for enumerating all Run-scoped state
+/// Also exposes `run_scoped_paths` for enumerating all Run-scoped state
 /// paths, enabling framework-driven cleanup at the start of each run.
 #[derive(Debug, Clone, Default)]
 pub struct StateScopeRegistry {
@@ -51,7 +51,7 @@ impl StateScopeRegistry {
     /// Resolve the scope of an [`AnyStateAction`].
     ///
     /// If the action targets a registered type, returns the registered scope.
-    /// Otherwise falls back to [`AnyStateAction::scope`].
+    /// Otherwise falls back to `AnyStateAction::scope`.
     pub fn resolve(&self, action: &AnyStateAction) -> StateScope {
         if let Some(scope) = self.scope_for_type_id(action.state_type_id()) {
             return scope;

--- a/crates/tirea-extension-mcp/src/lib.rs
+++ b/crates/tirea-extension-mcp/src/lib.rs
@@ -1,7 +1,7 @@
 //! Model Context Protocol (MCP) client integration for external tool servers.
 //!
 //! Provides [`McpToolRegistryManager`] for connecting to MCP servers and
-//! exposing their tools as tirea [`Tool`](tirea_contract::runtime::tool_call::Tool) instances.
+//! exposing their tools as tirea [`Tool`] instances.
 
 mod client_transport;
 

--- a/crates/tirea-extension-skills/src/mcp_registry.rs
+++ b/crates/tirea-extension-skills/src/mcp_registry.rs
@@ -363,10 +363,7 @@ fn render_prompt_content(content: &Value) -> String {
     serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string())
 }
 
-fn resource_uri_from_path<'a>(
-    kind: SkillResourceKind,
-    path: &'a str,
-) -> Result<&'a str, SkillError> {
+fn resource_uri_from_path(kind: SkillResourceKind, path: &str) -> Result<&str, SkillError> {
     let prefix = match kind {
         SkillResourceKind::Reference => "references/",
         SkillResourceKind::Asset => "assets/",

--- a/crates/tirea-extension-skills/src/tools.rs
+++ b/crates/tirea-extension-skills/src/tools.rs
@@ -107,7 +107,7 @@ impl SkillActivateTool {
             .activate(activation_args)
             .await
             .map_err(|e| map_skill_error(SKILL_ACTIVATE_TOOL_ID, e));
-        let activation = match activation {
+        let _activation = match activation {
             Ok(v) => v,
             Err(r) => return Ok(ToolExecutionEffect::from(r)),
         };

--- a/crates/tirea-protocol-ai-sdk-v6/src/events.rs
+++ b/crates/tirea-protocol-ai-sdk-v6/src/events.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 /// Stream event types compatible with AI SDK v6.
 ///
 /// These events map directly to the AI SDK UI Message Stream protocol.
-/// See: https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol
+/// See: <https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol>
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum UIStreamEvent {

--- a/crates/tirea-state/src/lattice/or_map.rs
+++ b/crates/tirea-state/src/lattice/or_map.rs
@@ -14,7 +14,7 @@ pub(crate) struct Entry<V> {
 
 /// An observed-remove map (OR-Map) with put-wins semantics and recursive value merge.
 ///
-/// Each key maps to an [`Entry`] containing a value `V: Lattice` and an insertion timestamp.
+/// Each key maps to an internal entry containing a value `V: Lattice` and an insertion timestamp.
 /// Removals record a tombstone timestamp. A key is considered present when its entry timestamp
 /// is greater than or equal to its tombstone timestamp (put-wins: concurrent put and
 /// remove resolve in favor of put).

--- a/crates/tirea-store-adapters/src/nats_buffered.rs
+++ b/crates/tirea-store-adapters/src/nats_buffered.rs
@@ -5,7 +5,7 @@
 //!
 //! # Run-end flush strategy
 //!
-//! During a run the [`AgentOs::run_stream`] checkpoint background task calls
+//! During a run the AgentOS checkpoint background task calls
 //! `append()` for each delta.  This storage publishes those deltas to a
 //! JetStream subject `thread.{thread_id}.deltas` so they are durably buffered
 //! in NATS.  No database writes happen during the run.

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -250,12 +250,22 @@ Core fields:
 
 The `extensions` field is a `TypeMap`-based store that lets plugins attach arbitrary typed configuration without modifying `AgentRunConfig` itself. Plugins insert config during resolve and read it during execution:
 
-```rust
-// During resolve (mutable phase):
-run_config.extensions_mut().insert(MyPluginConfig { ... });
+```rust,edition2021
+# extern crate tirea;
+use tirea::contracts::{AgentRunConfig, RunPolicy};
 
-// During execution (frozen phase):
+#[derive(Debug, Default)]
+struct MyPluginConfig {
+    enabled: bool,
+}
+
+let mut run_config = AgentRunConfig::new(RunPolicy::default());
+run_config
+    .extensions_mut()
+    .insert(MyPluginConfig { enabled: true });
+
 let cfg = run_config.extensions().get::<MyPluginConfig>();
+assert_eq!(cfg.map(|cfg| cfg.enabled), Some(true));
 ```
 
 This replaces the earlier pattern of passing `RunPolicy` directly to plugins and tools, providing a single extensible config surface for the entire run lifecycle.

--- a/docs/book/src/reference/derive-macro.md
+++ b/docs/book/src/reference/derive-macro.md
@@ -4,9 +4,13 @@
 
 ## Basic Usage
 
-```rust,ignore
+```rust,edition2021
+# extern crate serde;
+# extern crate serde_json;
+# extern crate tirea_state;
+# extern crate tirea_state_derive;
 use serde::{Deserialize, Serialize};
-use tirea_state::State;
+use tirea_state::{State as StateTrait, StateScope, StateSpec};
 use tirea_state_derive::State;
 
 #[derive(Debug, Clone, Serialize, Deserialize, State)]
@@ -14,6 +18,22 @@ use tirea_state_derive::State;
 struct Counter {
     value: i64,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum CounterAction {
+    Increment(i64),
+}
+
+impl Counter {
+    fn reduce(&mut self, action: CounterAction) {
+        match action {
+            CounterAction::Increment(amount) => self.value += amount,
+        }
+    }
+}
+
+assert_eq!(<Counter as StateTrait>::PATH, "counter");
+assert_eq!(<Counter as StateSpec>::SCOPE, StateScope::Run);
 ```
 
 ## Struct Attributes

--- a/docs/book/src/reference/errors.md
+++ b/docs/book/src/reference/errors.md
@@ -4,16 +4,16 @@
 
 ## TireaError
 
-```rust,ignore
-pub enum TireaError {
-    PathNotFound { path: Path },
-    IndexOutOfBounds { path: Path, index: usize, len: usize },
-    TypeMismatch { path: Path, expected: &'static str, found: &'static str },
-    NumericOperationOnNonNumber { path: Path },
-    MergeRequiresObject { path: Path },
-    AppendRequiresArray { path: Path },
-    InvalidOperation { message: String },
-    Serialization(serde_json::Error),
+```rust,edition2021
+# extern crate tirea_state;
+use tirea_state::{path, TireaError};
+
+let err = TireaError::path_not_found(path!("users", 0, "name"));
+match err {
+    TireaError::PathNotFound { path } => {
+        assert_eq!(path.to_string(), "$.users[0].name");
+    }
+    other => panic!("unexpected error variant: {other:?}"),
 }
 ```
 
@@ -34,19 +34,25 @@ pub enum TireaError {
 
 Convenience type alias:
 
-```rust,ignore
-pub type TireaResult<T> = Result<T, TireaError>;
+```rust,edition2021
+# extern crate tirea_state;
+use tirea_state::TireaResult;
+
+let result: TireaResult<i32> = Ok(42);
+assert_eq!(result.unwrap(), 42);
 ```
 
 ## Error Context with `with_prefix`
 
 When working with nested state, errors include the full path context. The `with_prefix` method prepends a path segment:
 
-```rust,ignore
-// If a nested struct at "address" has an error at "city":
+```rust,edition2021
+# extern crate tirea_state;
+use tirea_state::{path, TireaError};
+
 let err = TireaError::path_not_found(path!("city"));
 let contextualized = err.with_prefix(&path!("address"));
-// Error now shows: "path not found: address.city"
+assert_eq!(contextualized.to_string(), "path not found: $.address.city");
 ```
 
 ## Convenience Constructors

--- a/docs/book/src/reference/state-ops.md
+++ b/docs/book/src/reference/state-ops.md
@@ -124,11 +124,15 @@ Behavior:
 
 Numeric ops use `Number`:
 
-```rust,ignore
-pub enum Number {
-    Int(i64),
-    Float(f64),
-}
+```rust,edition2021
+# extern crate tirea_state;
+use tirea_state::Number;
+
+let int_value = Number::from(1_i64);
+let float_value = Number::from(1.5_f64);
+
+assert!(int_value.is_int());
+assert!(float_value.is_float());
 ```
 
 `From` is implemented for `i32`, `i64`, `u32`, `u64`, `f32`, `f64`.

--- a/docs/book/src/reference/typed-tool.md
+++ b/docs/book/src/reference/typed-tool.md
@@ -11,9 +11,19 @@
 
 ## Trait Shape
 
-```rust,ignore
+```rust,edition2021
+# extern crate async_trait;
+# extern crate schemars;
+# extern crate serde;
+# extern crate tirea;
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tirea::contracts::runtime::tool_call::{ToolError, ToolResult};
+use tirea::contracts::ToolCallContext;
+
 #[async_trait]
-pub trait TypedTool: Send + Sync {
+pub trait ExampleTypedTool: Send + Sync {
     type Args: for<'de> Deserialize<'de> + JsonSchema + Send;
 
     fn tool_id(&self) -> &str;
@@ -36,7 +46,12 @@ A blanket implementation converts every `TypedTool` into a normal `Tool`, so reg
 
 ## Minimal Example
 
-```rust,ignore
+```rust,edition2021
+# extern crate async_trait;
+# extern crate schemars;
+# extern crate serde;
+# extern crate serde_json;
+# extern crate tirea;
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -78,6 +93,9 @@ impl TypedTool for SelectTripTool {
         ))
     }
 }
+
+let tool = SelectTripTool;
+assert_eq!(tool.tool_id(), "select_trip");
 ```
 
 ## Validation Flow
@@ -98,7 +116,13 @@ That means:
 
 This example shows a state-writing tool using the plain `Tool` trait with `execute_effect`. State mutations must go through `ToolExecutionEffect` + `AnyStateAction` — the runtime rejects direct writes via `ctx.state::<T>().set_*()`.
 
-```rust,ignore
+```rust,edition2021
+# extern crate async_trait;
+# extern crate serde;
+# extern crate serde_json;
+# extern crate tirea;
+# extern crate tirea_state;
+# extern crate tirea_state_derive;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -142,7 +166,11 @@ impl Tool for RenameCounter {
             }))
     }
 
-    async fn execute(&self, args: Value, ctx: &ToolCallContext<'_>) -> Result<ToolResult, ToolError> {
+    async fn execute(
+        &self,
+        args: Value,
+        ctx: &ToolCallContext<'_>,
+    ) -> Result<ToolResult, ToolError> {
         Ok(<Self as Tool>::execute_effect(self, args, ctx).await?.result)
     }
 
@@ -164,6 +192,9 @@ impl Tool for RenameCounter {
         )))
     }
 }
+
+let tool = RenameCounter;
+assert_eq!(tool.descriptor().id, "rename_counter");
 ```
 
 ## Reading State
@@ -172,8 +203,25 @@ Inside a tool, state reads follow one of two patterns:
 
 Use `ctx.snapshot_of::<T>()` to read the current state as a deserialized Rust value:
 
-```rust,ignore
-let file: WorkspaceFile = ctx.snapshot_of::<WorkspaceFile>().unwrap_or_default();
+```rust,edition2021
+# extern crate serde;
+# extern crate serde_json;
+# extern crate tirea;
+# extern crate tirea_state;
+# extern crate tirea_state_derive;
+use serde::{Deserialize, Serialize};
+use tirea::contracts::ToolCallContext;
+use tirea_state_derive::State;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, State)]
+struct WorkspaceFile {
+    path: String,
+}
+
+fn read_file(ctx: &ToolCallContext<'_>) {
+    let file: WorkspaceFile = ctx.snapshot_of::<WorkspaceFile>().unwrap_or_default();
+    let _ = file.path;
+}
 ```
 
 For advanced cases where the same state type is reused at different paths, use `ctx.snapshot_at::<T>("some.path")`.
@@ -192,11 +240,32 @@ All state writes use the action-based pattern:
 
 State scope is declared on the state type, not on the tool.
 
-```rust,ignore
+```rust,edition2021
+# extern crate serde;
+# extern crate serde_json;
+# extern crate tirea_state;
+# extern crate tirea_state_derive;
+use serde::{Deserialize, Serialize};
+use tirea_state::{StateScope, StateSpec};
+use tirea_state_derive::State;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, State)]
 #[tirea(action = "FileAccessAction", scope = "thread")]
 struct FileAccessState {
     opened_paths: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum FileAccessAction {
+    Open(String),
+}
+
+impl FileAccessState {
+    fn reduce(&mut self, action: FileAccessAction) {
+        match action {
+            FileAccessAction::Open(path) => self.opened_paths.push(path),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, State)]
@@ -205,11 +274,41 @@ struct EditorRunState {
     current_goal: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum EditorRunAction {
+    SetGoal(String),
+}
+
+impl EditorRunState {
+    fn reduce(&mut self, action: EditorRunAction) {
+        match action {
+            EditorRunAction::SetGoal(goal) => self.current_goal = Some(goal),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, State)]
 #[tirea(action = "ApprovalAction", scope = "tool_call")]
 struct ApprovalState {
     requested: bool,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum ApprovalAction {
+    Request,
+}
+
+impl ApprovalState {
+    fn reduce(&mut self, action: ApprovalAction) {
+        match action {
+            ApprovalAction::Request => self.requested = true,
+        }
+    }
+}
+
+assert_eq!(<FileAccessState as StateSpec>::SCOPE, StateScope::Thread);
+assert_eq!(<EditorRunState as StateSpec>::SCOPE, StateScope::Run);
+assert_eq!(<ApprovalState as StateSpec>::SCOPE, StateScope::ToolCall);
 ```
 
 Use each scope for a different kind of data:

--- a/examples/copilotkit-starter/next.config.mjs
+++ b/examples/copilotkit-starter/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  webpack(config) {
+    config.ignoreWarnings = [
+      ...(config.ignoreWarnings ?? []),
+      {
+        module: /@whatwg-node\/fetch\/dist\/node-ponyfill\.js$/,
+        message: /Critical dependency: the request of a dependency is an expression/,
+      },
+    ];
+    return config;
+  },
+};
 
 export default nextConfig;

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 WORKSPACE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 if ! command -v mdbook >/dev/null 2>&1; then
-    echo "error: mdbook is required. Install with: cargo install mdbook --locked --version 0.5.2"
+    echo "error: mdbook is required. Install with: cargo install mdbook --locked --version 0.5.0"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- fix the docs workflow failure by converting fixable mdBook snippets into real doctests
- clean Rust/rustdoc warnings that were surfacing during docs and workspace checks
- align mdBook tooling versions and suppress the known third-party Next.js webpack warning

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --lib --bins --examples --locked -- -D clippy::correctness
- cargo test --workspace --locked
- bash scripts/build-docs.sh
- cd examples/ai-sdk-starter && npm ci && npm run build
- cd examples/copilotkit-starter && npm ci && npm run build