### PR TITLE
Docs: split bilingual mdBook navigation and reorganize reading paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Production AI agent runtime for Rust — type-safe state, multi-protocol serving
 
 Published on crates.io as `awaken-agent`; keep importing it in Rust as `awaken`.
 
+Docs: [GitHub Pages](https://awakenworks.github.io/awaken/) | [Chinese docs](https://awakenworks.github.io/awaken/zh-CN/)
+
 <p align="center">
   <img src="./docs/assets/demo.svg" alt="Awaken demo — tool call + LLM streaming" width="800">
 </p>
@@ -27,10 +29,10 @@ Prerequisites:
 
 ```toml
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.1" }
-tokio = { version = "1", features = ["full"] }
-async-trait = "0.1"
-serde_json = "1"
+awaken = { package = "awaken-agent", version = "0.1.1" }
+tokio = { version = "1.51.0", features = ["full"] }
+async-trait = "0.1.89"
+serde_json = "1.0.149"
 ```
 
 ```bash
@@ -237,10 +239,11 @@ cd examples/ai-sdk-starter && npm install && npm run dev
 
 | Goal | Start with | Then |
 |---|---|---|
-| Build your first agent | [First Agent tutorial](./docs/book/src/tutorials/first-agent.md) | [Build an Agent guide](./docs/book/src/how-to/build-an-agent.md) |
+| Build your first agent | [Get Started](https://awakenworks.github.io/awaken/get-started.html) | [Build Agents](https://awakenworks.github.io/awaken/build-agents.html) |
 | See a full-stack app | [AI SDK starter](./examples/ai-sdk-starter/) | [CopilotKit starter](./examples/copilotkit-starter/) |
-| Explore the API | [Reference docs](./docs/book/src/reference/overview.md) | `cargo doc --workspace --no-deps --open` |
-| Migrate from tirea | [Migration guide](./docs/book/src/appendix/migration-from-tirea.md) | |
+| Explore the API | [Reference docs](https://awakenworks.github.io/awaken/reference/overview.html) | `cargo doc --workspace --no-deps --open` |
+| Understand the runtime | [Architecture](https://awakenworks.github.io/awaken/explanation/architecture.html) | [Run Lifecycle and Phases](https://awakenworks.github.io/awaken/explanation/run-lifecycle-and-phases.html) |
+| Migrate from tirea | [Migration guide](https://awakenworks.github.io/awaken/appendix/migration-from-tirea.html) | |
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,6 +8,8 @@
 
 在 crates.io 上发布名为 `awaken-agent`，Rust 代码中的导入仍然保持为 `awaken`。
 
+在线文档：[GitHub Pages（英文）](https://awakenworks.github.io/awaken/) | [GitHub Pages（中文）](https://awakenworks.github.io/awaken/zh-CN/)
+
 <p align="center">
   <img src="./docs/assets/demo.svg" alt="Awaken 演示 — 工具调用 + LLM 流式输出" width="800">
 </p>
@@ -29,10 +31,10 @@ Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运
 
 ```toml
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.1" }
-tokio = { version = "1", features = ["full"] }
-async-trait = "0.1"
-serde_json = "1"
+awaken = { package = "awaken-agent", version = "0.1.1" }
+tokio = { version = "1.51.0", features = ["full"] }
+async-trait = "0.1.89"
+serde_json = "1.0.149"
 ```
 
 `src/main.rs`：
@@ -253,10 +255,11 @@ cd examples/ai-sdk-starter && npm install && npm run dev
 
 | 目标 | 从这里开始 | 然后 |
 |---|---|---|
-| 构建第一个 Agent | [First Agent 教程](./docs/book/src/tutorials/first-agent.md) | [构建 Agent 指南](./docs/book/src/how-to/build-an-agent.md) |
+| 构建第一个 Agent | [快速上手](https://awakenworks.github.io/awaken/zh-CN/get-started.html) | [构建 Agent 路径](https://awakenworks.github.io/awaken/zh-CN/build-agents.html) |
 | 查看全栈应用 | [AI SDK starter](./examples/ai-sdk-starter/) | [CopilotKit starter](./examples/copilotkit-starter/) |
-| 探索 API | [参考文档](./docs/book/src/reference/overview.md) | `cargo doc --workspace --no-deps --open` |
-| 从 tirea 迁移 | [迁移指南](./docs/book/src/appendix/migration-from-tirea.md) | |
+| 探索 API | [参考文档](https://awakenworks.github.io/awaken/zh-CN/reference/overview.html) | `cargo doc --workspace --no-deps --open` |
+| 理解运行时 | [架构](https://awakenworks.github.io/awaken/zh-CN/explanation/architecture.html) | [Run 生命周期与 Phases](https://awakenworks.github.io/awaken/zh-CN/explanation/run-lifecycle-and-phases.html) |
+| 从 tirea 迁移 | [迁移指南](https://awakenworks.github.io/awaken/zh-CN/appendix/migration-from-tirea.html) | |
 
 ## 参与贡献
 

--- a/docs/book/README.zh-CN.md
+++ b/docs/book/README.zh-CN.md
@@ -8,6 +8,8 @@
 
 在 crates.io 上发布名为 `awaken-agent`，Rust 代码中的导入仍然保持为 `awaken`。
 
+在线文档：[GitHub Pages（英文）](https://awakenworks.github.io/awaken/) | [GitHub Pages（中文）](https://awakenworks.github.io/awaken/zh-CN/)
+
 ## 30 秒速览
 
 1. **Tools** — 类型化函数，JSON Schema 在编译时自动生成
@@ -25,10 +27,10 @@ Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运
 
 ```toml
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.1" }
-tokio = { version = "1", features = ["full"] }
-async-trait = "0.1"
-serde_json = "1"
+awaken = { package = "awaken-agent", version = "0.1.1" }
+tokio = { version = "1.51.0", features = ["full"] }
+async-trait = "0.1.89"
+serde_json = "1.0.149"
 ```
 
 `src/main.rs`：
@@ -249,10 +251,11 @@ cd examples/ai-sdk-starter && npm install && npm run dev
 
 | 目标 | 从这里开始 | 然后 |
 |---|---|---|
-| 构建第一个 Agent | [First Agent 教程](./src/tutorials/first-agent.md) | [构建 Agent 指南](./src/how-to/build-an-agent.md) |
+| 构建第一个 Agent | [快速上手](https://awakenworks.github.io/awaken/zh-CN/get-started.html) | [构建 Agent 路径](https://awakenworks.github.io/awaken/zh-CN/build-agents.html) |
 | 查看全栈应用 | [AI SDK starter](../../examples/ai-sdk-starter/) | [CopilotKit starter](../../examples/copilotkit-starter/) |
-| 探索 API | [参考文档](./src/reference/overview.md) | `cargo doc --workspace --no-deps --open` |
-| 从 tirea 迁移 | [迁移指南](./src/appendix/migration-from-tirea.md) | |
+| 探索 API | [参考文档](https://awakenworks.github.io/awaken/zh-CN/reference/overview.html) | `cargo doc --workspace --no-deps --open` |
+| 理解运行时 | [架构](https://awakenworks.github.io/awaken/zh-CN/explanation/architecture.html) | [Run 生命周期与 Phases](https://awakenworks.github.io/awaken/zh-CN/explanation/run-lifecycle-and-phases.html) |
+| 从 tirea 迁移 | [迁移指南](https://awakenworks.github.io/awaken/zh-CN/appendix/migration-from-tirea.html) | |
 
 ## 参与贡献
 

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -18,4 +18,5 @@ command = "mdbook-mermaid"
 default-theme = "rust"
 git-repository-url = "https://github.com/AwakenWorks/awaken"
 edit-url-template = "https://github.com/AwakenWorks/awaken/edit/main/docs/book/{path}"
-additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-css = ["language-switcher.css"]
+additional-js = ["mermaid.min.js", "mermaid-init.js", "language-switcher.js"]

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -2,31 +2,47 @@
 
 - [Introduction](./introduction.md)
 
-# Tutorials
+# Get Started
 
+- [Get Started](./get-started.md)
 - [First Agent](./tutorials/first-agent.md)
 - [First Tool](./tutorials/first-tool.md)
 
-# How-to
+# Build Agents
 
+- [Build Agents](./build-agents.md)
 - [Build an Agent](./how-to/build-an-agent.md)
 - [Add a Tool](./how-to/add-a-tool.md)
 - [Add a Plugin](./how-to/add-a-plugin.md)
-- [Use File Store](./how-to/use-file-store.md)
-- [Use Postgres Store](./how-to/use-postgres-store.md)
-- [Expose HTTP SSE](./how-to/expose-http-sse.md)
-- [Integrate AI SDK Frontend](./how-to/integrate-ai-sdk-frontend.md)
-- [Integrate CopilotKit (AG-UI)](./how-to/integrate-copilotkit-ag-ui.md)
 - [Use Skills Subsystem](./how-to/use-skills-subsystem.md)
 - [Use MCP Tools](./how-to/use-mcp-tools.md)
-- [Enable Tool Permission HITL](./how-to/enable-tool-permission-hitl.md)
-- [Enable Observability](./how-to/enable-observability.md)
 - [Use Reminder Plugin](./how-to/use-reminder-plugin.md)
 - [Use Generative UI](./how-to/use-generative-ui.md)
 - [Use Agent Handoff](./how-to/use-agent-handoff.md)
-- [Configure Stop Policies](./how-to/configure-stop-policies.md)
 - [Use Deferred Tools](./how-to/use-deferred-tools.md)
+
+# Serve & Integrate
+
+- [Serve & Integrate](./serve-and-integrate.md)
+- [Expose HTTP SSE](./how-to/expose-http-sse.md)
+- [Integrate AI SDK Frontend](./how-to/integrate-ai-sdk-frontend.md)
+- [Integrate CopilotKit (AG-UI)](./how-to/integrate-copilotkit-ag-ui.md)
+
+# State & Storage
+
+- [State & Storage](./state-and-storage.md)
+- [Use File Store](./how-to/use-file-store.md)
+- [Use Postgres Store](./how-to/use-postgres-store.md)
 - [Optimize Context Window](./how-to/optimize-context-window.md)
+- [State Keys](./reference/state-keys.md)
+- [Thread Model](./reference/thread-model.md)
+
+# Operate
+
+- [Operate](./operate.md)
+- [Enable Tool Permission HITL](./how-to/enable-tool-permission-hitl.md)
+- [Configure Stop Policies](./how-to/configure-stop-policies.md)
+- [Enable Observability](./how-to/enable-observability.md)
 - [Report Tool Progress](./how-to/report-tool-progress.md)
 - [Testing Strategy](./how-to/testing-strategy.md)
 
@@ -34,10 +50,8 @@
 
 - [Overview](./reference/overview.md)
 - [Tool Trait](./reference/tool-trait.md)
-- [State Keys](./reference/state-keys.md)
 - [Scheduled Actions](./reference/scheduled-actions.md)
 - [Effects](./reference/effects.md)
-- [Thread Model](./reference/thread-model.md)
 - [Events](./reference/events.md)
 - [HTTP API](./reference/http-api.md)
 - [Config](./reference/config.md)
@@ -48,7 +62,7 @@
 - [Cancellation](./reference/cancellation.md)
 - [Tool Execution Modes](./reference/tool-execution-modes.md)
 
-# Explanation
+# Architecture
 
 - [Architecture](./explanation/architecture.md)
 - [Agent Resolution](./explanation/agent-resolution.md)
@@ -65,71 +79,3 @@
 - [Glossary](./appendix/glossary.md)
 - [FAQ](./appendix/faq.md)
 - [Migrating from Tirea](./appendix/migration-from-tirea.md)
-
-# 中文文档
-
-- [简介](./zh-CN/introduction.md)
-
-# 中文教程
-
-- [第一个 Agent](./zh-CN/tutorials/first-agent.md)
-- [第一个 Tool](./zh-CN/tutorials/first-tool.md)
-
-# 中文操作指南
-
-- [构建 Agent](./zh-CN/how-to/build-an-agent.md)
-- [添加 Tool](./zh-CN/how-to/add-a-tool.md)
-- [添加 Plugin](./zh-CN/how-to/add-a-plugin.md)
-- [使用文件存储](./zh-CN/how-to/use-file-store.md)
-- [使用 Postgres 存储](./zh-CN/how-to/use-postgres-store.md)
-- [通过 SSE 暴露 HTTP](./zh-CN/how-to/expose-http-sse.md)
-- [集成 AI SDK 前端](./zh-CN/how-to/integrate-ai-sdk-frontend.md)
-- [集成 CopilotKit（AG-UI）](./zh-CN/how-to/integrate-copilotkit-ag-ui.md)
-- [使用 Skills 子系统](./zh-CN/how-to/use-skills-subsystem.md)
-- [使用 MCP Tools](./zh-CN/how-to/use-mcp-tools.md)
-- [启用工具权限 HITL](./zh-CN/how-to/enable-tool-permission-hitl.md)
-- [启用可观测性](./zh-CN/how-to/enable-observability.md)
-- [使用 Reminder 插件](./zh-CN/how-to/use-reminder-plugin.md)
-- [使用 Generative UI（A2UI）](./zh-CN/how-to/use-generative-ui.md)
-- [使用 Agent Handoff](./zh-CN/how-to/use-agent-handoff.md)
-- [配置停止策略](./zh-CN/how-to/configure-stop-policies.md)
-- [使用延迟加载工具](./zh-CN/how-to/use-deferred-tools.md)
-- [优化上下文窗口](./zh-CN/how-to/optimize-context-window.md)
-- [上报 Tool 进度](./zh-CN/how-to/report-tool-progress.md)
-- [测试策略](./zh-CN/how-to/testing-strategy.md)
-
-# 中文参考
-
-- [概览](./zh-CN/reference/overview.md)
-- [Tool Trait](./zh-CN/reference/tool-trait.md)
-- [状态键](./zh-CN/reference/state-keys.md)
-- [Scheduled Actions](./zh-CN/reference/scheduled-actions.md)
-- [Effects](./zh-CN/reference/effects.md)
-- [线程模型](./zh-CN/reference/thread-model.md)
-- [事件](./zh-CN/reference/events.md)
-- [HTTP API](./zh-CN/reference/http-api.md)
-- [配置](./zh-CN/reference/config.md)
-- [错误](./zh-CN/reference/errors.md)
-- [AI SDK v6 协议](./zh-CN/reference/protocols/ai-sdk-v6.md)
-- [AG-UI 协议](./zh-CN/reference/protocols/ag-ui.md)
-- [A2A 协议](./zh-CN/reference/protocols/a2a.md)
-- [取消](./zh-CN/reference/cancellation.md)
-- [工具执行模式](./zh-CN/reference/tool-execution-modes.md)
-
-# 中文解释
-
-- [架构](./zh-CN/explanation/architecture.md)
-- [智能体解析](./zh-CN/explanation/agent-resolution.md)
-- [状态与快照模型](./zh-CN/explanation/state-and-snapshot-model.md)
-- [Run 生命周期与 Phases](./zh-CN/explanation/run-lifecycle-and-phases.md)
-- [HITL 与 Mailbox](./zh-CN/explanation/hitl-and-mailbox.md)
-- [多智能体模式](./zh-CN/explanation/multi-agent-patterns.md)
-- [Tool 与 Plugin 的边界](./zh-CN/explanation/tool-and-plugin-boundary.md)
-- [插件系统内部机制](./zh-CN/explanation/plugin-internals.md)
-- [设计取舍](./zh-CN/explanation/design-tradeoffs.md)
-
-# 中文附录
-
-- [术语表](./zh-CN/appendix/glossary.md)
-- [常见问题](./zh-CN/appendix/faq.md)
-- [从 Tirea 迁移](./zh-CN/appendix/migration-from-tirea.md)

--- a/docs/book/src/build-agents.md
+++ b/docs/book/src/build-agents.md
@@ -1,0 +1,16 @@
+# Build Agents
+
+This path is for composing agent behavior after you understand the basics.
+
+## Recommended order
+
+1. [Build an Agent](./how-to/build-an-agent.md) to define the runtime, model registry, and agent spec.
+2. [Add a Tool](./how-to/add-a-tool.md) and [Add a Plugin](./how-to/add-a-plugin.md) to extend behavior safely.
+3. Add discovery and delegation layers with [Use Skills Subsystem](./how-to/use-skills-subsystem.md), [Use MCP Tools](./how-to/use-mcp-tools.md), and [Use Agent Handoff](./how-to/use-agent-handoff.md).
+4. Add specialized behavior with [Use Reminder Plugin](./how-to/use-reminder-plugin.md), [Use Generative UI](./how-to/use-generative-ui.md), and [Use Deferred Tools](./how-to/use-deferred-tools.md).
+
+## Keep nearby
+
+- [Tool Trait](./reference/tool-trait.md) for exact tool contracts.
+- [Tool and Plugin Boundary](./explanation/tool-and-plugin-boundary.md) for extension design decisions.
+- [Architecture](./explanation/architecture.md) when you need the full runtime model.

--- a/docs/book/src/get-started.md
+++ b/docs/book/src/get-started.md
@@ -1,0 +1,16 @@
+# Get Started
+
+Use this path if you are new to Awaken and want a working mental model before wiring production features.
+
+## Read in order
+
+1. [First Agent](./tutorials/first-agent.md) for the smallest runnable runtime.
+2. [First Tool](./tutorials/first-tool.md) to understand tool schemas, execution, and state writes.
+3. [Build an Agent](./how-to/build-an-agent.md) when you want a reusable project baseline.
+4. [Tool Trait](./reference/tool-trait.md) before writing production tools.
+
+## Leave this path when
+
+- You need more agent capabilities: go to [Build Agents](./build-agents.md).
+- You need HTTP or frontend integration: go to [Serve & Integrate](./serve-and-integrate.md).
+- You need persistence or operational controls: go to [State & Storage](./state-and-storage.md) or [Operate](./operate.md).

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -43,20 +43,23 @@ All state access follows snapshot isolation. Phase hooks see an immutable snapsh
 
 ## What's in This Book
 
-- **Tutorials** — Learn by building a first agent and first tool
-- **How-to** — Task-focused implementation guides for integration and operations
+- **Get Started** — build a working mental model with the smallest runnable flows
+- **Build Agents** — add tools, plugins, MCP, skills, reminders, handoff, and UI capabilities
+- **Serve & Integrate** — expose HTTP endpoints and wire AI SDK or CopilotKit frontends
+- **State & Storage** — choose persistence, context shaping, and state lookup patterns
+- **Operate** — harden runtime behavior with observability, permissions, progress reporting, and tests
 - **Reference** — API, protocol, config, and schema lookup pages
-- **Explanation** — Architecture and design rationale
+- **Architecture** — runtime layering, phase execution, and design tradeoffs
 
 ## Recommended Reading Path
 
 If you are new to the repository, use this order:
 
-1. Read [First Agent](./tutorials/first-agent.md) to see the smallest runnable flow.
-2. Read [First Tool](./tutorials/first-tool.md) to understand state reads and writes.
-3. Read [Tool Trait](./reference/tool-trait.md) before writing production tools.
-4. Use [Build an Agent](./how-to/build-an-agent.md) and [Add a Tool](./how-to/add-a-tool.md) as implementation checklists.
-5. Return to [Architecture](./explanation/architecture.md) and [Run Lifecycle and Phases](./explanation/run-lifecycle-and-phases.md) when you need the full execution model.
+1. Start with [Get Started](./get-started.md) and complete [First Agent](./tutorials/first-agent.md).
+2. Move to [Build Agents](./build-agents.md) when you are ready to add tools and plugins.
+3. Use [Serve & Integrate](./serve-and-integrate.md) when the runtime needs to talk to HTTP clients or frontends.
+4. Use [State & Storage](./state-and-storage.md) and [Operate](./operate.md) as you move from demos to production behavior.
+5. Keep [Reference Overview](./reference/overview.md) and [Architecture](./explanation/architecture.md) open when you need exact contracts or runtime internals.
 
 ## Repository Map
 

--- a/docs/book/src/operate.md
+++ b/docs/book/src/operate.md
@@ -1,0 +1,16 @@
+# Operate
+
+This path is for hardening an agent service once the happy path already works.
+
+## Recommended order
+
+1. [Enable Observability](./how-to/enable-observability.md) to make runs, tools, and providers visible.
+2. [Enable Tool Permission HITL](./how-to/enable-tool-permission-hitl.md) to add approval control over tool execution.
+3. [Configure Stop Policies](./how-to/configure-stop-policies.md) to keep agent loops bounded and predictable.
+4. [Report Tool Progress](./how-to/report-tool-progress.md) and [Testing Strategy](./how-to/testing-strategy.md) to improve operator visibility and confidence.
+
+## Keep nearby
+
+- [Errors](./reference/errors.md)
+- [Cancellation](./reference/cancellation.md)
+- [HITL and Mailbox](./explanation/hitl-and-mailbox.md)

--- a/docs/book/src/serve-and-integrate.md
+++ b/docs/book/src/serve-and-integrate.md
@@ -1,0 +1,16 @@
+# Serve & Integrate
+
+This path is for turning a local runtime into something other systems can call.
+
+## Start here
+
+1. [Expose HTTP SSE](./how-to/expose-http-sse.md) to put the runtime behind HTTP and streaming endpoints.
+2. [Integrate AI SDK Frontend](./how-to/integrate-ai-sdk-frontend.md) for React clients that speak AI SDK v6.
+3. [Integrate CopilotKit (AG-UI)](./how-to/integrate-copilotkit-ag-ui.md) for CopilotKit frontends.
+
+## Reference pages to pair with this section
+
+- [HTTP API](./reference/http-api.md)
+- [AI SDK v6 Protocol](./reference/protocols/ai-sdk-v6.md)
+- [AG-UI Protocol](./reference/protocols/ag-ui.md)
+- [A2A Protocol](./reference/protocols/a2a.md)

--- a/docs/book/src/state-and-storage.md
+++ b/docs/book/src/state-and-storage.md
@@ -1,0 +1,20 @@
+# State & Storage
+
+This path is for teams moving beyond stateless demos.
+
+## Use this section to decide
+
+- where thread and run data should live
+- how state is keyed and merged
+- how much context should reach the model each turn
+
+## Recommended order
+
+1. [Use File Store](./how-to/use-file-store.md) or [Use Postgres Store](./how-to/use-postgres-store.md) to choose a persistence backend.
+2. [State Keys](./reference/state-keys.md) and [Thread Model](./reference/thread-model.md) to understand state layout and lifecycle.
+3. [Optimize Context Window](./how-to/optimize-context-window.md) when context size starts to matter.
+
+## Related internals
+
+- [State and Snapshot Model](./explanation/state-and-snapshot-model.md)
+- [Run Lifecycle and Phases](./explanation/run-lifecycle-and-phases.md)

--- a/docs/book/src/zh-CN/SUMMARY.md
+++ b/docs/book/src/zh-CN/SUMMARY.md
@@ -1,0 +1,81 @@
+# Summary
+
+- [简介](./introduction.md)
+
+# 快速上手
+
+- [快速上手](./get-started.md)
+- [第一个 Agent](./tutorials/first-agent.md)
+- [第一个 Tool](./tutorials/first-tool.md)
+
+# 构建 Agent
+
+- [构建 Agent 路径](./build-agents.md)
+- [构建 Agent](./how-to/build-an-agent.md)
+- [添加 Tool](./how-to/add-a-tool.md)
+- [添加 Plugin](./how-to/add-a-plugin.md)
+- [使用 Skills 子系统](./how-to/use-skills-subsystem.md)
+- [使用 MCP Tools](./how-to/use-mcp-tools.md)
+- [使用 Reminder 插件](./how-to/use-reminder-plugin.md)
+- [使用 Generative UI（A2UI）](./how-to/use-generative-ui.md)
+- [使用 Agent Handoff](./how-to/use-agent-handoff.md)
+- [使用延迟加载工具](./how-to/use-deferred-tools.md)
+
+# 服务与集成
+
+- [服务与集成](./serve-and-integrate.md)
+- [通过 SSE 暴露 HTTP](./how-to/expose-http-sse.md)
+- [集成 AI SDK 前端](./how-to/integrate-ai-sdk-frontend.md)
+- [集成 CopilotKit（AG-UI）](./how-to/integrate-copilotkit-ag-ui.md)
+
+# 状态与存储
+
+- [状态与存储](./state-and-storage.md)
+- [使用文件存储](./how-to/use-file-store.md)
+- [使用 Postgres 存储](./how-to/use-postgres-store.md)
+- [优化上下文窗口](./how-to/optimize-context-window.md)
+- [状态键](./reference/state-keys.md)
+- [线程模型](./reference/thread-model.md)
+
+# 运行与运维
+
+- [运行与运维](./operate.md)
+- [启用工具权限 HITL](./how-to/enable-tool-permission-hitl.md)
+- [配置停止策略](./how-to/configure-stop-policies.md)
+- [启用可观测性](./how-to/enable-observability.md)
+- [上报 Tool 进度](./how-to/report-tool-progress.md)
+- [测试策略](./how-to/testing-strategy.md)
+
+# 参考
+
+- [概览](./reference/overview.md)
+- [Tool Trait](./reference/tool-trait.md)
+- [Scheduled Actions](./reference/scheduled-actions.md)
+- [Effects](./reference/effects.md)
+- [事件](./reference/events.md)
+- [HTTP API](./reference/http-api.md)
+- [配置](./reference/config.md)
+- [错误](./reference/errors.md)
+- [AI SDK v6 协议](./reference/protocols/ai-sdk-v6.md)
+- [AG-UI 协议](./reference/protocols/ag-ui.md)
+- [A2A 协议](./reference/protocols/a2a.md)
+- [取消](./reference/cancellation.md)
+- [工具执行模式](./reference/tool-execution-modes.md)
+
+# 架构
+
+- [架构](./explanation/architecture.md)
+- [智能体解析](./explanation/agent-resolution.md)
+- [状态与快照模型](./explanation/state-and-snapshot-model.md)
+- [Run 生命周期与 Phases](./explanation/run-lifecycle-and-phases.md)
+- [HITL 与 Mailbox](./explanation/hitl-and-mailbox.md)
+- [多智能体模式](./explanation/multi-agent-patterns.md)
+- [Tool 与 Plugin 的边界](./explanation/tool-and-plugin-boundary.md)
+- [插件系统内部机制](./explanation/plugin-internals.md)
+- [设计取舍](./explanation/design-tradeoffs.md)
+
+# 附录
+
+- [术语表](./appendix/glossary.md)
+- [常见问题](./appendix/faq.md)
+- [从 Tirea 迁移](./appendix/migration-from-tirea.md)

--- a/docs/book/src/zh-CN/build-agents.md
+++ b/docs/book/src/zh-CN/build-agents.md
@@ -1,0 +1,16 @@
+# 构建 Agent 路径
+
+当你已经理解基础运行流程，接下来就进入这条路径，把 Agent 能力逐步拼装完整。
+
+## 推荐顺序
+
+1. 先读 [构建 Agent](./how-to/build-an-agent.md)，确定 runtime、model registry 和 agent spec 的骨架。
+2. 再读 [添加 Tool](./how-to/add-a-tool.md) 和 [添加 Plugin](./how-to/add-a-plugin.md)，用安全的方式扩展行为。
+3. 需要发现与委托能力时，继续阅读 [使用 Skills 子系统](./how-to/use-skills-subsystem.md)、[使用 MCP Tools](./how-to/use-mcp-tools.md) 和 [使用 Agent Handoff](./how-to/use-agent-handoff.md)。
+4. 需要更具体的能力时，再补上 [使用 Reminder 插件](./how-to/use-reminder-plugin.md)、[使用 Generative UI](./how-to/use-generative-ui.md) 和 [使用延迟加载工具](./how-to/use-deferred-tools.md)。
+
+## 建议搭配阅读
+
+- [Tool Trait](./reference/tool-trait.md) 用于核对精确契约。
+- [Tool 与 Plugin 的边界](./explanation/tool-and-plugin-boundary.md) 用于判断扩展应该放在哪一层。
+- [架构](./explanation/architecture.md) 用于理解完整运行时模型。

--- a/docs/book/src/zh-CN/get-started.md
+++ b/docs/book/src/zh-CN/get-started.md
@@ -1,0 +1,16 @@
+# 快速上手
+
+如果你第一次接触 Awaken，先走这条路径，用最小可运行流程建立整体心智模型。
+
+## 推荐顺序
+
+1. 阅读 [第一个 Agent](./tutorials/first-agent.md)，先跑通最小 runtime。
+2. 阅读 [第一个 Tool](./tutorials/first-tool.md)，理解 tool schema、执行流程和状态写入。
+3. 进入 [构建 Agent](./how-to/build-an-agent.md)，把示例整理成可复用的工程基线。
+4. 在写生产级工具前，补上 [Tool Trait](./reference/tool-trait.md)。
+
+## 何时离开这条路径
+
+- 需要更多 Agent 能力时，进入 [构建 Agent 路径](./build-agents.md)。
+- 需要 HTTP 或前端集成时，进入 [服务与集成](./serve-and-integrate.md)。
+- 需要持久化和运行控制时，进入 [状态与存储](./state-and-storage.md) 或 [运行与运维](./operate.md)。

--- a/docs/book/src/zh-CN/introduction.md
+++ b/docs/book/src/zh-CN/introduction.md
@@ -43,20 +43,23 @@ AgentRuntime
 
 ## 本书内容
 
-- **教程** — 通过构建第一个智能体和第一个工具来学习
-- **操作指南** — 面向任务的集成与运维实现指南
+- **快速上手** — 用最小可运行流程建立整体心智模型
+- **构建 Agent** — 添加 Tool、Plugin、MCP、Skills、Reminder、Handoff 和 UI 能力
+- **服务与集成** — 暴露 HTTP 端点并接入 AI SDK 或 CopilotKit 前端
+- **状态与存储** — 选择持久化、上下文裁剪和状态访问模式
+- **运行与运维** — 用可观测性、权限、进度上报和测试加固生产行为
 - **参考** — API、协议、配置和 Schema 查阅页面
-- **解释** — 架构与设计原理
+- **架构** — 运行时分层、phase 执行与设计取舍
 
 ## 推荐阅读路径
 
 如果你是第一次接触本项目，建议按以下顺序阅读：
 
-1. 阅读 [第一个 Agent](./tutorials/first-agent.md) 了解最小可运行流程。
-2. 阅读 [第一个 Tool](./tutorials/first-tool.md) 理解状态读写。
-3. 在编写生产工具前，阅读 [Tool Trait 参考](./reference/tool-trait.md)。
-4. 使用 [构建 Agent](./how-to/build-an-agent.md) 和 [添加 Tool](./how-to/add-a-tool.md) 作为实现检查清单。
-5. 需要完整执行模型时，返回阅读 [架构](./explanation/architecture.md) 和 [Run 生命周期与阶段](./explanation/run-lifecycle-and-phases.md)。
+1. 先阅读 [快速上手](./get-started.md)，并完成 [第一个 Agent](./tutorials/first-agent.md)。
+2. 需要扩展能力时，进入 [构建 Agent](./build-agents.md)。
+3. 需要对接 HTTP 客户端或前端时，进入 [服务与集成](./serve-and-integrate.md)。
+4. 从演示走向生产时，阅读 [状态与存储](./state-and-storage.md) 和 [运行与运维](./operate.md)。
+5. 需要精确契约或运行时内部细节时，回到 [参考概览](./reference/overview.md) 和 [架构](./explanation/architecture.md)。
 
 ## 仓库导航
 

--- a/docs/book/src/zh-CN/operate.md
+++ b/docs/book/src/zh-CN/operate.md
@@ -1,0 +1,16 @@
+# 运行与运维
+
+当 happy path 已经跑通，这条路径用于把 Agent 服务加固到可运维状态。
+
+## 推荐顺序
+
+1. 先启用 [可观测性](./how-to/enable-observability.md)，把 run、tool 和 provider 变得可见。
+2. 再启用 [工具权限 HITL](./how-to/enable-tool-permission-hitl.md)，为工具执行增加审批控制。
+3. 通过 [配置停止策略](./how-to/configure-stop-policies.md) 把 agent loop 约束在可预测范围内。
+4. 用 [上报 Tool 进度](./how-to/report-tool-progress.md) 和 [测试策略](./how-to/testing-strategy.md) 提升可观测性和上线信心。
+
+## 建议搭配阅读
+
+- [错误](./reference/errors.md)
+- [取消](./reference/cancellation.md)
+- [HITL 与 Mailbox](./explanation/hitl-and-mailbox.md)

--- a/docs/book/src/zh-CN/serve-and-integrate.md
+++ b/docs/book/src/zh-CN/serve-and-integrate.md
@@ -1,0 +1,16 @@
+# 服务与集成
+
+这条路径面向需要把本地 runtime 暴露给其他系统调用的场景。
+
+## 从这里开始
+
+1. 阅读 [通过 SSE 暴露 HTTP](./how-to/expose-http-sse.md)，先把 runtime 放到 HTTP 和流式端点后面。
+2. 阅读 [集成 AI SDK 前端](./how-to/integrate-ai-sdk-frontend.md)，对接 React + AI SDK v6。
+3. 阅读 [集成 CopilotKit（AG-UI）](./how-to/integrate-copilotkit-ag-ui.md)，对接 CopilotKit 前端。
+
+## 建议同时查阅
+
+- [HTTP API](./reference/http-api.md)
+- [AI SDK v6 协议](./reference/protocols/ai-sdk-v6.md)
+- [AG-UI 协议](./reference/protocols/ag-ui.md)
+- [A2A 协议](./reference/protocols/a2a.md)

--- a/docs/book/src/zh-CN/state-and-storage.md
+++ b/docs/book/src/zh-CN/state-and-storage.md
@@ -1,0 +1,20 @@
+# 状态与存储
+
+这条路径面向已经不满足无状态演示、需要认真设计状态与持久化的团队。
+
+## 你可以在这里决定
+
+- thread / run 数据放在哪里
+- 状态键和合并策略怎么组织
+- 每一轮究竟把多少上下文送给模型
+
+## 推荐顺序
+
+1. 从 [使用文件存储](./how-to/use-file-store.md) 或 [使用 Postgres 存储](./how-to/use-postgres-store.md) 开始，先确定持久化后端。
+2. 阅读 [状态键](./reference/state-keys.md) 和 [线程模型](./reference/thread-model.md)，理解状态布局和生命周期。
+3. 当上下文规模开始成为问题时，再阅读 [优化上下文窗口](./how-to/optimize-context-window.md)。
+
+## 相关内部机制
+
+- [状态与快照模型](./explanation/state-and-snapshot-model.md)
+- [Run 生命周期与 Phases](./explanation/run-lifecycle-and-phases.md)

--- a/docs/book/theme/language-switcher.css
+++ b/docs/book/theme/language-switcher.css
@@ -1,0 +1,42 @@
+.language-switcher {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 0.75rem;
+    border: 1px solid var(--searchbar-border-color);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.language-switcher-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 3rem;
+    padding: 0.15rem 0.65rem;
+    color: var(--fg);
+    font-size: 0.875rem;
+    text-decoration: none;
+    background: transparent;
+}
+
+.language-switcher-link:hover {
+    background: var(--theme-hover);
+    text-decoration: none;
+}
+
+.language-switcher-link.active {
+    background: var(--icons);
+    color: var(--bg);
+    font-weight: 600;
+}
+
+@media (max-width: 900px) {
+    .language-switcher {
+        margin-left: 0.5rem;
+    }
+
+    .language-switcher-link {
+        min-width: 2.5rem;
+        padding: 0.1rem 0.5rem;
+    }
+}

--- a/docs/book/theme/language-switcher.js
+++ b/docs/book/theme/language-switcher.js
@@ -1,0 +1,63 @@
+(function () {
+    if (document.body.classList.contains("sidebar-iframe-inner")) {
+        return;
+    }
+
+    const menuButtons = document.querySelector("#mdbook-menu-bar .right-buttons");
+    if (!menuButtons || document.querySelector(".language-switcher")) {
+        return;
+    }
+
+    const currentLang = document.documentElement.lang === "zh-CN" ? "zh-CN" : "en";
+    const pathToRoot = typeof path_to_root === "string" && path_to_root.length > 0 ? path_to_root : ".";
+    const bookRootUrl = new URL(pathToRoot, window.location.href);
+    let bookRootPath = bookRootUrl.pathname;
+
+    if (!bookRootPath.endsWith("/")) {
+        bookRootPath += "/";
+    }
+
+    const currentPath = window.location.pathname;
+    let pagePath = currentPath.startsWith(bookRootPath)
+        ? currentPath.slice(bookRootPath.length)
+        : "";
+
+    if (pagePath === "index.html") {
+        pagePath = "";
+    }
+
+    let alternateRootPath;
+    if (currentLang === "zh-CN") {
+        alternateRootPath = bookRootPath.replace(/zh-CN\/?$/, "");
+    } else {
+        alternateRootPath = `${bookRootPath.replace(/\/$/, "")}/zh-CN/`;
+    }
+
+    const alternateUrl = new URL(
+        `${pagePath}${window.location.search}${window.location.hash}`,
+        `${window.location.origin}${alternateRootPath}`
+    );
+
+    const switcher = document.createElement("nav");
+    switcher.className = "language-switcher";
+    switcher.setAttribute("aria-label", "Language switcher");
+
+    const entries = [
+        { code: "en", label: "EN", href: currentLang === "en" ? window.location.href : alternateUrl.href },
+        { code: "zh-CN", label: "中文", href: currentLang === "zh-CN" ? window.location.href : alternateUrl.href },
+    ];
+
+    entries.forEach((entry) => {
+        const link = document.createElement("a");
+        link.className = "language-switcher-link";
+        if (entry.code === currentLang) {
+            link.classList.add("active");
+            link.setAttribute("aria-current", "page");
+        }
+        link.href = entry.href;
+        link.textContent = entry.label;
+        switcher.appendChild(link);
+    });
+
+    menuButtons.prepend(switcher);
+})();

--- a/docs/book/theme/mermaid-init.js
+++ b/docs/book/theme/mermaid-init.js
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+(() => {
+    const darkThemes = ["ayu", "navy", "coal"];
+    const lightThemes = ["light", "rust"];
+    const classList = document.documentElement.classList;
+
+    let lastThemeWasLight = true;
+    for (const cssClass of classList) {
+        if (darkThemes.includes(cssClass)) {
+            lastThemeWasLight = false;
+            break;
+        }
+    }
+
+    const theme = lastThemeWasLight ? "default" : "dark";
+    mermaid.initialize({ startOnLoad: true, theme });
+
+    // Refresh the page after a theme flip so Mermaid diagrams rerender with the new palette.
+    const bindReload = (themeName, shouldReload) => {
+        const button =
+            document.getElementById(`mdbook-theme-${themeName}`) ||
+            document.getElementById(themeName);
+
+        if (!button) {
+            return;
+        }
+
+        button.addEventListener("click", () => {
+            if (shouldReload) {
+                window.location.reload();
+            }
+        });
+    };
+
+    for (const darkTheme of darkThemes) {
+        bindReload(darkTheme, lastThemeWasLight);
+    }
+
+    for (const lightTheme of lightThemes) {
+        bindReload(lightTheme, !lastThemeWasLight);
+    }
+})();

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 WORKSPACE_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BOOK_ROOT="$WORKSPACE_ROOT/docs/book"
+BOOK_OUTPUT_ROOT="$WORKSPACE_ROOT/target/book"
+BOOK_STAGE_ROOT="$WORKSPACE_ROOT/target/book-stage"
 
 if ! command -v mdbook >/dev/null 2>&1; then
     echo "error: mdbook is required. Install with: cargo install mdbook --locked"
@@ -16,16 +19,63 @@ fi
 echo "==> Building cargo doc..."
 cargo doc --workspace --no-deps --manifest-path "$WORKSPACE_ROOT/Cargo.toml"
 
-echo "==> Installing Mermaid support..."
-mdbook-mermaid install "$WORKSPACE_ROOT/docs/book"
+prepare_book_stage() {
+    local variant="$1"
+    local stage_dir="$BOOK_STAGE_ROOT/$variant"
+
+    rm -rf "$stage_dir"
+    mkdir -p "$stage_dir/src"
+
+    cp "$BOOK_ROOT/book.toml" "$stage_dir/book.toml"
+
+    if [ -d "$BOOK_ROOT/theme" ]; then
+        cp -a "$BOOK_ROOT/theme" "$stage_dir/theme"
+        cp "$BOOK_ROOT/theme/language-switcher.css" "$stage_dir/language-switcher.css"
+        cp "$BOOK_ROOT/theme/language-switcher.js" "$stage_dir/language-switcher.js"
+    fi
+
+    case "$variant" in
+        en)
+            cp -a "$BOOK_ROOT/src/." "$stage_dir/src/"
+            rm -rf "$stage_dir/src/zh-CN"
+            ;;
+        zh-CN)
+            cp -a "$BOOK_ROOT/src/zh-CN/." "$stage_dir/src/"
+            sed -i 's/^language = "en"$/language = "zh-CN"/' "$stage_dir/book.toml"
+            ;;
+        *)
+            echo "error: unknown book variant: $variant"
+            exit 1
+            ;;
+    esac
+}
+
+build_book_variant() {
+    local variant="$1"
+    local destination="$2"
+    local stage_dir="$BOOK_STAGE_ROOT/$variant"
+
+    prepare_book_stage "$variant"
+
+    echo "==> Installing Mermaid support for $variant..."
+    mdbook-mermaid install "$stage_dir"
+    cp "$BOOK_ROOT/theme/mermaid-init.js" "$stage_dir/mermaid-init.js"
+
+    echo "==> Building mdBook ($variant)..."
+    mdbook build "$stage_dir" -d "$destination"
+}
+
+rm -rf "$BOOK_OUTPUT_ROOT" "$BOOK_STAGE_ROOT"
+mkdir -p "$BOOK_OUTPUT_ROOT" "$BOOK_STAGE_ROOT"
 
 # Note: to test book code examples, use scripts/test-book.sh (build and test are separate)
-echo "==> Building mdBook..."
-mdbook build "$WORKSPACE_ROOT/docs/book"
+build_book_variant "en" "$BOOK_OUTPUT_ROOT"
+build_book_variant "zh-CN" "$BOOK_OUTPUT_ROOT/zh-CN"
 
 # Copy cargo doc output into book output for unified serving
-if [ -d "$WORKSPACE_ROOT/target/book" ] && [ -d "$WORKSPACE_ROOT/target/doc" ]; then
-    cp -r "$WORKSPACE_ROOT/target/doc" "$WORKSPACE_ROOT/target/book/doc"
+if [ -d "$BOOK_OUTPUT_ROOT" ] && [ -d "$WORKSPACE_ROOT/target/doc" ]; then
+    cp -r "$WORKSPACE_ROOT/target/doc" "$BOOK_OUTPUT_ROOT/doc"
     echo "==> Unified docs at: target/book/index.html"
     echo "    API docs at:     target/book/doc/awaken/index.html"
+    echo "    Chinese docs at: target/book/zh-CN/index.html"
 fi


### PR DESCRIPTION
## Summary
- split the published mdBook into separate English and Chinese sites so sidebar, search, and prev/next navigation stay language-local
- add a page-level EN/中文 switcher and a compatible Mermaid theme script for the current mdBook output
- reorganize docs navigation around task-based reading paths with new hub pages and update README links to point at GitHub Pages
- add docs structure validation so English and Chinese page trees and SUMMARY links stay in sync

## Testing
- `bash scripts/test-book.sh`
- `bash scripts/build-docs.sh`
