### PR TITLE
feat: add StateScope and key-based ProfileAccess for cross-boundary shared state

### DIFF
--- a/crates/awaken-contract/src/contract/mod.rs
+++ b/crates/awaken-contract/src/contract/mod.rs
@@ -12,6 +12,7 @@ pub mod mailbox;
 pub mod message;
 pub mod profile_store;
 pub mod progress;
+pub mod shared_state;
 pub mod storage;
 pub mod suspension;
 pub mod tool;

--- a/crates/awaken-contract/src/contract/shared_state.rs
+++ b/crates/awaken-contract/src/contract/shared_state.rs
@@ -1,0 +1,90 @@
+//! Shared state scoping for cross-boundary persistence.
+//!
+//! Shared state reuses the [`ProfileKey`](super::profile_store::ProfileKey)
+//! mechanism with [`StateScope`] as the dynamic key dimension.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Identifies a shared state scope at runtime.
+///
+/// A plain string that serves as the key dimension in `ProfileAccess`.
+/// Convenience constructors cover common patterns; arbitrary strings
+/// are accepted via `StateScope::new`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct StateScope(String);
+
+impl StateScope {
+    pub fn new(scope: impl Into<String>) -> Self {
+        Self(scope.into())
+    }
+
+    pub fn global() -> Self {
+        Self("global".into())
+    }
+
+    pub fn parent_thread(id: &str) -> Self {
+        Self(format!("parent_thread::{id}"))
+    }
+
+    pub fn agent_type(name: &str) -> Self {
+        Self(format!("agent_type::{name}"))
+    }
+
+    pub fn thread(id: &str) -> Self {
+        Self(format!("thread::{id}"))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for StateScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_scope_display() {
+        assert_eq!(StateScope::global().to_string(), "global");
+        assert_eq!(
+            StateScope::parent_thread("t1").to_string(),
+            "parent_thread::t1"
+        );
+        assert_eq!(
+            StateScope::agent_type("planner").to_string(),
+            "agent_type::planner"
+        );
+        assert_eq!(StateScope::thread("abc").to_string(), "thread::abc");
+        assert_eq!(StateScope::new("custom").to_string(), "custom");
+    }
+
+    #[test]
+    fn state_scope_equality() {
+        assert_eq!(StateScope::global(), StateScope::global());
+        assert_ne!(StateScope::global(), StateScope::thread("x"));
+    }
+
+    #[test]
+    fn state_scope_serde_roundtrip() {
+        let scopes = vec![
+            StateScope::global(),
+            StateScope::parent_thread("p1"),
+            StateScope::agent_type("worker"),
+            StateScope::thread("t1"),
+            StateScope::new("custom"),
+        ];
+        for scope in scopes {
+            let json = serde_json::to_string(&scope).expect("serialize");
+            let back: StateScope = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(scope, back);
+        }
+    }
+}

--- a/crates/awaken-contract/src/lib.rs
+++ b/crates/awaken-contract/src/lib.rs
@@ -57,6 +57,9 @@ pub use contract::mailbox::{
 // ── profile store ──
 pub use contract::profile_store::{ProfileEntry, ProfileKey, ProfileOwner, ProfileStore};
 
+// ── shared state ──
+pub use contract::shared_state::StateScope;
+
 // ── tool schema ──
 pub use contract::tool::TypedTool;
 pub use contract::tool_schema::{generate_tool_schema, sanitize_for_llm, validate_against_schema};

--- a/crates/awaken-ext-deferred-tools/src/plugin/hooks.rs
+++ b/crates/awaken-ext-deferred-tools/src/plugin/hooks.rs
@@ -9,8 +9,6 @@ use awaken_runtime::state::StateCommand;
 
 use awaken_runtime::phase::TypedScheduledActionHandler;
 
-use awaken_contract::contract::profile_store::ProfileOwner;
-
 use crate::config::{DeferredToolsConfigKey, ToolLoadMode};
 use crate::policy::DiscBetaEvaluator;
 use crate::state::{
@@ -315,9 +313,9 @@ impl PhaseHook for LoadPriorsHook {
         };
 
         let config = ctx.config::<DeferredToolsConfigKey>().unwrap_or_default();
-        let owner = ProfileOwner::Agent(ctx.agent_spec.id.clone());
+        let key = ctx.agent_spec.id.as_str();
 
-        let priors = match profile_access.read::<AgentToolPriorsKey>(&owner).await {
+        let priors = match profile_access.read::<AgentToolPriorsKey>(key).await {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to read agent tool priors");
@@ -377,9 +375,9 @@ impl PhaseHook for PersistPriorsHook {
             return Ok(StateCommand::new());
         }
 
-        let owner = ProfileOwner::Agent(ctx.agent_spec.id.clone());
+        let key = ctx.agent_spec.id.as_str();
 
-        let mut priors = match profile_access.read::<AgentToolPriorsKey>(&owner).await {
+        let mut priors = match profile_access.read::<AgentToolPriorsKey>(key).await {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to read agent tool priors before update");
@@ -399,7 +397,7 @@ impl PhaseHook for PersistPriorsHook {
         priors.session_count += 1;
 
         if let Err(e) = profile_access
-            .write::<AgentToolPriorsKey>(&owner, &priors)
+            .write::<AgentToolPriorsKey>(key, &priors)
             .await
         {
             tracing::warn!(error = %e, "failed to persist agent tool priors");

--- a/crates/awaken-runtime/src/profile/mod.rs
+++ b/crates/awaken-runtime/src/profile/mod.rs
@@ -37,12 +37,13 @@ impl ProfileAccess {
     }
 
     /// Read a typed value. Returns `K::Value::default()` if the entry is missing.
-    pub async fn read<K: ProfileKey>(
-        &self,
-        owner: &ProfileOwner,
-    ) -> Result<K::Value, StorageError> {
+    ///
+    /// - `K::KEY` is the namespace (which data type)
+    /// - `key` is the dynamic identifier (which instance)
+    pub async fn read<K: ProfileKey>(&self, key: &str) -> Result<K::Value, StorageError> {
         self.ensure_registered(K::KEY)?;
-        match self.store.get(owner, K::KEY).await? {
+        let owner = Self::key_to_owner(key);
+        match self.store.get(&owner, K::KEY).await? {
             Some(entry) => K::decode(entry.value).map_err(|e| StorageError::Io(e.to_string())),
             None => Ok(K::Value::default()),
         }
@@ -51,28 +52,33 @@ impl ProfileAccess {
     /// Write a typed value.
     pub async fn write<K: ProfileKey>(
         &self,
-        owner: &ProfileOwner,
+        key: &str,
         value: &K::Value,
     ) -> Result<(), StorageError> {
         self.ensure_registered(K::KEY)?;
         let json = K::encode(value).map_err(|e| StorageError::Io(e.to_string()))?;
-        self.store.set(owner, K::KEY, json).await
+        self.store.set(&Self::key_to_owner(key), K::KEY, json).await
     }
 
     /// Delete a typed entry.
-    pub async fn delete<K: ProfileKey>(&self, owner: &ProfileOwner) -> Result<(), StorageError> {
+    pub async fn delete<K: ProfileKey>(&self, key: &str) -> Result<(), StorageError> {
         self.ensure_registered(K::KEY)?;
-        self.store.delete(owner, K::KEY).await
+        self.store.delete(&Self::key_to_owner(key), K::KEY).await
     }
 
-    /// List all entries for an owner.
-    pub async fn list(&self, owner: &ProfileOwner) -> Result<Vec<ProfileEntry>, StorageError> {
-        self.store.list(owner).await
+    /// List all entries for a key.
+    pub async fn list(&self, key: &str) -> Result<Vec<ProfileEntry>, StorageError> {
+        self.store.list(&Self::key_to_owner(key)).await
     }
 
-    /// Delete all entries for an owner.
-    pub async fn clear_owner(&self, owner: &ProfileOwner) -> Result<(), StorageError> {
-        self.store.clear_owner(owner).await
+    /// Delete all entries for a key.
+    pub async fn clear(&self, key: &str) -> Result<(), StorageError> {
+        self.store.clear_owner(&Self::key_to_owner(key)).await
+    }
+
+    /// Map a user-facing key string to a `ProfileOwner` for storage.
+    fn key_to_owner(key: &str) -> ProfileOwner {
+        ProfileOwner::Agent(key.to_owned())
     }
 
     fn ensure_registered(&self, key: &str) -> Result<(), StorageError> {
@@ -179,59 +185,52 @@ mod tests {
     #[tokio::test]
     async fn read_missing_returns_default() {
         let access = make_access(&["locale"]);
-        let val = access.read::<Locale>(&ProfileOwner::System).await.unwrap();
+        let val = access.read::<Locale>("system").await.unwrap();
         assert_eq!(val, String::default());
     }
 
     #[tokio::test]
     async fn write_then_read_roundtrip() {
         let access = make_access(&["locale"]);
-        let owner = ProfileOwner::Agent("alice".into());
         access
-            .write::<Locale>(&owner, &"en-US".to_string())
+            .write::<Locale>("alice", &"en-US".to_string())
             .await
             .unwrap();
-        let val = access.read::<Locale>(&owner).await.unwrap();
+        let val = access.read::<Locale>("alice").await.unwrap();
         assert_eq!(val, "en-US");
     }
 
     #[tokio::test]
     async fn delete_removes_entry() {
         let access = make_access(&["locale"]);
-        let owner = ProfileOwner::System;
         access
-            .write::<Locale>(&owner, &"fr".to_string())
+            .write::<Locale>("system", &"fr".to_string())
             .await
             .unwrap();
-        access.delete::<Locale>(&owner).await.unwrap();
-        let val = access.read::<Locale>(&owner).await.unwrap();
+        access.delete::<Locale>("system").await.unwrap();
+        let val = access.read::<Locale>("system").await.unwrap();
         assert_eq!(val, String::default());
     }
 
     #[tokio::test]
     async fn unregistered_key_returns_error() {
         let access = make_access(&["locale"]);
-        let err = access
-            .read::<Unregistered>(&ProfileOwner::System)
-            .await
-            .unwrap_err();
+        let err = access.read::<Unregistered>("system").await.unwrap_err();
         assert!(err.to_string().contains("not registered"));
     }
 
     #[tokio::test]
-    async fn owners_are_isolated() {
+    async fn keys_are_isolated() {
         let access = make_access(&["locale"]);
-        let alice = ProfileOwner::Agent("alice".into());
-        let bob = ProfileOwner::Agent("bob".into());
         access
-            .write::<Locale>(&alice, &"en".to_string())
+            .write::<Locale>("alice", &"en".to_string())
             .await
             .unwrap();
         access
-            .write::<Locale>(&bob, &"fr".to_string())
+            .write::<Locale>("bob", &"fr".to_string())
             .await
             .unwrap();
-        assert_eq!(access.read::<Locale>(&alice).await.unwrap(), "en");
-        assert_eq!(access.read::<Locale>(&bob).await.unwrap(), "fr");
+        assert_eq!(access.read::<Locale>("alice").await.unwrap(), "en");
+        assert_eq!(access.read::<Locale>("bob").await.unwrap(), "fr");
     }
 }

--- a/crates/awaken-runtime/tests/profile_store_integration.rs
+++ b/crates/awaken-runtime/tests/profile_store_integration.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use awaken_contract::StateError;
-use awaken_contract::contract::profile_store::{ProfileKey, ProfileOwner};
+use awaken_contract::contract::profile_store::ProfileKey;
 use awaken_runtime::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
 use awaken_runtime::profile::{ProfileAccess, ProfileKeyRegistry};
 use awaken_stores::InMemoryStore;
@@ -55,11 +55,8 @@ fn build_access_from_plugin(plugin: &dyn Plugin) -> ProfileAccess {
 async fn plugin_registers_key_and_access_reads_writes() {
     let access = build_access_from_plugin(&TestProfilePlugin);
 
-    let alice = ProfileOwner::Agent("alice".into());
-    let bob = ProfileOwner::Agent("bob".into());
-
     // Read default (missing key returns Default)
-    let val = access.read::<AgentMemoryKey>(&alice).await.unwrap();
+    let val = access.read::<AgentMemoryKey>("alice").await.unwrap();
     assert_eq!(val, AgentMemory::default());
 
     // Write
@@ -67,16 +64,16 @@ async fn plugin_registers_key_and_access_reads_writes() {
         facts: vec!["likes rust".into(), "hates nulls".into()],
     };
     access
-        .write::<AgentMemoryKey>(&alice, &memory)
+        .write::<AgentMemoryKey>("alice", &memory)
         .await
         .unwrap();
 
     // Read back
-    let loaded = access.read::<AgentMemoryKey>(&alice).await.unwrap();
+    let loaded = access.read::<AgentMemoryKey>("alice").await.unwrap();
     assert_eq!(loaded, memory);
 
     // Isolation: bob still has default
-    let bob_val = access.read::<AgentMemoryKey>(&bob).await.unwrap();
+    let bob_val = access.read::<AgentMemoryKey>("bob").await.unwrap();
     assert_eq!(bob_val, AgentMemory::default());
 
     // Write for bob and verify both exist independently
@@ -84,38 +81,40 @@ async fn plugin_registers_key_and_access_reads_writes() {
         facts: vec!["prefers python".into()],
     };
     access
-        .write::<AgentMemoryKey>(&bob, &bob_memory)
+        .write::<AgentMemoryKey>("bob", &bob_memory)
         .await
         .unwrap();
-    assert_eq!(access.read::<AgentMemoryKey>(&alice).await.unwrap(), memory);
     assert_eq!(
-        access.read::<AgentMemoryKey>(&bob).await.unwrap(),
+        access.read::<AgentMemoryKey>("alice").await.unwrap(),
+        memory
+    );
+    assert_eq!(
+        access.read::<AgentMemoryKey>("bob").await.unwrap(),
         bob_memory
     );
 }
 
 #[tokio::test]
-async fn clear_owner_removes_all_entries() {
+async fn clear_removes_all_entries() {
     let access = build_access_from_plugin(&TestProfilePlugin);
 
-    let owner = ProfileOwner::Agent("charlie".into());
     let memory = AgentMemory {
         facts: vec!["fact one".into()],
     };
     access
-        .write::<AgentMemoryKey>(&owner, &memory)
+        .write::<AgentMemoryKey>("charlie", &memory)
         .await
         .unwrap();
 
     // Verify written
-    let entries = access.list(&owner).await.unwrap();
+    let entries = access.list("charlie").await.unwrap();
     assert_eq!(entries.len(), 1);
 
     // Clear
-    access.clear_owner(&owner).await.unwrap();
+    access.clear("charlie").await.unwrap();
 
     // Verify gone (reads default)
-    let val = access.read::<AgentMemoryKey>(&owner).await.unwrap();
+    let val = access.read::<AgentMemoryKey>("charlie").await.unwrap();
     assert_eq!(val, AgentMemory::default());
-    assert!(access.list(&owner).await.unwrap().is_empty());
+    assert!(access.list("charlie").await.unwrap().is_empty());
 }

--- a/crates/awaken-runtime/tests/shared_state_integration.rs
+++ b/crates/awaken-runtime/tests/shared_state_integration.rs
@@ -1,0 +1,290 @@
+//! Integration tests for shared state via ProfileAccess + StateScope.
+
+use std::sync::Arc;
+
+use awaken_contract::StateError;
+use awaken_contract::contract::profile_store::{ProfileKey, ProfileStore};
+use awaken_contract::contract::shared_state::StateScope;
+use awaken_runtime::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
+use awaken_runtime::profile::ProfileAccess;
+use awaken_stores::InMemoryStore;
+
+// ── Test types ──
+
+#[derive(Clone, Default, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+struct AgentMemory {
+    facts: Vec<String>,
+}
+
+struct AgentMemoryKey;
+impl ProfileKey for AgentMemoryKey {
+    const KEY: &'static str = "agent_memory";
+    type Value = AgentMemory;
+}
+
+#[derive(Clone, Default, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+struct SharedConfig {
+    max_retries: u32,
+}
+
+struct SharedConfigKey;
+impl ProfileKey for SharedConfigKey {
+    const KEY: &'static str = "shared_config";
+    type Value = SharedConfig;
+}
+
+// ── Test plugin ──
+
+struct SharedStateTestPlugin;
+
+impl Plugin for SharedStateTestPlugin {
+    fn descriptor(&self) -> PluginDescriptor {
+        PluginDescriptor {
+            name: "shared-state-test",
+        }
+    }
+
+    fn register(&self, r: &mut PluginRegistrar) -> Result<(), StateError> {
+        r.register_profile_key::<AgentMemoryKey>()?;
+        r.register_profile_key::<SharedConfigKey>()?;
+        Ok(())
+    }
+}
+
+// ── Helper ──
+
+fn build_access() -> ProfileAccess {
+    let mut registrar = PluginRegistrar::new_for_test();
+    SharedStateTestPlugin
+        .register(&mut registrar)
+        .expect("register");
+    let key_names = registrar.profile_keys_for_test().into_iter().map(|r| r.key);
+    let registry = awaken_runtime::profile::ProfileKeyRegistry::new(key_names);
+    let store: Arc<dyn ProfileStore> = Arc::new(InMemoryStore::default());
+    ProfileAccess::new(store, registry)
+}
+
+// ── Tests ──
+
+#[tokio::test]
+async fn global_scope_read_write() {
+    let access = build_access();
+    let key = StateScope::global();
+
+    let mem = AgentMemory {
+        facts: vec!["sky is blue".into()],
+    };
+    access
+        .write::<AgentMemoryKey>(key.as_str(), &mem)
+        .await
+        .unwrap();
+    let read = access.read::<AgentMemoryKey>(key.as_str()).await.unwrap();
+    assert_eq!(read, mem);
+}
+
+#[tokio::test]
+async fn parent_thread_scopes_are_isolated() {
+    let access = build_access();
+    let key_a = StateScope::parent_thread("parent-1");
+    let key_b = StateScope::parent_thread("parent-2");
+
+    access
+        .write::<AgentMemoryKey>(
+            key_a.as_str(),
+            &AgentMemory {
+                facts: vec!["from parent-1".into()],
+            },
+        )
+        .await
+        .unwrap();
+    access
+        .write::<AgentMemoryKey>(
+            key_b.as_str(),
+            &AgentMemory {
+                facts: vec!["from parent-2".into()],
+            },
+        )
+        .await
+        .unwrap();
+
+    let a = access.read::<AgentMemoryKey>(key_a.as_str()).await.unwrap();
+    let b = access.read::<AgentMemoryKey>(key_b.as_str()).await.unwrap();
+    assert_eq!(a.facts, vec!["from parent-1"]);
+    assert_eq!(b.facts, vec!["from parent-2"]);
+}
+
+#[tokio::test]
+async fn agent_type_scope() {
+    let access = build_access();
+    let key = StateScope::agent_type("planner");
+
+    access
+        .write::<SharedConfigKey>(key.as_str(), &SharedConfig { max_retries: 5 })
+        .await
+        .unwrap();
+    assert_eq!(
+        access
+            .read::<SharedConfigKey>(key.as_str())
+            .await
+            .unwrap()
+            .max_retries,
+        5
+    );
+
+    let other = StateScope::agent_type("executor");
+    assert_eq!(
+        access
+            .read::<SharedConfigKey>(other.as_str())
+            .await
+            .unwrap()
+            .max_retries,
+        0
+    );
+}
+
+#[tokio::test]
+async fn custom_scope_works() {
+    let access = build_access();
+    let key = StateScope::new("region::us-west::cluster-1");
+
+    let mem = AgentMemory {
+        facts: vec!["custom scope".into()],
+    };
+    access
+        .write::<AgentMemoryKey>(key.as_str(), &mem)
+        .await
+        .unwrap();
+    assert_eq!(
+        access.read::<AgentMemoryKey>(key.as_str()).await.unwrap(),
+        mem
+    );
+}
+
+#[tokio::test]
+async fn multiple_namespaces_same_key() {
+    let access = build_access();
+    let key = StateScope::global();
+
+    let mem = AgentMemory {
+        facts: vec!["fact".into()],
+    };
+    let config = SharedConfig { max_retries: 3 };
+
+    access
+        .write::<AgentMemoryKey>(key.as_str(), &mem)
+        .await
+        .unwrap();
+    access
+        .write::<SharedConfigKey>(key.as_str(), &config)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        access.read::<AgentMemoryKey>(key.as_str()).await.unwrap(),
+        mem
+    );
+    assert_eq!(
+        access.read::<SharedConfigKey>(key.as_str()).await.unwrap(),
+        config
+    );
+
+    let entries = access.list(key.as_str()).await.unwrap();
+    assert_eq!(entries.len(), 2);
+}
+
+#[tokio::test]
+async fn delete_is_idempotent() {
+    let access = build_access();
+    let key = StateScope::global();
+
+    access.delete::<AgentMemoryKey>(key.as_str()).await.unwrap();
+
+    access
+        .write::<AgentMemoryKey>(
+            key.as_str(),
+            &AgentMemory {
+                facts: vec!["gone".into()],
+            },
+        )
+        .await
+        .unwrap();
+    access.delete::<AgentMemoryKey>(key.as_str()).await.unwrap();
+    access.delete::<AgentMemoryKey>(key.as_str()).await.unwrap();
+
+    assert_eq!(
+        access.read::<AgentMemoryKey>(key.as_str()).await.unwrap(),
+        AgentMemory::default()
+    );
+}
+
+#[tokio::test]
+async fn overwrite_replaces_value() {
+    let access = build_access();
+    let key = StateScope::thread("t-1");
+
+    access
+        .write::<SharedConfigKey>(key.as_str(), &SharedConfig { max_retries: 1 })
+        .await
+        .unwrap();
+    access
+        .write::<SharedConfigKey>(key.as_str(), &SharedConfig { max_retries: 9 })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        access
+            .read::<SharedConfigKey>(key.as_str())
+            .await
+            .unwrap()
+            .max_retries,
+        9
+    );
+}
+
+#[tokio::test]
+async fn unregistered_namespace_errors() {
+    let access = build_access();
+
+    struct Rogue;
+    impl ProfileKey for Rogue {
+        const KEY: &'static str = "rogue_key";
+        type Value = String;
+    }
+
+    let err = access.read::<Rogue>(StateScope::global().as_str()).await;
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains("not registered"));
+}
+
+#[tokio::test]
+async fn different_keys_are_isolated() {
+    let access = build_access();
+
+    access
+        .write::<AgentMemoryKey>(
+            "alice",
+            &AgentMemory {
+                facts: vec!["profile data".into()],
+            },
+        )
+        .await
+        .unwrap();
+    access
+        .write::<AgentMemoryKey>(
+            StateScope::new("alice_scope").as_str(),
+            &AgentMemory {
+                facts: vec!["shared data".into()],
+            },
+        )
+        .await
+        .unwrap();
+
+    let profile = access.read::<AgentMemoryKey>("alice").await.unwrap();
+    let shared = access
+        .read::<AgentMemoryKey>(StateScope::new("alice_scope").as_str())
+        .await
+        .unwrap();
+
+    assert_eq!(profile.facts, vec!["profile data"]);
+    assert_eq!(shared.facts, vec!["shared data"]);
+}

--- a/docs/adr/0021-shared-state-scoping.md
+++ b/docs/adr/0021-shared-state-scoping.md
@@ -1,0 +1,89 @@
+# ADR-0021: Shared State Scoping
+
+- **Status**: Accepted
+- **Date**: 2026-04-07
+- **Depends on**: ADR-0002 (State Engine), ADR-0008 (State Scoping), ADR-0009 (Configuration and Profile)
+
+## Context
+
+The existing state system provides two distinct layers:
+
+1. **Run-scoped and Thread-scoped `StateKey`** — in-memory, synchronous, transactional via `TypedMap`. Each key maps one Rust type to one value per scope. Designed for hot-path plugin state within a single run or thread.
+2. **`ProfileKey` + `ProfileStore`** — persistent, async, key-scoped. Designed for long-lived per-agent or per-user data that survives across runs.
+
+Neither layer supports **cross-boundary sharing with dynamic keys**. Common coordination needs that fall outside both:
+
+- **Parent-child agent coordination**: a parent agent publishes state that child agents (running in separate threads) consume, keyed by `parent_thread_id`.
+- **Global configuration**: feature flags or shared settings readable by all agents regardless of thread or run.
+- **Agent-type-level state**: all instances of a given agent type share accumulated knowledge (e.g. learned preferences).
+- **Custom groupings**: arbitrary scope strings for domain-specific partitioning (e.g. `"team::engineering"`).
+
+Extending `StateKey` is not viable because `TypedMap` stores one value per type — there is no way to have multiple values of the same type under different dynamic scope strings. Extending `ProfileOwner` with new enum variants would conflate ownership semantics (who owns data) with scope semantics (who can see data), and every new scope pattern would require an enum change and recompilation.
+
+## Decision
+
+### D1: `ProfileKey` — compile-time namespace binding
+
+Shared state uses the same `ProfileKey` trait as profile data. No separate trait or alias is needed because shared state keys have exactly the same shape — a static `KEY` string (the namespace) and a typed `Value`:
+
+```rust
+pub trait ProfileKey: 'static + Send + Sync {
+    const KEY: &'static str;
+    type Value: Clone + Default + Serialize + DeserializeOwned + Send + Sync + 'static;
+}
+```
+
+Type safety is enforced at compile time: callers cannot accidentally read a key of one type and get back a different type. The two dimensions are:
+
+- **Namespace** (`ProfileKey::KEY`) — compile-time, binds to a `Value` type
+- **Key** (`&str` parameter) — runtime, identifies which instance
+
+### D2: `StateScope` — convenience key string builder
+
+`StateScope` is a helper type that builds well-known key strings from common scope patterns. It wraps a `String` and provides convenience constructors (`global()`, `parent_thread(id)`, `agent_type(name)`, `thread(id)`, `new(arbitrary)`). Callers use `scope.as_str()` to get the key string. Users can also pass any raw `&str` directly to `ProfileAccess` methods — `StateScope` is optional.
+
+### D3: `ProfileAccess` takes `key: &str`
+
+`ProfileAccess` methods accept a plain `key: &str` parameter for the runtime key dimension. No `ProfileOwner` is needed in the public access API:
+
+- `read::<K>(&self, key: &str) -> Result<K::Value>`
+- `write::<K>(&self, key: &str, &value) -> Result<()>`
+- `delete::<K>(&self, key: &str) -> Result<()>`
+
+Both shared state and profile state use the same methods — the only difference is the key string convention:
+
+```rust
+// Shared state — key is a scope string
+let scope = StateScope::parent_thread("pt-1");
+access.read::<TeamContext>(scope.as_str()).await?;
+
+// Profile state — key is an agent name or "system"
+access.read::<Locale>("alice").await?;
+access.write::<Locale>("system", &"en-US".into()).await?;
+```
+
+### D4: Four-layer state model
+
+| Layer | Scope | Access | Lifecycle | Use Case |
+|-------|-------|--------|-----------|----------|
+| Run State | `KeyScope::Run` | Sync, in-memory | Cleared at run start | Hot-path plugin state, permission overrides |
+| Thread State | `KeyScope::Global` | Sync, in-memory, transactional | Thread lifetime | Conversation history, handoff state |
+| Shared State | `ProfileKey` + `StateScope` | Async, via `ProfileAccess` | Persistent, explicit delete | Cross-agent coordination, global config |
+| Profile State | `ProfileKey` + `key: &str` | Async, via `ProfileAccess` | Persistent, key-scoped | Per-agent/user long-lived data |
+
+## Rationale
+
+**Why not extend `StateKey`?** `TypedMap` enforces one value per Rust type. Shared state requires multiple values of the same type under different scope strings. Forcing this into `TypedMap` would require wrapper types per scope, losing ergonomics and defeating the purpose of dynamic scoping.
+
+**Why a plain `&str` key instead of `ProfileOwner`?** The key dimension is just a string partition — it does not imply ownership or access policy. Using `&str` keeps the API simple and avoids coupling storage identity to access semantics. `StateScope` provides structured constructors for common patterns, but any string works.
+
+**Why keep Thread-scoped `StateKey`?** Synchronous, transactional access with optimistic locking is essential for hot-path operations (permission checks, tool interception, catalog rendering). Shared state is async and persistent — wrong trade-off for sub-millisecond phase hooks.
+
+## Consequences
+
+- `awaken-contract` gains `StateScope` as a key string builder.
+- `ProfileAccess` methods take `key: &str` — unified API for both profile and shared state.
+- `PluginRegistrar::register_profile_key::<K>()` is used to register both profile and shared state keys.
+- No new `ProfileAccess` methods needed — existing `read`, `write`, `delete` work for both use cases.
+- No changes required to `ProfileStore` or storage adapters.
+- Future: watch/subscribe for shared state changes is a natural extension but tracked separately from this ADR.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -45,6 +45,7 @@
 - [Enable Observability](./how-to/enable-observability.md)
 - [Report Tool Progress](./how-to/report-tool-progress.md)
 - [Testing Strategy](./how-to/testing-strategy.md)
+- [Use Shared State](./how-to/use-shared-state.md)
 
 # Reference
 
@@ -66,6 +67,7 @@
 
 - [Architecture](./explanation/architecture.md)
 - [Agent Resolution](./explanation/agent-resolution.md)
+- [State Management](./explanation/state-management.md)
 - [State and Snapshot Model](./explanation/state-and-snapshot-model.md)
 - [Run Lifecycle and Phases](./explanation/run-lifecycle-and-phases.md)
 - [HITL and Mailbox](./explanation/hitl-and-mailbox.md)

--- a/docs/book/src/explanation/state-and-snapshot-model.md
+++ b/docs/book/src/explanation/state-and-snapshot-model.md
@@ -108,8 +108,45 @@ State keys registered with `persistent: true` in `StateKeyOptions` are serialize
 - Commit hooks (`CommitHook`) that fire after each successful state mutation
 - `StateCommand` processing for programmatic state operations
 
+## Shared State
+
+For state that must be shared **across thread and agent boundaries**, awaken provides a separate persistent layer built on the same `ProfileStore` backend used by profile data.
+
+### ProfileKey for shared state
+
+Shared state uses the same `ProfileKey` trait as profile data. The `KEY` constant serves as the namespace, and the `key: &str` parameter passed to `ProfileAccess` methods identifies the runtime instance:
+
+```rust,ignore
+pub trait ProfileKey: 'static + Send + Sync {
+    const KEY: &'static str;
+    type Value: Clone + Default + Serialize + DeserializeOwned + Send + Sync + 'static;
+}
+```
+
+Unlike `StateKey`, shared state does not participate in the `MutationBatch` / snapshot workflow -- it is accessed asynchronously through `ProfileAccess` with a `key: &str` parameter.
+
+### StateScope
+
+```rust,ignore
+pub struct StateScope(String);
+```
+
+An optional convenience builder for common key string patterns. Constructors: `global()`, `parent_thread(id)`, `agent_type(name)`, `thread(id)`, `new(arbitrary)`. Call `.as_str()` to get the key string for `ProfileAccess` methods. Users can also pass any raw `&str` directly.
+
+### State Management Overview
+
+| Layer | Scope | Access | Lifecycle | Use Case |
+|-------|-------|--------|-----------|----------|
+| Run State | Current run | Sync snapshot | Cleared at run start | Transient flags, counters |
+| Thread State | Same thread | Sync snapshot | Export/restore across runs | Tool call state, active agent |
+| Shared State | `ProfileKey` + `StateScope` | Async | Persistent | Cross-boundary sharing |
+| Profile State | `ProfileKey` + `key: &str` | Async | Persistent | User/agent preferences |
+
+Choose shared state when you need **dynamic scoping** or **cross-boundary access**. Choose `StateKey` when you need **sync access** or **transactional merge** during parallel tool execution.
+
 ## See Also
 
 - [State Keys](../reference/state-keys.md)
 - [Run Lifecycle and Phases](./run-lifecycle-and-phases.md)
 - [Architecture](./architecture.md)
+- [Use Shared State](../how-to/use-shared-state.md)

--- a/docs/book/src/explanation/state-management.md
+++ b/docs/book/src/explanation/state-management.md
@@ -1,0 +1,175 @@
+# State Management
+
+Awaken provides four layers of state management, each designed for a different combination of scope, access pattern, and lifecycle. This page explains when and how to use each layer.
+
+## Overview
+
+| Layer | Trait | Scope | Access | Lifecycle | Primary Use Case |
+|-------|-------|-------|--------|-----------|------------------|
+| Run State | `StateKey` (`KeyScope::Run`) | Current run only | Sync (snapshot) | Cleared at run start | Transient counters, flags, step state |
+| Thread State | `StateKey` (`KeyScope::Thread`) | Same thread, cross-run | Sync (snapshot) | Auto-exported/restored across runs | Tool call state, active agent, permissions |
+| Shared State | `ProfileKey` + `StateScope` | Dynamic (global, parent thread, agent type, custom) | Async (`ProfileAccess`) | Persistent in `ProfileStore` | Cross-boundary sharing, global config |
+| Profile State | `ProfileKey` + `key: &str` | Per-key (agent/system) | Async (`ProfileAccess`) | Persistent in `ProfileStore` | User/agent preferences, locale |
+
+## Run State
+
+Run state is the most transient layer. It lives entirely in memory, is accessed synchronously through a `Snapshot`, and is cleared to its default value when a new run begins.
+
+Writes happen through `MutationBatch`, which collects updates produced by phase hooks. When multiple hooks run in parallel, the runtime uses `MergeStrategy` to determine whether concurrent writes to the same key can be safely merged (`Commutative`) or must be serialized (`Exclusive`). This makes run state the only layer that participates in the transactional merge protocol.
+
+Typical examples include `RunLifecycle` (tracking the current run phase), `PendingWorkKey` (counting outstanding async work), and `ContextThrottleState` (rate-limiting context injection).
+
+### When to use
+
+- Per-inference temporary state that does not need to survive beyond the current run
+- State that must participate in parallel merge (`MutationBatch` with `MergeStrategy`)
+- Counters, flags, and step-tracking metadata
+
+### Example
+
+```rust,ignore
+struct StepCounter;
+impl StateKey for StepCounter {
+    const KEY: &'static str = "step_counter";
+    type Value = usize;
+    type Update = usize;
+    fn apply(value: &mut Self::Value, update: Self::Update) {
+        *value += update;
+    }
+}
+
+// Register in plugin
+r.register_key::<StepCounter>(StateKeyOptions::default())?;
+
+// Read via snapshot
+let count = ctx.snapshot.get::<StepCounter>().copied().unwrap_or(0);
+
+// Write via MutationBatch
+cmd.update::<StepCounter>(1);
+```
+
+## Thread State
+
+Thread state shares the same access model as run state -- sync reads via `Snapshot`, transactional writes via `MutationBatch`, merge-safe through `MergeStrategy`. The difference is lifecycle: thread-scoped keys persist across runs on the same thread.
+
+The runtime handles this transparently. At the end of a run, thread-scoped keys are exported (serialized). When the next run starts on the same thread, they are restored to their previous values instead of being reset to defaults. From the hook author's perspective, the key simply "remembers" its value between runs.
+
+Typical examples include `ToolCallStates` (for resuming suspended tool calls across runs) and `ActiveAgentKey` (for persisting agent handoff state).
+
+### When to use
+
+- State that must survive across runs on the same thread
+- State that needs sync access and transactional merge guarantees within each run
+- State whose lifecycle should be managed automatically by the runtime
+
+### Example
+
+```rust,ignore
+r.register_key::<ToolCallStates>(StateKeyOptions {
+    scope: KeyScope::Thread,
+    persistent: true,
+    ..StateKeyOptions::default()
+})?;
+```
+
+## Shared State
+
+Shared state is a persistent, async layer built on the `ProfileStore` backend. It is designed for data that must cross thread and agent boundaries -- something neither run state nor thread state can do.
+
+Shared state uses `ProfileKey` to bind a compile-time namespace to a value type, and a `key: &str` parameter to identify the runtime instance. Together, `(ProfileKey::KEY, key)` uniquely identifies a shared state entry. Different agents and threads can read and write the same entry if they use the same key string. The same `ProfileAccess` methods (`read`, `write`, `delete`) serve both shared and profile state — they all take `key: &str`.
+
+Because shared state bypasses the snapshot/mutation-batch workflow, it does not participate in transactional merge. Concurrent writes follow last-write-wins semantics. Access is async through `ProfileAccess`, available in `PhaseContext`.
+
+### StateScope -- convenience key builder
+
+| Constructor | Key String | Scenario |
+|-------------|-----------|----------|
+| `StateScope::global()` | `"global"` | All agents share one instance |
+| `StateScope::parent_thread(id)` | `"parent_thread::{id}"` | Parent and child agents share within a delegation tree |
+| `StateScope::agent_type(name)` | `"agent_type::{name}"` | All instances of an agent type share |
+| `StateScope::thread(id)` | `"thread::{id}"` | Thread-local persistent state |
+| `StateScope::new(s)` | `"{s}"` | Arbitrary grouping (tenant, region, etc.) |
+
+The key is a plain `&str` -- fully extensible without code changes. `StateScope` is an optional convenience; any raw string works.
+
+### When to use
+
+- State shared across thread boundaries
+- State shared across agent boundaries
+- Dynamic scoping that cannot be determined at compile time
+- Data that serves as database-like indexed storage
+
+### Example
+
+```rust,ignore
+use awaken_contract::ProfileKey;
+
+struct TeamContextKey;
+impl ProfileKey for TeamContextKey {
+    const KEY: &'static str = "team_context";
+    type Value = TeamData;
+}
+
+// In a hook -- share context with child agents
+let scope = StateScope::parent_thread(&ctx.run_identity.parent_thread_id.unwrap());
+let mut team = access.read::<TeamContextKey>(scope.as_str()).await?;
+team.goals.push("new goal".into());
+access.write::<TeamContextKey>(scope.as_str(), &team).await?;
+```
+
+## Profile State
+
+Profile state is a persistent, async layer for per-entity preferences. Like shared state, it uses the `ProfileStore` backend and is accessed through `ProfileAccess`. The difference is the key convention: instead of a `StateScope` string, profile state typically uses an agent name or `"system"` as the key.
+
+A `ProfileKey` binds a static namespace string to a value type. The key parameter identifies which agent or system entity the data belongs to.
+
+### When to use
+
+- Per-agent persistent preferences (locale, display name, custom settings)
+- System-level configuration shared across all agents
+- Data belonging to a specific agent identity rather than a dynamic group
+
+### Example
+
+```rust,ignore
+struct Locale;
+impl ProfileKey for Locale {
+    const KEY: &'static str = "locale";
+    type Value = String;
+}
+
+let locale = access.read::<Locale>("alice").await?;
+access.write::<Locale>("system", &"en-US".into()).await?;
+```
+
+## Decision Guide
+
+```text
+Need state during a single run?
+  +-- Yes, sync + transactional --> Run State (StateKey, KeyScope::Run)
+  +-- No, needs to persist
+       +-- Same thread only, sync + transactional --> Thread State (StateKey, KeyScope::Thread)
+       +-- Cross-boundary, dynamic key --> Shared State (ProfileKey + StateScope)
+       +-- Per-agent/user preference --> Profile State (ProfileKey + agent/system key)
+```
+
+## Comparison: Shared State vs Thread State
+
+Both persist data across runs. The key differences:
+
+| Aspect | Thread State | Shared State |
+|--------|-------------|--------------|
+| Access | Sync (snapshot) | Async (ProfileAccess) |
+| Scope | Fixed to current thread | Dynamic (any string) |
+| Merge safety | MutationBatch + strategy | Last-write-wins |
+| Cross-boundary | No | Yes |
+| Lifecycle | Auto export/restore | Always persistent |
+
+Use **Thread State** when you need sync access and transactional guarantees within a run.
+Use **Shared State** when you need cross-boundary sharing or dynamic scoping.
+
+## See Also
+
+- [State and Snapshot Model](./state-and-snapshot-model.md) -- internal architecture
+- [State Keys](../reference/state-keys.md) -- API reference
+- [Use Shared State](../how-to/use-shared-state.md) -- practical how-to

--- a/docs/book/src/how-to/use-shared-state.md
+++ b/docs/book/src/how-to/use-shared-state.md
@@ -1,0 +1,132 @@
+# Use Shared State
+
+Use this when agents need to share persistent state across thread boundaries, agent types, or delegation trees. Shared state lives in the `ProfileStore` and is addressed by a typed **namespace** (`ProfileKey`) and a **key** (`&str`), giving you fine-grained control over who sees what.
+
+## Prerequisites
+
+- A working awaken agent runtime (see [First Agent](../tutorials/first-agent.md))
+- A `ProfileStore` backend configured on the runtime (e.g. file store or Postgres)
+
+## Concepts
+
+Shared state has two dimensions:
+
+| Dimension | Type | Purpose |
+|-----------|------|---------|
+| **Namespace** | `ProfileKey` | Defines *what* is stored — a compile-time binding between a static string key (`KEY`) and a typed `Value`. Each key is registered once per plugin via `register_profile_key`. |
+| **Key** | `&str` (or `StateScope` helper) | Defines *which instance* — a runtime string that partitions storage. Different keys isolate or share data between agents and threads. |
+
+Together, `(ProfileKey::KEY, key: &str)` uniquely identifies a shared state entry in the profile store.
+
+## Steps
+
+### 1. Define a shared state key
+
+Create a struct that implements `ProfileKey`. The `KEY` constant is the namespace; the `Value` type is what gets serialized.
+
+```rust,ignore
+use serde::{Deserialize, Serialize};
+use awaken_contract::ProfileKey;
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct TeamContext {
+    pub goal: String,
+    pub constraints: Vec<String>,
+}
+
+pub struct TeamContextKey;
+
+impl ProfileKey for TeamContextKey {
+    const KEY: &'static str = "team_context";
+    type Value = TeamContext;
+}
+```
+
+### 2. Register in a plugin
+
+Inside your plugin's `register` method, call `register_profile_key` on the registrar.
+
+```rust,ignore
+use awaken_contract::StateError;
+use awaken_runtime::plugins::registry::PluginRegistrar;
+
+fn register(&self, r: &mut PluginRegistrar) -> Result<(), StateError> {
+    r.register_profile_key::<TeamContextKey>()?;
+    Ok(())
+}
+```
+
+### 3. Read and write in a hook
+
+In any phase hook, obtain `ProfileAccess` from the context and use `read` / `write` with a key string. `StateScope` is a convenience builder for common key patterns — call `.as_str()` to get the key.
+
+```rust,ignore
+use awaken_contract::StateScope;
+
+async fn execute(&self, ctx: &mut PhaseContext) -> Result<(), anyhow::Error> {
+    let profile = ctx.profile().expect("ProfileStore not configured");
+    let identity = ctx.snapshot().run_identity();
+
+    // Build a scope key from the current agent's parent thread
+    let scope = match &identity.parent_thread_id {
+        Some(pid) => StateScope::parent_thread(pid),
+        None => StateScope::global(),
+    };
+
+    // Read (returns TeamContext::default() if missing)
+    let mut team: TeamContext = profile.read::<TeamContextKey>(scope.as_str()).await?;
+
+    // Mutate and write back
+    team.goal = "Ship the feature".into();
+    profile.write::<TeamContextKey>(scope.as_str(), &team).await?;
+
+    Ok(())
+}
+```
+
+### 4. Choose the right scope
+
+`StateScope` has several constructors. Pick the one that matches your sharing pattern:
+
+| Scenario | Scope | Example |
+|----------|-------|---------|
+| All agents across all threads | `StateScope::global()` | Org-wide configuration |
+| All agents spawned from the same parent thread | `StateScope::parent_thread(id)` | A delegation tree sharing context |
+| All instances of the same agent type | `StateScope::agent_type(name)` | Planner agents sharing learned heuristics |
+| Single thread only | `StateScope::thread(id)` | Thread-local scratchpad |
+| Custom partition | `StateScope::new("custom-key")` | Any application-defined grouping |
+
+You can also pass any raw `&str` directly — `StateScope` is optional convenience.
+
+## When to use shared state
+
+| Mechanism | Lifetime | Scope | Best for |
+|-----------|----------|-------|----------|
+| `StateKey` | Single run (in-memory snapshot) | One agent thread | Transient per-run state (counters, flags, accumulated context) |
+| `ProfileKey` with agent/system key | Persistent (profile store) | Per-agent or system | Per-agent or per-user settings that don't cross boundaries |
+| `ProfileKey` with `StateScope` key | Persistent (profile store) | Any `StateScope` string | Cross-agent, cross-thread persistent state |
+
+Use `ProfileKey` with a `StateScope` key when state must survive across runs **and** be visible to agents in different threads or of different types.
+
+## Common Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `profile key not registered: <ns>` | Key not registered in any plugin | Call `r.register_profile_key::<YourKey>()` in the plugin's `register` method |
+| Always reads `Value::default()` | Writing and reading use different key strings | Verify both sides construct the same `StateScope` or use the same `&str` key |
+| Data leaks between scopes | Using `StateScope::global()` when a narrower scope is needed | Switch to `parent_thread`, `agent_type`, or `thread` scope |
+
+## Key Files
+
+| Path | Purpose |
+|------|---------|
+| `crates/awaken-contract/src/contract/shared_state.rs` | `StateScope` type |
+| `crates/awaken-contract/src/contract/profile_store.rs` | `ProfileKey` trait, `ProfileOwner` enum |
+| `crates/awaken-runtime/src/profile/mod.rs` | `ProfileAccess` with `read`, `write`, `delete` methods |
+| `crates/awaken-runtime/src/plugins/registry.rs` | `PluginRegistrar::register_profile_key` registration |
+
+## Related
+
+- [State and Snapshot Model](../explanation/state-and-snapshot-model.md)
+- [State Keys](../reference/state-keys.md)
+- [Add a Plugin](./add-a-plugin.md)

--- a/docs/book/src/reference/state-keys.md
+++ b/docs/book/src/reference/state-keys.md
@@ -166,6 +166,87 @@ pub struct PersistedState {
 }
 ```
 
+## Shared State (ProfileKey + StateScope)
+
+For cross-boundary persistent state with dynamic scoping. Shared state uses `ProfileKey` --
+the same trait used for profile data -- combined with a `key: &str` parameter for the runtime
+key dimension. Unlike `StateKey`, shared state is accessed asynchronously through `ProfileAccess`
+and does not participate in the snapshot/mutation workflow.
+
+```rust,ignore
+pub trait ProfileKey: 'static + Send + Sync {
+    /// Namespace identifier (used as the storage namespace).
+    const KEY: &'static str;
+
+    /// The value type stored under this key.
+    type Value: Clone + Default + Serialize + DeserializeOwned + Send + Sync + 'static;
+
+    /// Serialize value to JSON.
+    fn encode(value: &Self::Value) -> Result<JsonValue, StateError>;
+
+    /// Deserialize value from JSON.
+    fn decode(value: JsonValue) -> Result<Self::Value, StateError>;
+}
+```
+
+The two dimensions for both shared and profile state are:
+- **Namespace** (`ProfileKey::KEY`) -- compile-time, binds to a `Value` type
+- **Key** (`&str` parameter) -- runtime, identifies which instance
+
+For shared state, the key is typically a `StateScope` string; for profile state, it is an agent name or `"system"`.
+
+**Crate path:** `awaken_contract::ProfileKey` (re-exported from `awaken_contract::contract::profile_store`)
+
+### StateScope
+
+```rust,ignore
+pub struct StateScope(String);
+```
+
+Optional convenience builder for common key string patterns. Constructors:
+
+| Method | Produced String | Use Case |
+|--------|----------------|----------|
+| `StateScope::global()` | `"global"` | System-wide shared state |
+| `StateScope::parent_thread(id)` | `"parent_thread::{id}"` | Parent-child agent sharing |
+| `StateScope::agent_type(name)` | `"agent_type::{name}"` | Per-agent-type sharing |
+| `StateScope::thread(id)` | `"thread::{id}"` | Thread-local persistent state |
+| `StateScope::new(s)` | `"{s}"` | Arbitrary grouping |
+
+Call `.as_str()` to get the key string. Users can also pass any raw `&str` directly.
+
+### ProfileAccess Methods
+
+`ProfileAccess` methods take `key: &str` for the runtime key dimension. The same methods
+serve both shared and profile state:
+
+```rust,ignore
+impl ProfileAccess {
+    async fn read<K: ProfileKey>(&self, key: &str) -> Result<K::Value, StorageError>;
+    async fn write<K: ProfileKey>(&self, key: &str, value: &K::Value) -> Result<(), StorageError>;
+    async fn delete<K: ProfileKey>(&self, key: &str) -> Result<(), StorageError>;
+}
+
+// Shared state usage:
+let scope = StateScope::global();
+let value = access.read::<MyKey>(scope.as_str()).await?;
+access.write::<MyKey>(scope.as_str(), &value).await?;
+
+// Profile state usage:
+let locale = access.read::<Locale>("alice").await?;
+access.write::<Locale>("system", &"en-US".into()).await?;
+```
+
+### Registration
+
+```rust,ignore
+impl PluginRegistrar {
+    /// Register a profile key (used for both profile state and shared state).
+    pub fn register_profile_key<K: ProfileKey>(&mut self) -> Result<(), StateError>;
+}
+```
+
 ## Related
 
 - [State and Snapshot Model](../explanation/state-and-snapshot-model.md)
+- [Use Shared State](../how-to/use-shared-state.md)


### PR DESCRIPTION
## Summary

Add `StateScope` and key-based `ProfileAccess` API for cross-boundary shared state.

**Two dimensions, one mechanism:**
- **Namespace** (`ProfileKey::KEY`) — compile-time, binds to `Value` type
- **Key** (`&str` parameter) — runtime, identifies which instance

```rust
// Shared state — key built with StateScope
access.read::<TeamContext>(StateScope::global().as_str()).await?;

// Profile — key is a plain string
access.read::<Locale>("alice").await?;
```

## Changes

- `ProfileAccess` methods take `key: &str` instead of `&ProfileOwner`
- `StateScope`: optional convenience builder for common key patterns (global, parent_thread, agent_type, thread, custom)
- `ProfileOwner` becomes internal to `ProfileAccess` — not in the public access API
- Same `ProfileKey` trait, same `register_profile_key`, same `read`/`write`/`delete` — for both profile and shared state

## Simple Design 4 Rules

1. **Passes tests** — 2000+ tests, 0 failures, 0 clippy warnings
2. **Reveals intention** — namespace (what type) vs key (which instance) is explicit in every call site
3. **No duplication** — one trait, one set of methods, one registration path
4. **Fewest elements** — only `StateScope` added; no new traits, aliases, or methods

## Test plan

- [x] Unit tests for `StateScope` (display, equality, serde)
- [x] Unit tests for `ProfileAccess` key-based methods (5 tests)
- [x] Integration tests (9 tests): scope isolation, namespace coexistence, delete idempotency, unregistered errors
- [x] Full workspace tests pass, clippy clean