### PR TITLE
feat(runtime): add AgentLocality and ScheduledBackend for distributed scheduling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -575,7 +575,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -704,9 +704,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -786,9 +786,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1207,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1408,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.6.0-beta.11"
+version = "0.6.0-beta.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904984030e3db4267ca33edd2c3cb30b17d470e0d6bedcedd40f1780f8fd4d3b"
+checksum = "ef666890593ff1235111f3dd2641c8865599dfcf0e1f55e2ec4ba1bedadac5a2"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1504,7 +1504,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1523,7 +1523,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1717,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1732,7 +1732,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1745,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -1780,7 +1779,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1819,12 +1818,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1832,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1859,15 +1859,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1879,15 +1879,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1956,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1971,9 +1971,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2056,19 +2056,21 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonschema"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
 dependencies = [
  "ahash",
  "bytecount",
@@ -2110,9 +2112,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -2151,9 +2153,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2225,10 +2227,10 @@ checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
 dependencies = [
  "base64 0.22.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2288,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2409,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2665,12 +2667,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,9 +2707,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3018,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -3116,7 +3112,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -3152,7 +3148,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3230,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3450,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3541,7 +3537,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -3568,7 +3564,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -3634,9 +3630,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -3729,7 +3725,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink 0.10.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "memchr",
  "once_cell",
@@ -4110,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4135,9 +4131,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -4152,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4410,9 +4406,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -4458,9 +4454,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4572,9 +4568,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4585,23 +4581,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4609,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4622,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4646,7 +4638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4685,15 +4677,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5155,7 +5147,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5186,7 +5178,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -5205,7 +5197,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -5217,15 +5209,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5234,9 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5246,18 +5238,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5266,18 +5258,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5293,9 +5285,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5304,9 +5296,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5315,9 +5307,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/awaken-contract/src/registry_spec.rs
+++ b/crates/awaken-contract/src/registry_spec.rs
@@ -99,9 +99,12 @@ pub struct AgentSpec {
     /// If None, this agent runs locally.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<RemoteEndpoint>,
-    /// Execution locality. Supersedes `endpoint` — when set, `endpoint` is ignored.
-    #[serde(default, skip_serializing_if = "is_local_locality")]
-    pub locality: AgentLocality,
+    /// Optional execution locality override.
+    ///
+    /// When present, this supersedes the legacy `endpoint` field. When absent,
+    /// `endpoint` retains its legacy meaning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locality: Option<AgentLocality>,
     /// IDs of sub-agents this agent can delegate to.
     /// Each ID must be a registered agent in the AgentSpecRegistry.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -217,10 +220,6 @@ pub enum SchedulingPolicy {
     LeastLoaded,
     /// Always use a specific Worker.
     Pinned { node_id: String },
-}
-
-fn is_local_locality(l: &AgentLocality) -> bool {
-    matches!(l, AgentLocality::Local)
 }
 
 #[derive(Debug, Deserialize)]
@@ -472,7 +471,7 @@ impl Default for AgentSpec {
             allowed_tools: None,
             excluded_tools: None,
             endpoint: None,
-            locality: AgentLocality::Local,
+            locality: None,
             delegates: Vec::new(),
             sections: HashMap::new(),
             registry: None,
@@ -592,29 +591,38 @@ impl AgentSpec {
         self
     }
 
-    /// Returns the effective locality, preferring `locality` over legacy `endpoint`.
+    /// Returns the effective locality, preferring explicit `locality` over legacy `endpoint`.
     pub fn effective_locality(&self) -> AgentLocality {
-        match &self.locality {
-            AgentLocality::Local => {
-                if let Some(ref ep) = self.endpoint {
-                    AgentLocality::Remote(ep.clone())
-                } else {
-                    AgentLocality::Local
-                }
-            }
-            other => other.clone(),
+        match self.locality.as_ref() {
+            Some(AgentLocality::Local) => AgentLocality::Local,
+            Some(other) => other.clone(),
+            None => match &self.endpoint {
+                Some(ep) => AgentLocality::Remote(ep.clone()),
+                None => AgentLocality::Local,
+            },
         }
     }
 
     #[must_use]
+    pub fn is_directly_runnable_locally(&self) -> bool {
+        matches!(self.effective_locality(), AgentLocality::Local)
+    }
+
+    #[must_use]
+    pub fn with_local_locality(mut self) -> Self {
+        self.locality = Some(AgentLocality::Local);
+        self
+    }
+
+    #[must_use]
     pub fn with_distributed(mut self, config: DistributedConfig) -> Self {
-        self.locality = AgentLocality::Distributed(config);
+        self.locality = Some(AgentLocality::Distributed(config));
         self
     }
 
     #[must_use]
     pub fn with_remote_locality(mut self, endpoint: RemoteEndpoint) -> Self {
-        self.locality = AgentLocality::Remote(endpoint);
+        self.locality = Some(AgentLocality::Remote(endpoint));
         self
     }
 
@@ -934,7 +942,7 @@ mod locality_tests {
         .unwrap();
 
         // locality field defaults to Local, but effective_locality upgrades
-        assert!(matches!(spec.locality, AgentLocality::Local));
+        assert!(spec.locality.is_none());
         assert!(matches!(
             spec.effective_locality(),
             AgentLocality::Remote(_)
@@ -968,6 +976,26 @@ mod locality_tests {
         if let AgentLocality::Distributed(cfg) = spec.effective_locality() {
             assert_eq!(cfg.adapter_type, "codex");
         }
+    }
+
+    #[test]
+    fn explicit_locality_local_overrides_legacy_endpoint_and_roundtrips() {
+        let spec = AgentSpec::new("test")
+            .with_endpoint(RemoteEndpoint {
+                base_url: "https://remote.example.com".into(),
+                ..Default::default()
+            })
+            .with_local_locality();
+
+        assert!(matches!(spec.locality, Some(AgentLocality::Local)));
+        assert!(matches!(spec.effective_locality(), AgentLocality::Local));
+
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(json["locality"], serde_json::json!({ "type": "local" }));
+
+        let parsed: AgentSpec = serde_json::from_value(json).unwrap();
+        assert!(matches!(parsed.locality, Some(AgentLocality::Local)));
+        assert!(matches!(parsed.effective_locality(), AgentLocality::Local));
     }
 
     #[test]

--- a/crates/awaken-contract/src/registry_spec.rs
+++ b/crates/awaken-contract/src/registry_spec.rs
@@ -99,6 +99,9 @@ pub struct AgentSpec {
     /// If None, this agent runs locally.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<RemoteEndpoint>,
+    /// Execution locality. Supersedes `endpoint` — when set, `endpoint` is ignored.
+    #[serde(default, skip_serializing_if = "is_local_locality")]
+    pub locality: AgentLocality,
     /// IDs of sub-agents this agent can delegate to.
     /// Each ID must be a registered agent in the AgentSpecRegistry.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -174,6 +177,50 @@ fn default_remote_backend() -> String {
 
 fn default_timeout() -> u64 {
     300_000
+}
+
+// ---------------------------------------------------------------------------
+// AgentLocality — execution location for agents
+// ---------------------------------------------------------------------------
+
+/// Execution location for an agent — determines which backend handles it.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentLocality {
+    /// Execute in the local process (default).
+    #[default]
+    Local,
+    /// Execute on a fixed remote endpoint via A2A protocol.
+    Remote(RemoteEndpoint),
+    /// Dynamically schedule to a Worker Node in the cluster.
+    Distributed(DistributedConfig),
+}
+
+/// Configuration for distributed (Worker-scheduled) agents.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DistributedConfig {
+    /// Adapter type on the Worker, e.g. "claude", "codex", "openclaw".
+    pub adapter_type: String,
+    /// Scheduling policy.
+    #[serde(default)]
+    pub scheduling: SchedulingPolicy,
+}
+
+/// How the Scheduler selects a Worker Node.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulingPolicy {
+    /// Prefer the Worker that caches this agent's session.
+    #[default]
+    SessionAffinity,
+    /// Pick the least-loaded Worker.
+    LeastLoaded,
+    /// Always use a specific Worker.
+    Pinned { node_id: String },
+}
+
+fn is_local_locality(l: &AgentLocality) -> bool {
+    matches!(l, AgentLocality::Local)
 }
 
 #[derive(Debug, Deserialize)]
@@ -425,6 +472,7 @@ impl Default for AgentSpec {
             allowed_tools: None,
             excluded_tools: None,
             endpoint: None,
+            locality: AgentLocality::Local,
             delegates: Vec::new(),
             sections: HashMap::new(),
             registry: None,
@@ -541,6 +589,32 @@ impl AgentSpec {
     #[must_use]
     pub fn with_endpoint(mut self, endpoint: RemoteEndpoint) -> Self {
         self.endpoint = Some(endpoint);
+        self
+    }
+
+    /// Returns the effective locality, preferring `locality` over legacy `endpoint`.
+    pub fn effective_locality(&self) -> AgentLocality {
+        match &self.locality {
+            AgentLocality::Local => {
+                if let Some(ref ep) = self.endpoint {
+                    AgentLocality::Remote(ep.clone())
+                } else {
+                    AgentLocality::Local
+                }
+            }
+            other => other.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_distributed(mut self, config: DistributedConfig) -> Self {
+        self.locality = AgentLocality::Distributed(config);
+        self
+    }
+
+    #[must_use]
+    pub fn with_remote_locality(mut self, endpoint: RemoteEndpoint) -> Self {
+        self.locality = AgentLocality::Remote(endpoint);
         self
     }
 
@@ -787,5 +861,153 @@ mod tests {
         assert_eq!(spec.id, "reviewer");
         assert_eq!(spec.model, "claude-opus");
         assert!(spec.active_hook_filter.contains("permission"));
+    }
+}
+
+#[cfg(test)]
+mod locality_tests {
+    use super::*;
+
+    #[test]
+    fn default_locality_is_local() {
+        let spec = AgentSpec::new("test");
+        assert!(matches!(spec.effective_locality(), AgentLocality::Local));
+    }
+
+    #[test]
+    fn legacy_endpoint_becomes_remote_locality() {
+        let spec = AgentSpec {
+            endpoint: Some(RemoteEndpoint {
+                base_url: "http://example.com".into(),
+                ..Default::default()
+            }),
+            ..AgentSpec::new("test")
+        };
+        assert!(matches!(
+            spec.effective_locality(),
+            AgentLocality::Remote(_)
+        ));
+    }
+
+    #[test]
+    fn explicit_distributed_locality() {
+        let spec = AgentSpec::new("test").with_distributed(DistributedConfig {
+            adapter_type: "codex".into(),
+            scheduling: SchedulingPolicy::SessionAffinity,
+        });
+        assert!(matches!(
+            spec.effective_locality(),
+            AgentLocality::Distributed(_)
+        ));
+    }
+
+    #[test]
+    fn locality_serde_roundtrip() {
+        let distributed = AgentLocality::Distributed(DistributedConfig {
+            adapter_type: "claude".into(),
+            scheduling: SchedulingPolicy::Pinned {
+                node_id: "node-1".into(),
+            },
+        });
+        let json = serde_json::to_string(&distributed).unwrap();
+        let parsed: AgentLocality = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed, AgentLocality::Distributed(_)));
+    }
+
+    #[test]
+    fn locality_skipped_when_local_in_serialization() {
+        let spec = AgentSpec::new("test");
+        let json = serde_json::to_value(&spec).unwrap();
+        assert!(json.get("locality").is_none());
+    }
+
+    #[test]
+    fn legacy_spec_with_only_endpoint_effective_locality_returns_remote() {
+        let spec: AgentSpec = serde_json::from_value(serde_json::json!({
+            "id": "legacy-agent",
+            "model": "gpt-4",
+            "system_prompt": "hello",
+            "endpoint": {
+                "base_url": "https://remote.example.com"
+            }
+        }))
+        .unwrap();
+
+        // locality field defaults to Local, but effective_locality upgrades
+        assert!(matches!(spec.locality, AgentLocality::Local));
+        assert!(matches!(
+            spec.effective_locality(),
+            AgentLocality::Remote(_)
+        ));
+        if let AgentLocality::Remote(ep) = spec.effective_locality() {
+            assert_eq!(ep.base_url, "https://remote.example.com");
+        }
+    }
+
+    #[test]
+    fn spec_with_endpoint_and_distributed_locality_locality_wins() {
+        let spec: AgentSpec = serde_json::from_value(serde_json::json!({
+            "id": "dual-agent",
+            "model": "gpt-4",
+            "system_prompt": "hello",
+            "endpoint": {
+                "base_url": "https://remote.example.com"
+            },
+            "locality": {
+                "type": "distributed",
+                "adapter_type": "codex"
+            }
+        }))
+        .unwrap();
+
+        // locality is Distributed, so effective_locality ignores the endpoint
+        assert!(matches!(
+            spec.effective_locality(),
+            AgentLocality::Distributed(_)
+        ));
+        if let AgentLocality::Distributed(cfg) = spec.effective_locality() {
+            assert_eq!(cfg.adapter_type, "codex");
+        }
+    }
+
+    #[test]
+    fn all_scheduling_policy_variants_roundtrip_json() {
+        let policies = vec![
+            SchedulingPolicy::SessionAffinity,
+            SchedulingPolicy::LeastLoaded,
+            SchedulingPolicy::Pinned {
+                node_id: "node-42".into(),
+            },
+        ];
+
+        for policy in policies {
+            let json = serde_json::to_string(&policy).unwrap();
+            let parsed: SchedulingPolicy = serde_json::from_str(&json).unwrap();
+            // Verify round-trip by re-serializing
+            let json2 = serde_json::to_string(&parsed).unwrap();
+            assert_eq!(json, json2, "policy round-trip mismatch for: {json}");
+        }
+    }
+
+    #[test]
+    fn distributed_config_with_empty_adapter_type_serializes() {
+        let config = DistributedConfig {
+            adapter_type: String::new(),
+            scheduling: SchedulingPolicy::default(),
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["adapter_type"], "");
+        assert_eq!(json["scheduling"], "session_affinity");
+
+        // Roundtrip
+        let parsed: DistributedConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.adapter_type, "");
+    }
+
+    #[test]
+    fn agent_locality_local_serializes_as_tagged_format() {
+        let locality = AgentLocality::Local;
+        let json = serde_json::to_value(&locality).unwrap();
+        assert_eq!(json, serde_json::json!({"type": "local"}));
     }
 }

--- a/crates/awaken-runtime/src/builder.rs
+++ b/crates/awaken-runtime/src/builder.rs
@@ -182,17 +182,31 @@ impl AgentRuntimeBuilder {
         self
     }
 
-    /// Build the `AgentRuntime` and validate all registered agents can
-    /// resolve successfully.
+    /// Build the `AgentRuntime` and validate all locally runnable registered
+    /// agents can resolve successfully.
     ///
-    /// Performs a dry-run resolve for every registered agent, catching
-    /// configuration errors (missing models, providers, plugins) at build time.
-    /// Use [`build_unchecked()`](Self::build_unchecked) to skip validation.
+    /// Performs a dry-run resolve for every registered agent whose effective
+    /// locality is local, catching configuration errors (missing models,
+    /// providers, plugins) at build time. Non-local agents stay registered for
+    /// delegation, but are not resolved as top-level local agents here. Use
+    /// [`build_unchecked()`](Self::build_unchecked) to skip validation.
     pub fn build(self) -> Result<AgentRuntime, BuildError> {
         let runtime = self.build_unchecked()?;
+        let registries = runtime
+            .registry_set()
+            .expect("builder-created runtimes always expose a registry snapshot");
         let resolver = runtime.resolver();
         let mut errors = Vec::new();
         for agent_id in resolver.agent_ids() {
+            let Some(spec) = registries.agents.get_agent(&agent_id) else {
+                errors.push(format!(
+                    "{agent_id}: missing agent spec in registry snapshot"
+                ));
+                continue;
+            };
+            if !spec.is_directly_runnable_locally() {
+                continue;
+            }
             if let Err(e) = resolver.resolve(&agent_id) {
                 errors.push(format!("{agent_id}: {e}"));
             }
@@ -597,6 +611,64 @@ mod tests {
             .build();
 
         assert!(result.is_ok());
+    }
+
+    #[cfg(feature = "a2a")]
+    #[test]
+    fn build_skips_validation_for_non_local_agents() {
+        let result = AgentRuntimeBuilder::new()
+            .with_agent_spec(
+                AgentSpec::new("distributed-worker")
+                    .with_model("missing-worker-model")
+                    .with_system_prompt("sys")
+                    .with_distributed(awaken_contract::registry_spec::DistributedConfig {
+                        adapter_type: "codex".into(),
+                        scheduling: awaken_contract::registry_spec::SchedulingPolicy::LeastLoaded,
+                    }),
+            )
+            .build();
+
+        let runtime =
+            result.expect("non-local agents should stay registered without local resolve");
+        let err = runtime
+            .resolver()
+            .resolve("distributed-worker")
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot be resolved locally"));
+    }
+
+    #[cfg(feature = "a2a")]
+    #[test]
+    fn build_allows_local_roots_to_delegate_to_distributed_agents_without_worker_models() {
+        let root = AgentSpec::new("root")
+            .with_model("m")
+            .with_system_prompt("root")
+            .with_delegate("worker");
+        let worker = AgentSpec::new("worker")
+            .with_model("missing-worker-model")
+            .with_system_prompt("worker")
+            .with_distributed(awaken_contract::registry_spec::DistributedConfig {
+                adapter_type: "codex".into(),
+                scheduling: awaken_contract::registry_spec::SchedulingPolicy::Pinned {
+                    node_id: "node-1".into(),
+                },
+            });
+
+        let runtime = AgentRuntimeBuilder::new()
+            .with_agent_specs(vec![root, worker])
+            .with_model(
+                "m",
+                ModelEntry {
+                    provider: "p".into(),
+                    model_name: "n".into(),
+                },
+            )
+            .with_provider("p", Arc::new(MockExecutor))
+            .build()
+            .expect("local roots should validate even when distributed delegates are not local");
+
+        let resolved = runtime.resolver().resolve("root").unwrap();
+        assert!(resolved.tools.contains_key("agent_run_worker"));
     }
 
     #[test]

--- a/crates/awaken-runtime/src/extensions/a2a/mod.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/mod.rs
@@ -8,6 +8,7 @@ mod agent_tool;
 mod backend;
 mod local_backend;
 mod progress_sink;
+pub(crate) mod scheduled_backend;
 
 pub use a2a_backend::{A2aBackendFactory, A2aConfig};
 pub use agent_tool::AgentTool;
@@ -16,6 +17,7 @@ pub use backend::{
     DelegateRunResult, DelegateRunStatus,
 };
 pub use local_backend::LocalBackend;
+pub use scheduled_backend::{ScheduledBackendFactory, ScheduledConfig};
 
 #[cfg(test)]
 mod tests;

--- a/crates/awaken-runtime/src/extensions/a2a/scheduled_backend.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/scheduled_backend.rs
@@ -1,0 +1,399 @@
+//! Scheduled agent delegation backend -- dispatches to ARD Server's Scheduler.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::content::ContentBlock;
+use awaken_contract::contract::event_sink::EventSink;
+use awaken_contract::contract::message::{Message, Role};
+use awaken_contract::registry_spec::RemoteEndpoint;
+use serde::{Deserialize, Serialize};
+
+use super::backend::{
+    AgentBackend, AgentBackendError, AgentBackendFactory, AgentBackendFactoryError,
+    DelegateRunResult, DelegateRunStatus,
+};
+
+const SCHEDULED_BACKEND: &str = "scheduled";
+const ADAPTER_TYPE_OPTION_KEY: &str = "adapter_type";
+
+/// Configuration for a scheduler-dispatched agent endpoint.
+#[derive(Debug, Clone)]
+pub struct ScheduledConfig {
+    /// Base URL of the scheduler (e.g. `http://127.0.0.1:7878`).
+    pub scheduler_url: String,
+    /// Adapter type on the Worker, e.g. "claude", "codex", "openclaw".
+    pub adapter_type: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ScheduledEndpointConfigError {
+    #[error("remote endpoint backend must be `scheduled`, got `{0}`")]
+    UnsupportedBackend(String),
+    #[error("remote endpoint base_url must not be empty")]
+    EmptyBaseUrl,
+    #[error("scheduled backend requires `adapter_type` in options")]
+    MissingAdapterType,
+}
+
+impl ScheduledConfig {
+    pub(crate) fn try_from_remote_endpoint(
+        endpoint: &RemoteEndpoint,
+    ) -> Result<Self, ScheduledEndpointConfigError> {
+        if endpoint.backend != SCHEDULED_BACKEND {
+            return Err(ScheduledEndpointConfigError::UnsupportedBackend(
+                endpoint.backend.clone(),
+            ));
+        }
+
+        if endpoint.base_url.trim().is_empty() {
+            return Err(ScheduledEndpointConfigError::EmptyBaseUrl);
+        }
+
+        let adapter_type = endpoint
+            .options
+            .get(ADAPTER_TYPE_OPTION_KEY)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or(ScheduledEndpointConfigError::MissingAdapterType)?;
+
+        Ok(Self {
+            scheduler_url: endpoint.base_url.clone(),
+            adapter_type: adapter_type.to_string(),
+        })
+    }
+}
+
+/// Backend that dispatches agent execution to the ARD Server's Scheduler.
+pub struct ScheduledBackend {
+    config: ScheduledConfig,
+    client: reqwest::Client,
+}
+
+/// Factory for the built-in scheduled remote backend.
+pub struct ScheduledBackendFactory;
+
+impl AgentBackendFactory for ScheduledBackendFactory {
+    fn backend(&self) -> &str {
+        SCHEDULED_BACKEND
+    }
+
+    fn build(
+        &self,
+        endpoint: &RemoteEndpoint,
+    ) -> Result<Arc<dyn AgentBackend>, AgentBackendFactoryError> {
+        let config = ScheduledConfig::try_from_remote_endpoint(endpoint)
+            .map_err(|error| AgentBackendFactoryError::InvalidConfig(error.to_string()))?;
+        Ok(Arc::new(ScheduledBackend::new(config)))
+    }
+}
+
+impl ScheduledBackend {
+    /// Create a new scheduled backend with the given configuration.
+    pub fn new(config: ScheduledConfig) -> Self {
+        Self {
+            config,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+/// Request body for the `/internal/dispatch` endpoint.
+#[derive(Debug, Serialize)]
+struct DispatchRequest {
+    agent_id: String,
+    adapter_type: String,
+    prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_run_id: Option<String>,
+}
+
+/// Response body from the `/internal/dispatch` endpoint.
+#[derive(Debug, Deserialize)]
+struct DispatchResponse {
+    status: String,
+    #[serde(default)]
+    response: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    steps: usize,
+    #[serde(default)]
+    run_id: Option<String>,
+}
+
+#[async_trait]
+impl AgentBackend for ScheduledBackend {
+    async fn execute(
+        &self,
+        agent_id: &str,
+        messages: Vec<Message>,
+        _event_sink: Arc<dyn EventSink>,
+        parent_run_id: Option<String>,
+        _parent_thread_id: Option<String>,
+        _parent_tool_call_id: Option<String>,
+    ) -> Result<DelegateRunResult, AgentBackendError> {
+        let prompt = messages
+            .iter()
+            .filter(|message| message.role == Role::User)
+            .flat_map(|message| message.content.iter())
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        if prompt.trim().is_empty() {
+            return Err(AgentBackendError::ExecutionFailed(
+                "no user message content to send".into(),
+            ));
+        }
+
+        let url = format!(
+            "{}/internal/dispatch",
+            self.config.scheduler_url.trim_end_matches('/')
+        );
+
+        let request = DispatchRequest {
+            agent_id: agent_id.to_string(),
+            adapter_type: self.config.adapter_type.clone(),
+            prompt,
+            parent_run_id,
+        };
+
+        let response = self
+            .client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| {
+                AgentBackendError::RemoteError(format!("failed to dispatch to scheduler: {e}"))
+            })?;
+
+        let response = response.error_for_status().map_err(|e| {
+            AgentBackendError::RemoteError(format!("scheduler dispatch rejected: {e}"))
+        })?;
+
+        let dispatch: DispatchResponse = response.json().await.map_err(|e| {
+            AgentBackendError::RemoteError(format!("failed to decode scheduler response: {e}"))
+        })?;
+
+        let status = match dispatch.status.as_str() {
+            "completed" => DelegateRunStatus::Completed,
+            "cancelled" => DelegateRunStatus::Cancelled,
+            "timeout" => DelegateRunStatus::Timeout,
+            "failed" => DelegateRunStatus::Failed(
+                dispatch
+                    .error
+                    .unwrap_or_else(|| "scheduler dispatch failed".into()),
+            ),
+            other => DelegateRunStatus::Failed(format!("unknown dispatch status: {other}")),
+        };
+
+        Ok(DelegateRunResult {
+            agent_id: agent_id.to_string(),
+            status,
+            response: dispatch.response,
+            steps: dispatch.steps,
+            run_id: dispatch.run_id,
+            inbox: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    use serde_json::json;
+
+    #[test]
+    fn config_from_endpoint_extracts_adapter_type() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("claude"));
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            options,
+            ..Default::default()
+        };
+
+        let config = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap();
+        assert_eq!(config.scheduler_url, "http://127.0.0.1:7878");
+        assert_eq!(config.adapter_type, "claude");
+    }
+
+    #[test]
+    fn config_from_endpoint_requires_adapter_type() {
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            ..Default::default()
+        };
+
+        let err = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap_err();
+        assert!(err.to_string().contains("adapter_type"));
+    }
+
+    #[test]
+    fn factory_backend_name_is_scheduled() {
+        let factory = ScheduledBackendFactory;
+        assert_eq!(factory.backend(), "scheduled");
+    }
+
+    #[test]
+    fn config_from_endpoint_rejects_wrong_backend() {
+        let endpoint = RemoteEndpoint {
+            backend: "a2a".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            ..Default::default()
+        };
+
+        let err = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap_err();
+        assert!(err.to_string().contains("scheduled"));
+    }
+
+    #[test]
+    fn config_from_endpoint_rejects_empty_base_url() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("claude"));
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "".into(),
+            options,
+            ..Default::default()
+        };
+
+        let err = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap_err();
+        assert!(err.to_string().contains("base_url"));
+    }
+
+    #[test]
+    fn factory_builds_backend_for_scheduled_endpoint() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("codex"));
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            options,
+            ..Default::default()
+        };
+
+        let backend = ScheduledBackendFactory.build(&endpoint).unwrap();
+        let _backend: Arc<dyn AgentBackend> = backend;
+    }
+
+    #[test]
+    fn factory_rejects_missing_adapter_type() {
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            ..Default::default()
+        };
+
+        let err = ScheduledBackendFactory
+            .build(&endpoint)
+            .err()
+            .expect("should fail");
+        assert!(err.to_string().contains("adapter_type"));
+    }
+
+    #[test]
+    fn config_with_bearer_token_extracts_correctly() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("claude"));
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            auth: Some(awaken_contract::registry_spec::RemoteAuth::bearer(
+                "secret-token",
+            )),
+            options,
+            ..Default::default()
+        };
+
+        let config = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap();
+        assert_eq!(config.scheduler_url, "http://127.0.0.1:7878");
+        assert_eq!(config.adapter_type, "claude");
+        // Auth is not part of ScheduledConfig but the endpoint parses without error
+        assert_eq!(
+            endpoint.auth.as_ref().unwrap().param_str("token"),
+            Some("secret-token")
+        );
+    }
+
+    #[test]
+    fn config_with_empty_base_url_still_rejected() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("claude"));
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "".into(),
+            options,
+            ..Default::default()
+        };
+
+        let err = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap_err();
+        assert!(
+            err.to_string().contains("base_url"),
+            "expected base_url error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn config_with_whitespace_only_base_url_rejected() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("claude"));
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "   ".into(),
+            options,
+            ..Default::default()
+        };
+
+        let err = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap_err();
+        assert!(err.to_string().contains("base_url"));
+    }
+
+    #[test]
+    fn factory_rejects_endpoint_with_wrong_backend_name() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("claude"));
+        let endpoint = RemoteEndpoint {
+            backend: "a2a".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            options,
+            ..Default::default()
+        };
+
+        let err = ScheduledBackendFactory
+            .build(&endpoint)
+            .err()
+            .expect("should fail for non-scheduled backend");
+        assert!(
+            err.to_string().contains("scheduled"),
+            "error should mention 'scheduled', got: {err}"
+        );
+    }
+
+    #[test]
+    fn config_with_empty_adapter_type_in_options_rejected() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!(""));
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            options,
+            ..Default::default()
+        };
+
+        let err = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap_err();
+        assert!(
+            err.to_string().contains("adapter_type"),
+            "expected adapter_type error, got: {err}"
+        );
+    }
+}

