### PR TITLE
fix(ai-sdk-v6): skip provider-executed tool results in resume detection

### DIFF
--- a/crates/awaken-server/src/protocols/ai_sdk_v6/request.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/request.rs
@@ -257,6 +257,18 @@ fn extract_tool_call_decisions(msgs: &[UIMessage]) -> Vec<(String, ToolCallResum
                 return None;
             }
 
+            // Skip tool results already executed by the provider (server-side).
+            // AI SDK v6 marks completed tool calls with providerExecuted: true
+            // in the message history. Without this check, historical tool results
+            // are misidentified as new resume decisions, breaking multi-turn chat.
+            let provider_executed = part
+                .get("providerExecuted")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if provider_executed {
+                return None;
+            }
+
             let state = part.get("state").and_then(Value::as_str)?;
             let tool_call_id = part
                 .get("toolCallId")
@@ -1009,5 +1021,134 @@ mod tests {
         }];
         let decisions = extract_tool_call_decisions(&msgs);
         assert!(decisions.is_empty());
+    }
+
+    #[test]
+    fn extract_decisions_skips_provider_executed_tools() {
+        // AI SDK v6 marks completed tool calls with providerExecuted: true in
+        // message history. These must NOT be treated as new resume decisions.
+        let msgs = vec![UIMessage {
+            id: None,
+            role: "assistant".into(),
+            parts: vec![raw_part(json!({
+                "type": "tool-invocation",
+                "toolCallId": "hist_call",
+                "state": "output-available",
+                "output": {"result": "done"},
+                "providerExecuted": true,
+            }))],
+        }];
+        let decisions = extract_tool_call_decisions(&msgs);
+        assert!(
+            decisions.is_empty(),
+            "providerExecuted tool results should be skipped, got {decisions:?}"
+        );
+
+        // Same part without providerExecuted should still be picked up.
+        let msgs2 = vec![UIMessage {
+            id: None,
+            role: "assistant".into(),
+            parts: vec![raw_part(json!({
+                "type": "tool-invocation",
+                "toolCallId": "new_call",
+                "state": "output-available",
+                "output": {"result": "pending"},
+            }))],
+        }];
+        let decisions2 = extract_tool_call_decisions(&msgs2);
+        assert_eq!(decisions2.len(), 1);
+        assert_eq!(decisions2[0].0, "new_call");
+    }
+
+    /// Regression: multi-turn conversation with completed tool calls in history.
+    ///
+    /// Simulates the exact sequence that caused the bug:
+    /// Turn 1: user → assistant (with tool call) → tool result (providerExecuted)
+    /// Turn 2: user sends follow-up
+    ///
+    /// Without the fix, the historical tool result creates a spurious decision,
+    /// `is_resume_only()` returns true, and the response is empty.
+    #[test]
+    fn multi_turn_with_provider_executed_history_produces_no_decisions() {
+        let msgs = vec![
+            // Turn 1: user message
+            UIMessage {
+                id: Some("msg-1".into()),
+                role: "user".into(),
+                parts: vec![raw_part(json!({
+                    "type": "text",
+                    "text": "Show me the fleet status",
+                }))],
+            },
+            // Turn 1: assistant response with tool call (completed)
+            UIMessage {
+                id: Some("msg-2".into()),
+                role: "assistant".into(),
+                parts: vec![
+                    raw_part(json!({
+                        "type": "text",
+                        "text": "Let me check the fleet status.",
+                    })),
+                    raw_part(json!({
+                        "type": "tool-invocation",
+                        "toolCallId": "call_fleet_1",
+                        "toolName": "get_fleet_status",
+                        "args": {},
+                        "state": "output-available",
+                        "output": [{"id": "ship-1", "status": "active"}],
+                        "providerExecuted": true,
+                    })),
+                ],
+            },
+            // Turn 2: user follow-up
+            UIMessage {
+                id: Some("msg-3".into()),
+                role: "user".into(),
+                parts: vec![raw_part(json!({
+                    "type": "text",
+                    "text": "Show me the anomalies",
+                }))],
+            },
+        ];
+
+        let decisions = extract_tool_call_decisions(&msgs);
+        assert!(
+            decisions.is_empty(),
+            "historical providerExecuted tool calls must not produce decisions, \
+             but got {decisions:?} — this would cause is_resume_only() to return \
+             true and the response to be empty"
+        );
+    }
+
+    /// Verify that is_resume_only is false when there are messages but no decisions.
+    #[test]
+    fn processed_request_with_messages_is_not_resume_only() {
+        let req = ProcessedRequest {
+            thread_id: "t1".into(),
+            messages: vec![Message::user("hello")],
+            decisions: vec![],
+            state: None,
+            agent_id: None,
+        };
+        assert!(
+            !req.is_resume_only(),
+            "request with messages should not be resume-only"
+        );
+    }
+
+    /// Verify that is_resume_only requires both empty messages AND non-empty decisions.
+    #[test]
+    fn processed_request_empty_messages_empty_decisions_is_not_resume_only() {
+        let req = ProcessedRequest {
+            thread_id: "t1".into(),
+            messages: vec![],
+            decisions: vec![],
+            state: None,
+            agent_id: None,
+        };
+        assert!(
+            !req.is_resume_only(),
+            "request with no messages and no decisions should not be resume-only"
+        );
     }
 }

