### PR TITLE
📝 Sync README and book docs with ToolGate runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Docs: [GitHub Pages](https://awakenworks.github.io/awaken/) | [Chinese docs](htt
 
 1. **Tools** — typed functions your agent can call; JSON schema is generated at compile time
 2. **Agents** — each agent has a system prompt, a model, and a set of allowed tools; the LLM drives orchestration through natural language — no predefined graphs
-3. **State** — typed and scoped (`thread` / `run`), with merge strategies for safe concurrent writes and immutable snapshots
+3. **State** — typed run/thread state plus persistent profile/shared state for cross-thread or cross-agent coordination
 4. **Plugins** — lifecycle hooks for permissions, observability, context management, skills, MCP, and more
 
-Your agent picks tools, calls them, reads and updates state, and repeats — all orchestrated by the runtime through 8 typed phases. Every state change is committed atomically after the gather phase.
+Your agent picks tools, calls them, reads and updates state, and repeats — all orchestrated by the runtime through 9 typed phases, including a pure `ToolGate` before tool execution. Every state change is committed atomically after the gather phase.
 
 ## Try it in 5 minutes
 
@@ -29,7 +29,7 @@ Prerequisites:
 
 ```toml
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.1.1" }
+awaken = { package = "awaken-agent", version = "0.1" }
 tokio = { version = "1.51.0", features = ["full"] }
 async-trait = "0.1.89"
 serde_json = "1.0.149"
@@ -179,6 +179,8 @@ All features are enabled by default via the `full` feature. Use `default-feature
 | **Generative UI** | Streams declarative UI components to frontends via the A2UI protocol. | `generative-ui` |
 
 `awaken-ext-deferred-tools` provides lazy tool loading; add it as a direct dependency if needed — it is not included in the `full` feature.
+
+Custom interception hooks should use `ToolGateHook` via `PluginRegistrar::register_tool_gate_hook()`. `BeforeToolExecute` is reserved for execution-time hooks that run only when a tool is actually about to execute.
 
 ## Why Awaken
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,10 +18,10 @@
 
 1. **Tools** — 类型化函数，JSON Schema 在编译时自动生成
 2. **Agents** — 每个 Agent 拥有系统提示词、模型和允许的工具集；LLM 通过自然语言驱动编排 — 无需预定义流程图
-3. **State** — 类型化，并按 `thread` / `run` 作用域管理，支持合并策略处理并发写入，以及不可变快照
-4. **Plugins** — 8 阶段生命周期钩子，覆盖权限、可观测性、上下文管理、Skills、MCP 等
+3. **State** — 既有 `run` / `thread` 作用域的类型化状态，也有用于跨线程/跨 Agent 协作的持久化 profile/shared state
+4. **Plugins** — 生命周期钩子覆盖权限、可观测性、上下文管理、Skills、MCP 等
 
-Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运行时通过 8 个类型化阶段编排。每次状态变更都在 gather 阶段后原子提交。
+Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运行时通过 9 个类型化阶段编排，其中在真正执行工具前增加了纯判定的 `ToolGate`。每次状态变更都在 gather 阶段后原子提交。
 
 ## 5 分钟上手
 
@@ -31,7 +31,7 @@ Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运
 
 ```toml
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.1.1" }
+awaken = { package = "awaken-agent", version = "0.1" }
 tokio = { version = "1.51.0", features = ["full"] }
 async-trait = "0.1.89"
 serde_json = "1.0.149"
@@ -192,11 +192,13 @@ import { CopilotKit } from "@copilotkit/react-core";
 
 `awaken-ext-deferred-tools` crate 提供基于概率模型的延迟工具加载，未包含在 `awaken` 门面 crate 中，如需使用请直接添加依赖。
 
+如需自定义工具拦截，应实现 `ToolGateHook` 并通过 `PluginRegistrar::register_tool_gate_hook()` 注册；`BeforeToolExecute` 仅用于真正执行前的一次性钩子。
+
 ## 为什么选择 Awaken
 
 - **一个后端服务所有前端** — 从同一个二进制文件提供 React（AI SDK v6）、Next.js（AG-UI）、其他 Agent（A2A）和工具服务器（MCP）。无需分别部署。
 - **LLM 编排一切，无需 DAG** — 定义 Agent 的身份和工具访问权限；LLM 决定何时委托、委托给谁、如何组合结果。无需手写流程图或状态机。
-- **可组合的插件体系** — 8 个类型化生命周期阶段。权限、上下文注入、可观测性、工具发现，全部声明式配置。`PhaseHook` trait 类型安全，插件注册 API 在构建时捕获配置错误。
+- **可组合的插件体系** — 9 个类型化生命周期阶段，其中包含纯判定的 `ToolGate`。权限、上下文注入、可观测性、工具发现，全部声明式配置。`PhaseHook` / `ToolGateHook` 类型安全，插件注册 API 在构建时捕获配置错误。
 - **类型安全的状态与回放** — State 是带编译时检查的 Rust 结构体。合并策略处理并发写入，无需锁。作用域限定为 thread 或 run，每次变更都是可回放的不可变快照。
 - **内置生产韧性** — 熔断器、指数退避、推理超时、优雅关闭、Prometheus 指标和健康探针，开箱即用。
 - **零 `unsafe` 代码** — 整个工作空间禁止 `unsafe`，内存安全由 Rust 编译器保证。

--- a/docs/adr/0001-phase-execution-model.md
+++ b/docs/adr/0001-phase-execution-model.md
@@ -38,7 +38,7 @@ Every action is:
 - Declared in `ExecutionEnv` at setup time via `PluginRegistrar::register_scheduled_action`.
 - Rejected at `submit_command` if the action key has no registered handler. This catches typos and misconfigurations immediately.
 
-**Consumption**: during the EXECUTE stage of the target phase, the runtime processes actions that have a registered handler — dequeuing them, calling the handler, and committing the resulting `StateCommand`. The orchestrator can also consume actions directly from the `StateCommand` returned by `collect_commands()` (GATHER-only) using `extract_actions`, bypassing the handler/accumulator pattern entirely. Loop actions (`SetInferenceOverride`, `ExcludeTool`, `IncludeOnlyTools`, `ToolInterceptAction`) are consumed this way — extracted from the collected command, with remaining actions (`AddContextMessage`) submitted for handler-based EXECUTE processing. This eliminates write-read-clear accumulator state keys.
+**Consumption**: during the EXECUTE stage of the target phase, the runtime processes actions that have a registered handler — dequeuing them, calling the handler, and committing the resulting `StateCommand`. The orchestrator can also consume actions directly from the `StateCommand` returned by `collect_commands()` (GATHER-only) using `extract_actions`, bypassing the handler/accumulator pattern entirely. Loop actions (`SetInferenceOverride`, `ExcludeTool`, `IncludeOnlyTools`) are consumed this way — extracted from the collected command, with remaining actions (`AddContextMessage`) submitted for handler-based EXECUTE processing. This eliminates write-read-clear accumulator state keys.
 
 Invariants:
 
@@ -140,6 +140,10 @@ Both GATHER and EXECUTE produce effects via `StateCommand`. Effects are dispatch
 
 `ScheduledAction` carries a `phase` field. EXECUTE only dequeues actions matching the current phase (and having handlers); others remain queued. Cross-phase communication prefers state keys over cross-phase action scheduling.
 
+### ToolGate: pure interception outside the scheduled-action queue
+
+Tool interception is no longer modeled as a scheduled action. The runtime runs `ToolGateHook`s directly during the `ToolGate` phase and resolves their `ToolInterceptPayload`s in memory using the same priority rules (`Block > Suspend > SetResult`). This keeps interception replay-safe and avoids reusing `BeforeToolExecute` for both decision making and execution-time side effects.
+
 ### ToolCall parallelism (deferred)
 
 Tool calls involve external resources (files, network, git worktrees) whose conflicts are not captured by `StateKey` merge strategies. Parallelizing tool execution requires a resource/object declaration mechanism beyond `MergeStrategy`. This is out of scope for the current design; tool calls remain governed by the execution mode in ADR-0007.
@@ -149,7 +153,8 @@ Tool calls involve external resources (files, network, git worktrees) whose conf
 - GATHER parallel hooks: implemented
 - GATHER Exclusive auto-fallback: implemented
 - State-driven termination via RunLifecycle: implemented
-- Loop actions (overrides, tool filters, intercept) consumed directly by orchestrator via collect_commands + extract_actions — no accumulator state keys
+- Loop actions (overrides, tool filters) consumed directly by orchestrator via collect_commands + extract_actions — no accumulator state keys
+- Tool interception handled by `ToolGateHook` / `ToolInterceptPayload`, not a scheduled action
 - RuntimeEffect enum: deleted (all variants replaced by State/Action)
 - CancellationToken: implemented
 - EXECUTE parallel actions: not implemented (currently serial)

--- a/docs/adr/0007-tool-call-lifecycle.md
+++ b/docs/adr/0007-tool-call-lifecycle.md
@@ -20,7 +20,7 @@ Pending → Running → Succeeded / Failed
 
 Implemented as `StateKey`s with ToolCall scope (namespaced per `call_id`).
 
-**Suspension is first-class**: Not an error path. A tool or `BeforeToolExecute` hook can suspend a call. Run transitions to Waiting; suspended state persists; external decision arrives asynchronously; agent loop replays at next step boundary. Three resume modes: ReplayToolCall (re-execute with decision context), UseDecisionAsResult (decision payload becomes result), PassDecisionToTool (decision as new arguments).
+**Suspension is first-class**: Not an error path. A tool or `ToolGateHook` can suspend a call. Run transitions to Waiting; suspended state persists; external decision arrives asynchronously; agent loop replays at the next step boundary. Three resume modes: ReplayToolCall (re-execute with decision context), UseDecisionAsResult (a `ToolGateHook` converts the decision payload into `SetResult`), PassDecisionToTool (decision as new arguments).
 
 **Three execution modes** (per-agent config):
 
@@ -35,3 +35,4 @@ Implemented as `StateKey`s with ToolCall scope (namespaced per `call_id`).
 - Suspension requires persistent ToolCall-scoped state (ADR-0008)
 - Parallel modes require state merge strategy (ADR-0008)
 - The server/client layer provides external decision transport
+- `BeforeToolExecute` remains available for execution-time side effects, but no longer decides suspend/block/set-result outcomes

--- a/docs/adr/0016-tool-interception-pipeline.md
+++ b/docs/adr/0016-tool-interception-pipeline.md
@@ -6,13 +6,18 @@
 
 ## Context
 
-Tool execution needs extension points for permission checks, frontend tool delegation, and human-in-the-loop workflows. Hooks in the `BeforeToolExecute` phase can intercept tool calls, but multiple interceptors may conflict. A deterministic priority system is needed to resolve conflicts without ambiguity.
+Tool execution needs extension points for permission checks, frontend tool delegation, and human-in-the-loop workflows. The original implementation modeled interception as a `BeforeToolExecute` scheduled action, but that blurred two responsibilities:
+
+- pure "may this call proceed?" decisions
+- one-shot execution-time hooks that should only run when a tool really executes
+
+The runtime now separates these responsibilities. `ToolGateHook` provides the pure interception layer, while `BeforeToolExecute` is reserved for execution-time side effects.
 
 ## Decision
 
-### D1: ToolInterceptAction with strict priority
+### D1: `ToolGateHook` with strict priority
 
-Tool execution can be intercepted during the `BeforeToolExecute` phase via `ToolInterceptAction`. Three intercept types exist, each with a fixed priority:
+Tool execution is intercepted during the `ToolGate` phase via `ToolGateHook`, which returns an optional `ToolInterceptPayload`. Three intercept payloads exist, each with a fixed priority:
 
 | Action | Priority | Behavior |
 |--------|----------|----------|
@@ -22,19 +27,20 @@ Tool execution can be intercepted during the `BeforeToolExecute` phase via `Tool
 
 ### D2: Same-priority conflict resolution
 
-When multiple interceptors produce actions at the same priority level, the first interceptor's action is kept and an error is logged. This is a conflict that indicates misconfiguration — two plugins should not both attempt to Block the same tool call.
+When multiple gate hooks produce payloads at the same priority level, the first payload is kept and an error is logged. This is a conflict that indicates misconfiguration — two plugins should not both attempt to Block the same tool call.
 
 ### D3: Higher priority always wins
 
-A higher-priority action always overrides a lower-priority one. A Block from a permission plugin cannot be overridden by a SetResult from a frontend tool plugin. This ensures security-critical intercepts are never bypassed.
+A higher-priority payload always overrides a lower-priority one. A Block from a permission plugin cannot be overridden by a SetResult from a frontend tool plugin. This ensures security-critical intercepts are never bypassed.
 
 ### D4: Resume semantics
 
-Suspended tool calls are resumed via `ToolCallResume` carrying either a `Resume` or `Cancel` action. On `Resume`, the permission hook that originally produced the Suspend skips re-evaluation — the external decision is authoritative. On `Cancel`, the tool call is abandoned.
+Suspended tool calls are resumed via `ToolCallResume` carrying either a `Resume` or `Cancel` action. On replay, the runtime re-enters the normal tool pipeline with `resume_input` injected into the `ToolGate` / tool context. Gate hooks can use that resume context to proceed, block, or produce a result directly (for example, frontend tools return `SetResult`, while permission `Ask` resumes without re-suspending). On `Cancel`, the tool call is abandoned.
 
 ## Consequences
 
 - Permission plugins use Block/Suspend; frontend tool plugins use SetResult. The priority system prevents lower-priority intercepts from overriding security decisions.
 - Same-priority conflicts are logged as errors, surfacing misconfiguration without silent behavior changes.
-- Resume flow avoids redundant permission re-evaluation, preventing infinite suspend loops.
+- `ToolGate` remains pure and replay-safe, so the runtime can re-evaluate it after earlier tool calls commit state in the same step.
+- `BeforeToolExecute` no longer participates in interception and keeps its run-once execution semantics.
 - The pipeline is extensible: new intercept priorities can be added if needed, though three levels have proven sufficient.

--- a/docs/book/README.zh-CN.md
+++ b/docs/book/README.zh-CN.md
@@ -14,10 +14,10 @@
 
 1. **Tools** — 类型化函数，JSON Schema 在编译时自动生成
 2. **Agents** — 每个 Agent 拥有系统提示词、模型和允许的工具集；LLM 通过自然语言驱动编排 — 无需预定义流程图
-3. **State** — 类型化，并按 `thread` / `run` 作用域管理，支持合并策略处理并发写入，以及不可变快照
-4. **Plugins** — 8 阶段生命周期钩子，覆盖权限、可观测性、上下文管理、Skills、MCP 等
+3. **State** — 既有 `run` / `thread` 作用域的类型化状态，也有用于跨线程/跨 Agent 协作的持久化 profile/shared state
+4. **Plugins** — 生命周期钩子覆盖权限、可观测性、上下文管理、Skills、MCP 等
 
-Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运行时通过 8 个类型化阶段编排。每次状态变更都在 gather 阶段后原子提交。
+Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运行时通过 9 个类型化阶段编排，其中在真正执行工具前增加了纯判定的 `ToolGate`。每次状态变更都在 gather 阶段后原子提交。
 
 ## 5 分钟上手
 
@@ -27,7 +27,7 @@ Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运
 
 ```toml
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.1.1" }
+awaken = { package = "awaken-agent", version = "0.1" }
 tokio = { version = "1.51.0", features = ["full"] }
 async-trait = "0.1.89"
 serde_json = "1.0.149"
@@ -188,11 +188,13 @@ import { CopilotKit } from "@copilotkit/react-core";
 
 `awaken-ext-deferred-tools` crate 提供基于概率模型的延迟工具加载，未包含在 `awaken` 门面 crate 中，如需使用请直接添加依赖。
 
+如需自定义工具拦截，应实现 `ToolGateHook` 并通过 `PluginRegistrar::register_tool_gate_hook()` 注册；`BeforeToolExecute` 仅用于真正执行前的一次性钩子。
+
 ## 为什么选择 Awaken
 
 - **一个后端服务所有前端** — 从同一个二进制文件提供 React（AI SDK v6）、Next.js（AG-UI）、其他 Agent（A2A）和工具服务器（MCP）。无需分别部署。
 - **LLM 编排一切，无需 DAG** — 定义 Agent 的身份和工具访问权限；LLM 决定何时委托、委托给谁、如何组合结果。无需手写流程图或状态机。
-- **可组合的插件体系** — 8 个类型化生命周期阶段。权限、上下文注入、可观测性、工具发现，全部声明式配置。`PhaseHook` trait 类型安全，插件注册 API 在构建时捕获配置错误。
+- **可组合的插件体系** — 9 个类型化生命周期阶段，其中包含纯判定的 `ToolGate`。权限、上下文注入、可观测性、工具发现，全部声明式配置。`PhaseHook` / `ToolGateHook` 类型安全，插件注册 API 在构建时捕获配置错误。
 - **类型安全的状态与回放** — State 是带编译时检查的 Rust 结构体。合并策略处理并发写入，无需锁。作用域限定为 thread 或 run，每次变更都是可回放的不可变快照。
 - **内置生产韧性** — 熔断器、指数退避、推理超时、优雅关闭、Prometheus 指标和健康探针，开箱即用。
 - **零 `unsafe` 代码** — 整个工作空间禁止 `unsafe`，内存安全由 Rust 编译器保证。

--- a/docs/book/src/appendix/glossary.md
+++ b/docs/book/src/appendix/glossary.md
@@ -4,7 +4,7 @@
 |------|------|-------------|
 | `Thread` | 会话线程 | Persisted conversation + state history. |
 | `Run` | 运行 | One execution attempt over a thread. |
-| `Phase` | 阶段 | Named step in the execution loop (RunStart, StepStart, BeforeInference, AfterInference, BeforeToolExecute, AfterToolExecute, StepEnd, RunEnd). |
+| `Phase` | 阶段 | Named step in the execution loop (RunStart, StepStart, BeforeInference, AfterInference, ToolGate, BeforeToolExecute, AfterToolExecute, StepEnd, RunEnd). |
 | `Snapshot` | 快照 | Immutable state snapshot (`struct Snapshot { revision: u64, ext: Arc<StateMap> }`) seen by phase hooks. |
 | `StateKey` | 状态键 | Typed key with scope, merge strategy, and value type. |
 | `MutationBatch` | 变更批次 | Collected state mutations applied atomically after phase convergence. |
@@ -14,6 +14,7 @@
 | `Plugin` | 插件 | System-level lifecycle hook registered via `PluginRegistrar`. |
 | `PluginRegistrar` | 插件注册器 | Registration API for phase hooks, tools, state keys, handlers. |
 | `PhaseHook` | 阶段钩子 | Async hook executed during a specific phase. |
+| `ToolGateHook` | 工具闸门钩子 | Pure hook that decides whether a tool call is allowed, blocked, suspended, or short-circuited before execution. |
 | `PhaseContext` | 阶段上下文 | Immutable context passed to phase hooks. |
 | `StateCommand` | 状态命令 | Result of a phase hook: mutations + scheduled actions + effects. |
 | `Tool` | 工具 | User-facing capability with descriptor, validation, and execution. |

--- a/docs/book/src/appendix/migration-from-tirea.md
+++ b/docs/book/src/appendix/migration-from-tirea.md
@@ -98,8 +98,8 @@ cmd.schedule_action::<AddContextMessage>(
 | `BeforeInferenceAction::AddContextMessage` | `AddContextMessage` | Same semantics |
 | `BeforeInferenceAction::SetInferenceOverride` | `SetInferenceOverride` | Same semantics |
 | `BeforeInferenceAction::ExcludeTool` | `ExcludeTool` | Same semantics |
-| `BeforeToolExecuteAction::Block` | `ToolInterceptAction` with `Block` payload | Unified intercept |
-| `BeforeToolExecuteAction::Suspend` | `ToolInterceptAction` with `Suspend` payload | Unified intercept |
+| `BeforeToolExecuteAction::Block` | `ToolGateHook` returning `ToolInterceptPayload::Block` | Interception moved to `ToolGate` |
+| `BeforeToolExecuteAction::Suspend` | `ToolGateHook` returning `ToolInterceptPayload::Suspend` | Interception moved to `ToolGate` |
 | `AfterToolExecuteAction::AddMessage` | `AddContextMessage` | Generalized |
 
 See [Scheduled Actions](../reference/scheduled-actions.md) for the full list.
@@ -202,7 +202,7 @@ The following tirea concepts have no awaken equivalent:
 | `Global` scope | Thread scope + `ProfileStore` covers this |
 | `RuntimeEffect` | Replaced by `StateCommand` effects |
 | `EffectLog` / `ScheduledActionLog` | Replaced by tracing |
-| `ConfigStore` / `ConfigSlot` | Replaced by `AgentSpec` sections |
+| `ConfigSlot` | Replaced by typed `AgentSpec` sections for static config, plus `ConfigStore` for runtime-managed config |
 | `AgentProfile` | Merged into `AgentSpec` |
 | `ExtensionContext` live activation | Replaced by static `plugin_ids` on `AgentSpec` |
 
@@ -212,7 +212,7 @@ The following tirea concepts have no awaken equivalent:
 |----------------|-------------|
 | `PluginRegistrar` | Structured registration (keys, tools, hooks, actions) |
 | `ToolOutput` with `StateCommand` | Tools can schedule actions as side-effects |
-| `ToolInterceptAction` | Unified Block/Suspend/SetResult pipeline |
+| `ToolGateHook` | Pure interception hook for Block / Suspend / SetResult decisions |
 | `CircuitBreaker` | Per-model LLM failure protection |
 | `Mailbox` | Durable job queue with lease-based claim |
 | `EventReplayBuffer` | SSE reconnection with frame replay |
@@ -226,7 +226,7 @@ The following tirea concepts have no awaken equivalent:
 - [ ] Convert `#[derive(StateSlot)]` to `impl StateKey for ...`
 - [ ] Convert `Extension` impls to `Plugin` impls with `PluginRegistrar`
 - [ ] Convert `TypedTool` impls to `Tool` impls
-- [ ] Replace action enum variants with `cmd.schedule_action::<ActionType>(...)`
+- [ ] Replace action enum variants with `cmd.schedule_action::<ActionType>(...)` or `ToolGateHook` for tool interception
 - [ ] Replace `AgentOsBuilder` with `AgentRuntimeBuilder`
 - [ ] Update store imports: `tirea_store_adapters` → `awaken_stores`
 - [ ] Update server imports: protocol crates → `awaken_server::protocols::*`

--- a/docs/book/src/explanation/architecture.md
+++ b/docs/book/src/explanation/architecture.md
@@ -49,6 +49,7 @@ sequenceDiagram
         LLM-->>Runtime: Response (text + tool_calls)
         Runtime->>Runtime: AfterInference phase
         opt Tool calls present
+            Runtime->>Runtime: ToolGate phase
             Runtime->>Runtime: BeforeToolExecute phase
             Runtime->>Tool: execute(args, ctx)
             Tool-->>Runtime: ToolResult
@@ -67,7 +68,7 @@ Every run proceeds through a fixed sequence of phases. Plugins register hooks th
 
 ```text
 RunStart -> [StepStart -> BeforeInference -> AfterInference
-             -> BeforeToolExecute -> AfterToolExecute -> StepEnd]* -> RunEnd
+             -> ToolGate -> BeforeToolExecute -> AfterToolExecute -> StepEnd]* -> RunEnd
 ```
 
 The step loop repeats until one of these conditions fires:

--- a/docs/book/src/explanation/design-tradeoffs.md
+++ b/docs/book/src/explanation/design-tradeoffs.md
@@ -64,7 +64,7 @@ This page documents key architectural decisions in Awaken and the tradeoffs they
 | Complexity | More registration ceremony | Simpler mental model (wrap and delegate) |
 | Cross-cutting concerns | Natural fit -- each plugin handles one concern | Each middleware handles one concern but sees all traffic |
 
-**Why plugin system**: Agent execution has many extension points that don't nest cleanly. A permission check happens at `BeforeToolExecute`, observability spans wrap tool execution, reminders inject messages at `AfterToolExecute`. These are independent concerns at different phases. A middleware chain would require each middleware to understand the full lifecycle and decide when to act. The plugin system lets each plugin declare exactly which phases it cares about.
+**Why plugin system**: Agent execution has many extension points that don't nest cleanly. A permission decision happens at `ToolGate`, observability spans wrap tool execution, reminders inject messages at `AfterToolExecute`. These are independent concerns at different phases. A middleware chain would require each middleware to understand the full lifecycle and decide when to act. The plugin system lets each plugin declare exactly which phases it cares about.
 
 ## Multi-Protocol Server vs Single Protocol
 

--- a/docs/book/src/explanation/plugin-internals.md
+++ b/docs/book/src/explanation/plugin-internals.md
@@ -16,6 +16,7 @@ When a plugin is loaded, its `register()` method is called with a `PluginRegistr
 
 **Behavioral components** are only active when the plugin passes the activation filter:
 
+- Tool gate hooks (`register_tool_gate_hook()`)
 - Phase hooks (`register_phase_hook()`)
 - Tools (`register_tool()`)
 - Request transforms (`register_request_transform()`)
@@ -185,9 +186,9 @@ pub fn merge(&mut self, other: InferenceOverride) {
 
 This allows plugins to override specific parameters without affecting others. A cost-control plugin can set `max_tokens` while a quality plugin sets `temperature`, and neither interferes with the other. If both set the same field, the last merge wins.
 
-## Tool Intercept Priority
+## ToolGate Decision Priority
 
-During `BeforeToolExecute`, plugins can schedule `ToolInterceptAction` to control tool execution flow. The action payload is one of three variants:
+During `ToolGate`, plugins implement `ToolGateHook` and return an optional `ToolInterceptPayload` to control tool execution flow:
 
 ```rust,ignore
 pub enum ToolInterceptPayload {
@@ -197,7 +198,7 @@ pub enum ToolInterceptPayload {
 }
 ```
 
-When multiple intercepts are scheduled for the same tool call, they are resolved by implicit priority:
+When multiple gate hooks return a decision for the same tool call, they are resolved by implicit priority:
 
 | Priority | Variant | Behavior |
 |----------|---------|----------|
@@ -205,13 +206,13 @@ When multiple intercepts are scheduled for the same tool call, they are resolved
 | 2 | `Suspend` | Pause execution, wait for external decision |
 | 1 (lowest) | `SetResult` | Short-circuit with a predefined result |
 
-The highest-priority intercept wins. If two intercepts have the same priority (e.g., two plugins both schedule `Block`), the first one processed takes effect and the conflict is logged as an error.
+The highest-priority decision wins. If two decisions have the same priority (e.g., two plugins both return `Block`), the first one processed takes effect and the conflict is logged as an error.
 
-If no intercept is scheduled, the tool executes normally (implicit proceed).
+If no hook returns a decision, the tool executes normally. `ToolGate` is pure and may be re-evaluated after earlier allowed tool calls commit new state in the same step; `BeforeToolExecute` runs only once a call is finally allowed.
 
 ```mermaid
 flowchart TD
-    BTE[BeforeToolExecute hooks run] --> INT{Any intercepts scheduled?}
+    TG[ToolGate hooks run] --> INT{Any decision returned?}
     INT -- No --> EXEC[Execute tool normally]
     INT -- Yes --> PRI[Resolve by priority]
     PRI --> B[Block: fail the call]

--- a/docs/book/src/explanation/run-lifecycle-and-phases.md
+++ b/docs/book/src/explanation/run-lifecycle-and-phases.md
@@ -58,7 +58,7 @@ Key transitions:
 
 ## Phase Enum
 
-The `Phase` enum defines the eight execution phases in order:
+The `Phase` enum defines the nine execution phases in order:
 
 ```rust,ignore
 pub enum Phase {
@@ -66,6 +66,7 @@ pub enum Phase {
     StepStart,
     BeforeInference,
     AfterInference,
+    ToolGate,
     BeforeToolExecute,
     AfterToolExecute,
     StepEnd,
@@ -81,7 +82,9 @@ pub enum Phase {
 
 **AfterInference** -- fires after the LLM response arrives. Plugins can inspect the response, modify tool call lists, or request termination.
 
-**BeforeToolExecute** -- fires before each tool call batch. Permission checks, interception, and suspension happen here.
+**ToolGate** -- fires before each tool call is allowed to execute. It is a pure decision phase used for allow / block / suspend / set-result interception, and the runtime may re-evaluate it after earlier tool calls commit state.
+
+**BeforeToolExecute** -- fires only for tool calls that will actually execute. Use it for execution-time side effects such as metrics, counters, or preflight state updates.
 
 **AfterToolExecute** -- fires after tool results are available. Plugins can inspect results and trigger side effects.
 
@@ -198,21 +201,23 @@ stays in `Waiting` until **all** suspended calls are resolved.
 
 ## Suspension Bridges Run and Tool-Call Layers
 
-### Current execution model (serial phases)
+### Current execution model
 
-Tool execution is split into two serial phases inside
-`execute_tools_with_interception`:
+Tool execution is split into three stages inside the step runner:
 
 ```text
-Phase 1 — Intercept (serial, per-call):
+Stage 1 — ToolGate (serial, per-call):
   for each call:
-    BeforeToolExecute hooks → check for intercept actions
+    ToolGate hooks → resolve allow / block / suspend / set-result
     Suspend?  → mark Suspended, set suspended=true, continue
     Block?    → mark Failed, return immediately
     SetResult → mark with provided result, continue
     None      → add to allowed_calls
 
-Phase 2 — Execute (allowed_calls only):
+Stage 2 — BeforeToolExecute (allowed_calls only):
+  run execution-time hooks once for the calls that will execute
+
+Stage 3 — Execute (allowed_calls only):
   Sequential mode: one by one, break on first suspension
   Parallel mode:   batch execute, collect all results
 ```
@@ -257,7 +262,7 @@ The `arguments` field already reflects the resume mode (set by
 | Resume Mode | Arguments on Replay | Behavior |
 |---|---|---|
 | `ReplayToolCall` | Original arguments | Full re-execution |
-| `UseDecisionAsToolResult` | Decision result | `FrontendToolPlugin` intercepts in `BeforeToolExecute`, returns `SetResult` |
+| `UseDecisionAsToolResult` | Decision result | A `ToolGateHook` returns `ToolInterceptPayload::SetResult` during replay |
 | `PassDecisionToTool` | Decision result | Tool receives decision as arguments |
 
 Already-completed calls (`Succeeded`, `Failed`, `Cancelled`) are skipped.

--- a/docs/book/src/explanation/tool-and-plugin-boundary.md
+++ b/docs/book/src/explanation/tool-and-plugin-boundary.md
@@ -18,7 +18,7 @@ Key properties:
 
 - **Registered by ID** -- each tool has a unique string identifier from `ToolDescriptor`.
 - **LLM-visible** -- the descriptor (name, description, JSON Schema for parameters) is included in inference requests.
-- **Executed in tool rounds** -- tools run during the `BeforeToolExecute` / `AfterToolExecute` phase window.
+- **Executed in tool rounds** -- tools pass through `ToolGate`, `BeforeToolExecute`, execution, and `AfterToolExecute`.
 - **Isolated** -- a tool receives only its arguments and a `ToolCallContext`. It cannot directly access other tools, the plugin system, or the phase runtime.
 - **User-defined** -- application code creates tools for domain-specific actions (file operations, API calls, database queries).
 
@@ -49,6 +49,7 @@ When `Plugin::register` is called, the plugin uses `PluginRegistrar` to declare 
 | Registration Method | Purpose |
 |---------------------|---------|
 | `register_key::<K>()` | Declare a `StateKey` for the plugin's state |
+| `register_tool_gate_hook()` | Add a pure tool-interception decision hook |
 | `register_phase_hook()` | Add a hook that runs at a specific phase |
 | `register_tool()` | Inject a tool into the runtime (plugin-provided tools) |
 | `register_effect_handler()` | Handle named effects emitted by hooks |
@@ -80,10 +81,10 @@ Use a plugin when:
 
 Plugins can influence tool execution without the tool knowing:
 
-- **Permission plugin** -- intercepts tool calls at `BeforeToolExecute`, blocks or suspends them based on policy rules. The tool itself has no permission logic.
+- **Permission plugin** -- decides at `ToolGate` whether a tool call is allowed, blocked, or suspended. The tool itself has no permission logic.
 - **Observability plugin** -- wraps tool execution with OpenTelemetry spans. The tool does not emit traces.
 - **Reminder plugin** -- injects context messages after specific tools execute. The tool does not know about reminders.
-- **Interception pipeline** -- plugins can modify tool arguments, replace tool results, or skip execution entirely through the tool interception mechanism.
+- **Interception pipeline** -- `ToolGate` hooks can replace tool results or skip execution entirely before any execution-time hooks run.
 
 This separation means tools remain simple and focused on their domain logic. Cross-cutting concerns are handled uniformly by plugins, applied consistently across all tools without per-tool opt-in.
 

--- a/docs/book/src/how-to/enable-tool-permission-hitl.md
+++ b/docs/book/src/how-to/enable-tool-permission-hitl.md
@@ -46,7 +46,7 @@ let runtime = AgentRuntimeBuilder::new()
     .expect("failed to build runtime");
 ```
 
-The plugin registers a `BeforeToolExecute` phase hook that evaluates permission rules before every tool call.
+The plugin registers a `ToolGateHook` that evaluates permission rules before every tool call.
 
 2. Define permission rules inline.
 
@@ -142,7 +142,7 @@ The pattern syntax supports:
 ## Verify
 
 1. Register a tool that matches a `deny` rule and attempt to invoke it.
-2. The tool call should be blocked and a `ToolInterceptAction` event emitted.
+2. The tool call should be blocked before execution, with the run terminating for deny rules.
 3. Register a tool matching an `ask` rule. The run should suspend, waiting for human approval via the mailbox.
 4. Send approval through the mailbox endpoint and confirm the run resumes.
 
@@ -167,7 +167,7 @@ The pattern syntax supports:
 | `crates/awaken-ext-permission/src/config.rs` | `PermissionRulesConfig` and YAML/JSON loading |
 | `crates/awaken-ext-permission/src/rules.rs` | Pattern syntax, `ToolPermissionBehavior`, rule evaluation |
 | `crates/awaken-ext-permission/src/plugin/plugin.rs` | `PermissionPlugin` registration |
-| `crates/awaken-ext-permission/src/plugin/checker.rs` | `PermissionInterceptHook` (BeforeToolExecute) |
+| `crates/awaken-ext-permission/src/plugin/checker.rs` | `PermissionToolGateHook` (`ToolGate`) |
 | `crates/awaken-tool-pattern/` | Shared glob/regex pattern matching library |
 
 ## Related

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -343,7 +343,7 @@ impl PluginConfigKey for RateLimitConfigKey {
 
 // In plugin register():
 fn register(&self, r: &mut PluginRegistrar) -> Result<(), StateError> {
-    r.register_hook(Phase::BeforeToolExecute, RateLimitHook);
+    r.register_phase_hook("rate_limit", Phase::BeforeToolExecute, RateLimitHook)?;
     Ok(())
 }
 
@@ -369,3 +369,27 @@ if cfg.max_calls_per_step > 0 { /* enforce limit */ }
 ## Related
 
 - [Build an Agent](../how-to/build-an-agent.md)
+
+## ConfigStore
+
+`ConfigStore` is the async persistence contract behind the server-side `/v1/config/*` APIs. Use it when configuration must be created, listed, or updated at runtime instead of being baked into `AgentSpec`.
+
+```rust,ignore
+#[async_trait]
+pub trait ConfigStore: Send + Sync {
+    async fn get(&self, namespace: &str, id: &str) -> Result<Option<Value>, StorageError>;
+    async fn list(
+        &self,
+        namespace: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Value)>, StorageError>;
+    async fn put(&self, namespace: &str, id: &str, value: &Value) -> Result<(), StorageError>;
+    async fn delete(&self, namespace: &str, id: &str) -> Result<(), StorageError>;
+}
+```
+
+Related types:
+
+- `ConfigChangeNotifier` / `ConfigChangeSubscriber` — optional native change notifications
+- `AppState::with_config_store(...)` — enables runtime config routes in `awaken-server`

--- a/docs/book/src/reference/scheduled-actions.md
+++ b/docs/book/src/reference/scheduled-actions.md
@@ -135,34 +135,10 @@ the include-only filter.
 cmd.schedule_action::<IncludeOnlyTools>(vec!["search".into(), "calculator".into()])?;
 ```
 
-### ToolInterceptAction
-
-| | |
-|---|---|
-| **Key** | `tool_intercept` |
-| **Phase** | `BeforeToolExecute` |
-| **Payload** | `ToolInterceptPayload` |
-| **Import** | `awaken_contract::contract::tool_intercept::ToolInterceptAction` |
-
-Intercepts a tool call before execution.  Three outcomes:
-
-| Variant | Effect |
-|---------|--------|
-| `Block { reason }` | Tool execution blocked, run terminates with the reason. |
-| `Suspend(SuspendTicket)` | Tool execution deferred; run pauses awaiting external decision (HITL). |
-| `SetResult(ToolResult)` | Tool execution short-circuited with a pre-built result. |
-
-When multiple intercepts are scheduled, priority is: **Block > Suspend > SetResult**.
-
-**Used by:** permission plugin (ask/deny policies).
-
-```rust,ignore
-use awaken_contract::contract::tool_intercept::{ToolInterceptAction, ToolInterceptPayload};
-
-cmd.schedule_action::<ToolInterceptAction>(
-    ToolInterceptPayload::Block { reason: "Tool is disabled".into() },
-)?;
-```
+> Tool interception is **not** modeled as a scheduled action anymore.
+> Implement `ToolGateHook` and register it with
+> `PluginRegistrar::register_tool_gate_hook()` when you need to block, suspend,
+> or short-circuit tool calls before execution.
 
 ---
 
@@ -216,15 +192,15 @@ cmd.schedule_action::<PromoteToolAction>(vec!["needed_tool".into()])?;
 
 Which plugins **schedule** which actions:
 
-| Plugin | AddContext | SetOverride | Exclude | IncludeOnly | Intercept | Defer | Promote |
-|--------|:---------:|:-----------:|:-------:|:-----------:|:---------:|:-----:|:-------:|
-| **permission** | | | X | | X | | |
+| Plugin | AddContext | SetOverride | Exclude | IncludeOnly | Defer | Promote |
+|--------|:---------:|:-----------:|:-------:|:-----------:|:-----:|:-------:|
+| **permission** | | | X | | | |
 | **skills** | X | | | | | | |
 | **reminder** | X | | | | | | |
-| **deferred-tools** | X | | X | | | X | X |
-| **observability** | | | | | | | |
-| **mcp** | | | | | | | |
-| **generative-ui** | | | | | | | |
+| **deferred-tools** | X | | X | | X | X |
+| **observability** | | | | | | |
+| **mcp** | | | | | | |
+| **generative-ui** | | | | | | |
 
 ---
 

--- a/docs/book/src/reference/tool-trait.md
+++ b/docs/book/src/reference/tool-trait.md
@@ -227,29 +227,40 @@ changing the tool itself.
 ```text
 LLM selects tool
   -> validate_args()
-  -> BeforeToolExecute phase (plugins run hooks)
-     Plugins may schedule ToolInterceptAction:
-       Block    -> run terminates with reason
-       Suspend  -> run pauses (HITL), tool not executed
-       SetResult -> tool skipped, pre-built result used
-  -> execute()                (only if not intercepted)
+  -> ToolGate phase          (pure allow/block/suspend/set-result decision)
+  -> BeforeToolExecute phase (execution-time hooks for allowed calls only)
+  -> execute()               (only if ToolGate allows)
   -> AfterToolExecute phase   (plugins run hooks)
      Plugins observe the ToolResult and may modify state
 ```
 
+### ToolGate
+
+Runs after argument validation and before any execution-time hook. Plugins
+implement `ToolGateHook` and return `Option<ToolInterceptPayload>`:
+
+| Variant | Effect |
+|---------|--------|
+| `Block { reason }` | Terminate the call and fail the run with the reason |
+| `Suspend(SuspendTicket)` | Pause the run and wait for an external decision |
+| `SetResult(ToolResult)` | Skip tool execution and use the provided result |
+
+When multiple gate hooks return a decision, priority is:
+**Block > Suspend > SetResult**.
+
+`ToolGate` is pure and may be re-evaluated after earlier allowed tool calls
+commit new state in the same step.
+
 ### BeforeToolExecute
 
-Runs once per tool call, after argument validation. Plugins receive a
-`PhaseContext` containing the tool name, call ID, and validated arguments.
-Hooks return a `StateCommand` that may schedule `ToolInterceptAction` to
-block, suspend, or short-circuit the call.
-
-When multiple intercepts are scheduled, priority is:
-**Block > Suspend > SetResult**.
+Runs once per tool call batch after `ToolGate` has already allowed the call.
+Plugins receive a `PhaseContext` containing the tool name, call ID, and
+validated arguments. Hooks return a `StateCommand` for execution-time work such
+as counters, throttling state, or observability setup.
 
 ### AfterToolExecute
 
-Runs after `execute()` completes (or after an intercept produces a result).
+Runs after `execute()` completes (or after `ToolGate` supplies a result).
 Plugins receive the `PhaseContext` with the `ToolResult` attached. Hooks can
 update state, emit events, or schedule actions for subsequent phases.
 

--- a/docs/book/src/zh-CN/appendix/glossary.md
+++ b/docs/book/src/zh-CN/appendix/glossary.md
@@ -4,7 +4,7 @@
 |------|------|------|
 | `Thread` | 会话线程 | 持久化的对话与状态历史。 |
 | `Run` | 运行 | 针对某个 thread 的一次执行尝试。 |
-| `Phase` | 阶段 | 执行循环中的命名阶段。 |
+| `Phase` | 阶段 | 执行循环中的命名阶段（`RunStart`、`StepStart`、`BeforeInference`、`AfterInference`、`ToolGate`、`BeforeToolExecute`、`AfterToolExecute`、`StepEnd`、`RunEnd`）。 |
 | `Snapshot` | 快照 | 传给 hook / tool 的不可变状态视图（`struct Snapshot { revision: u64, ext: Arc<StateMap> }`）。 |
 | `StateKey` | 状态键 | 带作用域、合并策略和值类型的类型化键。 |
 | `MutationBatch` | 变更批次 | 在提交前收集的一组状态变更。 |
@@ -14,6 +14,7 @@
 | `Plugin` | 插件 | 通过 `PluginRegistrar` 注册的系统级扩展。 |
 | `PluginRegistrar` | 插件注册器 | 注册 phase hook、tool、state key、handler 的入口。 |
 | `PhaseHook` | 阶段钩子 | 绑定到某个 phase 的异步 hook。 |
+| `ToolGateHook` | 工具闸门钩子 | 在工具真正执行前做纯判定的 hook，可返回放行、阻断、挂起或直接给结果。 |
 | `PhaseContext` | 阶段上下文 | hook 执行时拿到的只读上下文。 |
 | `StateCommand` | 状态命令 | hook 返回值，包含变更、action、effect。 |
 | `Tool` | 工具 | 暴露给 agent 的能力接口。 |

--- a/docs/book/src/zh-CN/appendix/migration-from-tirea.md
+++ b/docs/book/src/zh-CN/appendix/migration-from-tirea.md
@@ -75,6 +75,8 @@ cmd.schedule_action::<AddContextMessage>(
 )?;
 ```
 
+需要拦截工具调用时，不再调度 `ToolInterceptAction`；应实现 `ToolGateHook`，并返回 `ToolInterceptPayload::Block` / `Suspend` / `SetResult`。
+
 ## Plugin Trait
 
 ```rust,ignore
@@ -146,7 +148,7 @@ let runtime = AgentRuntimeBuilder::new()
 - `Global` scope
 - `RuntimeEffect`
 - `EffectLog` / `ScheduledActionLog`
-- `ConfigStore` / `ConfigSlot`
+- `ConfigSlot`
 - `AgentProfile`
 - `ExtensionContext` 的动态激活
 
@@ -154,7 +156,7 @@ let runtime = AgentRuntimeBuilder::new()
 
 - `PluginRegistrar`
 - 带 `StateCommand` 的 `ToolOutput`
-- `ToolInterceptAction`
+- `ToolGateHook`
 - `CircuitBreaker`
 - `Mailbox`
 - `EventReplayBuffer`
@@ -168,6 +170,6 @@ let runtime = AgentRuntimeBuilder::new()
 - [ ] `#[derive(StateSlot)]` 改成 `impl StateKey`
 - [ ] `Extension` 改成 `Plugin`
 - [ ] `TypedTool` 改成 `Tool`
-- [ ] action enum 改成 `cmd.schedule_action::<ActionType>(...)`
+- [ ] action enum 改成 `cmd.schedule_action::<ActionType>(...)`；工具拦截迁到 `ToolGateHook`
 - [ ] `AgentOsBuilder` 改成 `AgentRuntimeBuilder`
 - [ ] store 和 server import 切到 `awaken-stores`、`awaken-server`

--- a/docs/book/src/zh-CN/explanation/architecture.md
+++ b/docs/book/src/zh-CN/explanation/architecture.md
@@ -49,6 +49,7 @@ sequenceDiagram
         LLM-->>Runtime: Response (text + tool_calls)
         Runtime->>Runtime: AfterInference phase
         opt Tool calls present
+            Runtime->>Runtime: ToolGate phase
             Runtime->>Runtime: BeforeToolExecute phase
             Runtime->>Tool: execute(args, ctx)
             Tool-->>Runtime: ToolResult
@@ -67,7 +68,7 @@ sequenceDiagram
 
 ```text
 RunStart -> [StepStart -> BeforeInference -> AfterInference
-             -> BeforeToolExecute -> AfterToolExecute -> StepEnd]* -> RunEnd
+             -> ToolGate -> BeforeToolExecute -> AfterToolExecute -> StepEnd]* -> RunEnd
 ```
 
 步骤循环持续执行，直到以下任一条件触发：

--- a/docs/book/src/zh-CN/explanation/design-tradeoffs.md
+++ b/docs/book/src/zh-CN/explanation/design-tradeoffs.md
@@ -64,7 +64,7 @@
 | 复杂度 | 注册动作较多 | 心智模型简单 |
 | 横切关注点 | 天然契合——每个插件处理一个关注点 | 每个 middleware 处理一个关注点，但会看到全部流量 |
 
-**为什么选 Plugin System**：Awaken 的扩展点并不只在单一调用链上，而是散落在 phase、tool 拦截、state、effects、actions 等多个边界。
+**为什么选 Plugin System**：Awaken 的扩展点并不只在单一调用链上，而是散落在 `ToolGate`、phase、state、effects、actions 等多个边界。
 
 ## Multi-Protocol Server vs Single Protocol
 

--- a/docs/book/src/zh-CN/explanation/plugin-internals.md
+++ b/docs/book/src/zh-CN/explanation/plugin-internals.md
@@ -16,6 +16,7 @@
 
 **行为组件** 仅在插件通过激活过滤器时才处于活跃状态：
 
+- 工具闸门钩子（`register_tool_gate_hook()`）
 - 阶段钩子（`register_phase_hook()`）
 - 工具（`register_tool()`）
 - 请求变换（`register_request_transform()`）
@@ -185,9 +186,9 @@ pub fn merge(&mut self, other: InferenceOverride) {
 
 这允许插件覆盖特定参数而不影响其他参数。成本控制插件可以设置 `max_tokens`，而质量插件设置 `temperature`，两者互不干扰。如果两者设置同一字段，最后一次合并胜出。
 
-## 工具拦截优先级
+## ToolGate 决策优先级
 
-在 `BeforeToolExecute` 阶段，插件可以调度 `ToolInterceptAction` 来控制工具执行流。动作载荷是以下三个变体之一：
+在 `ToolGate` 阶段，插件实现 `ToolGateHook`，返回可选的 `ToolInterceptPayload` 来控制工具执行流：
 
 ```rust,ignore
 pub enum ToolInterceptPayload {
@@ -197,7 +198,7 @@ pub enum ToolInterceptPayload {
 }
 ```
 
-当多个拦截被调度给同一个工具调用时，按隐式优先级解决：
+当多个闸门钩子为同一个工具调用返回决策时，按隐式优先级解决：
 
 | 优先级 | 变体 | 行为 |
 |--------|------|------|
@@ -205,13 +206,13 @@ pub enum ToolInterceptPayload {
 | 2 | `Suspend` | 暂停执行，等待外部决策 |
 | 1（最低） | `SetResult` | 以预定义结果短路返回 |
 
-最高优先级的拦截胜出。如果两个拦截具有相同优先级（例如，两个插件都调度了 `Block`），第一个被处理的生效，冲突被记录为错误。
+最高优先级的决策胜出。如果两个决策具有相同优先级（例如，两个插件都返回了 `Block`），第一个被处理的生效，冲突被记录为错误。
 
-如果没有调度拦截，工具正常执行（隐式放行）。
+如果没有 hook 返回决策，工具正常执行。`ToolGate` 必须保持纯判定，可在同一步内于前序已放行工具提交新状态后被重新评估；`BeforeToolExecute` 只会在最终放行后运行一次。
 
 ```mermaid
 flowchart TD
-    BTE[BeforeToolExecute 钩子运行] --> INT{有调度的拦截？}
+    TG[ToolGate 钩子运行] --> INT{有返回的决策？}
     INT -- 否 --> EXEC[正常执行工具]
     INT -- 是 --> PRI[按优先级解决]
     PRI --> B[Block：使调用失败]

--- a/docs/book/src/zh-CN/explanation/run-lifecycle-and-phases.md
+++ b/docs/book/src/zh-CN/explanation/run-lifecycle-and-phases.md
@@ -1,6 +1,6 @@
 # Run 生命周期与 Phases
 
-本页描述 run 和 tool call 的状态机、8 个 phase、终止条件、checkpoint 触发点，以及挂起 / 恢复如何桥接 run 层与 tool-call 层。
+本页描述 run 和 tool call 的状态机、9 个 phase、终止条件、checkpoint 触发点，以及挂起 / 恢复如何桥接 run 层与 tool-call 层。
 
 ## RunStatus
 
@@ -43,7 +43,7 @@ pub enum ToolCallStatus {
 
 ## Phase Enum
 
-Awaken 的执行顺序由 8 个 phase 固定下来：
+Awaken 的执行顺序由 9 个 phase 固定下来：
 
 ```rust,ignore
 pub enum Phase {
@@ -51,6 +51,7 @@ pub enum Phase {
     StepStart,
     BeforeInference,
     AfterInference,
+    ToolGate,
     BeforeToolExecute,
     AfterToolExecute,
     StepEnd,
@@ -62,7 +63,8 @@ pub enum Phase {
 - `StepStart`：每轮推理开始
 - `BeforeInference`：最后修改推理请求
 - `AfterInference`：观察 LLM 返回，修改工具列表或请求终止
-- `BeforeToolExecute`：权限检查、拦截、挂起
+- `ToolGate`：纯判定阶段，用于 allow / block / suspend / set-result，可在前序 tool 提交状态后重判
+- `BeforeToolExecute`：只对真正要执行的 tool 运行一次，用于执行前副作用
 - `AfterToolExecute`：消费工具结果并触发副作用
 - `StepEnd`：checkpoint 和 stop policy
 - `RunEnd`：清理与最终持久化
@@ -145,16 +147,19 @@ t7    Succeeded      Succeeded      Succeeded      Done
 
 ## 挂起如何桥接 run 层与 tool-call 层
 
-### 当前执行模型（串行 phases）
+### 当前执行模型
 
-当前 `execute_tools_with_interception` 基本分两段：
+当前 step runner 基本分三段：
 
 ```text
-Phase 1 - Intercept:
-  BeforeToolExecute hooks
+Stage 1 - ToolGate:
+  ToolGate hooks
   可能得到 Suspend / Block / SetResult
 
-Phase 2 - Execute:
+Stage 2 - BeforeToolExecute:
+  仅对允许执行的调用运行执行前 hook
+
+Stage 3 - Execute:
   对允许执行的调用做串行或并行执行
 ```
 
@@ -185,7 +190,7 @@ loop {
 | Resume Mode | Replay 参数 | 行为 |
 |---|---|---|
 | `ReplayToolCall` | 原始参数 | 完整重跑 |
-| `UseDecisionAsToolResult` | decision 结果 | 直接作为 tool result |
+| `UseDecisionAsToolResult` | decision 结果 | `ToolGateHook` 在回放时返回 `ToolInterceptPayload::SetResult` |
 | `PassDecisionToTool` | decision 结果 | 作为新参数传给 tool |
 
 ### 局限：执行中到达的 decision

--- a/docs/book/src/zh-CN/explanation/tool-and-plugin-boundary.md
+++ b/docs/book/src/zh-CN/explanation/tool-and-plugin-boundary.md
@@ -18,7 +18,7 @@ pub trait Tool: Send + Sync {
 
 - 用 ID 注册
 - 对 LLM 可见
-- 在 `BeforeToolExecute` / `AfterToolExecute` 窗口执行
+- 会经过 `ToolGate`、`BeforeToolExecute`、真正执行以及 `AfterToolExecute`
 - 只能访问参数和 `ToolCallContext`
 - 适合文件操作、API 调用、数据库查询等业务能力
 
@@ -49,6 +49,7 @@ pub trait Plugin: Send + Sync + 'static {
 | 注册方法 | 用途 |
 |---------------------|------|
 | `register_key::<K>()` | 注册状态键 |
+| `register_tool_gate_hook()` | 注册纯判定的工具拦截钩子 |
 | `register_phase_hook()` | 在指定 phase 添加 hook |
 | `register_tool()` | 向运行时注入插件提供的工具 |
 | `register_effect_handler()` | 处理 effects |
@@ -79,10 +80,10 @@ pub trait Plugin: Send + Sync + 'static {
 
 插件可以影响 tool 执行，而 tool 自己并不需要感知：
 
-- permission 插件可在 `BeforeToolExecute` 阻断或挂起调用
+- permission 插件在 `ToolGate` 决定放行、阻断或挂起调用
 - observability 插件为 tool 执行包裹 trace
 - reminder 插件在工具完成后注入上下文提示
-- interception pipeline 可改参数、替换结果、甚至跳过执行
+- `ToolGate` 可在真正执行前替换结果、阻断调用或直接跳过执行
 
 ## 插件提供的 Tool 与用户 Tool
 

--- a/docs/book/src/zh-CN/how-to/enable-tool-permission-hitl.md
+++ b/docs/book/src/zh-CN/how-to/enable-tool-permission-hitl.md
@@ -46,6 +46,8 @@ let runtime = AgentRuntimeBuilder::new()
     .expect("failed to build runtime");
 ```
 
+permission 插件会注册一个 `ToolGateHook`，在每次工具真正执行前评估规则。
+
 2. 以内联方式定义规则：
 
 ```rust,ignore
@@ -117,7 +119,7 @@ let agent_spec = AgentSpec::new("my-agent")
 
 ## 验证
 
-1. 用一个命中 `deny` 的工具测试，调用应被拦截
+1. 用一个命中 `deny` 的工具测试，调用应在执行前被阻断
 2. 用一个命中 `ask` 的工具测试，run 应进入等待审批状态
 3. 通过 mailbox 接口提交审批
 4. 确认 run 恢复执行
@@ -141,7 +143,7 @@ let agent_spec = AgentSpec::new("my-agent")
 - `crates/awaken-ext-permission/src/config.rs`
 - `crates/awaken-ext-permission/src/rules.rs`
 - `crates/awaken-ext-permission/src/plugin/plugin.rs`
-- `crates/awaken-ext-permission/src/plugin/checker.rs`
+- `crates/awaken-ext-permission/src/plugin/checker.rs`（`PermissionToolGateHook`）
 - `crates/awaken-tool-pattern/`
 
 ## 相关

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -322,3 +322,27 @@ impl PluginConfigKey for RateLimitConfigKey {
 ## 相关
 
 - [构建 Agent](../how-to/build-an-agent.md)
+
+## ConfigStore
+
+`ConfigStore` 是服务端 `/v1/config/*` 路由背后的异步配置持久化契约。适用于需要在运行时创建、列举和更新配置，而不是把配置静态写死在 `AgentSpec` 中的场景。
+
+```rust,ignore
+#[async_trait]
+pub trait ConfigStore: Send + Sync {
+    async fn get(&self, namespace: &str, id: &str) -> Result<Option<Value>, StorageError>;
+    async fn list(
+        &self,
+        namespace: &str,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Value)>, StorageError>;
+    async fn put(&self, namespace: &str, id: &str, value: &Value) -> Result<(), StorageError>;
+    async fn delete(&self, namespace: &str, id: &str) -> Result<(), StorageError>;
+}
+```
+
+相关类型：
+
+- `ConfigChangeNotifier` / `ConfigChangeSubscriber` —— 可选的原生变更通知接口
+- `AppState::with_config_store(...)` —— 为 `awaken-server` 启用运行时配置路由

--- a/docs/book/src/zh-CN/reference/scheduled-actions.md
+++ b/docs/book/src/zh-CN/reference/scheduled-actions.md
@@ -88,25 +88,11 @@ async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput
 
 把当前步骤的工具集合限制为指定白名单。
 
-### ToolInterceptAction
+### 工具拦截
 
-| | |
-|---|---|
-| Key | `tool_intercept` |
-| Phase | `BeforeToolExecute` |
-| Payload | `ToolInterceptPayload` |
-
-在 tool 真正执行前拦截：
-
-| 变体 | 效果 |
-|------|------|
-| `Block { reason }` | 阻断 tool，run 终止 |
-| `Suspend(SuspendTicket)` | 挂起 tool，等待外部决策 |
-| `SetResult(ToolResult)` | 直接使用预构造结果，跳过执行 |
-
-优先级：
-
-`Block > Suspend > SetResult`
+> 工具拦截**不再**通过 scheduled action 实现。
+> 需要在执行前阻断、挂起或直接返回结果时，应实现 `ToolGateHook`
+> 并通过 `PluginRegistrar::register_tool_gate_hook()` 注册。
 
 ## Deferred Tools Actions（awaken-ext-deferred-tools）
 
@@ -132,15 +118,15 @@ async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput
 
 ## 插件 Action 使用矩阵
 
-| 插件 | AddContext | SetOverride | Exclude | IncludeOnly | Intercept | Defer | Promote |
-|--------|:---------:|:-----------:|:-------:|:-----------:|:---------:|:-----:|:-------:|
-| `permission` | | | X | | X | | |
+| 插件 | AddContext | SetOverride | Exclude | IncludeOnly | Defer | Promote |
+|--------|:---------:|:-----------:|:-------:|:-----------:|:-----:|:-------:|
+| `permission` | | | X | | | |
 | `skills` | X | | | | | | |
 | `reminder` | X | | | | | | |
-| `deferred-tools` | X | | X | | | X | X |
-| `observability` | | | | | | | |
-| `mcp` | | | | | | | |
-| `generative-ui` | | | | | | | |
+| `deferred-tools` | X | | X | | X | X |
+| `observability` | | | | | | |
+| `mcp` | | | | | | |
+| `generative-ui` | | | | | | |
 
 ## 定义自定义 action
 

--- a/docs/book/src/zh-CN/reference/tool-trait.md
+++ b/docs/book/src/zh-CN/reference/tool-trait.md
@@ -201,22 +201,32 @@ impl Tool for GetPreferences {
 ```text
 LLM 选择 tool
   -> validate_args()
+  -> ToolGate
+     纯判定：Allow / Block / Suspend / SetResult
   -> BeforeToolExecute
-     插件可调度 ToolInterceptAction:
-       Block
-       Suspend
-       SetResult
+     仅对放行的调用执行一次性钩子
   -> execute()
   -> AfterToolExecute
 ```
 
-### BeforeToolExecute
+### ToolGate
 
-参数校验后运行。插件可以在这里阻断、挂起，或直接提供预构造结果。
+参数校验后首先进入 `ToolGate`。插件实现 `ToolGateHook`，返回
+`Option<ToolInterceptPayload>`，用来决定：
+
+- `Block`
+- `Suspend`
+- `SetResult`
 
 拦截优先级：
 
 `Block > Suspend > SetResult`
+
+`ToolGate` 必须保持纯判定，可在同一步内于前序工具提交新状态后被重新评估。
+
+### BeforeToolExecute
+
+只有在 `ToolGate` 放行后才运行。适合做真正执行前的一次性副作用，例如计数、节流状态写入或观测打点。
 
 ### AfterToolExecute
 


### PR DESCRIPTION
## Summary
- sync README and book docs with the current 9-phase runtime model
- document `ToolGate` as the interception layer and `BeforeToolExecute` as execution-time hooks only
- refresh config, migration, and ADR docs to match the current `ConfigStore` and plugin APIs

## What changed
- updated README / README.zh-CN mental model, dependency example, and plugin guidance
- updated `docs/book/README.zh-CN.md` to match the current public README semantics
- removed scheduled-action docs for legacy `ToolInterceptAction` and pointed interception docs to `ToolGateHook`
- updated lifecycle, plugin, permission, tool, glossary, and migration pages in English and Chinese
- added `ConfigStore` / config notifier coverage to the config reference
- synced ADR-0001, ADR-0007, and ADR-0016 with the ToolGate-based interception model

## Validation
- `bash scripts/build-docs.sh`