--- a/crates/awaken-runtime/src/extensions/a2a/scheduled_backend.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/scheduled_backend.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use awaken_contract::contract::content::ContentBlock;
 use awaken_contract::contract::event_sink::EventSink;
 use awaken_contract::contract::message::{Message, Role};
-use awaken_contract::registry_spec::RemoteEndpoint;
+use awaken_contract::registry_spec::{RemoteEndpoint, SchedulingPolicy};
 use serde::{Deserialize, Serialize};
 
 use super::backend::{
@@ -16,6 +16,7 @@ use super::backend::{
 
 const SCHEDULED_BACKEND: &str = "scheduled";
 const ADAPTER_TYPE_OPTION_KEY: &str = "adapter_type";
+const SCHEDULING_OPTION_KEY: &str = "scheduling";
 
 /// Configuration for a scheduler-dispatched agent endpoint.
 #[derive(Debug, Clone)]
@@ -24,6 +25,8 @@ pub struct ScheduledConfig {
     pub scheduler_url: String,
     /// Adapter type on the Worker, e.g. "claude", "codex", "openclaw".
     pub adapter_type: String,
+    /// Scheduling policy to forward to the scheduler.
+    pub scheduling: SchedulingPolicy,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -34,6 +37,8 @@ pub(crate) enum ScheduledEndpointConfigError {
     EmptyBaseUrl,
     #[error("scheduled backend requires `adapter_type` in options")]
     MissingAdapterType,
+    #[error("scheduled backend requires a valid `scheduling` option: {0}")]
+    InvalidSchedulingPolicy(String),
 }
 
 impl ScheduledConfig {
@@ -57,9 +62,21 @@ impl ScheduledConfig {
             .filter(|s| !s.is_empty())
             .ok_or(ScheduledEndpointConfigError::MissingAdapterType)?;
 
+        let scheduling = endpoint
+            .options
+            .get(SCHEDULING_OPTION_KEY)
+            .map(|value| {
+                serde_json::from_value::<SchedulingPolicy>(value.clone()).map_err(|error| {
+                    ScheduledEndpointConfigError::InvalidSchedulingPolicy(error.to_string())
+                })
+            })
+            .transpose()?
+            .unwrap_or_default();
+
         Ok(Self {
             scheduler_url: endpoint.base_url.clone(),
             adapter_type: adapter_type.to_string(),
+            scheduling,
         })
     }
 }
@@ -103,6 +120,7 @@ impl ScheduledBackend {
 struct DispatchRequest {
     agent_id: String,
     adapter_type: String,
+    scheduling: SchedulingPolicy,
     prompt: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     parent_run_id: Option<String>,
@@ -158,6 +176,7 @@ impl AgentBackend for ScheduledBackend {
         let request = DispatchRequest {
             agent_id: agent_id.to_string(),
             adapter_type: self.config.adapter_type.clone(),
+            scheduling: self.config.scheduling.clone(),
             prompt,
             parent_run_id,
         };
@@ -224,6 +243,10 @@ mod tests {
         let config = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap();
         assert_eq!(config.scheduler_url, "http://127.0.0.1:7878");
         assert_eq!(config.adapter_type, "claude");
+        assert!(matches!(
+            config.scheduling,
+            SchedulingPolicy::SessionAffinity
+        ));
     }
 
     #[test]
@@ -284,6 +307,51 @@ mod tests {
 
         let backend = ScheduledBackendFactory.build(&endpoint).unwrap();
         let _backend: Arc<dyn AgentBackend> = backend;
+    }
+
+    #[test]
+    fn config_from_endpoint_extracts_scheduling_policy() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("codex"));
+        options.insert(
+            SCHEDULING_OPTION_KEY.into(),
+            serde_json::to_value(SchedulingPolicy::Pinned {
+                node_id: "node-7".into(),
+            })
+            .unwrap(),
+        );
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            options,
+            ..Default::default()
+        };
+
+        let config = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap();
+        assert_eq!(config.adapter_type, "codex");
+        assert!(matches!(
+            config.scheduling,
+            SchedulingPolicy::Pinned { ref node_id } if node_id == "node-7"
+        ));
+    }
+
+    #[test]
+    fn config_from_endpoint_rejects_invalid_scheduling_policy() {
+        let mut options = BTreeMap::new();
+        options.insert(ADAPTER_TYPE_OPTION_KEY.into(), json!("codex"));
+        options.insert(
+            SCHEDULING_OPTION_KEY.into(),
+            json!({ "pinned": { "node_id": 7 } }),
+        );
+        let endpoint = RemoteEndpoint {
+            backend: "scheduled".into(),
+            base_url: "http://127.0.0.1:7878".into(),
+            options,
+            ..Default::default()
+        };
+
+        let err = ScheduledConfig::try_from_remote_endpoint(&endpoint).unwrap_err();
+        assert!(err.to_string().contains("scheduling"));
     }
 
     #[test]
@@ -395,5 +463,23 @@ mod tests {
             err.to_string().contains("adapter_type"),
             "expected adapter_type error, got: {err}"
         );
+    }
+
+    #[test]
+    fn dispatch_request_serializes_scheduling_policy() {
+        let request = DispatchRequest {
+            agent_id: "worker".into(),
+            adapter_type: "codex".into(),
+            scheduling: SchedulingPolicy::LeastLoaded,
+            prompt: "hello".into(),
+            parent_run_id: Some("run-1".into()),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["agent_id"], "worker");
+        assert_eq!(json["adapter_type"], "codex");
+        assert_eq!(json["scheduling"], "least_loaded");
+        assert_eq!(json["prompt"], "hello");
+        assert_eq!(json["parent_run_id"], "run-1");
     }
 }

--- a/crates/awaken-runtime/src/registry/memory.rs
+++ b/crates/awaken-runtime/src/registry/memory.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use crate::builder::BuildError;
 #[cfg(feature = "a2a")]
-use crate::extensions::a2a::{A2aBackendFactory, AgentBackendFactory};
+use crate::extensions::a2a::{A2aBackendFactory, AgentBackendFactory, ScheduledBackendFactory};
 use crate::plugins::Plugin;
 use awaken_contract::contract::executor::LlmExecutor;
 use awaken_contract::contract::tool::Tool;
@@ -161,6 +161,9 @@ impl MapBackendRegistry {
             .register_backend_factory(Arc::new(A2aBackendFactory))
             .expect("fresh backend registry should accept built-in A2A backend");
         registry
+            .register_backend_factory(Arc::new(ScheduledBackendFactory))
+            .expect("fresh backend registry should accept built-in scheduled backend");
+        registry
     }
 }
 