--- a/crates/awaken-server/tests/ai_sdk_multi_turn.rs
+++ b/crates/awaken-server/tests/ai_sdk_multi_turn.rs
@@ -1,0 +1,244 @@
+//! Regression test: multi-turn AI SDK v6 chat must not break after tool calls.
+//!
+//! AI SDK v6 sends the full message history on every turn. Completed tool calls
+//! carry `providerExecuted: true`. Without filtering, `extract_tool_call_decisions()`
+//! misidentifies these as new resume decisions, routing the request to the
+//! "resume pending run" path which returns an empty stream.
+
+use async_trait::async_trait;
+use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest};
+use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+use awaken_contract::registry_spec::AgentSpec;
+use awaken_runtime::builder::AgentRuntimeBuilder;
+use awaken_runtime::registry::traits::ModelEntry;
+use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::routes::build_router;
+use awaken_stores::memory::InMemoryStore;
+use axum::body::to_bytes;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+// ── Mock executor that always returns a text response ──
+
+struct EchoExecutor;
+
+#[async_trait]
+impl awaken_contract::contract::executor::LlmExecutor for EchoExecutor {
+    async fn execute(
+        &self,
+        _request: InferenceRequest,
+    ) -> Result<StreamResult, InferenceExecutionError> {
+        use awaken_contract::contract::content::ContentBlock;
+        Ok(StreamResult {
+            content: vec![ContentBlock::Text {
+                text: "Here is the response.".into(),
+            }],
+            tool_calls: vec![],
+            usage: Some(TokenUsage::default()),
+            stop_reason: Some(StopReason::EndTurn),
+            has_incomplete_tool_calls: false,
+        })
+    }
+
+    fn name(&self) -> &str {
+        "echo"
+    }
+}
+
+fn make_app() -> axum::Router {
+    let store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_model(
+                "test-model",
+                ModelEntry {
+                    provider: "mock".into(),
+                    model_name: "mock-model".into(),
+                },
+            )
+            .with_provider("mock", Arc::new(EchoExecutor))
+            .with_thread_run_store(store.clone())
+            .with_agent_spec(AgentSpec {
+                id: "default".into(),
+                model: "test-model".into(),
+                system_prompt: "You are a test assistant.".into(),
+                max_rounds: 3,
+                ..Default::default()
+            })
+            .build()
+            .expect("build runtime"),
+    );
+    let mailbox_store = Arc::new(awaken_stores::InMemoryMailboxStore::new());
+    let mailbox = Arc::new(awaken_server::mailbox::Mailbox::new(
+        runtime.clone(),
+        mailbox_store,
+        "test".into(),
+        awaken_server::mailbox::MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime.clone(),
+        mailbox,
+        store.clone(),
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+    build_router().with_state(state)
+}
+
+/// Turn 3 of a multi-turn conversation where turns 1-2 included tool calls.
+///
+/// The payload contains the full history with providerExecuted: true on
+/// completed tool results — exactly what AI SDK v6 sends in practice.
+///
+/// Before the fix: the server would return an empty SSE stream (status 200,
+/// zero data bytes) because it mistakenly entered the "resume pending run" path.
+///
+/// After the fix: the server processes the new user message normally.
+#[tokio::test]
+async fn turn3_with_provider_executed_history_returns_non_empty_response() {
+    let app = make_app();
+
+    // Simulate Turn 3: full history with completed tool calls from Turn 2.
+    let payload = json!({
+        "threadId": "thread-multi-turn-test",
+        "messages": [
+            // Turn 1: user
+            {
+                "id": "msg-1",
+                "role": "user",
+                "parts": [{"type": "text", "text": "Show me the fleet status"}]
+            },
+            // Turn 1: assistant with completed tool call
+            {
+                "id": "msg-2",
+                "role": "assistant",
+                "parts": [
+                    {"type": "text", "text": "Let me check the fleet."},
+                    {
+                        "type": "tool-invocation",
+                        "toolCallId": "call_fleet_1",
+                        "toolName": "get_fleet_status",
+                        "args": {},
+                        "state": "output-available",
+                        "output": [{"id": "ship-1", "status": "active"}],
+                        "providerExecuted": true
+                    }
+                ]
+            },
+            // Turn 2: user
+            {
+                "id": "msg-3",
+                "role": "user",
+                "parts": [{"type": "text", "text": "Show me the anomalies"}]
+            },
+            // Turn 2: assistant with another completed tool call
+            {
+                "id": "msg-4",
+                "role": "assistant",
+                "parts": [
+                    {"type": "text", "text": "Checking anomalies now."},
+                    {
+                        "type": "tool-invocation",
+                        "toolCallId": "call_anomaly_1",
+                        "toolName": "get_anomalies",
+                        "args": {},
+                        "state": "output-available",
+                        "output": [{"id": "anomaly-1", "severity": "high"}],
+                        "providerExecuted": true
+                    }
+                ]
+            },
+            // Turn 3: new user message (this is the one that should get a response)
+            {
+                "id": "msg-5",
+                "role": "user",
+                "parts": [{"type": "text", "text": "Generate a report"}]
+            }
+        ]
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/ai-sdk/chat")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+
+    // The response must not be empty — it should contain SSE events.
+    assert!(
+        body.len() > 10,
+        "Turn 3 response body must not be empty (got {} bytes: {:?}). \
+         This indicates the server mistakenly treated providerExecuted \
+         tool results as resume decisions.",
+        body.len(),
+        &body_str[..body_str.len().min(200)],
+    );
+
+    // Verify the response contains actual text content from the mock executor.
+    assert!(
+        body_str.contains("Here is the response"),
+        "Response should contain executor output, got: {:?}",
+        &body_str[..body_str.len().min(500)],
+    );
+}
+
+/// Conversation with NO tool calls in history — plain text multi-turn.
+/// Verifies that the basic multi-turn path works without any tool complexity.
+#[tokio::test]
+async fn plain_multi_turn_without_tools_returns_non_empty_response() {
+    let app = make_app();
+
+    let payload = json!({
+        "threadId": "thread-plain-multi-turn",
+        "messages": [
+            {
+                "id": "msg-1",
+                "role": "user",
+                "parts": [{"type": "text", "text": "Hello"}]
+            },
+            {
+                "id": "msg-2",
+                "role": "assistant",
+                "parts": [{"type": "text", "text": "Hi there!"}]
+            },
+            {
+                "id": "msg-3",
+                "role": "user",
+                "parts": [{"type": "text", "text": "How are you?"}]
+            }
+        ]
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/ai-sdk/chat")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+    assert!(
+        body.len() > 10,
+        "Plain multi-turn response should not be empty (got {} bytes)",
+        body.len(),
+    );
+}


### PR DESCRIPTION
## Summary
- AI SDK v6 marks completed tool calls with `providerExecuted: true` in the message history sent on every turn
- `extract_tool_call_decisions()` was treating these historical results as new resume decisions, routing requests to the "resume pending run" path which returned empty SSE streams
- Adds a `providerExecuted` check to skip server-executed tool results before decision extraction

## Test plan
- [x] Unit tests: `extract_decisions_skips_provider_executed_tools`, `multi_turn_with_provider_executed_history_produces_no_decisions`, `processed_request_*` (51 total in request module)
- [x] Integration tests: `ai_sdk_multi_turn.rs` — `turn3_with_provider_executed_history_returns_non_empty_response`, `plain_multi_turn_without_tools_returns_non_empty_response`
- [x] E2E: BigModel OpenAI-compat (glm-4-flash-250414) — 7/7 scenarios pass
- [x] E2E: BigModel Anthropic-compat (glm-4.5-flash) — 5/5 scenarios pass
