### PR TITLE
🔧 chore(release): bump workspace to 0.2.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "awaken-examples",
  "clap",
@@ -231,7 +231,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awaken-agent"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-contract"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "futures",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-doctest"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-agent",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-examples"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-deferred-tools"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-generative-ui"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-mcp"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-observability"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-permission"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-reminder"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-skills"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-protocol-a2a"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -475,7 +475,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-stores"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-tool-pattern"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "glob-match",
  "regex",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "awaken-examples",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
@@ -31,19 +31,19 @@ keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
 rust-version = "1.85"
 
 [workspace.dependencies]
-awaken-contract = { version = "0.2.0", path = "crates/awaken-contract" }
-awaken-protocol-a2a = { version = "0.2.0", path = "crates/awaken-protocol-a2a" }
-awaken-stores = { version = "0.2.0", path = "crates/awaken-stores" }
-awaken-runtime = { version = "0.2.0", path = "crates/awaken-runtime" }
-awaken-ext-permission = { version = "0.2.0", path = "crates/awaken-ext-permission" }
-awaken-ext-observability = { version = "0.2.0", path = "crates/awaken-ext-observability" }
-awaken-ext-mcp = { version = "0.2.0", path = "crates/awaken-ext-mcp" }
-awaken-ext-skills = { version = "0.2.0", path = "crates/awaken-ext-skills" }
-awaken-ext-reminder = { version = "0.2.0", path = "crates/awaken-ext-reminder" }
-awaken-ext-generative-ui = { version = "0.2.0", path = "crates/awaken-ext-generative-ui" }
-awaken-ext-deferred-tools = { version = "0.2.0", path = "crates/awaken-ext-deferred-tools" }
-awaken-tool-pattern = { version = "0.2.0", path = "crates/awaken-tool-pattern" }
-awaken-server = { version = "0.2.0", path = "crates/awaken-server" }
+awaken-contract = { version = "0.2.1-dev", path = "crates/awaken-contract" }
+awaken-protocol-a2a = { version = "0.2.1-dev", path = "crates/awaken-protocol-a2a" }
+awaken-stores = { version = "0.2.1-dev", path = "crates/awaken-stores" }
+awaken-runtime = { version = "0.2.1-dev", path = "crates/awaken-runtime" }
+awaken-ext-permission = { version = "0.2.1-dev", path = "crates/awaken-ext-permission" }
+awaken-ext-observability = { version = "0.2.1-dev", path = "crates/awaken-ext-observability" }
+awaken-ext-mcp = { version = "0.2.1-dev", path = "crates/awaken-ext-mcp" }
+awaken-ext-skills = { version = "0.2.1-dev", path = "crates/awaken-ext-skills" }
+awaken-ext-reminder = { version = "0.2.1-dev", path = "crates/awaken-ext-reminder" }
+awaken-ext-generative-ui = { version = "0.2.1-dev", path = "crates/awaken-ext-generative-ui" }
+awaken-ext-deferred-tools = { version = "0.2.1-dev", path = "crates/awaken-ext-deferred-tools" }
+awaken-tool-pattern = { version = "0.2.1-dev", path = "crates/awaken-tool-pattern" }
+awaken-server = { version = "0.2.1-dev", path = "crates/awaken-server" }
 glob-match = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.2.0", path = "../awaken", features = ["full"] }
+awaken = { package = "awaken-agent", version = "0.2.1-dev", path = "../awaken", features = ["full"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
- Bump Rust workspace package version from 0.2.0 to 0.2.1-dev after the v0.2.0 release.
- Update internal workspace dependency version requirements and Cargo.lock.

## Verification
- cargo fmt --all --check
- cargo check --workspace --all-features
- pre-push hook validate