### PR TITLE
✨ feat(runtime): continue text after max tokens

### DIFF
--- a/crates/awaken-contract/src/contract/inference.rs
+++ b/crates/awaken-contract/src/contract/inference.rs
@@ -61,10 +61,18 @@ impl StreamResult {
         extract_text(&self.content)
     }
 
-    /// Whether this result was truncated mid-generation and has incomplete tool
-    /// calls that should be recovered via a continuation prompt.
+    /// Whether this result was truncated mid-generation and should be recovered
+    /// via a continuation prompt.
     pub fn needs_truncation_recovery(&self) -> bool {
-        self.stop_reason == Some(StopReason::MaxTokens) && self.has_incomplete_tool_calls
+        self.stop_reason == Some(StopReason::MaxTokens)
+            && (self.has_incomplete_tool_calls
+                || (self.tool_calls.is_empty() && self.has_text_output()))
+    }
+
+    fn has_text_output(&self) -> bool {
+        self.content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Text { text } if !text.is_empty()))
     }
 }
 
@@ -473,6 +481,18 @@ mod tests {
     }
 
     #[test]
+    fn stream_result_needs_truncation_recovery_for_text_max_tokens() {
+        let result = StreamResult {
+            content: vec![ContentBlock::text("partial answer")],
+            tool_calls: vec![],
+            usage: None,
+            stop_reason: Some(StopReason::MaxTokens),
+            has_incomplete_tool_calls: false,
+        };
+        assert!(result.needs_truncation_recovery());
+    }
+
+    #[test]
     fn stream_result_no_truncation_recovery_end_turn() {
         let result = StreamResult {
             content: vec![],
@@ -489,6 +509,18 @@ mod tests {
         let result = StreamResult {
             content: vec![],
             tool_calls: vec![ToolCall::new("c1", "search", json!({}))],
+            usage: None,
+            stop_reason: Some(StopReason::MaxTokens),
+            has_incomplete_tool_calls: false,
+        };
+        assert!(!result.needs_truncation_recovery());
+    }
+
+    #[test]
+    fn stream_result_no_truncation_recovery_empty_max_tokens() {
+        let result = StreamResult {
+            content: vec![],
+            tool_calls: vec![],
             usage: None,
             stop_reason: Some(StopReason::MaxTokens),
             has_incomplete_tool_calls: false,

--- a/crates/awaken-runtime/src/context/truncation.rs
+++ b/crates/awaken-runtime/src/context/truncation.rs
@@ -1,8 +1,8 @@
 //! Truncation recovery logic for the agent loop.
 //!
-//! When the LLM stops due to `MaxTokens` without emitting complete tool
-//! calls, this module provides helpers to inject a continuation prompt and
-//! re-enter inference.
+//! When the LLM stops due to `MaxTokens` before finishing text output or
+//! complete tool calls, this module provides helpers to inject a continuation
+//! prompt and re-enter inference.
 
 use awaken_contract::contract::inference::StreamResult;
 use awaken_contract::contract::message::{Message, Visibility};
@@ -27,7 +27,7 @@ impl TruncationState {
 ///
 /// Returns `true` (and increments the retry counter) when all three
 /// conditions are met:
-/// 1. The result needs truncation recovery (MaxTokens + incomplete tool calls)
+/// 1. The result needs truncation recovery (MaxTokens + text or incomplete tool calls)
 /// 2. Haven't exceeded the configured max retries
 /// 3. Configured retries > 0
 pub fn should_retry(
@@ -43,7 +43,7 @@ pub fn should_retry(
         tracing::info!(
             retry = state.truncation_retries,
             max = max_retries,
-            "truncation recovery: retrying after MaxTokens with incomplete tool calls"
+            "truncation recovery: retrying after MaxTokens with recoverable output"
         );
         true
     } else {
@@ -61,6 +61,7 @@ pub fn continuation_message() -> Message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use awaken_contract::contract::content::ContentBlock;
     use awaken_contract::contract::inference::{StopReason, TokenUsage};
     use awaken_contract::contract::message::ToolCall;
     use serde_json::json;
@@ -122,9 +123,22 @@ mod tests {
         }
     }
 
-    fn max_tokens_no_incomplete() -> StreamResult {
+    fn max_tokens_without_recoverable_output() -> StreamResult {
         StreamResult {
             content: vec![],
+            tool_calls: vec![],
+            usage: Some(TokenUsage {
+                completion_tokens: Some(4096),
+                ..Default::default()
+            }),
+            stop_reason: Some(StopReason::MaxTokens),
+            has_incomplete_tool_calls: false,
+        }
+    }
+
+    fn max_tokens_with_text() -> StreamResult {
+        StreamResult {
+            content: vec![ContentBlock::text("partial answer")],
             tool_calls: vec![],
             usage: Some(TokenUsage {
                 completion_tokens: Some(4096),
@@ -143,6 +157,13 @@ mod tests {
     fn triggers_retry_on_max_tokens_with_incomplete_tools() {
         let mut state = TruncationState::new();
         assert!(should_retry(&max_tokens_with_incomplete(), &mut state, 3));
+        assert_eq!(state.truncation_retries, 1);
+    }
+
+    #[test]
+    fn triggers_retry_on_max_tokens_with_text_output() {
+        let mut state = TruncationState::new();
+        assert!(should_retry(&max_tokens_with_text(), &mut state, 3));
         assert_eq!(state.truncation_retries, 1);
     }
 
@@ -179,9 +200,13 @@ mod tests {
     }
 
     #[test]
-    fn no_retry_when_max_tokens_but_no_incomplete_tools() {
+    fn no_retry_when_max_tokens_but_no_recoverable_output() {
         let mut state = TruncationState::new();
-        assert!(!should_retry(&max_tokens_no_incomplete(), &mut state, 3));
+        assert!(!should_retry(
+            &max_tokens_without_recoverable_output(),
+            &mut state,
+            3
+        ));
         assert_eq!(state.truncation_retries, 0);
     }
 
@@ -247,7 +272,7 @@ mod tests {
         assert_eq!(state.truncation_retries, 1);
 
         // Another retry
-        should_retry(&max_tokens_with_incomplete(), &mut state, 3);
+        should_retry(&max_tokens_with_text(), &mut state, 3);
         assert_eq!(state.truncation_retries, 2);
     }
 
@@ -267,7 +292,7 @@ mod tests {
     #[test]
     fn truncation_then_tool_use() {
         let mut state = TruncationState::new();
-        assert!(should_retry(&max_tokens_with_incomplete(), &mut state, 3));
+        assert!(should_retry(&max_tokens_with_text(), &mut state, 3));
         assert!(!should_retry(&tool_use_result(), &mut state, 3));
         assert_eq!(state.truncation_retries, 1);
     }

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -1539,6 +1539,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn text_truncation_recovery_continues_on_max_tokens() {
+        let llm = Arc::new(ScriptedLlm::new(vec![
+            StreamResult {
+                content: vec![ContentBlock::text("partial ")],
+                tool_calls: vec![],
+                usage: None,
+                stop_reason: Some(StopReason::MaxTokens),
+                has_incomplete_tool_calls: false,
+            },
+            StreamResult {
+                content: vec![ContentBlock::text("completed")],
+                tool_calls: vec![],
+                usage: None,
+                stop_reason: Some(StopReason::EndTurn),
+                has_incomplete_tool_calls: false,
+            },
+        ]));
+        let resolver = Arc::new(FixedResolver {
+            agent: ResolvedAgent::new("agent", "m", "sys", llm.clone())
+                .with_max_continuation_retries(2),
+            plugins: vec![],
+        });
+        let runtime = AgentRuntime::new(resolver);
+        let sink = Arc::new(VecEventSink::new());
+
+        let result = runtime
+            .run(
+                RunRequest::new("thread-text-trunc", vec![Message::user("hi")])
+                    .with_agent_id("agent"),
+                sink.clone(),
+            )
+            .await
+            .expect("run should succeed");
+
+        assert_eq!(
+            result.termination,
+            awaken_contract::contract::lifecycle::TerminationReason::NaturalEnd
+        );
+        assert_eq!(result.response, "completed");
+        assert_eq!(llm.seen_overrides.lock().expect("lock poisoned").len(), 2);
+
+        let text_deltas: Vec<String> = sink
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                AgentEvent::TextDelta { delta } => Some(delta),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(text_deltas, vec!["partial ", "completed"]);
+    }
+
+    #[tokio::test]
     async fn truncation_recovery_gives_up_after_max_retries() {
         // All calls return MaxTokens with truncated tool calls
         // (the TruncatingLlm always returns truncated on first call,

--- a/docs/book/src/how-to/optimize-context-window.md
+++ b/docs/book/src/how-to/optimize-context-window.md
@@ -126,7 +126,7 @@ Compaction boundaries are tracked durably via `CompactionState`, recording the s
 
 ## Truncation recovery
 
-When the LLM stops due to `MaxTokens` with incomplete tool calls (argument JSON was truncated mid-generation), the runtime can automatically retry by injecting a continuation prompt asking the model to break its work into smaller pieces and continue. The retry count is tracked by `TruncationState` and bounded by a configurable maximum.
+When the LLM stops due to `MaxTokens` after producing partial text or incomplete tool calls (argument JSON was truncated mid-generation), the runtime can automatically retry by injecting a continuation prompt asking the model to break its work into smaller pieces and continue. The retry count is tracked by `TruncationState` and bounded by a configurable maximum.
 
 ## Key Files
 

--- a/docs/book/src/zh-CN/how-to/optimize-context-window.md
+++ b/docs/book/src/zh-CN/how-to/optimize-context-window.md
@@ -114,7 +114,7 @@ let config = CompactionConfig {
 
 ## 截断恢复
 
-如果 LLM 因 `MaxTokens` 截断，而且生成到一半的 tool call 参数不完整，运行时可以自动注入 continuation prompt 并重试，直到达到最大重试次数。
+如果 LLM 因 `MaxTokens` 截断，而且已经产生部分文本或生成到一半的 tool call 参数不完整，运行时可以自动注入 continuation prompt 并重试，直到达到最大重试次数。
 
 ## 关键文件
 


### PR DESCRIPTION
## Summary
- Extend truncation recovery to text-only `max_tokens` stream results.
- Keep complete tool calls on the existing tool execution path.
- Sync existing context-window docs with the recovered-output behavior.

## Design
- Reuses the existing continuation prompt, retry state, and runner path.
- Adds no new config, retry loop, provider fallback, or token escalation.
- Keeps the recovery predicate narrow: incomplete tool calls or non-empty text when `max_tokens` stops generation.

## Tests
- `cargo fmt --check`
- `cargo test -p awaken-contract stream_result -- --nocapture`
- `cargo test -p awaken-runtime truncation -- --nocapture`
- `cargo test -p awaken-agent truncation -- --nocapture`
- `cargo clippy -p awaken-contract -p awaken-runtime --all-targets` (pre-existing warnings only)
- `cargo test -p awaken-contract -p awaken-runtime` (pre-existing warnings only)