### PR TITLE
♻️ refactor(config): simplify provider model bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::engine::GenaiExecutor;
 use awaken::registry_spec::AgentSpec;
-use awaken::registry::ModelEntry;
+use awaken::registry::ModelBinding;
 use awaken::{AgentRuntimeBuilder, RunRequest};
 
 struct EchoTool;
@@ -76,7 +76,7 @@ impl Tool for EchoTool {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent_spec = AgentSpec::new("assistant")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt("You are a helpful assistant. Use the echo tool when asked.")
         .with_max_rounds(5);
 
@@ -84,9 +84,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_agent_spec(agent_spec)
         .with_tool("echo", Arc::new(EchoTool))
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model("gpt-4o-mini", ModelEntry {
-            provider: "openai".into(),
-            model_name: "gpt-4o-mini".into(),
+        .with_model_binding("gpt-4o-mini", ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         })
         .build()?;
 

--- a/crates/awaken-contract/src/contract/executor.rs
+++ b/crates/awaken-contract/src/contract/executor.rs
@@ -10,15 +10,16 @@ use thiserror::Error;
 /// A provider-neutral LLM inference request.
 #[derive(Debug, Clone)]
 pub struct InferenceRequest {
-    /// Model identifier.
-    pub model: String,
+    /// Effective upstream model name sent to the resolved provider executor.
+    pub upstream_model: String,
     /// Messages to send.
     pub messages: Vec<Message>,
     /// Available tools.
     pub tools: Vec<ToolDescriptor>,
     /// System prompt content blocks. Empty means no system prompt.
     pub system: Vec<ContentBlock>,
-    /// Per-inference overrides (temperature, max_tokens, etc).
+    /// Per-inference overrides that remain after runtime routing is applied
+    /// (temperature, max_tokens, fallback upstream models, etc).
     pub overrides: Option<InferenceOverride>,
     /// Whether to apply prompt cache hints (e.g. `CacheControl::Ephemeral`) to system messages.
     pub enable_prompt_cache: bool,
@@ -216,7 +217,7 @@ mod tests {
             tool_calls: vec![],
         };
         let request = InferenceRequest {
-            model: "test-model".into(),
+            upstream_model: "test-model".into(),
             messages: vec![Message::user("hi")],
             tools: vec![],
             system: vec![],
@@ -236,7 +237,7 @@ mod tests {
             tool_calls: vec![ToolCall::new("c1", "search", json!({"q": "rust"}))],
         };
         let request = InferenceRequest {
-            model: "test-model".into(),
+            upstream_model: "test-model".into(),
             messages: vec![Message::user("search for rust")],
             tools: vec![ToolDescriptor::new("search", "search", "Web search")],
             system: vec![ContentBlock::text("You are helpful.")],
@@ -257,12 +258,11 @@ mod tests {
             tool_calls: vec![],
         };
         let request = InferenceRequest {
-            model: "base-model".into(),
+            upstream_model: "base-model".into(),
             messages: vec![],
             tools: vec![],
             system: vec![],
             overrides: Some(InferenceOverride {
-                model: Some("override-model".into()),
                 temperature: Some(0.7),
                 ..Default::default()
             }),

--- a/crates/awaken-contract/src/contract/inference.rs
+++ b/crates/awaken-contract/src/contract/inference.rs
@@ -164,15 +164,6 @@ pub enum ContextCompactionMode {
     CompactToSafeFrontier,
 }
 
-/// Override for model selection during inference.
-#[derive(Debug, Clone)]
-pub struct InferenceModelOverride {
-    /// Primary model identifier.
-    pub model: String,
-    /// Fallback model identifiers.
-    pub fallback_models: Vec<String>,
-}
-
 /// Reasoning effort hint, independent of any LLM provider SDK.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -191,11 +182,16 @@ pub enum ReasoningEffort {
 /// All fields are `Option` — `None` means "use the agent-level default".
 /// Multiple plugins can emit overrides; fields are merged with last-wins semantics.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InferenceOverride {
-    /// Primary model identifier.
-    pub model: Option<String>,
-    /// Fallback model identifiers.
-    pub fallback_models: Option<Vec<String>>,
+    /// Upstream model name to send to the already resolved provider.
+    ///
+    /// This does not re-resolve `AgentSpec.model_id` and therefore does not switch
+    /// providers. Use a different `AgentSpec.model_id` or agent handoff when a run
+    /// must move to another provider.
+    pub upstream_model: Option<String>,
+    /// Upstream fallback model names for the same resolved provider.
+    pub fallback_upstream_models: Option<Vec<String>>,
     /// Sampling temperature.
     pub temperature: Option<f64>,
     /// Maximum output tokens.
@@ -209,8 +205,8 @@ pub struct InferenceOverride {
 impl InferenceOverride {
     /// Returns true if all fields are `None` (no override set).
     pub fn is_empty(&self) -> bool {
-        self.model.is_none()
-            && self.fallback_models.is_none()
+        self.upstream_model.is_none()
+            && self.fallback_upstream_models.is_none()
             && self.temperature.is_none()
             && self.max_tokens.is_none()
             && self.top_p.is_none()
@@ -219,11 +215,11 @@ impl InferenceOverride {
 
     /// Merge `other` into `self` with last-wins semantics per field.
     pub fn merge(&mut self, other: InferenceOverride) {
-        if other.model.is_some() {
-            self.model = other.model;
+        if other.upstream_model.is_some() {
+            self.upstream_model = other.upstream_model;
         }
-        if other.fallback_models.is_some() {
-            self.fallback_models = other.fallback_models;
+        if other.fallback_upstream_models.is_some() {
+            self.fallback_upstream_models = other.fallback_upstream_models;
         }
         if other.temperature.is_some() {
             self.temperature = other.temperature;
@@ -236,20 +232,6 @@ impl InferenceOverride {
         }
         if other.reasoning_effort.is_some() {
             self.reasoning_effort = other.reasoning_effort;
-        }
-    }
-}
-
-impl From<InferenceModelOverride> for InferenceOverride {
-    fn from(m: InferenceModelOverride) -> Self {
-        Self {
-            model: Some(m.model),
-            fallback_models: if m.fallback_models.is_empty() {
-                None
-            } else {
-                Some(m.fallback_models)
-            },
-            ..Default::default()
         }
     }
 }
@@ -314,16 +296,16 @@ mod tests {
     #[test]
     fn inference_override_merge_last_wins() {
         let mut base = InferenceOverride {
-            model: Some("model-a".into()),
+            upstream_model: Some("model-a".into()),
             temperature: Some(0.5),
             ..Default::default()
         };
         base.merge(InferenceOverride {
-            model: Some("model-b".into()),
+            upstream_model: Some("model-b".into()),
             reasoning_effort: Some(ReasoningEffort::High),
             ..Default::default()
         });
-        assert_eq!(base.model.as_deref(), Some("model-b"));
+        assert_eq!(base.upstream_model.as_deref(), Some("model-b"));
         assert_eq!(base.temperature, Some(0.5));
         assert_eq!(base.reasoning_effort, Some(ReasoningEffort::High));
     }
@@ -341,25 +323,25 @@ mod tests {
     }
 
     #[test]
-    fn from_model_override_converts_correctly() {
-        let model_ovr = InferenceModelOverride {
-            model: "claude-sonnet".into(),
-            fallback_models: vec!["claude-haiku".into()],
+    fn inference_override_uses_canonical_names() {
+        let canonical = InferenceOverride {
+            upstream_model: Some("gpt-4o".into()),
+            fallback_upstream_models: Some(vec!["gpt-4o-mini".into()]),
+            ..Default::default()
         };
-        let ovr: InferenceOverride = model_ovr.into();
-        assert_eq!(ovr.model.as_deref(), Some("claude-sonnet"));
-        assert_eq!(ovr.fallback_models, Some(vec!["claude-haiku".into()]));
-        assert!(ovr.temperature.is_none());
+
+        let encoded = serde_json::to_value(&canonical).unwrap();
+        assert_eq!(encoded["upstream_model"], "gpt-4o");
+        assert_eq!(encoded["fallback_upstream_models"][0], "gpt-4o-mini");
     }
 
     #[test]
-    fn from_model_override_empty_fallbacks() {
-        let model_ovr = InferenceModelOverride {
-            model: "gpt-4o".into(),
-            fallback_models: vec![],
-        };
-        let ovr: InferenceOverride = model_ovr.into();
-        assert!(ovr.fallback_models.is_none());
+    fn inference_override_rejects_legacy_model_fields() {
+        let legacy = serde_json::from_value::<InferenceOverride>(json!({
+            "model": "gpt-4o",
+            "fallback_models": ["gpt-4o-mini"]
+        }));
+        assert!(legacy.is_err());
     }
 
     #[test]
@@ -560,9 +542,9 @@ mod tests {
     }
 
     #[test]
-    fn inference_override_not_empty_with_model() {
+    fn inference_override_not_empty_with_upstream_model() {
         let ovr = InferenceOverride {
-            model: Some("model-a".into()),
+            upstream_model: Some("model-a".into()),
             ..Default::default()
         };
         assert!(!ovr.is_empty());
@@ -605,9 +587,9 @@ mod tests {
     }
 
     #[test]
-    fn inference_override_not_empty_with_fallback_models() {
+    fn inference_override_not_empty_with_fallback_upstream_models() {
         let ovr = InferenceOverride {
-            fallback_models: Some(vec!["m1".into()]),
+            fallback_upstream_models: Some(vec!["m1".into()]),
             ..Default::default()
         };
         assert!(!ovr.is_empty());
@@ -761,14 +743,14 @@ mod tests {
     // ── InferenceOverride merge tests (migrated from uncarve) ──
 
     #[test]
-    fn inference_override_merge_fallback_models() {
+    fn inference_override_merge_fallback_upstream_models() {
         let mut base = InferenceOverride::default();
         base.merge(InferenceOverride {
-            fallback_models: Some(vec!["model-a".into(), "model-b".into()]),
+            fallback_upstream_models: Some(vec!["model-a".into(), "model-b".into()]),
             ..Default::default()
         });
         assert_eq!(
-            base.fallback_models,
+            base.fallback_upstream_models,
             Some(vec!["model-a".into(), "model-b".into()])
         );
     }

--- a/crates/awaken-contract/src/lib.rs
+++ b/crates/awaken-contract/src/lib.rs
@@ -37,8 +37,8 @@ pub use model::{
 
 // ── registry spec (AgentSpec, PluginConfigKey) ──
 pub use registry_spec::{
-    AgentSpec, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelSpec, PluginConfigKey,
-    ProviderSpec,
+    AgentSpec, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelBindingSpec,
+    PluginConfigKey, ProviderSpec,
 };
 
 // ── state ──

--- a/crates/awaken-contract/src/registry_spec.rs
+++ b/crates/awaken-contract/src/registry_spec.rs
@@ -1,7 +1,7 @@
 //! Serializable agent definition — pure data, no trait objects.
 //!
 //! `AgentSpec` is the unified agent configuration: it describes both the
-//! declarative registry references (model, plugins, tools) and the runtime
+//! declarative registry references (model binding, plugins, tools) and the runtime
 //! behavior (active_hook_filter filtering, typed plugin sections, context policy).
 //!
 //! Supersedes the former `AgentProfile` — see ADR-0009.
@@ -57,11 +57,12 @@ pub trait PluginConfigKey: 'static + Send + Sync {
 /// Also serves as the runtime behavior configuration passed to hooks via
 /// `PhaseContext.agent_spec`. Plugins read their typed config via `spec.config::<K>()`.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct AgentSpec {
     /// Unique agent identifier.
     pub id: String,
-    /// ModelRegistry ID — resolved to a [`super::traits::ModelEntry`].
-    pub model: String,
+    /// ModelRegistry ID — resolved to a runtime model binding.
+    pub model_id: String,
     /// System prompt sent to the LLM.
     pub system_prompt: String,
     /// Maximum inference rounds before the agent stops.
@@ -250,18 +251,19 @@ impl<'de> Deserialize<'de> for RemoteEndpoint {
 }
 
 // ---------------------------------------------------------------------------
-// ModelSpec
+// ModelBindingSpec
 // ---------------------------------------------------------------------------
 
-/// Serializable model definition mapping a stable ID to a provider and model name.
+/// Serializable model binding from a stable ID to a provider and upstream model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct ModelSpec {
+#[serde(deny_unknown_fields)]
+pub struct ModelBindingSpec {
     /// Unique identifier (for example `"gpt-4o-mini"` or `"research-default"`).
     pub id: String,
-    /// Provider spec ID referenced by this model.
-    pub provider: String,
+    /// Provider spec ID referenced by this binding.
+    pub provider_id: String,
     /// Actual model name sent to the upstream provider.
-    pub model: String,
+    pub upstream_model: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -414,7 +416,7 @@ impl Default for AgentSpec {
     fn default() -> Self {
         Self {
             id: String::new(),
-            model: String::new(),
+            model_id: String::new(),
             system_prompt: String::new(),
             max_rounds: default_max_rounds(),
             max_continuation_retries: default_max_continuation_retries(),
@@ -449,11 +451,11 @@ impl AgentSpec {
     /// use awaken_contract::registry_spec::AgentSpec;
     ///
     /// let spec = AgentSpec::new("assistant")
-    ///     .with_model("gpt-4o-mini")
+    ///     .with_model_id("gpt-4o-mini")
     ///     .with_system_prompt("You are helpful.")
     ///     .with_max_rounds(10);
     /// assert_eq!(spec.id, "assistant");
-    /// assert_eq!(spec.model, "gpt-4o-mini");
+    /// assert_eq!(spec.model_id, "gpt-4o-mini");
     /// assert_eq!(spec.system_prompt, "You are helpful.");
     /// assert_eq!(spec.max_rounds, 10);
     /// ```
@@ -494,8 +496,8 @@ impl AgentSpec {
     // -- Builder methods --
 
     #[must_use]
-    pub fn with_model(mut self, model: impl Into<String>) -> Self {
-        self.model = model.into();
+    pub fn with_model_id(mut self, model_id: impl Into<String>) -> Self {
+        self.model_id = model_id.into();
         self
     }
 
@@ -561,7 +563,7 @@ mod tests {
     fn agent_spec_serde_roundtrip() {
         let spec = AgentSpec {
             id: "coder".into(),
-            model: "claude-opus".into(),
+            model_id: "claude-opus".into(),
             system_prompt: "You are a coding assistant.".into(),
             max_rounds: 8,
             plugin_ids: vec!["permission".into(), "logging".into()],
@@ -579,7 +581,7 @@ mod tests {
         let parsed: AgentSpec = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(parsed.id, "coder");
-        assert_eq!(parsed.model, "claude-opus");
+        assert_eq!(parsed.model_id, "claude-opus");
         assert_eq!(parsed.system_prompt, "You are a coding assistant.");
         assert_eq!(parsed.max_rounds, 8);
         assert_eq!(parsed.plugin_ids, vec!["permission", "logging"]);
@@ -593,9 +595,10 @@ mod tests {
 
     #[test]
     fn agent_spec_defaults() {
-        let json_str = r#"{"id":"min","model":"m","system_prompt":"sp"}"#;
+        let json_str = r#"{"id":"min","model_id":"m","system_prompt":"sp"}"#;
         let spec: AgentSpec = serde_json::from_str(json_str).unwrap();
 
+        assert_eq!(spec.model_id, "m");
         assert_eq!(spec.max_rounds, 16);
         assert_eq!(spec.max_continuation_retries, 2);
         assert!(spec.context_policy.is_none());
@@ -604,6 +607,35 @@ mod tests {
         assert!(spec.allowed_tools.is_none());
         assert!(spec.excluded_tools.is_none());
         assert!(spec.sections.is_empty());
+    }
+
+    #[test]
+    fn model_binding_spec_uses_canonical_names() {
+        let canonical = ModelBindingSpec {
+            id: "default".into(),
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
+        };
+
+        let encoded = serde_json::to_value(&canonical).unwrap();
+        assert_eq!(encoded["provider_id"], "openai");
+        assert_eq!(encoded["upstream_model"], "gpt-4o-mini");
+        assert!(encoded.get("provider").is_none());
+        assert!(encoded.get("model").is_none());
+    }
+
+    #[test]
+    fn provider_model_legacy_fields_are_rejected() {
+        let agent =
+            serde_json::from_str::<AgentSpec>(r#"{"id":"min","model":"m","system_prompt":"sp"}"#);
+        assert!(agent.is_err());
+
+        let model = serde_json::from_value::<ModelBindingSpec>(json!({
+            "id": "default",
+            "provider": "openai",
+            "model": "gpt-4o-mini"
+        }));
+        assert!(model.is_err());
     }
 
     // -- Typed config tests (merged from AgentProfile) --
@@ -663,7 +695,7 @@ mod tests {
     #[test]
     fn config_serializes_to_json() {
         let spec = AgentSpec::new("coder")
-            .with_model("sonnet")
+            .with_model_id("sonnet")
             .with_config::<ModelNameKey>(ModelNameConfig {
                 name: "custom".into(),
             })
@@ -673,7 +705,7 @@ mod tests {
         let parsed: AgentSpec = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.id, "coder");
-        assert_eq!(parsed.model, "sonnet");
+        assert_eq!(parsed.model_id, "sonnet");
 
         let model: ModelNameConfig = parsed.config::<ModelNameKey>().unwrap();
         assert_eq!(model.name, "custom");
@@ -777,7 +809,7 @@ mod tests {
     #[test]
     fn builder() {
         let spec = AgentSpec::new("reviewer")
-            .with_model("claude-opus")
+            .with_model_id("claude-opus")
             .with_hook_filter("permission")
             .with_config::<PermKey>(PermConfig {
                 mode: "strict".into(),
@@ -785,7 +817,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(spec.id, "reviewer");
-        assert_eq!(spec.model, "claude-opus");
+        assert_eq!(spec.model_id, "claude-opus");
         assert!(spec.active_hook_filter.contains("permission"));
     }
 }

--- a/crates/awaken-contract/tests/contract_integration.rs
+++ b/crates/awaken-contract/tests/contract_integration.rs
@@ -3,8 +3,8 @@
 use awaken_contract::contract::content::ContentBlock;
 use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::inference::{
-    ContextCompactionMode, ContextWindowPolicy, InferenceError, InferenceModelOverride,
-    InferenceOverride, LLMResponse, ReasoningEffort, StopReason, StreamResult, TokenUsage,
+    ContextCompactionMode, ContextWindowPolicy, InferenceError, InferenceOverride, LLMResponse,
+    ReasoningEffort, StopReason, StreamResult, TokenUsage,
 };
 use awaken_contract::contract::lifecycle::TerminationReason;
 use awaken_contract::contract::message::{Message, MessageMetadata, Role, ToolCall, Visibility};
@@ -390,15 +390,14 @@ fn stream_result_to_message_to_event_pipeline() {
 // ── InferenceOverride cross-module compatibility ───────────────────
 
 #[test]
-fn inference_override_from_model_override_merges_with_params() {
-    let model = InferenceModelOverride {
-        model: "claude-opus".into(),
-        fallback_models: vec!["claude-sonnet".into()],
+fn inference_override_merges_upstream_model_and_params() {
+    let mut combined = InferenceOverride {
+        upstream_model: Some("claude-opus".into()),
+        fallback_upstream_models: Some(vec!["claude-sonnet".into()]),
+        ..Default::default()
     };
-
-    let mut combined = InferenceOverride::from(model);
     assert!(!combined.is_empty());
-    assert_eq!(combined.model.as_deref(), Some("claude-opus"));
+    assert_eq!(combined.upstream_model.as_deref(), Some("claude-opus"));
 
     // Merge with parameter overrides
     combined.merge(InferenceOverride {
@@ -408,11 +407,14 @@ fn inference_override_from_model_override_merges_with_params() {
         ..Default::default()
     });
 
-    assert_eq!(combined.model.as_deref(), Some("claude-opus"));
+    assert_eq!(combined.upstream_model.as_deref(), Some("claude-opus"));
     assert_eq!(combined.temperature, Some(0.7));
     assert_eq!(combined.max_tokens, Some(4096));
     assert_eq!(combined.reasoning_effort, Some(ReasoningEffort::High));
-    assert_eq!(combined.fallback_models, Some(vec!["claude-sonnet".into()]));
+    assert_eq!(
+        combined.fallback_upstream_models,
+        Some(vec!["claude-sonnet".into()])
+    );
 }
 
 #[test]

--- a/crates/awaken-ext-mcp/src/sampling.rs
+++ b/crates/awaken-ext-mcp/src/sampling.rs
@@ -29,17 +29,17 @@ pub trait SamplingHandler: Send + Sync {
 /// the response back to MCP format.
 pub struct DefaultSamplingHandler {
     executor: Arc<dyn LlmExecutor>,
-    model: String,
+    upstream_model: String,
 }
 
 impl DefaultSamplingHandler {
     /// Create a new handler backed by the given LLM executor.
     ///
-    /// `model` is the default model identifier used for inference requests.
-    pub fn new(executor: Arc<dyn LlmExecutor>, model: impl Into<String>) -> Self {
+    /// `upstream_model` is the model name sent to the configured executor.
+    pub fn new(executor: Arc<dyn LlmExecutor>, upstream_model: impl Into<String>) -> Self {
         Self {
             executor,
-            model: model.into(),
+            upstream_model: upstream_model.into(),
         }
     }
 
@@ -135,7 +135,7 @@ impl SamplingHandler for DefaultSamplingHandler {
         };
 
         let request = InferenceRequest {
-            model: self.model.clone(),
+            upstream_model: self.upstream_model.clone(),
             messages,
             tools: vec![],
             system,
@@ -148,7 +148,7 @@ impl SamplingHandler for DefaultSamplingHandler {
                 McpTransportError::TransportError(format!("LLM execution failed: {e}"))
             })?;
 
-        Ok(Self::convert_result(&result, &self.model))
+        Ok(Self::convert_result(&result, &self.upstream_model))
     }
 }
 

--- a/crates/awaken-runtime/src/builder.rs
+++ b/crates/awaken-runtime/src/builder.rs
@@ -19,7 +19,7 @@ use crate::registry::memory::{
     MapAgentSpecRegistry, MapModelRegistry, MapPluginSource, MapProviderRegistry, MapToolRegistry,
 };
 use crate::registry::snapshot::RegistryHandle;
-use crate::registry::traits::{AgentSpecRegistry, ModelEntry, RegistrySet};
+use crate::registry::traits::{AgentSpecRegistry, ModelBinding, RegistrySet};
 use crate::runtime::AgentRuntime;
 
 /// Error returned when the builder cannot construct the runtime.
@@ -118,9 +118,9 @@ impl AgentRuntimeBuilder {
         self
     }
 
-    /// Register a model entry by ID.
-    pub fn with_model(mut self, id: impl Into<String>, entry: ModelEntry) -> Self {
-        if let Err(e) = self.models.register_model(id, entry) {
+    /// Register a model binding by ID.
+    pub fn with_model_binding(mut self, id: impl Into<String>, binding: ModelBinding) -> Self {
+        if let Err(e) = self.models.register_model(id, binding) {
             self.errors.push(e);
         }
         self
@@ -335,12 +335,12 @@ mod tests {
         }
     }
 
-    fn make_registry_set(agent_id: &str, model_id: &str, model_name: &str) -> RegistrySet {
+    fn make_registry_set(agent_id: &str, model_id: &str, upstream_model: &str) -> RegistrySet {
         let mut agents = MapAgentSpecRegistry::new();
         agents
             .register_spec(AgentSpec {
                 id: agent_id.into(),
-                model: model_id.into(),
+                model_id: model_id.into(),
                 system_prompt: format!("system-{agent_id}"),
                 ..Default::default()
             })
@@ -350,9 +350,9 @@ mod tests {
         models
             .register_model(
                 model_id,
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: model_name.into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: upstream_model.into(),
                 },
             )
             .expect("register test model");
@@ -376,7 +376,7 @@ mod tests {
     fn builder_creates_runtime() {
         let spec = AgentSpec {
             id: "test-agent".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "You are helpful.".into(),
             ..Default::default()
         };
@@ -384,11 +384,11 @@ mod tests {
         let runtime = AgentRuntimeBuilder::new()
             .with_agent_spec(spec)
             .with_tool("echo", Arc::new(MockTool { id: "echo".into() }))
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider("mock", Arc::new(MockExecutor))
@@ -409,24 +409,24 @@ mod tests {
     fn builder_with_multiple_agents() {
         let spec1 = AgentSpec {
             id: "agent-1".into(),
-            model: "m".into(),
+            model_id: "m".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         };
         let spec2 = AgentSpec {
             id: "agent-2".into(),
-            model: "m".into(),
+            model_id: "m".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         };
 
         let runtime = AgentRuntimeBuilder::new()
             .with_agent_specs(vec![spec1, spec2])
-            .with_model(
+            .with_model_binding(
                 "m",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .with_provider("p", Arc::new(MockExecutor))
@@ -442,7 +442,7 @@ mod tests {
     fn builder_resolver_returns_correct_config() {
         let spec = AgentSpec {
             id: "my-agent".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "Be helpful.".into(),
             max_rounds: 10,
             ..Default::default()
@@ -456,11 +456,11 @@ mod tests {
                     id: "search".into(),
                 }),
             )
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "claude-test".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "claude-test".into(),
                 },
             )
             .with_provider("mock", Arc::new(MockExecutor))
@@ -469,7 +469,7 @@ mod tests {
 
         let resolved = runtime.resolver().resolve("my-agent").unwrap();
         assert_eq!(resolved.id(), "my-agent");
-        assert_eq!(resolved.model, "claude-test");
+        assert_eq!(resolved.upstream_model, "claude-test");
         assert_eq!(resolved.system_prompt(), "Be helpful.");
         assert_eq!(resolved.max_rounds(), 10);
         assert!(resolved.tools.contains_key("search"));
@@ -478,11 +478,11 @@ mod tests {
     #[test]
     fn builder_missing_agent_errors() {
         let runtime = AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "m",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .with_provider("p", Arc::new(MockExecutor))
@@ -527,7 +527,7 @@ mod tests {
     fn builder_chained_tools_all_registered() {
         let spec = AgentSpec {
             id: "agent".into(),
-            model: "m".into(),
+            model_id: "m".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         };
@@ -537,11 +537,11 @@ mod tests {
             .with_tool("t1", Arc::new(MockTool { id: "t1".into() }))
             .with_tool("t2", Arc::new(MockTool { id: "t2".into() }))
             .with_tool("t3", Arc::new(MockTool { id: "t3".into() }))
-            .with_model(
+            .with_model_binding(
                 "m",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .with_provider("p", Arc::new(MockExecutor))
@@ -558,7 +558,7 @@ mod tests {
     fn build_catches_missing_model() {
         let spec = AgentSpec {
             id: "bad-agent".into(),
-            model: "nonexistent-model".into(),
+            model_id: "nonexistent-model".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         };
@@ -579,18 +579,18 @@ mod tests {
     fn build_succeeds_with_valid_config() {
         let spec = AgentSpec {
             id: "good-agent".into(),
-            model: "m".into(),
+            model_id: "m".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         };
 
         let result = AgentRuntimeBuilder::new()
             .with_agent_spec(spec)
-            .with_model(
+            .with_model_binding(
                 "m",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .with_provider("p", Arc::new(MockExecutor))
@@ -604,15 +604,15 @@ mod tests {
         let runtime = AgentRuntimeBuilder::new()
             .with_agent_spec(AgentSpec {
                 id: "versioned-agent".into(),
-                model: "m".into(),
+                model_id: "m".into(),
                 system_prompt: "sys".into(),
                 ..Default::default()
             })
-            .with_model(
+            .with_model_binding(
                 "m",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "model-v1".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "model-v1".into(),
                 },
             )
             .with_provider("mock", Arc::new(MockExecutor))
@@ -628,15 +628,15 @@ mod tests {
         let runtime = AgentRuntimeBuilder::new()
             .with_agent_spec(AgentSpec {
                 id: "agent-v1".into(),
-                model: "m".into(),
+                model_id: "m".into(),
                 system_prompt: "sys".into(),
                 ..Default::default()
             })
-            .with_model(
+            .with_model_binding(
                 "m",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "model-v1".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "model-v1".into(),
                 },
             )
             .with_provider("mock", Arc::new(MockExecutor))
@@ -656,25 +656,25 @@ mod tests {
 
         let resolved = runtime.resolver().resolve("agent-v2").unwrap();
         assert_eq!(resolved.id(), "agent-v2");
-        assert_eq!(resolved.model, "model-v2");
+        assert_eq!(resolved.upstream_model, "model-v2");
     }
 
     #[test]
-    fn builder_model_entry_provider_name() {
+    fn builder_model_binding_provider_name() {
         let spec = AgentSpec {
             id: "agent".into(),
-            model: "gpt-4".into(),
+            model_id: "gpt-4".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         };
 
         let runtime = AgentRuntimeBuilder::new()
             .with_agent_spec(spec)
-            .with_model(
+            .with_model_binding(
                 "gpt-4",
-                ModelEntry {
-                    provider: "openai".into(),
-                    model_name: "gpt-4-turbo".into(),
+                ModelBinding {
+                    provider_id: "openai".into(),
+                    upstream_model: "gpt-4-turbo".into(),
                 },
             )
             .with_provider("openai", Arc::new(MockExecutor))
@@ -682,8 +682,8 @@ mod tests {
             .unwrap();
 
         let resolved = runtime.resolver().resolve("agent").unwrap();
-        // The model should be resolved to the actual model name
-        assert_eq!(resolved.model, "gpt-4-turbo");
+        // The model ID should resolve to the upstream model name
+        assert_eq!(resolved.upstream_model, "gpt-4-turbo");
     }
 
     #[test]
@@ -734,7 +734,7 @@ mod tests {
     fn duplicate_agent_spec_errors_at_build() {
         let spec = AgentSpec {
             id: "dup-agent".into(),
-            model: "m".into(),
+            model_id: "m".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         };
@@ -742,11 +742,11 @@ mod tests {
         let result = AgentRuntimeBuilder::new()
             .with_agent_spec(spec.clone())
             .with_agent_spec(spec)
-            .with_model(
+            .with_model_binding(
                 "m",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .with_provider("p", Arc::new(MockExecutor))
@@ -796,18 +796,18 @@ mod tests {
     #[test]
     fn duplicate_model_errors_at_build() {
         let result = AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "dup-model",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n1".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n1".into(),
                 },
             )
-            .with_model(
+            .with_model_binding(
                 "dup-model",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n2".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n2".into(),
                 },
             )
             .build();

--- a/crates/awaken-runtime/src/context/summarizer.rs
+++ b/crates/awaken-runtime/src/context/summarizer.rs
@@ -85,7 +85,7 @@ impl ContextSummarizer for DefaultSummarizer {
         let model = self.config.summary_model.clone().unwrap_or_default();
 
         let request = awaken_contract::contract::executor::InferenceRequest {
-            model,
+            upstream_model: model,
             messages: vec![
                 Message::system(&self.config.summarizer_system_prompt),
                 Message::user(user_prompt),

--- a/crates/awaken-runtime/src/engine/executor.rs
+++ b/crates/awaken-runtime/src/engine/executor.rs
@@ -186,7 +186,7 @@ impl LlmExecutor for GenaiExecutor {
         &self,
         request: InferenceRequest,
     ) -> Result<StreamResult, InferenceExecutionError> {
-        let model = request.model.clone();
+        let model = request.upstream_model.clone();
         let tools: Vec<_> = request.tools.clone();
         let chat_req = build_chat_request(
             &request.system,
@@ -253,7 +253,7 @@ impl LlmExecutor for GenaiExecutor {
         >,
     > {
         Box::pin(async move {
-            let model = request.model.clone();
+            let model = request.upstream_model.clone();
             let tools: Vec<_> = request.tools.clone();
             let chat_req = build_chat_request(
                 &request.system,
@@ -355,7 +355,7 @@ mod tests {
     /// Helper to build a minimal `InferenceRequest` with the given overrides.
     fn make_request(overrides: Option<InferenceOverride>) -> InferenceRequest {
         InferenceRequest {
-            model: "test-model".into(),
+            upstream_model: "test-model".into(),
             messages: vec![Message::user("hello")],
             tools: vec![],
             system: vec![],

--- a/crates/awaken-runtime/src/engine/mock.rs
+++ b/crates/awaken-runtime/src/engine/mock.rs
@@ -81,7 +81,7 @@ mod tests {
 
     fn make_request() -> InferenceRequest {
         InferenceRequest {
-            model: "mock".into(),
+            upstream_model: "mock".into(),
             messages: vec![Message::user("hello")],
             tools: vec![],
             system: vec![],

--- a/crates/awaken-runtime/src/engine/retry.rs
+++ b/crates/awaken-runtime/src/engine/retry.rs
@@ -1,4 +1,4 @@
-//! LLM retry policy with exponential backoff and optional model fallback.
+//! LLM retry policy with exponential backoff and optional upstream model fallback.
 //!
 //! Provides [`LlmRetryPolicy`] for configuring retry behavior and
 //! [`RetryingExecutor`] which wraps any [`LlmExecutor`] to apply the policy.
@@ -21,11 +21,12 @@ const MAX_BACKOFF_MS: u64 = 8_000;
 
 /// Policy for retrying failed LLM inference.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct LlmRetryPolicy {
     /// Maximum number of retry attempts (0 = no retry, only the initial attempt).
     pub max_retries: u32,
-    /// Fallback model names to try in order after the primary model exhausts retries.
-    pub fallback_models: Vec<String>,
+    /// Fallback upstream model names to try after the primary upstream model exhausts retries.
+    pub fallback_upstream_models: Vec<String>,
     /// Base delay in milliseconds for exponential backoff between retries.
     /// Actual delay = min(base_ms * 2^attempt, 8000ms). Set to 0 to disable backoff.
     #[serde(default = "default_backoff_base_ms")]
@@ -40,7 +41,7 @@ impl Default for LlmRetryPolicy {
     fn default() -> Self {
         Self {
             max_retries: 2,
-            fallback_models: Vec::new(),
+            fallback_upstream_models: Vec::new(),
             backoff_base_ms: default_backoff_base_ms(),
         }
     }
@@ -61,9 +62,9 @@ impl LlmRetryPolicy {
         self
     }
 
-    /// Append a fallback model name.
-    pub fn with_fallback_model(mut self, model: impl Into<String>) -> Self {
-        self.fallback_models.push(model.into());
+    /// Append a fallback upstream model name.
+    pub fn with_fallback_upstream_model(mut self, upstream_model: impl Into<String>) -> Self {
+        self.fallback_upstream_models.push(upstream_model.into());
         self
     }
 
@@ -103,7 +104,7 @@ fn is_retryable(err: &InferenceExecutionError) -> bool {
 ///
 /// On transient failure the wrapper retries the inner executor up to
 /// `policy.max_retries` times for the primary model, then tries each
-/// fallback model with the same retry budget.
+/// fallback upstream model with the same retry budget.
 pub struct RetryingExecutor {
     inner: Arc<dyn LlmExecutor>,
     policy: LlmRetryPolicy,
@@ -136,19 +137,19 @@ impl RetryingExecutor {
         for attempt in 0..=self.policy.max_retries {
             // Check circuit breaker before each attempt.
             if let Some(ref cb) = self.circuit_breaker {
-                cb.check(&request.model)?;
+                cb.check(&request.upstream_model)?;
             }
 
             match self.inner.execute(request.clone()).await {
                 Ok(result) => {
                     if let Some(ref cb) = self.circuit_breaker {
-                        cb.record_success(&request.model);
+                        cb.record_success(&request.upstream_model);
                     }
                     return Ok(result);
                 }
                 Err(err) => {
                     if let Some(ref cb) = self.circuit_breaker {
-                        cb.record_failure(&request.model);
+                        cb.record_failure(&request.upstream_model);
                     }
                     if !is_retryable(&err) {
                         return Err(err);
@@ -168,6 +169,59 @@ impl RetryingExecutor {
 
         Err(last_error.expect("at least one attempt was made"))
     }
+
+    fn fallback_upstream_models_for_request(&self, request: &InferenceRequest) -> Vec<String> {
+        request
+            .overrides
+            .as_ref()
+            .and_then(|overrides| overrides.fallback_upstream_models.clone())
+            .unwrap_or_else(|| self.policy.fallback_upstream_models.clone())
+    }
+
+    /// Attempt to open a streaming response with retries for one model variant.
+    ///
+    /// Retries apply only while creating the stream. Once a provider has returned
+    /// a stream, retrying later stream-item errors would duplicate already
+    /// emitted deltas, so those errors are surfaced to the caller.
+    async fn try_stream_with_retries(
+        &self,
+        request: &InferenceRequest,
+    ) -> Result<InferenceStream, InferenceExecutionError> {
+        let mut last_error = None;
+
+        for attempt in 0..=self.policy.max_retries {
+            if let Some(ref cb) = self.circuit_breaker {
+                cb.check(&request.upstream_model)?;
+            }
+
+            match self.inner.execute_stream(request.clone()).await {
+                Ok(stream) => {
+                    if let Some(ref cb) = self.circuit_breaker {
+                        cb.record_success(&request.upstream_model);
+                    }
+                    return Ok(stream);
+                }
+                Err(err) => {
+                    if let Some(ref cb) = self.circuit_breaker {
+                        cb.record_failure(&request.upstream_model);
+                    }
+                    if !is_retryable(&err) {
+                        return Err(err);
+                    }
+                    last_error = Some(err);
+                    if attempt == self.policy.max_retries {
+                        break;
+                    }
+                    let delay = self.policy.backoff_delay(attempt);
+                    if !delay.is_zero() {
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_error.expect("at least one stream attempt was made"))
+    }
 }
 
 #[async_trait]
@@ -176,25 +230,27 @@ impl LlmExecutor for RetryingExecutor {
         &self,
         request: InferenceRequest,
     ) -> Result<StreamResult, InferenceExecutionError> {
+        let fallback_upstream_models = self.fallback_upstream_models_for_request(&request);
+
         // Try primary model.
         match self.try_with_retries(&request).await {
             Ok(result) => return Ok(result),
-            Err(err) if !is_retryable(&err) || self.policy.fallback_models.is_empty() => {
+            Err(err) if !is_retryable(&err) || fallback_upstream_models.is_empty() => {
                 return Err(err);
             }
             Err(_) => {}
         }
 
-        // Try fallback models in order.
+        // Try fallback upstream models in order.
         let mut last_error = None;
-        for (i, fallback_model) in self.policy.fallback_models.iter().enumerate() {
+        for (i, fallback_upstream_model) in fallback_upstream_models.iter().enumerate() {
             let mut fallback_request = request.clone();
-            fallback_request.model = fallback_model.clone();
+            fallback_request.upstream_model = fallback_upstream_model.clone();
 
             match self.try_with_retries(&fallback_request).await {
                 Ok(result) => return Ok(result),
                 Err(err) => {
-                    let is_last = i == self.policy.fallback_models.len() - 1;
+                    let is_last = i == fallback_upstream_models.len() - 1;
                     if !is_retryable(&err) || is_last {
                         last_error = Some(err);
                         break;
@@ -217,7 +273,37 @@ impl LlmExecutor for RetryingExecutor {
                 + '_,
         >,
     > {
-        self.inner.execute_stream(request)
+        Box::pin(async move {
+            let fallback_upstream_models = self.fallback_upstream_models_for_request(&request);
+
+            match self.try_stream_with_retries(&request).await {
+                Ok(stream) => return Ok(stream),
+                Err(err) if !is_retryable(&err) || fallback_upstream_models.is_empty() => {
+                    return Err(err);
+                }
+                Err(_) => {}
+            }
+
+            let mut last_error = None;
+            for (i, fallback_upstream_model) in fallback_upstream_models.iter().enumerate() {
+                let mut fallback_request = request.clone();
+                fallback_request.upstream_model = fallback_upstream_model.clone();
+
+                match self.try_stream_with_retries(&fallback_request).await {
+                    Ok(stream) => return Ok(stream),
+                    Err(err) => {
+                        let is_last = i == fallback_upstream_models.len() - 1;
+                        if !is_retryable(&err) || is_last {
+                            last_error = Some(err);
+                            break;
+                        }
+                        last_error = Some(err);
+                    }
+                }
+            }
+
+            Err(last_error.expect("at least one stream fallback was attempted"))
+        })
     }
 
     fn name(&self) -> &str {
@@ -237,7 +323,7 @@ impl awaken_contract::registry_spec::PluginConfigKey for RetryConfigKey {
 mod tests {
     use super::*;
     use awaken_contract::contract::content::ContentBlock;
-    use awaken_contract::contract::inference::{StopReason, TokenUsage};
+    use awaken_contract::contract::inference::{InferenceOverride, StopReason, TokenUsage};
     use awaken_contract::contract::message::Message;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -289,7 +375,7 @@ mod tests {
 
     fn test_request() -> InferenceRequest {
         InferenceRequest {
-            model: "primary-model".into(),
+            upstream_model: "primary-model".into(),
             messages: vec![Message::user("hello")],
             tools: vec![],
             system: vec![],
@@ -342,7 +428,10 @@ mod tests {
             &self,
             request: InferenceRequest,
         ) -> Result<StreamResult, InferenceExecutionError> {
-            self.models.lock().unwrap().push(request.model.clone());
+            self.models
+                .lock()
+                .unwrap()
+                .push(request.upstream_model.clone());
             match &self.error {
                 InferenceExecutionError::Provider(s) => {
                     Err(InferenceExecutionError::Provider(s.clone()))
@@ -411,14 +500,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fallback_model_used_after_primary_exhausts_retries() {
+    async fn fallback_upstream_model_used_after_primary_exhausts_retries() {
         let inner = Arc::new(ModelRecorder::always_fail_with(
             InferenceExecutionError::RateLimited("overloaded".into()),
         ));
         let policy = test_policy()
             .with_max_retries(1)
-            .with_fallback_model("fallback-a")
-            .with_fallback_model("fallback-b");
+            .with_fallback_upstream_model("fallback-a")
+            .with_fallback_upstream_model("fallback-b");
         let executor = RetryingExecutor::new(inner.clone(), policy);
 
         let result = executor.execute(test_request()).await;
@@ -438,11 +527,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_override_fallback_upstream_models_replace_policy_fallbacks() {
+        let inner = Arc::new(ModelRecorder::always_fail_with(
+            InferenceExecutionError::RateLimited("overloaded".into()),
+        ));
+        let policy = test_policy()
+            .with_max_retries(0)
+            .with_fallback_upstream_model("policy-fallback");
+        let executor = RetryingExecutor::new(inner.clone(), policy);
+
+        let mut request = test_request();
+        request.overrides = Some(InferenceOverride {
+            fallback_upstream_models: Some(vec!["override-fallback".into()]),
+            ..Default::default()
+        });
+
+        let result = executor.execute(request).await;
+        assert!(result.is_err());
+
+        assert_eq!(
+            inner.recorded_models(),
+            vec!["primary-model", "override-fallback"]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_stream_retries_stream_start_until_success() {
+        let inner = Arc::new(FailNThenSucceed::new(1));
+        let policy = test_policy().with_max_retries(2);
+        let executor = RetryingExecutor::new(inner.clone(), policy);
+
+        let result = executor.execute_stream(test_request()).await;
+        assert!(result.is_ok());
+        assert_eq!(inner.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn execute_stream_uses_request_override_fallback_upstream_models() {
+        let inner = Arc::new(ModelRecorder::always_fail_with(
+            InferenceExecutionError::RateLimited("overloaded".into()),
+        ));
+        let policy = test_policy()
+            .with_max_retries(0)
+            .with_fallback_upstream_model("policy-fallback");
+        let executor = RetryingExecutor::new(inner.clone(), policy);
+
+        let mut request = test_request();
+        request.overrides = Some(InferenceOverride {
+            fallback_upstream_models: Some(vec!["override-fallback".into()]),
+            ..Default::default()
+        });
+
+        let result = executor.execute_stream(request).await;
+        assert!(result.is_err());
+
+        assert_eq!(
+            inner.recorded_models(),
+            vec!["primary-model", "override-fallback"]
+        );
+    }
+
+    #[tokio::test]
     async fn fallback_succeeds_after_primary_fails() {
         let inner = Arc::new(FailNThenSucceed::new(3));
         let policy = test_policy()
             .with_max_retries(1)
-            .with_fallback_model("fallback-model");
+            .with_fallback_upstream_model("fallback-model");
         let executor = RetryingExecutor::new(inner.clone(), policy);
 
         let result = executor.execute(test_request()).await;
@@ -485,7 +635,7 @@ mod tests {
                 request: InferenceRequest,
             ) -> Result<StreamResult, InferenceExecutionError> {
                 let n = self.calls.fetch_add(1, Ordering::SeqCst);
-                if request.model.starts_with("primary") {
+                if request.upstream_model.starts_with("primary") {
                     Err(InferenceExecutionError::Provider("down".into()))
                 } else {
                     let _ = n;
@@ -501,8 +651,8 @@ mod tests {
         let inner = Arc::new(PrimaryRetryableFallbackFatal { calls: cc });
         let policy = test_policy()
             .with_max_retries(0)
-            .with_fallback_model("fallback-a")
-            .with_fallback_model("fallback-b");
+            .with_fallback_upstream_model("fallback-a")
+            .with_fallback_upstream_model("fallback-b");
         let executor = RetryingExecutor::new(inner, policy);
 
         let result = executor.execute(test_request()).await;
@@ -515,7 +665,7 @@ mod tests {
     fn default_policy_values() {
         let policy = LlmRetryPolicy::default();
         assert_eq!(policy.max_retries, 2);
-        assert!(policy.fallback_models.is_empty());
+        assert!(policy.fallback_upstream_models.is_empty());
         assert_eq!(policy.backoff_base_ms, 500);
     }
 
@@ -523,7 +673,7 @@ mod tests {
     fn no_retry_policy_values() {
         let policy = LlmRetryPolicy::no_retry();
         assert_eq!(policy.max_retries, 0);
-        assert!(policy.fallback_models.is_empty());
+        assert!(policy.fallback_upstream_models.is_empty());
     }
 
     #[test]
@@ -556,11 +706,11 @@ mod tests {
     fn builder_methods_chain() {
         let policy = LlmRetryPolicy::default()
             .with_max_retries(5)
-            .with_fallback_model("model-a")
-            .with_fallback_model("model-b")
+            .with_fallback_upstream_model("model-a")
+            .with_fallback_upstream_model("model-b")
             .with_backoff_base_ms(100);
         assert_eq!(policy.max_retries, 5);
-        assert_eq!(policy.fallback_models, vec!["model-a", "model-b"]);
+        assert_eq!(policy.fallback_upstream_models, vec!["model-a", "model-b"]);
         assert_eq!(policy.backoff_base_ms, 100);
     }
 
@@ -684,7 +834,7 @@ mod tests {
         let inner = Arc::new(FailNThenSucceed::new(1)); // primary fails, fallback succeeds
         let policy = test_policy()
             .with_max_retries(0)
-            .with_fallback_model("fallback");
+            .with_fallback_upstream_model("fallback");
         let executor = RetryingExecutor::new(inner.clone(), policy);
 
         let result = executor.execute(test_request()).await;
@@ -693,10 +843,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_fallbacks_configured_returns_primary_error() {
+    async fn no_fallback_upstream_models_configured_returns_primary_error() {
         let inner = Arc::new(FailNThenSucceed::new(100));
         let policy = test_policy().with_max_retries(1);
-        // No fallback models
+        // No fallback upstream models
         let executor = RetryingExecutor::new(inner.clone(), policy);
 
         let result = executor.execute(test_request()).await;
@@ -739,7 +889,7 @@ mod tests {
         let inner = Arc::new(FailNThenSucceed::new(0)); // never fails
         let policy = test_policy()
             .with_max_retries(3)
-            .with_fallback_model("fallback-a");
+            .with_fallback_upstream_model("fallback-a");
         let executor = RetryingExecutor::new(inner.clone(), policy);
 
         let result = executor.execute(test_request()).await;
@@ -756,22 +906,32 @@ mod tests {
     fn retry_policy_serde_roundtrip() {
         let policy = LlmRetryPolicy::default()
             .with_max_retries(5)
-            .with_fallback_model("fallback-a")
-            .with_fallback_model("fallback-b")
+            .with_fallback_upstream_model("fallback-a")
+            .with_fallback_upstream_model("fallback-b")
             .with_backoff_base_ms(200);
         let json = serde_json::to_string(&policy).unwrap();
         let parsed: LlmRetryPolicy = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.max_retries, 5);
-        assert_eq!(parsed.fallback_models, vec!["fallback-a", "fallback-b"]);
+        assert_eq!(
+            parsed.fallback_upstream_models,
+            vec!["fallback-a", "fallback-b"]
+        );
         assert_eq!(parsed.backoff_base_ms, 200);
     }
 
     #[test]
     fn retry_policy_serde_default_backoff() {
         // Deserializing without backoff_base_ms should use the default.
-        let json = r#"{"max_retries":2,"fallback_models":[]}"#;
+        let json = r#"{"max_retries":2,"fallback_upstream_models":[]}"#;
         let parsed: LlmRetryPolicy = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.backoff_base_ms, 500);
+    }
+
+    #[test]
+    fn retry_policy_rejects_legacy_fallback_field() {
+        let json = r#"{"max_retries":2,"fallback_models":[]}"#;
+        let parsed = serde_json::from_str::<LlmRetryPolicy>(json);
+        assert!(parsed.is_err());
     }
 
     #[tokio::test]
@@ -840,7 +1000,7 @@ mod tests {
         let inner = Arc::new(FailNThenSucceed::new(0));
         let policy = test_policy()
             .with_max_retries(0)
-            .with_fallback_model("fallback-model");
+            .with_fallback_upstream_model("fallback-model");
         let executor = RetryingExecutor::new(inner.clone(), policy).with_circuit_breaker(cb);
 
         let result = executor.execute(test_request()).await;
@@ -892,14 +1052,14 @@ mod tests {
             ) {
                 let policy = LlmRetryPolicy {
                     max_retries,
-                    fallback_models: (0..num_fallbacks).map(|i| format!("model-{i}")).collect(),
+                    fallback_upstream_models: (0..num_fallbacks).map(|i| format!("model-{i}")).collect(),
                     backoff_base_ms,
                 };
                 let json = serde_json::to_string(&policy).unwrap();
                 let parsed: LlmRetryPolicy = serde_json::from_str(&json).unwrap();
                 prop_assert_eq!(parsed.max_retries, max_retries);
                 prop_assert_eq!(parsed.backoff_base_ms, backoff_base_ms);
-                prop_assert_eq!(parsed.fallback_models.len(), num_fallbacks);
+                prop_assert_eq!(parsed.fallback_upstream_models.len(), num_fallbacks);
             }
 
             #[test]

--- a/crates/awaken-runtime/src/extensions/a2a/local_backend.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/local_backend.rs
@@ -194,7 +194,7 @@ mod tests {
                 id.to_string(),
                 AgentSpec {
                     id: id.into(),
-                    model: "test-model".into(),
+                    model_id: "test-model".into(),
                     system_prompt: "system".into(),
                     ..Default::default()
                 },
@@ -219,7 +219,7 @@ mod tests {
                 })?;
             let mut agent = ResolvedAgent::new(
                 &spec.id,
-                &spec.model,
+                &spec.model_id,
                 &spec.system_prompt,
                 Arc::new(MockExecutor),
             );

--- a/crates/awaken-runtime/src/extensions/a2a/tests.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/tests.rs
@@ -31,7 +31,7 @@ impl MockResolver {
             id.to_string(),
             AgentSpec {
                 id: id.into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "sys".into(),
                 ..Default::default()
             },
@@ -72,7 +72,7 @@ impl AgentResolver for MockResolver {
             })?;
         let mut agent = ResolvedAgent::new(
             &spec.id,
-            &spec.model,
+            &spec.model_id,
             &spec.system_prompt,
             Arc::new(MockExecutor),
         );
@@ -420,7 +420,7 @@ fn mock_resolver_with_multiple_agents() {
         "writer".to_string(),
         AgentSpec {
             id: "writer".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         },
@@ -429,7 +429,7 @@ fn mock_resolver_with_multiple_agents() {
         "reviewer".to_string(),
         AgentSpec {
             id: "reviewer".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "sys".into(),
             ..Default::default()
         },

--- a/crates/awaken-runtime/src/extensions/handoff/mod.rs
+++ b/crates/awaken-runtime/src/extensions/handoff/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! 1. `HandoffState` tracks active and requested agent variants.
 //! 2. `HandoffPlugin` reads state and applies agent overlays dynamically.
-//! 3. `AgentOverlay` defines per-variant overrides (system prompt, model, tools).
+//! 3. `AgentOverlay` defines per-variant overrides (system prompt, model ID, tools).
 //!
 //! No run termination or re-resolution occurs — handoff is instant.
 

--- a/crates/awaken-runtime/src/extensions/handoff/tests.rs
+++ b/crates/awaken-runtime/src/extensions/handoff/tests.rs
@@ -142,7 +142,7 @@ fn overlay_lookup() {
     overlays.insert(
         "fast".to_string(),
         AgentOverlay {
-            model: Some("claude-haiku".into()),
+            model_id: Some("claude-haiku".into()),
             system_prompt: Some("You are in fast mode.".into()),
             ..Default::default()
         },
@@ -292,7 +292,7 @@ fn action_all_variants_serialization() {
 fn overlay_default_is_all_none() {
     let overlay = AgentOverlay::default();
     assert!(overlay.system_prompt.is_none());
-    assert!(overlay.model.is_none());
+    assert!(overlay.model_id.is_none());
     assert!(overlay.allowed_tools.is_none());
     assert!(overlay.excluded_tools.is_none());
 }
@@ -301,14 +301,14 @@ fn overlay_default_is_all_none() {
 fn overlay_serialization_roundtrip() {
     let overlay = AgentOverlay {
         system_prompt: Some("You are helpful".into()),
-        model: Some("gpt-4".into()),
+        model_id: Some("gpt-4".into()),
         allowed_tools: Some(vec!["search".into(), "read".into()]),
         excluded_tools: Some(vec!["delete".into()]),
     };
     let json = serde_json::to_value(&overlay).unwrap();
     let back: AgentOverlay = serde_json::from_value(json).unwrap();
     assert_eq!(back.system_prompt.as_deref(), Some("You are helpful"));
-    assert_eq!(back.model.as_deref(), Some("gpt-4"));
+    assert_eq!(back.model_id.as_deref(), Some("gpt-4"));
     assert_eq!(back.allowed_tools.as_ref().unwrap().len(), 2);
     assert_eq!(back.excluded_tools.as_ref().unwrap().len(), 1);
 }
@@ -319,24 +319,24 @@ fn plugin_overlay_returns_configured_overlay() {
     overlays.insert(
         "fast".to_string(),
         AgentOverlay {
-            model: Some("haiku".into()),
+            model_id: Some("haiku".into()),
             ..Default::default()
         },
     );
     overlays.insert(
         "deep".to_string(),
         AgentOverlay {
-            model: Some("opus".into()),
+            model_id: Some("opus".into()),
             ..Default::default()
         },
     );
     let plugin = HandoffPlugin::new(overlays);
     assert_eq!(
-        plugin.overlay("fast").unwrap().model.as_deref(),
+        plugin.overlay("fast").unwrap().model_id.as_deref(),
         Some("haiku")
     );
     assert_eq!(
-        plugin.overlay("deep").unwrap().model.as_deref(),
+        plugin.overlay("deep").unwrap().model_id.as_deref(),
         Some("opus")
     );
     assert!(plugin.overlay("nonexistent").is_none());

--- a/crates/awaken-runtime/src/extensions/handoff/types.rs
+++ b/crates/awaken-runtime/src/extensions/handoff/types.rs
@@ -4,13 +4,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// Each field, when `Some`, overrides the base agent configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentOverlay {
     /// Override the system prompt.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system_prompt: Option<String>,
-    /// Override the model ID.
+    /// Override the model registry ID.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
+    pub model_id: Option<String>,
     /// Whitelist of allowed tool IDs (None = all tools allowed).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,

--- a/crates/awaken-runtime/src/hooks/context.rs
+++ b/crates/awaken-runtime/src/hooks/context.rs
@@ -200,12 +200,12 @@ mod tests {
     fn phase_context_with_agent_spec() {
         let spec = Arc::new(
             AgentSpec::new("reviewer")
-                .with_model("opus")
+                .with_model_id("opus")
                 .with_hook_filter("perm"),
         );
         let ctx = PhaseContext::new(Phase::RunStart, empty_snapshot()).with_agent_spec(spec);
         assert_eq!(ctx.agent_spec.id, "reviewer");
-        assert_eq!(ctx.agent_spec.model, "opus");
+        assert_eq!(ctx.agent_spec.model_id, "opus");
         assert!(ctx.agent_spec.active_hook_filter.contains("perm"));
     }
 

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -309,7 +309,7 @@ mod tests {
 
     fn make_request() -> InferenceRequest {
         InferenceRequest {
-            model: "test-model".into(),
+            upstream_model: "test-model".into(),
             messages: vec![Message::user("hello")],
             tools: vec![],
             system: vec![],

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -227,6 +227,7 @@ async fn recover_truncation(
     transform_arcs: &[std::sync::Arc<
         dyn awaken_contract::contract::transform::InferenceRequestTransform,
     >],
+    overrides: Option<InferenceOverride>,
 ) -> Result<StreamResult, AgentLoopError> {
     while should_retry(
         &stream_result,
@@ -249,13 +250,14 @@ async fn recover_truncation(
             &ctx.agent.tool_descriptors(),
             transform_arcs,
         );
+        let upstream_model = effective_upstream_model(ctx.agent, overrides.as_ref())?;
 
         let cont_request = InferenceRequest {
-            model: ctx.agent.model.clone(),
+            upstream_model,
             messages: cont_messages,
             tools: ctx.agent.tool_descriptors(),
             system: vec![],
-            overrides: ctx.run_overrides.clone(),
+            overrides: executor_overrides(overrides.clone()),
             enable_prompt_cache: false,
         };
 
@@ -270,6 +272,33 @@ async fn recover_truncation(
         .await?;
     }
     Ok(stream_result)
+}
+
+fn effective_upstream_model(
+    agent: &ResolvedAgent,
+    overrides: Option<&InferenceOverride>,
+) -> Result<String, AgentLoopError> {
+    let Some(upstream_model) = overrides.and_then(|overrides| overrides.upstream_model.as_ref())
+    else {
+        return Ok(agent.upstream_model.clone());
+    };
+    if upstream_model.trim().is_empty() {
+        return Err(AgentLoopError::InferenceFailed(
+            "inference override upstream_model cannot be empty".into(),
+        ));
+    }
+    Ok(upstream_model.clone())
+}
+
+fn executor_overrides(mut overrides: Option<InferenceOverride>) -> Option<InferenceOverride> {
+    if let Some(overrides) = overrides.as_mut() {
+        // The primary upstream model is applied to `InferenceRequest.upstream_model`.
+        // Keeping it in `InferenceRequest.overrides` would give executors two
+        // sources of truth for the same routing decision.
+        overrides.upstream_model = None;
+    }
+
+    overrides.filter(|overrides| !overrides.is_empty())
 }
 
 /// Run the BeforeInference phase via collect_commands, submit all actions to
@@ -360,14 +389,19 @@ async fn run_before_inference(
     ))
 }
 
+struct InferencePhaseOutput {
+    stream_result: StreamResult,
+    duration_ms: u64,
+    upstream_model: String,
+}
+
 /// Run the inference phase: compaction, request building, streaming.
-/// Returns the stream result and wall-clock duration in milliseconds.
 async fn run_inference_phase(
     ctx: &mut StepContext<'_>,
     overrides: Option<InferenceOverride>,
     exclusion_payloads: Vec<String>,
     inclusion_payloads: Vec<Vec<String>>,
-) -> Result<(StreamResult, u64), AgentLoopError> {
+) -> Result<InferencePhaseOutput, AgentLoopError> {
     let store = ctx.runtime.store();
 
     // LLM compaction
@@ -408,12 +442,13 @@ async fn run_inference_phase(
         .agent
         .context_policy()
         .is_some_and(|p| p.enable_prompt_cache);
+    let request_upstream_model = effective_upstream_model(ctx.agent, overrides.as_ref())?;
     let request = InferenceRequest {
-        model: ctx.agent.model.clone(),
+        upstream_model: request_upstream_model.clone(),
         messages: request_messages,
         tools,
         system: vec![],
-        overrides,
+        overrides: executor_overrides(overrides.clone()),
         enable_prompt_cache,
     };
 
@@ -429,18 +464,22 @@ async fn run_inference_phase(
     .await?;
 
     // Truncation recovery (separated from main inference for clarity)
-    let stream_result = recover_truncation(ctx, stream_result, &transform_arcs).await?;
+    let stream_result = recover_truncation(ctx, stream_result, &transform_arcs, overrides).await?;
 
     let duration_ms = start.elapsed().as_millis() as u64;
     tracing::info!(
-        model = %ctx.agent.model,
+        model = %request_upstream_model,
         input_tokens = *ctx.total_input_tokens,
         output_tokens = *ctx.total_output_tokens,
         duration_ms,
         "inference_complete"
     );
 
-    Ok((stream_result, duration_ms))
+    Ok(InferencePhaseOutput {
+        stream_result,
+        duration_ms,
+        upstream_model: request_upstream_model,
+    })
 }
 
 /// Run ToolGate hooks for a tool call and resolve the winning decision.
@@ -1095,14 +1134,19 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
     }
 
     // --- Inference ---
-    let (stream_result, duration_ms) =
+    let inference =
         run_inference_phase(ctx, overrides, exclusion_payloads, inclusion_payloads).await?;
+    let InferencePhaseOutput {
+        stream_result,
+        duration_ms,
+        upstream_model,
+    } = inference;
 
     // --- Post-inference cancellation check ---
     if ctx.cancellation_token.is_some_and(|t| t.is_cancelled()) {
         ctx.sink
             .emit(AgentEvent::InferenceComplete {
-                model: ctx.agent.model.clone(),
+                model: upstream_model.clone(),
                 usage: stream_result.usage.clone(),
                 duration_ms,
             })
@@ -1118,7 +1162,7 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
     }
     ctx.sink
         .emit(AgentEvent::InferenceComplete {
-            model: ctx.agent.model.clone(),
+            model: upstream_model,
             usage: stream_result.usage.clone(),
             duration_ms,
         })

--- a/crates/awaken-runtime/src/loop_runner/tests.rs
+++ b/crates/awaken-runtime/src/loop_runner/tests.rs
@@ -612,7 +612,7 @@ fn exclude_nonexistent_tool_is_harmless() {
 #[test]
 fn inference_override_state_merges_correctly() {
     let ovr1 = awaken_contract::contract::inference::InferenceOverride {
-        model: Some("gpt-4".into()),
+        upstream_model: Some("gpt-4".into()),
         temperature: Some(0.7),
         ..Default::default()
     };
@@ -627,7 +627,7 @@ fn inference_override_state_merges_correctly() {
     InferenceOverrideState::apply(&mut val, InferenceOverrideStateAction::Merge(ovr2));
 
     let ovr = val.overrides.expect("should have overrides");
-    assert_eq!(ovr.model.as_deref(), Some("gpt-4"));
+    assert_eq!(ovr.upstream_model.as_deref(), Some("gpt-4"));
     assert_eq!(ovr.temperature, Some(0.9)); // last-wins
     assert_eq!(ovr.max_tokens, Some(1000));
 }
@@ -639,7 +639,7 @@ fn inference_override_state_clear_resets() {
         &mut val,
         InferenceOverrideStateAction::Merge(
             awaken_contract::contract::inference::InferenceOverride {
-                model: Some("gpt-4".into()),
+                upstream_model: Some("gpt-4".into()),
                 ..Default::default()
             },
         ),
@@ -651,7 +651,7 @@ fn inference_override_state_clear_resets() {
 #[test]
 fn inference_override_merge_helper_works() {
     let ovr1 = awaken_contract::contract::inference::InferenceOverride {
-        model: Some("gpt-4".into()),
+        upstream_model: Some("gpt-4".into()),
         temperature: Some(0.7),
         ..Default::default()
     };
@@ -664,7 +664,7 @@ fn inference_override_merge_helper_works() {
     let mut overrides = None;
     merge_override_payloads(&mut overrides, vec![ovr1, ovr2]);
     let ovr = overrides.expect("should have overrides");
-    assert_eq!(ovr.model.as_deref(), Some("gpt-4"));
+    assert_eq!(ovr.upstream_model.as_deref(), Some("gpt-4"));
     assert_eq!(ovr.temperature, Some(0.9)); // last-wins
     assert_eq!(ovr.max_tokens, Some(1000));
 }

--- a/crates/awaken-runtime/src/registry/composite.rs
+++ b/crates/awaken-runtime/src/registry/composite.rs
@@ -233,7 +233,7 @@ fn agent_card_to_spec(
             .clone()
             .unwrap_or_else(|| slugify_agent_name(&card.name)),
         // Remote agents don't need a local model — they run on the remote server.
-        model: String::new(),
+        model_id: String::new(),
         system_prompt: card.description.clone(),
         endpoint: Some(RemoteEndpoint {
             backend: "a2a".into(),
@@ -302,7 +302,7 @@ mod tests {
         let mut reg = MapAgentSpecRegistry::new();
         reg.register_spec(AgentSpec {
             id: "local-agent".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "Local agent.".into(),
             ..Default::default()
         })
@@ -344,7 +344,7 @@ mod tests {
                     "cloud".into(),
                     AgentSpec {
                         id: "remote-coder".into(),
-                        model: String::new(),
+                        model_id: String::new(),
                         system_prompt: "A remote coding agent.".into(),
                         endpoint: Some(RemoteEndpoint {
                             base_url: "https://remote.example.com".into(),
@@ -376,7 +376,7 @@ mod tests {
                     "cloud".into(),
                     AgentSpec {
                         id: "local-agent".into(),
-                        model: String::new(),
+                        model_id: String::new(),
                         system_prompt: "Remote version.".into(),
                         endpoint: Some(RemoteEndpoint {
                             base_url: "https://remote.example.com".into(),

--- a/crates/awaken-runtime/src/registry/config.rs
+++ b/crates/awaken-runtime/src/registry/config.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use awaken_contract::contract::executor::LlmExecutor;
+use awaken_contract::registry_spec::{AgentSpec, ModelBindingSpec};
 
 use crate::builder::BuildError;
 
@@ -20,7 +21,7 @@ use super::memory::MapBackendRegistry;
 use super::memory::{
     MapAgentSpecRegistry, MapModelRegistry, MapPluginSource, MapProviderRegistry, MapToolRegistry,
 };
-use super::traits::{ModelEntry, RegistrySet};
+use super::traits::{ModelBinding, RegistrySet};
 
 /// Serializable system configuration covering models and agents.
 ///
@@ -28,21 +29,12 @@ use super::traits::{ModelEntry, RegistrySet};
 /// that cannot be deserialized. Pass them to [`AgentSystemConfig::build_registries`] instead.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSystemConfig {
-    /// Model definitions keyed by model ID.
+    /// Model bindings.
     #[serde(default)]
-    pub models: HashMap<String, ModelConfig>,
+    pub models: Vec<ModelBindingSpec>,
     /// Agent definitions.
     #[serde(default)]
-    pub agents: Vec<awaken_contract::registry_spec::AgentSpec>,
-}
-
-/// Maps a model ID to a provider and the actual model name for API calls.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelConfig {
-    /// Provider ID — must match a key in the `providers` map passed to `build_registries`.
-    pub provider: String,
-    /// Actual model name sent to the LLM API.
-    pub model: String,
+    pub agents: Vec<AgentSpec>,
 }
 
 impl AgentSystemConfig {
@@ -59,14 +51,8 @@ impl AgentSystemConfig {
         providers: HashMap<String, Arc<dyn LlmExecutor>>,
     ) -> Result<RegistrySet, BuildError> {
         let mut model_reg = MapModelRegistry::new();
-        for (id, cfg) in &self.models {
-            model_reg.register_model(
-                id.clone(),
-                ModelEntry {
-                    provider: cfg.provider.clone(),
-                    model_name: cfg.model.clone(),
-                },
-            )?;
+        for binding in &self.models {
+            model_reg.register_model(binding.id.clone(), ModelBinding::from(binding))?;
         }
 
         let mut agent_reg = MapAgentSpecRegistry::new();
@@ -95,52 +81,52 @@ impl AgentSystemConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use awaken_contract::registry_spec::AgentSpec;
     use serde_json::json;
 
     #[test]
     fn parse_minimal_config() {
         let json = json!({
-            "models": {
-                "gpt4": {
-                    "provider": "openai",
-                    "model": "gpt-4o"
+            "models": [
+                {
+                    "id": "gpt4",
+                    "provider_id": "openai",
+                    "upstream_model": "gpt-4o"
                 }
-            },
+            ],
             "agents": [{
                 "id": "assistant",
-                "model": "gpt4",
+                "model_id": "gpt4",
                 "system_prompt": "You are helpful."
             }]
         });
 
         let config = AgentSystemConfig::from_json(&json.to_string()).unwrap();
         assert_eq!(config.models.len(), 1);
-        assert_eq!(config.models["gpt4"].provider, "openai");
-        assert_eq!(config.models["gpt4"].model, "gpt-4o");
+        assert_eq!(config.models[0].provider_id, "openai");
+        assert_eq!(config.models[0].upstream_model, "gpt-4o");
         assert_eq!(config.agents.len(), 1);
         assert_eq!(config.agents[0].id, "assistant");
-        assert_eq!(config.agents[0].model, "gpt4");
+        assert_eq!(config.agents[0].model_id, "gpt4");
     }
 
     #[test]
     fn parse_multiple_agents() {
         let json = json!({
-            "models": {
-                "claude": { "provider": "anthropic", "model": "claude-opus-4-0-20250514" },
-                "local": { "provider": "ollama", "model": "llama3" }
-            },
+            "models": [
+                { "id": "claude", "provider_id": "anthropic", "upstream_model": "claude-opus-4-0-20250514" },
+                { "id": "local", "provider_id": "ollama", "upstream_model": "llama3" }
+            ],
             "agents": [
                 {
                     "id": "coder",
-                    "model": "claude",
+                    "model_id": "claude",
                     "system_prompt": "You write code.",
                     "allowed_tools": ["read_file", "write_file"],
                     "excluded_tools": ["delete_file"]
                 },
                 {
                     "id": "reviewer",
-                    "model": "local",
+                    "model_id": "local",
                     "system_prompt": "You review code.",
                     "allowed_tools": ["read_file"]
                 }
@@ -160,7 +146,7 @@ mod tests {
 
         let reviewer = &config.agents[1];
         assert_eq!(reviewer.id, "reviewer");
-        assert_eq!(reviewer.model, "local");
+        assert_eq!(reviewer.model_id, "local");
         assert_eq!(reviewer.allowed_tools, Some(vec!["read_file".to_string()]));
         assert!(reviewer.excluded_tools.is_none());
     }
@@ -192,12 +178,12 @@ mod tests {
 
         let config = AgentSystemConfig::from_json(
             &json!({
-                "models": {
-                    "m1": { "provider": "stub", "model": "test-model" }
-                },
+                "models": [
+                    { "id": "m1", "provider_id": "stub", "upstream_model": "test-model" }
+                ],
                 "agents": [{
                     "id": "a1",
-                    "model": "m1",
+                    "model_id": "m1",
                     "system_prompt": "test"
                 }]
             })
@@ -215,8 +201,8 @@ mod tests {
 
         // Verify model registry
         let model = reg.models.get_model("m1").unwrap();
-        assert_eq!(model.provider, "stub");
-        assert_eq!(model.model_name, "test-model");
+        assert_eq!(model.provider_id, "stub");
+        assert_eq!(model.upstream_model, "test-model");
 
         // Verify agent registry
         let agent = reg.agents.get_agent("a1").unwrap();
@@ -232,20 +218,14 @@ mod tests {
     #[test]
     fn config_serde_roundtrip() {
         let original = AgentSystemConfig {
-            models: {
-                let mut m = HashMap::new();
-                m.insert(
-                    "opus".to_string(),
-                    ModelConfig {
-                        provider: "anthropic".to_string(),
-                        model: "claude-opus-4-0-20250514".to_string(),
-                    },
-                );
-                m
-            },
+            models: vec![ModelBindingSpec {
+                id: "opus".to_string(),
+                provider_id: "anthropic".to_string(),
+                upstream_model: "claude-opus-4-0-20250514".to_string(),
+            }],
             agents: vec![AgentSpec {
                 id: "coder".into(),
-                model: "opus".into(),
+                model_id: "opus".into(),
                 system_prompt: "Code assistant.".into(),
                 max_rounds: 10,
                 plugin_ids: vec!["logging".into()],
@@ -259,8 +239,12 @@ mod tests {
         let restored: AgentSystemConfig = serde_json::from_str(&json_str).unwrap();
 
         assert_eq!(restored.models.len(), 1);
-        assert_eq!(restored.models["opus"].provider, "anthropic");
-        assert_eq!(restored.models["opus"].model, "claude-opus-4-0-20250514");
+        assert_eq!(restored.models[0].id, "opus");
+        assert_eq!(restored.models[0].provider_id, "anthropic");
+        assert_eq!(
+            restored.models[0].upstream_model,
+            "claude-opus-4-0-20250514"
+        );
         assert_eq!(restored.agents.len(), 1);
         assert_eq!(restored.agents[0].id, "coder");
         assert_eq!(restored.agents[0].max_rounds, 10);

--- a/crates/awaken-runtime/src/registry/memory.rs
+++ b/crates/awaken-runtime/src/registry/memory.rs
@@ -13,7 +13,7 @@ use awaken_contract::contract::tool::Tool;
 #[cfg(feature = "a2a")]
 use super::traits::BackendRegistry;
 use super::traits::{
-    AgentSpecRegistry, ModelEntry, ModelRegistry, PluginSource, ProviderRegistry, ToolRegistry,
+    AgentSpecRegistry, ModelBinding, ModelRegistry, PluginSource, ProviderRegistry, ToolRegistry,
 };
 use awaken_contract::registry_spec::AgentSpec;
 
@@ -74,7 +74,7 @@ impl<V: Clone> MapRegistry<V> {
 // ---------------------------------------------------------------------------
 
 pub type MapToolRegistry = MapRegistry<Arc<dyn Tool>>;
-pub type MapModelRegistry = MapRegistry<ModelEntry>;
+pub type MapModelRegistry = MapRegistry<ModelBinding>;
 pub type MapProviderRegistry = MapRegistry<Arc<dyn LlmExecutor>>;
 pub type MapAgentSpecRegistry = MapRegistry<AgentSpec>;
 pub type MapPluginSource = MapRegistry<Arc<dyn Plugin>>;
@@ -101,9 +101,9 @@ impl MapModelRegistry {
     pub fn register_model(
         &mut self,
         id: impl Into<String>,
-        entry: ModelEntry,
+        binding: ModelBinding,
     ) -> Result<(), BuildError> {
-        self.register(id, entry, |msg| {
+        self.register(id, binding, |msg| {
             BuildError::ModelRegistryConflict(format!("model {msg}"))
         })
     }
@@ -179,7 +179,7 @@ impl ToolRegistry for MapToolRegistry {
 }
 
 impl ModelRegistry for MapModelRegistry {
-    fn get_model(&self, id: &str) -> Option<ModelEntry> {
+    fn get_model(&self, id: &str) -> Option<ModelBinding> {
         self.get_cloned(id)
     }
 

--- a/crates/awaken-runtime/src/registry/mod.rs
+++ b/crates/awaken-runtime/src/registry/mod.rs
@@ -14,7 +14,7 @@ pub mod traits;
 pub use awaken_contract::registry_spec::AgentSpec;
 #[cfg(feature = "a2a")]
 pub use composite::{CompositeAgentSpecRegistry, DiscoveryError, RemoteAgentSource};
-pub use config::{AgentSystemConfig, ModelConfig};
+pub use config::AgentSystemConfig;
 #[cfg(feature = "a2a")]
 pub use memory::MapBackendRegistry;
 pub use memory::{
@@ -27,6 +27,6 @@ pub use snapshot::{RegistryHandle, RegistrySnapshot};
 #[cfg(feature = "a2a")]
 pub use traits::BackendRegistry;
 pub use traits::{
-    AgentSpecRegistry, ModelEntry, ModelRegistry, PluginSource, ProviderRegistry, RegistrySet,
+    AgentSpecRegistry, ModelBinding, ModelRegistry, PluginSource, ProviderRegistry, RegistrySet,
     ToolRegistry,
 };

--- a/crates/awaken-runtime/src/registry/resolve/pipeline.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline.rs
@@ -52,7 +52,7 @@ pub(crate) fn resolve_registry_set(
 ) -> Result<ResolvedAgent, ResolveError> {
     // Stage 1: Lookup
     let spec = lookup_spec(registries, agent_id)?;
-    let (executor, model_name) = resolve_model_and_executor(registries, &spec)?;
+    let (executor, upstream_model) = resolve_model_and_executor(registries, &spec)?;
 
     // Stage 2: Plugin pipeline
     let plugins = build_plugin_chain(registries, &spec)?;
@@ -66,7 +66,7 @@ pub(crate) fn resolve_registry_set(
 
     Ok(ResolvedAgent {
         spec: spec_arc,
-        model: model_name,
+        upstream_model,
         tools,
         llm_executor: executor,
         tool_executor: Arc::new(SequentialToolExecutor),
@@ -101,29 +101,41 @@ fn lookup_spec(registries: &RegistrySet, agent_id: &str) -> Result<AgentSpec, Re
     Ok(spec)
 }
 
-/// Resolve model and LLM executor, applying retry decoration if configured.
+/// Resolve model and LLM executor, applying the agent retry policy.
 fn resolve_model_and_executor(
     registries: &RegistrySet,
     spec: &AgentSpec,
 ) -> Result<(Arc<dyn LlmExecutor>, String), ResolveError> {
-    let model = registries
+    let binding = registries
         .models
-        .get_model(&spec.model)
-        .ok_or_else(|| ResolveError::ModelNotFound(spec.model.clone()))?;
+        .get_model(&spec.model_id)
+        .ok_or_else(|| ResolveError::ModelNotFound(spec.model_id.clone()))?;
 
     let executor = registries
         .providers
-        .get_provider(&model.provider)
-        .ok_or_else(|| ResolveError::ProviderNotFound(model.provider.clone()))?;
+        .get_provider(&binding.provider_id)
+        .ok_or_else(|| ResolveError::ProviderNotFound(binding.provider_id.clone()))?;
 
-    let executor = match spec.config::<crate::engine::RetryConfigKey>() {
-        Ok(policy) if policy.max_retries > 0 || !policy.fallback_models.is_empty() => {
-            Arc::new(crate::engine::RetryingExecutor::new(executor, policy)) as Arc<dyn LlmExecutor>
-        }
-        _ => executor,
+    let policy = spec
+        .config::<crate::engine::RetryConfigKey>()
+        .map_err(|error| match error {
+            awaken_contract::StateError::KeyDecode { key, message } => {
+                ResolveError::InvalidPluginConfig {
+                    plugin: "retry".into(),
+                    key,
+                    message,
+                }
+            }
+            other => ResolveError::EnvBuild(other),
+        })?;
+
+    let executor = if policy.max_retries > 0 || !policy.fallback_upstream_models.is_empty() {
+        Arc::new(crate::engine::RetryingExecutor::new(executor, policy)) as Arc<dyn LlmExecutor>
+    } else {
+        executor
     };
 
-    Ok((executor, model.model_name.clone()))
+    Ok((executor, binding.upstream_model.clone()))
 }
 
 // ---------------------------------------------------------------------------
@@ -431,7 +443,7 @@ mod tests {
         MapAgentSpecRegistry, MapModelRegistry, MapPluginSource, MapProviderRegistry,
         MapToolRegistry,
     };
-    use crate::registry::traits::ModelEntry;
+    use crate::registry::traits::ModelBinding;
     use async_trait::async_trait;
     #[cfg(feature = "a2a")]
     use awaken_contract::contract::event_sink::EventSink;
@@ -558,7 +570,7 @@ mod tests {
     fn build_registries(
         tools: Vec<(&str, Arc<dyn Tool>)>,
         model_id: &str,
-        model_entry: ModelEntry,
+        model_binding: ModelBinding,
         provider_id: &str,
         executor: Arc<dyn LlmExecutor>,
         plugins: Vec<(&str, Arc<dyn Plugin>)>,
@@ -573,7 +585,7 @@ mod tests {
 
         let mut model_reg = MapModelRegistry::new();
         model_reg
-            .register_model(model_id, model_entry)
+            .register_model(model_id, model_binding)
             .expect("duplicate model in test");
 
         let mut provider_reg = MapProviderRegistry::new();
@@ -608,7 +620,7 @@ mod tests {
     fn make_spec(id: &str) -> AgentSpec {
         AgentSpec {
             id: id.into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "You are helpful.".into(),
             ..Default::default()
         }
@@ -629,9 +641,9 @@ mod tests {
                 ("write", Arc::new(MockTool { id: "write".into() })),
             ],
             "test-model",
-            ModelEntry {
-                provider: "anthropic".into(),
-                model_name: "claude-opus-4-20250514".into(),
+            ModelBinding {
+                provider_id: "anthropic".into(),
+                upstream_model: "claude-opus-4-20250514".into(),
             },
             "anthropic",
             Arc::new(MockExecutor),
@@ -641,7 +653,7 @@ mod tests {
 
         let run = resolve(&regs, "agent-1").unwrap();
         assert_eq!(run.id(), "agent-1");
-        assert_eq!(run.model, "claude-opus-4-20250514");
+        assert_eq!(run.upstream_model, "claude-opus-4-20250514");
         assert_eq!(run.tools.len(), 2);
         assert!(run.tools.contains_key("read"));
         assert!(run.tools.contains_key("write"));
@@ -653,9 +665,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "m",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -684,9 +696,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -725,9 +737,9 @@ mod tests {
         model_reg
             .register_model(
                 "test-model",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .unwrap();
@@ -782,9 +794,9 @@ mod tests {
         model_reg
             .register_model(
                 "test-model",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .unwrap();
@@ -839,14 +851,14 @@ mod tests {
     #[test]
     fn resolve_model_not_found() {
         let mut spec = make_spec("a");
-        spec.model = "nonexistent-model".into();
+        spec.model_id = "nonexistent-model".into();
 
         let regs = build_registries(
             vec![],
             "other-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -863,9 +875,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "missing-provider".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "missing-provider".into(),
+                upstream_model: "n".into(),
             },
             "other-provider",
             Arc::new(MockExecutor),
@@ -878,6 +890,44 @@ mod tests {
     }
 
     #[test]
+    fn resolve_invalid_retry_config_fails() {
+        let spec = make_spec("a").with_section(
+            "retry",
+            serde_json::json!({
+                "max_retries": "not-a-number",
+                "fallback_upstream_models": []
+            }),
+        );
+
+        let regs = build_registries(
+            vec![],
+            "test-model",
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
+            },
+            "p",
+            Arc::new(MockExecutor),
+            vec![],
+            spec,
+        );
+
+        let err = resolve(&regs, "a").unwrap_err();
+        match err {
+            ResolveError::InvalidPluginConfig {
+                plugin,
+                key,
+                message,
+            } => {
+                assert_eq!(plugin, "retry");
+                assert_eq!(key, "retry");
+                assert!(!message.is_empty(), "expected non-empty error message");
+            }
+            other => panic!("expected InvalidPluginConfig, got: {other:?}"),
+        }
+    }
+
+    #[test]
     fn resolve_plugin_not_found() {
         let spec = AgentSpec {
             plugin_ids: vec!["missing-plugin".into()],
@@ -887,9 +937,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -920,9 +970,9 @@ mod tests {
                 ),
             ],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -954,9 +1004,9 @@ mod tests {
                 ),
             ],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -992,9 +1042,9 @@ mod tests {
                 ("exec", Arc::new(MockTool { id: "exec".into() })),
             ],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1015,9 +1065,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1079,9 +1129,9 @@ mod tests {
                 ("write", Arc::new(MockTool { id: "write".into() })),
             ],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "claude-test".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "claude-test".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1093,7 +1143,7 @@ mod tests {
         let resolved = resolver.resolve("my-agent").unwrap();
         assert_eq!(resolved.id(), "my-agent");
         assert_eq!(resolved.model_id(), "test-model");
-        assert_eq!(resolved.model, "claude-test");
+        assert_eq!(resolved.upstream_model, "claude-test");
         assert_eq!(resolved.system_prompt(), "You are helpful.");
         assert_eq!(resolved.tools.len(), 2);
         assert!(resolved.tools.contains_key("read"));
@@ -1106,9 +1156,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1161,9 +1211,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1190,9 +1240,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1227,9 +1277,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1252,9 +1302,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1303,9 +1353,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1338,9 +1388,9 @@ mod tests {
                 }),
             )],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1380,9 +1430,9 @@ mod tests {
                 }),
             )],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1417,9 +1467,9 @@ mod tests {
                 }),
             )],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1452,9 +1502,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1476,9 +1526,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1500,9 +1550,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1524,9 +1574,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1539,13 +1589,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_model_name_from_model_entry() {
+    fn resolve_upstream_model_from_model_binding() {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "claude-opus-4-20250514".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "claude-opus-4-20250514".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1554,7 +1604,7 @@ mod tests {
         );
 
         let run = resolve(&regs, "a").unwrap();
-        assert_eq!(run.model, "claude-opus-4-20250514");
+        assert_eq!(run.upstream_model, "claude-opus-4-20250514");
     }
 
     #[test]
@@ -1570,9 +1620,9 @@ mod tests {
                 ("write", Arc::new(MockTool { id: "write".into() })),
             ],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1594,9 +1644,9 @@ mod tests {
         let regs = build_registries(
             vec![("read", Arc::new(MockTool { id: "read".into() }))],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1616,9 +1666,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1649,9 +1699,9 @@ mod tests {
         model_reg
             .register_model(
                 "test-model",
-                ModelEntry {
-                    provider: "p".into(),
-                    model_name: "n".into(),
+                ModelBinding {
+                    provider_id: "p".into(),
+                    upstream_model: "n".into(),
                 },
             )
             .unwrap();
@@ -1760,9 +1810,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1793,9 +1843,9 @@ mod tests {
         let regs_without = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1815,9 +1865,9 @@ mod tests {
         let regs_with = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1850,9 +1900,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1893,9 +1943,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),
@@ -1932,9 +1982,9 @@ mod tests {
         let regs = build_registries(
             vec![],
             "test-model",
-            ModelEntry {
-                provider: "p".into(),
-                model_name: "n".into(),
+            ModelBinding {
+                provider_id: "p".into(),
+                upstream_model: "n".into(),
             },
             "p",
             Arc::new(MockExecutor),

--- a/crates/awaken-runtime/src/registry/resolver.rs
+++ b/crates/awaken-runtime/src/registry/resolver.rs
@@ -19,8 +19,8 @@ use crate::phase::ExecutionEnv;
 pub struct ResolvedAgent {
     /// The source agent specification.
     pub spec: Arc<AgentSpec>,
-    /// Actual model name for API calls (resolved from ModelEntry, may differ from spec.model).
-    pub model: String,
+    /// Actual model name sent to the upstream provider.
+    pub upstream_model: String,
     pub tools: HashMap<String, Arc<dyn Tool>>,
     pub llm_executor: Arc<dyn LlmExecutor>,
     pub tool_executor: Arc<dyn ToolExecutor>,
@@ -35,14 +35,14 @@ impl ResolvedAgent {
     /// Create a minimal ResolvedAgent (for tests).
     pub fn new(
         id: impl Into<String>,
-        model: impl Into<String>,
+        upstream_model: impl Into<String>,
         system_prompt: impl Into<String>,
         llm_executor: Arc<dyn LlmExecutor>,
     ) -> Self {
-        let model = model.into();
+        let upstream_model = upstream_model.into();
         let spec = Arc::new(AgentSpec {
             id: id.into(),
-            model: model.clone(),
+            model_id: upstream_model.clone(),
             system_prompt: system_prompt.into(),
             max_rounds: 16,
             max_continuation_retries: 2,
@@ -59,7 +59,7 @@ impl ResolvedAgent {
         });
         Self {
             spec,
-            model,
+            upstream_model,
             tools: HashMap::new(),
             llm_executor,
             tool_executor: Arc::new(SequentialToolExecutor),
@@ -75,7 +75,7 @@ impl ResolvedAgent {
     }
 
     pub fn model_id(&self) -> &str {
-        &self.spec.model
+        &self.spec.model_id
     }
 
     pub fn system_prompt(&self) -> &str {
@@ -241,7 +241,7 @@ mod tests {
     fn new_defaults() {
         let agent = ResolvedAgent::new("agent-1", "model-1", "system prompt", mock_executor());
         assert_eq!(agent.id(), "agent-1");
-        assert_eq!(agent.model, "model-1");
+        assert_eq!(agent.upstream_model, "model-1");
         assert_eq!(agent.system_prompt(), "system prompt");
         assert_eq!(agent.max_rounds(), 16);
         assert!(agent.tools.is_empty());
@@ -323,7 +323,7 @@ mod tests {
     fn model_id_equals_model_by_default() {
         let agent = ResolvedAgent::new("a", "claude-3", "s", mock_executor());
         assert_eq!(agent.model_id(), "claude-3");
-        assert_eq!(agent.model, "claude-3");
+        assert_eq!(agent.upstream_model, "claude-3");
     }
 
     #[test]
@@ -467,7 +467,7 @@ mod tests {
             .with_tool_executor(Arc::new(crate::execution::SequentialToolExecutor));
 
         assert_eq!(agent.id(), "full-agent");
-        assert_eq!(agent.model, "gpt-4");
+        assert_eq!(agent.upstream_model, "gpt-4");
         assert_eq!(agent.system_prompt(), "Be helpful.");
         assert_eq!(agent.max_rounds(), 32);
         assert_eq!(agent.max_continuation_retries(), 10);
@@ -535,12 +535,12 @@ mod tests {
     }
 
     #[test]
-    fn model_id_and_model_independent_after_creation() {
+    fn model_id_and_upstream_model_independent_after_creation() {
         let mut agent = ResolvedAgent::new("a", "original-model", "s", mock_executor());
-        // Manually change model_name (simulating what resolve pipeline does)
-        agent.model = "resolved-model-name".into();
+        // Manually change upstream_model (simulating what resolve pipeline does)
+        agent.upstream_model = "resolved-model-name".into();
         assert_eq!(agent.model_id(), "original-model");
-        assert_eq!(agent.model, "resolved-model-name");
+        assert_eq!(agent.upstream_model, "resolved-model-name");
     }
 
     #[test]

--- a/crates/awaken-runtime/src/registry/snapshot.rs
+++ b/crates/awaken-runtime/src/registry/snapshot.rs
@@ -75,7 +75,7 @@ mod tests {
         agents
             .register_spec(AgentSpec {
                 id: agent_id.into(),
-                model: "default".into(),
+                model_id: "default".into(),
                 system_prompt: "test".into(),
                 ..Default::default()
             })
@@ -85,9 +85,9 @@ mod tests {
         models
             .register_model(
                 "default",
-                crate::registry::ModelEntry {
-                    provider: "provider".into(),
-                    model_name: "gpt-test".into(),
+                crate::registry::ModelBinding {
+                    provider_id: "provider".into(),
+                    upstream_model: "gpt-test".into(),
                 },
             )
             .expect("register test model");

--- a/crates/awaken-runtime/src/registry/traits.rs
+++ b/crates/awaken-runtime/src/registry/traits.rs
@@ -8,7 +8,7 @@ use crate::plugins::Plugin;
 use awaken_contract::contract::executor::LlmExecutor;
 use awaken_contract::contract::tool::Tool;
 
-use awaken_contract::registry_spec::AgentSpec;
+use awaken_contract::registry_spec::{AgentSpec, ModelBindingSpec};
 
 // ---------------------------------------------------------------------------
 // ToolRegistry
@@ -23,22 +23,31 @@ pub trait ToolRegistry: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
-// ModelEntry + ModelRegistry
+// ModelBinding + ModelRegistry
 // ---------------------------------------------------------------------------
 
-/// Model definition: maps a model ID to a provider and model name.
+/// Runtime model binding from a model registry ID to a provider and upstream model.
 #[derive(Debug, Clone)]
-pub struct ModelEntry {
+pub struct ModelBinding {
     /// ProviderRegistry ID.
-    pub provider: String,
-    /// Actual model name for the API call.
-    pub model_name: String,
+    pub provider_id: String,
+    /// Actual model name sent to the upstream provider.
+    pub upstream_model: String,
+}
+
+impl From<&ModelBindingSpec> for ModelBinding {
+    fn from(spec: &ModelBindingSpec) -> Self {
+        Self {
+            provider_id: spec.provider_id.clone(),
+            upstream_model: spec.upstream_model.clone(),
+        }
+    }
 }
 
 /// Lookup interface for model definitions.
 pub trait ModelRegistry: Send + Sync {
-    /// Get a model entry by its ID.
-    fn get_model(&self, id: &str) -> Option<ModelEntry>;
+    /// Get a model binding by its ID.
+    fn get_model(&self, id: &str) -> Option<ModelBinding>;
     /// List all registered model IDs.
     fn model_ids(&self) -> Vec<String>;
 }
@@ -109,4 +118,23 @@ pub struct RegistrySet {
     pub plugins: Arc<dyn PluginSource>,
     #[cfg(feature = "a2a")]
     pub backends: Arc<dyn BackendRegistry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_binding_spec_converts_to_runtime_model_binding() {
+        let spec = ModelBindingSpec {
+            id: "default".into(),
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
+        };
+
+        let binding = ModelBinding::from(&spec);
+
+        assert_eq!(binding.provider_id, "openai");
+        assert_eq!(binding.upstream_model, "gpt-4o-mini");
+    }
 }

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -760,8 +760,9 @@ mod tests {
             plugins: vec![],
         });
         let runtime = AgentRuntime::new(resolver);
-        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+        let sink = Arc::new(VecEventSink::new());
         let override_req = InferenceOverride {
+            upstream_model: Some("override-model".into()),
             temperature: Some(0.3),
             max_tokens: Some(77),
             ..Default::default()
@@ -791,6 +792,17 @@ mod tests {
             seen[0].as_ref().and_then(|o| o.max_tokens),
             override_req.max_tokens
         );
+        assert!(
+            seen[0]
+                .as_ref()
+                .and_then(|o| o.upstream_model.as_ref())
+                .is_none()
+        );
+        let complete_model = sink.events().into_iter().find_map(|event| match event {
+            AgentEvent::InferenceComplete { model, .. } => Some(model),
+            _ => None,
+        });
+        assert_eq!(complete_model.as_deref(), Some("override-model"));
     }
 
     #[tokio::test]
@@ -1415,6 +1427,7 @@ mod tests {
         call_count: AtomicUsize,
         /// Responses to return after the first (truncated) call.
         followup_responses: Mutex<Vec<StreamResult>>,
+        upstream_models_seen: Mutex<Vec<String>>,
     }
 
     impl TruncatingLlm {
@@ -1422,6 +1435,7 @@ mod tests {
             Self {
                 call_count: AtomicUsize::new(0),
                 followup_responses: Mutex::new(followup_responses),
+                upstream_models_seen: Mutex::new(Vec::new()),
             }
         }
     }
@@ -1437,7 +1451,7 @@ mod tests {
 
         fn execute_stream(
             &self,
-            _request: InferenceRequest,
+            request: InferenceRequest,
         ) -> std::pin::Pin<
             Box<
                 dyn std::future::Future<
@@ -1453,6 +1467,10 @@ mod tests {
             use awaken_contract::contract::inference::TokenUsage;
 
             Box::pin(async move {
+                self.upstream_models_seen
+                    .lock()
+                    .expect("lock poisoned")
+                    .push(request.upstream_model.clone());
                 let n = self.call_count.fetch_add(1, Ordering::SeqCst);
                 if n == 0 {
                     // First call: emit a tool call with truncated JSON, then MaxTokens
@@ -1589,6 +1607,49 @@ mod tests {
             })
             .collect();
         assert_eq!(text_deltas, vec!["partial ", "completed"]);
+    }
+
+    #[tokio::test]
+    async fn truncation_recovery_preserves_model_override() {
+        let llm = Arc::new(TruncatingLlm::new(vec![StreamResult {
+            content: vec![ContentBlock::text("completed response")],
+            tool_calls: vec![],
+            usage: None,
+            stop_reason: Some(StopReason::EndTurn),
+            has_incomplete_tool_calls: false,
+        }]));
+        let resolver = Arc::new(FixedResolver {
+            agent: ResolvedAgent::new("agent", "base-model", "sys", llm.clone())
+                .with_max_continuation_retries(2),
+            plugins: vec![],
+        });
+        let runtime = AgentRuntime::new(resolver);
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        let result = runtime
+            .run(
+                RunRequest::new("thread-trunc-override", vec![Message::user("hi")])
+                    .with_agent_id("agent")
+                    .with_overrides(InferenceOverride {
+                        upstream_model: Some("override-model".into()),
+                        ..Default::default()
+                    }),
+                sink,
+            )
+            .await
+            .expect("run should succeed");
+
+        assert_eq!(
+            result.termination,
+            awaken_contract::contract::lifecycle::TerminationReason::NaturalEnd
+        );
+        assert_eq!(
+            llm.upstream_models_seen
+                .lock()
+                .expect("lock poisoned")
+                .clone(),
+            vec!["override-model".to_string(), "override-model".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/crates/awaken-server/src/protocols/acp/stdio.rs
+++ b/crates/awaken-server/src/protocols/acp/stdio.rs
@@ -481,7 +481,7 @@ mod tests {
     use awaken_contract::contract::message::ToolCall as RuntimeToolCall;
     use awaken_contract::contract::tool::{FrontEndTool, ToolDescriptor};
     use awaken_runtime::builder::AgentRuntimeBuilder;
-    use awaken_runtime::registry::traits::ModelEntry;
+    use awaken_runtime::registry::traits::ModelBinding;
     use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, split};
     use tokio::time::{Duration, timeout};
 
@@ -545,11 +545,11 @@ mod tests {
         let frontend_tool = ToolDescriptor::new("ask_user", "ask_user", "Ask the user a question");
 
         let builder = AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider(
@@ -561,7 +561,7 @@ mod tests {
             .with_tool("ask_user", Arc::new(FrontEndTool::new(frontend_tool)))
             .with_agent_spec(awaken_contract::registry_spec::AgentSpec {
                 id: "frontend".into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "You delegate to a frontend tool".into(),
                 max_rounds: 2,
                 ..Default::default()

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
@@ -128,9 +128,9 @@ async fn ai_sdk_chat_preview_agent(
         mut agent,
     } = payload;
 
-    if agent.model.trim().is_empty() {
+    if agent.model_id.trim().is_empty() {
         return Err(ApiError::BadRequest(
-            "preview agent model cannot be empty".to_string(),
+            "preview agent model_id cannot be empty".to_string(),
         ));
     }
 

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -9,18 +9,18 @@ use awaken_contract::contract::config_store::{ConfigChangeNotifier, ConfigStore}
 use awaken_contract::contract::executor::LlmExecutor;
 use awaken_contract::contract::storage::StorageError;
 use awaken_contract::{
-    AgentSpec, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelSpec, PeriodicRefresher,
-    ProviderSpec,
+    AgentSpec, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelBindingSpec,
+    PeriodicRefresher, ProviderSpec,
 };
 use awaken_ext_mcp::{McpServerConnectionConfig, McpToolRegistry, McpToolRegistryManager};
-use awaken_runtime::engine::{GenaiExecutor, LlmRetryPolicy, RetryingExecutor};
+use awaken_runtime::engine::GenaiExecutor;
 use awaken_runtime::registry::BackendRegistry;
 use awaken_runtime::registry::memory::{
     MapAgentSpecRegistry, MapModelRegistry, MapProviderRegistry,
 };
 use awaken_runtime::registry::resolve::RegistrySetResolver;
 use awaken_runtime::registry::{
-    AgentSpecRegistry, ModelEntry, PluginSource, RegistrySet, ToolRegistry,
+    AgentSpecRegistry, ModelBinding, PluginSource, RegistrySet, ToolRegistry,
 };
 use awaken_runtime::{AgentResolver, AgentRuntime};
 use genai::Client;
@@ -267,7 +267,7 @@ impl PreparedMcpRegistry {
 
 struct ManagedConfigSnapshot {
     providers: Vec<ProviderSpec>,
-    models: Vec<ModelSpec>,
+    models: Vec<ModelBindingSpec>,
     agents: Vec<AgentSpec>,
     mcp_servers: Vec<McpServerSpec>,
     fingerprint: u64,
@@ -358,7 +358,7 @@ impl ConfigRuntimeManager {
     pub async fn bootstrap_if_empty(
         &self,
         providers: &[ProviderSpec],
-        models: &[ModelSpec],
+        models: &[ModelBindingSpec],
         agents: &[AgentSpec],
         mcp_servers: &[McpServerSpec],
     ) -> Result<bool, ConfigRuntimeError> {
@@ -732,7 +732,7 @@ impl ConfigRuntimeManager {
     fn compile_registry_set(
         &self,
         providers: &[ProviderSpec],
-        models: &[ModelSpec],
+        models: &[ModelBindingSpec],
         agents: &[AgentSpec],
         dynamic_tools: Option<Arc<dyn ToolRegistry>>,
     ) -> Result<RegistrySet, ConfigRuntimeError> {
@@ -746,13 +746,7 @@ impl ConfigRuntimeManager {
         let mut model_registry = MapModelRegistry::new();
         for model in models {
             model_registry
-                .register_model(
-                    model.id.clone(),
-                    ModelEntry {
-                        provider: model.provider.clone(),
-                        model_name: model.model.clone(),
-                    },
-                )
+                .register_model(model.id.clone(), ModelBinding::from(model))
                 .map_err(|error| ConfigRuntimeError::InvalidConfig(error.to_string()))?;
         }
 
@@ -853,10 +847,7 @@ pub fn build_genai_provider_executor(
     let client = builder.build();
     let executor = GenaiExecutor::with_client(client)
         .with_timeout(Duration::from_secs(spec.timeout_secs.max(1)));
-    Ok(Arc::new(RetryingExecutor::new(
-        Arc::new(executor),
-        LlmRetryPolicy::default(),
-    )))
+    Ok(Arc::new(executor))
 }
 
 /// Canonical list of provider adapter identifiers supported by the runtime.

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::StorageError;
-use awaken_contract::{AgentSpec, McpServerSpec, ModelSpec, ProviderSpec};
+use awaken_contract::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
 use serde_json::{Map, Value, json};
 
 use crate::app::AppState;
@@ -40,7 +40,7 @@ impl ConfigNamespace {
     pub fn schema_json(self) -> Result<Value, ConfigServiceError> {
         let schema = match self {
             Self::Agents => schemars::schema_for!(AgentSpec),
-            Self::Models => schemars::schema_for!(ModelSpec),
+            Self::Models => schemars::schema_for!(ModelBindingSpec),
             Self::Providers => schemars::schema_for!(ProviderSpec),
             Self::McpServers => schemars::schema_for!(McpServerSpec),
         };
@@ -137,8 +137,8 @@ impl<'a> ConfigService<'a> {
                 registries.models.get_model(&id).map(|model| {
                     json!({
                         "id": id,
-                        "provider": model.provider,
-                        "model": model.model_name,
+                        "provider_id": model.provider_id,
+                        "upstream_model": model.upstream_model,
                     })
                 })
             })
@@ -390,7 +390,7 @@ impl<'a> ConfigService<'a> {
                 let _: AgentSpec = from_value(body)?;
             }
             ConfigNamespace::Models => {
-                let _: ModelSpec = from_value(body)?;
+                let _: ModelBindingSpec = from_value(body)?;
             }
             ConfigNamespace::Providers => {
                 let spec: ProviderSpec = from_value(body)?;
@@ -552,9 +552,9 @@ mod tests {
         InferenceExecutionError, InferenceRequest, LlmExecutor,
     };
     use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
-    use awaken_contract::{AgentSpec, ModelSpec, ProviderSpec};
+    use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
     use awaken_runtime::builder::AgentRuntimeBuilder;
-    use awaken_runtime::registry::traits::ModelEntry;
+    use awaken_runtime::registry::traits::ModelBinding;
     use serde_json::{Value, json};
     use tokio::sync::Notify;
 
@@ -684,7 +684,7 @@ mod tests {
     fn bootstrap_agent() -> AgentSpec {
         AgentSpec {
             id: "bootstrap".into(),
-            model: "bootstrap".into(),
+            model_id: "bootstrap".into(),
             system_prompt: "bootstrap".into(),
             max_rounds: 1,
             ..Default::default()
@@ -698,11 +698,11 @@ mod tests {
         let runtime = Arc::new(
             AgentRuntimeBuilder::new()
                 .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-                .with_model(
+                .with_model_binding(
                     "bootstrap",
-                    ModelEntry {
-                        provider: "bootstrap".into(),
-                        model_name: "bootstrap-model".into(),
+                    ModelBinding {
+                        provider_id: "bootstrap".into(),
+                        upstream_model: "bootstrap-model".into(),
                     },
                 )
                 .with_agent_spec(bootstrap_agent())
@@ -724,10 +724,10 @@ mod tests {
                     adapter: "stub".into(),
                     ..Default::default()
                 }],
-                &[ModelSpec {
+                &[ModelBindingSpec {
                     id: "bootstrap".into(),
-                    provider: "bootstrap".into(),
-                    model: "bootstrap-model".into(),
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
                 }],
                 &[bootstrap_agent()],
                 &[],
@@ -855,11 +855,11 @@ mod tests {
         let runtime = Arc::new(
             AgentRuntimeBuilder::new()
                 .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-                .with_model(
+                .with_model_binding(
                     "bootstrap",
-                    ModelEntry {
-                        provider: "bootstrap".into(),
-                        model_name: "bootstrap-model".into(),
+                    ModelBinding {
+                        provider_id: "bootstrap".into(),
+                        upstream_model: "bootstrap-model".into(),
                     },
                 )
                 .with_agent_spec(bootstrap_agent())

--- a/crates/awaken-server/tests/a2a_http.rs
+++ b/crates/awaken-server/tests/a2a_http.rs
@@ -5,7 +5,7 @@ use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequ
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
@@ -66,11 +66,11 @@ where
     E: LlmExecutor + 'static,
 {
     let mut builder = AgentRuntimeBuilder::new()
-        .with_model(
+        .with_model_binding(
             "test-model",
-            ModelEntry {
-                provider: "mock".into(),
-                model_name: "mock-model".into(),
+            ModelBinding {
+                provider_id: "mock".into(),
+                upstream_model: "mock-model".into(),
             },
         )
         .with_provider("mock", executor);
@@ -78,7 +78,7 @@ where
     for agent_id in agent_ids {
         builder = builder.with_agent_spec(AgentSpec {
             id: (*agent_id).to_string(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "test".into(),
             max_rounds: 0,
             ..Default::default()

--- a/crates/awaken-server/tests/a2a_loopback.rs
+++ b/crates/awaken-server/tests/a2a_loopback.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use awaken_contract::registry_spec::{AgentSpec, RemoteEndpoint};
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::engine::executor::GenaiExecutor;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
@@ -159,7 +159,7 @@ async fn a2a_loopback_orchestrator_delegates_to_worker() {
     // This avoids infinite recursion (worker resolving its own endpoint).
 
     let worker_local = AgentSpec::new("worker")
-        .with_model("default")
+        .with_model_id("default")
         .with_system_prompt(
             "You are a simple worker agent. \
              Always reply with exactly one word: PONG. \
@@ -169,7 +169,7 @@ async fn a2a_loopback_orchestrator_delegates_to_worker() {
 
     let worker_remote = AgentSpec {
         id: "worker-remote".into(),
-        model: "default".into(),
+        model_id: "default".into(),
         system_prompt: "Reply with PONG".into(),
         max_rounds: 1,
         endpoint: Some(RemoteEndpoint {
@@ -187,7 +187,7 @@ async fn a2a_loopback_orchestrator_delegates_to_worker() {
     };
 
     let orchestrator_spec = AgentSpec::new("orchestrator")
-        .with_model("default")
+        .with_model_id("default")
         .with_system_prompt(
             "You are an orchestrator. You MUST delegate every user request to the worker \
              by calling the `agent_run_worker-remote` tool with the user's message as the prompt. \
@@ -204,11 +204,11 @@ async fn a2a_loopback_orchestrator_delegates_to_worker() {
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("default", executor)
-            .with_model(
+            .with_model_binding(
                 "default",
-                ModelEntry {
-                    provider: "default".into(),
-                    model_name,
+                ModelBinding {
+                    provider_id: "default".into(),
+                    upstream_model: model_name,
                 },
             )
             .with_agent_spec(orchestrator_spec)

--- a/crates/awaken-server/tests/acp_stdio.rs
+++ b/crates/awaken-server/tests/acp_stdio.rs
@@ -18,7 +18,7 @@ use awaken_contract::contract::tool::{
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_ext_permission::PermissionPlugin;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::protocols::acp::stdio::serve_stdio_io;
 use serde_json::{Value, json};
 use tokio::io::{BufReader, split};
@@ -153,17 +153,17 @@ impl Tool for GetWeatherTool {
 
 fn echo_runtime() -> Arc<awaken_runtime::AgentRuntime> {
     let builder = AgentRuntimeBuilder::new()
-        .with_model(
+        .with_model_binding(
             "test-model",
-            ModelEntry {
-                provider: "mock".into(),
-                model_name: "mock-model".into(),
+            ModelBinding {
+                provider_id: "mock".into(),
+                upstream_model: "mock-model".into(),
             },
         )
         .with_provider("mock", Arc::new(EchoExecutor))
         .with_agent_spec(AgentSpec {
             id: "echo".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "You are an echo bot".into(),
             max_rounds: 2,
             ..Default::default()
@@ -176,11 +176,11 @@ fn permission_runtime() -> Arc<awaken_runtime::AgentRuntime> {
     sections.insert("permission".to_string(), json!({"default_behavior": "ask"}));
 
     let builder = AgentRuntimeBuilder::new()
-        .with_model(
+        .with_model_binding(
             "test-model",
-            ModelEntry {
-                provider: "mock".into(),
-                model_name: "mock-model".into(),
+            ModelBinding {
+                provider_id: "mock".into(),
+                upstream_model: "mock-model".into(),
             },
         )
         .with_provider(
@@ -193,7 +193,7 @@ fn permission_runtime() -> Arc<awaken_runtime::AgentRuntime> {
         .with_plugin("permission", Arc::new(PermissionPlugin))
         .with_agent_spec(AgentSpec {
             id: "weather".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "You are a weather bot".into(),
             max_rounds: 2,
             plugin_ids: vec!["permission".into()],

--- a/crates/awaken-server/tests/ai_sdk_multi_turn.rs
+++ b/crates/awaken-server/tests/ai_sdk_multi_turn.rs
@@ -10,7 +10,7 @@ use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequ
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
@@ -51,18 +51,18 @@ fn make_app() -> axum::Router {
     let store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider("mock", Arc::new(EchoExecutor))
             .with_thread_run_store(store.clone())
             .with_agent_spec(AgentSpec {
                 id: "default".into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "You are a test assistant.".into(),
                 max_rounds: 3,
                 ..Default::default()

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -13,12 +13,12 @@ use awaken_contract::contract::storage::StorageError;
 use awaken_contract::contract::tool::{
     Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
 };
-use awaken_contract::{AgentSpec, McpServerSpec, ModelSpec, ProviderSpec};
+use awaken_contract::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
 use awaken_runtime::AgentRuntime;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::ToolRegistry;
 use awaken_runtime::registry::memory::MapToolRegistry;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{
     AppState, ServerConfig, SkillCatalogArgument, SkillCatalogContext, SkillCatalogEntry,
     SkillCatalogProvider,
@@ -385,10 +385,10 @@ impl SkillCatalogProvider for StaticSkillCatalogProvider {
     }
 }
 
-fn agent_spec(id: &str, model: &str) -> AgentSpec {
+fn agent_spec(id: &str, model_id: &str) -> AgentSpec {
     AgentSpec {
         id: id.into(),
-        model: model.into(),
+        model_id: model_id.into(),
         system_prompt: format!("agent {id}"),
         max_rounds: 1,
         ..Default::default()
@@ -420,21 +420,21 @@ async fn make_runtime_manager_with_options(
         adapter: "stub".into(),
         ..Default::default()
     };
-    let bootstrap_model = ModelSpec {
+    let bootstrap_model = ModelBindingSpec {
         id: "bootstrap".into(),
-        provider: "bootstrap".into(),
-        model: "bootstrap-model".into(),
+        provider_id: "bootstrap".into(),
+        upstream_model: "bootstrap-model".into(),
     };
     let bootstrap_agent = agent_spec("bootstrap", "bootstrap");
 
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model(
+            .with_model_binding(
                 "bootstrap",
-                ModelEntry {
-                    provider: "bootstrap".into(),
-                    model_name: "bootstrap-model".into(),
+                ModelBinding {
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
                 },
             )
             .with_agent_spec(bootstrap_agent.clone())
@@ -716,8 +716,8 @@ async fn published_config_updates_live_capabilities_and_resolver() {
         "/v1/config/models",
         Some(json!({
             "id": "model-1",
-            "provider": "provider-1",
-            "model": "test-model"
+            "provider_id": "provider-1",
+            "upstream_model": "test-model"
         })),
     )
     .await;
@@ -729,7 +729,7 @@ async fn published_config_updates_live_capabilities_and_resolver() {
         "/v1/config/agents",
         Some(json!({
             "id": "agent-1",
-            "model": "model-1",
+            "model_id": "model-1",
             "system_prompt": "hello",
             "max_rounds": 2
         })),
@@ -1110,7 +1110,7 @@ async fn put_rejects_path_and_body_id_mismatch() {
         "/v1/config/agents/left",
         Some(json!({
             "id": "right",
-            "model": "bootstrap",
+            "model_id": "bootstrap",
             "system_prompt": "mismatch"
         })),
     )

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -5,10 +5,10 @@ use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::contract::storage::{RunStore, ThreadRunStore, ThreadStore};
-use awaken_contract::{AgentSpec, ModelSpec, ProviderSpec};
+use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
 use awaken_runtime::AgentRuntime;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
@@ -72,18 +72,18 @@ fn bootstrap_provider() -> ProviderSpec {
     }
 }
 
-fn bootstrap_model() -> ModelSpec {
-    ModelSpec {
+fn bootstrap_model() -> ModelBindingSpec {
+    ModelBindingSpec {
         id: "bootstrap".into(),
-        provider: "bootstrap".into(),
-        model: "bootstrap-model".into(),
+        provider_id: "bootstrap".into(),
+        upstream_model: "bootstrap-model".into(),
     }
 }
 
 fn bootstrap_agent() -> AgentSpec {
     AgentSpec {
         id: "bootstrap".into(),
-        model: "bootstrap".into(),
+        model_id: "bootstrap".into(),
         system_prompt: "bootstrap agent".into(),
         max_rounds: 1,
         ..Default::default()
@@ -101,11 +101,11 @@ where
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model(
+            .with_model_binding(
                 "bootstrap",
-                ModelEntry {
-                    provider: "bootstrap".into(),
-                    model_name: "bootstrap-model".into(),
+                ModelBinding {
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
                 },
             )
             .with_agent_spec(bootstrap_agent.clone())
@@ -230,8 +230,8 @@ async fn seed_managed_agent(router: &axum::Router, prefix: &str) {
         "/v1/config/models",
         Some(json!({
             "id": model_id,
-            "provider": format!("{prefix}-provider"),
-            "model": format!("{prefix}-model-upstream")
+            "provider_id": format!("{prefix}-provider"),
+            "upstream_model": format!("{prefix}-model-upstream")
         })),
     )
     .await;
@@ -243,7 +243,7 @@ async fn seed_managed_agent(router: &axum::Router, prefix: &str) {
         "/v1/config/agents",
         Some(json!({
             "id": agent_id,
-            "model": format!("{prefix}-model"),
+            "model_id": format!("{prefix}-model"),
             "system_prompt": "configured agent",
             "max_rounds": 1
         })),

--- a/crates/awaken-server/tests/http_api.rs
+++ b/crates/awaken-server/tests/http_api.rs
@@ -267,7 +267,7 @@ mod integration {
     use awaken_contract::registry_spec::AgentSpec;
     use awaken_contract::thread::Thread;
     use awaken_runtime::builder::AgentRuntimeBuilder;
-    use awaken_runtime::registry::traits::ModelEntry;
+    use awaken_runtime::registry::traits::ModelBinding;
     use awaken_server::app::{AppState, ServerConfig};
     use awaken_server::routes::build_router;
     use awaken_stores::memory::InMemoryStore;
@@ -307,17 +307,17 @@ mod integration {
         let store = Arc::new(InMemoryStore::new());
         let runtime = Arc::new(
             AgentRuntimeBuilder::new()
-                .with_model(
+                .with_model_binding(
                     "test-model",
-                    ModelEntry {
-                        provider: "mock".into(),
-                        model_name: "mock-model".into(),
+                    ModelBinding {
+                        provider_id: "mock".into(),
+                        upstream_model: "mock-model".into(),
                     },
                 )
                 .with_provider("mock", Arc::new(ImmediateExecutor))
                 .with_agent_spec(AgentSpec {
                     id: "test-agent".into(),
-                    model: "test-model".into(),
+                    model_id: "test-model".into(),
                     system_prompt: "test".into(),
                     max_rounds: 0,
                     ..Default::default()

--- a/crates/awaken-server/tests/protocol_ag_ui_e2e.rs
+++ b/crates/awaken-server/tests/protocol_ag_ui_e2e.rs
@@ -13,7 +13,7 @@ use awaken_contract::contract::tool::{
 };
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
@@ -178,17 +178,17 @@ struct TestApp {
 fn make_ag_ui_app(llm: Arc<dyn LlmExecutor>, tools: Vec<(String, Arc<dyn Tool>)>) -> TestApp {
     let store = Arc::new(InMemoryStore::new());
     let mut builder = AgentRuntimeBuilder::new()
-        .with_model(
+        .with_model_binding(
             "test-model",
-            ModelEntry {
-                provider: "mock".into(),
-                model_name: "mock-model".into(),
+            ModelBinding {
+                provider_id: "mock".into(),
+                upstream_model: "mock-model".into(),
             },
         )
         .with_provider("mock", llm)
         .with_agent_spec(AgentSpec {
             id: "test-agent".into(),
-            model: "test-model".into(),
+            model_id: "test-model".into(),
             system_prompt: "You are a test assistant.".into(),
             max_rounds: 5,
             ..Default::default()
@@ -980,17 +980,17 @@ async fn multiple_sequential_runs_on_same_thread() {
     let store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider("mock", llm)
             .with_agent_spec(AgentSpec {
                 id: "test-agent".into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "test".into(),
                 max_rounds: 5,
                 ..Default::default()

--- a/crates/awaken-server/tests/protocol_mcp.rs
+++ b/crates/awaken-server/tests/protocol_mcp.rs
@@ -9,7 +9,7 @@ use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequ
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
@@ -62,17 +62,17 @@ impl awaken_contract::contract::executor::LlmExecutor for EchoExecutor {
 fn make_mcp_app() -> axum::Router {
     let runtime = {
         let builder = AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider("mock", Arc::new(EchoExecutor))
             .with_agent_spec(AgentSpec {
                 id: "echo".into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "You are an echo bot".into(),
                 max_rounds: 2,
                 ..Default::default()
@@ -420,17 +420,17 @@ async fn mcp_unknown_method_returns_error() {
 async fn stdio_e2e_full_flow() {
     let runtime = {
         let builder = AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider("mock", Arc::new(EchoExecutor))
             .with_agent_spec(AgentSpec {
                 id: "echo".into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "You are an echo bot".into(),
                 max_rounds: 2,
                 ..Default::default()

--- a/crates/awaken-server/tests/protocol_parity.rs
+++ b/crates/awaken-server/tests/protocol_parity.rs
@@ -11,7 +11,7 @@ use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage}
 use awaken_contract::contract::transport::Transcoder;
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::protocols::{
     acp::encoder::AcpEncoder, ag_ui::encoder::AgUiEncoder, ai_sdk_v6::encoder::AiSdkEncoder,
@@ -53,17 +53,17 @@ impl awaken_contract::contract::executor::LlmExecutor for ImmediateExecutor {
 fn make_app() -> axum::Router {
     let runtime = {
         let builder = AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider("mock", Arc::new(ImmediateExecutor))
             .with_agent_spec(AgentSpec {
                 id: "test".into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "test".into(),
                 max_rounds: 0,
                 ..Default::default()

--- a/crates/awaken-server/tests/run_api.rs
+++ b/crates/awaken-server/tests/run_api.rs
@@ -15,7 +15,7 @@ use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::storage::{RunRecord, RunStore, ThreadStore};
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
@@ -130,17 +130,17 @@ fn make_test_app_with_executor(
     let store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
-            .with_model(
+            .with_model_binding(
                 "test-model",
-                ModelEntry {
-                    provider: "mock".into(),
-                    model_name: "mock-model".into(),
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
                 },
             )
             .with_provider("mock", executor)
             .with_agent_spec(AgentSpec {
                 id: "test-agent".into(),
-                model: "test-model".into(),
+                model_id: "test-model".into(),
                 system_prompt: "test".into(),
                 max_rounds: 0,
                 ..Default::default()
@@ -454,7 +454,7 @@ async fn ai_sdk_agent_preview_runs_with_draft_system_prompt_and_history() {
         json!({
             "agent": {
                 "id": "",
-                "model": "test-model",
+                "model_id": "test-model",
                 "system_prompt": "draft system prompt",
                 "max_rounds": 0
             },

--- a/crates/awaken-stores/tests/config_store.rs
+++ b/crates/awaken-stores/tests/config_store.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use awaken_contract::contract::config_store::ConfigStore;
-use awaken_contract::{AgentSpec, ModelSpec, ProviderSpec};
+use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
 use awaken_stores::InMemoryStore;
 
 #[cfg(feature = "file")]
@@ -15,14 +15,14 @@ async fn exercise_store(store: Arc<dyn ConfigStore>) {
         base_url: Some("https://proxy.example.com/v1".into()),
         timeout_secs: 120,
     };
-    let model = ModelSpec {
+    let model = ModelBindingSpec {
         id: "gpt-4o-mini".into(),
-        provider: "openai".into(),
-        model: "gpt-4o-mini".into(),
+        provider_id: "openai".into(),
+        upstream_model: "gpt-4o-mini".into(),
     };
     let agent = AgentSpec {
         id: "assistant".into(),
-        model: "gpt-4o-mini".into(),
+        model_id: "gpt-4o-mini".into(),
         system_prompt: "You are helpful.".into(),
         ..Default::default()
     };
@@ -47,12 +47,12 @@ async fn exercise_store(store: Arc<dyn ConfigStore>) {
     assert!(store.exists("providers", "openai").await.unwrap());
 
     let model_value = store.get("models", "gpt-4o-mini").await.unwrap().unwrap();
-    let model_read: ModelSpec = serde_json::from_value(model_value).unwrap();
-    assert_eq!(model_read.provider, "openai");
+    let model_read: ModelBindingSpec = serde_json::from_value(model_value).unwrap();
+    assert_eq!(model_read.provider_id, "openai");
 
     let agent_value = store.get("agents", "assistant").await.unwrap().unwrap();
     let agent_read: AgentSpec = serde_json::from_value(agent_value).unwrap();
-    assert_eq!(agent_read.model, "gpt-4o-mini");
+    assert_eq!(agent_read.model_id, "gpt-4o-mini");
 
     let listed = store.list("agents", 0, 10).await.unwrap();
     assert_eq!(listed.len(), 1);

--- a/crates/awaken/src/prelude.rs
+++ b/crates/awaken/src/prelude.rs
@@ -9,7 +9,7 @@
 //! feature flag is active.
 
 // ── Building agents ──
-pub use crate::registry::traits::ModelEntry;
+pub use crate::registry::traits::ModelBinding;
 pub use crate::{AgentRuntime, AgentRuntimeBuilder, BuildError, RunRequest, RuntimeError};
 pub use crate::{AgentSpec, PluginConfigKey};
 

--- a/crates/awaken/tests/agent_loop.rs
+++ b/crates/awaken/tests/agent_loop.rs
@@ -9,7 +9,7 @@ use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::{NullEventSink, VecEventSink};
 use awaken::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
 use awaken::contract::identity::{RunIdentity, RunOrigin};
-use awaken::contract::inference::{StopReason, StreamResult, TokenUsage};
+use awaken::contract::inference::{InferenceOverride, StopReason, StreamResult, TokenUsage};
 use awaken::contract::lifecycle::{RunStatus, TerminationReason};
 use awaken::contract::message::{Message, Role, ToolCall};
 use awaken::contract::suspension::{
@@ -253,6 +253,72 @@ async fn single_step_natural_end() {
     assert_eq!(lifecycle.status_reason.as_deref(), Some("natural"));
     assert_eq!(lifecycle.step_count, 1);
     assert_eq!(lifecycle.run_id, "run-1");
+}
+
+#[tokio::test]
+async fn run_level_model_override_selects_upstream_model() {
+    struct CapturingUpstreamModelLlm {
+        upstream_models_seen: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl LlmExecutor for CapturingUpstreamModelLlm {
+        async fn execute(
+            &self,
+            req: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            self.upstream_models_seen
+                .lock()
+                .unwrap()
+                .push(req.upstream_model);
+            Ok(StreamResult {
+                content: vec![ContentBlock::text("ok")],
+                tool_calls: vec![],
+                usage: None,
+                stop_reason: Some(StopReason::EndTurn),
+                has_incomplete_tool_calls: false,
+            })
+        }
+
+        fn name(&self) -> &str {
+            "capturing-upstream-model"
+        }
+    }
+
+    let llm = Arc::new(CapturingUpstreamModelLlm {
+        upstream_models_seen: Mutex::new(Vec::new()),
+    });
+    let agent = ResolvedAgent::new("test", "base-upstream-model", "sys", llm.clone());
+    let runtime = make_runtime();
+    let resolver = FixedResolver::new(agent);
+
+    let result = run_agent_loop(AgentLoopParams {
+        resolver: &resolver,
+        agent_id: "test",
+        runtime: &runtime,
+        sink: Arc::new(NullEventSink),
+        checkpoint_store: None,
+        messages: vec![Message::user("go")],
+        run_identity: test_identity(),
+        cancellation_token: None,
+        decision_rx: None,
+        overrides: Some(InferenceOverride {
+            upstream_model: Some("override-upstream-model".into()),
+            ..Default::default()
+        }),
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: false,
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(result.termination, TerminationReason::NaturalEnd);
+    let upstream_models_seen = llm.upstream_models_seen.lock().unwrap().clone();
+    assert_eq!(
+        upstream_models_seen,
+        vec!["override-upstream-model".to_string()]
+    );
 }
 
 #[tokio::test]
@@ -4015,22 +4081,22 @@ impl LlmExecutor for CountingLlm {
     }
 }
 
-/// An LLM that records the model field from each request.
+/// An LLM that records the upstream_model field from each request.
 struct ModelRecordingLlm {
-    models_seen: Mutex<Vec<String>>,
+    upstream_models_seen: Mutex<Vec<String>>,
     responses: Mutex<Vec<StreamResult>>,
 }
 
 impl ModelRecordingLlm {
     fn new(responses: Vec<StreamResult>) -> Self {
         Self {
-            models_seen: Mutex::new(Vec::new()),
+            upstream_models_seen: Mutex::new(Vec::new()),
             responses: Mutex::new(responses),
         }
     }
 
-    fn models(&self) -> Vec<String> {
-        self.models_seen.lock().unwrap().clone()
+    fn upstream_models(&self) -> Vec<String> {
+        self.upstream_models_seen.lock().unwrap().clone()
     }
 }
 
@@ -4040,7 +4106,10 @@ impl LlmExecutor for ModelRecordingLlm {
         &self,
         req: InferenceRequest,
     ) -> Result<StreamResult, InferenceExecutionError> {
-        self.models_seen.lock().unwrap().push(req.model.clone());
+        self.upstream_models_seen
+            .lock()
+            .unwrap()
+            .push(req.upstream_model.clone());
         let mut responses = self.responses.lock().unwrap();
         if responses.is_empty() {
             Ok(StreamResult {
@@ -4097,9 +4166,9 @@ async fn retry_startup_error_propagates() {
     );
 }
 
-/// 2. Model name in inference request matches ResolvedAgent.model.
+/// 2. Upstream model in inference request matches ResolvedAgent.upstream_model.
 #[tokio::test]
-async fn inference_request_uses_configured_model_name() {
+async fn inference_request_uses_configured_upstream_model() {
     let llm = Arc::new(ModelRecordingLlm::new(vec![StreamResult {
         content: vec![ContentBlock::text("ok")],
         tool_calls: vec![],
@@ -4132,11 +4201,15 @@ async fn inference_request_uses_configured_model_name() {
     .await
     .unwrap();
 
-    let models = llm_clone.models();
-    assert_eq!(models.len(), 1, "should have exactly one inference call");
+    let upstream_models = llm_clone.upstream_models();
     assert_eq!(
-        models[0], "claude-3-opus",
-        "inference request should use the configured model name"
+        upstream_models.len(),
+        1,
+        "should have exactly one inference call"
+    );
+    assert_eq!(
+        upstream_models[0], "claude-3-opus",
+        "inference request should use the configured upstream model"
     );
 }
 
@@ -5272,7 +5345,7 @@ async fn agent_config_builder_chain() {
         .with_tool(Arc::new(EchoTool))
         .with_tool(Arc::new(CalcTool));
 
-    assert_eq!(config.model, "gpt-4");
+    assert_eq!(config.upstream_model, "gpt-4");
     assert_eq!(config.max_rounds(), 5);
     assert_eq!(config.system_prompt(), "You are helpful.");
     assert_eq!(config.tools.len(), 2);

--- a/crates/awaken/tests/skill_permission_e2e.rs
+++ b/crates/awaken/tests/skill_permission_e2e.rs
@@ -284,7 +284,7 @@ fn make_agent_spec_deny_all_with_extra_allowed_tools(extra_allowed_tools: &[&str
 
     AgentSpec {
         id: "test".into(),
-        model: "m".into(),
+        model_id: "m".into(),
         system_prompt: "sys".into(),
         max_rounds: 16,
         max_continuation_retries: 2,

--- a/crates/awaken/tests/tool_executor.rs
+++ b/crates/awaken/tests/tool_executor.rs
@@ -1218,7 +1218,7 @@ async fn before_inference_hook_override_reaches_request() {
 
     // LLM that captures the InferenceRequest
     struct CapturingLlm {
-        captured: Mutex<Vec<Option<InferenceOverride>>>,
+        captured: Mutex<Vec<(String, Option<InferenceOverride>)>>,
     }
 
     #[async_trait]
@@ -1227,7 +1227,10 @@ async fn before_inference_hook_override_reaches_request() {
             &self,
             req: InferenceRequest,
         ) -> Result<StreamResult, InferenceExecutionError> {
-            self.captured.lock().unwrap().push(req.overrides);
+            self.captured
+                .lock()
+                .unwrap()
+                .push((req.upstream_model, req.overrides));
             Ok(StreamResult {
                 content: vec![ContentBlock::text("done")],
                 tool_calls: vec![],
@@ -1297,10 +1300,12 @@ async fn before_inference_hook_override_reaches_request() {
 
     let captured = llm.captured.lock().unwrap();
     assert_eq!(captured.len(), 1);
-    let overrides = captured[0].as_ref().expect("overrides should be set");
+    let (upstream_model, overrides) = &captured[0];
+    assert_eq!(upstream_model, "m");
+    let overrides = overrides.as_ref().expect("overrides should be set");
     assert_eq!(overrides.temperature, Some(0.0));
     assert_eq!(overrides.max_tokens, Some(256));
-    assert!(overrides.model.is_none());
+    assert!(overrides.upstream_model.is_none());
 }
 
 #[tokio::test]
@@ -1308,7 +1313,7 @@ async fn multiple_hooks_merge_inference_overrides_last_wins() {
     use awaken::contract::inference::InferenceOverride;
 
     struct CapturingLlm {
-        captured: Mutex<Vec<Option<InferenceOverride>>>,
+        captured: Mutex<Vec<(String, Option<InferenceOverride>)>>,
     }
 
     #[async_trait]
@@ -1317,7 +1322,10 @@ async fn multiple_hooks_merge_inference_overrides_last_wins() {
             &self,
             req: InferenceRequest,
         ) -> Result<StreamResult, InferenceExecutionError> {
-            self.captured.lock().unwrap().push(req.overrides);
+            self.captured
+                .lock()
+                .unwrap()
+                .push((req.upstream_model, req.overrides));
             Ok(StreamResult {
                 content: vec![ContentBlock::text("done")],
                 tool_calls: vec![],
@@ -1331,7 +1339,7 @@ async fn multiple_hooks_merge_inference_overrides_last_wins() {
         }
     }
 
-    // Plugin A sets temperature=0.5, model="model-a"
+    // Plugin A sets temperature=0.5, upstream_model="model-a"
     struct OverridePluginA;
     impl Plugin for OverridePluginA {
         fn descriptor(&self) -> PluginDescriptor {
@@ -1345,7 +1353,7 @@ async fn multiple_hooks_merge_inference_overrides_last_wins() {
                     let mut cmd = StateCommand::new();
                     cmd.schedule_action::<SetInferenceOverride>(InferenceOverride {
                         temperature: Some(0.5),
-                        model: Some("model-a".into()),
+                        upstream_model: Some("model-a".into()),
                         ..Default::default()
                     })?;
                     Ok(cmd)
@@ -1356,7 +1364,7 @@ async fn multiple_hooks_merge_inference_overrides_last_wins() {
         }
     }
 
-    // Plugin B sets temperature=0.9, max_tokens=512 (overwrites A's temperature, A's model preserved)
+    // Plugin B sets temperature=0.9, max_tokens=512 (overwrites A's temperature).
     struct OverridePluginB;
     impl Plugin for OverridePluginB {
         fn descriptor(&self) -> PluginDescriptor {
@@ -1411,13 +1419,15 @@ async fn multiple_hooks_merge_inference_overrides_last_wins() {
 
     let captured = llm.captured.lock().unwrap();
     assert_eq!(captured.len(), 1);
-    let overrides = captured[0].as_ref().expect("overrides should be set");
+    let (upstream_model, overrides) = &captured[0];
+    assert_eq!(upstream_model, "model-a");
+    let overrides = overrides.as_ref().expect("overrides should be set");
     // B's temperature wins (last-wins)
     assert_eq!(overrides.temperature, Some(0.9));
     // B's max_tokens set
     assert_eq!(overrides.max_tokens, Some(512));
-    // A's model preserved (B didn't set it)
-    assert_eq!(overrides.model.as_deref(), Some("model-a"));
+    // Primary upstream selection has a single source of truth on InferenceRequest.
+    assert!(overrides.upstream_model.is_none());
 }
 
 #[tokio::test]

--- a/docs/adr/0009-layered-config-and-profile-switch.md
+++ b/docs/adr/0009-layered-config-and-profile-switch.md
@@ -124,7 +124,7 @@ Model override, thinking adjustment, temperature change for one inference — th
 
 ```rust
 cmd.effect(RuntimeEffect::InferenceOverride {
-    model: Some("gpt-4o".into()),
+    upstream_model: Some("gpt-4o".into()),
     thinking: Some(ThinkingConfig { enabled: false }),
 })?;
 ```

--- a/docs/adr/0010-registry-and-resolve.md
+++ b/docs/adr/0010-registry-and-resolve.md
@@ -18,7 +18,7 @@ Reference: uncarve's `AgentDefinition` + `RegistrySet` + `resolve()` pattern —
 #[derive(Serialize, Deserialize)]
 pub struct AgentSpec {
     pub id: String,
-    pub model: String,                         // ModelRegistry ID
+    pub model_id: String,                      // ModelRegistry ID
     pub system_prompt: String,
     pub max_rounds: usize,
     pub tool_execution_mode: ToolExecutionMode,
@@ -39,7 +39,7 @@ No `Arc<dyn T>`, no trait objects. Pure data. Can be saved to JSON, loaded from 
 | Registry | Key | Value | Purpose |
 |----------|-----|-------|---------|
 | `ToolRegistry` | tool_id | `Arc<dyn Tool>` | Available tools |
-| `ModelRegistry` | model_id | `ModelEntry` | Model name + provider + default options |
+| `ModelRegistry` | model_id | `ModelBinding` | Provider id + upstream model name |
 | `ProviderRegistry` | provider_id | `Arc<dyn LlmExecutor>` | LLM API clients |
 | `AgentRegistry` | agent_id | `AgentSpec` | Agent definitions |
 | `PluginRegistry` | plugin_id | `Arc<dyn Plugin>` | All extensions: hooks, permissions, MCP, skills |
@@ -58,17 +58,16 @@ Each registry is a trait with `get(id) -> Option<&T>` and `ids() -> Vec<String>`
 
 **No separate BehaviorRegistry or ExtensionRegistry.** Behaviors, extensions, MCP bridges, skill runtimes, permission checkers — all are `Plugin`. A Plugin that contributes tools registers them in `ToolRegistry` during build. A Plugin that contributes hooks does so via its `register()` method. The `PluginRegistry` is the single source of all pluggable functionality.
 
-### D3: ModelEntry and provider resolution
+### D3: ModelBinding and provider resolution
 
 ```rust
-pub struct ModelEntry {
-    pub provider: String,           // ProviderRegistry ID
-    pub model_name: String,         // Actual model name for API call
-    pub default_options: ChatOptions,
+pub struct ModelBinding {
+    pub provider_id: String,        // ProviderRegistry ID
+    pub upstream_model: String,     // Actual model name for API call
 }
 ```
 
-Resolution: `model_id → ModelEntry → provider_id → Arc<dyn LlmExecutor>`.
+Resolution: `model_id → ModelBinding → provider_id → Arc<dyn LlmExecutor>`.
 
 ### D4: resolve(agent_id) → ResolvedRun
 
@@ -78,8 +77,8 @@ pub fn resolve(
     agent_id: &str,
 ) -> Result<ResolvedRun, ResolveError> {
     let spec = registries.agents.get(agent_id)?;
-    let model = registries.models.get(&spec.model)?;
-    let executor = registries.providers.get(&model.provider)?;
+    let model = registries.models.get(&spec.model_id)?;
+    let executor = registries.providers.get(&model.provider_id)?;
 
     // Resolve tools: snapshot + allow/exclude filter
     let tools = resolve_tools(registries, spec)?;
@@ -90,8 +89,7 @@ pub fn resolve(
     Ok(ResolvedRun {
         spec: spec.clone(),
         executor: Arc::clone(executor),
-        model_name: model.model_name.clone(),
-        chat_options: model.default_options.clone(),
+        upstream_model: model.upstream_model.clone(),
         tools,
         plugins,
     })
@@ -104,7 +102,7 @@ pub fn resolve(
 pub struct ResolvedRun {
     pub spec: AgentSpec,
     pub executor: Arc<dyn LlmExecutor>,
-    pub model_name: String,
+    pub upstream_model: String,
     pub chat_options: ChatOptions,
     pub tools: HashMap<String, Arc<dyn Tool>>,
     pub plugins: Vec<Arc<dyn Plugin>>,
@@ -174,38 +172,15 @@ A plugin that bridges MCP servers contributes tools to `ToolRegistry` and hooks 
 #[derive(Serialize, Deserialize)]
 pub struct AgentSystemConfig {
     #[serde(default)]
-    pub providers: HashMap<String, ProviderConfig>,
-    #[serde(default)]
-    pub models: HashMap<String, ModelConfig>,
+    pub models: Vec<ModelBindingSpec>,
     #[serde(default)]
     pub agents: Vec<AgentSpec>,
 }
-
-#[derive(Serialize, Deserialize)]
-pub struct ProviderConfig {
-    pub kind: String,                   // "anthropic", "openai", "ollama"
-    pub endpoint: Option<String>,
-    pub auth: Option<AuthConfig>,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct AuthConfig {
-    pub env: Option<String>,            // Environment variable name
-    pub token: Option<String>,          // Literal token (dev only)
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct ModelConfig {
-    pub provider: String,               // ProviderConfig key
-    pub model: String,                  // Actual model name
-    #[serde(default)]
-    pub options: ChatOptions,
-}
 ```
 
-Parse flow: `JSON/TOML → AgentSystemConfig → build registries → resolve agents`.
+Parse flow: `JSON/TOML → AgentSystemConfig + provider executors → build registries → resolve agents`.
 
-Plugins are not in the config file — they are registered programmatically (they hold trait object implementations). The config file covers data-only definitions (agents, models, providers).
+Providers and plugins are registered programmatically in this low-level helper because they hold trait object implementations. The managed server config path uses serializable `ProviderSpec`, `ModelBindingSpec`, and `AgentSpec` documents, then compiles them into the same runtime registries before resolution.
 
 ### D8: ~~run_agent_loop accepts ResolvedRun~~ (superseded by ADR-0011 D6)
 
@@ -228,14 +203,10 @@ Handoff is resolved inside the loop at step boundaries via `ActiveAgentKey` chec
 - `MapXxxRegistry` implementations (5): implemented
 - `RegistrySet`: implemented
 - `AgentSpec`: implemented
-- `ModelEntry`: implemented (without ChatOptions)
+- `ModelBinding`: implemented
 - `resolve()` → `ResolvedRun` (internal): implemented
 - `RegistrySet` implements `AgentResolver`: implemented
 - `AgentRuntime::run(RunRequest)`: implemented
-
-### To implement
-- `AgentSystemConfig` (JSON config format)
-- `ChatOptions` on `ModelEntry`
 
 ### Deferred
 - `CompositeXxxRegistry` (merge multiple sources)

--- a/docs/adr/0014-agent-spec-resolution-model.md
+++ b/docs/adr/0014-agent-spec-resolution-model.md
@@ -25,7 +25,7 @@ Re-resolution occurs at step boundaries only when `ActiveAgentIdKey` indicates t
 
 ### D4: No per-phase live config resolution
 
-A persisted `ConfigStore` may exist to hold serializable `AgentSpec` / `ModelSpec` / `ProviderSpec` / `McpServerSpec` documents, but runtime execution does not query it directly at every boundary. Config changes are compiled into versioned registry snapshots; new runs see the latest published snapshot, while active runs and in-flight steps keep their pinned snapshot. Dynamic config changes still require either a handoff (agent switch) or a new run to observe different agent specs.
+A persisted `ConfigStore` may exist to hold serializable `AgentSpec` / `ModelBindingSpec` / `ProviderSpec` / `McpServerSpec` documents, but runtime execution does not query it directly at every boundary. Config changes are compiled into versioned registry snapshots; new runs see the latest published snapshot, while active runs and in-flight steps keep their pinned snapshot. Dynamic config changes still require either a handoff (agent switch) or a new run to observe different agent specs.
 
 ## Consequences
 

--- a/docs/book/README.zh-CN.md
+++ b/docs/book/README.zh-CN.md
@@ -45,7 +45,7 @@ use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::engine::GenaiExecutor;
 use awaken::registry_spec::AgentSpec;
-use awaken::registry::ModelEntry;
+use awaken::registry::ModelBinding;
 use awaken::{AgentRuntimeBuilder, RunRequest};
 
 struct EchoTool;
@@ -74,7 +74,7 @@ impl Tool for EchoTool {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent_spec = AgentSpec::new("assistant")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt("You are a helpful assistant. Use the echo tool when asked.")
         .with_max_rounds(5);
 
@@ -82,9 +82,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_agent_spec(agent_spec)
         .with_tool("echo", Arc::new(EchoTool))
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model("gpt-4o-mini", ModelEntry {
-            provider: "openai".into(),
-            model_name: "gpt-4o-mini".into(),
+        .with_model_binding("gpt-4o-mini", ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         })
         .build()?;
 

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -18,5 +18,5 @@ command = "mdbook-mermaid"
 default-theme = "rust"
 git-repository-url = "https://github.com/AwakenWorks/awaken"
 edit-url-template = "https://github.com/AwakenWorks/awaken/edit/main/docs/book/{path}"
-additional-css = ["language-switcher.css"]
-additional-js = ["mermaid.min.js", "mermaid-init.js", "language-switcher.js"]
+additional-css = ["theme/language-switcher.css"]
+additional-js = ["mermaid.min.js", "mermaid-init.js", "theme/language-switcher.js"]

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -56,6 +56,7 @@
 - [Events](./reference/events.md)
 - [HTTP API](./reference/http-api.md)
 - [Config](./reference/config.md)
+- [Provider and Model Configuration](./reference/provider-model-config.md)
 - [Errors](./reference/errors.md)
 - [AI SDK v6 Protocol](./reference/protocols/ai-sdk-v6.md)
 - [AG-UI Protocol](./reference/protocols/ag-ui.md)

--- a/docs/book/src/explanation/agent-resolution.md
+++ b/docs/book/src/explanation/agent-resolution.md
@@ -9,7 +9,7 @@ Resolution is a pure function: `(RegistrySet, agent_id) -> ResolvedAgent`. It pr
 ```mermaid
 flowchart LR
     subgraph Stage1["Stage 1: Lookup"]
-        A1[Fetch AgentSpec] --> A2[Resolve ModelSpec]
+        A1[Fetch AgentSpec] --> A2[Resolve ModelBinding]
         A2 --> A3[Get LlmExecutor]
         A3 --> A4{Retry config?}
         A4 -- yes --> A5[Wrap in RetryingExecutor]
@@ -44,11 +44,13 @@ The first stage fetches the raw data from registries:
 
 1. **AgentSpec** -- looked up from `AgentSpecRegistry` by `agent_id`. If the spec has an `endpoint` field (remote backend agent), resolution fails with `RemoteAgentNotDirectlyRunnable` -- remote agents can only be used as delegates, not run directly.
 
-2. **ModelSpec** -- the spec's `model` field (a string ID like `"gpt-4"`) is resolved through `ModelRegistry` into a `ModelSpec`, which maps it to a provider ID and an actual API model name (for example, provider `"openai"`, model `"gpt-4o"`).
+2. **ModelBinding** -- the spec's `model_id` field (a model registry ID like `"default"`) is resolved through `ModelRegistry` into a `ModelBinding`, which maps it to a provider ID and an upstream API model name (for example, provider `"openai"`, upstream model `"gpt-4o"`). Serializable `ModelBindingSpec` values from managed config are compiled into these runtime bindings before resolution.
 
-3. **LlmExecutor** -- the provider ID from the model entry is resolved through `ProviderRegistry` to get a live `LlmExecutor` instance.
+3. **LlmExecutor** -- the provider ID from the model binding is resolved through `ProviderRegistry` to get a live `LlmExecutor` instance.
 
-4. **Retry decoration** -- if the agent spec contains a `RetryConfigKey` section with `max_retries > 0` or non-empty `fallback_models`, the executor is wrapped in a `RetryingExecutor` decorator.
+4. **Retry decoration** -- the agent spec is read through `RetryConfigKey`; a missing section uses `LlmRetryPolicy::default()`. If the resulting policy has `max_retries > 0` or non-empty `fallback_upstream_models`, the executor is wrapped in a `RetryingExecutor` decorator.
+
+For the provider/model data flow, see [Provider and Model Configuration](../reference/provider-model-config.md).
 
 ## Stage 2: Plugin Pipeline
 
@@ -145,7 +147,7 @@ The builder (`AgentRuntimeBuilder`) is the standard way to construct an `AgentRu
 |---|---|---|
 | `MapAgentSpecRegistry` | `with_agent_spec()` / `with_agent_specs()` | Agent definitions |
 | `MapToolRegistry` | `with_tool()` | Global tools |
-| `MapModelRegistry` | `with_model()` | Model ID to provider + model name mappings |
+| `MapModelRegistry` | `with_model_binding()` | Model ID to provider + upstream model mappings |
 | `MapProviderRegistry` | `with_provider()` | LLM executor instances |
 | `MapPluginSource` | `with_plugin()` | Plugin instances |
 

--- a/docs/book/src/explanation/architecture.md
+++ b/docs/book/src/explanation/architecture.md
@@ -19,7 +19,7 @@ Server + storage surfaces
   thread/run persistence, profile storage
 ```
 
-**Contract layer** -- `awaken-contract` defines the shared types used everywhere: `AgentSpec`, `ModelSpec`, `ProviderSpec`, `Tool`, `AgentEvent`, transport traits, and the typed state model. This is the vocabulary that the rest of the system speaks.
+**Contract layer** -- `awaken-contract` defines the shared types used everywhere: `AgentSpec`, `ModelBindingSpec`, `ProviderSpec`, `Tool`, `AgentEvent`, transport traits, and the typed state model. This is the vocabulary that the rest of the system speaks.
 
 **Runtime core** -- `awaken-runtime` is the orchestration layer. It resolves agent IDs to fully wired configurations (`ResolvedAgent`), builds an `ExecutionEnv` from plugins, manages active runs, and delegates execution to the loop runner plus phase engine.
 

--- a/docs/book/src/explanation/multi-agent-patterns.md
+++ b/docs/book/src/explanation/multi-agent-patterns.md
@@ -9,7 +9,7 @@ An agent can declare sub-agents it is allowed to delegate to:
 ```json
 {
   "id": "orchestrator",
-  "model": "gpt-4o",
+  "model_id": "gpt-4o",
   "system_prompt": "You coordinate tasks across specialized agents.",
   "delegates": ["researcher", "writer", "reviewer"]
 }
@@ -29,7 +29,7 @@ Remote agents are declared with an `endpoint` in `AgentSpec`:
 ```json
 {
   "id": "remote-analyst",
-  "model": "unused-for-remote",
+  "model_id": "unused-for-remote",
   "system_prompt": "",
   "endpoint": {
     "backend": "a2a",

--- a/docs/book/src/explanation/plugin-internals.md
+++ b/docs/book/src/explanation/plugin-internals.md
@@ -161,14 +161,18 @@ Multiple plugins can influence inference parameters by scheduling `SetInferenceO
 
 ```rust,ignore
 pub struct InferenceOverride {
-    pub model: Option<String>,
-    pub fallback_models: Option<Vec<String>>,
+    pub upstream_model: Option<String>,
+    pub fallback_upstream_models: Option<Vec<String>>,
     pub temperature: Option<f64>,
     pub max_tokens: Option<u32>,
     pub top_p: Option<f64>,
     pub reasoning_effort: Option<ReasoningEffort>,
 }
 ```
+
+`upstream_model` and `fallback_upstream_models` are upstream model names for the already
+resolved provider; they do not switch provider executors. See
+[Provider and Model Configuration](../reference/provider-model-config.md).
 
 When two overrides are merged, each field independently takes the last non-`None` value:
 

--- a/docs/book/src/how-to/add-a-plugin.md
+++ b/docs/book/src/how-to/add-a-plugin.md
@@ -101,7 +101,7 @@ use std::sync::Arc;
 use awaken::{AgentSpec, AgentRuntimeBuilder};
 
 let spec = AgentSpec::new("assistant")
-    .with_model("anthropic/claude-sonnet")
+    .with_model_id("anthropic/claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("audit");
 

--- a/docs/book/src/how-to/build-an-agent.md
+++ b/docs/book/src/how-to/build-an-agent.md
@@ -14,10 +14,11 @@ Use this when you need to assemble an agent with tools, persistence, and a provi
 
 ```rust,ignore
 use awaken::engine::GenaiExecutor;
-use awaken::{AgentSpec, AgentRuntimeBuilder, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::{AgentSpec, AgentRuntimeBuilder};
 
 let spec = AgentSpec::new("assistant")
-    .with_model("claude-sonnet")
+    .with_model_id("claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_max_rounds(10);
 ```
@@ -38,10 +39,9 @@ let builder = AgentRuntimeBuilder::new()
 ```rust,ignore
 let builder = builder
     .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model("claude-sonnet", ModelSpec {
-        id: "claude-sonnet".into(),
-        provider: "anthropic".into(),
-        model: "claude-sonnet-4-20250514".into(),
+    .with_model_binding("claude-sonnet", ModelBinding {
+        provider_id: "anthropic".into(),
+        upstream_model: "claude-sonnet-4-20250514".into(),
     });
 ```
 

--- a/docs/book/src/how-to/enable-observability.md
+++ b/docs/book/src/how-to/enable-observability.md
@@ -22,24 +22,24 @@ tokio = { version = "1", features = ["full"] }
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_observability::{ObservabilityPlugin, InMemorySink};
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let sink = InMemorySink::new();
 let obs_plugin = ObservabilityPlugin::new(sink.clone());
 let agent_spec = AgentSpec::new("observed-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("observability");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)
@@ -76,7 +76,8 @@ for stat in metrics.stats_by_tool() {
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_observability::{ObservabilityPlugin, OtelMetricsSink};
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 use opentelemetry_sdk::trace::SdkTracerProvider;
 
@@ -87,18 +88,17 @@ let tracer = provider.tracer("awaken");
 
 let obs_plugin = ObservabilityPlugin::new(OtelMetricsSink::new(tracer));
 let agent_spec = AgentSpec::new("observed-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("observability");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/how-to/enable-tool-permission-hitl.md
+++ b/docs/book/src/how-to/enable-tool-permission-hitl.md
@@ -22,22 +22,22 @@ serde_json = "1"
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_permission::PermissionPlugin;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("permission");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)
@@ -114,7 +114,7 @@ let ruleset = config.into_ruleset().expect("invalid rules");
 use awaken::registry_spec::AgentSpec;
 
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("permission");
 ```

--- a/docs/book/src/how-to/expose-http-sse.md
+++ b/docs/book/src/how-to/expose-http-sse.md
@@ -23,7 +23,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 ```rust,ignore
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
-use awaken::{AgentRuntimeBuilder, AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::{AgentRuntimeBuilder, AgentSpec};
 use awaken::stores::InMemoryStore;
 
 let store = Arc::new(InMemoryStore::new());
@@ -31,15 +32,14 @@ let store = Arc::new(InMemoryStore::new());
 let runtime = AgentRuntimeBuilder::new()
     .with_agent_spec(
         AgentSpec::new("assistant")
-            .with_model("claude-sonnet")
+            .with_model_id("claude-sonnet")
             .with_system_prompt("You are a helpful assistant."),
     )
     .with_tool("search", Arc::new(SearchTool))
     .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model("claude-sonnet", ModelSpec {
-        id: "claude-sonnet".into(),
-        provider: "anthropic".into(),
-        model: "claude-sonnet-4-20250514".into(),
+    .with_model_binding("claude-sonnet", ModelBinding {
+        provider_id: "anthropic".into(),
+        upstream_model: "claude-sonnet-4-20250514".into(),
     })
     .with_thread_run_store(store.clone())
     .build()?;

--- a/docs/book/src/how-to/integrate-ai-sdk-frontend.md
+++ b/docs/book/src/how-to/integrate-ai-sdk-frontend.md
@@ -26,7 +26,8 @@ use std::sync::Arc;
 
 use awaken::engine::GenaiExecutor;
 use awaken::contract::storage::ThreadRunStore;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::stores::{InMemoryMailboxStore, InMemoryStore};
 use awaken::AgentRuntimeBuilder;
 use awaken::server::app::{AppState, ServerConfig};
@@ -38,18 +39,17 @@ async fn main() {
     tracing_subscriber::fmt().with_target(true).init();
 
     let agent_spec = AgentSpec::new("my-agent")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt("You are a helpful assistant.")
         .with_max_rounds(10);
 
     let runtime = AgentRuntimeBuilder::new()
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model(
+        .with_model_binding(
             "gpt-4o-mini",
-            ModelSpec {
-                id: "gpt-4o-mini".into(),
-                provider: "openai".into(),
-                model: "gpt-4o-mini".into(),
+            ModelBinding {
+                provider_id: "openai".into(),
+                upstream_model: "gpt-4o-mini".into(),
             },
         )
         .with_agent_spec(agent_spec)

--- a/docs/book/src/how-to/integrate-copilotkit-ag-ui.md
+++ b/docs/book/src/how-to/integrate-copilotkit-ag-ui.md
@@ -26,7 +26,8 @@ use std::sync::Arc;
 
 use awaken::engine::GenaiExecutor;
 use awaken::contract::storage::ThreadRunStore;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::stores::{InMemoryMailboxStore, InMemoryStore};
 use awaken::AgentRuntimeBuilder;
 use awaken::server::app::{AppState, ServerConfig};
@@ -38,7 +39,7 @@ async fn main() {
     tracing_subscriber::fmt().with_target(true).init();
 
     let agent_spec = AgentSpec::new("copilotkit-agent")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt(
             "You are a CopilotKit-powered assistant. \
              Update shared state and suggest actions when appropriate.",
@@ -47,12 +48,11 @@ async fn main() {
 
     let runtime = AgentRuntimeBuilder::new()
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model(
+        .with_model_binding(
             "gpt-4o-mini",
-            ModelSpec {
-                id: "gpt-4o-mini".into(),
-                provider: "openai".into(),
-                model: "gpt-4o-mini".into(),
+            ModelBinding {
+                provider_id: "openai".into(),
+                upstream_model: "gpt-4o-mini".into(),
             },
         )
         .with_agent_spec(agent_spec)

--- a/docs/book/src/how-to/optimize-context-window.md
+++ b/docs/book/src/how-to/optimize-context-window.md
@@ -97,7 +97,7 @@ let config = CompactionConfig {
         Be concise but complete.".into(),
     summarizer_user_prompt: "Summarize the following conversation:\n\n{messages}".into(),
     summary_max_tokens: Some(1024),
-    summary_model: Some("claude-3-haiku".into()),
+    summary_upstream_model: Some("claude-3-haiku".into()),
     min_savings_ratio: 0.3,
 };
 ```

--- a/docs/book/src/how-to/use-agent-handoff.md
+++ b/docs/book/src/how-to/use-agent-handoff.md
@@ -24,14 +24,14 @@ Key types:
 
 Each overlay specifies which parts of the base agent configuration to override. Fields left as `None` inherit the base agent's values.
 
-The `model` field uses the same model registry ID that `AgentSpec.model` uses.
+The `model` field uses the same model registry ID that `AgentSpec.model_id` uses.
 
 ```rust,ignore
 use awaken::extensions::handoff::AgentOverlay;
 
 let researcher = AgentOverlay {
     system_prompt: Some("You are a research specialist. Find and cite sources.".into()),
-    model: Some("claude-sonnet".into()),
+    upstream_model: Some("claude-sonnet".into()),
     allowed_tools: Some(vec!["web_search".into(), "read_document".into()]),
     excluded_tools: None,
 };

--- a/docs/book/src/how-to/use-deferred-tools.md
+++ b/docs/book/src/how-to/use-deferred-tools.md
@@ -24,7 +24,8 @@ Collect all tool descriptors your agent exposes, then pass them to `DeferredTool
 ```rust,ignore
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 use awaken_ext_deferred_tools::DeferredToolsPlugin;
 
@@ -36,18 +37,17 @@ let seed_tools = vec![
     // ... all tool descriptors
 ];
 let agent_spec = AgentSpec::new("deferred-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Search for tools only when needed.")
     .with_hook_filter("ext-deferred-tools");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/how-to/use-generative-ui.md
+++ b/docs/book/src/how-to/use-generative-ui.md
@@ -23,23 +23,23 @@ serde_json = "1"
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_generative_ui::A2uiPlugin;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let plugin = A2uiPlugin::with_catalog_id("my-catalog");
 let agent_spec = AgentSpec::new("ui-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Render structured UI when visual output helps.")
     .with_hook_filter("generative-ui");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/how-to/use-mcp-tools.md
+++ b/docs/book/src/how-to/use-mcp-tools.md
@@ -59,22 +59,22 @@ for id in registry.ids() {
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_mcp::McpPlugin;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let agent_spec = AgentSpec::new("mcp-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Use MCP tools when they help answer the user.")
     .with_hook_filter("mcp");
 
 let mut builder = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/how-to/use-reminder-plugin.md
+++ b/docs/book/src/how-to/use-reminder-plugin.md
@@ -186,7 +186,7 @@ let rules = config.into_rules().expect("invalid rules");
 use awaken::registry_spec::AgentSpec;
 
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("anthropic/claude-sonnet")
+    .with_model_id("anthropic/claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("reminder");
 ```

--- a/docs/book/src/how-to/use-skills-subsystem.md
+++ b/docs/book/src/how-to/use-skills-subsystem.md
@@ -91,24 +91,24 @@ let registry = Arc::new(InMemorySkillRegistry::from_skills(vec![Arc::new(skill)]
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_skills::SkillSubsystem;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let subsystem = SkillSubsystem::new(registry);
 let agent_spec = AgentSpec::new("skills-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Discover and activate skills when specialized help is useful.")
     .with_hook_filter("skills-discovery")
     .with_hook_filter("skills-active-instructions");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -8,7 +8,7 @@ programmatically via builder methods.
 ```rust,ignore
 pub struct AgentSpec {
     pub id: String,
-    pub model: String,
+    pub model_id: String,                            // model registry id
     pub system_prompt: String,
     pub max_rounds: usize,                          // default: 16
     pub max_continuation_retries: usize,            // default: 2
@@ -30,7 +30,7 @@ pub struct AgentSpec {
 
 ```rust,ignore
 AgentSpec::new(id) -> Self
-    .with_model(model) -> Self
+    .with_model_id(model_id) -> Self
     .with_system_prompt(prompt) -> Self
     .with_max_rounds(n) -> Self
     .with_hook_filter(plugin_id) -> Self
@@ -82,11 +82,15 @@ Per-inference parameter override. All fields are `Option`; `None` means "use
 agent-level default". Multiple plugins can emit overrides; fields merge with
 last-wins semantics.
 
+`upstream_model` and `fallback_upstream_models` are upstream model names for the already resolved
+provider. They do not re-resolve `AgentSpec.model_id` and do not switch providers.
+See [Provider and Model Configuration](./provider-model-config.md).
+
 ```rust,no_run
 # pub enum ReasoningEffort { None, Low, Medium, High, Max, Budget(u32) }
 pub struct InferenceOverride {
-    pub model: Option<String>,
-    pub fallback_models: Option<Vec<String>>,
+    pub upstream_model: Option<String>,      // upstream model name
+    pub fallback_upstream_models: Option<Vec<String>>, // upstream model names
     pub temperature: Option<f64>,
     pub max_tokens: Option<u32>,
     pub top_p: Option<f64>,
@@ -219,10 +223,16 @@ Policy for retrying failed LLM inference calls with exponential backoff and
 optional model fallback. Can be set per-agent via the `"retry"` section in
 `AgentSpec`.
 
+Retry is applied during agent resolution. A missing `"retry"` section uses
+`LlmRetryPolicy::default()`. Set `max_retries` to `0` and keep
+`fallback_upstream_models` empty to disable retry wrapping. Providers are not wrapped
+with a separate hidden retry policy during provider construction. For streaming
+inference, retry and fallback only apply while opening the stream.
+
 ```rust,ignore
 pub struct LlmRetryPolicy {
     pub max_retries: u32,              // default: 2
-    pub fallback_models: Vec<String>,  // default: []
+    pub fallback_upstream_models: Vec<String>,  // default: []
     pub backoff_base_ms: u64,          // default: 500
 }
 ```
@@ -232,7 +242,7 @@ pub struct LlmRetryPolicy {
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `max_retries` | `u32` | `2` | Maximum retry attempts after the initial call (0 = no retry) |
-| `fallback_models` | `Vec<String>` | `[]` | Model names to try in order after the primary model exhausts retries |
+| `fallback_upstream_models` | `Vec<String>` | `[]` | Model names to try in order after the primary model exhausts retries |
 | `backoff_base_ms` | `u64` | `500` | Base delay in milliseconds for exponential backoff; actual delay = min(base * 2^attempt, 8000ms). Set to 0 to disable backoff |
 
 ### AgentSpec integration
@@ -245,7 +255,7 @@ use awaken_runtime::engine::retry::RetryConfigKey;
 let spec = AgentSpec::new("my-agent")
     .with_config::<RetryConfigKey>(LlmRetryPolicy {
         max_retries: 3,
-        fallback_models: vec!["claude-sonnet-4-20250514".into()],
+        fallback_upstream_models: vec!["claude-sonnet-4-20250514".into()],
         backoff_base_ms: 1000,
     })?;
 ```

--- a/docs/book/src/reference/overview.md
+++ b/docs/book/src/reference/overview.md
@@ -10,7 +10,7 @@ so that downstream code only needs a single dependency.
 |---|---|---|
 | `awaken::contract` | `awaken-contract` | Tool trait, events, messages, suspension, lifecycle |
 | `awaken::model` | `awaken-contract` | Phase, EffectSpec, ScheduledActionSpec, JsonValue |
-| `awaken::registry_spec` | `awaken-contract` | AgentSpec, ModelSpec, ProviderSpec, McpServerSpec, PluginConfigKey |
+| `awaken::registry_spec` | `awaken-contract` | AgentSpec, ModelBindingSpec, ProviderSpec, McpServerSpec, PluginConfigKey |
 | `awaken::state` | `awaken-contract` + `awaken-runtime` | StateKey, StateMap, Snapshot, StateStore, MutationBatch |
 | `awaken::agent` | `awaken-runtime` | Agent configuration and state |
 | `awaken::builder` | `awaken-runtime` | AgentRuntimeBuilder, BuildError |

--- a/docs/book/src/reference/provider-model-config.md
+++ b/docs/book/src/reference/provider-model-config.md
@@ -1,0 +1,180 @@
+# Provider and Model Configuration
+
+Awaken keeps provider wiring and model selection separate. The runtime always resolves an agent through this chain:
+
+```text
+AgentSpec.model_id
+  -> ModelRegistry[model id]
+  -> ModelBinding { provider_id, upstream_model }
+  -> ProviderRegistry[provider id]
+  -> Arc<dyn LlmExecutor>
+  -> InferenceRequest.upstream_model = upstream_model
+```
+
+## Terms
+
+| Term | Type | Meaning |
+|---|---|---|
+| Agent model id | `AgentSpec.model_id` | Stable model registry id used by an agent, for example `"default"` or `"research"`. |
+| Runtime model binding | `ModelBinding` | Runtime mapping from model id to provider id and upstream model name. |
+| Config model binding | `ModelBindingSpec` | Serializable mapping stored in managed config. It is compiled into `ModelBinding`. |
+| Provider config | `ProviderSpec` | Serializable provider settings used by the server to construct an executor. |
+| Provider executor | `Arc<dyn LlmExecutor>` | Live provider client used to execute inference. |
+| Upstream model name | `ModelBinding.upstream_model`, `ModelBindingSpec.upstream_model`, `InferenceRequest.upstream_model` | The actual model string sent to the provider API. |
+
+The important distinction is:
+
+- `AgentSpec.model_id` is a registry id.
+- `ModelBindingSpec.upstream_model`, `ModelBinding.upstream_model`, and `InferenceRequest.upstream_model` are upstream provider model names.
+
+## Programmatic builder path
+
+Use this path when the application owns provider construction in code.
+
+```rust,ignore
+use std::sync::Arc;
+use awaken::engine::GenaiExecutor;
+use awaken::registry::ModelBinding;
+use awaken::{AgentRuntimeBuilder, AgentSpec};
+
+let agent = AgentSpec::new("assistant")
+    .with_model_id("default")
+    .with_system_prompt("You are helpful.");
+
+let runtime = AgentRuntimeBuilder::new()
+    .with_provider("openai", Arc::new(GenaiExecutor::new()))
+    .with_model_binding("default", ModelBinding {
+        provider_id: "openai".into(),
+        upstream_model: "gpt-4o-mini".into(),
+    })
+    .with_agent_spec(agent)
+    .build()?;
+```
+
+`build()` validates every registered agent by resolving its model id and provider id. Missing models, providers, or plugins fail at startup.
+
+## Managed config path
+
+Use this path when the server owns dynamic config through `ConfigStore`.
+
+Managed config is stored by namespace:
+
+| Namespace | Serializable type |
+|---|---|
+| `providers` | `ProviderSpec` |
+| `models` | `ModelBindingSpec` |
+| `agents` | `AgentSpec` |
+| `mcp-servers` | `McpServerSpec` |
+
+Example config documents:
+
+```json
+{
+  "id": "openai",
+  "adapter": "openai",
+  "api_key": "sk-...",
+  "base_url": null,
+  "timeout_secs": 300
+}
+```
+
+```json
+{
+  "id": "default",
+  "provider_id": "openai",
+  "upstream_model": "gpt-4o-mini"
+}
+```
+
+```json
+{
+  "id": "assistant",
+  "model_id": "default",
+  "system_prompt": "You are helpful."
+}
+```
+
+The server compiles these documents into runtime registries:
+
+```text
+ProviderSpec -> ProviderExecutorFactory -> Arc<dyn LlmExecutor>
+ModelBindingSpec    -> ModelBinding
+AgentSpec    -> AgentSpecRegistry
+```
+
+Configuration documents use only canonical field names. Use `model_id` on
+agents, `provider_id` and `upstream_model` on model bindings, and
+`fallback_upstream_models` in retry or inference overrides.
+
+The candidate registry set is validated before it replaces the active runtime snapshot. If validation fails, the config write is rolled back.
+
+## Migration from legacy model fields
+
+This version intentionally rejects legacy provider/model field names instead of
+silently normalizing them. Update stored config, test fixtures, and clients
+before upgrading:
+
+| Old field or shape | New canonical form |
+|---|---|
+| `AgentSpec.model` | `AgentSpec.model_id` |
+| `ModelBindingSpec.provider` | `ModelBindingSpec.provider_id` |
+| `ModelBindingSpec.model` | `ModelBindingSpec.upstream_model` |
+| `InferenceOverride.model` | `InferenceOverride.upstream_model` |
+| `fallback_models` | `fallback_upstream_models` |
+| `AgentSystemConfig.models` as an object keyed by model id | `AgentSystemConfig.models` as a list of `ModelBindingSpec` objects with explicit `id` |
+
+Upgrade check:
+
+```bash
+rg '"model"\s*:|"provider"\s*:|fallback_models' config/ docs/ tests/
+```
+
+Each match should be checked. Protocol payloads may still use a field named
+`model` when they mirror an external protocol; managed Awaken config should not.
+
+## Provider secrets
+
+Provider API keys are write-only through the config API:
+
+- responses redact `api_key`;
+- responses expose `has_api_key: true` when a key is stored;
+- updating a provider without `api_key` preserves the existing key;
+- setting `api_key` to `null` or an empty string clears it.
+
+## Runtime snapshot behavior
+
+The runtime does not read `ConfigStore` during each inference step. Managed config changes are compiled into a new registry snapshot:
+
+```text
+ConfigStore change -> compile RegistrySet -> validate -> replace runtime snapshot
+```
+
+New runs use the latest published snapshot. Active runs keep the snapshot they started with.
+
+## Inference overrides
+
+`InferenceOverride.upstream_model` and `InferenceOverride.fallback_upstream_models` use upstream model names for the already resolved provider. They do not re-resolve `AgentSpec.model_id` and do not switch provider executors.
+
+At execution time the primary override is applied to `InferenceRequest.upstream_model`; executors should treat that field as the single source of truth for the primary upstream model. Remaining override fields carry generation parameters and fallback upstream models.
+
+Use model overrides for same-provider model changes:
+
+```rust,ignore
+use awaken::contract::inference::InferenceOverride;
+
+let overrides = InferenceOverride {
+    upstream_model: Some("gpt-4o".into()),
+    fallback_upstream_models: Some(vec!["gpt-4o-mini".into()]),
+    ..Default::default()
+};
+```
+
+Use a different `AgentSpec.model_id` or agent handoff when execution must move to another provider.
+
+## Retry and fallback
+
+Per-agent retry is read through the `"retry"` section via `RetryConfigKey`. When the section is absent, `LlmRetryPolicy::default()` is used. Resolution wraps the provider executor in `RetryingExecutor` when the resulting policy has retries or fallback upstream models. Set `max_retries` to `0` and leave `fallback_upstream_models` empty to disable the wrapper.
+
+Provider factories return provider executors; retry is added by the resolve pipeline, not hidden inside provider construction.
+
+For collected execution, retry and fallback apply to the full inference call. For streaming execution, retry and fallback apply while opening the stream. Once a stream has started, later stream-item errors are surfaced directly because retrying would duplicate already emitted deltas.

--- a/docs/book/src/tutorials/first-agent.md
+++ b/docs/book/src/tutorials/first-agent.md
@@ -36,7 +36,7 @@ use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::engine::GenaiExecutor;
 use awaken::registry_spec::AgentSpec;
-use awaken::registry::ModelEntry;
+use awaken::registry::ModelBinding;
 use awaken::{AgentRuntimeBuilder, RunRequest};
 
 struct EchoTool;
@@ -65,7 +65,7 @@ impl Tool for EchoTool {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent_spec = AgentSpec::new("assistant")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt("You are a helpful assistant. Use the echo tool when asked.")
         .with_max_rounds(5);
 
@@ -73,9 +73,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_agent_spec(agent_spec)
         .with_tool("echo", Arc::new(EchoTool))
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model("gpt-4o-mini", ModelEntry {
-            provider: "openai".into(),
-            model_name: "gpt-4o-mini".into(),
+        .with_model_binding("gpt-4o-mini", ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         })
         .build()?;
 
@@ -126,9 +126,9 @@ let runtime = AgentRuntimeBuilder::new()
     .with_agent_spec(agent_spec)
     .with_tool("echo", Arc::new(EchoTool))
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model("gpt-4o-mini", ModelEntry {
-        provider: "openai".into(),
-        model_name: "gpt-4o-mini".into(),
+    .with_model_binding("gpt-4o-mini", ModelBinding {
+        provider_id: "openai".into(),
+        upstream_model: "gpt-4o-mini".into(),
     })
     .build()?;
 ```

--- a/docs/book/src/tutorials/first-tool.md
+++ b/docs/book/src/tutorials/first-tool.md
@@ -145,7 +145,7 @@ use awaken::AgentRuntimeBuilder;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let agent_spec = AgentSpec::new("assistant")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant. Use the greet tool when asked.")
     .with_max_rounds(5);
 
@@ -193,7 +193,7 @@ use awaken::RunRequest;
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # let runtime = AgentRuntimeBuilder::new()
-#     .with_agent_spec(AgentSpec::new("assistant").with_model("gpt-4o-mini"))
+#     .with_agent_spec(AgentSpec::new("assistant").with_model_id("gpt-4o-mini"))
 #     .with_tool("greet", Arc::new(GreetTool))
 #     .build()?;
 let request = RunRequest::new(

--- a/docs/book/src/zh-CN/SUMMARY.md
+++ b/docs/book/src/zh-CN/SUMMARY.md
@@ -55,6 +55,7 @@
 - [事件](./reference/events.md)
 - [HTTP API](./reference/http-api.md)
 - [配置](./reference/config.md)
+- [Provider 与 Model 配置](./reference/provider-model-config.md)
 - [错误](./reference/errors.md)
 - [AI SDK v6 协议](./reference/protocols/ai-sdk-v6.md)
 - [AG-UI 协议](./reference/protocols/ag-ui.md)

--- a/docs/book/src/zh-CN/appendix/faq.md
+++ b/docs/book/src/zh-CN/appendix/faq.md
@@ -2,7 +2,7 @@
 
 ## 支持哪些 LLM provider？
 
-任何兼容 `genai` 的 provider 都可以，包括 OpenAI、Anthropic、DeepSeek、Google Gemini、Ollama 等。当前做法不是在 `AgentSpec` 里直接写 provider 名，而是把 `AgentSpec.model` 写成模型注册表里的 ID，再由 `ModelSpec` 解析到 provider 和真实模型名。
+任何兼容 `genai` 的 provider 都可以，包括 OpenAI、Anthropic、DeepSeek、Google Gemini、Ollama 等。当前做法不是在 `AgentSpec` 里直接写 provider 名，而是把 `AgentSpec.model_id` 写成模型注册表里的 ID，再由 `ModelBindingSpec` 解析到 provider 和真实模型名。
 
 ## 如何添加新的存储后端？
 

--- a/docs/book/src/zh-CN/explanation/agent-resolution.md
+++ b/docs/book/src/zh-CN/explanation/agent-resolution.md
@@ -9,7 +9,7 @@
 ```mermaid
 flowchart LR
     subgraph Stage1["Stage 1: Lookup"]
-        A1[Fetch AgentSpec] --> A2[Resolve ModelSpec]
+        A1[Fetch AgentSpec] --> A2[Resolve ModelBinding]
         A2 --> A3[Get LlmExecutor]
         A3 --> A4{Retry config?}
         A4 -- yes --> A5[Wrap in RetryingExecutor]
@@ -44,11 +44,13 @@ flowchart LR
 
 1. **AgentSpec** -- 通过 `agent_id` 从 `AgentSpecRegistry` 中查找。如果规格包含 `endpoint` 字段（远程 backend 智能体），解析会以 `RemoteAgentNotDirectlyRunnable` 失败 -- 远程智能体只能作为委托使用，不能直接运行。
 
-2. **ModelSpec** -- 规格的 `model` 字段（一个字符串 ID，如 `"gpt-4"`）通过 `ModelRegistry` 解析为 `ModelSpec`，将其映射到一个 provider ID 和实际 API 模型名（例如，provider `"openai"`，模型 `"gpt-4o"`）。
+2. **ModelBinding** -- 规格的 `model_id` 字段（模型注册表 ID，如 `"default"`）通过 `ModelRegistry` 解析为 `ModelBinding`，将其映射到一个 provider ID 和上游 API 模型名（例如，provider `"openai"`，上游模型 `"gpt-4o"`）。托管配置中的可序列化 `ModelBindingSpec` 会先编译成这些运行时绑定。
 
-3. **LlmExecutor** -- 模型条目中的提供者 ID 通过 `ProviderRegistry` 解析为一个活的 `LlmExecutor` 实例。
+3. **LlmExecutor** -- model binding 中的 provider ID 通过 `ProviderRegistry` 解析为一个活的 `LlmExecutor` 实例。
 
-4. **重试装饰** -- 如果智能体规格包含 `RetryConfigKey` 配置段，且 `max_retries > 0` 或 `fallback_models` 非空，则执行器会被包装在 `RetryingExecutor` 装饰器中。
+4. **重试装饰** -- 通过 `RetryConfigKey` 读取 agent 配置；缺失 section 时使用 `LlmRetryPolicy::default()`。如果最终 policy 的 `max_retries > 0` 或 `fallback_upstream_models` 非空，则执行器会被包装在 `RetryingExecutor` 装饰器中。
+
+Provider/model 的完整数据流见 [Provider 与 Model 配置](../reference/provider-model-config.md)。
 
 ## 阶段 2：插件流水线
 
@@ -145,7 +147,7 @@ flowchart LR
 |---|---|---|
 | `MapAgentSpecRegistry` | `with_agent_spec()` / `with_agent_specs()` | 智能体定义 |
 | `MapToolRegistry` | `with_tool()` | 全局工具 |
-| `MapModelRegistry` | `with_model()` | 模型 ID 到提供者 + 模型名称的映射 |
+| `MapModelRegistry` | `with_model_binding()` | 模型 ID 到 provider + 上游模型名的映射 |
 | `MapProviderRegistry` | `with_provider()` | LLM 执行器实例 |
 | `MapPluginSource` | `with_plugin()` | 插件实例 |
 

--- a/docs/book/src/zh-CN/explanation/architecture.md
+++ b/docs/book/src/zh-CN/explanation/architecture.md
@@ -19,7 +19,7 @@ AgentRuntime
   thread/run 持久化、profile storage
 ```
 
-**契约层** -- `awaken-contract` 定义全系统共用的类型：`AgentSpec`、`ModelSpec`、`ProviderSpec`、`Tool`、`AgentEvent`、transport trait 以及类型化状态模型。这是系统其余部分共同使用的"词汇表"。
+**契约层** -- `awaken-contract` 定义全系统共用的类型：`AgentSpec`、`ModelBindingSpec`、`ProviderSpec`、`Tool`、`AgentEvent`、transport trait 以及类型化状态模型。这是系统其余部分共同使用的"词汇表"。
 
 **运行时核心** -- `awaken-runtime` 是编排层。它将 agent ID 解析为完整配置（`ResolvedAgent`），从插件构建 `ExecutionEnv`，管理活跃 run，并将执行委托给循环运行器和阶段引擎。
 

--- a/docs/book/src/zh-CN/explanation/multi-agent-patterns.md
+++ b/docs/book/src/zh-CN/explanation/multi-agent-patterns.md
@@ -9,7 +9,7 @@ agent 可以通过 `delegates` 声明它允许委托的子 agent：
 ```json
 {
   "id": "orchestrator",
-  "model": "gpt-4o",
+  "model_id": "gpt-4o",
   "system_prompt": "You coordinate tasks across specialized agents.",
   "delegates": ["researcher", "writer", "reviewer"]
 }
@@ -24,7 +24,7 @@ agent 可以通过 `delegates` 声明它允许委托的子 agent：
 ```json
 {
   "id": "remote-analyst",
-  "model": "unused-for-remote",
+  "model_id": "unused-for-remote",
   "system_prompt": "",
   "endpoint": {
     "backend": "a2a",

--- a/docs/book/src/zh-CN/explanation/plugin-internals.md
+++ b/docs/book/src/zh-CN/explanation/plugin-internals.md
@@ -161,14 +161,17 @@ pub trait EffectSpec: 'static + Send + Sync {
 
 ```rust,ignore
 pub struct InferenceOverride {
-    pub model: Option<String>,
-    pub fallback_models: Option<Vec<String>>,
+    pub upstream_model: Option<String>,
+    pub fallback_upstream_models: Option<Vec<String>>,
     pub temperature: Option<f64>,
     pub max_tokens: Option<u32>,
     pub top_p: Option<f64>,
     pub reasoning_effort: Option<ReasoningEffort>,
 }
 ```
+
+`upstream_model` 和 `fallback_upstream_models` 是当前已解析 provider 的上游模型名；
+它们不会切换 provider executor。详见 [Provider 与 Model 配置](../reference/provider-model-config.md)。
 
 当两个覆盖被合并时，每个字段独立取最后一个非 `None` 的值：
 

--- a/docs/book/src/zh-CN/how-to/add-a-plugin.md
+++ b/docs/book/src/zh-CN/how-to/add-a-plugin.md
@@ -99,10 +99,11 @@ impl Plugin for AuditPlugin {
 ```rust,ignore
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
-use awaken::{AgentSpec, AgentRuntimeBuilder, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::{AgentSpec, AgentRuntimeBuilder};
 
 let spec = AgentSpec::new("assistant")
-    .with_model("claude-sonnet")
+    .with_model_id("claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("audit");
 
@@ -110,10 +111,9 @@ let runtime = AgentRuntimeBuilder::new()
     .with_plugin("audit", Arc::new(AuditPlugin))
     .with_agent_spec(spec)
     .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model("claude-sonnet", ModelSpec {
-        id: "claude-sonnet".into(),
-        provider: "anthropic".into(),
-        model: "claude-sonnet-4-20250514".into(),
+    .with_model_binding("claude-sonnet", ModelBinding {
+        provider_id: "anthropic".into(),
+        upstream_model: "claude-sonnet-4-20250514".into(),
     })
     .build()?;
 ```

--- a/docs/book/src/zh-CN/how-to/build-an-agent.md
+++ b/docs/book/src/zh-CN/how-to/build-an-agent.md
@@ -14,10 +14,11 @@
 
 ```rust,ignore
 use awaken::engine::GenaiExecutor;
-use awaken::{AgentSpec, AgentRuntimeBuilder, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::{AgentSpec, AgentRuntimeBuilder};
 
 let spec = AgentSpec::new("assistant")
-    .with_model("claude-sonnet")
+    .with_model_id("claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_max_rounds(10);
 ```
@@ -38,10 +39,9 @@ let builder = AgentRuntimeBuilder::new()
 ```rust,ignore
 let builder = builder
     .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model("claude-sonnet", ModelSpec {
-        id: "claude-sonnet".into(),
-        provider: "anthropic".into(),
-        model: "claude-sonnet-4-20250514".into(),
+    .with_model_binding("claude-sonnet", ModelBinding {
+        provider_id: "anthropic".into(),
+        upstream_model: "claude-sonnet-4-20250514".into(),
     });
 ```
 

--- a/docs/book/src/zh-CN/how-to/enable-observability.md
+++ b/docs/book/src/zh-CN/how-to/enable-observability.md
@@ -22,24 +22,24 @@ tokio = { version = "1", features = ["full"] }
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_observability::{ObservabilityPlugin, InMemorySink};
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let sink = InMemorySink::new();
 let obs_plugin = ObservabilityPlugin::new(sink.clone());
 let agent_spec = AgentSpec::new("observed-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("observability");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)
@@ -56,7 +56,8 @@ run 结束后，可以直接读取 `sink.metrics()`。
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_observability::{ObservabilityPlugin, OtelMetricsSink};
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 use opentelemetry_sdk::trace::SdkTracerProvider;
 

--- a/docs/book/src/zh-CN/how-to/enable-tool-permission-hitl.md
+++ b/docs/book/src/zh-CN/how-to/enable-tool-permission-hitl.md
@@ -22,22 +22,22 @@ serde_json = "1"
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_permission::PermissionPlugin;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("permission");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)
@@ -94,7 +94,7 @@ rules:
 
 ```rust,ignore
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("permission");
 ```

--- a/docs/book/src/zh-CN/how-to/expose-http-sse.md
+++ b/docs/book/src/zh-CN/how-to/expose-http-sse.md
@@ -23,7 +23,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 ```rust,ignore
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
-use awaken::{AgentRuntimeBuilder, AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::{AgentRuntimeBuilder, AgentSpec};
 use awaken::stores::InMemoryStore;
 
 let store = Arc::new(InMemoryStore::new());
@@ -31,15 +32,14 @@ let store = Arc::new(InMemoryStore::new());
 let runtime = AgentRuntimeBuilder::new()
     .with_agent_spec(
         AgentSpec::new("assistant")
-            .with_model("claude-sonnet")
+            .with_model_id("claude-sonnet")
             .with_system_prompt("You are a helpful assistant."),
     )
     .with_tool("search", Arc::new(SearchTool))
     .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model("claude-sonnet", ModelSpec {
-        id: "claude-sonnet".into(),
-        provider: "anthropic".into(),
-        model: "claude-sonnet-4-20250514".into(),
+    .with_model_binding("claude-sonnet", ModelBinding {
+        provider_id: "anthropic".into(),
+        upstream_model: "claude-sonnet-4-20250514".into(),
     })
     .with_thread_run_store(store.clone())
     .build()?;

--- a/docs/book/src/zh-CN/how-to/integrate-ai-sdk-frontend.md
+++ b/docs/book/src/zh-CN/how-to/integrate-ai-sdk-frontend.md
@@ -26,7 +26,8 @@ use std::sync::Arc;
 
 use awaken::engine::GenaiExecutor;
 use awaken::contract::storage::ThreadRunStore;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::stores::{InMemoryMailboxStore, InMemoryStore};
 use awaken::AgentRuntimeBuilder;
 use awaken::server::app::{AppState, ServerConfig};
@@ -38,18 +39,17 @@ async fn main() {
     tracing_subscriber::fmt().with_target(true).init();
 
     let agent_spec = AgentSpec::new("my-agent")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt("You are a helpful assistant.")
         .with_max_rounds(10);
 
     let runtime = AgentRuntimeBuilder::new()
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model(
+        .with_model_binding(
             "gpt-4o-mini",
-            ModelSpec {
-                id: "gpt-4o-mini".into(),
-                provider: "openai".into(),
-                model: "gpt-4o-mini".into(),
+            ModelBinding {
+                provider_id: "openai".into(),
+                upstream_model: "gpt-4o-mini".into(),
             },
         )
         .with_agent_spec(agent_spec)

--- a/docs/book/src/zh-CN/how-to/integrate-copilotkit-ag-ui.md
+++ b/docs/book/src/zh-CN/how-to/integrate-copilotkit-ag-ui.md
@@ -26,7 +26,8 @@ use std::sync::Arc;
 
 use awaken::engine::GenaiExecutor;
 use awaken::contract::storage::ThreadRunStore;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::stores::{InMemoryMailboxStore, InMemoryStore};
 use awaken::AgentRuntimeBuilder;
 use awaken::server::app::{AppState, ServerConfig};
@@ -38,7 +39,7 @@ async fn main() {
     tracing_subscriber::fmt().with_target(true).init();
 
     let agent_spec = AgentSpec::new("copilotkit-agent")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt(
             "You are a CopilotKit-powered assistant. \
              Update shared state and suggest actions when appropriate.",
@@ -47,12 +48,11 @@ async fn main() {
 
     let runtime = AgentRuntimeBuilder::new()
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model(
+        .with_model_binding(
             "gpt-4o-mini",
-            ModelSpec {
-                id: "gpt-4o-mini".into(),
-                provider: "openai".into(),
-                model: "gpt-4o-mini".into(),
+            ModelBinding {
+                provider_id: "openai".into(),
+                upstream_model: "gpt-4o-mini".into(),
             },
         )
         .with_agent_spec(agent_spec)

--- a/docs/book/src/zh-CN/how-to/optimize-context-window.md
+++ b/docs/book/src/zh-CN/how-to/optimize-context-window.md
@@ -91,7 +91,7 @@ let config = CompactionConfig {
         Be concise but complete.".into(),
     summarizer_user_prompt: "Summarize the following conversation:\n\n{messages}".into(),
     summary_max_tokens: Some(1024),
-    summary_model: Some("claude-3-haiku".into()),
+    summary_upstream_model: Some("claude-3-haiku".into()),
     min_savings_ratio: 0.3,
 };
 ```

--- a/docs/book/src/zh-CN/how-to/use-agent-handoff.md
+++ b/docs/book/src/zh-CN/how-to/use-agent-handoff.md
@@ -27,7 +27,7 @@ use awaken::extensions::handoff::AgentOverlay;
 
 let researcher = AgentOverlay {
     system_prompt: Some("You are a research specialist. Find and cite sources.".into()),
-    model: Some("claude-sonnet".into()),
+    upstream_model: Some("claude-sonnet".into()),
     allowed_tools: Some(vec!["web_search".into(), "read_document".into()]),
     excluded_tools: None,
 };

--- a/docs/book/src/zh-CN/how-to/use-deferred-tools.md
+++ b/docs/book/src/zh-CN/how-to/use-deferred-tools.md
@@ -24,7 +24,8 @@ serde_json = "1"
 ```rust,ignore
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 use awaken_ext_deferred_tools::DeferredToolsPlugin;
 
@@ -36,18 +37,17 @@ let seed_tools = vec![
     // ... all tool descriptors
 ];
 let agent_spec = AgentSpec::new("deferred-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Search for tools only when needed.")
     .with_hook_filter("ext-deferred-tools");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/zh-CN/how-to/use-generative-ui.md
+++ b/docs/book/src/zh-CN/how-to/use-generative-ui.md
@@ -23,23 +23,23 @@ serde_json = "1"
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_generative_ui::A2uiPlugin;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let plugin = A2uiPlugin::with_catalog_id("my-catalog");
 let agent_spec = AgentSpec::new("ui-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Render structured UI when visual output helps.")
     .with_hook_filter("generative-ui");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/zh-CN/how-to/use-mcp-tools.md
+++ b/docs/book/src/zh-CN/how-to/use-mcp-tools.md
@@ -57,22 +57,22 @@ MCP 工具的 ID 格式通常是 `mcp__{server}__{tool}`。
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_mcp::McpPlugin;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let agent_spec = AgentSpec::new("mcp-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Use MCP tools when they help answer the user.")
     .with_hook_filter("mcp");
 
 let mut builder = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/zh-CN/how-to/use-reminder-plugin.md
+++ b/docs/book/src/zh-CN/how-to/use-reminder-plugin.md
@@ -22,7 +22,8 @@ serde_json = "1"
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_reminder::{ReminderPlugin, ReminderRulesConfig};
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let json = r#"{
@@ -42,18 +43,17 @@ let config = ReminderRulesConfig::from_str(json, Some("json"))
     .expect("failed to parse reminder config");
 let rules = config.into_rules().expect("invalid rules");
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("claude-sonnet")
+    .with_model_id("claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("reminder");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("anthropic", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "claude-sonnet",
-        ModelSpec {
-            id: "claude-sonnet".into(),
-            provider: "anthropic".into(),
-            model: "claude-3-7-sonnet-latest".into(),
+        ModelBinding {
+            provider_id: "anthropic".into(),
+            upstream_model: "claude-3-7-sonnet-latest".into(),
         },
     )
     .with_agent_spec(agent_spec)
@@ -122,7 +122,7 @@ let config = ReminderRulesConfig::from_file("reminders.json")
 
 ```rust,ignore
 let agent_spec = AgentSpec::new("my-agent")
-    .with_model("claude-sonnet")
+    .with_model_id("claude-sonnet")
     .with_system_prompt("You are a helpful assistant.")
     .with_hook_filter("reminder");
 ```

--- a/docs/book/src/zh-CN/how-to/use-skills-subsystem.md
+++ b/docs/book/src/zh-CN/how-to/use-skills-subsystem.md
@@ -87,24 +87,24 @@ let registry = Arc::new(InMemorySkillRegistry::from_skills(vec![Arc::new(skill)]
 use std::sync::Arc;
 use awaken::engine::GenaiExecutor;
 use awaken::ext_skills::SkillSubsystem;
-use awaken::registry_spec::{AgentSpec, ModelSpec};
+use awaken::registry::ModelBinding;
+use awaken::registry_spec::AgentSpec;
 use awaken::{AgentRuntimeBuilder, Plugin};
 
 let subsystem = SkillSubsystem::new(registry);
 let agent_spec = AgentSpec::new("skills-agent")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("Discover and activate skills when specialized help is useful.")
     .with_hook_filter("skills-discovery")
     .with_hook_filter("skills-active-instructions");
 
 let runtime = AgentRuntimeBuilder::new()
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model(
+    .with_model_binding(
         "gpt-4o-mini",
-        ModelSpec {
-            id: "gpt-4o-mini".into(),
-            provider: "openai".into(),
-            model: "gpt-4o-mini".into(),
+        ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         },
     )
     .with_agent_spec(agent_spec)

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -7,7 +7,7 @@
 ```rust,ignore
 pub struct AgentSpec {
     pub id: String,
-    pub model: String,
+    pub model_id: String,                            // model registry id
     pub system_prompt: String,
     pub max_rounds: usize,
     pub max_continuation_retries: usize,
@@ -30,7 +30,7 @@ pub struct AgentSpec {
 
 ```rust,ignore
 AgentSpec::new(id) -> Self
-    .with_model(model) -> Self
+    .with_model_id(model_id) -> Self
     .with_system_prompt(prompt) -> Self
     .with_max_rounds(n) -> Self
     .with_reasoning_effort(effort) -> Self
@@ -77,10 +77,13 @@ pub enum ContextCompactionMode {
 
 用于单次推理的参数覆盖。所有字段都是 `Option`，多插件同时写时按字段 last-wins 合并。
 
+`upstream_model` 和 `fallback_upstream_models` 是当前已解析 provider 的上游模型名。它们不会重新解析
+`AgentSpec.model_id`，也不会切换 provider。详见 [Provider 与 Model 配置](./provider-model-config.md)。
+
 ```rust,ignore
 pub struct InferenceOverride {
-    pub model: Option<String>,
-    pub fallback_models: Option<Vec<String>>,
+    pub upstream_model: Option<String>,      // 上游模型名
+    pub fallback_upstream_models: Option<Vec<String>>, // 上游模型名列表
     pub temperature: Option<f64>,
     pub max_tokens: Option<u32>,
     pub top_p: Option<f64>,
@@ -204,12 +207,17 @@ pub struct MailboxConfig {
 
 ## LlmRetryPolicy
 
-LLM 推理失败后的重试与 fallback model 策略，支持指数退避。可通过 `AgentSpec` 的 `"retry"` section 按 agent 配置。
+LLM 推理失败后的重试与 fallback upstream model 策略，支持指数退避。可通过 `AgentSpec` 的 `"retry"` section 按 agent 配置。
+
+Retry 在 agent 解析阶段生效。缺失 `"retry"` section 时使用 `LlmRetryPolicy::default()`。
+将 `max_retries` 设为 `0` 且保持 `fallback_upstream_models` 为空可以禁用 retry 包装。Provider
+构造阶段不会额外隐藏一层 retry 策略。对于流式推理，retry 与 fallback 只作用于打开
+stream 的阶段。
 
 ```rust,ignore
 pub struct LlmRetryPolicy {
     pub max_retries: u32,              // default: 2
-    pub fallback_models: Vec<String>,  // default: []
+    pub fallback_upstream_models: Vec<String>,  // default: []
     pub backoff_base_ms: u64,          // default: 500
 }
 ```
@@ -219,7 +227,7 @@ pub struct LlmRetryPolicy {
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
 | `max_retries` | `u32` | `2` | 初次调用后的最大重试次数（0 表示不重试） |
-| `fallback_models` | `Vec<String>` | `[]` | 主模型耗尽重试后依次尝试的备用模型列表 |
+| `fallback_upstream_models` | `Vec<String>` | `[]` | 主模型耗尽重试后依次尝试的备用模型列表 |
 | `backoff_base_ms` | `u64` | `500` | 指数退避的基础延迟（毫秒）；实际延迟 = min(base × 2^attempt, 8000ms)。设为 0 可禁用退避 |
 
 ### AgentSpec 集成
@@ -232,7 +240,7 @@ use awaken_runtime::engine::retry::RetryConfigKey;
 let spec = AgentSpec::new("my-agent")
     .with_config::<RetryConfigKey>(LlmRetryPolicy {
         max_retries: 3,
-        fallback_models: vec!["claude-sonnet-4-20250514".into()],
+        fallback_upstream_models: vec!["claude-sonnet-4-20250514".into()],
         backoff_base_ms: 1000,
     })?;
 ```

--- a/docs/book/src/zh-CN/reference/overview.md
+++ b/docs/book/src/zh-CN/reference/overview.md
@@ -8,7 +8,7 @@
 |---|---|---|
 | `awaken::contract` | `awaken-contract` | tool、event、message、suspension、lifecycle 等契约 |
 | `awaken::model` | `awaken-contract` | `Phase`、`EffectSpec`、`ScheduledActionSpec`、`JsonValue` |
-| `awaken::registry_spec` | `awaken-contract` | `AgentSpec`、`ModelSpec`、`ProviderSpec`、`McpServerSpec`、`PluginConfigKey` |
+| `awaken::registry_spec` | `awaken-contract` | `AgentSpec`、`ModelBindingSpec`、`ProviderSpec`、`McpServerSpec`、`PluginConfigKey` |
 | `awaken::state` | `awaken-contract` + `awaken-runtime` | `StateKey`、`StateMap`、`Snapshot`、`StateStore`、`MutationBatch` |
 | `awaken::agent` | `awaken-runtime` | agent 配置与状态 |
 | `awaken::builder` | `awaken-runtime` | `AgentRuntimeBuilder`、`BuildError` |

--- a/docs/book/src/zh-CN/reference/provider-model-config.md
+++ b/docs/book/src/zh-CN/reference/provider-model-config.md
@@ -1,0 +1,179 @@
+# Provider 与 Model 配置
+
+Awaken 把 provider 连接和 model 选择分开处理。运行时总是通过下面这条链路解析 agent：
+
+```text
+AgentSpec.model_id
+  -> ModelRegistry[model id]
+  -> ModelBinding { provider_id, upstream_model }
+  -> ProviderRegistry[provider id]
+  -> Arc<dyn LlmExecutor>
+  -> InferenceRequest.upstream_model = upstream_model
+```
+
+## 术语
+
+| 术语 | 类型 | 含义 |
+|---|---|---|
+| Agent model id | `AgentSpec.model_id` | Agent 使用的稳定模型注册表 ID，例如 `"default"` 或 `"research"`。 |
+| Runtime model binding | `ModelBinding` | 运行时映射：model id -> provider id + 上游模型名。 |
+| Config model binding | `ModelBindingSpec` | 托管配置中的可序列化模型配置，发布时会编译成 `ModelBinding`。 |
+| Provider config | `ProviderSpec` | 可序列化 provider 配置，用于构造 executor。 |
+| Provider executor | `Arc<dyn LlmExecutor>` | 真正执行推理的 provider client。 |
+| 上游模型名 | `ModelBinding.upstream_model`、`ModelBindingSpec.upstream_model`、`InferenceRequest.upstream_model` | 最终发送给 provider API 的模型字符串。 |
+
+最重要的区别是：
+
+- `AgentSpec.model_id` 是注册表 ID。
+- `ModelBindingSpec.upstream_model`、`ModelBinding.upstream_model`、`InferenceRequest.upstream_model` 是上游 provider 模型名。
+
+## 代码构建路径
+
+当应用在代码里构造 provider 时使用这条路径。
+
+```rust,ignore
+use std::sync::Arc;
+use awaken::engine::GenaiExecutor;
+use awaken::registry::ModelBinding;
+use awaken::{AgentRuntimeBuilder, AgentSpec};
+
+let agent = AgentSpec::new("assistant")
+    .with_model_id("default")
+    .with_system_prompt("You are helpful.");
+
+let runtime = AgentRuntimeBuilder::new()
+    .with_provider("openai", Arc::new(GenaiExecutor::new()))
+    .with_model_binding("default", ModelBinding {
+        provider_id: "openai".into(),
+        upstream_model: "gpt-4o-mini".into(),
+    })
+    .with_agent_spec(agent)
+    .build()?;
+```
+
+`build()` 会解析每个已注册 agent，提前发现缺失 model、provider 或 plugin 的问题。
+
+## 托管配置路径
+
+当服务端通过 `ConfigStore` 管理动态配置时使用这条路径。
+
+托管配置按 namespace 存储：
+
+| Namespace | 可序列化类型 |
+|---|---|
+| `providers` | `ProviderSpec` |
+| `models` | `ModelBindingSpec` |
+| `agents` | `AgentSpec` |
+| `mcp-servers` | `McpServerSpec` |
+
+配置示例：
+
+```json
+{
+  "id": "openai",
+  "adapter": "openai",
+  "api_key": "sk-...",
+  "base_url": null,
+  "timeout_secs": 300
+}
+```
+
+```json
+{
+  "id": "default",
+  "provider_id": "openai",
+  "upstream_model": "gpt-4o-mini"
+}
+```
+
+```json
+{
+  "id": "assistant",
+  "model_id": "default",
+  "system_prompt": "You are helpful."
+}
+```
+
+服务端会把这些文档编译成运行时注册表：
+
+```text
+ProviderSpec -> ProviderExecutorFactory -> Arc<dyn LlmExecutor>
+ModelBindingSpec    -> ModelBinding
+AgentSpec    -> AgentSpecRegistry
+```
+
+配置文档只使用 canonical 字段名：agent 使用 `model_id`，model binding 使用
+`provider_id` 和 `upstream_model`，retry 或 inference override 使用
+`fallback_upstream_models`。
+
+候选注册表会先验证，再替换 runtime 的活动快照。验证失败时，本次配置写入会回滚。
+
+## 从旧 model 字段迁移
+
+这个版本会有意拒绝旧的 provider/model 字段名，而不是静默归一化。升级前需要更新
+已保存配置、测试 fixture 和客户端：
+
+| 旧字段或旧形状 | 新 canonical 形式 |
+|---|---|
+| `AgentSpec.model` | `AgentSpec.model_id` |
+| `ModelBindingSpec.provider` | `ModelBindingSpec.provider_id` |
+| `ModelBindingSpec.model` | `ModelBindingSpec.upstream_model` |
+| `InferenceOverride.model` | `InferenceOverride.upstream_model` |
+| `fallback_models` | `fallback_upstream_models` |
+| `AgentSystemConfig.models` 使用以 model id 为 key 的对象 | `AgentSystemConfig.models` 使用显式包含 `id` 的 `ModelBindingSpec` 列表 |
+
+升级检查：
+
+```bash
+rg '"model"\s*:|"provider"\s*:|fallback_models' config/ docs/ tests/
+```
+
+每个匹配项都需要人工确认。某些外部协议 payload 可能仍然有名为 `model` 的字段；
+Awaken 托管配置不应再使用这些旧字段。
+
+## Provider 密钥
+
+Provider API key 通过配置 API 写入后不会明文返回：
+
+- 响应会移除 `api_key`；
+- 已保存 key 时响应包含 `has_api_key: true`；
+- 更新 provider 时省略 `api_key` 会保留已有 key；
+- 把 `api_key` 设为 `null` 或空字符串会清除 key。
+
+## Runtime 快照行为
+
+运行时不会在每个推理步骤直接读取 `ConfigStore`。托管配置变更会先编译成新的 registry 快照：
+
+```text
+ConfigStore change -> compile RegistrySet -> validate -> replace runtime snapshot
+```
+
+新 run 使用最新发布的快照。已经开始的 run 保持启动时绑定的快照。
+
+## 推理覆盖
+
+`InferenceOverride.upstream_model` 和 `InferenceOverride.fallback_upstream_models` 使用的是当前已解析 provider 的上游模型名。它们不会重新解析 `AgentSpec.model_id`，也不会切换 provider executor。
+
+执行时，primary override 会应用到 `InferenceRequest.upstream_model`；executor 应把这个字段作为 primary 上游模型的唯一来源。其余 override 字段保留生成参数和 fallback upstream models。
+
+同 provider 内切换模型时可以使用 model override：
+
+```rust,ignore
+use awaken::contract::inference::InferenceOverride;
+
+let overrides = InferenceOverride {
+    upstream_model: Some("gpt-4o".into()),
+    fallback_upstream_models: Some(vec!["gpt-4o-mini".into()]),
+    ..Default::default()
+};
+```
+
+如果需要切换到另一个 provider，请使用不同的 `AgentSpec.model_id` 或 agent handoff。
+
+## Retry 与 fallback
+
+每个 agent 通过 `RetryConfigKey` 读取 `"retry"` section。缺失 section 时使用 `LlmRetryPolicy::default()`。解析阶段会在最终 policy 配置了 retry 或 fallback upstream model 时，用 `RetryingExecutor` 包装 provider executor。将 `max_retries` 设为 `0` 且保持 `fallback_upstream_models` 为空可以禁用该包装。
+
+Provider factory 只返回 provider executor；retry 由解析流水线添加，不隐藏在 provider 构造里。
+
+非流式执行中，retry 与 fallback 作用于完整推理调用。流式执行中，retry 与 fallback 只作用于打开 stream 的阶段。stream 已经开始后，如果后续 stream item 报错，会直接向上返回，因为重试会导致已经发出的 delta 重复。

--- a/docs/book/src/zh-CN/tutorials/first-agent.md
+++ b/docs/book/src/zh-CN/tutorials/first-agent.md
@@ -36,7 +36,7 @@ use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::VecEventSink;
 use awaken::engine::GenaiExecutor;
 use awaken::registry_spec::AgentSpec;
-use awaken::registry::ModelEntry;
+use awaken::registry::ModelBinding;
 use awaken::{AgentRuntimeBuilder, RunRequest};
 
 struct EchoTool;
@@ -65,7 +65,7 @@ impl Tool for EchoTool {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let agent_spec = AgentSpec::new("assistant")
-        .with_model("gpt-4o-mini")
+        .with_model_id("gpt-4o-mini")
         .with_system_prompt("You are a helpful assistant. Use the echo tool when asked.")
         .with_max_rounds(5);
 
@@ -73,9 +73,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_agent_spec(agent_spec)
         .with_tool("echo", Arc::new(EchoTool))
         .with_provider("openai", Arc::new(GenaiExecutor::new()))
-        .with_model("gpt-4o-mini", ModelEntry {
-            provider: "openai".into(),
-            model_name: "gpt-4o-mini".into(),
+        .with_model_binding("gpt-4o-mini", ModelBinding {
+            provider_id: "openai".into(),
+            upstream_model: "gpt-4o-mini".into(),
         })
         .build()?;
 
@@ -126,9 +126,9 @@ let runtime = AgentRuntimeBuilder::new()
     .with_agent_spec(agent_spec)
     .with_tool("echo", Arc::new(EchoTool))
     .with_provider("openai", Arc::new(GenaiExecutor::new()))
-    .with_model("gpt-4o-mini", ModelEntry {
-        provider: "openai".into(),
-        model_name: "gpt-4o-mini".into(),
+    .with_model_binding("gpt-4o-mini", ModelBinding {
+        provider_id: "openai".into(),
+        upstream_model: "gpt-4o-mini".into(),
     })
     .build()?;
 ```

--- a/docs/book/src/zh-CN/tutorials/first-tool.md
+++ b/docs/book/src/zh-CN/tutorials/first-tool.md
@@ -145,7 +145,7 @@ use awaken::AgentRuntimeBuilder;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let agent_spec = AgentSpec::new("assistant")
-    .with_model("gpt-4o-mini")
+    .with_model_id("gpt-4o-mini")
     .with_system_prompt("You are a helpful assistant. Use the greet tool when asked.")
     .with_max_rounds(5);
 
@@ -193,7 +193,7 @@ use awaken::RunRequest;
 # #[tokio::main]
 # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 # let runtime = AgentRuntimeBuilder::new()
-#     .with_agent_spec(AgentSpec::new("assistant").with_model("gpt-4o-mini"))
+#     .with_agent_spec(AgentSpec::new("assistant").with_model_id("gpt-4o-mini"))
 #     .with_tool("greet", Arc::new(GreetTool))
 #     .build()?;
 let request = RunRequest::new(

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -24,7 +24,7 @@ use awaken_contract::contract::inference::ContextWindowPolicy;
 use awaken_contract::contract::storage::ThreadRunStore;
 use awaken_contract::contract::tool::Tool;
 use awaken_contract::registry_spec::{
-    AgentSpec, McpServerSpec, McpTransportKind, ModelSpec, ProviderSpec,
+    AgentSpec, McpServerSpec, McpTransportKind, ModelBindingSpec, ProviderSpec,
 };
 use awaken_ext_generative_ui::{
     A2uiPlugin, A2uiPromptConfig, A2uiPromptConfigKey, json_render, openui,
@@ -40,12 +40,11 @@ use awaken_ext_skills::{
     InMemorySkillRegistry, SkillDiscoveryPlugin, SkillRegistry,
 };
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::engine::{LlmRetryPolicy, RetryingExecutor};
 use awaken_runtime::plugins::Plugin;
 use awaken_runtime::policies::{
     ConsecutiveErrorsPolicy, StopConditionPlugin, StopPolicy, TimeoutPolicy, TokenBudgetPolicy,
 };
-use awaken_runtime::registry::traits::ModelEntry;
+use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{
     AppState, ServerConfig, SkillCatalogArgument, SkillCatalogContext, SkillCatalogEntry,
     SkillCatalogProvider,
@@ -139,10 +138,8 @@ struct StarterProviderFactory;
 impl ProviderExecutorFactory for StarterProviderFactory {
     fn build(&self, spec: &ProviderSpec) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
         if spec.adapter.eq_ignore_ascii_case(SCRIPTED_PROVIDER_ADAPTER) {
-            let executor: Arc<dyn LlmExecutor> = Arc::new(RetryingExecutor::new(
-                Arc::new(scripted_executor::ScriptedLlmExecutor::new()),
-                LlmRetryPolicy::default(),
-            ));
+            let executor: Arc<dyn LlmExecutor> =
+                Arc::new(scripted_executor::ScriptedLlmExecutor::new());
             return Ok(executor);
         }
 
@@ -422,7 +419,7 @@ Deterministic compatibility directives:\n\
     let default_agent = apply_agent_prompt_override(
         AgentSpec {
             id: default_id.clone(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: base_prompt.clone(),
             max_rounds: 3,
             reasoning_effort: reasoning_effort.clone(),
@@ -433,7 +430,7 @@ Deterministic compatibility directives:\n\
     );
     let permission_agent = AgentSpec {
         id: "permission".into(),
-        model: "default".into(),
+        model_id: "default".into(),
         system_prompt: base_prompt.clone(),
         max_rounds: args.max_rounds,
         plugin_ids: vec!["permission".into(), "frontend_tools".into()],
@@ -474,7 +471,7 @@ Deterministic compatibility directives:\n\
     let travel_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "travel".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: concat!(
                 "You are a travel planning assistant. Help users plan trips by adding, ",
                 "updating, and searching for places of interest. Use the provided tools ",
@@ -493,7 +490,7 @@ Deterministic compatibility directives:\n\
     let research_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "research".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: concat!(
                 "You are a research assistant. Help users research topics by searching ",
                 "the web, extracting resources, and writing comprehensive reports.\n\n",
@@ -515,7 +512,7 @@ Deterministic compatibility directives:\n\
     let skills_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "skills".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: base_prompt.clone(),
             max_rounds: args.max_rounds,
             plugin_ids: vec!["skills-discovery".into(), "frontend_tools".into()],
@@ -526,7 +523,7 @@ Deterministic compatibility directives:\n\
     let limited_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "limited".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: "You are a test assistant. Respond briefly to every message.".into(),
             max_rounds: 1,
             plugin_ids: vec!["permission".into()],
@@ -538,7 +535,7 @@ Deterministic compatibility directives:\n\
     let thinking_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "thinking".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: "You are a helpful assistant. Be concise.".into(),
             max_rounds: 1,
             reasoning_effort: reasoning_effort.clone(),
@@ -549,7 +546,7 @@ Deterministic compatibility directives:\n\
     let a2a_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "a2a".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: base_prompt.clone(),
             max_rounds: args.max_rounds,
             plugin_ids: vec!["frontend_tools".into()],
@@ -560,7 +557,7 @@ Deterministic compatibility directives:\n\
     let phases_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "phases".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: "You are a test assistant demonstrating phase hooks. Respond briefly."
                 .into(),
             max_rounds: 2,
@@ -571,7 +568,7 @@ Deterministic compatibility directives:\n\
     );
     let genui_agent = apply_agent_prompt_override(AgentSpec {
         id: "genui".into(),
-        model: "default".into(),
+        model_id: "default".into(),
         system_prompt: concat!(
             "You are a generative UI assistant that outputs JSON Render documents.\n\n",
             "When users ask for forms or interfaces, respond with ONLY a JSON object in this format:\n",
@@ -599,7 +596,7 @@ Deterministic compatibility directives:\n\
 
     let a2ui_agent = AgentSpec {
         id: "a2ui".into(),
-        model: "default".into(),
+        model_id: "default".into(),
         system_prompt: A2UI_AGENT_PROMPT.into(),
         max_rounds: 8,
         plugin_ids: vec!["generative-ui".into()],
@@ -616,7 +613,7 @@ Deterministic compatibility directives:\n\
     let json_render_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "json-render".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: JSON_RENDER_AGENT_PROMPT.into(),
             max_rounds: 4,
             allowed_tools: Some(vec!["render_json_ui".into()]),
@@ -627,7 +624,7 @@ Deterministic compatibility directives:\n\
     let openui_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "openui".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: OPENUI_AGENT_PROMPT.into(),
             max_rounds: 4,
             allowed_tools: Some(vec!["render_openui_ui".into()]),
@@ -638,7 +635,7 @@ Deterministic compatibility directives:\n\
     let json_render_ui_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "json-render-ui".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: json_render_ui_prompt,
             max_rounds: 1,
             // Sub-agents generate pure text (UI markup); no tools needed.
@@ -652,7 +649,7 @@ Deterministic compatibility directives:\n\
     let openui_ui_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "openui-ui".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: openui_ui_prompt,
             max_rounds: 1,
             allowed_tools: Some(vec![]),
@@ -667,7 +664,7 @@ Deterministic compatibility directives:\n\
     let profile_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "profile".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: "You are a stateful assistant that remembers user preferences \
             across runs using profile storage. When the user sets a preference, \
             acknowledge it. When asked to recall, retrieve it from the profile store."
@@ -686,7 +683,7 @@ Deterministic compatibility directives:\n\
     let creative_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "creative".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: "You are a creative writing assistant. Produce vivid, \
             imaginative prose. Use metaphors and varied sentence structures."
                 .into(),
@@ -708,7 +705,7 @@ Deterministic compatibility directives:\n\
     let compact_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "compact".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: "You are a context-aware assistant. Your context window is managed \
             with auto-compaction so long conversations stay within token limits."
                 .into(),
@@ -732,7 +729,7 @@ Deterministic compatibility directives:\n\
     let budget_agent = apply_agent_prompt_override(
         AgentSpec {
             id: "budget".into(),
-            model: "default".into(),
+            model_id: "default".into(),
             system_prompt: "You are a budget-constrained assistant with token limits and timeout. \
             The run will stop if you exceed 50k tokens, 60 seconds, or 3 consecutive errors."
                 .into(),
@@ -843,10 +840,10 @@ Deterministic compatibility directives:\n\
 
     let provider_factory = Arc::new(StarterProviderFactory) as Arc<dyn ProviderExecutorFactory>;
     let default_provider = build_default_provider_spec(&args.model);
-    let default_model = ModelSpec {
+    let default_model = ModelBindingSpec {
         id: DEFAULT_MODEL_ID.into(),
-        provider: DEFAULT_PROVIDER_ID.into(),
-        model: args.model.clone(),
+        provider_id: DEFAULT_PROVIDER_ID.into(),
+        upstream_model: args.model.clone(),
     };
     let executor = provider_factory
         .build(&default_provider)
@@ -880,11 +877,11 @@ Deterministic compatibility directives:\n\
 
     let mut builder = AgentRuntimeBuilder::new()
         .with_provider(DEFAULT_PROVIDER_ID, executor)
-        .with_model(
+        .with_model_binding(
             DEFAULT_MODEL_ID,
-            ModelEntry {
-                provider: default_model.provider.clone(),
-                model_name: default_model.model.clone(),
+            ModelBinding {
+                provider_id: default_model.provider_id.clone(),
+                upstream_model: default_model.upstream_model.clone(),
             },
         )
         .with_thread_run_store(file_store.clone() as Arc<dyn ThreadRunStore>)

--- a/examples/src/starter_backend/scripted_executor.rs
+++ b/examples/src/starter_backend/scripted_executor.rs
@@ -183,7 +183,7 @@ mod tests {
 
     fn make_request(text: &str) -> InferenceRequest {
         InferenceRequest {
-            model: "scripted".into(),
+            upstream_model: "scripted".into(),
             messages: vec![Message::user(text)],
             tools: vec![],
             system: vec![],


### PR DESCRIPTION
## Summary
- simplify provider/model concepts to one canonical chain: AgentSpec.model_id -> ModelBinding -> ProviderRegistry -> InferenceRequest.upstream_model
- remove deprecated provider/model wrappers, aliases, legacy normalization, and duplicate config structs
- make provider/model config canonical-only with explicit rejection of legacy field names
- apply upstream model overrides before executor calls so InferenceRequest.upstream_model is the single primary model source
- emit AgentEvent::InferenceComplete with the effective upstream model, including run/step overrides and cancellation-after-inference paths
- add provider/model migration notes with legacy-to-canonical field mapping and upgrade checks
- update docs and tests for the canonical provider/model configuration path

## Breaking change
Provider/model configuration is canonical-only. Legacy field names such as AgentSpec.model, ModelBindingSpec.provider, ModelBindingSpec.model, InferenceOverride.model, and fallback_models now fail deserialization instead of being normalized. Existing stored config, fixtures, and clients must migrate to model_id, provider_id, upstream_model, and fallback_upstream_models before upgrading.

## Validation
- cargo fmt
- cargo test -p awaken-contract --lib
- cargo test -p awaken-runtime --lib
- cargo test -p awaken-server --test config_api --test config_backends
- cargo test -p awaken-agent --test agent_loop run_level_model_override_selects_upstream_model
- cargo test -p awaken-agent --test tool_executor multiple_hooks_merge_inference_overrides_last_wins
- cargo test -p awaken-runtime --lib truncation_recovery
- cargo test -p awaken-runtime --lib run_request_overrides_are_forwarded_to_inference
- cargo check --workspace --all-targets
- cargo clippy -p awaken-server --lib
- mdbook build docs/book
- git diff --check origin/main..HEAD