@@ -255,6 +258,15 @@ mod tests {
     fn get_missing_key_returns_none() {
         let reg = MapRegistry::<String>::new();
         assert_eq!(reg.get("missing"), None);
+    }
+
+    #[cfg(feature = "a2a")]
+    #[test]
+    fn default_remote_backends_include_scheduled_backend() {
+        let reg = MapBackendRegistry::with_default_remote_backends();
+        let mut backends = reg.backend_ids();
+        backends.sort();
+        assert_eq!(backends, vec!["a2a".to_string(), "scheduled".to_string()]);
     }
 
     #[test]

--- a/crates/awaken-runtime/src/registry/resolve/error.rs
+++ b/crates/awaken-runtime/src/registry/resolve/error.rs
@@ -27,7 +27,7 @@ pub enum ResolveError {
         backend: String,
         message: String,
     },
-    #[error("remote agent `{0}` cannot be resolved locally — use it as a delegate instead")]
+    #[error("non-local agent `{0}` cannot be resolved locally — use it as a delegate instead")]
     RemoteAgentNotDirectlyRunnable(String),
     #[error("tool ID conflict: \"{tool_id}\" registered by both {source_a} and {source_b}")]
     ToolIdConflict {

--- a/crates/awaken-runtime/src/registry/resolve/pipeline.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline.rs
@@ -13,7 +13,7 @@ use awaken_contract::contract::tool::Tool;
 
 use crate::registry::snapshot::RegistryHandle;
 use crate::registry::traits::RegistrySet;
-use awaken_contract::registry_spec::AgentSpec;
+use awaken_contract::registry_spec::{AgentLocality, AgentSpec};
 
 use super::error::ResolveError;
 
@@ -217,34 +217,79 @@ fn resolve_delegate_tools(
 
             let description: String = delegate_spec.system_prompt.chars().take(100).collect();
 
-            let tool: Arc<dyn Tool> = if let Some(endpoint) = &delegate_spec.endpoint {
-                let factory = registries
-                    .backends
-                    .get_backend_factory(&endpoint.backend)
-                    .ok_or_else(|| ResolveError::UnsupportedRemoteBackend {
-                        agent_id: delegate_id.clone(),
-                        backend: endpoint.backend.clone(),
+            let tool: Arc<dyn Tool> = match delegate_spec.effective_locality() {
+                AgentLocality::Local => {
+                    let resolver: Arc<dyn crate::registry::AgentResolver> =
+                        Arc::new(RegistrySetResolver::new(registries.clone()));
+                    Arc::new(crate::extensions::a2a::AgentTool::local(
+                        delegate_id,
+                        &description,
+                        resolver,
+                    ))
+                }
+                AgentLocality::Remote(ref endpoint) => {
+                    let factory = registries
+                        .backends
+                        .get_backend_factory(&endpoint.backend)
+                        .ok_or_else(|| ResolveError::UnsupportedRemoteBackend {
+                            agent_id: delegate_id.clone(),
+                            backend: endpoint.backend.clone(),
+                        })?;
+                    let backend = factory.build(endpoint).map_err(|error| {
+                        ResolveError::InvalidRemoteEndpointConfig {
+                            agent_id: delegate_id.clone(),
+                            backend: endpoint.backend.clone(),
+                            message: error.to_string(),
+                        }
                     })?;
-                let backend = factory.build(endpoint).map_err(|error| {
-                    ResolveError::InvalidRemoteEndpointConfig {
-                        agent_id: delegate_id.clone(),
-                        backend: endpoint.backend.clone(),
-                        message: error.to_string(),
-                    }
-                })?;
-                Arc::new(crate::extensions::a2a::AgentTool::with_backend(
-                    delegate_id,
-                    &description,
-                    backend,
-                ))
-            } else {
-                let resolver: Arc<dyn crate::registry::AgentResolver> =
-                    Arc::new(RegistrySetResolver::new(registries.clone()));
-                Arc::new(crate::extensions::a2a::AgentTool::local(
-                    delegate_id,
-                    &description,
-                    resolver,
-                ))
+                    Arc::new(crate::extensions::a2a::AgentTool::with_backend(
+                        delegate_id,
+                        &description,
+                        backend,
+                    ))
+                }
+                AgentLocality::Distributed(ref config) => {
+                    let scheduler_url = std::env::var("ARD_SCHEDULER_URL").unwrap_or_else(|_| {
+                        let port = std::env::var("ARD_PORT")
+                            .ok()
+                            .and_then(|p| p.parse::<u16>().ok())
+                            .unwrap_or(7878);
+                        format!("http://127.0.0.1:{port}")
+                    });
+
+                    let mut options = std::collections::BTreeMap::new();
+                    options.insert(
+                        "adapter_type".into(),
+                        serde_json::Value::String(config.adapter_type.clone()),
+                    );
+
+                    let endpoint = awaken_contract::registry_spec::RemoteEndpoint {
+                        backend: "scheduled".into(),
+                        base_url: scheduler_url,
+                        options,
+                        ..Default::default()
+                    };
+
+                    let factory = registries
+                        .backends
+                        .get_backend_factory("scheduled")
+                        .ok_or_else(|| ResolveError::UnsupportedRemoteBackend {
+                            agent_id: delegate_id.clone(),
+                            backend: "scheduled".into(),
+                        })?;
+                    let backend = factory.build(&endpoint).map_err(|error| {
+                        ResolveError::InvalidRemoteEndpointConfig {
+                            agent_id: delegate_id.clone(),
+                            backend: "scheduled".into(),
+                            message: error.to_string(),
+                        }
+                    })?;
+                    Arc::new(crate::extensions::a2a::AgentTool::with_backend(
+                        delegate_id,
+                        &description,
+                        backend,
+                    ))
+                }
             };
             let tool_id = tool.descriptor().id;
             tools.insert(tool_id, tool);

--- a/crates/awaken-runtime/src/registry/resolve/pipeline.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline.rs
@@ -14,6 +14,8 @@ use awaken_contract::contract::tool::Tool;
 use crate::registry::snapshot::RegistryHandle;
 use crate::registry::traits::RegistrySet;
 use awaken_contract::registry_spec::{AgentLocality, AgentSpec};
+#[cfg(feature = "a2a")]
+use awaken_contract::registry_spec::{DistributedConfig, RemoteEndpoint};
 
 use super::error::ResolveError;
 
@@ -92,7 +94,7 @@ fn lookup_spec(registries: &RegistrySet, agent_id: &str) -> Result<AgentSpec, Re
         .ok_or_else(|| ResolveError::AgentNotFound(agent_id.into()))?;
 
     #[cfg(feature = "a2a")]
-    if spec.endpoint.is_some() {
+    if !spec.is_directly_runnable_locally() {
         return Err(ResolveError::RemoteAgentNotDirectlyRunnable(
             spec.id.clone(),
         ));
@@ -249,26 +251,7 @@ fn resolve_delegate_tools(
                     ))
                 }
                 AgentLocality::Distributed(ref config) => {
-                    let scheduler_url = std::env::var("ARD_SCHEDULER_URL").unwrap_or_else(|_| {
-                        let port = std::env::var("ARD_PORT")
-                            .ok()
-                            .and_then(|p| p.parse::<u16>().ok())
-                            .unwrap_or(7878);
-                        format!("http://127.0.0.1:{port}")
-                    });
-
-                    let mut options = std::collections::BTreeMap::new();
-                    options.insert(
-                        "adapter_type".into(),
-                        serde_json::Value::String(config.adapter_type.clone()),
-                    );
-
-                    let endpoint = awaken_contract::registry_spec::RemoteEndpoint {
-                        backend: "scheduled".into(),
-                        base_url: scheduler_url,
-                        options,
-                        ..Default::default()
-                    };
+                    let endpoint = distributed_endpoint(delegate_id, config)?;
 
                     let factory = registries
                         .backends
@@ -304,6 +287,43 @@ fn resolve_delegate_tools(
     }
 
     Ok(())
+}
+
+#[cfg(feature = "a2a")]
+fn distributed_endpoint(
+    agent_id: &str,
+    config: &DistributedConfig,
+) -> Result<RemoteEndpoint, ResolveError> {
+    let scheduler_url = std::env::var("ARD_SCHEDULER_URL").unwrap_or_else(|_| {
+        let port = std::env::var("ARD_PORT")
+            .ok()
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(7878);
+        format!("http://127.0.0.1:{port}")
+    });
+
+    let mut options = std::collections::BTreeMap::new();
+    options.insert(
+        "adapter_type".into(),
+        serde_json::Value::String(config.adapter_type.clone()),
+    );
+    options.insert(
+        "scheduling".into(),
+        serde_json::to_value(&config.scheduling).map_err(|error| {
+            ResolveError::InvalidRemoteEndpointConfig {
+                agent_id: agent_id.to_string(),
+                backend: "scheduled".into(),
+                message: format!("failed to encode scheduling policy: {error}"),
+            }
+        })?,
+    );
+
+    Ok(RemoteEndpoint {
+        backend: "scheduled".into(),
+        base_url: scheduler_url,
+        options,
+        ..Default::default()
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -749,6 +769,66 @@ mod tests {
 
     #[cfg(feature = "a2a")]
     #[test]
+    fn resolve_remote_locality_agent_returns_error_before_model_lookup() {
+        let spec = AgentSpec::new("remote-agent")
+            .with_model("missing-model")
+            .with_remote_locality(RemoteEndpoint {
+                backend: "a2a".into(),
+                base_url: "https://remote.example.com".into(),
+                ..Default::default()
+            });
+
+        let regs = build_registries(
+            vec![],
+            "test-model",
+            ModelEntry {
+                provider: "p".into(),
+                model_name: "n".into(),
+            },
+            "p",
+            Arc::new(MockExecutor),
+            vec![],
+            spec,
+        );
+
+        let err = resolve(&regs, "remote-agent").unwrap_err();
+        assert!(
+            matches!(err, ResolveError::RemoteAgentNotDirectlyRunnable(ref id) if id == "remote-agent")
+        );
+    }
+
+    #[cfg(feature = "a2a")]
+    #[test]
+    fn resolve_distributed_agent_returns_error_before_model_lookup() {
+        let spec = AgentSpec::new("distributed-agent")
+            .with_model("missing-model")
+            .with_distributed(awaken_contract::registry_spec::DistributedConfig {
+                adapter_type: "codex".into(),
+                scheduling: awaken_contract::registry_spec::SchedulingPolicy::LeastLoaded,
+            });
+
+        let regs = build_registries(
+            vec![],
+            "test-model",
+            ModelEntry {
+                provider: "p".into(),
+                model_name: "n".into(),
+            },
+            "p",
+            Arc::new(MockExecutor),
+            vec![],
+            spec,
+        );
+
+        let err = resolve(&regs, "distributed-agent").unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::RemoteAgentNotDirectlyRunnable(ref id) if id == "distributed-agent"
+        ));
+    }
+
+    #[cfg(feature = "a2a")]
+    #[test]
     fn resolve_delegate_rejects_unknown_remote_backend() {
         use awaken_contract::registry_spec::RemoteEndpoint;
 
@@ -879,6 +959,57 @@ mod tests {
 
         assert!(output.result.is_success());
         assert_eq!(output.result.data["response"], "from custom backend");
+    }
+
+    #[cfg(feature = "a2a")]
+    #[test]
+    fn resolve_distributed_delegate_uses_default_scheduled_backend() {
+        let root = AgentSpec {
+            delegates: vec!["distributed-worker".into()],
+            ..make_spec("root")
+        };
+        let worker = AgentSpec::new("distributed-worker")
+            .with_model("worker-model-not-registered")
+            .with_distributed(awaken_contract::registry_spec::DistributedConfig {
+                adapter_type: "codex".into(),
+                scheduling: awaken_contract::registry_spec::SchedulingPolicy::Pinned {
+                    node_id: "node-3".into(),
+                },
+            })
+            .with_system_prompt("remote worker");
+
+        let mut model_reg = MapModelRegistry::new();
+        model_reg
+            .register_model(
+                "test-model",
+                ModelEntry {
+                    provider: "p".into(),
+                    model_name: "n".into(),
+                },
+            )
+            .unwrap();
+
+        let mut provider_reg = MapProviderRegistry::new();
+        provider_reg
+            .register_provider("p", Arc::new(MockExecutor))
+            .unwrap();
+
+        let mut agent_reg = MapAgentSpecRegistry::new();
+        agent_reg.register_spec(root).unwrap();
+        agent_reg.register_spec(worker).unwrap();
+
+        let regs = RegistrySet {
+            agents: Arc::new(agent_reg),
+            tools: Arc::new(MapToolRegistry::new()),
+            models: Arc::new(model_reg),
+            providers: Arc::new(provider_reg),
+            plugins: Arc::new(MapPluginSource::new()),
+            backends: Arc::new(MapBackendRegistry::with_default_remote_backends())
+                as Arc<dyn BackendRegistry>,
+        };
+
+        let run = resolve(&regs, "root").unwrap();
+        assert!(run.tools.contains_key("agent_run_distributed-worker"));
     }
 
     #[test]
@@ -1096,7 +1227,7 @@ mod tests {
             ),
             (
                 ResolveError::RemoteAgentNotDirectlyRunnable("r".into()),
-                "remote agent `r` cannot be resolved locally — use it as a delegate instead",
+                "non-local agent `r` cannot be resolved locally — use it as a delegate instead",
             ),
             (
                 ResolveError::ToolIdConflict {

--- a/crates/awaken-runtime/src/registry/resolver.rs
+++ b/crates/awaken-runtime/src/registry/resolver.rs
@@ -56,6 +56,7 @@ impl ResolvedAgent {
             delegates: Vec::new(),
             sections: Default::default(),
             registry: None,
+            locality: Default::default(),
         });
         Self {
             spec,

--- a/crates/awaken/tests/skill_permission_e2e.rs
+++ b/crates/awaken/tests/skill_permission_e2e.rs
@@ -233,6 +233,7 @@ fn make_agent_spec_deny_all() -> AgentSpec {
                 ]
             }),
         )]),
+        locality: Default::default(),
         registry: None,
     }
 }


### PR DESCRIPTION
## Summary

- Add `AgentLocality` enum to `AgentSpec` with `Local`, `Remote`, and `Distributed` variants
- Add `ScheduledBackend` implementing `AgentBackend` for Worker-dispatched agent execution
- Extend resolve pipeline to select backend based on agent locality

## Motivation

Enable agents to be scheduled to distributed Worker Nodes (e.g., Claude Code, Codex CLI) rather than executing only in-process or on fixed remote endpoints. This is the framework-level support for the distributed CLI agent architecture.

## Changes

- `crates/awaken-contract/src/registry_spec.rs` — add `AgentLocality`, `DistributedConfig`, `SchedulingPolicy` types (+222 lines)
- `crates/awaken-runtime/src/extensions/a2a/scheduled_backend.rs` — new `ScheduledBackend` impl (+399 lines)
- `crates/awaken-runtime/src/registry/resolve/pipeline.rs` — route `Distributed` locality to `ScheduledBackend` (+73/-28 lines)
- `crates/awaken-runtime/src/extensions/a2a/mod.rs` — module export (+2 lines)
- `crates/awaken-runtime/src/registry/resolver.rs` — add `locality` field default (+1 line)

## Test plan

- [ ] Unit tests for `AgentLocality` serialization roundtrip
- [ ] `ScheduledBackend` integration with mock `ScheduledBackendFactory`
- [ ] Resolve pipeline selects correct backend for each locality variant