### PR TITLE
🔖 release(v0.5.0): bump all crates to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "tirea-examples",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "tirea-examples",
@@ -2889,7 +2889,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phoenix-test-helpers"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -4580,7 +4580,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tirea"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-agentos"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-agentos-server"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-nats",
  "async-stream",
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-contract"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-examples"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum 0.7.9",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-extension-a2ui"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "schemars 1.2.1",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-extension-handoff"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-extension-mcp"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "model-context-protocol",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-extension-observability"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-extension-permission"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "glob-match",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-extension-skills"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-protocol-acp"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-protocol-ag-ui"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-protocol-ai-sdk-v6"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-state"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "serde",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-state-derive"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "tirea-store-adapters"
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 dependencies = [
  "async-nats",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,31 +24,31 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0-alpha.1"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tirea-ai/tirea"
 
 [workspace.dependencies]
 # Internal crates
-tirea-state = { version = "0.5.0-alpha.1", path = "crates/tirea-state" }
-tirea-state-derive = { version = "0.5.0-alpha.1", path = "crates/tirea-state-derive" }
-tirea-contract = { version = "0.5.0-alpha.1", path = "crates/tirea-contract" }
-tirea-agentos = { version = "0.5.0-alpha.1", path = "crates/tirea-agentos" }
-tirea-agentos-server = { version = "0.5.0-alpha.1", path = "crates/tirea-agentos-server" }
-tirea-extension-permission = { version = "0.5.0-alpha.1", path = "crates/tirea-extension-permission" }
-tirea-extension-observability = { version = "0.5.0-alpha.1", path = "crates/tirea-extension-observability" }
-tirea-extension-skills = { version = "0.5.0-alpha.1", path = "crates/tirea-extension-skills" }
-tirea-extension-mcp = { version = "0.5.0-alpha.1", path = "crates/tirea-extension-mcp" }
-tirea-extension-handoff = { version = "0.5.0-alpha.1", path = "crates/tirea-extension-handoff" }
-tirea-extension-a2ui = { version = "0.5.0-alpha.1", path = "crates/tirea-extension-a2ui" }
-tirea-protocol-acp = { version = "0.5.0-alpha.1", path = "crates/tirea-protocol-acp" }
-tirea-protocol-ag-ui = { version = "0.5.0-alpha.1", path = "crates/tirea-protocol-ag-ui" }
-tirea-protocol-ai-sdk-v6 = { version = "0.5.0-alpha.1", path = "crates/tirea-protocol-ai-sdk-v6" }
-tirea = { version = "0.5.0-alpha.1", path = "crates/tirea" }
-tirea-store-adapters = { version = "0.5.0-alpha.1", path = "crates/tirea-store-adapters" }
-tirea-examples = { version = "0.5.0-alpha.1", path = "examples" }
-phoenix-test-helpers = { version = "0.5.0-alpha.1", path = "e2e/phoenix/test-helpers" }
+tirea-state = { version = "0.5.0", path = "crates/tirea-state" }
+tirea-state-derive = { version = "0.5.0", path = "crates/tirea-state-derive" }
+tirea-contract = { version = "0.5.0", path = "crates/tirea-contract" }
+tirea-agentos = { version = "0.5.0", path = "crates/tirea-agentos" }
+tirea-agentos-server = { version = "0.5.0", path = "crates/tirea-agentos-server" }
+tirea-extension-permission = { version = "0.5.0", path = "crates/tirea-extension-permission" }
+tirea-extension-observability = { version = "0.5.0", path = "crates/tirea-extension-observability" }
+tirea-extension-skills = { version = "0.5.0", path = "crates/tirea-extension-skills" }
+tirea-extension-mcp = { version = "0.5.0", path = "crates/tirea-extension-mcp" }
+tirea-extension-handoff = { version = "0.5.0", path = "crates/tirea-extension-handoff" }
+tirea-extension-a2ui = { version = "0.5.0", path = "crates/tirea-extension-a2ui" }
+tirea-protocol-acp = { version = "0.5.0", path = "crates/tirea-protocol-acp" }
+tirea-protocol-ag-ui = { version = "0.5.0", path = "crates/tirea-protocol-ag-ui" }
+tirea-protocol-ai-sdk-v6 = { version = "0.5.0", path = "crates/tirea-protocol-ai-sdk-v6" }
+tirea = { version = "0.5.0", path = "crates/tirea" }
+tirea-store-adapters = { version = "0.5.0", path = "crates/tirea-store-adapters" }
+tirea-examples = { version = "0.5.0", path = "examples" }
+phoenix-test-helpers = { version = "0.5.0", path = "e2e/phoenix/test-helpers" }
 
 # LLM client
 genai = "0.6.0-beta.5"

--- a/docs/book/src/how-to/use-postgres-store.md
+++ b/docs/book/src/how-to/use-postgres-store.md
@@ -14,7 +14,7 @@ Use `PostgresStore` when you need shared durable storage across instances.
 
 ```toml
 [dependencies]
-tirea-store-adapters = { version = "0.5.0-alpha.1", features = ["postgres"] }
+tirea-store-adapters = { version = "0.5.0", features = ["postgres"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"], default-features = false }
 ```
 

--- a/docs/book/src/tutorials/first-agent.md
+++ b/docs/book/src/tutorials/first-agent.md
@@ -8,9 +8,9 @@ Run one agent end-to-end and confirm you receive a complete event stream.
 
 ```toml
 [dependencies]
-tirea = "0.5.0-alpha.1"
-tirea-agentos-server = "0.5.0-alpha.1"
-tirea-store-adapters = "0.5.0-alpha.1"
+tirea = "0.5.0"
+tirea-agentos-server = "0.5.0"
+tirea-store-adapters = "0.5.0"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 futures = "0.3"

--- a/docs/book/src/tutorials/first-tool.md
+++ b/docs/book/src/tutorials/first-tool.md
@@ -17,8 +17,8 @@ Implement one tool that reads and updates typed state.
 async-trait = "0.1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-tirea = "0.5.0-alpha.1"
-tirea-state-derive = "0.5.0-alpha.1"
+tirea = "0.5.0"
+tirea-state-derive = "0.5.0"
 ```
 
 ## 1. Define Typed State with Action

--- a/docs/book/src/zh-CN/tutorials/first-agent.md
+++ b/docs/book/src/zh-CN/tutorials/first-agent.md
@@ -10,9 +10,9 @@
 
 ```toml
 [dependencies]
-tirea = "0.5.0-alpha.1"
-tirea-agentos-server = "0.5.0-alpha.1"
-tirea-store-adapters = "0.5.0-alpha.1"
+tirea = "0.5.0"
+tirea-agentos-server = "0.5.0"
+tirea-store-adapters = "0.5.0"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 futures = "0.3"

--- a/docs/book/src/zh-CN/tutorials/first-tool.md
+++ b/docs/book/src/zh-CN/tutorials/first-tool.md
@@ -19,8 +19,8 @@
 async-trait = "0.1"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-tirea = "0.5.0-alpha.1"
-tirea-state-derive = "0.5.0-alpha.1"
+tirea = "0.5.0"
+tirea-state-derive = "0.5.0"
 ```
 
 ## 1. 定义带 Action 的类型化状态


### PR DESCRIPTION
## Summary
- Bump all 19 workspace crates from `0.5.0-alpha.1` to `0.5.0`
- Update version references in tutorial and how-to docs

## Changes since v0.4.0
- MCP prompt and resource discovery
- Unified runtime/context message model (major refactor)
- Merged StoredPromptSegment into ContextMessage, deleted reminder crate
- Async RunDoneCallback for run completion
- CI and docs stabilization fixes

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo doc --workspace --no-deps` passes
- [x] No remaining `0.5.0-alpha` references