### PR TITLE
fix(mcp): align transport and lifecycle with MCP spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "async-trait",
  "awaken-contract",
  "awaken-runtime",
+ "futures",
  "model-context-protocol",
  "reqwest 0.13.2",
  "serde",

--- a/crates/awaken-ext-mcp/Cargo.toml
+++ b/crates/awaken-ext-mcp/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "process", "time"] }
 reqwest = { workspace = true }
+futures = { workspace = true }
 mcp = { package = "model-context-protocol", version = "0.2", default-features = false, features = ["client"] }
 
 [dev-dependencies]

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use mcp::transport::{
     ClientInfo, InitializeCapabilities, InitializeResult, McpServerConnectionConfig,
     McpTransportError, SamplingCapabilities, ServerCapabilities, TransportTypeId,
@@ -546,10 +547,21 @@ pub(crate) struct ProgressAwareHttpTransport {
     next_id: AtomicI64,
     next_progress_token: AtomicI64,
     capabilities: tokio::sync::Mutex<Option<ServerCapabilities>>,
+    session: tokio::sync::RwLock<HttpSessionState>,
+    sampling_handler: Option<Arc<dyn SamplingHandler>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct HttpSessionState {
+    session_id: Option<String>,
+    protocol_version: Option<String>,
 }
 
 impl ProgressAwareHttpTransport {
-    pub(crate) fn connect(config: &McpServerConnectionConfig) -> Result<Self, McpTransportError> {
+    pub(crate) fn connect(
+        config: &McpServerConnectionConfig,
+        sampling_handler: Option<Arc<dyn SamplingHandler>>,
+    ) -> Result<Self, McpTransportError> {
         let endpoint = config.url.as_ref().ok_or_else(|| {
             McpTransportError::TransportError("HTTP transport requires URL".to_string())
         })?;
@@ -567,6 +579,8 @@ impl ProgressAwareHttpTransport {
             next_id: AtomicI64::new(1),
             next_progress_token: AtomicI64::new(1),
             capabilities: tokio::sync::Mutex::new(None),
+            session: tokio::sync::RwLock::new(HttpSessionState::default()),
+            sampling_handler,
         })
     }
 
@@ -581,14 +595,39 @@ impl ProgressAwareHttpTransport {
     }
 
     async fn initialize(&self) -> Result<ServerCapabilities, McpTransportError> {
-        let result: InitializeResult = serde_json::from_value(
-            self.send_request(
-                "initialize",
-                Some(initialize_params(json!({}), Value::Null)),
-                None,
+        let request_id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let response = self
+            .post_message(
+                JsonRpcMessage::Request(JsonRpcRequest::new(
+                    JsonRpcId::Number(request_id),
+                    "initialize".to_string(),
+                    Some(initialize_params(json!({}), Value::Null)),
+                )),
+                false,
             )
-            .await?,
-        )?;
+            .await?;
+
+        let session_id = response
+            .headers()
+            .get("MCP-Session-Id")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+
+        let body = self
+            .decode_http_body(response, request_id, None)
+            .await
+            .map_err(|e| McpTransportError::ProtocolError(format!("initialize failed: {e}")))?;
+        let result: InitializeResult = serde_json::from_value(body)?;
+
+        {
+            let mut session = self.session.write().await;
+            session.session_id = session_id;
+            session.protocol_version = Some(result.protocol_version.clone());
+        }
+
+        self.send_notification("notifications/initialized", Some(json!({})))
+            .await?;
+
         Ok(result.capabilities)
     }
 
@@ -600,30 +639,11 @@ impl ProgressAwareHttpTransport {
     ) -> Result<Value, McpTransportError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let request = JsonRpcRequest::new(JsonRpcId::Number(id), method.to_string(), params);
-
         let response = self
-            .client
-            .post(&self.endpoint)
-            .json(&request)
-            .send()
+            .post_message(JsonRpcMessage::Request(request), true)
+            .await?;
+        self.decode_http_body(response, id, progress_registration)
             .await
-            .map_err(|e| {
-                McpTransportError::TransportError(format!("HTTP request failed: {}", e))
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(McpTransportError::TransportError(format!(
-                "HTTP error: {} - {}",
-                status, body
-            )));
-        }
-
-        let body: Value = response.json().await.map_err(|e| {
-            McpTransportError::TransportError(format!("Failed to parse JSON response: {}", e))
-        })?;
-        decode_http_response_payload(body, id, progress_registration)
     }
 
     async fn send_initialized_request(
@@ -633,8 +653,274 @@ impl ProgressAwareHttpTransport {
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
         self.initialize_if_needed().await?;
-        self.send_request(method, params, progress_registration)
+        match self
+            .send_request(method, params.clone(), progress_registration.clone())
             .await
+        {
+            Ok(value) => Ok(value),
+            Err(McpTransportError::ProtocolError(message)) if message == "MCP session expired" => {
+                self.reset_session().await;
+                self.initialize_if_needed().await?;
+                self.send_request(method, params, progress_registration)
+                    .await
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn post_message(
+        &self,
+        message: JsonRpcMessage,
+        expect_response: bool,
+    ) -> Result<reqwest::Response, McpTransportError> {
+        let mut request = self.client.post(&self.endpoint).header(
+            reqwest::header::ACCEPT,
+            "application/json, text/event-stream",
+        );
+
+        let session = self.session.read().await.clone();
+        if let Some(protocol_version) = session.protocol_version {
+            request = request.header("MCP-Protocol-Version", protocol_version);
+        }
+        if let Some(session_id) = session.session_id {
+            request = request.header("MCP-Session-Id", session_id);
+        }
+
+        request = match message {
+            JsonRpcMessage::Request(request_body) => request.json(&request_body),
+            JsonRpcMessage::Notification(notification) => request.json(&notification),
+            JsonRpcMessage::Response(response) => request.json(&response),
+        };
+
+        let response = request.send().await.map_err(|e| {
+            McpTransportError::TransportError(format!("HTTP request failed: {}", e))
+        })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            if status == reqwest::StatusCode::NOT_FOUND
+                && self.session.read().await.session_id.is_some()
+            {
+                return Err(McpTransportError::ProtocolError(
+                    "MCP session expired".to_string(),
+                ));
+            }
+
+            let body = response.text().await.unwrap_or_default();
+            return Err(McpTransportError::TransportError(format!(
+                "HTTP error: {} - {}",
+                status, body
+            )));
+        }
+
+        if !expect_response
+            && status != reqwest::StatusCode::ACCEPTED
+            && status != reqwest::StatusCode::NO_CONTENT
+            && status != reqwest::StatusCode::OK
+        {
+            return Err(McpTransportError::ProtocolError(format!(
+                "Expected 202 Accepted for HTTP notification/response, got {}",
+                status
+            )));
+        }
+
+        Ok(response)
+    }
+
+    async fn send_notification(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<(), McpTransportError> {
+        let notification = JsonRpcNotification::new(method, params);
+        self.post_message(JsonRpcMessage::Notification(notification), false)
+            .await?;
+        Ok(())
+    }
+
+    async fn send_response_message(
+        &self,
+        response: JsonRpcResponse,
+    ) -> Result<(), McpTransportError> {
+        self.post_message(JsonRpcMessage::Response(response), false)
+            .await?;
+        Ok(())
+    }
+
+    async fn decode_http_body(
+        &self,
+        response: reqwest::Response,
+        request_id: i64,
+        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+    ) -> Result<Value, McpTransportError> {
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        if content_type.starts_with("application/json") {
+            let body: Value = response.json().await.map_err(|e| {
+                McpTransportError::TransportError(format!("Failed to parse JSON response: {}", e))
+            })?;
+            return decode_http_response_payload(body, request_id, progress_registration);
+        }
+
+        if content_type.starts_with("text/event-stream") {
+            return self
+                .decode_sse_response(response, request_id, progress_registration)
+                .await;
+        }
+
+        Err(McpTransportError::ProtocolError(format!(
+            "Unsupported HTTP content type: {}",
+            content_type
+        )))
+    }
+
+    async fn decode_sse_response(
+        &self,
+        response: reqwest::Response,
+        request_id: i64,
+        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+    ) -> Result<Value, McpTransportError> {
+        let progress_key = progress_registration.as_ref().map(|(key, _)| key.clone());
+        let progress_tx = progress_registration.as_ref().map(|(_, tx)| tx.clone());
+        let mut matched_response: Option<Result<Value, McpTransportError>> = None;
+        let mut event_lines: Vec<String> = Vec::new();
+        let mut line_buf: Vec<u8> = Vec::new();
+        let mut stream = response.bytes_stream();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| {
+                McpTransportError::TransportError(format!(
+                    "Failed to read SSE response body: {}",
+                    e
+                ))
+            })?;
+
+            for byte in chunk {
+                if byte == b'\n' {
+                    let mut line =
+                        String::from_utf8(std::mem::take(&mut line_buf)).map_err(|e| {
+                            McpTransportError::ProtocolError(format!(
+                                "Invalid UTF-8 in SSE response: {}",
+                                e
+                            ))
+                        })?;
+                    if line.ends_with('\r') {
+                        line.pop();
+                    }
+
+                    if line.is_empty() {
+                        if let Some(result) = self
+                            .process_sse_event(
+                                &event_lines,
+                                request_id,
+                                progress_key.as_ref(),
+                                progress_tx.as_ref(),
+                            )
+                            .await?
+                        {
+                            matched_response = Some(result);
+                            break;
+                        }
+                        event_lines.clear();
+                    } else {
+                        event_lines.push(line);
+                    }
+                } else {
+                    line_buf.push(byte);
+                }
+            }
+
+            if matched_response.is_some() {
+                break;
+            }
+        }
+
+        if matched_response.is_none() && !event_lines.is_empty() {
+            matched_response = self
+                .process_sse_event(
+                    &event_lines,
+                    request_id,
+                    progress_key.as_ref(),
+                    progress_tx.as_ref(),
+                )
+                .await?;
+        }
+
+        matched_response.unwrap_or_else(|| {
+            Err(McpTransportError::ProtocolError(format!(
+                "Missing response for request id {}",
+                request_id
+            )))
+        })
+    }
+
+    async fn process_sse_event(
+        &self,
+        lines: &[String],
+        request_id: i64,
+        progress_key: Option<&ProgressTokenKey>,
+        progress_tx: Option<&mpsc::UnboundedSender<McpProgressUpdate>>,
+    ) -> Result<Option<Result<Value, McpTransportError>>, McpTransportError> {
+        let mut data_parts = Vec::new();
+        for line in lines {
+            if line.starts_with(':') {
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("data:") {
+                data_parts.push(rest.trim_start().to_string());
+            }
+        }
+
+        if data_parts.is_empty() {
+            return Ok(None);
+        }
+
+        let payload = data_parts.join("\n");
+        if payload.is_empty() {
+            return Ok(None);
+        }
+
+        let message =
+            parse_json_rpc_message(serde_json::from_str::<Value>(&payload).map_err(|e| {
+                McpTransportError::ProtocolError(format!(
+                    "Invalid JSON payload in HTTP SSE response: {}",
+                    e
+                ))
+            })?)?;
+
+        match message {
+            JsonRpcMessage::Response(response) => {
+                if matches!(response.id, JsonRpcId::Number(id) if id == request_id) {
+                    return Ok(Some(map_response_payload(response.payload)));
+                }
+                Ok(None)
+            }
+            JsonRpcMessage::Notification(notification) => {
+                if let (Some(expected_key), Some(sender)) = (progress_key, progress_tx)
+                    && let Some((key, update)) = decode_progress_notification(notification)
+                    && key == *expected_key
+                {
+                    let _ = sender.send(update);
+                }
+                Ok(None)
+            }
+            JsonRpcMessage::Request(request) => {
+                let response =
+                    handle_server_request(self.sampling_handler.as_deref(), &request).await;
+                self.send_response_message(response).await?;
+                Ok(None)
+            }
+        }
+    }
+
+    async fn reset_session(&self) {
+        *self.capabilities.lock().await = None;
+        *self.session.write().await = HttpSessionState::default();
     }
 }
 
@@ -754,7 +1040,7 @@ pub(crate) async fn connect_transport(
             Ok(Arc::new(transport))
         }
         TransportTypeId::Http => {
-            let transport = ProgressAwareHttpTransport::connect(config)?;
+            let transport = ProgressAwareHttpTransport::connect(config, sampling_handler)?;
             Ok(Arc::new(transport))
         }
     }

--- a/crates/awaken-ext-mcp/tests/mcp_tests.rs
+++ b/crates/awaken-ext-mcp/tests/mcp_tests.rs
@@ -322,10 +322,17 @@ impl McpToolTransport for FakeUiTransport {
 // ── HTTP test helpers ──
 
 #[derive(Clone)]
+struct HttpRequestSpec {
+    headers: std::collections::HashMap<String, String>,
+    body: Value,
+}
+
+#[derive(Clone)]
 struct HttpResponseSpec {
     status: u16,
     content_type: &'static str,
     body: String,
+    headers: Vec<(String, String)>,
 }
 
 impl HttpResponseSpec {
@@ -334,6 +341,22 @@ impl HttpResponseSpec {
             status: 200,
             content_type: "application/json",
             body: body.to_string(),
+            headers: Vec::new(),
+        }
+    }
+
+    fn json_with_headers(
+        body: Value,
+        headers: Vec<(impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        Self {
+            status: 200,
+            content_type: "application/json",
+            body: body.to_string(),
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         }
     }
 
@@ -342,6 +365,25 @@ impl HttpResponseSpec {
             status,
             content_type: "text/plain",
             body: body.into(),
+            headers: Vec::new(),
+        }
+    }
+
+    fn accepted() -> Self {
+        Self {
+            status: 202,
+            content_type: "text/plain",
+            body: String::new(),
+            headers: Vec::new(),
+        }
+    }
+
+    fn sse(body: impl Into<String>) -> Self {
+        Self {
+            status: 200,
+            content_type: "text/event-stream",
+            body: body.into(),
+            headers: Vec::new(),
         }
     }
 }
@@ -349,6 +391,7 @@ impl HttpResponseSpec {
 fn status_text(status: u16) -> &'static str {
     match status {
         200 => "OK",
+        202 => "Accepted",
         400 => "Bad Request",
         500 => "Internal Server Error",
         _ => "OK",
@@ -373,7 +416,17 @@ fn content_length(headers: &str) -> usize {
         .unwrap_or(0)
 }
 
-async fn read_json_body(stream: &mut TcpStream) -> Option<Value> {
+fn parse_headers(raw: &str) -> std::collections::HashMap<String, String> {
+    raw.lines()
+        .skip(1)
+        .filter_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            Some((key.trim().to_ascii_lowercase(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> Option<HttpRequestSpec> {
     let mut buf = Vec::new();
     let mut chunk = [0_u8; 1024];
     let (header_end_pos, body_len) = loop {
@@ -398,11 +451,16 @@ async fn read_json_body(stream: &mut TcpStream) -> Option<Value> {
         buf.extend_from_slice(&chunk[..n]);
     }
 
-    serde_json::from_slice(&buf[header_end_pos..header_end_pos + body_len]).ok()
+    let headers = std::str::from_utf8(&buf[..header_end_pos]).ok()?;
+    let body = serde_json::from_slice(&buf[header_end_pos..header_end_pos + body_len]).ok()?;
+    Some(HttpRequestSpec {
+        headers: parse_headers(headers),
+        body,
+    })
 }
 
 async fn spawn_http_server(
-    handler: Arc<dyn Fn(Value) -> HttpResponseSpec + Send + Sync>,
+    handler: Arc<dyn Fn(HttpRequestSpec) -> HttpResponseSpec + Send + Sync>,
 ) -> (String, tokio::task::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -415,18 +473,28 @@ async fn spawn_http_server(
             };
             let handler = Arc::clone(&handler);
             tokio::spawn(async move {
-                let Some(request_body) = read_json_body(&mut stream).await else {
+                let Some(request) = read_http_request(&mut stream).await else {
                     return;
                 };
-                let response = handler(request_body);
+                let response = if request.body["method"].is_null()
+                    && (request.body.get("result").is_some() || request.body.get("error").is_some())
+                {
+                    HttpResponseSpec::accepted()
+                } else {
+                    handler(request)
+                };
                 let payload = response.body;
-                let head = format!(
-                    "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                let mut head = format!(
+                    "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n",
                     response.status,
                     status_text(response.status),
                     response.content_type,
                     payload.len()
                 );
+                for (key, value) in response.headers {
+                    head.push_str(&format!("{key}: {value}\r\n"));
+                }
+                head.push_str("\r\n");
                 let _ = stream.write_all(head.as_bytes()).await;
                 let _ = stream.write_all(payload.as_bytes()).await;
                 let _ = stream.shutdown().await;
@@ -436,19 +504,22 @@ async fn spawn_http_server(
     (format!("http://{}", addr), handle)
 }
 
-fn initialize_response(request: &Value, capabilities: Value) -> HttpResponseSpec {
-    HttpResponseSpec::json(json!({
-        "jsonrpc": "2.0",
-        "id": request["id"].clone(),
-        "result": {
-            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
-            "capabilities": capabilities,
-            "serverInfo": {
-                "name": "test-server",
-                "version": "1.0.0"
+fn initialize_response(request: &HttpRequestSpec, capabilities: Value) -> HttpResponseSpec {
+    HttpResponseSpec::json_with_headers(
+        json!({
+            "jsonrpc": "2.0",
+            "id": request.body["id"].clone(),
+            "result": {
+                "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                "capabilities": capabilities,
+                "serverInfo": {
+                    "name": "test-server",
+                    "version": "1.0.0"
+                }
             }
-        }
-    }))
+        }),
+        vec![("MCP-Session-Id", "test-session")],
+    )
 }
 
 async fn wait_until(
@@ -1459,21 +1530,31 @@ async fn mcp_tool_command_is_empty() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn connect_http_registry_discovers_tools_and_executes() {
-    let (endpoint, server) = spawn_http_server(Arc::new(|request| {
-        let method = request["method"].as_str().unwrap_or_default();
+    let seen_requests = Arc::new(std::sync::Mutex::new(Vec::<HttpRequestSpec>::new()));
+    let seen_requests_for_handler = Arc::clone(&seen_requests);
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        seen_requests_for_handler
+            .lock()
+            .unwrap()
+            .push(request.clone());
+        let method = request.body["method"].as_str().unwrap_or_default();
         match method {
-            "initialize" => HttpResponseSpec::json(json!({
-                "jsonrpc": "2.0",
-                "id": request["id"].clone(),
-                "result": {
-                    "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "http-test", "version": "1.0.0"}
-                }
-            })),
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => HttpResponseSpec::json_with_headers(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "http-test", "version": "1.0.0"}
+                    }
+                }),
+                vec![("MCP-Session-Id", "test-session")],
+            ),
             "tools/list" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {
                     "tools": [{
                         "name": "echo_http",
@@ -1488,12 +1569,14 @@ async fn connect_http_registry_discovers_tools_and_executes() {
                 }
             })),
             "tools/call" => {
-                let token = request["params"]["_meta"]["progressToken"].clone();
-                let text = request["params"]["arguments"]["message"]
+                let token = request.body["params"]["_meta"]["progressToken"].clone();
+                let text = request.body["params"]["arguments"]["message"]
                     .as_str()
                     .unwrap_or("ok");
-                HttpResponseSpec::json(json!([
-                    {
+                HttpResponseSpec::sse(format!(
+                    "data: {}\n\n\
+                     data: {}\n\n",
+                    json!({
                         "jsonrpc": "2.0",
                         "method": "notifications/progress",
                         "params": {
@@ -1502,19 +1585,19 @@ async fn connect_http_registry_discovers_tools_and_executes() {
                             "total": 4.0,
                             "message": "working"
                         }
-                    },
-                    {
+                    }),
+                    json!({
                         "jsonrpc": "2.0",
-                        "id": request["id"].clone(),
+                        "id": request.body["id"].clone(),
                         "result": {
                             "content": [{"type":"text", "text": text}]
                         }
-                    }
-                ]))
+                    })
+                ))
             }
             _ => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {}
             })),
         }
@@ -1547,12 +1630,52 @@ async fn connect_http_registry_discovers_tools_and_executes() {
         .unwrap();
     server.abort();
     assert!(result.result.is_success());
+
+    let seen_requests = seen_requests.lock().unwrap();
+    let initialize_request = seen_requests
+        .iter()
+        .find(|request| request.body["method"] == "initialize")
+        .expect("initialize request");
+    assert_eq!(
+        initialize_request.headers.get("accept").map(String::as_str),
+        Some("application/json, text/event-stream")
+    );
+
+    let initialized_notification = seen_requests
+        .iter()
+        .find(|request| request.body["method"] == "notifications/initialized")
+        .expect("initialized notification");
+    assert_eq!(
+        initialized_notification
+            .headers
+            .get("mcp-session-id")
+            .map(String::as_str),
+        Some("test-session")
+    );
+
+    let tools_list_request = seen_requests
+        .iter()
+        .find(|request| request.body["method"] == "tools/list")
+        .expect("tools/list request");
+    assert_eq!(
+        tools_list_request
+            .headers
+            .get("mcp-protocol-version")
+            .map(String::as_str),
+        Some(mcp::MCP_PROTOCOL_VERSION)
+    );
 }
 
 #[tokio::test]
 async fn http_non_success_status_is_reported() {
-    let (endpoint, server) =
-        spawn_http_server(Arc::new(|_| HttpResponseSpec::text(500, "upstream error"))).await;
+    let (endpoint, server) = spawn_http_server(Arc::new(|request| {
+        if request.body["method"] == "notifications/initialized" {
+            HttpResponseSpec::accepted()
+        } else {
+            HttpResponseSpec::text(500, "upstream error")
+        }
+    }))
+    .await;
     let cfg = McpServerConnectionConfig::http("http_error_status", endpoint);
     let err = McpToolRegistryManager::connect([cfg])
         .await
@@ -1564,18 +1687,19 @@ async fn http_non_success_status_is_reported() {
 #[tokio::test]
 async fn http_call_tool_with_is_error_result_returns_server_error() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
-        match request["method"].as_str().unwrap_or_default() {
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({})),
             "tools/list" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {
                     "tools": [{"name": "echo", "inputSchema": {"type": "object", "properties": {}}}]
                 }
             })),
             "tools/call" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {
                     "content": [{"type": "text", "text": "tool failed"}],
                     "isError": true
@@ -1607,18 +1731,19 @@ async fn http_call_tool_with_is_error_result_returns_server_error() {
 #[tokio::test]
 async fn http_call_tool_preserves_structured_content() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
-        match request["method"].as_str().unwrap_or_default() {
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({})),
             "tools/list" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {
                     "tools": [{"name": "sum", "inputSchema": {"type": "object", "properties": {}}}]
                 }
             })),
             "tools/call" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {
                     "content": [{"type": "text", "text": "sum complete"}],
                     "structuredContent": {"sum": 3, "values": [1, 2]}
@@ -1650,16 +1775,17 @@ async fn http_call_tool_preserves_structured_content() {
 #[tokio::test]
 async fn http_list_prompts_parses_prompt_definitions() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
-        match request["method"].as_str().unwrap_or_default() {
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({"prompts": {}})),
             "tools/list" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {"tools": []}
             })),
             "prompts/list" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {
                     "prompts": [{
                         "name": "review",
@@ -1691,16 +1817,17 @@ async fn http_list_prompts_parses_prompt_definitions() {
 #[tokio::test]
 async fn http_list_resources_parses_resource_definitions() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
-        match request["method"].as_str().unwrap_or_default() {
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({"resources": {}})),
             "tools/list" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {"tools": []}
             })),
             "resources/list" => HttpResponseSpec::json(json!({
                 "jsonrpc": "2.0",
-                "id": request["id"].clone(),
+                "id": request.body["id"].clone(),
                 "result": {
                     "resources": [{
                         "uri": "file://guide.md",

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -96,6 +96,8 @@ pub struct AppState {
     /// Per-run replay buffers for SSE stream resumption.
     /// Stores `(buffer, created_at)` so stale entries can be purged.
     pub replay_buffers: ReplayBufferMap,
+    /// MCP Streamable HTTP session state.
+    pub mcp_http: Arc<crate::protocols::mcp::http::McpHttpState>,
 }
 
 impl AppState {
@@ -114,6 +116,7 @@ impl AppState {
             resolver,
             config,
             replay_buffers: Arc::new(Mutex::new(HashMap::new())),
+            mcp_http: Arc::new(crate::protocols::mcp::http::McpHttpState::new()),
         }
     }
 

--- a/crates/awaken-server/src/protocols/mcp/adapter.rs
+++ b/crates/awaken-server/src/protocols/mcp/adapter.rs
@@ -3,8 +3,8 @@
 //! Each registered agent becomes one `McpTool` whose `call()` runs the agent
 //! loop, collects the final assistant text, and returns it as `ToolContent`.
 //!
-//! Progress notifications are forwarded via the MCP server's outbound channel
-//! so that clients receive real-time updates during long-running agent runs.
+//! Logging notifications are forwarded via the MCP server's outbound channel
+//! so that clients can observe long-running agent runs.
 
 use std::sync::Arc;
 
@@ -24,8 +24,8 @@ use crate::transport::channel_sink::ChannelEventSink;
 /// Calling this tool sends a user message to the agent, runs the full agent
 /// loop, and returns the final assistant text as `ToolContent::text`.
 ///
-/// If `outbound_tx` is set, progress notifications (tool calls, text streaming)
-/// are sent as MCP `notifications/progress` messages during execution.
+/// If `outbound_tx` is set, structured logging notifications are sent during
+/// execution.
 pub struct AgentMcpTool {
     agent_id: String,
     description: String,
@@ -43,28 +43,10 @@ impl AgentMcpTool {
         }
     }
 
-    /// Attach the MCP server's outbound channel for sending progress notifications.
+    /// Attach the MCP server's outbound channel for sending logging notifications.
     pub fn with_outbound(mut self, tx: mpsc::Sender<ServerOutbound>) -> Self {
         self.outbound_tx = Some(tx);
         self
-    }
-
-    /// Send a progress notification via the MCP server's outbound channel.
-    async fn send_progress(&self, progress: f64, total: f64, message: &str) {
-        if let Some(tx) = &self.outbound_tx {
-            let params = serde_json::json!({
-                "progressToken": self.agent_id,
-                "progress": progress,
-                "total": total,
-                "message": message,
-            });
-            let notification = JsonRpcNotification {
-                jsonrpc: "2.0".to_string(),
-                method: "notifications/progress".to_string(),
-                params: Some(params),
-            };
-            let _ = tx.send(ServerOutbound::Notification(notification)).await;
-        }
     }
 
     /// Send a log notification via the MCP server's outbound channel.
@@ -73,7 +55,7 @@ impl AgentMcpTool {
             let params = serde_json::json!({
                 "level": level,
                 "logger": format!("agent/{}", self.agent_id),
-                "message": message,
+                "data": message,
             });
             let notification = JsonRpcNotification {
                 jsonrpc: "2.0".to_string(),
@@ -120,12 +102,12 @@ impl McpTool for AgentMcpTool {
             let (event_tx, mut event_rx) = mpsc::unbounded_channel();
             let sink = Arc::new(ChannelEventSink::new(event_tx));
 
-            self.send_progress(0.0, 1.0, "starting agent run").await;
+            self.send_log("info", "starting agent run").await;
 
             let runtime = Arc::clone(&self.runtime);
             let run_handle = tokio::spawn(async move { runtime.run(request, sink).await });
 
-            // Collect text deltas and emit progress from agent events.
+            // Collect text deltas and emit logs from agent events.
             let mut assistant_text = String::new();
             let mut step_count: u32 = 0;
             while let Some(event) = event_rx.recv().await {
@@ -135,12 +117,7 @@ impl McpTool for AgentMcpTool {
                     }
                     AgentEvent::StepStart { .. } => {
                         step_count += 1;
-                        self.send_progress(
-                            step_count as f64,
-                            0.0, // total unknown
-                            &format!("step {step_count}"),
-                        )
-                        .await;
+                        self.send_log("info", &format!("step {step_count}")).await;
                     }
                     AgentEvent::ToolCallStart { name, .. } => {
                         self.send_log("info", &format!("calling tool: {name}"))
@@ -174,7 +151,7 @@ impl McpTool for AgentMcpTool {
             // Await the run to propagate panics.
             match run_handle.await {
                 Ok(Ok(_)) => {
-                    self.send_progress(1.0, 1.0, "completed").await;
+                    self.send_log("notice", "completed").await;
                 }
                 Ok(Err(e)) => {
                     self.send_log("error", &format!("agent run failed: {e}"))
@@ -263,12 +240,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn progress_notifications_are_sent() {
+    async fn logging_notifications_are_sent() {
         let (tx, mut rx) = mpsc::channel(64);
         let tool = AgentMcpTool::new("test-agent".to_string(), "test".to_string(), test_runtime())
             .with_outbound(tx);
 
-        // Call will fail (stub resolver), but progress should be sent first.
+        // Call will fail (stub resolver), but logs should be sent first.
         let _ = tool.call(json!({"message": "hello"})).await;
 
         // Collect all notifications.
@@ -279,12 +256,12 @@ mod tests {
             }
         }
 
-        // Should have at least the "starting" progress notification.
+        // Should have at least one structured logging notification.
         assert!(
             notifications
                 .iter()
-                .any(|n| n.method == "notifications/progress"),
-            "expected at least one progress notification, got: {notifications:?}"
+                .any(|n| n.method == "notifications/message"),
+            "expected at least one logging notification, got: {notifications:?}"
         );
     }
 }

--- a/crates/awaken-server/src/protocols/mcp/http.rs
+++ b/crates/awaken-server/src/protocols/mcp/http.rs
@@ -1,172 +1,639 @@
 //! MCP HTTP transport: Axum routes for MCP Streamable HTTP.
 //!
 //! Implements the MCP Streamable HTTP transport specification:
-//! - `POST /v1/mcp` — accepts a JSON-RPC request, returns a JSON-RPC response.
-//! - `GET  /v1/mcp` — SSE endpoint for server-initiated messages (notifications).
+//! - `POST /v1/mcp` — accepts a JSON-RPC request/notification/response.
+//! - `GET  /v1/mcp` — optional SSE endpoint for server-initiated messages.
+//! - `DELETE /v1/mcp` — optional explicit session termination.
 
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
+use axum::body::Bytes;
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::header::{HOST, ORIGIN};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
-use serde_json::Value;
-use tokio::sync::mpsc;
-
-use mcp::protocol::{ClientInbound, JsonRpcId, JsonRpcRequest, ServerOutbound};
+use futures::StreamExt;
+use mcp::protocol::{
+    ClientInbound, JsonRpcId, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+    ServerOutbound,
+};
 use mcp::server::McpServer;
+use serde_json::Value;
+use tokio::sync::{Mutex, RwLock, Semaphore, mpsc, oneshot};
+use uuid::Uuid;
 
 use crate::app::AppState;
+use crate::http_sse::{format_sse_data_with_id, sse_body_stream, sse_response};
 
-/// Shared state for the MCP protocol layer.
-///
-/// Held in an `Arc` inside `AppState` (via extension) so that all MCP routes
-/// share the same server instance and channels.
-pub struct McpState {
-    pub server: Arc<McpServer>,
-    pub inbound_tx: mpsc::Sender<ClientInbound>,
+const HEADER_SESSION_ID: &str = "MCP-Session-Id";
+const HEADER_PROTOCOL_VERSION: &str = "MCP-Protocol-Version";
+const JSON_RPC_VERSION: &str = "2.0";
+
+#[derive(Default)]
+pub struct McpHttpState {
+    sessions: RwLock<HashMap<String, Arc<McpHttpSession>>>,
+}
+
+impl McpHttpState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    async fn insert(&self, session: Arc<McpHttpSession>) {
+        self.sessions
+            .write()
+            .await
+            .insert(session.id.clone(), session);
+    }
+
+    async fn get(&self, session_id: &str) -> Option<Arc<McpHttpSession>> {
+        self.sessions.read().await.get(session_id).cloned()
+    }
+
+    async fn remove(&self, session_id: &str) -> Option<Arc<McpHttpSession>> {
+        self.sessions.write().await.remove(session_id)
+    }
+}
+
+struct ActiveSseStream {
+    request_id: JsonRpcId,
+    tx: mpsc::Sender<Bytes>,
+}
+
+struct McpHttpSession {
+    id: String,
+    server: Arc<McpServer>,
+    inbound_tx: mpsc::Sender<ClientInbound>,
+    protocol_version: RwLock<String>,
+    pending_responses: Mutex<HashMap<JsonRpcId, oneshot::Sender<JsonRpcResponse>>>,
+    active_stream: Mutex<Option<ActiveSseStream>>,
+    request_permit: Arc<Semaphore>,
+    next_event_id: AtomicU64,
+}
+
+impl McpHttpSession {
+    fn new(runtime: &Arc<awaken_runtime::AgentRuntime>) -> Arc<Self> {
+        let (server, mut channels) = super::create_mcp_server(runtime);
+        let session = Arc::new(Self {
+            id: Uuid::new_v4().to_string(),
+            server,
+            inbound_tx: channels.inbound_tx.clone(),
+            protocol_version: RwLock::new(mcp::MCP_PROTOCOL_VERSION.to_string()),
+            pending_responses: Mutex::new(HashMap::new()),
+            active_stream: Mutex::new(None),
+            request_permit: Arc::new(Semaphore::new(1)),
+            next_event_id: AtomicU64::new(1),
+        });
+
+        let weak = Arc::downgrade(&session);
+        tokio::spawn(async move {
+            while let Some(outbound) = channels.outbound_rx.recv().await {
+                let Some(session) = weak.upgrade() else {
+                    break;
+                };
+                session.route_outbound(outbound).await;
+            }
+        });
+
+        session
+    }
+
+    async fn stop(&self) {
+        self.server.stop();
+    }
+
+    async fn set_protocol_version(&self, version: String) {
+        *self.protocol_version.write().await = version;
+    }
+
+    async fn protocol_version(&self) -> String {
+        self.protocol_version.read().await.clone()
+    }
+
+    async fn dispatch_json_request(
+        &self,
+        request: JsonRpcRequest,
+    ) -> Result<JsonRpcResponse, McpApiError> {
+        let _permit = self
+            .request_permit
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| McpApiError::internal("failed to acquire MCP request permit"))?;
+
+        let (tx, rx) = oneshot::channel();
+        self.pending_responses
+            .lock()
+            .await
+            .insert(request.id.clone(), tx);
+
+        if let Err(_e) = self
+            .inbound_tx
+            .send(ClientInbound::Request(request.clone()))
+            .await
+        {
+            self.pending_responses.lock().await.remove(&request.id);
+            return Err(McpApiError::internal("server channel closed"));
+        }
+
+        rx.await
+            .map_err(|_| McpApiError::internal("no response from MCP server"))
+    }
+
+    async fn dispatch_streaming_request(
+        &self,
+        request: JsonRpcRequest,
+    ) -> Result<Response, McpApiError> {
+        let permit = self
+            .request_permit
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| McpApiError::internal("failed to acquire MCP request permit"))?;
+
+        let (tx, rx) = mpsc::channel::<Bytes>(64);
+        tx.send(self.prime_sse_frame())
+            .await
+            .map_err(|_| McpApiError::internal("failed to prime MCP SSE stream"))?;
+
+        {
+            let mut active = self.active_stream.lock().await;
+            *active = Some(ActiveSseStream {
+                request_id: request.id.clone(),
+                tx: tx.clone(),
+            });
+        }
+
+        if let Err(_e) = self.inbound_tx.send(ClientInbound::Request(request)).await {
+            self.active_stream.lock().await.take();
+            return Err(McpApiError::internal("server channel closed"));
+        }
+
+        let stream = sse_body_stream(rx);
+        let guarded = async_stream::stream! {
+            let _permit = permit;
+            tokio::pin!(stream);
+            while let Some(item) = stream.next().await {
+                yield item;
+            }
+        };
+
+        Ok(sse_response(guarded))
+    }
+
+    async fn send_inbound(&self, inbound: ClientInbound) -> Result<(), McpApiError> {
+        self.inbound_tx
+            .send(inbound)
+            .await
+            .map_err(|_| McpApiError::internal("server channel closed"))
+    }
+
+    async fn route_outbound(&self, outbound: ServerOutbound) {
+        match outbound {
+            ServerOutbound::Response(response) => {
+                if self.route_response_to_stream(&response).await {
+                    return;
+                }
+                if let Some(tx) = self.pending_responses.lock().await.remove(&response.id) {
+                    let _ = tx.send(response);
+                }
+            }
+            ServerOutbound::Notification(notification) => {
+                self.route_stream_message(JsonRpcMessage::Notification(notification))
+                    .await;
+            }
+            ServerOutbound::Request(request) => {
+                self.route_stream_message(JsonRpcMessage::Request(request))
+                    .await;
+            }
+        }
+    }
+
+    async fn route_response_to_stream(&self, response: &JsonRpcResponse) -> bool {
+        let maybe_tx = {
+            let mut active = self.active_stream.lock().await;
+            if active
+                .as_ref()
+                .is_some_and(|stream| stream.request_id == response.id)
+            {
+                active.take().map(|stream| stream.tx)
+            } else {
+                None
+            }
+        };
+
+        let Some(tx) = maybe_tx else {
+            return false;
+        };
+        let Ok(json) = serde_json::to_string(response) else {
+            return true;
+        };
+        let _ = tx.send(self.sse_data_frame(&json)).await;
+        true
+    }
+
+    async fn route_stream_message(&self, message: JsonRpcMessage) {
+        let tx = {
+            self.active_stream
+                .lock()
+                .await
+                .as_ref()
+                .map(|stream| stream.tx.clone())
+        };
+        let Some(tx) = tx else {
+            return;
+        };
+        let Ok(json) = serde_json::to_string(&message) else {
+            return;
+        };
+        let _ = tx.send(self.sse_data_frame(&json)).await;
+    }
+
+    fn next_event_id(&self) -> u64 {
+        self.next_event_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn prime_sse_frame(&self) -> Bytes {
+        Bytes::from(format!("id: {}\ndata:\n\n", self.next_event_id()))
+    }
+
+    fn sse_data_frame(&self, json: &str) -> Bytes {
+        format_sse_data_with_id(json, self.next_event_id())
+    }
+}
+
+#[derive(Debug)]
+enum ParsedInbound {
+    Request(JsonRpcRequest),
+    Notification(JsonRpcNotification),
+    Response(JsonRpcResponse),
 }
 
 /// Build MCP routes.
-///
-/// The MCP server is lazily created from `AppState.runtime` on first access.
-/// We store it as an Axum extension for subsequent requests.
 pub fn mcp_routes() -> Router<AppState> {
     Router::new()
         .route("/v1/mcp", post(mcp_post))
         .route("/v1/mcp", get(mcp_sse))
+        .route("/v1/mcp", delete(mcp_delete))
 }
 
-/// POST /v1/mcp — JSON-RPC request/response.
-///
-/// Accepts a single JSON-RPC 2.0 message, dispatches it through the MCP server,
-/// and returns the response synchronously.
 async fn mcp_post(
     State(st): State<AppState>,
-    Json(body): Json<Value>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Result<Response, McpApiError> {
-    // Parse the JSON-RPC request.
-    let method = body
-        .get("method")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
+    validate_origin(&headers)?;
+    validate_protocol_header_for_initialize(&headers)?;
 
-    let id = body
-        .get("id")
-        .map(|v| {
-            if let Some(n) = v.as_i64() {
-                JsonRpcId::Number(n)
-            } else if let Some(s) = v.as_str() {
-                JsonRpcId::String(s.to_string())
-            } else {
-                JsonRpcId::Null
-            }
-        })
-        .unwrap_or(JsonRpcId::Null);
-
-    let params = body.get("params").cloned();
-
-    if method.is_empty() {
-        return Err(McpApiError::BadRequest("missing 'method' field".into()));
-    }
-
-    // Check if this is a notification (no id field in original body).
-    let is_notification = body.get("id").is_none_or(|v| v.is_null());
-
-    // Create a dedicated McpServer per request pair to avoid channel contention.
-    // For a production-grade implementation, you'd use a session-based approach.
-    let (_server, mut channels) = super::create_mcp_server(&st.runtime);
-
-    if is_notification {
-        // Notifications don't expect a response.
-        let notification = mcp::JsonRpcNotification {
-            jsonrpc: "2.0".to_string(),
-            method,
-            params,
-        };
-        let _ = channels
-            .inbound_tx
-            .send(ClientInbound::Notification(notification))
-            .await;
-        return Ok(StatusCode::ACCEPTED.into_response());
-    }
-
-    let request = JsonRpcRequest {
-        jsonrpc: "2.0".to_string(),
-        id: id.clone(),
-        method,
-        params,
-    };
-
-    channels
-        .inbound_tx
-        .send(ClientInbound::Request(request))
-        .await
-        .map_err(|_| McpApiError::Internal("server channel closed".into()))?;
-
-    // Read the response from the outbound channel.
-    // Skip notifications (progress, logs) and wait for the actual Response.
-    loop {
-        let outbound = channels
-            .outbound_rx
-            .recv()
-            .await
-            .ok_or_else(|| McpApiError::Internal("no response from MCP server".into()))?;
-
-        match outbound {
-            ServerOutbound::Response(resp) => {
-                let json = serde_json::to_value(&resp)
-                    .map_err(|e| McpApiError::Internal(format!("serialization error: {e}")))?;
-                return Ok(Json(json).into_response());
-            }
-            ServerOutbound::Notification(_) | ServerOutbound::Request(_) => {
-                // Skip notifications/server-requests, keep waiting for the response.
-                continue;
-            }
+    match parse_inbound_message(&body)? {
+        ParsedInbound::Request(request) => handle_request_post(&st, headers, request).await,
+        ParsedInbound::Notification(notification) => {
+            let session = require_session(&st, &headers).await?;
+            validate_session_protocol_header(&headers, &session).await?;
+            session
+                .send_inbound(ClientInbound::Notification(notification))
+                .await?;
+            Ok(StatusCode::ACCEPTED.into_response())
+        }
+        ParsedInbound::Response(response) => {
+            let session = require_session(&st, &headers).await?;
+            validate_session_protocol_header(&headers, &session).await?;
+            session
+                .send_inbound(ClientInbound::Response(response))
+                .await?;
+            Ok(StatusCode::ACCEPTED.into_response())
         }
     }
 }
 
-/// GET /v1/mcp — SSE endpoint for server-initiated messages.
-///
-/// Returns a simple informational response for now (SSE streaming for
-/// server-initiated notifications can be added when needed).
-async fn mcp_sse(State(_st): State<AppState>) -> Response {
-    // MCP Streamable HTTP: the GET endpoint is for server-initiated messages.
-    // For tool-call-only scenarios (no server push), return 405.
-    (
-        StatusCode::METHOD_NOT_ALLOWED,
-        Json(serde_json::json!({
-            "error": "SSE endpoint not yet implemented; use POST /v1/mcp for requests"
-        })),
+async fn handle_request_post(
+    st: &AppState,
+    headers: HeaderMap,
+    request: JsonRpcRequest,
+) -> Result<Response, McpApiError> {
+    if request.method == "initialize" {
+        if headers.contains_key(HEADER_SESSION_ID) {
+            return Err(McpApiError::bad_request(
+                "initialize requests must not include an MCP session id",
+            ));
+        }
+
+        let session = McpHttpSession::new(&st.runtime);
+        let response = session.dispatch_json_request(request).await?;
+        if response.is_success() {
+            if let Some(version) = response_protocol_version(&response) {
+                session.set_protocol_version(version).await;
+            }
+            st.mcp_http.insert(Arc::clone(&session)).await;
+
+            let mut http_response = Json(serde_json::to_value(&response).map_err(|e| {
+                McpApiError::internal(format!("failed to serialize MCP response: {e}"))
+            })?)
+            .into_response();
+            http_response.headers_mut().insert(
+                HEADER_SESSION_ID,
+                HeaderValue::from_str(&session.id).map_err(|e| {
+                    McpApiError::internal(format!("invalid MCP session id header: {e}"))
+                })?,
+            );
+            return Ok(http_response);
+        }
+
+        session.stop().await;
+        return Ok(Json(serde_json::to_value(response).map_err(|e| {
+            McpApiError::internal(format!("failed to serialize MCP response: {e}"))
+        })?)
+        .into_response());
+    }
+
+    let session = require_session(st, &headers).await?;
+    validate_session_protocol_header(&headers, &session).await?;
+
+    if request.method == "tools/call" {
+        return session.dispatch_streaming_request(request).await;
+    }
+
+    let response = session.dispatch_json_request(request).await?;
+    Ok(Json(
+        serde_json::to_value(response)
+            .map_err(|e| McpApiError::internal(format!("failed to serialize MCP response: {e}")))?,
     )
-        .into_response()
+    .into_response())
 }
 
-/// MCP-specific API error.
+async fn mcp_sse(State(_st): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(err) = validate_origin(&headers) {
+        return err.into_response();
+    }
+    StatusCode::METHOD_NOT_ALLOWED.into_response()
+}
+
+async fn mcp_delete(
+    State(st): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Response, McpApiError> {
+    validate_origin(&headers)?;
+    let session_id = header_value(&headers, HEADER_SESSION_ID)
+        .ok_or_else(|| McpApiError::bad_request("missing MCP-Session-Id header"))?;
+
+    let Some(session) = st.mcp_http.remove(&session_id).await else {
+        return Ok(StatusCode::NOT_FOUND.into_response());
+    };
+
+    session.stop().await;
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
+fn parse_inbound_message(body: &[u8]) -> Result<ParsedInbound, McpApiError> {
+    let value: Value = serde_json::from_slice(body)
+        .map_err(|e| McpApiError::parse_error(format!("failed to parse JSON-RPC message: {e}")))?;
+
+    if !value.is_object() {
+        return Err(McpApiError::invalid_request(
+            None,
+            "HTTP body must contain exactly one JSON-RPC object",
+        ));
+    }
+
+    let id = parse_json_rpc_id(&value);
+    validate_jsonrpc_version(&value, id.clone())?;
+
+    let method = value.get("method").and_then(Value::as_str);
+    if let Some(method) = method {
+        if method.is_empty() {
+            return Err(McpApiError::invalid_request(id, "missing 'method' field"));
+        }
+
+        match value.get("id") {
+            Some(Value::Null) => {
+                return Err(McpApiError::invalid_request(
+                    Some(JsonRpcId::Null),
+                    "MCP requests MUST use string or integer IDs; notifications MUST omit the id field",
+                ));
+            }
+            Some(_) => {
+                let request: JsonRpcRequest = serde_json::from_value(value).map_err(|e| {
+                    McpApiError::invalid_request(id, format!("invalid JSON-RPC request: {e}"))
+                })?;
+                return Ok(ParsedInbound::Request(request));
+            }
+            None => {
+                let notification: JsonRpcNotification =
+                    serde_json::from_value(value).map_err(|e| {
+                        McpApiError::invalid_request(
+                            None,
+                            format!("invalid JSON-RPC notification: {e}"),
+                        )
+                    })?;
+                return Ok(ParsedInbound::Notification(notification));
+            }
+        }
+    }
+
+    if matches!(value.get("id"), Some(Value::Null)) {
+        return Err(McpApiError::invalid_request(
+            Some(JsonRpcId::Null),
+            "JSON-RPC responses MUST use the original string or integer request id",
+        ));
+    }
+
+    if value.get("result").is_some() || value.get("error").is_some() {
+        let response: JsonRpcResponse = serde_json::from_value(value).map_err(|e| {
+            McpApiError::invalid_request(id, format!("invalid JSON-RPC response: {e}"))
+        })?;
+        return Ok(ParsedInbound::Response(response));
+    }
+
+    Err(McpApiError::invalid_request(
+        id,
+        "unrecognized JSON-RPC payload",
+    ))
+}
+
+fn validate_jsonrpc_version(value: &Value, id: Option<JsonRpcId>) -> Result<(), McpApiError> {
+    match value.get("jsonrpc").and_then(Value::as_str) {
+        Some(JSON_RPC_VERSION) => Ok(()),
+        _ => Err(McpApiError::invalid_request(
+            id,
+            "JSON-RPC messages MUST include \"jsonrpc\": \"2.0\"",
+        )),
+    }
+}
+
+fn parse_json_rpc_id(value: &Value) -> Option<JsonRpcId> {
+    value.get("id").map(|id| match id {
+        Value::String(s) => JsonRpcId::String(s.clone()),
+        Value::Number(n) => JsonRpcId::Number(n.as_i64().unwrap_or_default()),
+        Value::Null => JsonRpcId::Null,
+        _ => JsonRpcId::Null,
+    })
+}
+
+async fn require_session(
+    st: &AppState,
+    headers: &HeaderMap,
+) -> Result<Arc<McpHttpSession>, McpApiError> {
+    let session_id = header_value(headers, HEADER_SESSION_ID)
+        .ok_or_else(|| McpApiError::bad_request("missing MCP-Session-Id header"))?;
+    st.mcp_http
+        .get(&session_id)
+        .await
+        .ok_or_else(|| McpApiError::not_found("unknown MCP session"))
+}
+
+fn validate_origin(headers: &HeaderMap) -> Result<(), McpApiError> {
+    let Some(origin_header) = headers.get(ORIGIN) else {
+        return Ok(());
+    };
+    let origin = origin_header
+        .to_str()
+        .map_err(|_| McpApiError::forbidden("invalid Origin header"))?;
+    let origin_uri: axum::http::Uri = origin
+        .parse()
+        .map_err(|_| McpApiError::forbidden("invalid Origin header"))?;
+    let Some(origin_host) = origin_uri.host() else {
+        return Err(McpApiError::forbidden("invalid Origin header"));
+    };
+
+    if is_loopback_host(origin_host) {
+        return Ok(());
+    }
+
+    if let Some(host) = header_value(headers, HOST.as_str()) {
+        let request_host = host.split(':').next().unwrap_or(host.as_str());
+        if origin_host.eq_ignore_ascii_case(request_host) {
+            return Ok(());
+        }
+    }
+
+    Err(McpApiError::forbidden(
+        "Origin header is not allowed for this MCP endpoint",
+    ))
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "::1" | "[::1]")
+}
+
+fn validate_protocol_header_for_initialize(headers: &HeaderMap) -> Result<(), McpApiError> {
+    let Some(version) = header_value(headers, HEADER_PROTOCOL_VERSION) else {
+        return Ok(());
+    };
+    if version == mcp::MCP_PROTOCOL_VERSION {
+        return Ok(());
+    }
+    Err(McpApiError::bad_request(format!(
+        "unsupported MCP protocol version: {version}"
+    )))
+}
+
+async fn validate_session_protocol_header(
+    headers: &HeaderMap,
+    session: &McpHttpSession,
+) -> Result<(), McpApiError> {
+    let Some(version) = header_value(headers, HEADER_PROTOCOL_VERSION) else {
+        return Ok(());
+    };
+    let expected = session.protocol_version().await;
+    if version == expected {
+        return Ok(());
+    }
+    Err(McpApiError::bad_request(format!(
+        "unsupported MCP protocol version: {version}"
+    )))
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn response_protocol_version(response: &JsonRpcResponse) -> Option<String> {
+    response
+        .result()
+        .and_then(|result| result.get("protocolVersion"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
 #[derive(Debug)]
-pub enum McpApiError {
-    BadRequest(String),
-    Internal(String),
+pub struct McpApiError {
+    status: StatusCode,
+    code: i64,
+    message: String,
+    id: Option<JsonRpcId>,
+}
+
+impl McpApiError {
+    fn parse_error(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: -32700,
+            message: message.into(),
+            id: None,
+        }
+    }
+
+    fn invalid_request(id: Option<JsonRpcId>, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: -32600,
+            message: message.into(),
+            id,
+        }
+    }
+
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self::invalid_request(None, message)
+    }
+
+    fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: -32600,
+            message: message.into(),
+            id: None,
+        }
+    }
+
+    fn forbidden(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: -32600,
+            message: message.into(),
+            id: None,
+        }
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: -32603,
+            message: message.into(),
+            id: None,
+        }
+    }
 }
 
 impl IntoResponse for McpApiError {
     fn into_response(self) -> Response {
-        let (status, message) = match self {
-            McpApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            McpApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-        };
         (
-            status,
+            self.status,
             Json(serde_json::json!({
-                "jsonrpc": "2.0",
+                "jsonrpc": JSON_RPC_VERSION,
                 "error": {
-                    "code": -32600,
-                    "message": message
+                    "code": self.code,
+                    "message": self.message,
                 },
-                "id": null
+                "id": self.id.map(|id| serde_json::to_value(id).unwrap_or(Value::Null)).unwrap_or(Value::Null),
             })),
         )
             .into_response()
@@ -212,109 +679,155 @@ mod tests {
         )
     }
 
-    #[tokio::test]
-    async fn post_initialize_returns_protocol_version() {
-        let app = Router::new()
-            .merge(mcp_routes())
-            .with_state(make_app_state());
+    fn extract_session_id(response: &Response) -> String {
+        response
+            .headers()
+            .get(HEADER_SESSION_ID)
+            .and_then(|value| value.to_str().ok())
+            .expect("missing session id")
+            .to_string()
+    }
 
-        let body = json!({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 1
-        });
-
-        let request = axum::http::Request::builder()
-            .method("POST")
-            .uri("/v1/mcp")
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
-            .unwrap();
-
-        let response = tower::ServiceExt::oneshot(app, request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = http_body_util::BodyExt::collect(response.into_body())
-            .await
-            .unwrap()
-            .to_bytes();
-        let json: Value = serde_json::from_slice(&body).unwrap();
-        assert!(json["result"]["protocolVersion"].is_string());
+    async fn call(app: axum::Router, request: axum::http::Request<axum::body::Body>) -> Response {
+        tower::ServiceExt::oneshot(app, request).await.unwrap()
     }
 
     #[tokio::test]
-    async fn post_tools_list_returns_agent_tools() {
+    async fn post_initialize_assigns_session_id() {
         let app = Router::new()
             .merge(mcp_routes())
             .with_state(make_app_state());
 
         let body = json!({
-            "jsonrpc": "2.0",
+            "jsonrpc": JSON_RPC_VERSION,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0.0"}
+            },
+            "id": 1
+        });
+
+        let response = call(
+            app,
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/v1/mcp")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key(HEADER_SESSION_ID));
+    }
+
+    #[tokio::test]
+    async fn post_requires_session_after_initialize() {
+        let app = Router::new()
+            .merge(mcp_routes())
+            .with_state(make_app_state());
+
+        let body = json!({
+            "jsonrpc": JSON_RPC_VERSION,
             "method": "tools/list",
             "id": 2
         });
 
-        let request = axum::http::Request::builder()
-            .method("POST")
-            .uri("/v1/mcp")
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
-            .unwrap();
+        let response = call(
+            app,
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/v1/mcp")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await;
 
-        let response = tower::ServiceExt::oneshot(app, request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
-
-        let body = http_body_util::BodyExt::collect(response.into_body())
-            .await
-            .unwrap()
-            .to_bytes();
-        let json: Value = serde_json::from_slice(&body).unwrap();
-        let tools = json["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0]["name"], "echo-agent");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
-    async fn post_notification_returns_accepted() {
+    async fn delete_terminates_known_session() {
         let app = Router::new()
             .merge(mcp_routes())
             .with_state(make_app_state());
 
-        let body = json!({
-            "jsonrpc": "2.0",
-            "method": "notifications/initialized"
-        });
-
-        let request = axum::http::Request::builder()
-            .method("POST")
-            .uri("/v1/mcp")
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
-            .unwrap();
-
-        let response = tower::ServiceExt::oneshot(app, request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::ACCEPTED);
-    }
-
-    #[tokio::test]
-    async fn post_missing_method_returns_bad_request() {
-        let app = Router::new()
-            .merge(mcp_routes())
-            .with_state(make_app_state());
-
-        let body = json!({
-            "jsonrpc": "2.0",
+        let init = json!({
+            "jsonrpc": JSON_RPC_VERSION,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0.0"}
+            },
             "id": 1
         });
 
-        let request = axum::http::Request::builder()
-            .method("POST")
-            .uri("/v1/mcp")
-            .header("content-type", "application/json")
-            .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
-            .unwrap();
+        let init_response = call(
+            app.clone(),
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/v1/mcp")
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(serde_json::to_vec(&init).unwrap()))
+                .unwrap(),
+        )
+        .await;
+        let session_id = extract_session_id(&init_response);
 
-        let response = tower::ServiceExt::oneshot(app, request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let delete_response = call(
+            app,
+            axum::http::Request::builder()
+                .method("DELETE")
+                .uri("/v1/mcp")
+                .header(HEADER_SESSION_ID, session_id)
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn parse_inbound_rejects_id_null_request() {
+        let body = serde_json::to_vec(&json!({
+            "jsonrpc": JSON_RPC_VERSION,
+            "method": "tools/list",
+            "id": null
+        }))
+        .unwrap();
+        let err = parse_inbound_message(&body).unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert_eq!(err.code, -32600);
+    }
+
+    #[test]
+    fn validate_origin_accepts_loopback() {
+        let mut headers = HeaderMap::new();
+        headers.insert(ORIGIN, HeaderValue::from_static("http://127.0.0.1:3000"));
+        assert!(validate_origin(&headers).is_ok());
+    }
+
+    #[test]
+    fn validate_origin_rejects_remote_origin() {
+        let mut headers = HeaderMap::new();
+        headers.insert(ORIGIN, HeaderValue::from_static("https://evil.example"));
+        headers.insert(HOST, HeaderValue::from_static("127.0.0.1:3000"));
+        let err = validate_origin(&headers).unwrap_err();
+        assert_eq!(err.status, StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn sse_prime_frame_contains_empty_data_event() {
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let session = McpHttpSession::new(&runtime);
+        let frame = session.prime_sse_frame();
+        let text = std::str::from_utf8(&frame).unwrap();
+        assert!(text.contains("data:\n\n"));
     }
 }

--- a/crates/awaken-server/src/protocols/mcp/stdio.rs
+++ b/crates/awaken-server/src/protocols/mcp/stdio.rs
@@ -1,17 +1,19 @@
 //! MCP Stdio transport: line-delimited JSON-RPC over stdin/stdout.
 //!
 //! Reads JSON-RPC messages from stdin, dispatches them through [`McpServer`],
-//! and writes responses to stdout. Follows the same pattern as ACP stdio.
+//! and writes responses to stdout.
 
 use std::sync::Arc;
 
 use mcp::protocol::{
-    ClientInbound, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ServerOutbound,
+    ClientInbound, JsonRpcId, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, ServerOutbound,
 };
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 use awaken_runtime::AgentRuntime;
+
+const JSON_RPC_VERSION: &str = "2.0";
 
 /// Run the MCP stdio server on actual stdin/stdout.
 pub async fn serve_stdio(runtime: Arc<AgentRuntime>) {
@@ -30,6 +32,7 @@ where
     let mut lines = input.lines();
     let mut pending_requests: usize = 0;
     let mut input_done = false;
+    let mut saw_initialize = false;
 
     loop {
         if input_done && pending_requests == 0 {
@@ -37,7 +40,6 @@ where
         }
 
         tokio::select! {
-            // Only read input if we haven't reached EOF.
             line_result = lines.next_line(), if !input_done => {
                 match line_result {
                     Ok(Some(line)) => {
@@ -45,14 +47,31 @@ where
                         if line.is_empty() {
                             continue;
                         }
-                        match handle_line(&line, &channels.inbound_tx).await {
-                            Ok(is_request) => {
-                                if is_request {
-                                    pending_requests += 1;
+                        match parse_line(&line) {
+                            Ok(parsed) => {
+                                if let Some(error) = lifecycle_error(&parsed, saw_initialize) {
+                                    let _ = write_line(&mut output, &error).await;
+                                    continue;
+                                }
+
+                                if matches!(&parsed, ParsedInbound::Request(request) if request.method == "initialize") {
+                                    saw_initialize = true;
+                                }
+
+                                match dispatch(parsed, &channels.inbound_tx).await {
+                                    Ok(expects_response) => {
+                                        if expects_response {
+                                            pending_requests += 1;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        let resp = make_error_response(None, -32603, &e);
+                                        let _ = write_line(&mut output, &resp).await;
+                                    }
                                 }
                             }
-                            Err(e) => {
-                                let resp = make_error_response(None, -32700, &e);
+                            Err(err) => {
+                                let resp = make_error_response(err.id, err.code, &err.message);
                                 let _ = write_line(&mut output, &resp).await;
                             }
                         }
@@ -73,78 +92,178 @@ where
                                 pending_requests = pending_requests.saturating_sub(1);
                                 serde_json::to_string(resp).ok()
                             }
-                            ServerOutbound::Notification(notif) => {
-                                serde_json::to_string(notif).ok()
-                            }
-                            ServerOutbound::Request(req) => {
-                                serde_json::to_string(req).ok()
-                            }
+                            ServerOutbound::Notification(notif) => serde_json::to_string(notif).ok(),
+                            ServerOutbound::Request(req) => serde_json::to_string(req).ok(),
                         };
                         if let Some(line) = line {
                             let _ = write_line(&mut output, &line).await;
                         }
                     }
-                    None => break, // Server shut down.
+                    None => break,
                 }
             }
         }
     }
 }
 
-/// Parse and dispatch a single JSON-RPC line to the MCP server.
-///
-/// Returns `Ok(true)` if a request was sent (expecting a response),
-/// `Ok(false)` for notifications/responses.
-async fn handle_line(
-    line: &str,
-    inbound_tx: &tokio::sync::mpsc::Sender<ClientInbound>,
-) -> Result<bool, String> {
-    let value: Value = serde_json::from_str(line).map_err(|e| format!("parse error: {e}"))?;
+#[derive(Debug)]
+enum ParsedInbound {
+    Request(JsonRpcRequest),
+    Notification(JsonRpcNotification),
+    Response(JsonRpcResponse),
+}
 
-    let method = value
-        .get("method")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .to_string();
+struct LineParseError {
+    id: Option<Value>,
+    code: i64,
+    message: String,
+}
 
-    if method.is_empty() {
-        // Could be a response to a server-initiated request.
-        if value.get("result").is_some() || value.get("error").is_some() {
-            let resp: JsonRpcResponse =
-                serde_json::from_value(value).map_err(|e| format!("invalid response: {e}"))?;
-            inbound_tx
-                .send(ClientInbound::Response(resp))
-                .await
-                .map_err(|_| "channel closed".to_string())?;
-            return Ok(false);
-        }
-        return Err("missing 'method' field".into());
+fn parse_line(line: &str) -> Result<ParsedInbound, LineParseError> {
+    let value: Value = serde_json::from_str(line).map_err(|e| LineParseError {
+        id: None,
+        code: -32700,
+        message: format!("parse error: {e}"),
+    })?;
+
+    if !value.is_object() {
+        return Err(LineParseError {
+            id: None,
+            code: -32600,
+            message: "expected a single JSON-RPC object".to_string(),
+        });
     }
 
-    let has_id = value.get("id").is_some_and(|v| !v.is_null());
+    let id = value.get("id").cloned();
+    match value.get("jsonrpc").and_then(Value::as_str) {
+        Some(JSON_RPC_VERSION) => {}
+        _ => {
+            return Err(LineParseError {
+                id,
+                code: -32600,
+                message: "JSON-RPC messages must include \"jsonrpc\": \"2.0\"".to_string(),
+            });
+        }
+    }
 
-    if has_id {
-        let request: JsonRpcRequest =
-            serde_json::from_value(value).map_err(|e| format!("invalid request: {e}"))?;
-        inbound_tx
-            .send(ClientInbound::Request(request))
-            .await
-            .map_err(|_| "channel closed".to_string())?;
-        Ok(true)
+    if let Some(method) = value.get("method").and_then(Value::as_str) {
+        if method.is_empty() {
+            return Err(LineParseError {
+                id,
+                code: -32600,
+                message: "missing 'method' field".to_string(),
+            });
+        }
+        match value.get("id") {
+            Some(Value::Null) => Err(LineParseError {
+                id,
+                code: -32600,
+                message: "MCP requests MUST use string or integer IDs; notifications MUST omit the id field".to_string(),
+            }),
+            Some(_) => serde_json::from_value(value)
+                .map(ParsedInbound::Request)
+                .map_err(|e| LineParseError {
+                    id: None,
+                    code: -32600,
+                    message: format!("invalid request: {e}"),
+                }),
+            None => serde_json::from_value(value)
+                .map(ParsedInbound::Notification)
+                .map_err(|e| LineParseError {
+                    id: None,
+                    code: -32600,
+                    message: format!("invalid notification: {e}"),
+                }),
+        }
+    } else if value.get("result").is_some() || value.get("error").is_some() {
+        if matches!(value.get("id"), Some(Value::Null)) {
+            return Err(LineParseError {
+                id,
+                code: -32600,
+                message: "JSON-RPC responses MUST use the original string or integer request id"
+                    .to_string(),
+            });
+        }
+        serde_json::from_value(value)
+            .map(ParsedInbound::Response)
+            .map_err(|e| LineParseError {
+                id: None,
+                code: -32600,
+                message: format!("invalid response: {e}"),
+            })
     } else {
-        let notification: JsonRpcNotification =
-            serde_json::from_value(value).map_err(|e| format!("invalid notification: {e}"))?;
-        inbound_tx
-            .send(ClientInbound::Notification(notification))
-            .await
-            .map_err(|_| "channel closed".to_string())?;
-        Ok(false)
+        Err(LineParseError {
+            id,
+            code: -32600,
+            message: "missing 'method' field".to_string(),
+        })
+    }
+}
+
+fn lifecycle_error(parsed: &ParsedInbound, saw_initialize: bool) -> Option<String> {
+    match parsed {
+        ParsedInbound::Request(request)
+            if !saw_initialize && request.method != "initialize" && request.method != "ping" =>
+        {
+            Some(make_error_response(
+                Some(json_rpc_id_to_value(&request.id)),
+                -32600,
+                "initialize must be the first request in an MCP stdio session",
+            ))
+        }
+        ParsedInbound::Notification(notification)
+            if !saw_initialize && notification.method == "notifications/initialized" =>
+        {
+            Some(make_error_response(
+                None,
+                -32600,
+                "received notifications/initialized before initialize",
+            ))
+        }
+        _ => None,
+    }
+}
+
+async fn dispatch(
+    parsed: ParsedInbound,
+    inbound_tx: &tokio::sync::mpsc::Sender<ClientInbound>,
+) -> Result<bool, String> {
+    match parsed {
+        ParsedInbound::Request(request) => {
+            inbound_tx
+                .send(ClientInbound::Request(request))
+                .await
+                .map_err(|_| "channel closed".to_string())?;
+            Ok(true)
+        }
+        ParsedInbound::Notification(notification) => {
+            inbound_tx
+                .send(ClientInbound::Notification(notification))
+                .await
+                .map_err(|_| "channel closed".to_string())?;
+            Ok(false)
+        }
+        ParsedInbound::Response(response) => {
+            inbound_tx
+                .send(ClientInbound::Response(response))
+                .await
+                .map_err(|_| "channel closed".to_string())?;
+            Ok(false)
+        }
+    }
+}
+
+fn json_rpc_id_to_value(id: &JsonRpcId) -> Value {
+    match id {
+        JsonRpcId::String(value) => Value::String(value.clone()),
+        JsonRpcId::Number(value) => serde_json::json!(*value),
+        JsonRpcId::Null => Value::Null,
     }
 }
 
 fn make_error_response(id: Option<Value>, code: i64, message: &str) -> String {
     serde_json::json!({
-        "jsonrpc": "2.0",
+        "jsonrpc": JSON_RPC_VERSION,
         "error": {
             "code": code,
             "message": message
@@ -181,7 +300,6 @@ mod tests {
         Arc::new(AgentRuntime::new(Arc::new(StubResolver)))
     }
 
-    /// Helper: run stdio with given input, return output string.
     async fn run_stdio(input: &[u8]) -> String {
         let runtime = test_runtime();
         let mut output = Vec::new();
@@ -189,7 +307,6 @@ mod tests {
         String::from_utf8(output).unwrap()
     }
 
-    /// Parse first response from output.
     fn first_response(output: &str) -> Value {
         let line = output.lines().next().expect("no output");
         serde_json::from_str(line).expect("invalid JSON")
@@ -197,7 +314,10 @@ mod tests {
 
     #[tokio::test]
     async fn stdio_initialize() {
-        let output = run_stdio(b"{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1}\n").await;
+        let output = run_stdio(
+            b"{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0.0\"}},\"id\":1}\n",
+        )
+        .await;
 
         let resp = first_response(&output);
         assert!(resp["result"]["protocolVersion"].is_string());
@@ -205,75 +325,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stdio_tools_list() {
+    async fn stdio_rejects_request_before_initialize() {
         let output = run_stdio(b"{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":2}\n").await;
-
         let resp = first_response(&output);
-        let tools = resp["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0]["name"], "test-agent");
+        assert_eq!(resp["error"]["code"], -32600);
     }
 
     #[tokio::test]
     async fn stdio_unknown_method() {
-        let output =
-            run_stdio(b"{\"jsonrpc\":\"2.0\",\"method\":\"unknown/foo\",\"id\":3}\n").await;
-
-        let resp = first_response(&output);
-        assert!(resp["error"].is_object());
+        let output = run_stdio(
+            concat!(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0.0\"}},\"id\":1}\n",
+                "{\"jsonrpc\":\"2.0\",\"method\":\"unknown/foo\",\"id\":3}\n",
+            )
+            .as_bytes(),
+        )
+        .await;
+        let responses: Vec<Value> = output
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        let resp = responses
+            .into_iter()
+            .find(|value| value["id"] == 3)
+            .unwrap();
         assert_eq!(resp["error"]["code"], -32601);
     }
 
-    #[tokio::test]
-    async fn stdio_parse_error() {
-        let output = run_stdio(b"not json\n").await;
-        let resp = first_response(&output);
-        assert!(resp["error"].is_object());
-        assert_eq!(resp["error"]["code"], -32700);
+    #[test]
+    fn parse_line_rejects_null_id_request() {
+        let err = parse_line(r#"{"jsonrpc":"2.0","method":"tools/list","id":null}"#)
+            .expect_err("null id must be rejected");
+        assert_eq!(err.code, -32600);
     }
 
-    #[tokio::test]
-    async fn stdio_empty_lines_skipped() {
-        let output =
-            run_stdio(b"\n  \n{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1}\n\n").await;
-
-        let lines: Vec<&str> = output.trim().lines().collect();
-        assert_eq!(lines.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn stdio_multiple_requests() {
-        let input = concat!(
-            "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1}\n",
-            "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":2}\n",
-        );
-        let output = run_stdio(input.as_bytes()).await;
-
-        let lines: Vec<&str> = output.trim().lines().collect();
-        assert_eq!(lines.len(), 2);
-
-        let resp1: Value = serde_json::from_str(lines[0]).unwrap();
-        assert!(resp1["result"]["protocolVersion"].is_string());
-
-        let resp2: Value = serde_json::from_str(lines[1]).unwrap();
-        assert!(resp2["result"]["tools"].is_array());
-    }
-
-    #[tokio::test]
-    async fn stdio_notification_no_response() {
-        let output =
-            run_stdio(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n").await;
-
-        // Notifications don't produce a response.
-        assert!(output.trim().is_empty());
-    }
-
-    #[tokio::test]
-    async fn stdio_ping() {
-        let output = run_stdio(b"{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"id\":99}\n").await;
-
-        let resp = first_response(&output);
-        assert!(resp["result"].is_object());
-        assert_eq!(resp["id"], 99);
+    #[test]
+    fn make_error_response_preserves_id() {
+        let resp = make_error_response(Some(Value::from(7)), -32600, "bad request");
+        let parsed: Value = serde_json::from_str(&resp).unwrap();
+        assert_eq!(parsed["id"], 7);
     }
 }

--- a/crates/awaken-server/tests/protocol_mcp.rs
+++ b/crates/awaken-server/tests/protocol_mcp.rs
@@ -14,7 +14,7 @@ use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
-use axum::http::{Request, StatusCode};
+use axum::http::{Request, Response, StatusCode};
 use serde_json::{Value, json};
 use std::sync::Arc;
 use tower::ServiceExt;
@@ -97,26 +97,112 @@ fn make_mcp_app() -> axum::Router {
     build_router().with_state(state)
 }
 
-async fn mcp_post(app: axum::Router, payload: Value) -> (StatusCode, Value) {
-    let resp = app
+async fn mcp_post(
+    app: &axum::Router,
+    payload: Value,
+    session_id: Option<&str>,
+) -> Response<axum::body::Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/v1/mcp")
+        .header("content-type", "application/json");
+    if let Some(session_id) = session_id {
+        builder = builder
+            .header("MCP-Session-Id", session_id)
+            .header("MCP-Protocol-Version", mcp::MCP_PROTOCOL_VERSION);
+    }
+
+    app.clone()
         .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/v1/mcp")
-                .header("content-type", "application/json")
+            builder
                 .body(axum::body::Body::from(
                     serde_json::to_vec(&payload).unwrap(),
                 ))
                 .expect("request build"),
         )
         .await
-        .expect("app should handle request");
+        .expect("app should handle request")
+}
+
+async fn response_json(resp: Response<axum::body::Body>) -> (StatusCode, Value) {
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
     let body = to_bytes(resp.into_body(), 1024 * 1024)
         .await
         .expect("body readable");
-    let json: Value = serde_json::from_slice(&body).unwrap_or(json!(null));
+    let json = if content_type.starts_with("text/event-stream") {
+        let text = String::from_utf8(body.to_vec()).expect("valid utf-8 sse body");
+        let parsed = text
+            .split("\n\n")
+            .filter_map(|event| {
+                let payload = event
+                    .lines()
+                    .filter_map(|line| {
+                        line.strip_prefix("data: ")
+                            .or_else(|| line.strip_prefix("data:"))
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if payload.trim().is_empty() {
+                    None
+                } else {
+                    serde_json::from_str::<Value>(&payload).ok()
+                }
+            })
+            .find(|value| value.get("id").is_some())
+            .unwrap_or(json!(null));
+        parsed
+    } else {
+        serde_json::from_slice(&body).unwrap_or(json!(null))
+    };
     (status, json)
+}
+
+async fn initialize_session(app: axum::Router) -> (axum::Router, String) {
+    let init_response = mcp_post(
+        &app,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+                "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"}
+            },
+            "id": 1
+        }),
+        None,
+    )
+    .await;
+    let session_id = init_response
+        .headers()
+        .get("MCP-Session-Id")
+        .and_then(|value| value.to_str().ok())
+        .expect("session id header")
+        .to_string();
+    let (_, init_json) = response_json(init_response).await;
+    assert_eq!(
+        init_json["result"]["protocolVersion"],
+        mcp::MCP_PROTOCOL_VERSION
+    );
+
+    let initialized_response = mcp_post(
+        &app,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }),
+        Some(&session_id),
+    )
+    .await;
+    assert_eq!(initialized_response.status(), StatusCode::ACCEPTED);
+
+    (app, session_id)
 }
 
 // ============================================================================
@@ -126,13 +212,22 @@ async fn mcp_post(app: axum::Router, payload: Value) -> (StatusCode, Value) {
 #[tokio::test]
 async fn mcp_initialize_returns_server_info() {
     let app = make_mcp_app();
-    let (status, json) = mcp_post(
-        app,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 1
-        }),
+    let (status, json) = response_json(
+        mcp_post(
+            &app,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0.0"}
+                },
+                "id": 1
+            }),
+            None,
+        )
+        .await,
     )
     .await;
 
@@ -143,14 +238,18 @@ async fn mcp_initialize_returns_server_info() {
 
 #[tokio::test]
 async fn mcp_tools_list_discovers_agents() {
-    let app = make_mcp_app();
-    let (status, json) = mcp_post(
-        app,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "tools/list",
-            "id": 2
-        }),
+    let (app, session_id) = initialize_session(make_mcp_app()).await;
+    let (status, json) = response_json(
+        mcp_post(
+            &app,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 2
+            }),
+            Some(&session_id),
+        )
+        .await,
     )
     .await;
 
@@ -175,20 +274,24 @@ async fn mcp_tools_list_discovers_agents() {
 
 #[tokio::test]
 async fn mcp_tools_call_runs_agent_and_returns_text() {
-    let app = make_mcp_app();
-    let (status, json) = mcp_post(
-        app,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "params": {
-                "name": "echo",
-                "arguments": {
-                    "message": "hello world"
-                }
-            },
-            "id": 3
-        }),
+    let (app, session_id) = initialize_session(make_mcp_app()).await;
+    let (status, json) = response_json(
+        mcp_post(
+            &app,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "echo",
+                    "arguments": {
+                        "message": "hello world"
+                    }
+                },
+                "id": 3
+            }),
+            Some(&session_id),
+        )
+        .await,
     )
     .await;
 
@@ -212,20 +315,24 @@ async fn mcp_tools_call_runs_agent_and_returns_text() {
 
 #[tokio::test]
 async fn mcp_tools_call_unknown_tool_returns_error() {
-    let app = make_mcp_app();
-    let (status, json) = mcp_post(
-        app,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "params": {
-                "name": "nonexistent",
-                "arguments": {
-                    "message": "hello"
-                }
-            },
-            "id": 4
-        }),
+    let (app, session_id) = initialize_session(make_mcp_app()).await;
+    let (status, json) = response_json(
+        mcp_post(
+            &app,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "nonexistent",
+                    "arguments": {
+                        "message": "hello"
+                    }
+                },
+                "id": 4
+            }),
+            Some(&session_id),
+        )
+        .await,
     )
     .await;
 
@@ -236,18 +343,22 @@ async fn mcp_tools_call_unknown_tool_returns_error() {
 
 #[tokio::test]
 async fn mcp_tools_call_missing_message_returns_tool_error() {
-    let app = make_mcp_app();
-    let (status, json) = mcp_post(
-        app,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "params": {
-                "name": "echo",
-                "arguments": {}
-            },
-            "id": 5
-        }),
+    let (app, session_id) = initialize_session(make_mcp_app()).await;
+    let (status, json) = response_json(
+        mcp_post(
+            &app,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "echo",
+                    "arguments": {}
+                },
+                "id": 5
+            }),
+            Some(&session_id),
+        )
+        .await,
     )
     .await;
 
@@ -262,14 +373,18 @@ async fn mcp_tools_call_missing_message_returns_tool_error() {
 
 #[tokio::test]
 async fn mcp_ping_responds() {
-    let app = make_mcp_app();
-    let (status, json) = mcp_post(
-        app,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "ping",
-            "id": 6
-        }),
+    let (app, session_id) = initialize_session(make_mcp_app()).await;
+    let (status, json) = response_json(
+        mcp_post(
+            &app,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "ping",
+                "id": 6
+            }),
+            Some(&session_id),
+        )
+        .await,
     )
     .await;
 
@@ -279,14 +394,18 @@ async fn mcp_ping_responds() {
 
 #[tokio::test]
 async fn mcp_unknown_method_returns_error() {
-    let app = make_mcp_app();
-    let (status, json) = mcp_post(
-        app,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "unknown/method",
-            "id": 7
-        }),
+    let (app, session_id) = initialize_session(make_mcp_app()).await;
+    let (status, json) = response_json(
+        mcp_post(
+            &app,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "unknown/method",
+                "id": 7
+            }),
+            Some(&session_id),
+        )
+        .await,
     )
     .await;
 
@@ -338,7 +457,7 @@ async fn stdio_e2e_full_flow() {
         .collect();
 
     // Should have responses for initialize(1), tools/list(2), tools/call(3).
-    // Plus possibly progress/log notifications.
+    // Plus possibly logging notifications.
     let responses: Vec<&Value> = lines.iter().filter(|v| v.get("id").is_some()).collect();
     assert!(
         responses.len() >= 3,
@@ -365,17 +484,17 @@ async fn stdio_e2e_full_flow() {
         "expected echo response, got: {text}"
     );
 
-    // Check for progress/log notifications.
+    // Check for logging notifications.
     let notifications: Vec<&Value> = lines
         .iter()
         .filter(|v| v.get("method").is_some() && v.get("id").is_none())
         .collect();
-    // Should have at least one progress notification from the tool call.
-    let has_progress = notifications
+    // Should have at least one log notification from the tool call.
+    let has_logging = notifications
         .iter()
-        .any(|n| n["method"] == "notifications/progress");
+        .any(|n| n["method"] == "notifications/message");
     assert!(
-        has_progress,
-        "expected progress notifications, got: {notifications:?}"
+        has_logging,
+        "expected logging notifications, got: {notifications:?}"
     );
 }


### PR DESCRIPTION
## Summary
- align Awaken MCP HTTP transport with MCP lifecycle/session requirements
- fix HTTP client transport to send initialized/session/protocol headers and handle SSE responses
- tighten stdio lifecycle validation and replace non-compliant server-side progress notifications with spec-compliant logging

## Verification
- cargo test -p awaken-server --test protocol_mcp
- cargo test -p awaken-ext-mcp --test mcp_tests
- live validation with Codex as MCP client and Awaken as MCP server against BigModel OpenAI-compatible API