### PR TITLE
♻️ refactor(runtime): remove legacy intercept and stage tool transcripts

### DIFF
--- a/crates/awaken-contract/src/contract/tool_intercept.rs
+++ b/crates/awaken-contract/src/contract/tool_intercept.rs
@@ -1,18 +1,11 @@
-//! Tool interception types for the BeforeToolExecute phase.
-//!
-//! [`ToolInterceptAction`]: scheduled action that controls whether a tool call
-//! proceeds, is blocked, suspended, or short-circuited with a pre-built result.
+//! Tool interception payloads resolved by `ToolGate` hooks.
 
 use serde::{Deserialize, Serialize};
 
 use crate::contract::suspension::SuspendTicket;
 use crate::contract::tool::ToolResult;
-use crate::model::Phase;
 
-/// Payload for the [`ToolInterceptAction`] scheduled action.
-///
-/// BeforeToolExecute phase hooks schedule this to control tool execution flow.
-/// If no intercept is scheduled, the tool executes normally (implicit proceed).
+/// Tool interception decision returned by `ToolGate` hooks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ToolInterceptPayload {
     /// Block tool execution and terminate the run.
@@ -23,19 +16,6 @@ pub enum ToolInterceptPayload {
     SetResult(ToolResult),
 }
 
-/// Scheduled action spec for tool interception.
-///
-/// Hooks schedule this during `BeforeToolExecute` to intercept tool calls.
-/// Multiple hooks may schedule intercepts; the handler aggregates by priority:
-/// `Block > Suspend > SetResult`.
-pub struct ToolInterceptAction;
-
-impl crate::model::ScheduledActionSpec for ToolInterceptAction {
-    const KEY: &'static str = "tool_intercept";
-    const PHASE: Phase = Phase::BeforeToolExecute;
-    type Payload = ToolInterceptPayload;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -43,7 +23,6 @@ mod tests {
         PendingToolCall, SuspendTicket, Suspension, ToolCallResumeMode,
     };
     use crate::contract::tool::ToolResult;
-    use crate::model::ScheduledActionSpec;
     use serde_json::json;
 
     #[test]
@@ -94,11 +73,5 @@ mod tests {
             }
             other => panic!("expected SetResult, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn tool_intercept_action_spec_constants() {
-        assert_eq!(ToolInterceptAction::KEY, "tool_intercept");
-        assert_eq!(ToolInterceptAction::PHASE, Phase::BeforeToolExecute);
     }
 }

--- a/crates/awaken-contract/src/model/phase.rs
+++ b/crates/awaken-contract/src/model/phase.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// assert!(Phase::RunStart.is_run_level());
 /// assert!(!Phase::RunStart.is_step_level());
 /// assert!(Phase::BeforeInference.is_step_level());
-/// assert_eq!(Phase::ALL.len(), 8);
+/// assert_eq!(Phase::ALL.len(), 9);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -19,6 +19,7 @@ pub enum Phase {
     StepStart,
     BeforeInference,
     AfterInference,
+    ToolGate,
     BeforeToolExecute,
     AfterToolExecute,
     StepEnd,
