### PR TITLE
✅ test(ai-sdk): normalize direct requests to canonical parts

### DIFF
--- a/crates/awaken-server/tests/ai_sdk_multi_turn.rs
+++ b/crates/awaken-server/tests/ai_sdk_multi_turn.rs
@@ -242,3 +242,50 @@ async fn plain_multi_turn_without_tools_returns_non_empty_response() {
         body.len(),
     );
 }
+
+/// AI SDK v6 must receive canonical `UIMessage.parts`.
+/// Legacy `content` payloads bypass the official transport normalization and
+/// are rejected at the HTTP boundary.
+#[tokio::test]
+async fn legacy_content_messages_are_rejected() {
+    let app = make_app();
+
+    let payload = json!({
+        "threadId": "thread-legacy-content",
+        "agentId": "default",
+        "messages": [
+            {
+                "id": "msg-system",
+                "role": "system",
+                "content": "You are concise."
+            },
+            {
+                "id": "msg-user",
+                "role": "user",
+                "content": "Say hello"
+            }
+        ]
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/ai-sdk/chat")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("no new messages or interaction responses"),
+        "legacy content payload should be rejected, got: {:?}",
+        &body_str[..body_str.len().min(500)],
+    );
+}

--- a/e2e/tests/advanced-agents.spec.ts
+++ b/e2e/tests/advanced-agents.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 const BASE_URL = 'http://127.0.0.1:38080';
 
@@ -115,7 +116,7 @@ test.describe('advanced agent variants', () => {
       const res = await request.post('/v1/ai-sdk/chat', {
         data: {
           agentId,
-          messages: [{ role: 'user', content: `Test ${agentId}` }],
+          messages: aiSdkTextMessages([{ role: 'user', text: `Test ${agentId}` }]),
         },
       });
       expect(res.ok()).toBeTruthy();
@@ -125,7 +126,7 @@ test.describe('advanced agent variants', () => {
     test(`${agentId} agent via AI SDK protocol`, async () => {
       const { status } = await postAndCheckHeaders('/v1/ai-sdk/chat', {
         agentId,
-        messages: [{ role: 'user', content: `Test ${agentId}` }],
+        messages: aiSdkTextMessages([{ role: 'user', text: `Test ${agentId}` }]),
       });
       expect(status).toBe(200);
     });

--- a/e2e/tests/agents.spec.ts
+++ b/e2e/tests/agents.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 const BASE_URL = 'http://127.0.0.1:38080';
 
@@ -120,7 +121,7 @@ test.describe('multi-agent variants', () => {
   test('AI SDK routes to research agent', async () => {
     const { status } = await postAndCheckHeaders('/v1/ai-sdk/chat', {
       agentId: 'research',
-      messages: [{ role: 'user', content: 'Search for AI papers' }],
+      messages: aiSdkTextMessages([{ role: 'user', text: 'Search for AI papers' }]),
     });
     expect(status).toBe(200);
   });

--- a/e2e/tests/ai-sdk-test-utils.ts
+++ b/e2e/tests/ai-sdk-test-utils.ts
@@ -1,0 +1,39 @@
+type AiSdkRole = 'system' | 'user' | 'assistant';
+
+let nextMessageId = 0;
+
+export function aiSdkTextPart(text: string) {
+  return { type: 'text' as const, text };
+}
+
+export function aiSdkFilePart(url: string, mediaType: string, filename?: string) {
+  return {
+    type: 'file' as const,
+    url,
+    mediaType,
+    ...(filename ? { filename } : {}),
+  };
+}
+
+export function aiSdkMessage(
+  role: AiSdkRole,
+  parts: Array<ReturnType<typeof aiSdkTextPart> | ReturnType<typeof aiSdkFilePart>>,
+  id?: string,
+) {
+  nextMessageId += 1;
+  return {
+    id: id ?? `${role}-${nextMessageId}`,
+    role,
+    parts,
+  };
+}
+
+export function aiSdkTextMessage(role: AiSdkRole, text: string, id?: string) {
+  return aiSdkMessage(role, [aiSdkTextPart(text)], id);
+}
+
+export function aiSdkTextMessages(
+  messages: Array<{ role: AiSdkRole; text: string; id?: string }>,
+) {
+  return messages.map(message => aiSdkTextMessage(message.role, message.text, message.id));
+}

--- a/e2e/tests/ai-sdk.spec.ts
+++ b/e2e/tests/ai-sdk.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 test('AI SDK chat endpoint returns SSE stream', async ({ request }) => {
   const response = await request.post('/v1/ai-sdk/chat', {
     data: {
       agentId: 'default',
-      messages: [{ role: 'user', content: 'What is the weather?' }],
+      messages: aiSdkTextMessages([{ role: 'user', text: 'What is the weather?' }]),
     },
   });
   expect(response.ok()).toBeTruthy();

--- a/e2e/tests/concurrency.spec.ts
+++ b/e2e/tests/concurrency.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 test.describe('concurrent operations', () => {
   test('multiple runs on same thread execute without server error', async ({ request }) => {
@@ -88,7 +89,7 @@ test.describe('concurrent operations', () => {
       request.post('/v1/ai-sdk/chat', {
         data: {
           agentId: 'limited',
-          messages: [{ role: 'user', content: 'AI SDK concurrent' }],
+          messages: aiSdkTextMessages([{ role: 'user', text: 'AI SDK concurrent' }]),
         },
       }),
       request.post('/v1/runs', {

--- a/e2e/tests/error-recovery.spec.ts
+++ b/e2e/tests/error-recovery.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 test.describe('error recovery and edge cases', () => {
   test('nonexistent agent returns error without crashing server', async ({ request }) => {
@@ -108,10 +109,11 @@ test.describe('error recovery and edge cases', () => {
 
   test('multiple protocols concurrently without error', async ({ request }) => {
     const msg = [{ role: 'user', content: 'Quick' }];
+    const aiSdkMessages = aiSdkTextMessages([{ role: 'user', text: 'Quick' }]);
     const [r1, r2, r3] = await Promise.all([
       request.post('/v1/runs', { data: { agentId: 'limited', messages: msg } }),
       request.post('/v1/ag-ui/run', { data: { agentId: 'limited', messages: msg } }),
-      request.post('/v1/ai-sdk/chat', { data: { agentId: 'limited', messages: msg } }),
+      request.post('/v1/ai-sdk/chat', { data: { agentId: 'limited', messages: aiSdkMessages } }),
     ]);
     expect(r1.status()).toBeLessThan(500);
     expect(r2.status()).toBeLessThan(500);

--- a/e2e/tests/errors.spec.ts
+++ b/e2e/tests/errors.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 test.describe('input validation', () => {
   test('POST /v1/runs with empty body returns 400', async ({ request }) => {
@@ -51,7 +52,7 @@ test.describe('input validation', () => {
   test('AI SDK with missing agentId returns error', async ({ request }) => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
-        messages: [{ role: 'user', content: 'Hello' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Hello' }]),
       },
     });
     expect(res.status()).toBeLessThan(500);

--- a/e2e/tests/generative-ui.spec.ts
+++ b/e2e/tests/generative-ui.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 /**
  * Parse SSE text into an array of {event, data} objects.
@@ -76,7 +77,7 @@ test.describe('generative UI (A2UI)', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'a2ui',
-        messages: [{ role: 'user', content: 'Render a card' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Render a card' }]),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/e2e/tests/lifecycle.spec.ts
+++ b/e2e/tests/lifecycle.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 const BASE_URL = 'http://127.0.0.1:38080';
 
@@ -184,11 +185,11 @@ test.describe('protocol endpoints', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [
-          { role: 'user', content: 'Hello' },
-          { role: 'assistant', content: 'Hi there!' },
-          { role: 'user', content: 'What can you do?' },
-        ],
+        messages: aiSdkTextMessages([
+          { role: 'user', text: 'Hello' },
+          { role: 'assistant', text: 'Hi there!' },
+          { role: 'user', text: 'What can you do?' },
+        ]),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/e2e/tests/llm-integration.spec.ts
+++ b/e2e/tests/llm-integration.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 // These tests require a real LLM backend (not ScriptedLlmExecutor).
 // They verify that the LLM produces meaningful responses and follows instructions.
@@ -116,7 +117,7 @@ test.describe('LLM integration', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [{ role: 'user', content: 'Say hello' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Say hello' }]),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/e2e/tests/multimodal.spec.ts
+++ b/e2e/tests/multimodal.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkFilePart, aiSdkMessage, aiSdkTextPart } from './ai-sdk-test-utils';
 
 test.describe('AG-UI multimodal input', () => {
   test('text string backward compatible', async ({ request }) => {
@@ -123,13 +124,12 @@ test.describe('AI SDK multimodal', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [{
-          role: 'user',
-          content: [
-            { type: 'text', text: 'What do you see?' },
-            { type: 'image', image: 'https://example.com/photo.png' },
-          ],
-        }],
+        messages: [
+          aiSdkMessage('user', [
+            aiSdkTextPart('What do you see?'),
+            aiSdkFilePart('https://example.com/photo.png', 'image/png'),
+          ]),
+        ],
       },
     });
     expect(res.status()).toBeLessThan(500);

--- a/e2e/tests/phase-hooks.spec.ts
+++ b/e2e/tests/phase-hooks.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 const BASE_URL = 'http://127.0.0.1:38080';
 
@@ -45,7 +46,7 @@ test.describe('phase hooks', () => {
   test('phases agent via AI SDK protocol', async () => {
     const { status } = await postAndCheckHeaders('/v1/ai-sdk/chat', {
       agentId: 'phases',
-      messages: [{ role: 'user', content: 'Phase hooks AI SDK' }],
+      messages: aiSdkTextMessages([{ role: 'user', text: 'Phase hooks AI SDK' }]),
     });
     expect(status).toBe(200);
   });

--- a/e2e/tests/protocols.spec.ts
+++ b/e2e/tests/protocols.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 test.describe('AI SDK v6 protocol specifics', () => {
   test('AI SDK chat returns streaming text format', async ({ request }) => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [{ role: 'user', content: 'Tell me something' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Tell me something' }]),
       },
     });
     expect(res.ok()).toBeTruthy();
@@ -20,10 +21,10 @@ test.describe('AI SDK v6 protocol specifics', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [
-          { role: 'system', content: 'You are helpful' },
-          { role: 'user', content: 'Hello' },
-        ],
+        messages: aiSdkTextMessages([
+          { role: 'system', text: 'You are helpful' },
+          { role: 'user', text: 'Hello' },
+        ]),
       },
     });
     expect(res.ok()).toBeTruthy();
@@ -40,7 +41,7 @@ test.describe('AI SDK v6 protocol specifics', () => {
       data: {
         agentId: 'default',
         threadId: thread.id,
-        messages: [{ role: 'user', content: 'With thread' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'With thread' }]),
       },
     });
     expect(res.ok()).toBeTruthy();
@@ -127,6 +128,7 @@ test.describe('A2A protocol specifics', () => {
 test.describe('cross-protocol consistency', () => {
   test('same message produces responses from all protocols', async ({ request }) => {
     const msg = [{ role: 'user', content: 'Cross-protocol test' }];
+    const aiSdkMessages = aiSdkTextMessages([{ role: 'user', text: 'Cross-protocol test' }]);
 
     const [runs, agUi, aiSdk] = await Promise.all([
       request.post('/v1/runs', {
@@ -136,7 +138,7 @@ test.describe('cross-protocol consistency', () => {
         data: { agentId: 'default', messages: msg },
       }),
       request.post('/v1/ai-sdk/chat', {
-        data: { agentId: 'default', messages: msg },
+        data: { agentId: 'default', messages: aiSdkMessages },
       }),
     ]);
 

--- a/e2e/tests/real-llm.spec.ts
+++ b/e2e/tests/real-llm.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 function parseSSE(raw: string): Array<{ data: string }> {
   return raw.split('\n')
@@ -118,7 +119,7 @@ test.describe('real LLM integration', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [{ role: 'user', content: 'Say one word' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Say one word' }]),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/e2e/tests/run-status.spec.ts
+++ b/e2e/tests/run-status.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 test.describe('run status and listing', () => {
   test('list all runs returns paginated response', async ({ request }) => {
@@ -136,7 +137,7 @@ test.describe('run status and listing', () => {
     const aiSdkRes = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [{ role: 'user', content: 'AI SDK tracked' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'AI SDK tracked' }]),
       },
     });
     expect(aiSdkRes.ok()).toBeTruthy();

--- a/e2e/tests/sse-events.spec.ts
+++ b/e2e/tests/sse-events.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 const BASE_URL = 'http://127.0.0.1:38080';
 
@@ -98,7 +99,7 @@ test.describe('SSE event structure', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [{ role: 'user', content: 'Hello AI SDK' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Hello AI SDK' }]),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/e2e/tests/stop-policy.spec.ts
+++ b/e2e/tests/stop-policy.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 test.describe('stop policies', () => {
   test('limited agent (max_rounds=1) terminates quickly', async ({ request }) => {
@@ -32,7 +33,7 @@ test.describe('stop policies', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'limited',
-        messages: [{ role: 'user', content: 'Quick AI SDK response' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Quick AI SDK response' }]),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/e2e/tests/tool-execution.spec.ts
+++ b/e2e/tests/tool-execution.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 /**
  * Parse SSE text into an array of {event, data} objects.
@@ -105,7 +106,7 @@ test.describe('tool execution and SSE streaming', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'limited',
-        messages: [{ role: 'user', content: 'Say hello' }],
+        messages: aiSdkTextMessages([{ role: 'user', text: 'Say hello' }]),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/e2e/tests/tool-lifecycle.spec.ts
+++ b/e2e/tests/tool-lifecycle.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { aiSdkTextMessages } from './ai-sdk-test-utils';
 
 function parseSSE(raw: string): Array<{ data: string }> {
   return raw.split('\n')
@@ -96,7 +97,9 @@ test.describe('tool call lifecycle', () => {
     const res = await request.post('/v1/ai-sdk/chat', {
       data: {
         agentId: 'default',
-        messages: [{ role: 'user', content: 'RUN_WEATHER_TOOL - get weather for Tokyo' }],
+        messages: aiSdkTextMessages([
+          { role: 'user', text: 'RUN_WEATHER_TOOL - get weather for Tokyo' },
+        ]),
       },
     });
     expect(res.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary
- normalize direct `/v1/ai-sdk/chat` test callers to canonical `UIMessage.parts`
- add shared AI SDK test helpers for text and file parts
- add a regression test that rejects legacy `content` payloads at the HTTP boundary

## Validation
- `cargo test -p awaken-server --test ai_sdk_multi_turn legacy_content_messages_are_rejected`
- `npm test -- tests/agents.spec.ts tests/ai-sdk.spec.ts tests/concurrency.spec.ts tests/error-recovery.spec.ts tests/errors.spec.ts tests/generative-ui.spec.ts tests/lifecycle.spec.ts tests/llm-integration.spec.ts tests/multimodal.spec.ts tests/phase-hooks.spec.ts tests/protocols.spec.ts tests/real-llm.spec.ts tests/run-status.spec.ts tests/sse-events.spec.ts tests/stop-policy.spec.ts tests/tool-execution.spec.ts tests/tool-lifecycle.spec.ts`