@@ -27,11 +28,12 @@ pub enum Phase {
 
 impl Phase {
     /// All phases in execution order.
-    pub const ALL: [Phase; 8] = [
+    pub const ALL: [Phase; 9] = [
         Phase::RunStart,
         Phase::StepStart,
         Phase::BeforeInference,
         Phase::AfterInference,
+        Phase::ToolGate,
         Phase::BeforeToolExecute,
         Phase::AfterToolExecute,
         Phase::StepEnd,
@@ -56,6 +58,7 @@ impl std::fmt::Display for Phase {
             Phase::StepStart => write!(f, "StepStart"),
             Phase::BeforeInference => write!(f, "BeforeInference"),
             Phase::AfterInference => write!(f, "AfterInference"),
+            Phase::ToolGate => write!(f, "ToolGate"),
             Phase::BeforeToolExecute => write!(f, "BeforeToolExecute"),
             Phase::AfterToolExecute => write!(f, "AfterToolExecute"),
             Phase::StepEnd => write!(f, "StepEnd"),
@@ -69,8 +72,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn phase_all_has_8_variants() {
-        assert_eq!(Phase::ALL.len(), 8);
+    fn phase_all_has_9_variants() {
+        assert_eq!(Phase::ALL.len(), 9);
     }
 
     #[test]
@@ -80,10 +83,11 @@ mod tests {
         assert_eq!(order[1], Phase::StepStart);
         assert_eq!(order[2], Phase::BeforeInference);
         assert_eq!(order[3], Phase::AfterInference);
-        assert_eq!(order[4], Phase::BeforeToolExecute);
-        assert_eq!(order[5], Phase::AfterToolExecute);
-        assert_eq!(order[6], Phase::StepEnd);
-        assert_eq!(order[7], Phase::RunEnd);
+        assert_eq!(order[4], Phase::ToolGate);
+        assert_eq!(order[5], Phase::BeforeToolExecute);
+        assert_eq!(order[6], Phase::AfterToolExecute);
+        assert_eq!(order[7], Phase::StepEnd);
+        assert_eq!(order[8], Phase::RunEnd);
     }
 
     #[test]
@@ -96,6 +100,7 @@ mod tests {
             Phase::StepStart,
             Phase::BeforeInference,
             Phase::AfterInference,
+            Phase::ToolGate,
             Phase::BeforeToolExecute,
             Phase::AfterToolExecute,
             Phase::StepEnd,
@@ -130,6 +135,10 @@ mod tests {
             serde_json::to_string(&Phase::BeforeToolExecute).unwrap(),
             "\"before_tool_execute\""
         );
+        assert_eq!(
+            serde_json::to_string(&Phase::ToolGate).unwrap(),
+            "\"tool_gate\""
+        );
     }
 
     #[test]
@@ -139,6 +148,7 @@ mod tests {
             "StepStart",
             "BeforeInference",
             "AfterInference",
+            "ToolGate",
             "BeforeToolExecute",
             "AfterToolExecute",
             "StepEnd",
@@ -158,7 +168,7 @@ mod tests {
         for phase in Phase::ALL {
             assert!(set.insert(phase), "duplicate phase: {phase}");
         }
-        assert_eq!(set.len(), 8);
+        assert_eq!(set.len(), 9);
     }
 
     #[test]

--- a/crates/awaken-ext-permission/src/plugin/checker.rs
+++ b/crates/awaken-ext-permission/src/plugin/checker.rs
@@ -1,29 +1,27 @@
 use async_trait::async_trait;
 
 use awaken_contract::StateError;
-use awaken_contract::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
-use awaken_runtime::state::StateCommand;
-use awaken_runtime::{PhaseContext, PhaseHook};
+use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
+use awaken_runtime::{PhaseContext, ToolGateHook};
 
 use crate::rules::{ToolPermissionBehavior, evaluate_tool_permission};
 use crate::state::{PermissionOverridesKey, PermissionPolicyKey, permission_rules_from_state};
 
-/// BeforeToolExecute hook that evaluates permission rules and schedules
-/// `ToolInterceptAction` to block or suspend tool calls.
+/// Tool gate hook that evaluates permission rules before a tool call executes.
 ///
 /// - `Allow` → no intercept (tool proceeds normally)
-/// - `Deny` → schedules `Block` intercept
-/// - `Ask` → schedules `Suspend` intercept (awaits external approval)
+/// - `Deny` → returns `Block`
+/// - `Ask` → returns `Suspend` (awaits external approval)
 ///
 /// On resume after `Ask`, checks `resume_input` — if approved, proceeds.
-pub(super) struct PermissionInterceptHook;
+pub(super) struct PermissionToolGateHook;
 
 #[async_trait]
-impl PhaseHook for PermissionInterceptHook {
-    async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, StateError> {
+impl ToolGateHook for PermissionToolGateHook {
+    async fn run(&self, ctx: &PhaseContext) -> Result<Option<ToolInterceptPayload>, StateError> {
         let tool_name = match &ctx.tool_name {
             Some(name) => name.as_str(),
-            None => return Ok(StateCommand::new()),
+            None => return Ok(None),
         };
         let tool_args = ctx.tool_args.clone().unwrap_or_default();
 
@@ -36,43 +34,38 @@ impl PhaseHook for PermissionInterceptHook {
         let ruleset = permission_rules_from_state(policy, overrides);
         let evaluation = evaluate_tool_permission(&ruleset, tool_name, &tool_args);
 
-        let mut cmd = StateCommand::new();
-        match evaluation.behavior {
-            ToolPermissionBehavior::Allow => {} // No intercept = proceed
-            ToolPermissionBehavior::Deny => {
-                cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Block {
-                    reason: format!("Tool '{}' denied by permission rules", tool_name),
-                })?;
-            }
+        let intercept = match evaluation.behavior {
+            ToolPermissionBehavior::Allow => None,
+            ToolPermissionBehavior::Deny => Some(ToolInterceptPayload::Block {
+                reason: format!("Tool '{}' denied by permission rules", tool_name),
+            }),
             ToolPermissionBehavior::Ask => {
-                // On resume the user already approved, so skip re-suspension.
                 if is_resume {
-                    return Ok(StateCommand::new());
+                    None
+                } else {
+                    use awaken_contract::contract::suspension::{
+                        PendingToolCall, SuspendTicket, Suspension, ToolCallResumeMode,
+                    };
+                    let call_id = ctx.tool_call_id.as_deref().unwrap_or("");
+                    Some(ToolInterceptPayload::Suspend(SuspendTicket::new(
+                        Suspension {
+                            id: format!("perm_{call_id}"),
+                            action: "tool:PermissionConfirm".into(),
+                            message: format!("Permission required for tool '{tool_name}'"),
+                            parameters: tool_args.clone(),
+                            ..Default::default()
+                        },
+                        PendingToolCall::new(
+                            format!("perm_{call_id}"),
+                            "permission_confirm",
+                            tool_args,
+                        ),
+                        ToolCallResumeMode::ReplayToolCall,
+                    )))
                 }
-                // For now, suspend without a detailed ticket.
-                // Future: build SuspendTicket with permission confirmation UI schema.
-                use awaken_contract::contract::suspension::{
-                    PendingToolCall, SuspendTicket, Suspension, ToolCallResumeMode,
-                };
-                let call_id = ctx.tool_call_id.as_deref().unwrap_or("");
-                let ticket = SuspendTicket::new(
-                    Suspension {
-                        id: format!("perm_{call_id}"),
-                        action: "tool:PermissionConfirm".into(),
-                        message: format!("Permission required for tool '{tool_name}'"),
-                        parameters: tool_args.clone(),
-                        ..Default::default()
-                    },
-                    PendingToolCall::new(
-                        format!("perm_{call_id}"),
-                        "permission_confirm",
-                        tool_args,
-                    ),
-                    ToolCallResumeMode::ReplayToolCall,
-                );
-                cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Suspend(ticket))?;
             }
-        }
-        Ok(cmd)
+        };
+
+        Ok(intercept)
     }
 }

--- a/crates/awaken-ext-permission/src/plugin/checker_tests.rs
+++ b/crates/awaken-ext-permission/src/plugin/checker_tests.rs
@@ -2,16 +2,16 @@ use std::sync::Arc;
 
 use awaken_contract::StateMap;
 use awaken_contract::contract::suspension::{ResumeDecisionAction, ToolCallResume};
-use awaken_contract::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
-use awaken_contract::model::{Phase, ScheduledActionSpec};
+use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
+use awaken_contract::model::Phase;
 use awaken_contract::state::Snapshot;
-use awaken_runtime::{PhaseContext, PhaseHook};
+use awaken_runtime::{PhaseContext, ToolGateHook};
 use serde_json::json;
 
 use crate::rules::{PermissionRule, ToolPermissionBehavior};
 use crate::state::{PermissionPolicy, PermissionPolicyKey};
 
-use super::checker::PermissionInterceptHook;
+use super::checker::PermissionToolGateHook;
 
 fn snapshot_with_policy(policy: PermissionPolicy) -> Snapshot {
     let mut state_map = StateMap::default();
@@ -20,7 +20,7 @@ fn snapshot_with_policy(policy: PermissionPolicy) -> Snapshot {
 }
 
 fn make_ctx(snapshot: Snapshot, tool_name: &str, tool_args: serde_json::Value) -> PhaseContext {
-    PhaseContext::new(Phase::BeforeToolExecute, snapshot).with_tool_info(
+    PhaseContext::new(Phase::ToolGate, snapshot).with_tool_info(
         tool_name,
         "call_1",
         Some(tool_args),
@@ -37,13 +37,6 @@ fn resume_input() -> ToolCallResume {
     }
 }
 
-fn decode_intercept(cmd: &awaken_runtime::state::StateCommand) -> Option<ToolInterceptPayload> {
-    cmd.scheduled_actions()
-        .iter()
-        .find(|a| a.key == ToolInterceptAction::KEY)
-        .map(|a| ToolInterceptAction::decode_payload(a.payload.clone()).unwrap())
-}
-
 // -----------------------------------------------------------------------
 // Vulnerability test: resumed denied tool must still be blocked
 // -----------------------------------------------------------------------
@@ -57,8 +50,7 @@ async fn resumed_denied_tool_is_blocked() {
     let ctx = make_ctx(snapshot_with_policy(policy), "dangerous_tool", json!({}))
         .with_resume_input(resume_input());
 
-    let cmd = PermissionInterceptHook.run(&ctx).await.unwrap();
-    let intercept = decode_intercept(&cmd);
+    let intercept = PermissionToolGateHook.run(&ctx).await.unwrap();
 
     // A denied tool MUST be blocked even when resumed
     assert!(
@@ -80,9 +72,8 @@ async fn resumed_allowed_tool_proceeds() {
     let ctx = make_ctx(snapshot_with_policy(policy), "safe_tool", json!({}))
         .with_resume_input(resume_input());
 
-    let cmd = PermissionInterceptHook.run(&ctx).await.unwrap();
     assert!(
-        decode_intercept(&cmd).is_none(),
+        PermissionToolGateHook.run(&ctx).await.unwrap().is_none(),
         "allowed tool should proceed on resume"
     );
 }
@@ -100,10 +91,9 @@ async fn resumed_ask_tool_proceeds() {
     let ctx = make_ctx(snapshot_with_policy(policy), "ask_tool", json!({}))
         .with_resume_input(resume_input());
 
-    let cmd = PermissionInterceptHook.run(&ctx).await.unwrap();
     // Ask was already approved by user via resume, should not re-suspend
     assert!(
-        decode_intercept(&cmd).is_none(),
+        PermissionToolGateHook.run(&ctx).await.unwrap().is_none(),
         "ask tool should proceed on resume (user already approved)"
     );
 }
@@ -120,9 +110,8 @@ async fn non_resumed_denied_tool_is_blocked() {
 
     let ctx = make_ctx(snapshot_with_policy(policy), "dangerous_tool", json!({}));
 
-    let cmd = PermissionInterceptHook.run(&ctx).await.unwrap();
     assert!(matches!(
-        decode_intercept(&cmd),
+        PermissionToolGateHook.run(&ctx).await.unwrap(),
         Some(ToolInterceptPayload::Block { .. })
     ));
 }
@@ -139,9 +128,8 @@ async fn non_resumed_ask_tool_is_suspended() {
 
     let ctx = make_ctx(snapshot_with_policy(policy), "ask_tool", json!({}));
 
-    let cmd = PermissionInterceptHook.run(&ctx).await.unwrap();
     assert!(matches!(
-        decode_intercept(&cmd),
+        PermissionToolGateHook.run(&ctx).await.unwrap(),
         Some(ToolInterceptPayload::Suspend(_))
     ));
 }

--- a/crates/awaken-ext-permission/src/plugin/filter.rs
+++ b/crates/awaken-ext-permission/src/plugin/filter.rs
@@ -11,8 +11,8 @@ use crate::state::{PermissionOverridesKey, PermissionPolicyKey, permission_rules
 /// tool list before the LLM sees them.
 ///
 /// Only exact-match, argument-independent Deny rules are applied here.
-/// Conditional denies (argument-based) remain handled by
-/// [`super::checker::PermissionInterceptHook`] at `BeforeToolExecute`.
+/// Conditional rules remain handled by [`super::checker::PermissionToolGateHook`]
+/// at `ToolGate`.
 pub(super) struct PermissionToolFilterHook;
 
 #[async_trait]

--- a/crates/awaken-ext-permission/src/plugin/plugin.rs
+++ b/crates/awaken-ext-permission/src/plugin/plugin.rs
@@ -7,7 +7,7 @@ use awaken_runtime::state::{KeyScope, MutationBatch, StateKeyOptions};
 use crate::config::{PermissionConfigKey, PermissionRulesConfig};
 use crate::state::{PermissionAction, PermissionOverridesKey, PermissionPolicyKey};
 
-use super::checker::PermissionInterceptHook;
+use super::checker::PermissionToolGateHook;
 use super::filter::PermissionToolFilterHook;
 
 /// Stable plugin name for the permission extension.
@@ -20,8 +20,7 @@ pub const PERMISSION_PLUGIN_NAME: &str = "permission";
 /// - [`PermissionOverridesKey`]: run-scoped temporary overrides
 /// - A `BeforeInference` phase hook that removes unconditionally denied tools
 ///   from the tool list before the LLM sees them
-/// - A `BeforeToolExecute` phase hook that evaluates rules and schedules
-///   `ToolInterceptAction` to block or suspend tool calls
+/// - A `ToolGate` hook that evaluates rules and blocks or suspends tool calls
 pub struct PermissionPlugin;
 
 impl Plugin for PermissionPlugin {
@@ -50,11 +49,7 @@ impl Plugin for PermissionPlugin {
             PermissionToolFilterHook,
         )?;
 
-        registrar.register_phase_hook(
-            PERMISSION_PLUGIN_NAME,
-            Phase::BeforeToolExecute,
-            PermissionInterceptHook,
-        )?;
+        registrar.register_tool_gate_hook(PERMISSION_PLUGIN_NAME, PermissionToolGateHook)?;
 
         Ok(())
     }

--- a/crates/awaken-runtime/src/agent/state/loop_actions.rs
+++ b/crates/awaken-runtime/src/agent/state/loop_actions.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use crate::state::{MergeStrategy, StateKey};
 use awaken_contract::contract::context_message::ContextMessage;
 use awaken_contract::contract::inference::InferenceOverride;
-use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
 
 // ---------------------------------------------------------------------------
 // Action specs
@@ -213,35 +212,6 @@ impl StateKey for InferenceOverrideState {
             InferenceOverrideStateAction::Clear => {
                 value.overrides = None;
             }
-        }
-    }
-}
-
-/// Accumulated tool intercept decisions for the current tool call.
-/// Written by `ToolInterceptAction` handler. Read and cleared by orchestrator.
-pub struct ToolInterceptState;
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ToolInterceptStateValue {
-    pub payloads: Vec<ToolInterceptPayload>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ToolInterceptStateAction {
-    Push(Box<ToolInterceptPayload>),
-    Clear,
-}
-
-impl StateKey for ToolInterceptState {
-    const KEY: &'static str = "__runtime.tool_intercept_state";
-    const MERGE: MergeStrategy = MergeStrategy::Commutative;
-    type Value = ToolInterceptStateValue;
-    type Update = ToolInterceptStateAction;
-
-    fn apply(value: &mut Self::Value, update: Self::Update) {
-        match update {
-            ToolInterceptStateAction::Push(payload) => value.payloads.push(*payload),
-            ToolInterceptStateAction::Clear => value.payloads.clear(),
         }
     }
 }

--- a/crates/awaken-runtime/src/hooks/mod.rs
+++ b/crates/awaken-runtime/src/hooks/mod.rs
@@ -1,12 +1,15 @@
 mod context;
 mod handlers;
 mod phase_hook;
+mod tool_gate_hook;
 
 pub use context::PhaseContext;
 pub use handlers::{TypedEffectHandler, TypedScheduledActionHandler};
 pub use phase_hook::PhaseHook;
+pub use tool_gate_hook::ToolGateHook;
 
 pub(crate) use handlers::{
     EffectHandlerArc, ScheduledActionHandlerArc, TypedEffectAdapter, TypedScheduledActionAdapter,
 };
 pub(crate) use phase_hook::PhaseHookArc;
+pub(crate) use tool_gate_hook::ToolGateHookArc;

--- a/crates/awaken-runtime/src/hooks/tool_gate_hook.rs
+++ b/crates/awaken-runtime/src/hooks/tool_gate_hook.rs
@@ -1,0 +1,14 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::PhaseContext;
+use awaken_contract::StateError;
+use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
+
+#[async_trait]
+pub trait ToolGateHook: Send + Sync + 'static {
+    async fn run(&self, ctx: &PhaseContext) -> Result<Option<ToolInterceptPayload>, StateError>;
+}
+
+pub(crate) type ToolGateHookArc = Arc<dyn ToolGateHook>;

--- a/crates/awaken-runtime/src/lib.rs
+++ b/crates/awaken-runtime/src/lib.rs
@@ -35,7 +35,7 @@ pub use profile::ProfileAccess;
 
 pub use builder::{AgentRuntimeBuilder, BuildError};
 pub use phase::{
-    DEFAULT_MAX_PHASE_ROUNDS, ExecutionEnv, PhaseContext, PhaseHook, PhaseRuntime,
+    DEFAULT_MAX_PHASE_ROUNDS, ExecutionEnv, PhaseContext, PhaseHook, PhaseRuntime, ToolGateHook,
     TypedEffectHandler, TypedScheduledActionHandler,
 };
 pub use plugins::{Plugin, PluginDescriptor, PluginRegistrar};

--- a/crates/awaken-runtime/src/loop_runner/actions.rs
+++ b/crates/awaken-runtime/src/loop_runner/actions.rs
@@ -2,7 +2,7 @@
 //!
 //! All scheduled actions flow through the handler queue via
 //! `TypedScheduledActionHandler`. Accumulator actions (`ExcludeTool`,
-//! `IncludeOnlyTools`, `SetInferenceOverride`, `ToolInterceptAction`) write to
+//! `IncludeOnlyTools`, `SetInferenceOverride`) write to
 //! transient state keys. The orchestrator reads from state after the EXECUTE
 //! loop and clears the accumulators for the next step/call.
 
@@ -17,15 +17,13 @@ use awaken_contract::StateError;
 use awaken_contract::contract::context_message::ContextMessage;
 use awaken_contract::contract::inference::InferenceOverride;
 use awaken_contract::contract::message::{Message, Role};
-use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
 
 use crate::agent::state::{
     AddContextMessage, ContextMessageAction, ContextMessageStore, ContextThrottleState,
     ContextThrottleUpdate, ExcludeTool, IncludeOnlyTools, InferenceOverrideState,
     InferenceOverrideStateAction, RunLifecycle, SetInferenceOverride, ToolFilterState,
-    ToolFilterStateAction, ToolInterceptState, ToolInterceptStateAction,
+    ToolFilterStateAction,
 };
-use awaken_contract::contract::tool_intercept::ToolInterceptAction;
 
 /// Merge multiple inference override payloads with last-wins-per-field semantics.
 pub(super) fn merge_override_payloads(
@@ -156,22 +154,6 @@ impl TypedScheduledActionHandler<SetInferenceOverride> for SetInferenceOverrideH
     }
 }
 
-/// Handler for `ToolInterceptAction` — writes to [`ToolInterceptState`].
-pub(super) struct ToolInterceptHandler;
-
-#[async_trait]
-impl TypedScheduledActionHandler<ToolInterceptAction> for ToolInterceptHandler {
-    async fn handle_typed(
-        &self,
-        _ctx: &PhaseContext,
-        payload: ToolInterceptPayload,
-    ) -> Result<StateCommand, StateError> {
-        let mut cmd = StateCommand::new();
-        cmd.update::<ToolInterceptState>(ToolInterceptStateAction::Push(Box::new(payload)));
-        Ok(cmd)
-    }
-}
-
 /// Handler for `AddContextMessage` — applies throttle logic, upserts accepted
 /// messages into [`ContextMessageStore`], updates [`ContextThrottleState`].
 pub(super) struct ContextMessageHandler;
@@ -261,14 +243,11 @@ impl crate::plugins::Plugin for LoopActionHandlersPlugin {
         // State keys for action accumulators
         r.register_key::<ToolFilterState>(StateKeyOptions::default())?;
         r.register_key::<InferenceOverrideState>(StateKeyOptions::default())?;
-        r.register_key::<ToolInterceptState>(StateKeyOptions::default())?;
-
         // Handlers
         r.register_scheduled_action::<AddContextMessage, _>(ContextMessageHandler)?;
         r.register_scheduled_action::<ExcludeTool, _>(ExcludeToolHandler)?;
         r.register_scheduled_action::<IncludeOnlyTools, _>(IncludeOnlyToolsHandler)?;
         r.register_scheduled_action::<SetInferenceOverride, _>(SetInferenceOverrideHandler)?;
-        r.register_scheduled_action::<ToolInterceptAction, _>(ToolInterceptHandler)?;
         Ok(())
     }
 }

--- a/crates/awaken-runtime/src/loop_runner/resume.rs
+++ b/crates/awaken-runtime/src/loop_runner/resume.rs
@@ -15,7 +15,7 @@ use futures::StreamExt;
 use futures::channel::mpsc::UnboundedReceiver;
 use serde_json::Value;
 
-use super::step::{StepContext, execute_tools_with_interception};
+use super::step::{StepContext, ToolBatchTranscript, execute_tools_with_interception};
 use super::{AgentLoopError, commit_update, now_ms};
 use crate::agent::state::{ToolCallState, ToolCallStates, ToolCallStatesUpdate};
 use crate::context::TruncationState;
@@ -197,7 +197,15 @@ pub(super) async fn detect_and_replay_resume(
             run_created_at,
         };
 
-        let _ = execute_tools_with_interception(&mut step_ctx, std::slice::from_ref(&call)).await?;
+        let mut transcript = ToolBatchTranscript::for_resume();
+        let _ = execute_tools_with_interception(
+            &mut step_ctx,
+            &mut transcript,
+            std::slice::from_ref(&call),
+        )
+        .await?;
+        drop(step_ctx);
+        transcript.commit_into(messages);
     }
 
     Ok(())

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -18,8 +18,8 @@ use awaken_contract::contract::message::{Message, ToolCall};
 use awaken_contract::contract::storage::ThreadRunStore;
 use awaken_contract::contract::suspension::{SuspendTicket, ToolCallOutcome, ToolCallStatus};
 use awaken_contract::contract::tool::ToolCallContext;
-use awaken_contract::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
-use awaken_contract::model::{Phase, ScheduledActionSpec};
+use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
+use awaken_contract::model::Phase;
 
 use super::actions::{
     apply_context_messages, apply_tool_filter_payloads, merge_override_payloads,
@@ -31,8 +31,9 @@ use super::{AgentLoopError, commit_update, now_ms, tool_result_to_content};
 use crate::agent::state::{
     InferenceOverrideState, InferenceOverrideStateAction, RunLifecycle, RunLifecycleUpdate,
     ToolCallState, ToolCallStates, ToolCallStatesUpdate, ToolFilterState, ToolFilterStateAction,
-    ToolInterceptState, ToolInterceptStateAction,
 };
+
+const INTERRUPTED_TOOL_MESSAGE: &str = "[Tool execution was interrupted]";
 
 /// Outcome of a single step.
 pub(super) enum StepOutcome {
@@ -66,7 +67,46 @@ pub(super) struct StepContext<'a> {
     pub run_created_at: u64,
 }
 
-const INTERRUPTED_TOOL_MESSAGE: &str = "[Tool execution was interrupted]";
+pub(super) struct ToolBatchTranscript {
+    assistant_message: Option<Arc<Message>>,
+    tool_messages: Vec<Arc<Message>>,
+}
+
+impl ToolBatchTranscript {
+    pub(super) fn for_inference(text: String, calls: Vec<ToolCall>) -> Self {
+        Self {
+            assistant_message: Some(Arc::new(Message::assistant_with_tool_calls(text, calls))),
+            tool_messages: Vec::new(),
+        }
+    }
+
+    pub(super) fn for_resume() -> Self {
+        Self {
+            assistant_message: None,
+            tool_messages: Vec::new(),
+        }
+    }
+
+    fn visible_messages(&self, committed: &[Arc<Message>]) -> Vec<Arc<Message>> {
+        let mut visible = committed.to_vec();
+        if let Some(message) = &self.assistant_message {
+            visible.push(Arc::clone(message));
+        }
+        visible.extend(self.tool_messages.iter().cloned());
+        visible
+    }
+
+    fn push_tool_message(&mut self, message: Arc<Message>) {
+        self.tool_messages.push(message);
+    }
+
+    pub(super) fn commit_into(self, committed: &mut Vec<Arc<Message>>) {
+        if let Some(message) = self.assistant_message {
+            committed.push(message);
+        }
+        committed.extend(self.tool_messages);
+    }
+}
 
 pub(super) fn make_ctx(
     phase: Phase,
@@ -82,6 +122,23 @@ pub(super) fn make_ctx(
         Some(token) => ctx.with_cancellation_token(token.clone()),
         None => ctx,
     }
+}
+
+fn tool_phase_context(
+    ctx: &StepContext<'_>,
+    transcript: &ToolBatchTranscript,
+    phase: Phase,
+    call: &ToolCall,
+) -> PhaseContext {
+    let visible_messages = transcript.visible_messages(ctx.messages);
+    make_ctx(
+        phase,
+        &visible_messages,
+        ctx.run_identity,
+        ctx.runtime.store(),
+        ctx.cancellation_token,
+    )
+    .with_tool_info(&call.name, &call.id, Some(call.arguments.clone()))
 }
 
 fn active_resume_state(store: &crate::state::StateStore, call_id: &str) -> Option<ToolCallState> {
@@ -386,93 +443,119 @@ async fn run_inference_phase(
     Ok((stream_result, duration_ms))
 }
 
-/// Run BeforeToolExecute phase via collect_commands and check for intercept.
+/// Run ToolGate hooks for a tool call and resolve the winning decision.
 ///
-/// Returns `Some(payload)` if any hook scheduled a `ToolInterceptAction`,
-/// `None` if the tool should execute normally.
-async fn intercept_tool_call(
+/// ToolGate is pure and may be re-evaluated after earlier allowed tool calls
+/// commit new state in the same step.
+async fn run_tool_gate(
     ctx: &mut StepContext<'_>,
+    transcript: &ToolBatchTranscript,
     call: &ToolCall,
-) -> Result<Option<awaken_contract::contract::tool_intercept::ToolInterceptPayload>, AgentLoopError>
-{
+) -> Result<Option<ToolInterceptPayload>, AgentLoopError> {
     let store = ctx.runtime.store();
-    let (cmd, resume_state) = collect_before_tool_execute_command(ctx, call).await?;
+    let resume_state = active_resume_state(store, &call.id);
+    let gate_ctx = apply_resume_context(
+        tool_phase_context(ctx, transcript, Phase::ToolGate, call),
+        resume_state.as_ref(),
+    );
+
+    let mut payloads = Vec::new();
+    for hook in ctx.agent.env.tool_gate_hooks() {
+        if let Some(payload) = hook.hook.run(&gate_ctx).await? {
+            tracing::debug!(
+                plugin_id = %hook.plugin_id,
+                tool_name = %call.name,
+                call_id = %call.id,
+                payload = ?payload,
+                "tool_gate_decision"
+            );
+            payloads.push(payload);
+        }
+    }
+
+    Ok(resolve_intercept_payloads(payloads))
+}
+
+/// Run BeforeToolExecute immediately before the tool actually executes.
+async fn run_before_tool_execute(
+    ctx: &mut StepContext<'_>,
+    transcript: &ToolBatchTranscript,
+    call: &ToolCall,
+) -> Result<(), AgentLoopError> {
+    let store = ctx.runtime.store();
+    let resume_state = active_resume_state(store, &call.id);
+    let before_ctx = apply_resume_context(
+        tool_phase_context(ctx, transcript, Phase::BeforeToolExecute, call),
+        resume_state.as_ref(),
+    );
+
+    // GATHER only — submit ALL actions to handler queue
+    let cmd = ctx
+        .runtime
+        .collect_commands(&ctx.agent.env, before_ctx.clone())
+        .await?;
 
     if !cmd.is_empty() {
         ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
         // Run EXECUTE for any remaining handler-based actions
-        let exec_ctx = apply_resume_context(
-            make_ctx(
-                Phase::BeforeToolExecute,
-                ctx.messages,
-                ctx.run_identity,
-                store,
-                ctx.cancellation_token,
-            )
-            .with_tool_info(&call.name, &call.id, Some(call.arguments.clone())),
-            resume_state.as_ref(),
-        );
+        let exec_ctx = tool_phase_context(ctx, transcript, Phase::BeforeToolExecute, call);
+        let exec_ctx = apply_resume_context(exec_ctx, resume_state.as_ref());
         ctx.runtime
             .run_execute_loop(&ctx.agent.env, exec_ctx)
             .await?;
     }
-
-    // Read accumulated intercepts from state
-    let intercept_state = store.read::<ToolInterceptState>().unwrap_or_default();
-
-    // Clear accumulator for next tool call
-    let mut clear_patch = crate::state::MutationBatch::new();
-    clear_patch.update::<ToolInterceptState>(ToolInterceptStateAction::Clear);
-    store.commit(clear_patch)?;
-
-    // Resolve winning intercept from accumulated payloads
-    Ok(resolve_intercept_payloads(intercept_state.payloads))
+    Ok(())
 }
 
-async fn collect_before_tool_execute_command(
+struct AppliedIntercept {
+    blocked_reason: Option<String>,
+    suspended: bool,
+}
+
+async fn apply_intercept_payload(
     ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
     call: &ToolCall,
-) -> Result<(StateCommand, Option<ToolCallState>), AgentLoopError> {
-    let store = ctx.runtime.store();
-    let resume_state = active_resume_state(store, &call.id);
-    let before_ctx = apply_resume_context(
-        make_ctx(
-            Phase::BeforeToolExecute,
-            ctx.messages,
-            ctx.run_identity,
-            store,
-            ctx.cancellation_token,
-        )
-        .with_tool_info(&call.name, &call.id, Some(call.arguments.clone())),
-        resume_state.as_ref(),
-    );
-    let cmd = ctx
-        .runtime
-        .collect_commands(&ctx.agent.env, before_ctx)
-        .await?;
-    Ok((cmd, resume_state))
-}
-
-fn resolve_intercept_payloads_from_command(
-    command: &StateCommand,
-) -> Result<Option<ToolInterceptPayload>, AgentLoopError> {
-    let payloads = command
-        .scheduled_actions()
-        .iter()
-        .filter(|action| {
-            action.phase == ToolInterceptAction::PHASE && action.key == ToolInterceptAction::KEY
-        })
-        .map(|action| ToolInterceptAction::decode_payload(action.payload.clone()))
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(resolve_intercept_payloads(payloads))
-}
-
-async fn peek_tool_intercept(
-    ctx: &mut StepContext<'_>,
-    call: &ToolCall,
-) -> Result<Option<ToolInterceptPayload>, AgentLoopError> {
-    let (cmd, _) = collect_before_tool_execute_command(ctx, call).await?;
-    resolve_intercept_payloads_from_command(&cmd)
+    payload: ToolInterceptPayload,
+) -> Result<AppliedIntercept, AgentLoopError> {
+    match payload {
+        ToolInterceptPayload::Block { reason } => {
+            let result = awaken_contract::contract::tool::ToolResult::error(&call.name, &reason);
+            let cmd = build_tool_state_command(
+                ctx,
+                transcript,
+                call,
+                &result,
+                StateCommand::new(),
+                ToolCallOutcome::Failed,
+            )
+            .await?;
+            ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
+            emit_tool_completion(ctx, transcript, call, &result, ToolCallOutcome::Failed).await;
+            Ok(AppliedIntercept {
+                blocked_reason: Some(reason),
+                suspended: false,
+            })
+        }
+        ToolInterceptPayload::Suspend(ticket) => {
+            let cmd = build_suspend_state_command(call, &ticket);
+            ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
+            emit_suspend_completion(ctx, transcript, call, &ticket).await;
+            Ok(AppliedIntercept {
+                blocked_reason: None,
+                suspended: true,
+            })
+        }
+        ToolInterceptPayload::SetResult(result) => {
+            let outcome = ToolCallOutcome::from_tool_result(&result);
+            complete_tool_call(ctx, transcript, call, &result, StateCommand::new(), outcome)
+                .await?;
+            Ok(AppliedIntercept {
+                blocked_reason: None,
+                suspended: outcome == ToolCallOutcome::Suspended,
+            })
+        }
+    }
 }
 
 /// Build a StateCommand for a completed tool call.
@@ -485,6 +568,7 @@ async fn peek_tool_intercept(
 /// Pure state construction — no side effects (no events, no messages, no commit).
 async fn build_tool_state_command(
     ctx: &mut StepContext<'_>,
+    transcript: &ToolBatchTranscript,
     call: &ToolCall,
     tool_result: &awaken_contract::contract::tool::ToolResult,
     tool_command: StateCommand,
@@ -528,15 +612,8 @@ async fn build_tool_state_command(
 
     // Collect AfterToolExecute hook commands (same as plugin gather)
     let after_ctx = apply_resume_context(
-        make_ctx(
-            Phase::AfterToolExecute,
-            ctx.messages,
-            ctx.run_identity,
-            store,
-            ctx.cancellation_token,
-        )
-        .with_tool_info(&call.name, &call.id, Some(call.arguments.clone()))
-        .with_tool_result(tool_result.clone()),
+        tool_phase_context(ctx, transcript, Phase::AfterToolExecute, call)
+            .with_tool_result(tool_result.clone()),
         resume_state.as_ref(),
     );
     let after_cmd = ctx
@@ -554,6 +631,7 @@ async fn build_tool_state_command(
 /// Side-effect only — no state mutation.
 async fn emit_tool_completion(
     ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
     call: &ToolCall,
     tool_result: &awaken_contract::contract::tool::ToolResult,
     outcome: ToolCallOutcome,
@@ -582,8 +660,7 @@ async fn emit_tool_completion(
     ctx.sink.emit(event).await;
 
     let tool_content = tool_result_to_content(tool_result);
-    ctx.messages
-        .push(Arc::new(Message::tool(&call.id, tool_content)));
+    transcript.push_tool_message(Arc::new(Message::tool(&call.id, tool_content)));
 }
 
 /// Complete a single tool call: build state, emit events, commit.
@@ -592,13 +669,15 @@ async fn emit_tool_completion(
 /// where each tool commits individually.
 async fn complete_tool_call(
     ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
     call: &ToolCall,
     tool_result: &awaken_contract::contract::tool::ToolResult,
     tool_command: StateCommand,
     outcome: ToolCallOutcome,
 ) -> Result<(), AgentLoopError> {
-    let cmd = build_tool_state_command(ctx, call, tool_result, tool_command, outcome).await?;
-    emit_tool_completion(ctx, call, tool_result, outcome).await;
+    let cmd =
+        build_tool_state_command(ctx, transcript, call, tool_result, tool_command, outcome).await?;
+    emit_tool_completion(ctx, transcript, call, tool_result, outcome).await;
     ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
     Ok(())
 }
@@ -626,6 +705,7 @@ fn build_suspend_state_command(call: &ToolCall, ticket: &SuspendTicket) -> State
 /// Emit suspend-related events and append message.
 async fn emit_suspend_completion(
     ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
     call: &ToolCall,
     ticket: &SuspendTicket,
 ) {
@@ -653,48 +733,68 @@ async fn emit_suspend_completion(
             outcome: ToolCallOutcome::Suspended,
         })
         .await;
-    ctx.messages.push(Arc::new(Message::tool(
+    transcript.push_tool_message(Arc::new(Message::tool(
         &call.id,
         format!("Tool '{}' suspended: awaiting decision", call.name),
     )));
 }
 
+async fn complete_interrupted_tool_call(
+    ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
+    call: &ToolCall,
+) -> Result<(), AgentLoopError> {
+    let result =
+        awaken_contract::contract::tool::ToolResult::error(&call.name, INTERRUPTED_TOOL_MESSAGE);
+    let mut cmd = StateCommand::new();
+    cmd.update::<ToolCallStates>(ToolCallStatesUpdate::Put(ToolCallState::new(
+        call.id.clone(),
+        call.name.clone(),
+        call.arguments.clone(),
+        ToolCallStatus::Failed,
+        now_ms(),
+    )));
+    emit_tool_completion(ctx, transcript, call, &result, ToolCallOutcome::Failed).await;
+    ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
+    Ok(())
+}
+
 async fn backfill_interrupted_tool_calls(
     ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
     calls: &[ToolCall],
 ) -> Result<(), AgentLoopError> {
     for call in calls {
-        let result = awaken_contract::contract::tool::ToolResult::error(
-            &call.name,
-            INTERRUPTED_TOOL_MESSAGE,
-        );
-        let mut cmd = StateCommand::new();
-        cmd.update::<ToolCallStates>(ToolCallStatesUpdate::Put(ToolCallState::new(
-            call.id.clone(),
-            call.name.clone(),
-            call.arguments.clone(),
-            ToolCallStatus::Failed,
-            now_ms(),
-        )));
-        ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
-        emit_tool_completion(ctx, call, &result, ToolCallOutcome::Failed).await;
+        complete_interrupted_tool_call(ctx, transcript, call).await?;
     }
     Ok(())
 }
 
-struct AllowedExecutionOutcome {
+struct ReadyExecutionOutcome {
     suspended: bool,
     processed_calls: usize,
 }
 
-async fn execute_allowed_tool_calls(
+async fn run_before_tool_execute_batch(
     ctx: &mut StepContext<'_>,
+    transcript: &ToolBatchTranscript,
+    calls: &[ToolCall],
+) -> Result<(), AgentLoopError> {
+    for call in calls {
+        run_before_tool_execute(ctx, transcript, call).await?;
+    }
+    Ok(())
+}
+
+async fn execute_ready_tool_calls(
+    ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
     allowed_calls: &[ToolCall],
-) -> Result<AllowedExecutionOutcome, AgentLoopError> {
+) -> Result<ReadyExecutionOutcome, AgentLoopError> {
     let store = ctx.runtime.store();
 
     if allowed_calls.is_empty() {
-        return Ok(AllowedExecutionOutcome {
+        return Ok(ReadyExecutionOutcome {
             suspended: false,
             processed_calls: 0,
         });
@@ -721,6 +821,7 @@ async fn execute_allowed_tool_calls(
 
     if ctx.agent.tool_executor.requires_incremental_state() {
         for call in allowed_calls {
+            run_before_tool_execute_batch(ctx, transcript, std::slice::from_ref(call)).await?;
             let resume_state = active_resume_state(store, &call.id);
             let mut tool_ctx = base_tool_ctx.clone();
             tool_ctx.call_id = call.id.clone();
@@ -741,6 +842,7 @@ async fn execute_allowed_tool_calls(
             let outcome = exec_result.outcome;
             complete_tool_call(
                 ctx,
+                transcript,
                 &exec_result.call,
                 &exec_result.result,
                 exec_result.command,
@@ -761,6 +863,7 @@ async fn execute_allowed_tool_calls(
             let resume_state = active_resume_state(store, &call.id);
 
             if let Some(resume_state) = resume_state.as_ref() {
+                run_before_tool_execute_batch(ctx, transcript, std::slice::from_ref(call)).await?;
                 let mut tool_ctx = base_tool_ctx.clone();
                 tool_ctx.call_id = call.id.clone();
                 tool_ctx.tool_name = call.name.clone();
@@ -781,6 +884,7 @@ async fn execute_allowed_tool_calls(
                 let outcome = exec_result.outcome;
                 complete_tool_call(
                     ctx,
+                    transcript,
                     &exec_result.call,
                     &exec_result.result,
                     exec_result.command,
@@ -805,6 +909,7 @@ async fn execute_allowed_tool_calls(
                 index += 1;
             }
             let segment = &allowed_calls[segment_start..index];
+            run_before_tool_execute_batch(ctx, transcript, segment).await?;
             let mut segment_ctx = base_tool_ctx.clone();
             segment_ctx.snapshot = store.snapshot();
 
@@ -820,6 +925,7 @@ async fn execute_allowed_tool_calls(
                 let outcome = exec_result.outcome;
                 complete_tool_call(
                     ctx,
+                    transcript,
                     &exec_result.call,
                     &exec_result.result,
                     exec_result.command,
@@ -838,6 +944,7 @@ async fn execute_allowed_tool_calls(
             }
         }
     } else {
+        run_before_tool_execute_batch(ctx, transcript, allowed_calls).await?;
         let exec_results = ctx
             .agent
             .tool_executor
@@ -849,6 +956,7 @@ async fn execute_allowed_tool_calls(
             let outcome = exec_result.outcome;
             complete_tool_call(
                 ctx,
+                transcript,
                 &exec_result.call,
                 &exec_result.result,
                 exec_result.command,
@@ -862,9 +970,28 @@ async fn execute_allowed_tool_calls(
         }
     }
 
-    Ok(AllowedExecutionOutcome {
+    Ok(ReadyExecutionOutcome {
         suspended,
         processed_calls,
+    })
+}
+
+struct AllowedExecutionOutcome {
+    blocked_reason: Option<String>,
+    suspended: bool,
+    processed_calls: usize,
+}
+
+async fn execute_allowed_tool_calls(
+    ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
+    allowed_calls: &[ToolCall],
+) -> Result<AllowedExecutionOutcome, AgentLoopError> {
+    let batch = execute_ready_tool_calls(ctx, transcript, allowed_calls).await?;
+    Ok(AllowedExecutionOutcome {
+        blocked_reason: None,
+        suspended: batch.suspended,
+        processed_calls: batch.processed_calls,
     })
 }
 
@@ -878,64 +1005,61 @@ async fn execute_allowed_tool_calls(
 /// Returns (block_reason, any_suspended).
 pub(super) async fn execute_tools_with_interception(
     ctx: &mut StepContext<'_>,
+    transcript: &mut ToolBatchTranscript,
     calls: &[ToolCall],
 ) -> Result<(Option<String>, bool), AgentLoopError> {
     let mut suspended = false;
     let mut allowed_calls: Vec<ToolCall> = Vec::new();
     for (index, call) in calls.iter().enumerate() {
-        if !allowed_calls.is_empty() && peek_tool_intercept(ctx, call).await?.is_some() {
-            let batch = execute_allowed_tool_calls(ctx, &allowed_calls).await?;
+        let mut intercept = run_tool_gate(ctx, transcript, call).await?;
+
+        if intercept.is_some() && !allowed_calls.is_empty() {
+            let batch = execute_allowed_tool_calls(ctx, transcript, &allowed_calls).await?;
             let interrupted_allowed = allowed_calls[batch.processed_calls..].to_vec();
             allowed_calls.clear();
-            if batch.suspended {
-                suspended = true;
-                backfill_interrupted_tool_calls(ctx, &interrupted_allowed).await?;
-                backfill_interrupted_tool_calls(ctx, &calls[index..]).await?;
-                return Ok((None, suspended));
-            }
-        }
 
-        match intercept_tool_call(ctx, call).await? {
-            Some(ToolInterceptPayload::Block { reason }) => {
-                let result =
-                    awaken_contract::contract::tool::ToolResult::error(&call.name, &reason);
-                let cmd = build_tool_state_command(
-                    ctx,
-                    call,
-                    &result,
-                    StateCommand::new(),
-                    ToolCallOutcome::Failed,
-                )
-                .await?;
-                ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
-                emit_tool_completion(ctx, call, &result, ToolCallOutcome::Failed).await;
-                backfill_interrupted_tool_calls(ctx, &calls[index + 1..]).await?;
+            if let Some(reason) = batch.blocked_reason {
+                backfill_interrupted_tool_calls(ctx, transcript, &calls[index..]).await?;
                 return Ok((Some(reason), suspended));
             }
-            Some(ToolInterceptPayload::Suspend(ticket)) => {
-                let cmd = build_suspend_state_command(call, &ticket);
-                ctx.runtime.submit_command(&ctx.agent.env, cmd).await?;
-                emit_suspend_completion(ctx, call, &ticket).await;
+
+            if batch.suspended {
+                suspended = true;
+                backfill_interrupted_tool_calls(ctx, transcript, &interrupted_allowed).await?;
+                backfill_interrupted_tool_calls(ctx, transcript, &calls[index..]).await?;
+                return Ok((None, suspended));
+            }
+
+            intercept = run_tool_gate(ctx, transcript, call).await?;
+        }
+
+        if let Some(payload) = intercept {
+            let applied = apply_intercept_payload(ctx, transcript, call, payload).await?;
+            if let Some(reason) = applied.blocked_reason {
+                backfill_interrupted_tool_calls(ctx, transcript, &calls[index + 1..]).await?;
+                return Ok((Some(reason), suspended));
+            }
+            if applied.suspended {
                 suspended = true;
             }
-            Some(ToolInterceptPayload::SetResult(result)) => {
-                let outcome = ToolCallOutcome::from_tool_result(&result);
-                complete_tool_call(ctx, call, &result, StateCommand::new(), outcome).await?;
-                if outcome == ToolCallOutcome::Suspended {
-                    suspended = true;
-                }
-            }
-            None => {
-                allowed_calls.push(call.clone());
-            }
+        } else {
+            allowed_calls.push(call.clone());
         }
     }
 
     if !allowed_calls.is_empty() {
-        let batch = execute_allowed_tool_calls(ctx, &allowed_calls).await?;
+        let batch = execute_allowed_tool_calls(ctx, transcript, &allowed_calls).await?;
+        if let Some(reason) = batch.blocked_reason {
+            return Ok((Some(reason), suspended));
+        }
         if batch.suspended {
             suspended = true;
-            backfill_interrupted_tool_calls(ctx, &allowed_calls[batch.processed_calls..]).await?;
+            backfill_interrupted_tool_calls(
+                ctx,
+                transcript,
+                &allowed_calls[batch.processed_calls..],
+            )
+            .await?;
         }
     }
 
@@ -1044,15 +1168,14 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
     }
 
     // --- Tool calls ---
-    ctx.messages
-        .push(Arc::new(Message::assistant_with_tool_calls(
-            stream_result.text(),
-            stream_result.tool_calls.clone(),
-        )));
+    let mut transcript =
+        ToolBatchTranscript::for_inference(stream_result.text(), stream_result.tool_calls.clone());
 
-    // Intercept + execute tool calls via unified pipeline
+    // Intercept + execute tool calls via unified pipeline.
+    // Messages stay step-local until the batch has complete visible outputs.
     let (blocked_reason, suspended) =
-        execute_tools_with_interception(ctx, &stream_result.tool_calls).await?;
+        execute_tools_with_interception(ctx, &mut transcript, &stream_result.tool_calls).await?;
+    transcript.commit_into(ctx.messages);
 
     if let Some(reason) = blocked_reason {
         commit_update::<RunLifecycle>(

--- a/crates/awaken-runtime/src/loop_runner/tests.rs
+++ b/crates/awaken-runtime/src/loop_runner/tests.rs
@@ -4,28 +4,20 @@ use super::*;
 use crate::hooks::PhaseContext;
 use crate::phase::ExecutionEnv;
 use crate::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
-use crate::registry::ResolvedAgent;
 use crate::state::StateStore;
-use crate::{PhaseHook, StateCommand};
-use awaken_contract::StateError;
 use awaken_contract::contract::content::ContentBlock;
 use awaken_contract::contract::context_message::ContextMessage;
 use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::event_sink::VecEventSink;
 use awaken_contract::contract::message::{Message, Role};
-use awaken_contract::contract::suspension::{
-    PendingToolCall, SuspendTicket, Suspension, ToolCallOutcome, ToolCallResumeMode,
-};
+use awaken_contract::contract::suspension::{SuspendTicket, ToolCallOutcome, ToolCallStatus};
 use awaken_contract::contract::tool::{
     Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
 };
-use awaken_contract::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
 use awaken_contract::model::{
     PendingScheduledActions, Phase, ScheduledAction, ScheduledActionEnvelope,
     ScheduledActionQueueUpdate, ScheduledActionSpec,
 };
-use awaken_contract::state::{StateKey, StateKeyOptions};
-use serde_json::{Value, json};
 
 use super::actions::{
     LoopActionHandlersPlugin, apply_context_messages, apply_tool_filter_payloads,
@@ -33,10 +25,11 @@ use super::actions::{
 };
 use crate::agent::state::{
     AddContextMessage, InferenceOverrideState, InferenceOverrideStateAction,
-    InferenceOverrideStateValue, RunLifecycle, RunLifecycleUpdate, ToolFilterState,
+    InferenceOverrideStateValue, RunLifecycle, RunLifecycleUpdate, ToolCallStates, ToolFilterState,
     ToolFilterStateAction, ToolFilterStateValue,
 };
-use crate::phase::PhaseRuntime;
+use crate::phase::{PhaseRuntime, ToolGateHook};
+use crate::state::{StateCommand, StateKey, StateKeyOptions};
 
 /// Helper: create a PhaseRuntime + ExecutionEnv with action handlers registered.
 fn test_runtime() -> (PhaseRuntime, ExecutionEnv) {
@@ -63,10 +56,7 @@ fn test_runtime() -> (PhaseRuntime, ExecutionEnv) {
     (runtime, env)
 }
 
-fn test_runtime_with_plugin<P>(plugin: P) -> (PhaseRuntime, ExecutionEnv)
-where
-    P: Plugin + Clone,
-{
+fn test_runtime_with_plugins(plugins: Vec<Arc<dyn Plugin>>) -> (PhaseRuntime, ExecutionEnv) {
     let store = StateStore::new();
     store
         .install_plugin(LoopStatePlugin)
@@ -74,9 +64,6 @@ where
     store
         .install_plugin(LoopActionHandlersPlugin)
         .expect("install LoopActionHandlersPlugin");
-    store
-        .install_plugin(plugin.clone())
-        .expect("install plugin");
 
     let mut patch = crate::state::MutationBatch::new();
     patch.update::<RunLifecycle>(RunLifecycleUpdate::Start {
@@ -86,11 +73,9 @@ where
     store.commit(patch).expect("init lifecycle");
 
     let runtime = PhaseRuntime::new(store).expect("create runtime");
-
-    let env_plugins: Vec<Arc<dyn Plugin>> =
-        vec![Arc::new(LoopActionHandlersPlugin), Arc::new(plugin)];
-    let env = ExecutionEnv::from_plugins(&env_plugins, &Default::default())
-        .expect("build env with plugin");
+    let mut all_plugins: Vec<Arc<dyn Plugin>> = vec![Arc::new(LoopActionHandlersPlugin)];
+    all_plugins.extend(plugins);
+    let env = ExecutionEnv::from_plugins(&all_plugins, &Default::default()).expect("build env");
     (runtime, env)
 }
 
@@ -800,6 +785,157 @@ impl crate::execution::ToolExecutor for RecordingExecutor {
     }
 }
 
+struct ToolGateUnlockKey;
+
+impl StateKey for ToolGateUnlockKey {
+    const KEY: &'static str = "test.tool_gate.unlock";
+    type Value = bool;
+    type Update = bool;
+
+    fn apply(value: &mut Self::Value, update: Self::Update) {
+        *value = update;
+    }
+}
+
+struct UnlockTool;
+
+#[async_trait::async_trait]
+impl Tool for UnlockTool {
+    fn descriptor(&self) -> ToolDescriptor {
+        ToolDescriptor::new("unlock", "unlock", "unlock state")
+    }
+
+    async fn execute(
+        &self,
+        _args: serde_json::Value,
+        _ctx: &ToolCallContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let mut command = StateCommand::new();
+        command.update::<ToolGateUnlockKey>(true);
+        Ok(ToolOutput::with_command(
+            ToolResult::success("unlock", serde_json::json!({"unlocked": true})),
+            command,
+        ))
+    }
+}
+
+struct SuspendedUnlockTool;
+
+#[async_trait::async_trait]
+impl Tool for SuspendedUnlockTool {
+    fn descriptor(&self) -> ToolDescriptor {
+        ToolDescriptor::new("unlock", "unlock", "suspending unlock state")
+    }
+
+    async fn execute(
+        &self,
+        _args: serde_json::Value,
+        _ctx: &ToolCallContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let ticket = SuspendTicket::new(
+            awaken_contract::contract::suspension::Suspension {
+                id: "suspend_unlock".into(),
+                action: "tool:UnlockConfirm".into(),
+                message: "unlock requires approval".into(),
+                parameters: serde_json::json!({}),
+                response_schema: None,
+            },
+            awaken_contract::contract::suspension::PendingToolCall::new(
+                "call_unlock",
+                "unlock",
+                serde_json::json!({}),
+            ),
+            awaken_contract::contract::suspension::ToolCallResumeMode::ReplayToolCall,
+        );
+        Ok(ToolResult::suspended_with("unlock", "unlock suspended", ticket).into())
+    }
+}
+
+struct GuardedTool;
+
+#[async_trait::async_trait]
+impl Tool for GuardedTool {
+    fn descriptor(&self) -> ToolDescriptor {
+        ToolDescriptor::new("guarded", "guarded", "guarded")
+    }
+
+    async fn execute(
+        &self,
+        _args: serde_json::Value,
+        _ctx: &ToolCallContext,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(ToolResult::success("guarded", serde_json::json!({"ok": true})).into())
+    }
+}
+
+struct UnlockingToolGateHook;
+
+#[async_trait::async_trait]
+impl ToolGateHook for UnlockingToolGateHook {
+    async fn run(
+        &self,
+        ctx: &PhaseContext,
+    ) -> Result<
+        Option<awaken_contract::contract::tool_intercept::ToolInterceptPayload>,
+        awaken_contract::StateError,
+    > {
+        if ctx.tool_name.as_deref() != Some("guarded") {
+            return Ok(None);
+        }
+
+        if ctx.state::<ToolGateUnlockKey>().copied().unwrap_or(false) {
+            Ok(None)
+        } else {
+            Ok(Some(
+                awaken_contract::contract::tool_intercept::ToolInterceptPayload::Block {
+                    reason: "guarded locked".into(),
+                },
+            ))
+        }
+    }
+}
+
+struct GuardedBeforeHook {
+    calls: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl crate::hooks::PhaseHook for GuardedBeforeHook {
+    async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, awaken_contract::StateError> {
+        if ctx.tool_name.as_deref() == Some("guarded")
+            && let Some(call_id) = ctx.tool_call_id.clone()
+        {
+            self.calls.lock().expect("lock poisoned").push(call_id);
+        }
+        Ok(StateCommand::new())
+    }
+}
+
+struct ToolGateTestPlugin {
+    before_calls: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl Plugin for ToolGateTestPlugin {
+    fn descriptor(&self) -> PluginDescriptor {
+        PluginDescriptor {
+            name: "tool-gate-test",
+        }
+    }
+
+    fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), awaken_contract::StateError> {
+        registrar.register_key::<ToolGateUnlockKey>(StateKeyOptions::default())?;
+        registrar.register_tool_gate_hook("tool-gate-test", UnlockingToolGateHook)?;
+        registrar.register_phase_hook(
+            "tool-gate-test",
+            Phase::BeforeToolExecute,
+            GuardedBeforeHook {
+                calls: Arc::clone(&self.before_calls),
+            },
+        )?;
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn resumed_calls_do_not_serialize_neighboring_fresh_batches() {
     let (runtime, _env) = test_runtime();
@@ -869,9 +1005,13 @@ async fn resumed_calls_do_not_serialize_neighboring_fresh_batches() {
         awaken_contract::contract::message::ToolCall::new("c5", "epsilon", serde_json::json!({})),
     ];
 
-    let (_blocked, suspended) = super::step::execute_tools_with_interception(&mut ctx, &calls)
-        .await
-        .expect("tool execution should succeed");
+    let mut transcript = super::step::ToolBatchTranscript::for_resume();
+    let (_blocked, suspended) =
+        super::step::execute_tools_with_interception(&mut ctx, &mut transcript, &calls)
+            .await
+            .expect("tool execution should succeed");
+    drop(ctx);
+    transcript.commit_into(&mut messages);
     assert!(!suspended, "recording executor never suspends");
     assert_eq!(
         executor.take(),
@@ -880,6 +1020,10 @@ async fn resumed_calls_do_not_serialize_neighboring_fresh_batches() {
             vec![String::from("c3")],
             vec![String::from("c4"), String::from("c5")],
         ]
+    );
+    assert!(
+        messages.iter().all(|message| message.tool_calls.is_none()),
+        "resume replay should not append a fresh assistant tool-call message"
     );
 
     let states = store.read::<ToolCallStates>().expect("tool call states");
@@ -895,336 +1039,6 @@ async fn resumed_calls_do_not_serialize_neighboring_fresh_batches() {
     assert!(
         resumed.suspension_id.is_none() && resumed.suspension_reason.is_none(),
         "terminal tool state should not retain an active suspension context"
-    );
-}
-
-struct UnlockState;
-
-impl StateKey for UnlockState {
-    const KEY: &'static str = "test.loop_runner.unlock_state";
-    type Value = bool;
-    type Update = bool;
-
-    fn apply(value: &mut Self::Value, update: Self::Update) {
-        *value = update;
-    }
-}
-
-struct BeforeToolCountState;
-
-impl StateKey for BeforeToolCountState {
-    const KEY: &'static str = "test.loop_runner.before_tool_count";
-    type Value = usize;
-    type Update = usize;
-
-    fn apply(value: &mut Self::Value, update: Self::Update) {
-        *value += update;
-    }
-}
-
-struct UnlockTool;
-
-#[async_trait::async_trait]
-impl Tool for UnlockTool {
-    fn descriptor(&self) -> ToolDescriptor {
-        ToolDescriptor::new("unlock", "unlock", "unlock guarded tools")
-    }
-
-    async fn execute(&self, _args: Value, _ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
-        let mut cmd = StateCommand::new();
-        cmd.update::<UnlockState>(true);
-        Ok(ToolOutput::with_command(
-            ToolResult::success("unlock", json!({"unlocked": true})),
-            cmd,
-        ))
-    }
-}
-
-struct GuardedTool;
-
-#[async_trait::async_trait]
-impl Tool for GuardedTool {
-    fn descriptor(&self) -> ToolDescriptor {
-        ToolDescriptor::new("guarded", "guarded", "guarded tool")
-    }
-
-    async fn execute(&self, _args: Value, _ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
-        Ok(ToolResult::success("guarded", json!({"ok": true})).into())
-    }
-}
-
-struct SuspendingTool;
-
-#[async_trait::async_trait]
-impl Tool for SuspendingTool {
-    fn descriptor(&self) -> ToolDescriptor {
-        ToolDescriptor::new("suspending", "suspending", "always suspends")
-    }
-
-    async fn execute(&self, _args: Value, _ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
-        let ticket = SuspendTicket::new(
-            Suspension {
-                id: "suspend-1".into(),
-                action: "tool:PermissionConfirm".into(),
-                message: "Approve?".into(),
-                parameters: json!({"tool": "suspending"}),
-                response_schema: None,
-            },
-            PendingToolCall::new("c1", "suspending", json!({})),
-            ToolCallResumeMode::ReplayToolCall,
-        );
-        Ok(ToolResult::suspended_with("suspending", "needs approval", ticket).into())
-    }
-}
-
-#[derive(Clone)]
-struct CountingGuardHook;
-
-#[async_trait::async_trait]
-impl PhaseHook for CountingGuardHook {
-    async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, StateError> {
-        let Some(tool_name) = ctx.tool_name.as_deref() else {
-            return Ok(StateCommand::new());
-        };
-        if tool_name != "guarded" {
-            return Ok(StateCommand::new());
-        }
-
-        let mut cmd = StateCommand::new();
-        cmd.update::<BeforeToolCountState>(1);
-        if !ctx.state::<UnlockState>().copied().unwrap_or(false) {
-            cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Block {
-                reason: "guarded tool requires unlock".into(),
-            })?;
-        }
-        Ok(cmd)
-    }
-}
-
-#[derive(Clone)]
-struct AlwaysBlockGuardedHook;
-
-#[async_trait::async_trait]
-impl PhaseHook for AlwaysBlockGuardedHook {
-    async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, StateError> {
-        let Some(tool_name) = ctx.tool_name.as_deref() else {
-            return Ok(StateCommand::new());
-        };
-        if tool_name != "guarded" {
-            return Ok(StateCommand::new());
-        }
-
-        let mut cmd = StateCommand::new();
-        cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Block {
-            reason: "guarded tool blocked".into(),
-        })?;
-        Ok(cmd)
-    }
-}
-
-#[derive(Clone)]
-struct GuardPlugin<H> {
-    name: &'static str,
-    hook: H,
-}
-
-impl<H> Plugin for GuardPlugin<H>
-where
-    H: PhaseHook + Clone,
-{
-    fn descriptor(&self) -> PluginDescriptor {
-        PluginDescriptor { name: self.name }
-    }
-
-    fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-        registrar.register_key::<UnlockState>(StateKeyOptions::default())?;
-        registrar.register_key::<BeforeToolCountState>(StateKeyOptions::default())?;
-        registrar.register_phase_hook(self.name, Phase::BeforeToolExecute, self.hook.clone())?;
-        Ok(())
-    }
-}
-
-fn make_step_context<'a>(
-    runtime: &'a PhaseRuntime,
-    agent: &'a mut ResolvedAgent,
-    messages: &'a mut Vec<Arc<Message>>,
-    sink: Arc<dyn awaken_contract::contract::event_sink::EventSink>,
-    run_identity: &'a awaken_contract::contract::identity::RunIdentity,
-    run_overrides: &'a Option<awaken_contract::contract::inference::InferenceOverride>,
-    total_input_tokens: &'a mut u64,
-    total_output_tokens: &'a mut u64,
-    truncation_state: &'a mut crate::context::TruncationState,
-) -> super::step::StepContext<'a> {
-    super::step::StepContext {
-        agent,
-        messages,
-        runtime,
-        sink,
-        checkpoint_store: None,
-        run_identity,
-        cancellation_token: None,
-        run_overrides,
-        total_input_tokens,
-        total_output_tokens,
-        truncation_state,
-        run_created_at: 0,
-    }
-}
-
-#[tokio::test]
-async fn recheck_after_flushing_allowed_calls_does_not_double_apply_before_tool_side_effects() {
-    let plugin = GuardPlugin {
-        name: "counting-guard",
-        hook: CountingGuardHook,
-    };
-    let (runtime, env) = test_runtime_with_plugin(plugin);
-    let store = runtime.store();
-
-    let mut agent = ResolvedAgent::new("agent", "model", "system", Arc::new(DummyLlm))
-        .with_tool(Arc::new(UnlockTool))
-        .with_tool(Arc::new(GuardedTool));
-    agent.env = env;
-
-    let sink: Arc<dyn awaken_contract::contract::event_sink::EventSink> =
-        Arc::new(awaken_contract::contract::event_sink::NullEventSink);
-    let mut messages = vec![Arc::new(Message::user("go"))];
-    let run_identity = awaken_contract::contract::identity::RunIdentity::default();
-    let run_overrides = None;
-    let mut total_input_tokens = 0;
-    let mut total_output_tokens = 0;
-    let mut truncation_state = crate::context::TruncationState::new();
-    let mut ctx = make_step_context(
-        &runtime,
-        &mut agent,
-        &mut messages,
-        sink,
-        &run_identity,
-        &run_overrides,
-        &mut total_input_tokens,
-        &mut total_output_tokens,
-        &mut truncation_state,
-    );
-    let calls = vec![
-        awaken_contract::contract::message::ToolCall::new("u1", "unlock", json!({})),
-        awaken_contract::contract::message::ToolCall::new("g1", "guarded", json!({})),
-    ];
-
-    let (blocked, suspended) = super::step::execute_tools_with_interception(&mut ctx, &calls)
-        .await
-        .expect("tool execution should succeed");
-
-    assert!(blocked.is_none(), "guarded call should be re-allowed");
-    assert!(!suspended, "no tool should suspend");
-    assert_eq!(
-        store.read::<BeforeToolCountState>().unwrap_or_default(),
-        1,
-        "BeforeToolExecute side effects should only commit once for the guarded call",
-    );
-    assert_eq!(
-        store.read::<UnlockState>(),
-        Some(true),
-        "unlock tool should commit state before guarded tool is rechecked",
-    );
-}
-
-#[tokio::test]
-async fn suspended_flush_backfills_interrupted_results_for_unprocessed_calls() {
-    let plugin = GuardPlugin {
-        name: "always-block-guarded",
-        hook: AlwaysBlockGuardedHook,
-    };
-    let (runtime, env) = test_runtime_with_plugin(plugin);
-
-    let mut agent = ResolvedAgent::new("agent", "model", "system", Arc::new(DummyLlm))
-        .with_tool(Arc::new(SuspendingTool))
-        .with_tool(Arc::new(GuardedTool))
-        .with_tool_executor(Arc::new(crate::execution::SequentialToolExecutor));
-    agent.env = env;
-
-    let sink = Arc::new(VecEventSink::new());
-    let mut messages = vec![
-        Arc::new(Message::user("go")),
-        Arc::new(Message::assistant_with_tool_calls(
-            "",
-            vec![
-                awaken_contract::contract::message::ToolCall::new("c1", "suspending", json!({})),
-                awaken_contract::contract::message::ToolCall::new("c2", "guarded", json!({})),
-                awaken_contract::contract::message::ToolCall::new("c3", "tail", json!({})),
-            ],
-        )),
-    ];
-    let run_identity = awaken_contract::contract::identity::RunIdentity::default();
-    let run_overrides = None;
-    let mut total_input_tokens = 0;
-    let mut total_output_tokens = 0;
-    let mut truncation_state = crate::context::TruncationState::new();
-    let mut ctx = make_step_context(
-        &runtime,
-        &mut agent,
-        &mut messages,
-        sink.clone(),
-        &run_identity,
-        &run_overrides,
-        &mut total_input_tokens,
-        &mut total_output_tokens,
-        &mut truncation_state,
-    );
-    let calls = vec![
-        awaken_contract::contract::message::ToolCall::new("c1", "suspending", json!({})),
-        awaken_contract::contract::message::ToolCall::new("c2", "guarded", json!({})),
-        awaken_contract::contract::message::ToolCall::new("c3", "tail", json!({})),
-    ];
-
-    let (blocked, suspended) = super::step::execute_tools_with_interception(&mut ctx, &calls)
-        .await
-        .expect("tool execution should succeed");
-
-    assert!(
-        blocked.is_none(),
-        "suspending prefix should not be reported as blocked"
-    );
-    assert!(suspended, "the run should suspend on the first tool");
-
-    let tool_messages: Vec<_> = messages
-        .iter()
-        .filter(|message| message.role == Role::Tool)
-        .map(|message| {
-            (
-                message.tool_call_id.clone().expect("tool message call id"),
-                message.text(),
-            )
-        })
-        .collect();
-    assert_eq!(
-        tool_messages.len(),
-        3,
-        "all tool calls need a terminal placeholder"
-    );
-    assert!(
-        tool_messages[1].1.contains("interrupted"),
-        "current guarded call should be backfilled with an interrupted result"
-    );
-    assert!(
-        tool_messages[2].1.contains("interrupted"),
-        "later calls should also be backfilled with interrupted results"
-    );
-
-    let done_events: Vec<_> = sink
-        .events()
-        .into_iter()
-        .filter_map(|event| match event {
-            AgentEvent::ToolCallDone { id, outcome, .. } => Some((id, outcome)),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(
-        done_events,
-        vec![
-            ("c1".into(), ToolCallOutcome::Suspended),
-            ("c2".into(), ToolCallOutcome::Failed),
-            ("c3".into(), ToolCallOutcome::Failed),
-        ],
-        "unprocessed calls should no longer be silently dropped after a suspended flush",
     );
 }
 
@@ -1357,4 +1171,190 @@ async fn cancelled_resume_is_emitted_once_even_when_other_calls_replay() {
         cancelled.suspension_id.is_none() && cancelled.suspension_reason.is_none(),
         "cancelled terminal state should not retain an active suspension context"
     );
+}
+
+#[tokio::test]
+async fn tool_gate_recheck_executes_before_tool_hook_once() {
+    let before_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (runtime, env) = test_runtime_with_plugins(vec![Arc::new(ToolGateTestPlugin {
+        before_calls: Arc::clone(&before_calls),
+    })]);
+    runtime
+        .store()
+        .install_plugin(ToolGateTestPlugin {
+            before_calls: Arc::clone(&before_calls),
+        })
+        .expect("install tool gate test plugin keys");
+    let store = runtime.store();
+
+    let sink = Arc::new(VecEventSink::new());
+    let sink_dyn: Arc<dyn awaken_contract::contract::event_sink::EventSink> = sink.clone();
+    let mut messages = vec![Arc::new(Message::user("go"))];
+    let run_identity = awaken_contract::contract::identity::RunIdentity::default();
+    let run_overrides = None;
+    let mut total_input_tokens = 0;
+    let mut total_output_tokens = 0;
+    let mut truncation_state = crate::context::TruncationState::new();
+    let mut agent =
+        crate::registry::ResolvedAgent::new("agent", "model", "system", Arc::new(DummyLlm))
+            .with_tools(vec![Arc::new(UnlockTool), Arc::new(GuardedTool)]);
+    agent.env = env;
+
+    let mut ctx = super::step::StepContext {
+        agent: &mut agent,
+        messages: &mut messages,
+        runtime: &runtime,
+        sink: sink_dyn,
+        checkpoint_store: None,
+        run_identity: &run_identity,
+        cancellation_token: None,
+        run_overrides: &run_overrides,
+        total_input_tokens: &mut total_input_tokens,
+        total_output_tokens: &mut total_output_tokens,
+        truncation_state: &mut truncation_state,
+        run_created_at: 0,
+    };
+    let calls = vec![
+        awaken_contract::contract::message::ToolCall::new("c1", "unlock", serde_json::json!({})),
+        awaken_contract::contract::message::ToolCall::new("c2", "guarded", serde_json::json!({})),
+    ];
+
+    let mut transcript =
+        super::step::ToolBatchTranscript::for_inference(String::new(), calls.clone());
+    let (blocked, suspended) =
+        super::step::execute_tools_with_interception(&mut ctx, &mut transcript, &calls)
+            .await
+            .expect("tool execution should succeed");
+    drop(ctx);
+    transcript.commit_into(&mut messages);
+
+    assert!(blocked.is_none(), "tool gate should re-open after unlock");
+    assert!(!suspended, "unlock + guarded should complete");
+    assert_eq!(
+        before_calls.lock().expect("lock poisoned").as_slice(),
+        &["c2".to_string()],
+        "BeforeToolExecute should run once for the guarded call after ToolGate recheck",
+    );
+    assert_eq!(store.read::<ToolGateUnlockKey>(), Some(true));
+
+    let states = store.read::<ToolCallStates>().expect("tool call states");
+    assert_eq!(
+        states.calls.get("c1").expect("unlock state").status,
+        ToolCallStatus::Succeeded
+    );
+    assert_eq!(
+        states.calls.get("c2").expect("guarded state").status,
+        ToolCallStatus::Succeeded
+    );
+}
+
+#[tokio::test]
+async fn tool_gate_flush_suspension_backfills_rechecked_and_later_calls() {
+    let before_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (runtime, env) = test_runtime_with_plugins(vec![Arc::new(ToolGateTestPlugin {
+        before_calls: Arc::clone(&before_calls),
+    })]);
+    runtime
+        .store()
+        .install_plugin(ToolGateTestPlugin {
+            before_calls: Arc::clone(&before_calls),
+        })
+        .expect("install tool gate test plugin keys");
+    let store = runtime.store();
+
+    let sink = Arc::new(VecEventSink::new());
+    let sink_dyn: Arc<dyn awaken_contract::contract::event_sink::EventSink> = sink.clone();
+    let mut messages = vec![Arc::new(Message::user("go"))];
+    let run_identity = awaken_contract::contract::identity::RunIdentity::default();
+    let run_overrides = None;
+    let mut total_input_tokens = 0;
+    let mut total_output_tokens = 0;
+    let mut truncation_state = crate::context::TruncationState::new();
+    let mut agent =
+        crate::registry::ResolvedAgent::new("agent", "model", "system", Arc::new(DummyLlm))
+            .with_tools(vec![Arc::new(SuspendedUnlockTool), Arc::new(GuardedTool)]);
+    agent.env = env;
+
+    let mut ctx = super::step::StepContext {
+        agent: &mut agent,
+        messages: &mut messages,
+        runtime: &runtime,
+        sink: sink_dyn,
+        checkpoint_store: None,
+        run_identity: &run_identity,
+        cancellation_token: None,
+        run_overrides: &run_overrides,
+        total_input_tokens: &mut total_input_tokens,
+        total_output_tokens: &mut total_output_tokens,
+        truncation_state: &mut truncation_state,
+        run_created_at: 0,
+    };
+    let calls = vec![
+        awaken_contract::contract::message::ToolCall::new("c1", "unlock", serde_json::json!({})),
+        awaken_contract::contract::message::ToolCall::new("c2", "guarded", serde_json::json!({})),
+        awaken_contract::contract::message::ToolCall::new("c3", "guarded", serde_json::json!({})),
+    ];
+
+    let mut transcript =
+        super::step::ToolBatchTranscript::for_inference(String::new(), calls.clone());
+    let (blocked, suspended) =
+        super::step::execute_tools_with_interception(&mut ctx, &mut transcript, &calls)
+            .await
+            .expect("tool execution should succeed");
+    drop(ctx);
+    transcript.commit_into(&mut messages);
+
+    assert!(blocked.is_none());
+    assert!(suspended, "suspending prefix call should suspend the batch");
+    assert!(
+        before_calls.lock().expect("lock poisoned").is_empty(),
+        "guarded calls should never reach BeforeToolExecute after prefix suspension",
+    );
+
+    let states = store.read::<ToolCallStates>().expect("tool call states");
+    assert_eq!(
+        states.calls.get("c1").expect("unlock state").status,
+        ToolCallStatus::Suspended
+    );
+    assert_eq!(
+        states.calls.get("c2").expect("guarded state").status,
+        ToolCallStatus::Failed
+    );
+    assert_eq!(
+        states.calls.get("c3").expect("later guarded state").status,
+        ToolCallStatus::Failed
+    );
+
+    let interrupted: Vec<_> = messages
+        .iter()
+        .filter(|message| {
+            message.role == Role::Tool
+                && matches!(message.tool_call_id.as_deref(), Some("c2" | "c3"))
+        })
+        .map(|message| text_of(message))
+        .collect();
+    assert_eq!(
+        interrupted,
+        vec![
+            "[Tool execution was interrupted]".to_string(),
+            "[Tool execution was interrupted]".to_string(),
+        ]
+    );
+
+    let failed_events: Vec<_> = sink
+        .events()
+        .into_iter()
+        .filter_map(|event| match event {
+            AgentEvent::ToolCallDone { id, outcome, .. }
+                if matches!(
+                    (id.as_str(), outcome),
+                    ("c2", ToolCallOutcome::Failed) | ("c3", ToolCallOutcome::Failed)
+                ) =>
+            {
+                Some(id)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(failed_events, vec!["c2".to_string(), "c3".to_string()]);
 }

--- a/crates/awaken-runtime/src/phase/env.rs
+++ b/crates/awaken-runtime/src/phase/env.rs
@@ -13,13 +13,20 @@ use awaken_contract::model::Phase;
 
 use crate::plugins::{KeyRegistration, ProfileKeyRegistration, RequestTransformArc};
 
-use super::{EffectHandlerArc, PhaseHookArc, ScheduledActionHandlerArc};
+use super::{EffectHandlerArc, PhaseHookArc, ScheduledActionHandlerArc, ToolGateHookArc};
 
 /// A phase hook with its owning plugin ID.
 #[derive(Clone)]
 pub(crate) struct TaggedPhaseHook {
     pub(crate) plugin_id: String,
     pub(crate) hook: PhaseHookArc,
+}
+
+/// A tool gate hook with its owning plugin ID.
+#[derive(Clone)]
+pub(crate) struct TaggedToolGateHook {
+    pub(crate) plugin_id: String,
+    pub(crate) hook: ToolGateHookArc,
 }
 
 /// A request transform with its owning plugin ID.
@@ -37,6 +44,7 @@ pub(crate) struct TaggedRequestTransform {
 #[derive(Clone)]
 pub struct ExecutionEnv {
     pub(crate) phase_hooks: HashMap<Phase, Vec<TaggedPhaseHook>>,
+    pub(crate) tool_gate_hooks: Vec<TaggedToolGateHook>,
     pub(crate) scheduled_action_handlers: HashMap<String, ScheduledActionHandlerArc>,
     pub(crate) effect_handlers: HashMap<String, EffectHandlerArc>,
     /// Request transforms applied after message assembly, before LLM call.
@@ -69,6 +77,7 @@ impl ExecutionEnv {
         active_plugin_filter: &HashSet<String>,
     ) -> Result<Self, StateError> {
         let mut all_hooks: HashMap<Phase, Vec<TaggedPhaseHook>> = HashMap::new();
+        let mut all_tool_gate_hooks: Vec<TaggedToolGateHook> = Vec::new();
         let mut all_action_handlers: HashMap<String, ScheduledActionHandlerArc> = HashMap::new();
         let mut all_effect_handlers: HashMap<String, EffectHandlerArc> = HashMap::new();
         let mut all_transforms: Vec<TaggedRequestTransform> = Vec::new();
@@ -115,6 +124,12 @@ impl ExecutionEnv {
                             hook: entry.hook,
                         });
                 }
+                for entry in registrar.tool_gate_hooks {
+                    all_tool_gate_hooks.push(TaggedToolGateHook {
+                        plugin_id: entry.plugin_id,
+                        hook: entry.hook,
+                    });
+                }
             }
 
             // Collect action handlers (check duplicates)
@@ -159,6 +174,7 @@ impl ExecutionEnv {
 
         Ok(Self {
             phase_hooks: all_hooks,
+            tool_gate_hooks: all_tool_gate_hooks,
             scheduled_action_handlers: all_action_handlers,
             effect_handlers: all_effect_handlers,
             request_transforms: all_transforms,
@@ -173,6 +189,7 @@ impl ExecutionEnv {
     pub fn empty() -> Self {
         Self {
             phase_hooks: HashMap::new(),
+            tool_gate_hooks: Vec::new(),
             scheduled_action_handlers: HashMap::new(),
             effect_handlers: HashMap::new(),
             request_transforms: Vec::new(),
@@ -200,6 +217,10 @@ impl ExecutionEnv {
             .get(&phase)
             .map(|v| v.as_slice())
             .unwrap_or(&[])
+    }
+
+    pub(crate) fn tool_gate_hooks(&self) -> &[TaggedToolGateHook] {
+        &self.tool_gate_hooks
     }
 }
 

--- a/crates/awaken-runtime/src/phase/mod.rs
+++ b/crates/awaken-runtime/src/phase/mod.rs
@@ -3,7 +3,9 @@ mod env;
 mod queue_plugin;
 mod reports;
 
-pub use crate::hooks::{PhaseContext, PhaseHook, TypedEffectHandler, TypedScheduledActionHandler};
+pub use crate::hooks::{
+    PhaseContext, PhaseHook, ToolGateHook, TypedEffectHandler, TypedScheduledActionHandler,
+};
 pub use engine::PhaseRuntime;
 pub use env::ExecutionEnv;
 pub use reports::{
@@ -11,6 +13,6 @@ pub use reports::{
 };
 
 pub(crate) use crate::hooks::{
-    EffectHandlerArc, PhaseHookArc, ScheduledActionHandlerArc, TypedEffectAdapter,
+    EffectHandlerArc, PhaseHookArc, ScheduledActionHandlerArc, ToolGateHookArc, TypedEffectAdapter,
     TypedScheduledActionAdapter,
 };

--- a/crates/awaken-runtime/src/plugins/registry.rs
+++ b/crates/awaken-runtime/src/plugins/registry.rs
@@ -3,8 +3,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::phase::{
-    EffectHandlerArc, PhaseHook, PhaseHookArc, ScheduledActionHandlerArc, TypedEffectAdapter,
-    TypedEffectHandler, TypedScheduledActionAdapter, TypedScheduledActionHandler,
+    EffectHandlerArc, PhaseHook, PhaseHookArc, ScheduledActionHandlerArc, ToolGateHook,
+    ToolGateHookArc, TypedEffectAdapter, TypedEffectHandler, TypedScheduledActionAdapter,
+    TypedScheduledActionHandler,
 };
 use crate::state::{KeyScope, MergeStrategy, StateKey, StateKeyOptions, StateMap};
 use awaken_contract::StateError;
@@ -70,6 +71,11 @@ pub(crate) struct PhaseHookRegistration {
     pub(crate) hook: PhaseHookArc,
 }
 
+pub(crate) struct ToolGateHookRegistration {
+    pub(crate) plugin_id: String,
+    pub(crate) hook: ToolGateHookArc,
+}
+
 pub(crate) type RequestTransformArc =
     std::sync::Arc<dyn awaken_contract::contract::transform::InferenceRequestTransform>;
 
@@ -123,6 +129,7 @@ pub struct PluginRegistrar {
     pub(crate) effects: Vec<EffectHandlerRegistration>,
     effect_keys: HashSet<String>,
     pub(crate) phase_hooks: Vec<PhaseHookRegistration>,
+    pub(crate) tool_gate_hooks: Vec<ToolGateHookRegistration>,
     pub(crate) request_transforms: Vec<RequestTransformRegistration>,
     pub(crate) tools: Vec<ToolRegistration>,
     tool_ids: HashSet<String>,
@@ -142,6 +149,7 @@ impl PluginRegistrar {
             effects: Vec::new(),
             effect_keys: HashSet::new(),
             phase_hooks: Vec::new(),
+            tool_gate_hooks: Vec::new(),
             request_transforms: Vec::new(),
             tools: Vec::new(),
             tool_ids: HashSet::new(),
@@ -215,6 +223,21 @@ impl PluginRegistrar {
     {
         self.phase_hooks.push(PhaseHookRegistration {
             phase,
+            plugin_id: plugin_id.into(),
+            hook: Arc::new(hook),
+        });
+        Ok(())
+    }
+
+    pub fn register_tool_gate_hook<H>(
+        &mut self,
+        plugin_id: impl Into<String>,
+        hook: H,
+    ) -> Result<(), StateError>
+    where
+        H: ToolGateHook,
+    {
+        self.tool_gate_hooks.push(ToolGateHookRegistration {
             plugin_id: plugin_id.into(),
             hook: Arc::new(hook),
         });

--- a/crates/awaken-runtime/tests/event_lifecycle.rs
+++ b/crates/awaken-runtime/tests/event_lifecycle.rs
@@ -26,7 +26,7 @@ use awaken_contract::state::{StateKey, StateKeyOptions};
 use awaken_runtime::engine::MockLlmExecutor;
 use awaken_runtime::execution::ParallelToolExecutor;
 use awaken_runtime::loop_runner::build_agent_env;
-use awaken_runtime::phase::PhaseHook;
+use awaken_runtime::phase::ToolGateHook;
 use awaken_runtime::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
 use awaken_runtime::registry::{AgentResolver, ResolvedAgent};
 use awaken_runtime::runtime::{AgentRuntime, RunRequest};
@@ -132,22 +132,23 @@ impl Tool for GuardedTool {
 struct UnlockGuardHook;
 
 #[async_trait]
-impl PhaseHook for UnlockGuardHook {
-    async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, StateError> {
+impl ToolGateHook for UnlockGuardHook {
+    async fn run(
+        &self,
+        ctx: &PhaseContext,
+    ) -> Result<Option<awaken_contract::contract::tool_intercept::ToolInterceptPayload>, StateError>
+    {
         let Some(tool_name) = ctx.tool_name.as_deref() else {
-            return Ok(StateCommand::new());
+            return Ok(None);
         };
         if tool_name != "guarded" || ctx.state::<UnlockState>().copied().unwrap_or(false) {
-            return Ok(StateCommand::new());
+            return Ok(None);
         }
-
-        let mut cmd = StateCommand::new();
-        cmd.schedule_action::<awaken_contract::contract::tool_intercept::ToolInterceptAction>(
+        Ok(Some(
             awaken_contract::contract::tool_intercept::ToolInterceptPayload::Block {
                 reason: "guarded tool requires unlock".into(),
             },
-        )?;
-        Ok(cmd)
+        ))
     }
 }
 
@@ -162,11 +163,7 @@ impl Plugin for UnlockGuardPlugin {
 
     fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
         registrar.register_key::<UnlockState>(StateKeyOptions::default())?;
-        registrar.register_phase_hook(
-            "unlock-guard-plugin",
-            awaken_contract::model::Phase::BeforeToolExecute,
-            UnlockGuardHook,
-        )?;
+        registrar.register_tool_gate_hook("unlock-guard-plugin", UnlockGuardHook)?;
         Ok(())
     }
 }
@@ -713,11 +710,11 @@ async fn guarded_tool_before_unlock_still_blocks_same_step() {
         vec![
             (
                 "g1",
-                awaken_contract::contract::suspension::ToolCallOutcome::Failed
+                awaken_contract::contract::suspension::ToolCallOutcome::Failed,
             ),
             (
                 "u1",
-                awaken_contract::contract::suspension::ToolCallOutcome::Failed
+                awaken_contract::contract::suspension::ToolCallOutcome::Failed,
             ),
         ]
     );

--- a/crates/awaken/src/lib.rs
+++ b/crates/awaken/src/lib.rs
@@ -135,5 +135,6 @@ pub use awaken_runtime::{
     AgentResolver, AgentRuntime, AgentRuntimeBuilder, BuildError, CancellationToken, CommitEvent,
     CommitHook, DEFAULT_MAX_PHASE_ROUNDS, ExecutionEnv, MutationBatch, PhaseContext, PhaseHook,
     PhaseRuntime, Plugin, PluginDescriptor, PluginRegistrar, ResolvedAgent, RunRequest,
-    RuntimeError, StateCommand, StateStore, TypedEffectHandler, TypedScheduledActionHandler,
+    RuntimeError, StateCommand, StateStore, ToolGateHook, TypedEffectHandler,
+    TypedScheduledActionHandler,
 };

--- a/crates/awaken/src/prelude.rs
+++ b/crates/awaken/src/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::{AgentSpec, PluginConfigKey};
 // ── Plugin system ──
 pub use crate::CancellationToken;
 pub use crate::{EffectSpec, ScheduledActionSpec, TypedEffect};
-pub use crate::{Phase, PhaseContext, PhaseHook};
+pub use crate::{Phase, PhaseContext, PhaseHook, ToolGateHook};
 pub use crate::{Plugin, PluginDescriptor, PluginRegistrar};
 pub use crate::{TypedEffectHandler, TypedScheduledActionHandler};
 
@@ -34,8 +34,8 @@ pub use awaken_contract::contract::tool_schema::{
     generate_tool_schema, sanitize_for_llm, validate_against_schema,
 };
 
-// ── Tool interception (deferred tools / BeforeToolExecute control) ──
-pub use awaken_contract::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
+// ── Tool interception (ToolGate decisions) ──
+pub use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
 
 // ── Context messages (system reminders / prompt injection) ──
 pub use awaken_contract::contract::context_message::{ContextMessage, ContextMessageTarget};

--- a/crates/awaken/tests/agent_loop.rs
+++ b/crates/awaken/tests/agent_loop.rs
@@ -11,14 +11,14 @@ use awaken::contract::executor::{InferenceExecutionError, InferenceRequest, LlmE
 use awaken::contract::identity::{RunIdentity, RunOrigin};
 use awaken::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken::contract::lifecycle::{RunStatus, TerminationReason};
-use awaken::contract::message::{Message, ToolCall};
+use awaken::contract::message::{Message, Role, ToolCall};
 use awaken::contract::suspension::{
     ResumeDecisionAction, ToolCallResume, ToolCallResumeMode, ToolCallStatus,
 };
 use awaken::contract::tool::{
     Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
 };
-use awaken::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
+use awaken::contract::tool_intercept::ToolInterceptPayload;
 use awaken::loop_runner::{AgentLoopParams, build_agent_env, prepare_resume, run_agent_loop};
 use awaken::*;
 use awaken::{AgentResolver, ResolvedAgent};
@@ -853,6 +853,18 @@ fn make_tool_call_response(tool_name: &str, call_id: &str, args: Value) -> Strea
         stop_reason: Some(StopReason::ToolUse),
         has_incomplete_tool_calls: false,
     }
+}
+
+fn message_text(message: &Message) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
 }
 
 #[tokio::test]
@@ -1703,7 +1715,7 @@ async fn state_snapshot_emitted_after_phase() {
 // Frontend tool interception tests
 // ---------------------------------------------------------------------------
 
-/// A plugin that intercepts "frontend" tools via BeforeToolExecute.
+/// A plugin that intercepts "frontend" tools via ToolGate.
 ///
 /// On first entry: suspends with UseDecisionAsToolResult mode.
 /// On resume: the runtime turns decision.result into the tool result directly.
@@ -1713,25 +1725,25 @@ struct FrontendToolInterceptPlugin {
 }
 
 #[async_trait]
-impl PhaseHook for FrontendToolInterceptPlugin {
+impl ToolGateHook for FrontendToolInterceptPlugin {
     async fn run(
         &self,
         ctx: &awaken::PhaseContext,
-    ) -> Result<awaken::StateCommand, awaken::StateError> {
+    ) -> Result<Option<ToolInterceptPayload>, awaken::StateError> {
         use awaken::contract::suspension::{PendingToolCall, SuspendTicket, Suspension};
 
         let tool_name = match &ctx.tool_name {
             Some(name) => name.as_str(),
-            None => return Ok(awaken::StateCommand::new()),
+            None => return Ok(None),
         };
 
         if !self.frontend_tool_ids.iter().any(|id| id == tool_name) {
-            return Ok(awaken::StateCommand::new());
+            return Ok(None);
         }
 
         // If resuming, don't intercept — let the tool execute with decision args
         if ctx.resume_input.is_some() {
-            return Ok(awaken::StateCommand::new());
+            return Ok(None);
         }
 
         // First entry: suspend with UseDecisionAsToolResult
@@ -1749,9 +1761,7 @@ impl PhaseHook for FrontendToolInterceptPlugin {
             ToolCallResumeMode::UseDecisionAsToolResult,
         );
 
-        let mut cmd = awaken::StateCommand::new();
-        cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Suspend(ticket))?;
-        Ok(cmd)
+        Ok(Some(ToolInterceptPayload::Suspend(ticket)))
     }
 }
 
@@ -1767,11 +1777,7 @@ impl Plugin for FrontendToolInterceptPluginWrapper {
     }
 
     fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-        registrar.register_phase_hook(
-            "frontend-tool-intercept",
-            awaken::Phase::BeforeToolExecute,
-            self.plugin.clone(),
-        )?;
+        registrar.register_tool_gate_hook("frontend-tool-intercept", self.plugin.clone())?;
         Ok(())
     }
 }
@@ -2035,7 +2041,7 @@ async fn injected_frontend_tool_uses_suspension_id_resume_chain() {
 // Tool interception tests: Block, SetResult, state transitions
 // ---------------------------------------------------------------------------
 
-/// Plugin that blocks a specific tool via BeforeToolExecute.
+/// Plugin that blocks a specific tool via ToolGate.
 struct BlockingPlugin {
     blocked_tool: String,
     reason: String,
@@ -2051,25 +2057,23 @@ impl Clone for BlockingPlugin {
 }
 
 #[async_trait]
-impl PhaseHook for BlockingPlugin {
+impl ToolGateHook for BlockingPlugin {
     async fn run(
         &self,
         ctx: &awaken::PhaseContext,
-    ) -> Result<awaken::StateCommand, awaken::StateError> {
+    ) -> Result<Option<ToolInterceptPayload>, awaken::StateError> {
         let tool_name = match &ctx.tool_name {
             Some(name) => name.as_str(),
-            None => return Ok(awaken::StateCommand::new()),
+            None => return Ok(None),
         };
 
         if tool_name != self.blocked_tool {
-            return Ok(awaken::StateCommand::new());
+            return Ok(None);
         }
 
-        let mut cmd = awaken::StateCommand::new();
-        cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Block {
+        Ok(Some(ToolInterceptPayload::Block {
             reason: self.reason.clone(),
-        })?;
-        Ok(cmd)
+        }))
     }
 }
 
@@ -2083,11 +2087,7 @@ impl Plugin for BlockingPluginWrapper {
     }
 
     fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-        registrar.register_phase_hook(
-            "blocking-plugin",
-            awaken::Phase::BeforeToolExecute,
-            self.0.clone(),
-        )?;
+        registrar.register_tool_gate_hook("blocking-plugin", self.0.clone())?;
         Ok(())
     }
 }
@@ -2154,25 +2154,21 @@ impl Clone for SetResultPlugin {
 }
 
 #[async_trait]
-impl PhaseHook for SetResultPlugin {
+impl ToolGateHook for SetResultPlugin {
     async fn run(
         &self,
         ctx: &awaken::PhaseContext,
-    ) -> Result<awaken::StateCommand, awaken::StateError> {
+    ) -> Result<Option<ToolInterceptPayload>, awaken::StateError> {
         let tool_name = match &ctx.tool_name {
             Some(name) => name.as_str(),
-            None => return Ok(awaken::StateCommand::new()),
+            None => return Ok(None),
         };
 
         if tool_name != self.target_tool {
-            return Ok(awaken::StateCommand::new());
+            return Ok(None);
         }
 
-        let mut cmd = awaken::StateCommand::new();
-        cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::SetResult(
-            self.result.clone(),
-        ))?;
-        Ok(cmd)
+        Ok(Some(ToolInterceptPayload::SetResult(self.result.clone())))
     }
 }
 
@@ -2186,11 +2182,7 @@ impl Plugin for SetResultPluginWrapper {
     }
 
     fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-        registrar.register_phase_hook(
-            "set-result-plugin",
-            awaken::Phase::BeforeToolExecute,
-            self.0.clone(),
-        )?;
+        registrar.register_tool_gate_hook("set-result-plugin", self.0.clone())?;
         Ok(())
     }
 }
@@ -3016,7 +3008,7 @@ async fn concurrent_suspend_and_resume_via_channel() {
     use awaken::contract::suspension::{PendingToolCall, SuspendTicket, Suspension};
     use futures::channel::mpsc;
 
-    // Plugin that suspends ALL tool calls via BeforeToolExecute intercept
+    // Plugin that suspends ALL tool calls via ToolGate
     struct SuspendAllPlugin;
     impl Clone for SuspendAllPlugin {
         fn clone(&self) -> Self {
@@ -3024,18 +3016,18 @@ async fn concurrent_suspend_and_resume_via_channel() {
         }
     }
     #[async_trait]
-    impl PhaseHook for SuspendAllPlugin {
+    impl ToolGateHook for SuspendAllPlugin {
         async fn run(
             &self,
             ctx: &awaken::PhaseContext,
-        ) -> Result<awaken::StateCommand, awaken::StateError> {
+        ) -> Result<Option<ToolInterceptPayload>, awaken::StateError> {
             let tool_name = match &ctx.tool_name {
                 Some(name) => name.as_str(),
-                None => return Ok(awaken::StateCommand::new()),
+                None => return Ok(None),
             };
             // If resuming, let it proceed
             if ctx.resume_input.is_some() {
-                return Ok(awaken::StateCommand::new());
+                return Ok(None);
             }
             let call_id = ctx.tool_call_id.as_deref().unwrap_or("");
             let args = ctx.tool_args.clone().unwrap_or_default();
@@ -3050,9 +3042,7 @@ async fn concurrent_suspend_and_resume_via_channel() {
                 PendingToolCall::new(call_id, tool_name, args),
                 ToolCallResumeMode::ReplayToolCall,
             );
-            let mut cmd = awaken::StateCommand::new();
-            cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Suspend(ticket))?;
-            Ok(cmd)
+            Ok(Some(ToolInterceptPayload::Suspend(ticket)))
         }
     }
     struct SuspendAllPluginWrapper;
@@ -3063,11 +3053,7 @@ async fn concurrent_suspend_and_resume_via_channel() {
             }
         }
         fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-            registrar.register_phase_hook(
-                "suspend-all",
-                awaken::Phase::BeforeToolExecute,
-                SuspendAllPlugin,
-            )?;
+            registrar.register_tool_gate_hook("suspend-all", SuspendAllPlugin)?;
             Ok(())
         }
     }
@@ -4557,17 +4543,17 @@ async fn all_tools_suspended_pauses_run() {
         }
     }
     #[async_trait]
-    impl PhaseHook for SuspendAllHook {
+    impl ToolGateHook for SuspendAllHook {
         async fn run(
             &self,
             ctx: &awaken::PhaseContext,
-        ) -> Result<awaken::StateCommand, awaken::StateError> {
+        ) -> Result<Option<ToolInterceptPayload>, awaken::StateError> {
             let tool_name = match &ctx.tool_name {
                 Some(name) => name.as_str(),
-                None => return Ok(awaken::StateCommand::new()),
+                None => return Ok(None),
             };
             if ctx.resume_input.is_some() {
-                return Ok(awaken::StateCommand::new());
+                return Ok(None);
             }
             let call_id = ctx.tool_call_id.as_deref().unwrap_or("");
             let args = ctx.tool_args.clone().unwrap_or_default();
@@ -4582,9 +4568,7 @@ async fn all_tools_suspended_pauses_run() {
                 PendingToolCall::new(call_id, tool_name, args),
                 ToolCallResumeMode::ReplayToolCall,
             );
-            let mut cmd = awaken::StateCommand::new();
-            cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Suspend(ticket))?;
-            Ok(cmd)
+            Ok(Some(ToolInterceptPayload::Suspend(ticket)))
         }
     }
     struct SuspendAllWrapper;
@@ -4595,11 +4579,7 @@ async fn all_tools_suspended_pauses_run() {
             }
         }
         fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-            registrar.register_phase_hook(
-                "suspend-all-test",
-                awaken::Phase::BeforeToolExecute,
-                SuspendAllHook,
-            )?;
+            registrar.register_tool_gate_hook("suspend-all-test", SuspendAllHook)?;
             Ok(())
         }
     }
@@ -5230,13 +5210,11 @@ async fn mixed_suspended_and_completed_tools() {
         "dangerous tool should be suspended"
     );
 
-    // calc (c3) should not execute, but it should be backfilled with an
-    // interrupted failed result so the assistant tool-call batch stays
-    // structurally complete in message/state history.
+    // calc (c3) should be backfilled as interrupted after sequential suspension.
     assert_eq!(
         tc_states.calls["c3"].status,
         ToolCallStatus::Failed,
-        "later tools after a suspension should be backfilled as interrupted"
+        "calc tool should be backfilled as interrupted after suspension"
     );
 
     // Verify events
@@ -5265,7 +5243,7 @@ async fn mixed_suspended_and_completed_tools() {
             calc_outcome,
             Some((_, awaken::contract::suspension::ToolCallOutcome::Failed))
         ),
-        "later calc tool should be backfilled as Failed instead of being silently dropped"
+        "calc should emit Failed ToolCallDone when interrupted"
     );
 }
 
@@ -8212,6 +8190,145 @@ async fn checkpoint_stores_thread_messages() {
         "should store at least user + assistant messages, got {}",
         msgs.len()
     );
+}
+
+#[tokio::test]
+async fn checkpoint_stores_blocked_tool_batch_consistently() {
+    use awaken::stores::InMemoryStore;
+
+    let llm = Arc::new(ScriptedLlm::new(vec![StreamResult {
+        content: vec![],
+        tool_calls: vec![
+            ToolCall::new("c1", "echo", json!({"message": "hello"})),
+            ToolCall::new("c2", "calc", json!({"result": 2})),
+        ],
+        usage: None,
+        stop_reason: Some(StopReason::ToolUse),
+        has_incomplete_tool_calls: false,
+    }]));
+
+    let agent = ResolvedAgent::new("test", "m", "sys", llm)
+        .with_tool(Arc::new(EchoTool))
+        .with_tool(Arc::new(CalcTool));
+    let runtime = make_runtime();
+    let resolver = FixedResolver::with_plugins(
+        agent,
+        vec![Arc::new(BlockingPluginWrapper(BlockingPlugin {
+            blocked_tool: "echo".into(),
+            reason: "tool is forbidden".into(),
+        }))],
+    );
+
+    let checkpoint = Arc::new(InMemoryStore::new());
+    let sink: Arc<dyn awaken::contract::event_sink::EventSink> = Arc::new(NullEventSink);
+    let result = run_agent_loop(AgentLoopParams {
+        resolver: &resolver,
+        agent_id: "test",
+        runtime: &runtime,
+        sink,
+        checkpoint_store: Some(checkpoint.as_ref()),
+        messages: vec![Message::user("use tools")],
+        run_identity: test_identity(),
+        cancellation_token: None,
+        decision_rx: None,
+        overrides: None,
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: false,
+    })
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        result.termination,
+        TerminationReason::Blocked(ref reason) if reason == "tool is forbidden"
+    ));
+
+    use awaken::contract::storage::ThreadStore;
+    let msgs = checkpoint
+        .load_messages("thread-1")
+        .await
+        .unwrap()
+        .expect("checkpoint messages");
+    assert_eq!(msgs.len(), 4);
+    assert_eq!(msgs[0].role, Role::User);
+    assert_eq!(message_text(&msgs[0]), "use tools");
+    assert_eq!(msgs[1].role, Role::Assistant);
+    let calls = msgs[1].tool_calls.as_ref().expect("assistant tool calls");
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].id, "c1");
+    assert_eq!(calls[1].id, "c2");
+    assert_eq!(msgs[2].role, Role::Tool);
+    assert_eq!(msgs[2].tool_call_id.as_deref(), Some("c1"));
+    assert_eq!(message_text(&msgs[2]), "tool is forbidden");
+    assert_eq!(msgs[3].role, Role::Tool);
+    assert_eq!(msgs[3].tool_call_id.as_deref(), Some("c2"));
+    assert_eq!(message_text(&msgs[3]), "[Tool execution was interrupted]");
+}
+
+#[tokio::test]
+async fn checkpoint_stores_suspended_tool_batch_consistently() {
+    use awaken::stores::InMemoryStore;
+
+    let llm = Arc::new(ScriptedLlm::new(vec![StreamResult {
+        content: vec![],
+        tool_calls: vec![
+            ToolCall::new("c1", "dangerous", json!({"action": "delete"})),
+            ToolCall::new("c2", "calc", json!({"result": 2})),
+        ],
+        usage: None,
+        stop_reason: Some(StopReason::ToolUse),
+        has_incomplete_tool_calls: false,
+    }]));
+
+    let agent = ResolvedAgent::new("test", "m", "sys", llm)
+        .with_tool(Arc::new(SuspendingTool))
+        .with_tool(Arc::new(CalcTool));
+    let runtime = make_runtime();
+    let resolver = FixedResolver::new(agent);
+
+    let checkpoint = Arc::new(InMemoryStore::new());
+    let sink: Arc<dyn awaken::contract::event_sink::EventSink> = Arc::new(NullEventSink);
+    let result = run_agent_loop(AgentLoopParams {
+        resolver: &resolver,
+        agent_id: "test",
+        runtime: &runtime,
+        sink,
+        checkpoint_store: Some(checkpoint.as_ref()),
+        messages: vec![Message::user("run dangerous tool")],
+        run_identity: test_identity(),
+        cancellation_token: None,
+        decision_rx: None,
+        overrides: None,
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: false,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result.termination, TerminationReason::Suspended);
+
+    use awaken::contract::storage::ThreadStore;
+    let msgs = checkpoint
+        .load_messages("thread-1")
+        .await
+        .unwrap()
+        .expect("checkpoint messages");
+    assert_eq!(msgs.len(), 4);
+    assert_eq!(msgs[0].role, Role::User);
+    assert_eq!(message_text(&msgs[0]), "run dangerous tool");
+    assert_eq!(msgs[1].role, Role::Assistant);
+    let calls = msgs[1].tool_calls.as_ref().expect("assistant tool calls");
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].id, "c1");
+    assert_eq!(calls[1].id, "c2");
+    assert_eq!(msgs[2].role, Role::Tool);
+    assert_eq!(msgs[2].tool_call_id.as_deref(), Some("c1"));
+    assert_eq!(message_text(&msgs[2]), "needs user approval");
+    assert_eq!(msgs[3].role, Role::Tool);
+    assert_eq!(msgs[3].tool_call_id.as_deref(), Some("c2"));
+    assert_eq!(message_text(&msgs[3]), "[Tool execution was interrupted]");
 }
 
 /// Checkpoint records correct agent_id from identity.

--- a/crates/awaken/tests/skill_permission_e2e.rs
+++ b/crates/awaken/tests/skill_permission_e2e.rs
@@ -1070,9 +1070,10 @@ async fn guarded_tool_before_skill_blocks_same_step_activation_attempt() {
         })
         .collect();
     assert_eq!(tool_dones.get("c1"), Some(&ToolCallOutcome::Failed));
-    assert!(
-        matches!(tool_dones.get("c2"), Some(ToolCallOutcome::Failed)),
-        "later skill call should be backfilled as interrupted instead of being silently dropped"
+    assert_eq!(
+        tool_dones.get("c2"),
+        Some(&ToolCallOutcome::Failed),
+        "later skill call should be backfilled as interrupted, not executed"
     );
 }
 
@@ -1158,9 +1159,10 @@ async fn allowed_prefix_commits_before_later_guarded_tool_blocks() {
         .collect();
     assert_eq!(tool_dones.get("c1"), Some(&ToolCallOutcome::Succeeded));
     assert_eq!(tool_dones.get("c2"), Some(&ToolCallOutcome::Failed));
-    assert!(
-        matches!(tool_dones.get("c3"), Some(ToolCallOutcome::Failed)),
-        "later skill call should be backfilled as interrupted once a prior guarded tool blocks"
+    assert_eq!(
+        tool_dones.get("c3"),
+        Some(&ToolCallOutcome::Failed),
+        "later skill call should be backfilled as interrupted, not executed"
     );
 }
 

--- a/crates/awaken/tests/tool_executor.rs
+++ b/crates/awaken/tests/tool_executor.rs
@@ -300,20 +300,25 @@ async fn sequential_stops_after_first_suspension_in_loop() {
     let lifecycle = rt.store().read::<RunLifecycle>().unwrap();
     assert_eq!(lifecycle.status, RunStatus::Waiting);
 
-    // The second tool should not execute, but it should be backfilled as an
-    // interrupted failed result so the tool-call batch remains complete.
+    // The second tool should not execute, but its call is backfilled as interrupted.
     let events = sink.take();
     let tool_dones: Vec<_> = events
         .iter()
-        .filter_map(|event| match event {
-            AgentEvent::ToolCallDone { id, outcome, .. } => Some((id.as_str(), *outcome)),
-            _ => None,
+        .filter_map(|e| {
+            if let AgentEvent::ToolCallDone { id, outcome, .. } = e {
+                Some((id.as_str(), *outcome))
+            } else {
+                None
+            }
         })
         .collect();
-    assert_eq!(tool_dones.len(), 2);
-    let by_id: std::collections::HashMap<_, _> = tool_dones.into_iter().collect();
-    assert_eq!(by_id.get("c1"), Some(&ToolCallOutcome::Suspended));
-    assert_eq!(by_id.get("c2"), Some(&ToolCallOutcome::Failed));
+    assert_eq!(
+        tool_dones,
+        vec![
+            ("c1", ToolCallOutcome::Suspended),
+            ("c2", ToolCallOutcome::Failed),
+        ]
+    );
 }
 
 // ===========================================================================

--- a/examples/src/starter_backend/frontend_tools.rs
+++ b/examples/src/starter_backend/frontend_tools.rs
@@ -7,10 +7,9 @@ use awaken_contract::contract::suspension::{
     PendingToolCall, SuspendTicket, Suspension, ToolCallResumeMode,
 };
 use awaken_contract::contract::tool::ToolResult;
-use awaken_contract::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
-use awaken_contract::model::Phase;
+use awaken_contract::contract::tool_intercept::ToolInterceptPayload;
 use awaken_runtime::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
-use awaken_runtime::{PhaseContext, PhaseHook, StateCommand};
+use awaken_runtime::{PhaseContext, ToolGateHook};
 
 const FRONTEND_TOOLS_PLUGIN_NAME: &str = "frontend_tools";
 
@@ -46,9 +45,8 @@ impl Plugin for FrontendToolPlugin {
     }
 
     fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-        registrar.register_phase_hook(
+        registrar.register_tool_gate_hook(
             FRONTEND_TOOLS_PLUGIN_NAME,
-            Phase::BeforeToolExecute,
             FrontendToolInterceptHook {
                 tools: self.tools.clone(),
             },
@@ -62,15 +60,15 @@ struct FrontendToolInterceptHook {
 }
 
 #[async_trait]
-impl PhaseHook for FrontendToolInterceptHook {
-    async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, StateError> {
+impl ToolGateHook for FrontendToolInterceptHook {
+    async fn run(&self, ctx: &PhaseContext) -> Result<Option<ToolInterceptPayload>, StateError> {
         let tool_name = match &ctx.tool_name {
             Some(name) => name.as_str(),
-            None => return Ok(StateCommand::new()),
+            None => return Ok(None),
         };
 
         if !self.tools.contains(tool_name) {
-            return Ok(StateCommand::new());
+            return Ok(None);
         }
 
         // If resuming after frontend response, use the decision as tool result
@@ -89,9 +87,7 @@ impl PhaseHook for FrontendToolInterceptHook {
                         .unwrap_or_else(|| "User denied the action".to_string()),
                 ),
             };
-            let mut cmd = StateCommand::new();
-            cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::SetResult(result))?;
-            return Ok(cmd);
+            return Ok(Some(ToolInterceptPayload::SetResult(result)));
         }
 
         // First encounter: suspend for frontend handling
@@ -110,8 +106,6 @@ impl PhaseHook for FrontendToolInterceptHook {
             ToolCallResumeMode::UseDecisionAsToolResult,
         );
 
-        let mut cmd = StateCommand::new();
-        cmd.schedule_action::<ToolInterceptAction>(ToolInterceptPayload::Suspend(ticket))?;
-        Ok(cmd)
+        Ok(Some(ToolInterceptPayload::Suspend(ticket)))
     }
 }


### PR DESCRIPTION
## Summary
- remove the legacy BeforeToolExecute interception path and route interception through ToolGate only
- stage assistant tool-call batches and tool results in a step-local transcript before committing them to messages
- backfill interrupted tail calls explicitly so suspend/block paths keep transcript and checkpoint state consistent
- migrate the starter backend frontend tool example to ToolGate so examples continue to build

## Migration
This is an explicit source-breaking migration for interception hooks.

- `ToolInterceptAction` has been removed
- `BeforeToolExecute` no longer participates in interception decisions
- plugins that previously intercepted by scheduling `ToolInterceptAction` from `BeforeToolExecute` must migrate to `ToolGateHook`

Old interception plugins should fail to compile after upgrade rather than silently continue with changed runtime behavior.

## Validation
- cargo fmt --check
- cargo test -p awaken-contract --lib
- cargo test -p awaken-ext-permission --lib
- cargo test -p awaken-runtime loop_runner --lib
- cargo test -p awaken-runtime --test event_lifecycle -- --nocapture
- cargo test -p awaken-agent --test agent_loop -- --nocapture
- cargo test -p awaken-agent --test tool_executor -- --nocapture
- cargo test -p awaken-agent --test skill_permission_e2e -- --nocapture
- cargo test -p awaken-server --test protocol_ai_sdk -- --nocapture
- cargo test -p awaken-server --test protocol_ag_ui -- --nocapture
- cargo test -p awaken-examples --lib
- cargo clippy --workspace --lib --bins --examples --locked -- -D clippy::correctness