### PR TITLE
🧵 feat(mailbox): distributed live steering + NATS backends for 0.2.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,5 +63,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.85
+      - uses: dtolnay/rust-toolchain@1.93.0
       - run: cargo check --workspace --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "genai"
-version = "0.6.0-beta.11"
+version = "0.6.0-beta.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904984030e3db4267ca33edd2c3cb30b17d470e0d6bedcedd40f1780f8fd4d3b"
+checksum = "4e3ef54d7d3f34521d1ba8f4c2febb03ce32c26b4b11612fb40d3629a85096eb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1589,6 +1589,7 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "mime_guess",
+ "regex",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -3990,9 +3991,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -4864,9 +4865,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-nats"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-webpki 0.102.8",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,8 +554,10 @@ dependencies = [
 name = "awaken-stores"
 version = "0.2.1-dev"
 dependencies = [
+ "async-nats",
  "async-trait",
  "awaken-contract",
+ "bytes",
  "futures",
  "proptest",
  "rusqlite",
@@ -527,6 +565,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tempfile",
+ "testcontainers",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -676,6 +715,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +793,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -956,6 +1048,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +1200,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1227,28 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "signature",
+ "subtle",
+]
 
 [[package]]
 name = "either"
@@ -1213,6 +1364,23 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1742,6 +1910,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,7 +1934,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1794,6 +1977,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2328,10 +2526,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2346,6 +2544,21 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.5",
+ "signatory",
 ]
 
 [[package]]
@@ -2365,6 +2578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2509,6 +2731,12 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -2636,6 +2864,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn",
 ]
 
 [[package]]
@@ -2995,6 +3248,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -3099,7 +3361,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3279,10 +3541,24 @@ checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -3291,10 +3567,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3304,6 +3580,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3328,10 +3613,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
+ "rustls-webpki 0.103.10",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3342,6 +3627,17 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3442,6 +3738,19 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
@@ -3524,6 +3833,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,6 +3850,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3635,6 +3964,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -3925,6 +4266,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4041,6 +4405,35 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -4208,6 +4601,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,6 +4627,27 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "httparse",
+ "rand 0.8.5",
+ "ring",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4364,6 +4793,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "typedmap"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4457,6 +4896,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5235,6 +5675,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
 homepage = "https://github.com/AwakenWorks/awaken"
 keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
-rust-version = "1.85"
+rust-version = "1.93"
 
 [workspace.dependencies]
 awaken-contract = { version = "0.2.1-dev", path = "crates/awaken-contract" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ futures = "0.3"
 tracing = "0.1"
 typedmap = { version = "0.6", features = ["clone"] }
 uuid = { version = "1", features = ["v7"] }
-genai = "0.6.0-beta.10"
+genai = "0.6.0-beta.17"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 reqwest = { version = "0.13", features = ["json"] }
 schemars = "1"

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [English](./README.md) | [中文](./README.zh-CN.md)
 
-[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io](https://img.shields.io/crates/v/awaken-agent.svg?label=crates.io)](https://crates.io/crates/awaken-agent) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.85-orange)
+[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io](https://img.shields.io/crates/v/awaken-agent.svg?label=crates.io)](https://crates.io/crates/awaken-agent) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.93-orange)
 
 Production AI agent runtime for Rust — type-safe state, multi-protocol serving, plugin extensibility.
 
 Published on crates.io as `awaken-agent`; keep importing it in Rust as `awaken`.
-The workspace uses Rust 1.93.0 for development; the crate MSRV is 1.85.
+The workspace uses Rust 1.93.0 for development; the crate MSRV is 1.93.
 
 Docs: [GitHub Pages](https://awakenworks.github.io/awaken/) | [Chinese docs](https://awakenworks.github.io/awaken/zh-CN/)
 
@@ -34,10 +34,10 @@ Your agent picks tools, calls them, reads and updates state, and repeats — all
 
 ## Try it in 5 minutes
 
-Prerequisites: Rust 1.85+ for the published crate, or the pinned `rust-toolchain.toml`
+Prerequisites: Rust 1.93+ for the published crate, or the pinned `rust-toolchain.toml`
 toolchain when working from this repository, plus an LLM provider API key.
 
-- Rust 1.85 or newer. This repository pins Rust 1.93.0 for local development.
+- Rust 1.93 or newer. This repository pins Rust 1.93.0 for local development.
 - An OpenAI-compatible API key.
 
 ```toml

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,12 +2,12 @@
 
 [English](./README.md) | [中文](./README.zh-CN.md)
 
-[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io](https://img.shields.io/crates/v/awaken-agent.svg?label=crates.io)](https://crates.io/crates/awaken-agent) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.85-orange)
+[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io](https://img.shields.io/crates/v/awaken-agent.svg?label=crates.io)](https://crates.io/crates/awaken-agent) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.93-orange)
 
 生产级 Rust AI Agent 运行时 — 类型安全状态、多协议服务、插件化扩展。
 
 在 crates.io 上发布名为 `awaken-agent`，Rust 代码中的导入仍然保持为 `awaken`。
-仓库开发工具链由 Rust 1.93.0 固定，crate 的 MSRV 为 1.85。
+仓库开发工具链由 Rust 1.93.0 固定，crate 的 MSRV 为 1.93。
 
 在线文档：[GitHub Pages（英文）](https://awakenworks.github.io/awaken/) | [GitHub Pages（中文）](https://awakenworks.github.io/awaken/zh-CN/)
 
@@ -34,7 +34,7 @@ Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运
 
 ## 5 分钟上手
 
-**前置条件：** 使用发布 crate 时需要 Rust `1.85+`；从本仓库运行示例时使用 `rust-toolchain.toml` 固定的 `1.93.0`；还需要一个 LLM 提供商 API Key。
+**前置条件：** 使用发布 crate 时需要 Rust `1.93+`；从本仓库运行示例时使用 `rust-toolchain.toml` 固定的 `1.93.0`；还需要一个 LLM 提供商 API Key。
 
 在 `Cargo.toml` 中添加：
 

--- a/crates/awaken-contract/src/contract/mailbox.rs
+++ b/crates/awaken-contract/src/contract/mailbox.rs
@@ -1,10 +1,15 @@
 //! Run dispatch types and persistent store trait for the unified run queue.
 
+use std::pin::Pin;
+
 use async_trait::async_trait;
+use futures::Stream;
 use serde::{Deserialize, Serialize};
 
 use super::lifecycle::{RunStatus, TerminationReason};
+use super::message::Message;
 use super::storage::StorageError;
+use super::suspension::ToolCallResume;
 
 // ── RunDispatchStatus ───────────────────────────────────────────────
 
@@ -150,6 +155,74 @@ pub struct MailboxInterrupt {
     pub active_dispatch: Option<RunDispatch>,
     /// Number of Queued dispatches superseded.
     pub superseded_count: usize,
+}
+
+// ── LiveRunCommand ─────────────────────────────────────────────────────────
+
+/// Control command delivered to an active run's owning node (out-of-band
+/// relative to durable dispatch). Consumed by the runtime forwarder attached
+/// to each `RunHandle`; unsubscribed targets silently drop commands (best
+/// effort — steering is ephemeral by design).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum LiveRunCommand {
+    /// Inject messages into the running agent's inbox. Agent picks them up
+    /// at the next step boundary (`turn-boundary` semantics).
+    Messages(Vec<Message>),
+    /// Cooperatively cancel the run (`immediate` semantics — triggers the
+    /// run's cancellation token).
+    Cancel,
+    /// Deliver tool-call resume decisions to the run.
+    Decision(Vec<(String, ToolCallResume)>),
+}
+
+/// Completion receipt for a delivered `LiveRunCommand`. Consumers call
+/// [`LiveCommandReceipt::ack`] **only after the run has actually accepted
+/// the command** (e.g. the inbox channel returned success). A dropped
+/// receipt signals the producer that delivery did not complete, and the
+/// producer's `deliver_live` resolves as
+/// [`LiveDeliveryOutcome::NoSubscriber`] so the caller can fall back to
+/// durable dispatch. Producers MUST NOT observe `Delivered` until the
+/// receipt has been acknowledged.
+pub trait LiveCommandReceipt: Send + Sync {
+    /// Confirm the command was handed to the live consumer. Consumes the
+    /// receipt; dropping the handle without calling `ack` is treated as
+    /// non-delivery by the producer.
+    fn ack(self: Box<Self>);
+}
+
+/// Entry yielded by a [`LiveRunCommandStream`]: the command plus the
+/// receipt the consumer must `ack` once the run has received it.
+pub struct LiveRunCommandEntry {
+    pub command: LiveRunCommand,
+    pub receipt: Box<dyn LiveCommandReceipt>,
+}
+
+impl std::fmt::Debug for LiveRunCommandEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveRunCommandEntry")
+            .field("command", &self.command)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Stream of [`LiveRunCommandEntry`] consumed by the owning node's runtime
+/// forwarder.
+pub type LiveRunCommandStream = Pin<Box<dyn Stream<Item = LiveRunCommandEntry> + Send>>;
+
+/// Outcome of a `MailboxStore::deliver_live` call — lets the caller decide
+/// whether to fall back to the durable queue. `NoSubscriber` means *no node
+/// acknowledged the command*; the command was either lost in transit or
+/// the run failed to accept it. Callers must treat `NoSubscriber` as
+/// "did not deliver" and fall back to durable dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveDeliveryOutcome {
+    /// The owning run accepted the command (forwarder acked after handing
+    /// the command to the in-process channel).
+    Delivered,
+    /// No subscriber, or the subscriber failed to accept within the
+    /// producer's timeout. Caller should fall back to durable dispatch.
+    NoSubscriber,
 }
 
 // ── MailboxStore trait ──────────────────────────────────────────────
@@ -301,6 +374,37 @@ pub trait MailboxStore: Send + Sync {
     /// List distinct thread_ids that have at least one Queued dispatch.
     /// Used by recover() at startup.
     async fn queued_thread_ids(&self) -> Result<Vec<String>, StorageError>;
+
+    // ── live-channel (ephemeral steering) ──
+    //
+    // Separate from durable dispatch: these deliver best-effort control
+    // commands to whichever node currently owns the run. Default impls are
+    // no-ops so stores that don't support live delivery (test fakes) opt out.
+
+    /// Deliver a `LiveRunCommand` to the run currently active for `thread_id`.
+    /// Implementations report `Delivered` when at least one subscriber has
+    /// observed the command, or `NoSubscriber` when delivery would be a
+    /// silent drop (the caller then owns durable-fallback policy). The
+    /// default implementation is `NoSubscriber` so stores that opt out of
+    /// live delivery force every caller to fall back automatically.
+    async fn deliver_live(
+        &self,
+        thread_id: &str,
+        cmd: LiveRunCommand,
+    ) -> Result<LiveDeliveryOutcome, StorageError> {
+        let _ = (thread_id, cmd);
+        Ok(LiveDeliveryOutcome::NoSubscriber)
+    }
+
+    /// Subscribe to the live-command stream for `thread_id`. Called by the
+    /// runtime on the owning node when a run is registered.
+    async fn open_live_channel(
+        &self,
+        thread_id: &str,
+    ) -> Result<LiveRunCommandStream, StorageError> {
+        let _ = thread_id;
+        Ok(Box::pin(futures::stream::empty()))
+    }
 }
 
 #[cfg(test)]

--- a/crates/awaken-contract/src/contract/mailbox.rs
+++ b/crates/awaken-contract/src/contract/mailbox.rs
@@ -1,6 +1,7 @@
 //! Run dispatch types and persistent store trait for the unified run queue.
 
 use std::pin::Pin;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::Stream;
@@ -176,6 +177,36 @@ pub enum LiveRunCommand {
     Decision(Vec<(String, ToolCallResume)>),
 }
 
+/// Exact live-run target for cross-node ephemeral control.
+///
+/// Thread-only routing is intentionally insufficient for distributed
+/// backends: a stale subscriber for the same thread must not be able to ack a
+/// command intended for a newer run/dispatch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveRunTarget {
+    pub thread_id: String,
+    pub run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dispatch_id: Option<String>,
+}
+
+impl LiveRunTarget {
+    #[must_use]
+    pub fn new(thread_id: impl Into<String>, run_id: impl Into<String>) -> Self {
+        Self {
+            thread_id: thread_id.into(),
+            run_id: run_id.into(),
+            dispatch_id: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_dispatch_id(mut self, dispatch_id: impl Into<String>) -> Self {
+        self.dispatch_id = Some(dispatch_id.into());
+        self
+    }
+}
+
 /// Completion receipt for a delivered `LiveRunCommand`. Consumers call
 /// [`LiveCommandReceipt::ack`] **only after the run has actually accepted
 /// the command** (e.g. the inbox channel returned success). A dropped
@@ -223,6 +254,39 @@ pub enum LiveDeliveryOutcome {
     /// No subscriber, or the subscriber failed to accept within the
     /// producer's timeout. Caller should fall back to durable dispatch.
     NoSubscriber,
+}
+
+// ── DispatchSignal ─────────────────────────────────────────────────────────
+
+/// Receipt for a durable dispatch delivery signal.
+///
+/// Implementations should ack only after the scheduler has attempted to claim
+/// the indicated thread. Nack requests redelivery when the scheduler cannot
+/// safely make a claim decision.
+#[async_trait]
+pub trait DispatchSignalReceipt: Send + Sync {
+    async fn ack(self: Box<Self>) -> Result<(), StorageError>;
+    async fn nack(self: Box<Self>) -> Result<(), StorageError>;
+    async fn nack_with_delay(self: Box<Self>, delay: Duration) -> Result<(), StorageError> {
+        let _ = delay;
+        self.nack().await
+    }
+}
+
+/// One durable dispatch delivery signal pulled from a backend work queue.
+pub struct DispatchSignalEntry {
+    pub thread_id: String,
+    pub dispatch_id: String,
+    pub receipt: Box<dyn DispatchSignalReceipt>,
+}
+
+impl std::fmt::Debug for DispatchSignalEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DispatchSignalEntry")
+            .field("thread_id", &self.thread_id)
+            .field("dispatch_id", &self.dispatch_id)
+            .finish_non_exhaustive()
+    }
 }
 
 // ── MailboxStore trait ──────────────────────────────────────────────
@@ -375,6 +439,26 @@ pub trait MailboxStore: Send + Sync {
     /// Used by recover() at startup.
     async fn queued_thread_ids(&self) -> Result<Vec<String>, StorageError>;
 
+    // ── dispatch signals (durable wakeups) ──
+
+    /// Whether this store exposes durable dispatch delivery signals.
+    fn supports_dispatch_signals(&self) -> bool {
+        false
+    }
+
+    /// Pull durable dispatch delivery signals, if supported by the backend.
+    ///
+    /// The default is empty so non-work-queue stores continue relying on local
+    /// submit, startup recovery, and sweep.
+    async fn pull_dispatch_signals(
+        &self,
+        max: usize,
+        expires: Duration,
+    ) -> Result<Vec<DispatchSignalEntry>, StorageError> {
+        let _ = (max, expires);
+        Ok(Vec::new())
+    }
+
     // ── live-channel (ephemeral steering) ──
     //
     // Separate from durable dispatch: these deliver best-effort control
@@ -396,6 +480,19 @@ pub trait MailboxStore: Send + Sync {
         Ok(LiveDeliveryOutcome::NoSubscriber)
     }
 
+    /// Deliver a live command to an exact run target.
+    ///
+    /// Backends with targeted live subjects should override this. The default
+    /// preserves compatibility for stores that only support thread-level live
+    /// routing.
+    async fn deliver_live_to(
+        &self,
+        target: &LiveRunTarget,
+        cmd: LiveRunCommand,
+    ) -> Result<LiveDeliveryOutcome, StorageError> {
+        self.deliver_live(&target.thread_id, cmd).await
+    }
+
     /// Subscribe to the live-command stream for `thread_id`. Called by the
     /// runtime on the owning node when a run is registered.
     async fn open_live_channel(
@@ -404,6 +501,14 @@ pub trait MailboxStore: Send + Sync {
     ) -> Result<LiveRunCommandStream, StorageError> {
         let _ = thread_id;
         Ok(Box::pin(futures::stream::empty()))
+    }
+
+    /// Subscribe to the live-command stream for an exact run target.
+    async fn open_live_channel_for(
+        &self,
+        target: &LiveRunTarget,
+    ) -> Result<LiveRunCommandStream, StorageError> {
+        self.open_live_channel(&target.thread_id).await
     }
 }
 

--- a/crates/awaken-runtime/Cargo.toml
+++ b/crates/awaken-runtime/Cargo.toml
@@ -23,14 +23,14 @@ typedmap = { workspace = true }
 uuid = { workspace = true }
 genai = { workspace = true }
 tokio = { workspace = true }
-reqwest = { workspace = true, optional = true }
+reqwest = { workspace = true }
 schemars = { workspace = true }
 jsonschema = { workspace = true }
 parking_lot = { workspace = true }
 
 [features]
 default = ["a2a", "handoff", "background"]
-a2a = ["dep:reqwest"]
+a2a = []
 handoff = []
 background = []
 parallel-tools = []

--- a/crates/awaken-runtime/src/backend/local.rs
+++ b/crates/awaken-runtime/src/backend/local.rs
@@ -47,6 +47,16 @@ impl ExecutionBackend for LocalBackend {
         &self,
         request: BackendRootRunRequest<'_>,
     ) -> Result<BackendRunResult, ExecutionBackendError> {
+        self.execute_root_with_thread_context(request, None).await
+    }
+}
+
+impl LocalBackend {
+    pub(crate) async fn execute_root_with_thread_context(
+        &self,
+        request: BackendRootRunRequest<'_>,
+        thread_ctx: Option<crate::ThreadContextSnapshot>,
+    ) -> Result<BackendRunResult, ExecutionBackendError> {
         let phase_runtime = request
             .local
             .as_ref()
@@ -64,21 +74,24 @@ impl ExecutionBackend for LocalBackend {
                 .map_err(ExecutionBackendError::Loop)?;
         }
 
-        let result = run_agent_loop(AgentLoopParams {
-            resolver: request.resolver,
-            agent_id: request.agent_id,
-            runtime: phase_runtime,
-            sink: request.sink,
-            checkpoint_store: request.checkpoint_store,
-            messages: request.messages,
-            run_identity,
-            cancellation_token: request.control.cancellation_token,
-            decision_rx: request.control.decision_rx,
-            overrides: request.overrides,
-            frontend_tools: request.frontend_tools,
-            inbox: request.inbox,
-            is_continuation: request.is_continuation,
-        })
+        let result = crate::loop_runner::run_agent_loop_with_thread_context(
+            AgentLoopParams {
+                resolver: request.resolver,
+                agent_id: request.agent_id,
+                runtime: phase_runtime,
+                sink: request.sink,
+                checkpoint_store: request.checkpoint_store,
+                messages: request.messages,
+                run_identity,
+                cancellation_token: request.control.cancellation_token,
+                decision_rx: request.control.decision_rx,
+                overrides: request.overrides,
+                frontend_tools: request.frontend_tools,
+                inbox: request.inbox,
+                is_continuation: request.is_continuation,
+            },
+            thread_ctx,
+        )
         .await
         .map_err(ExecutionBackendError::Loop)?;
 
@@ -100,9 +113,7 @@ impl ExecutionBackend for LocalBackend {
             state: None,
         })
     }
-}
 
-impl LocalBackend {
     pub async fn execute_delegate(
         &self,
         request: BackendDelegateRunRequest<'_>,

--- a/crates/awaken-runtime/src/builder.rs
+++ b/crates/awaken-runtime/src/builder.rs
@@ -8,6 +8,7 @@ use awaken_contract::contract::storage::ThreadRunStore;
 use awaken_contract::contract::tool::Tool;
 use awaken_contract::registry_spec::AgentSpec;
 
+#[cfg(feature = "a2a")]
 use crate::backend::ExecutionBackendFactory;
 use crate::plugins::Plugin;
 #[cfg(feature = "a2a")]

--- a/crates/awaken-runtime/src/cancellation.rs
+++ b/crates/awaken-runtime/src/cancellation.rs
@@ -3,4 +3,5 @@
 //! The canonical definition now lives in `awaken_contract::cancellation`.
 //! This module preserves `crate::cancellation::*` import paths within the runtime.
 
+#[allow(unused_imports)]
 pub use awaken_contract::cancellation::{CancellationHandle, CancellationToken};

--- a/crates/awaken-runtime/src/inbox.rs
+++ b/crates/awaken-runtime/src/inbox.rs
@@ -51,14 +51,42 @@ impl InboxSender {
     /// the receiver was dropped — in that case `on_closed` (if set) is
     /// also invoked so the infrastructure layer can take action.
     pub fn send(&self, msg: serde_json::Value) -> bool {
-        if self.tx.unbounded_send(msg.clone()).is_ok() {
-            return true;
+        match self.tx.unbounded_send(msg) {
+            Ok(()) => {
+                let depth = self.tx.len();
+                if depth > 0 && depth.is_multiple_of(Self::DEPTH_WARNING_THRESHOLD) {
+                    tracing::warn!(depth, "inbox channel depth is high");
+                }
+                true
+            }
+            Err(e) => {
+                if let Some(ref cb) = self.on_closed {
+                    cb.closed(&e.into_inner());
+                }
+                false
+            }
         }
-        // Receiver gone — invoke fallback
-        if let Some(ref cb) = self.on_closed {
-            cb.closed(&msg);
-        }
-        false
+    }
+
+    const DEPTH_WARNING_THRESHOLD: usize = 256;
+
+    /// Try to send a message without invoking the closed-channel fallback.
+    ///
+    /// Runtime control paths use this when the caller owns fallback policy
+    /// itself, for example live user-input steering that should queue a
+    /// durable dispatch if the active receiver is gone.
+    pub fn try_send(&self, msg: serde_json::Value) -> bool {
+        self.tx.unbounded_send(msg).is_ok()
+    }
+
+    /// Returns the number of messages currently buffered in the channel.
+    pub fn len(&self) -> usize {
+        self.tx.len()
+    }
+
+    /// Returns `true` when the channel buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.tx.is_empty()
     }
 
     /// Returns `true` when the receiving half has been dropped.
@@ -121,6 +149,35 @@ pub fn inbox_event_message(json: &serde_json::Value) -> Message {
     msg
 }
 
+/// Convert direct messages into a single inbox payload.
+pub fn inbox_messages_payload(messages: Vec<Message>) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "messages",
+        "messages": messages,
+    })
+}
+
+/// Convert any inbox payload into messages for the owner agent.
+///
+/// Unknown payloads are treated as background-task events to preserve the
+/// historical inbox behavior.
+pub fn inbox_payload_messages(json: &serde_json::Value) -> Vec<Message> {
+    if json.get("kind").and_then(|kind| kind.as_str()) == Some("messages")
+        && let Some(values) = json
+            .get("messages")
+            .and_then(|messages| messages.as_array())
+    {
+        let messages = values
+            .iter()
+            .filter_map(|value| serde_json::from_value::<Message>(value.clone()).ok())
+            .collect::<Vec<_>>();
+        if !messages.is_empty() {
+            return messages;
+        }
+    }
+    vec![inbox_event_message(json)]
+}
+
 /// Create a new `(InboxSender, InboxReceiver)` pair.
 pub fn inbox_channel() -> (InboxSender, InboxReceiver) {
     let (tx, rx) = mpsc::unbounded();
@@ -165,6 +222,23 @@ mod tests {
         assert_eq!(msgs[1], "done");
 
         assert!(rx.try_recv().is_none());
+    }
+
+    #[test]
+    fn try_send_does_not_invoke_closed_fallback() {
+        struct Counter(AtomicUsize);
+        impl OnInboxClosed for Counter {
+            fn closed(&self, _msg: &serde_json::Value) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let counter = Arc::new(Counter(AtomicUsize::new(0)));
+        let (tx, rx) = inbox_channel_with_fallback(counter.clone());
+        drop(rx);
+
+        assert!(!tx.try_send(serde_json::json!("lost")));
+        assert_eq!(counter.0.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -240,5 +314,29 @@ mod tests {
         assert_eq!(msg.visibility, Visibility::Internal);
         assert!(msg.text().contains("background-task-event"));
         assert!(msg.text().contains("bg_1"));
+    }
+
+    #[test]
+    fn inbox_messages_payload_roundtrips_direct_messages() {
+        let payload = inbox_messages_payload(vec![Message::user("live steering")]);
+        let messages = inbox_payload_messages(&payload);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].role,
+            awaken_contract::contract::message::Role::User
+        );
+        assert_eq!(messages[0].visibility, Visibility::All);
+        assert_eq!(messages[0].text(), "live steering");
+    }
+
+    #[test]
+    fn inbox_payload_messages_keeps_background_event_fallback() {
+        let messages = inbox_payload_messages(&serde_json::json!({
+            "kind": "completed",
+            "task_id": "bg_2",
+        }));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].visibility, Visibility::Internal);
+        assert!(messages[0].text().contains("background-task-event"));
     }
 }

--- a/crates/awaken-runtime/src/lib.rs
+++ b/crates/awaken-runtime/src/lib.rs
@@ -50,5 +50,5 @@ pub use phase::{
 };
 pub use plugins::{Plugin, PluginDescriptor, PluginRegistrar};
 pub use registry::{AgentResolver, ExecutionResolver, ResolvedAgent, ResolvedExecution};
-pub use runtime::{AgentRuntime, RunRequest};
+pub use runtime::{AgentRuntime, RunRequest, ThreadContextSnapshot};
 pub use state::{CommitEvent, CommitHook, MutationBatch, StateCommand, StateStore};

--- a/crates/awaken-runtime/src/loop_runner/checkpoint.rs
+++ b/crates/awaken-runtime/src/loop_runner/checkpoint.rs
@@ -32,6 +32,7 @@ pub(super) struct StepCompletion<'a> {
     pub(super) run_created_at: u64,
     pub(super) total_input_tokens: u64,
     pub(super) total_output_tokens: u64,
+    pub(super) thread_ctx: Option<&'a crate::ThreadContextSnapshot>,
 }
 
 pub(super) struct CheckpointPersist<'a> {
@@ -46,6 +47,7 @@ pub(super) struct CheckpointPersist<'a> {
     pub(super) termination_reason: Option<TerminationReason>,
     pub(super) final_output: Option<String>,
     pub(super) error_payload: Option<Value>,
+    pub(super) thread_ctx: Option<&'a crate::ThreadContextSnapshot>,
 }
 
 pub(super) async fn complete_step(params: StepCompletion<'_>) -> Result<(), AgentLoopError> {
@@ -61,6 +63,7 @@ pub(super) async fn complete_step(params: StepCompletion<'_>) -> Result<(), Agen
         run_created_at,
         total_input_tokens,
         total_output_tokens,
+        thread_ctx,
     } = params;
 
     commit_update::<RunLifecycle>(
@@ -86,6 +89,7 @@ pub(super) async fn complete_step(params: StepCompletion<'_>) -> Result<(), Agen
         termination_reason: None,
         final_output: None,
         error_payload: None,
+        thread_ctx,
     })
     .await?;
 
@@ -110,6 +114,7 @@ pub(super) async fn persist_checkpoint(
         termination_reason,
         final_output,
         error_payload,
+        thread_ctx,
     } = params;
     let Some(storage) = checkpoint_store else {
         return Ok(());
@@ -119,10 +124,14 @@ pub(super) async fn persist_checkpoint(
     let state = store
         .export_persisted()
         .map_err(AgentLoopError::PhaseError)?;
-    let previous = storage
-        .load_run(&run_identity.run_id)
-        .await
-        .map_err(|e| AgentLoopError::StorageError(e.to_string()))?;
+    let previous = if let Some(ctx) = thread_ctx {
+        ctx.run_cache.get(&run_identity.run_id).cloned()
+    } else {
+        storage
+            .load_run(&run_identity.run_id)
+            .await
+            .map_err(|e| AgentLoopError::StorageError(e.to_string()))?
+    };
     let created_at = previous
         .as_ref()
         .map(|record| record.created_at)

--- a/crates/awaken-runtime/src/loop_runner/mod.rs
+++ b/crates/awaken-runtime/src/loop_runner/mod.rs
@@ -216,5 +216,12 @@ pub fn build_agent_env(
 /// Supports dynamic agent handoff via `ActiveAgentIdKey` re-resolve at step boundaries.
 /// Cooperative cancellation via `CancellationToken`.
 pub async fn run_agent_loop(params: AgentLoopParams<'_>) -> Result<AgentRunResult, AgentLoopError> {
-    orchestrator::run_agent_loop_impl(params).await
+    orchestrator::run_agent_loop_impl(params, None).await
+}
+
+pub(crate) async fn run_agent_loop_with_thread_context(
+    params: AgentLoopParams<'_>,
+    thread_ctx: Option<crate::ThreadContextSnapshot>,
+) -> Result<AgentRunResult, AgentLoopError> {
+    orchestrator::run_agent_loop_impl(params, thread_ctx).await
 }

--- a/crates/awaken-runtime/src/loop_runner/orchestrator.rs
+++ b/crates/awaken-runtime/src/loop_runner/orchestrator.rs
@@ -1,7 +1,7 @@
 //! Main agent loop orchestration.
 
 use crate::context::TruncationState;
-use crate::inbox::inbox_event_message;
+use crate::inbox::inbox_payload_messages;
 use crate::state::StateStore;
 use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::lifecycle::{RunStatus, TerminationReason};
@@ -19,6 +19,7 @@ use super::setup::{PreparedRun, prepare_run};
 use super::step::{self, StepContext, StepOutcome, execute_step};
 use super::{AgentLoopError, AgentLoopParams, AgentRunResult, commit_update, now_ms};
 use crate::agent::state::{RunLifecycle, RunLifecycleUpdate, ToolCallStates, ToolCallStatesUpdate};
+#[cfg(feature = "handoff")]
 use crate::state::MutationBatch;
 
 /// Returns `true` when any plugin has declared pending work.
@@ -34,9 +35,16 @@ fn has_pending_work(store: &StateStore) -> bool {
         .unwrap_or(false)
 }
 
+fn push_inbox_payload(messages: &mut Vec<std::sync::Arc<Message>>, payload: &serde_json::Value) {
+    for message in inbox_payload_messages(payload) {
+        messages.push(std::sync::Arc::new(message));
+    }
+}
+
 #[tracing::instrument(skip_all, fields(agent_id = %params.agent_id, run_id = %params.run_identity.run_id))]
 pub(super) async fn run_agent_loop_impl(
     params: AgentLoopParams<'_>,
+    thread_ctx: Option<crate::ThreadContextSnapshot>,
 ) -> Result<AgentRunResult, AgentLoopError> {
     let AgentLoopParams {
         resolver,
@@ -222,6 +230,7 @@ pub(super) async fn run_agent_loop_impl(
             total_output_tokens: &mut total_output_tokens,
             truncation_state: &mut truncation_state,
             run_created_at,
+            thread_ctx: thread_ctx.as_ref(),
         };
 
         let step_result = match execute_step(&mut step_ctx).await {
@@ -246,6 +255,7 @@ pub(super) async fn run_agent_loop_impl(
                     run_created_at,
                     total_input_tokens,
                     total_output_tokens,
+                    thread_ctx: thread_ctx.as_ref(),
                 })
                 .await?;
                 break TerminationReason::Cancelled;
@@ -257,7 +267,7 @@ pub(super) async fn run_agent_loop_impl(
                 let mut has_new_messages = false;
                 if let Some(ref mut inbox) = inbox {
                     for msg in inbox.drain() {
-                        messages.push(std::sync::Arc::new(inbox_event_message(&msg)));
+                        push_inbox_payload(&mut messages, &msg);
                         has_new_messages = true;
                     }
                 }
@@ -278,10 +288,9 @@ pub(super) async fn run_agent_loop_impl(
                         if let Some(ref mut inbox) = inbox {
                             match inbox.recv_or_cancel(cancellation_token.as_ref()).await {
                                 Some(msg) => {
-                                    messages.push(std::sync::Arc::new(inbox_event_message(&msg)));
+                                    push_inbox_payload(&mut messages, &msg);
                                     for extra in inbox.drain() {
-                                        messages
-                                            .push(std::sync::Arc::new(inbox_event_message(&extra)));
+                                        push_inbox_payload(&mut messages, &extra);
                                     }
                                     continue; // back to loop — LLM processes events
                                 }
@@ -319,6 +328,7 @@ pub(super) async fn run_agent_loop_impl(
                     run_created_at,
                     total_input_tokens,
                     total_output_tokens,
+                    thread_ctx: thread_ctx.as_ref(),
                 })
                 .await?;
                 break TerminationReason::Blocked(reason);
@@ -339,6 +349,7 @@ pub(super) async fn run_agent_loop_impl(
                     run_created_at,
                     total_input_tokens,
                     total_output_tokens,
+                    thread_ctx: thread_ctx.as_ref(),
                 })
                 .await?;
                 break reason;
@@ -364,6 +375,7 @@ pub(super) async fn run_agent_loop_impl(
                     run_created_at,
                     total_input_tokens,
                     total_output_tokens,
+                    thread_ctx: thread_ctx.as_ref(),
                 })
                 .await?;
 
@@ -430,7 +442,7 @@ pub(super) async fn run_agent_loop_impl(
                         }
                         WaitOutcome::InboxMessages(events) => {
                             for event in events {
-                                messages.push(std::sync::Arc::new(inbox_event_message(&event)));
+                                push_inbox_payload(&mut messages, &event);
                             }
                             persist_checkpoint(CheckpointPersist {
                                 store,
@@ -444,6 +456,7 @@ pub(super) async fn run_agent_loop_impl(
                                 termination_reason: None,
                                 final_output: None,
                                 error_payload: None,
+                                thread_ctx: thread_ctx.as_ref(),
                             })
                             .await?;
                             continue;
@@ -470,12 +483,13 @@ pub(super) async fn run_agent_loop_impl(
                     run_created_at,
                     total_input_tokens,
                     total_output_tokens,
+                    thread_ctx: thread_ctx.as_ref(),
                 })
                 .await?;
                 // Drain inbox messages that arrived during step execution
                 if let Some(ref mut inbox) = inbox {
                     for msg in inbox.drain() {
-                        messages.push(std::sync::Arc::new(inbox_event_message(&msg)));
+                        push_inbox_payload(&mut messages, &msg);
                     }
                 }
                 if let Some(reason) = check_termination(store) {
@@ -534,6 +548,7 @@ pub(super) async fn run_agent_loop_impl(
             TerminationReason::Error(message) => Some(serde_json::json!({ "message": message })),
             _ => None,
         },
+        thread_ctx: thread_ctx.as_ref(),
     })
     .await?;
 

--- a/crates/awaken-runtime/src/loop_runner/resume.rs
+++ b/crates/awaken-runtime/src/loop_runner/resume.rs
@@ -197,6 +197,7 @@ pub(super) async fn detect_and_replay_resume(
             total_output_tokens: &mut total_output_tokens,
             truncation_state: &mut truncation_state,
             run_created_at,
+            thread_ctx: None,
         };
 
         let mut transcript = ToolBatchTranscript::for_resume();

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -66,6 +66,7 @@ pub(super) struct StepContext<'a> {
     pub total_output_tokens: &'a mut u64,
     pub truncation_state: &'a mut TruncationState,
     pub run_created_at: u64,
+    pub thread_ctx: Option<&'a crate::ThreadContextSnapshot>,
 }
 
 pub(super) struct ToolBatchTranscript {
@@ -1208,6 +1209,7 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
             run_created_at: ctx.run_created_at,
             total_input_tokens: *ctx.total_input_tokens,
             total_output_tokens: *ctx.total_output_tokens,
+            thread_ctx: ctx.thread_ctx,
         })
         .await?;
         return Ok(StepOutcome::NaturalEnd);

--- a/crates/awaken-runtime/src/loop_runner/tests.rs
+++ b/crates/awaken-runtime/src/loop_runner/tests.rs
@@ -998,6 +998,7 @@ async fn resumed_calls_do_not_serialize_neighboring_fresh_batches() {
         total_output_tokens: &mut total_output_tokens,
         truncation_state: &mut truncation_state,
         run_created_at: 0,
+        thread_ctx: None,
     };
     let calls = vec![
         awaken_contract::contract::message::ToolCall::new("c1", "alpha", serde_json::json!({})),
@@ -1217,6 +1218,7 @@ async fn tool_gate_recheck_executes_before_tool_hook_once() {
         total_output_tokens: &mut total_output_tokens,
         truncation_state: &mut truncation_state,
         run_created_at: 0,
+        thread_ctx: None,
     };
     let calls = vec![
         awaken_contract::contract::message::ToolCall::new("c1", "unlock", serde_json::json!({})),
@@ -1294,6 +1296,7 @@ async fn tool_gate_flush_suspension_backfills_rechecked_and_later_calls() {
         total_output_tokens: &mut total_output_tokens,
         truncation_state: &mut truncation_state,
         run_created_at: 0,
+        thread_ctx: None,
     };
     let calls = vec![
         awaken_contract::contract::message::ToolCall::new("c1", "unlock", serde_json::json!({})),

--- a/crates/awaken-runtime/src/registry/memory.rs
+++ b/crates/awaken-runtime/src/registry/memory.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[cfg(feature = "a2a")]
 use crate::backend::ExecutionBackendFactory;
 use crate::builder::BuildError;
 #[cfg(feature = "a2a")]

--- a/crates/awaken-runtime/src/registry/resolve/pipeline.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline.rs
@@ -8,9 +8,9 @@ use crate::error::RuntimeError;
 use crate::execution::SequentialToolExecutor;
 use crate::phase::ExecutionEnv;
 use crate::plugins::Plugin;
-use crate::registry::{
-    AgentResolver, ExecutionResolver, ResolvedAgent, ResolvedBackendAgent, ResolvedExecution,
-};
+#[cfg(feature = "a2a")]
+use crate::registry::ResolvedBackendAgent;
+use crate::registry::{AgentResolver, ExecutionResolver, ResolvedAgent, ResolvedExecution};
 use awaken_contract::contract::executor::LlmExecutor;
 use awaken_contract::contract::tool::Tool;
 

--- a/crates/awaken-runtime/src/runtime/agent_runtime/active_registry.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/active_registry.rs
@@ -66,7 +66,9 @@ impl ActiveRunRegistry {
     /// Notifies any waiters that the thread slot is now free.
     pub(super) fn unregister(&self, run_id: &str) {
         let mut inner = self.inner.write();
-        inner.by_run_id.remove(run_id);
+        if let Some(handle) = inner.by_run_id.remove(run_id) {
+            handle.stop_live_forwarder();
+        }
 
         let thread_id = inner.run_to_thread.remove(run_id);
         if let Some(ref tid) = thread_id {
@@ -84,8 +86,7 @@ impl ActiveRunRegistry {
     }
 
     /// Check whether a thread has an active run.
-    #[cfg(test)]
-    fn has_active_thread(&self, thread_id: &str) -> bool {
+    pub(crate) fn has_active_thread(&self, thread_id: &str) -> bool {
         self.inner.read().by_thread_id.contains_key(thread_id)
     }
 
@@ -152,7 +153,9 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded::<Vec<(String, ToolCallResume)>>();
         RunHandle {
             run_id: run_id.to_string(),
+            dispatch_id: None,
             cancellation_token: token,
+            live_forwarder_token: CancellationToken::new(),
             decision_tx: tx,
             inbox_tx: None,
         }
@@ -258,7 +261,9 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded::<Vec<(String, ToolCallResume)>>();
         let handle = RunHandle {
             run_id: "r1".to_string(),
+            dispatch_id: None,
             cancellation_token: token,
+            live_forwarder_token: CancellationToken::new(),
             decision_tx: tx,
             inbox_tx: None,
         };

--- a/crates/awaken-runtime/src/runtime/agent_runtime/active_registry.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/active_registry.rs
@@ -15,38 +15,49 @@ pub(super) enum HandleLookup {
     Ambiguous,
 }
 
+struct RegistryInner {
+    by_run_id: HashMap<String, RunHandle>,
+    by_thread_id: HashMap<String, String>,
+    run_to_thread: HashMap<String, String>,
+    completion_notify: HashMap<String, Arc<Notify>>,
+}
+
 /// Tracks active runs with dual indexing by run_id and thread_id.
 /// At most one active run per thread.
 pub(crate) struct ActiveRunRegistry {
-    by_run_id: RwLock<HashMap<String, RunHandle>>,
-    by_thread_id: RwLock<HashMap<String, String>>, // thread_id → run_id
-    /// Notified when a run for a given thread_id is unregistered.
-    completion_notify: RwLock<HashMap<String, Arc<Notify>>>,
+    inner: RwLock<RegistryInner>,
 }
 
 impl ActiveRunRegistry {
     pub(crate) fn new() -> Self {
         Self {
-            by_run_id: RwLock::new(HashMap::new()),
-            by_thread_id: RwLock::new(HashMap::new()),
-            completion_notify: RwLock::new(HashMap::new()),
+            inner: RwLock::new(RegistryInner {
+                by_run_id: HashMap::new(),
+                by_thread_id: HashMap::new(),
+                run_to_thread: HashMap::new(),
+                completion_notify: HashMap::new(),
+            }),
         }
     }
 
     /// Register a run with both run_id and thread_id indexing.
     /// Returns `false` if either the thread or run_id is already active.
     pub(super) fn register(&self, run_id: &str, thread_id: &str, handle: RunHandle) -> bool {
-        let mut by_thread = self.by_thread_id.write();
-        let mut by_run = self.by_run_id.write();
+        let mut inner = self.inner.write();
 
-        if by_thread.contains_key(thread_id) || by_run.contains_key(run_id) {
+        if inner.by_thread_id.contains_key(thread_id) || inner.by_run_id.contains_key(run_id) {
             return false;
         }
 
-        by_thread.insert(thread_id.to_string(), run_id.to_string());
-        by_run.insert(run_id.to_string(), handle);
-        self.completion_notify
-            .write()
+        inner
+            .by_thread_id
+            .insert(thread_id.to_string(), run_id.to_string());
+        inner
+            .run_to_thread
+            .insert(run_id.to_string(), thread_id.to_string());
+        inner.by_run_id.insert(run_id.to_string(), handle);
+        inner
+            .completion_notify
             .insert(thread_id.to_string(), Arc::new(Notify::new()));
         true
     }
@@ -54,20 +65,20 @@ impl ActiveRunRegistry {
     /// Unregister a run by run_id. Removes both run_id and thread_id mappings.
     /// Notifies any waiters that the thread slot is now free.
     pub(super) fn unregister(&self, run_id: &str) {
-        let mut by_thread = self.by_thread_id.write();
-        let mut by_run = self.by_run_id.write();
-        by_run.remove(run_id);
+        let mut inner = self.inner.write();
+        inner.by_run_id.remove(run_id);
 
-        // Find the thread_id for this run_id and notify waiters.
-        let thread_id = by_thread
-            .iter()
-            .find(|(_, v)| v.as_str() == run_id)
-            .map(|(k, _)| k.clone());
-        by_thread.retain(|_, v| v != run_id);
+        let thread_id = inner.run_to_thread.remove(run_id);
+        if let Some(ref tid) = thread_id {
+            inner.by_thread_id.remove(tid);
+        }
 
         if let Some(tid) = thread_id
-            && let Some(notify) = self.completion_notify.write().remove(&tid)
+            && let Some(notify) = inner.completion_notify.remove(&tid)
         {
+            // Release the lock before notifying to avoid holding it while
+            // waiters wake up and potentially re-acquire.
+            drop(inner);
             notify.notify_waiters();
         }
     }
@@ -75,27 +86,30 @@ impl ActiveRunRegistry {
     /// Check whether a thread has an active run.
     #[cfg(test)]
     fn has_active_thread(&self, thread_id: &str) -> bool {
-        self.by_thread_id.read().contains_key(thread_id)
+        self.inner.read().by_thread_id.contains_key(thread_id)
     }
 
     /// Cancel the active run for a thread and return a `Notify` that will
     /// fire when the run slot is freed via `unregister()`.
     /// Returns `None` if no active run exists for the thread.
     pub(crate) fn cancel_and_get_notify(&self, thread_id: &str) -> Option<Arc<Notify>> {
-        let handle = self.get_by_thread_id(thread_id)?;
+        let inner = self.inner.read();
+        let run_id = inner.by_thread_id.get(thread_id)?;
+        let handle = inner.by_run_id.get(run_id)?;
         handle.cancel();
-        self.completion_notify.read().get(thread_id).cloned()
+        inner.completion_notify.get(thread_id).cloned()
     }
 
     /// Look up a handle by run_id.
     pub(super) fn get_by_run_id(&self, run_id: &str) -> Option<RunHandle> {
-        self.by_run_id.read().get(run_id).cloned()
+        self.inner.read().by_run_id.get(run_id).cloned()
     }
 
     /// Look up a handle by thread_id (resolves thread_id -> run_id -> handle).
     pub(super) fn get_by_thread_id(&self, thread_id: &str) -> Option<RunHandle> {
-        let run_id = self.by_thread_id.read().get(thread_id).cloned()?;
-        self.by_run_id.read().get(&run_id).cloned()
+        let inner = self.inner.read();
+        let run_id = inner.by_thread_id.get(thread_id)?;
+        inner.by_run_id.get(run_id).cloned()
     }
 
     /// Look up a handle by control id with ambiguity detection.
@@ -103,13 +117,13 @@ impl ActiveRunRegistry {
     /// If `id` matches both a `run_id` and a `thread_id` that point to
     /// different runs, returns `Ambiguous`.
     pub(super) fn lookup_strict(&self, id: &str) -> HandleLookup {
-        let by_run = self.by_run_id.read();
-        let by_thread = self.by_thread_id.read();
+        let inner = self.inner.read();
 
-        let by_run_hit = by_run.get(id).cloned();
-        let by_thread_hit = by_thread
+        let by_run_hit = inner.by_run_id.get(id).cloned();
+        let by_thread_hit = inner
+            .by_thread_id
             .get(id)
-            .and_then(|run_id| by_run.get(run_id))
+            .and_then(|run_id| inner.by_run_id.get(run_id))
             .cloned();
 
         match (by_run_hit, by_thread_hit) {
@@ -140,6 +154,7 @@ mod tests {
             run_id: run_id.to_string(),
             cancellation_token: token,
             decision_tx: tx,
+            inbox_tx: None,
         }
     }
 
@@ -245,6 +260,7 @@ mod tests {
             run_id: "r1".to_string(),
             cancellation_token: token,
             decision_tx: tx,
+            inbox_tx: None,
         };
         assert!(reg.register("r1", "t1", handle));
         assert!(!cloned.is_cancelled());

--- a/crates/awaken-runtime/src/runtime/agent_runtime/control.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/control.rs
@@ -1,5 +1,6 @@
 //! Control methods: cancel, send_decisions — with dual-index lookup (run_id + thread_id).
 
+use awaken_contract::contract::message::Message;
 use awaken_contract::contract::suspension::ToolCallResume;
 
 use super::AgentRuntime;
@@ -84,6 +85,19 @@ impl AgentRuntime {
             HandleLookup::NotFound => false,
             HandleLookup::Ambiguous => {
                 tracing::warn!(id = %id, "send_decision rejected: ambiguous control id");
+                false
+            }
+        }
+    }
+
+    /// Send direct input messages to an active run by run ID or thread ID.
+    /// Ambiguous IDs are rejected.
+    pub fn send_messages(&self, id: &str, messages: Vec<Message>) -> bool {
+        match self.active_runs.lookup_strict(id) {
+            HandleLookup::Found(handle) => handle.send_messages(messages),
+            HandleLookup::NotFound => false,
+            HandleLookup::Ambiguous => {
+                tracing::warn!(id = %id, "send_messages rejected: ambiguous control id");
                 false
             }
         }
@@ -307,6 +321,43 @@ mod tests {
         drop(rx);
 
         assert!(!rt.send_decision("r1", "tc1".into(), make_resume()));
+    }
+
+    // -- send_messages (dual-index) --
+
+    #[test]
+    fn send_messages_by_run_id_delivers_to_inbox() {
+        let rt = make_runtime();
+        let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+        let (handle, _token, _rx) = rt.create_run_channels_with_inbox("r1".into(), Some(inbox_tx));
+        rt.register_run("t1", handle).unwrap();
+
+        assert!(rt.send_messages("r1", vec![Message::user("live")]));
+
+        let payload = inbox_rx.try_recv().expect("payload should be delivered");
+        let messages = crate::inbox::inbox_payload_messages(&payload);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].text(), "live");
+    }
+
+    #[test]
+    fn send_messages_returns_false_without_inbox() {
+        let rt = make_runtime();
+        let (handle, _token, _rx) = rt.create_run_channels("r1".into());
+        rt.register_run("t1", handle).unwrap();
+
+        assert!(!rt.send_messages("r1", vec![Message::user("live")]));
+    }
+
+    #[test]
+    fn send_messages_returns_false_for_closed_inbox() {
+        let rt = make_runtime();
+        let (inbox_tx, inbox_rx) = crate::inbox::inbox_channel();
+        drop(inbox_rx);
+        let (handle, _token, _rx) = rt.create_run_channels_with_inbox("r1".into(), Some(inbox_tx));
+        rt.register_run("t1", handle).unwrap();
+
+        assert!(!rt.send_messages("r1", vec![Message::user("live")]));
     }
 
     // -- cancel after unregister --

--- a/crates/awaken-runtime/src/runtime/agent_runtime/control.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/control.rs
@@ -6,19 +6,29 @@ use awaken_contract::contract::suspension::ToolCallResume;
 use super::AgentRuntime;
 use super::active_registry::HandleLookup;
 
+#[cfg(not(test))]
+const CANCEL_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(test)]
+const CANCEL_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(25);
+
 impl AgentRuntime {
     /// Cancel an active run by thread ID and wait for it to finish.
     ///
-    /// Returns `true` if a run was cancelled, `false` if no active run existed.
-    /// Waits up to 5 seconds for the run to actually unregister.
+    /// Returns `true` only when the run slot is released before the wait timeout.
+    /// Returns `false` when no active run exists or cancellation does not finish in time.
     pub async fn cancel_and_wait_by_thread(&self, thread_id: &str) -> bool {
         let notify = match self.active_runs.cancel_and_get_notify(thread_id) {
             Some(n) => n,
             None => return false,
         };
+        if !self.active_runs.has_active_thread(thread_id) {
+            return true;
+        }
         // Wait for the RunSlotGuard to drop (calls unregister, which fires the notify).
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), notify.notified()).await;
-        true
+        tokio::time::timeout(CANCEL_WAIT_TIMEOUT, notify.notified())
+            .await
+            .is_ok()
+            || !self.active_runs.has_active_thread(thread_id)
     }
 
     /// Cancel an active run by thread ID.
@@ -329,7 +339,8 @@ mod tests {
     fn send_messages_by_run_id_delivers_to_inbox() {
         let rt = make_runtime();
         let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
-        let (handle, _token, _rx) = rt.create_run_channels_with_inbox("r1".into(), Some(inbox_tx));
+        let (handle, _token, _rx) =
+            rt.create_run_channels_with_inbox("r1".into(), None, Some(inbox_tx));
         rt.register_run("t1", handle).unwrap();
 
         assert!(rt.send_messages("r1", vec![Message::user("live")]));
@@ -354,7 +365,8 @@ mod tests {
         let rt = make_runtime();
         let (inbox_tx, inbox_rx) = crate::inbox::inbox_channel();
         drop(inbox_rx);
-        let (handle, _token, _rx) = rt.create_run_channels_with_inbox("r1".into(), Some(inbox_tx));
+        let (handle, _token, _rx) =
+            rt.create_run_channels_with_inbox("r1".into(), None, Some(inbox_tx));
         rt.register_run("t1", handle).unwrap();
 
         assert!(!rt.send_messages("r1", vec![Message::user("live")]));
@@ -382,6 +394,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_and_wait_returns_false_when_run_does_not_unregister() {
+        let rt = make_runtime();
+        let (handle, token, _rx) = rt.create_run_channels("r1".into());
+        rt.register_run("t1", handle).unwrap();
+
+        assert!(!rt.cancel_and_wait_by_thread("t1").await);
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
     async fn cancel_and_wait_completes_after_unregister() {
         use std::sync::Arc;
 
@@ -392,7 +414,7 @@ mod tests {
         // Spawn a task that unregisters after a short delay
         let rt2 = Arc::clone(&rt);
         tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
             rt2.unregister_run("r1");
         });
 

--- a/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
@@ -7,7 +7,9 @@ mod runner;
 
 use std::sync::Arc;
 
-use awaken_contract::contract::mailbox::{LiveRunCommand, LiveRunCommandEntry, MailboxStore};
+use awaken_contract::contract::mailbox::{
+    LiveRunCommand, LiveRunCommandEntry, LiveRunTarget, MailboxStore,
+};
 use awaken_contract::contract::storage::ThreadRunStore;
 
 use crate::error::RuntimeError;
@@ -42,7 +44,9 @@ pub(crate) type DecisionBatch = Vec<(String, ToolCallResume)>;
 #[derive(Clone)]
 pub(crate) struct RunHandle {
     pub(crate) run_id: String,
+    pub(crate) dispatch_id: Option<String>,
     cancellation_token: CancellationToken,
+    live_forwarder_token: CancellationToken,
     decision_tx: mpsc::UnboundedSender<DecisionBatch>,
     inbox_tx: Option<InboxSender>,
 }
@@ -51,6 +55,10 @@ impl RunHandle {
     /// Cancel the running agent loop cooperatively.
     pub(crate) fn cancel(&self) {
         self.cancellation_token.cancel();
+    }
+
+    pub(crate) fn stop_live_forwarder(&self) {
+        self.live_forwarder_token.cancel();
     }
 
     /// Send one or more tool call decisions to the running loop atomically.
@@ -239,12 +247,13 @@ impl AgentRuntime {
         CancellationToken,
         mpsc::UnboundedReceiver<DecisionBatch>,
     ) {
-        self.create_run_channels_with_inbox(run_id, None)
+        self.create_run_channels_with_inbox(run_id, None, None)
     }
 
     pub(crate) fn create_run_channels_with_inbox(
         &self,
         run_id: String,
+        dispatch_id: Option<String>,
         inbox_tx: Option<InboxSender>,
     ) -> (
         RunHandle,
@@ -252,11 +261,14 @@ impl AgentRuntime {
         mpsc::UnboundedReceiver<DecisionBatch>,
     ) {
         let token = CancellationToken::new();
+        let live_forwarder_token = CancellationToken::new();
         let (tx, rx) = mpsc::unbounded();
 
         let handle = RunHandle {
             run_id,
+            dispatch_id,
             cancellation_token: token.clone(),
+            live_forwarder_token,
             decision_tx: tx,
             inbox_tx,
         };
@@ -275,11 +287,13 @@ impl AgentRuntime {
         handle: RunHandle,
     ) -> Result<(), RuntimeError> {
         let run_id = handle.run_id.clone();
+        let dispatch_id = handle.dispatch_id.clone();
         let forwarder_inputs = self.mailbox_store.as_ref().map(|store| {
             (
                 Arc::clone(store),
                 handle.inbox_tx.clone(),
                 handle.cancellation_token.clone(),
+                handle.live_forwarder_token.clone(),
                 handle.decision_tx.clone(),
             )
         });
@@ -288,10 +302,15 @@ impl AgentRuntime {
                 thread_id: thread_id.to_string(),
             });
         }
-        if let Some((store, inbox_tx, token, decision_tx)) = forwarder_inputs {
+        if let Some((store, inbox_tx, token, forwarder_token, decision_tx)) = forwarder_inputs {
             let thread_id = thread_id.to_string();
+            let mut target = LiveRunTarget::new(thread_id.clone(), run_id.clone());
+            if let Some(dispatch_id) = dispatch_id {
+                target = target.with_dispatch_id(dispatch_id);
+            }
             tokio::spawn(async move {
-                run_live_forwarder(store, thread_id, inbox_tx, token, decision_tx).await;
+                run_live_forwarder(store, target, inbox_tx, token, forwarder_token, decision_tx)
+                    .await;
             });
         } else if !self
             .missing_mailbox_store_warned
@@ -316,25 +335,44 @@ impl AgentRuntime {
 /// thread and translates each `LiveRunCommand` into the matching in-process signal.
 ///
 /// Exits when:
+/// - the run is unregistered and its forwarder token is cancelled,
 /// - the subscription stream ends (store closed the channel),
 /// - a `Cancel` has been dispatched (nothing more for this run to process),
 /// - or a downstream channel is closed (agent loop already finished).
 async fn run_live_forwarder(
     store: Arc<dyn MailboxStore>,
-    thread_id: String,
+    target: LiveRunTarget,
     inbox_tx: Option<InboxSender>,
     cancellation_token: CancellationToken,
+    live_forwarder_token: CancellationToken,
     decision_tx: mpsc::UnboundedSender<DecisionBatch>,
 ) {
-    let mut stream = match store.open_live_channel(&thread_id).await {
+    let mut stream = match store.open_live_channel_for(&target).await {
         Ok(s) => s,
         Err(err) => {
-            tracing::warn!(thread_id, error = %err, "live channel subscribe failed");
+            tracing::warn!(
+                thread_id = %target.thread_id,
+                run_id = %target.run_id,
+                dispatch_id = ?target.dispatch_id,
+                error = %err,
+                "live channel subscribe failed"
+            );
             return;
         }
     };
 
-    while let Some(LiveRunCommandEntry { command, receipt }) = stream.next().await {
+    loop {
+        if live_forwarder_token.is_cancelled() {
+            break;
+        }
+        let next = tokio::select! {
+            biased;
+            _ = live_forwarder_token.cancelled() => break,
+            next = stream.next() => next,
+        };
+        let Some(LiveRunCommandEntry { command, receipt }) = next else {
+            break;
+        };
         match command {
             LiveRunCommand::Messages(messages) => {
                 let Some(tx) = inbox_tx.as_ref() else {
@@ -382,7 +420,9 @@ async fn run_live_forwarder(
                 // already mutated. Cancel the run so the caller observes
                 // the version mismatch instead of getting corrupted output.
                 tracing::error!(
-                    thread_id,
+                    thread_id = %target.thread_id,
+                    run_id = %target.run_id,
+                    dispatch_id = ?target.dispatch_id,
                     "unsupported live run command received; cancelling run to avoid silent divergence"
                 );
                 cancellation_token.cancel();
@@ -582,13 +622,13 @@ mod tests {
             let rt = make_runtime().with_mailbox_store(store.clone());
             let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
             let (handle, _token, _rx) =
-                rt.create_run_channels_with_inbox("run-1".into(), Some(inbox_tx));
+                rt.create_run_channels_with_inbox("run-1".into(), None, Some(inbox_tx));
             rt.register_run("thread-1", handle).unwrap();
             settle().await;
 
             store
-                .deliver_live(
-                    "thread-1",
+                .deliver_live_to(
+                    &LiveRunTarget::new("thread-1", "run-1"),
                     LiveRunCommand::Messages(vec![Message::user("live-1")]),
                 )
                 .await
@@ -617,7 +657,10 @@ mod tests {
             settle().await;
 
             store
-                .deliver_live("thread-1", LiveRunCommand::Cancel)
+                .deliver_live_to(
+                    &LiveRunTarget::new("thread-1", "run-1"),
+                    LiveRunCommand::Cancel,
+                )
                 .await
                 .unwrap();
 
@@ -642,7 +685,10 @@ mod tests {
 
             let decisions = vec![("call-1".into(), make_resume())];
             store
-                .deliver_live("thread-1", LiveRunCommand::Decision(decisions))
+                .deliver_live_to(
+                    &LiveRunTarget::new("thread-1", "run-1"),
+                    LiveRunCommand::Decision(decisions),
+                )
                 .await
                 .unwrap();
 
@@ -667,7 +713,7 @@ mod tests {
             let rt = make_runtime(); // no store
             let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
             let (handle, token, _rx) =
-                rt.create_run_channels_with_inbox("run-1".into(), Some(inbox_tx));
+                rt.create_run_channels_with_inbox("run-1".into(), None, Some(inbox_tx));
             rt.register_run("thread-1", handle).unwrap();
             settle().await;
 
@@ -692,16 +738,16 @@ mod tests {
             let (tx_a, mut rx_a) = crate::inbox::inbox_channel();
             let (tx_b, mut rx_b) = crate::inbox::inbox_channel();
             let (h_a, _tok_a, _dec_a) =
-                rt.create_run_channels_with_inbox("run-a".into(), Some(tx_a));
+                rt.create_run_channels_with_inbox("run-a".into(), None, Some(tx_a));
             let (h_b, _tok_b, _dec_b) =
-                rt.create_run_channels_with_inbox("run-b".into(), Some(tx_b));
+                rt.create_run_channels_with_inbox("run-b".into(), None, Some(tx_b));
             rt.register_run("thread-a", h_a).unwrap();
             rt.register_run("thread-b", h_b).unwrap();
             settle().await;
 
             store
-                .deliver_live(
-                    "thread-a",
+                .deliver_live_to(
+                    &LiveRunTarget::new("thread-a", "run-a"),
                     LiveRunCommand::Messages(vec![Message::user("for-a")]),
                 )
                 .await
@@ -716,6 +762,38 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn unregister_stops_live_forwarder_subscription() {
+            let store = Arc::new(InMemoryMailboxStore::new());
+            let rt = make_runtime().with_mailbox_store(store.clone());
+            let (handle, _token, _rx) = rt.create_run_channels("run-1".into());
+            rt.register_run("thread-1", handle).unwrap();
+            settle().await;
+
+            rt.unregister_run("run-1");
+            let target = LiveRunTarget::new("thread-1", "run-1");
+            let mut outcome = store
+                .deliver_live_to(&target, LiveRunCommand::Cancel)
+                .await
+                .unwrap();
+            for _ in 0..50 {
+                if outcome == awaken_contract::contract::mailbox::LiveDeliveryOutcome::NoSubscriber
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                outcome = store
+                    .deliver_live_to(&target, LiveRunCommand::Cancel)
+                    .await
+                    .unwrap();
+            }
+            assert_eq!(
+                outcome,
+                awaken_contract::contract::mailbox::LiveDeliveryOutcome::NoSubscriber,
+                "unregister must stop the old live forwarder"
+            );
+        }
+
+        #[tokio::test]
         async fn cancel_then_messages_messages_not_processed() {
             // After forwarder dispatches Cancel it exits, so subsequent
             // Messages on the same thread should not reach the inbox via
@@ -725,12 +803,15 @@ mod tests {
             let rt = make_runtime().with_mailbox_store(store.clone());
             let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
             let (handle, token, _rx) =
-                rt.create_run_channels_with_inbox("run-1".into(), Some(inbox_tx));
+                rt.create_run_channels_with_inbox("run-1".into(), None, Some(inbox_tx));
             rt.register_run("thread-1", handle).unwrap();
             settle().await;
 
             store
-                .deliver_live("thread-1", LiveRunCommand::Cancel)
+                .deliver_live_to(
+                    &LiveRunTarget::new("thread-1", "run-1"),
+                    LiveRunCommand::Cancel,
+                )
                 .await
                 .unwrap();
             // Wait for cancel to propagate.
@@ -743,8 +824,8 @@ mod tests {
             assert!(token.is_cancelled());
 
             store
-                .deliver_live(
-                    "thread-1",
+                .deliver_live_to(
+                    &LiveRunTarget::new("thread-1", "run-1"),
                     LiveRunCommand::Messages(vec![Message::user("too-late")]),
                 )
                 .await

--- a/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
@@ -7,21 +7,25 @@ mod runner;
 
 use std::sync::Arc;
 
+use awaken_contract::contract::mailbox::{LiveRunCommand, LiveRunCommandEntry, MailboxStore};
 use awaken_contract::contract::storage::ThreadRunStore;
 
 use crate::error::RuntimeError;
 #[cfg(feature = "a2a")]
 use crate::registry::composite::CompositeAgentSpecRegistry;
+use awaken_contract::contract::message::Message;
 use awaken_contract::contract::suspension::ToolCallResume;
+use futures::StreamExt;
 use futures::channel::mpsc;
 
 use crate::cancellation::CancellationToken;
+use crate::inbox::InboxSender;
 use crate::registry::{
     AgentResolver, ExecutionResolver, LocalExecutionResolver, RegistryHandle, RegistrySet,
     RegistrySnapshot,
 };
 
-pub use run_request::RunRequest;
+pub use run_request::{RunRequest, ThreadContextSnapshot};
 
 use active_registry::ActiveRunRegistry;
 
@@ -40,6 +44,7 @@ pub(crate) struct RunHandle {
     pub(crate) run_id: String,
     cancellation_token: CancellationToken,
     decision_tx: mpsc::UnboundedSender<DecisionBatch>,
+    inbox_tx: Option<InboxSender>,
 }
 
 impl RunHandle {
@@ -64,6 +69,17 @@ impl RunHandle {
     ) -> Result<(), Box<mpsc::TrySendError<DecisionBatch>>> {
         self.send_decisions(vec![(call_id, resume)])
     }
+
+    /// Send direct input messages into the running loop's inbox.
+    pub(crate) fn send_messages(&self, messages: Vec<Message>) -> bool {
+        let Some(inbox_tx) = self.inbox_tx.as_ref() else {
+            return false;
+        };
+        if messages.is_empty() || inbox_tx.is_closed() {
+            return false;
+        }
+        inbox_tx.try_send(crate::inbox::inbox_messages_payload(messages))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -79,8 +95,13 @@ pub struct AgentRuntime {
     pub(crate) storage: Option<Arc<dyn ThreadRunStore>>,
     pub(crate) profile_store:
         Option<Arc<dyn awaken_contract::contract::profile_store::ProfileStore>>,
+    pub(crate) mailbox_store: Option<Arc<dyn MailboxStore>>,
     pub(crate) active_runs: ActiveRunRegistry,
     pub(crate) registry_handle: Option<RegistryHandle>,
+    /// One-shot guard for the "mailbox_store not wired" warning; flips true
+    /// on the first `register_run` without a store so we emit exactly one
+    /// tracing event per runtime instance.
+    missing_mailbox_store_warned: std::sync::atomic::AtomicBool,
     #[cfg(feature = "a2a")]
     composite_registry: Option<Arc<CompositeAgentSpecRegistry>>,
 }
@@ -95,8 +116,10 @@ impl AgentRuntime {
             resolver,
             storage: None,
             profile_store: None,
+            mailbox_store: None,
             active_runs: ActiveRunRegistry::new(),
             registry_handle: None,
+            missing_mailbox_store_warned: std::sync::atomic::AtomicBool::new(false),
             #[cfg(feature = "a2a")]
             composite_registry: None,
         }
@@ -111,6 +134,15 @@ impl AgentRuntime {
     #[must_use]
     pub fn with_thread_run_store(mut self, store: Arc<dyn ThreadRunStore>) -> Self {
         self.storage = Some(store);
+        self
+    }
+
+    /// Wire the mailbox store used to subscribe to live-steering commands for
+    /// each active run. If unset, runs never receive remote `LiveRunCommand`s — this
+    /// is the single-process / test default.
+    #[must_use]
+    pub fn with_mailbox_store(mut self, store: Arc<dyn MailboxStore>) -> Self {
+        self.mailbox_store = Some(store);
         self
     }
 
@@ -198,9 +230,22 @@ impl AgentRuntime {
     /// Create a run handle pair (handle + internal channels).
     ///
     /// Returns (RunHandle for caller, CancellationToken for loop, decision_rx for loop).
+    #[cfg(test)]
     pub(crate) fn create_run_channels(
         &self,
         run_id: String,
+    ) -> (
+        RunHandle,
+        CancellationToken,
+        mpsc::UnboundedReceiver<DecisionBatch>,
+    ) {
+        self.create_run_channels_with_inbox(run_id, None)
+    }
+
+    pub(crate) fn create_run_channels_with_inbox(
+        &self,
+        run_id: String,
+        inbox_tx: Option<InboxSender>,
     ) -> (
         RunHandle,
         CancellationToken,
@@ -213,6 +258,7 @@ impl AgentRuntime {
             run_id,
             cancellation_token: token.clone(),
             decision_tx: tx,
+            inbox_tx,
         };
 
         (handle, token, rx)
@@ -221,16 +267,41 @@ impl AgentRuntime {
     /// Register an active run. Returns error if thread already has one.
     ///
     /// Uses atomic try-insert to avoid TOCTOU race between check and insert.
+    /// When a mailbox store is wired, spawns the live-command forwarder that
+    /// dispatches remote `LiveRunCommand`s into this run's in-process channels.
     pub(crate) fn register_run(
         &self,
         thread_id: &str,
         handle: RunHandle,
     ) -> Result<(), RuntimeError> {
         let run_id = handle.run_id.clone();
+        let forwarder_inputs = self.mailbox_store.as_ref().map(|store| {
+            (
+                Arc::clone(store),
+                handle.inbox_tx.clone(),
+                handle.cancellation_token.clone(),
+                handle.decision_tx.clone(),
+            )
+        });
         if !self.active_runs.register(&run_id, thread_id, handle) {
             return Err(RuntimeError::ThreadAlreadyRunning {
                 thread_id: thread_id.to_string(),
             });
+        }
+        if let Some((store, inbox_tx, token, decision_tx)) = forwarder_inputs {
+            let thread_id = thread_id.to_string();
+            tokio::spawn(async move {
+                run_live_forwarder(store, thread_id, inbox_tx, token, decision_tx).await;
+            });
+        } else if !self
+            .missing_mailbox_store_warned
+            .swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            tracing::warn!(
+                "AgentRuntime has no mailbox_store wired: cross-node live steering \
+                 (LiveRunCommand) will always fall through to durable queue. Call \
+                 `AgentRuntime::with_mailbox_store(store)` on multi-node deployments."
+            );
         }
         Ok(())
     }
@@ -238,6 +309,87 @@ impl AgentRuntime {
     /// Unregister an active run when it completes (by run_id).
     pub(crate) fn unregister_run(&self, run_id: &str) {
         self.active_runs.unregister(run_id);
+    }
+}
+
+/// Forwarder task: subscribes to the mailbox's live channel for a specific
+/// thread and translates each `LiveRunCommand` into the matching in-process signal.
+///
+/// Exits when:
+/// - the subscription stream ends (store closed the channel),
+/// - a `Cancel` has been dispatched (nothing more for this run to process),
+/// - or a downstream channel is closed (agent loop already finished).
+async fn run_live_forwarder(
+    store: Arc<dyn MailboxStore>,
+    thread_id: String,
+    inbox_tx: Option<InboxSender>,
+    cancellation_token: CancellationToken,
+    decision_tx: mpsc::UnboundedSender<DecisionBatch>,
+) {
+    let mut stream = match store.open_live_channel(&thread_id).await {
+        Ok(s) => s,
+        Err(err) => {
+            tracing::warn!(thread_id, error = %err, "live channel subscribe failed");
+            return;
+        }
+    };
+
+    while let Some(LiveRunCommandEntry { command, receipt }) = stream.next().await {
+        match command {
+            LiveRunCommand::Messages(messages) => {
+                let Some(tx) = inbox_tx.as_ref() else {
+                    // No inbox: can't deliver. Drop the receipt without
+                    // acking so the producer's `deliver_live` resolves as
+                    // `NoSubscriber` and falls back to durable dispatch.
+                    drop(receipt);
+                    continue;
+                };
+                if tx.is_closed() {
+                    drop(receipt);
+                    break;
+                }
+                if tx.try_send(crate::inbox::inbox_messages_payload(messages)) {
+                    receipt.ack();
+                } else {
+                    // Channel full or closed between the `is_closed` check
+                    // and the send; treat as non-delivery.
+                    drop(receipt);
+                }
+            }
+            LiveRunCommand::Cancel => {
+                cancellation_token.cancel();
+                // Cancellation is idempotent and always "accepted" once
+                // the token is flipped; ack before exiting.
+                receipt.ack();
+                break;
+            }
+            LiveRunCommand::Decision(decisions) => {
+                if decision_tx.is_closed() {
+                    drop(receipt);
+                    break;
+                }
+                if decision_tx.unbounded_send(decisions).is_ok() {
+                    receipt.ack();
+                } else {
+                    drop(receipt);
+                }
+            }
+            _ => {
+                // `LiveRunCommand` is `#[non_exhaustive]`. A variant this
+                // forwarder doesn't recognize usually means the producer is
+                // newer than the consumer; silently dropping would let the
+                // run continue in a state the producer believes it has
+                // already mutated. Cancel the run so the caller observes
+                // the version mismatch instead of getting corrupted output.
+                tracing::error!(
+                    thread_id,
+                    "unsupported live run command received; cancelling run to avoid silent divergence"
+                );
+                cancellation_token.cancel();
+                drop(receipt);
+                break;
+            }
+        }
     }
 }
 
@@ -401,5 +553,207 @@ mod tests {
 
         let result = handle.send_decisions(vec![("call-1".into(), make_resume())]);
         assert!(result.is_err(), "send should fail when receiver is dropped");
+    }
+
+    // ── Live forwarder integration ──
+
+    mod live_forwarder {
+        use super::*;
+        use awaken_contract::contract::mailbox::LiveRunCommand;
+        use awaken_stores::InMemoryMailboxStore;
+        use std::time::Duration;
+
+        /// Publish on `store` until the subscriber count for `thread_id` is
+        /// non-zero so the forwarder's background subscription is guaranteed
+        /// active. We cannot inspect the broadcast state directly from here
+        /// (the broadcast sender is private to the store), so we send a
+        /// single no-op ping that will be consumed by the forwarder and
+        /// poll until the first test-visible side effect proves it ran.
+        async fn settle() {
+            // 20ms is enough for a tokio::spawn + one await + subscribe call
+            // in CI. Tests that observe the forwarder output should use
+            // additional polling with timeouts.
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        #[tokio::test]
+        async fn messages_variant_lands_in_inbox() {
+            let store = Arc::new(InMemoryMailboxStore::new());
+            let rt = make_runtime().with_mailbox_store(store.clone());
+            let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+            let (handle, _token, _rx) =
+                rt.create_run_channels_with_inbox("run-1".into(), Some(inbox_tx));
+            rt.register_run("thread-1", handle).unwrap();
+            settle().await;
+
+            store
+                .deliver_live(
+                    "thread-1",
+                    LiveRunCommand::Messages(vec![Message::user("live-1")]),
+                )
+                .await
+                .unwrap();
+
+            let mut received = None;
+            for _ in 0..50 {
+                if let Some(json) = inbox_rx.try_recv() {
+                    received = Some(json);
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            let payload = received.expect("forwarder must deliver Messages within 500ms");
+            let messages = crate::inbox::inbox_payload_messages(&payload);
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].text(), "live-1");
+        }
+
+        #[tokio::test]
+        async fn cancel_variant_triggers_token() {
+            let store = Arc::new(InMemoryMailboxStore::new());
+            let rt = make_runtime().with_mailbox_store(store.clone());
+            let (handle, token, _rx) = rt.create_run_channels("run-1".into());
+            rt.register_run("thread-1", handle).unwrap();
+            settle().await;
+
+            store
+                .deliver_live("thread-1", LiveRunCommand::Cancel)
+                .await
+                .unwrap();
+
+            let mut cancelled = false;
+            for _ in 0..50 {
+                if token.is_cancelled() {
+                    cancelled = true;
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            assert!(cancelled, "forwarder must cancel token within 500ms");
+        }
+
+        #[tokio::test]
+        async fn decision_variant_lands_on_decision_channel() {
+            let store = Arc::new(InMemoryMailboxStore::new());
+            let rt = make_runtime().with_mailbox_store(store.clone());
+            let (handle, _token, mut rx) = rt.create_run_channels("run-1".into());
+            rt.register_run("thread-1", handle).unwrap();
+            settle().await;
+
+            let decisions = vec![("call-1".into(), make_resume())];
+            store
+                .deliver_live("thread-1", LiveRunCommand::Decision(decisions))
+                .await
+                .unwrap();
+
+            let mut got = None;
+            for _ in 0..50 {
+                if let Ok(batch) = rx.try_recv() {
+                    got = Some(batch);
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            let batch = got.expect("forwarder must deliver Decision within 500ms");
+            assert_eq!(batch.len(), 1);
+            assert_eq!(batch[0].0, "call-1");
+        }
+
+        #[tokio::test]
+        async fn no_store_wired_no_forwarder_runs() {
+            // Baseline: without `with_mailbox_store`, deliver_live published
+            // elsewhere must not reach this runtime's channels.
+            let detached_store = InMemoryMailboxStore::new();
+            let rt = make_runtime(); // no store
+            let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+            let (handle, token, _rx) =
+                rt.create_run_channels_with_inbox("run-1".into(), Some(inbox_tx));
+            rt.register_run("thread-1", handle).unwrap();
+            settle().await;
+
+            detached_store
+                .deliver_live(
+                    "thread-1",
+                    LiveRunCommand::Messages(vec![Message::user("ignored")]),
+                )
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            assert!(inbox_rx.try_recv().is_none());
+            assert!(!token.is_cancelled());
+        }
+
+        #[tokio::test]
+        async fn separate_threads_isolated() {
+            let store = Arc::new(InMemoryMailboxStore::new());
+            let rt = make_runtime().with_mailbox_store(store.clone());
+
+            let (tx_a, mut rx_a) = crate::inbox::inbox_channel();
+            let (tx_b, mut rx_b) = crate::inbox::inbox_channel();
+            let (h_a, _tok_a, _dec_a) =
+                rt.create_run_channels_with_inbox("run-a".into(), Some(tx_a));
+            let (h_b, _tok_b, _dec_b) =
+                rt.create_run_channels_with_inbox("run-b".into(), Some(tx_b));
+            rt.register_run("thread-a", h_a).unwrap();
+            rt.register_run("thread-b", h_b).unwrap();
+            settle().await;
+
+            store
+                .deliver_live(
+                    "thread-a",
+                    LiveRunCommand::Messages(vec![Message::user("for-a")]),
+                )
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(80)).await;
+
+            assert!(rx_a.try_recv().is_some(), "thread-a must receive");
+            assert!(
+                rx_b.try_recv().is_none(),
+                "thread-b must not receive thread-a's message"
+            );
+        }
+
+        #[tokio::test]
+        async fn cancel_then_messages_messages_not_processed() {
+            // After forwarder dispatches Cancel it exits, so subsequent
+            // Messages on the same thread should not reach the inbox via
+            // this forwarder instance (agent loop is expected to be torn
+            // down anyway).
+            let store = Arc::new(InMemoryMailboxStore::new());
+            let rt = make_runtime().with_mailbox_store(store.clone());
+            let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+            let (handle, token, _rx) =
+                rt.create_run_channels_with_inbox("run-1".into(), Some(inbox_tx));
+            rt.register_run("thread-1", handle).unwrap();
+            settle().await;
+
+            store
+                .deliver_live("thread-1", LiveRunCommand::Cancel)
+                .await
+                .unwrap();
+            // Wait for cancel to propagate.
+            for _ in 0..50 {
+                if token.is_cancelled() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            assert!(token.is_cancelled());
+
+            store
+                .deliver_live(
+                    "thread-1",
+                    LiveRunCommand::Messages(vec![Message::user("too-late")]),
+                )
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            assert!(
+                inbox_rx.try_recv().is_none(),
+                "forwarder must have exited after Cancel"
+            );
+        }
     }
 }

--- a/crates/awaken-runtime/src/runtime/agent_runtime/run_request.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/run_request.rs
@@ -1,12 +1,37 @@
 //! RunRequest — unified request for starting or resuming a run.
 
+use std::collections::HashMap;
+
 use crate::inbox::{InboxReceiver, InboxSender};
 use awaken_contract::contract::inference::InferenceOverride;
 use awaken_contract::contract::message::Message;
-use awaken_contract::contract::storage::RunRequestOrigin;
+use awaken_contract::contract::storage::{RunRecord, RunRequestOrigin};
 use awaken_contract::contract::suspension::ToolCallResume;
 use awaken_contract::contract::tool::ToolDescriptor;
 use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
+
+/// Read-only snapshot of cached thread state, passed from mailbox to runtime.
+#[non_exhaustive]
+pub struct ThreadContextSnapshot {
+    pub messages: Vec<Message>,
+    pub latest_run: Option<RunRecord>,
+    pub run_cache: HashMap<String, RunRecord>,
+}
+
+impl ThreadContextSnapshot {
+    #[must_use]
+    pub fn new(
+        messages: Vec<Message>,
+        latest_run: Option<RunRecord>,
+        run_cache: HashMap<String, RunRecord>,
+    ) -> Self {
+        Self {
+            messages,
+            latest_run,
+            run_cache,
+        }
+    }
+}
 
 /// In-process inbox pair owned by a single run.
 pub struct RunInbox {

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -224,8 +224,11 @@ impl AgentRuntime {
             };
         let run_created_at = now_ms();
 
-        let (handle, cancellation_token, raw_decision_rx) =
-            self.create_run_channels_with_inbox(run_id.clone(), live_inbox_sender);
+        let (handle, cancellation_token, raw_decision_rx) = self.create_run_channels_with_inbox(
+            run_id.clone(),
+            run_identity.trace.dispatch_id.clone(),
+            live_inbox_sender,
+        );
         let runtime_cancellation_token = cancellation_token.clone();
         let decision_rx = if capabilities.decisions {
             Some(raw_decision_rx)

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use crate::backend::{
-    BackendControl, BackendLocalRootContext, BackendRootRunRequest, ExecutionBackend,
-    ExecutionBackendError, LocalBackend, execute_remote_root_lifecycle, execution_capabilities,
+    BackendControl, BackendLocalRootContext, BackendRootRunRequest, ExecutionBackendError,
+    LocalBackend, execute_remote_root_lifecycle, execution_capabilities,
     validate_root_execution_request,
 };
 use crate::loop_runner::{AgentLoopError, AgentRunResult};
@@ -19,7 +19,7 @@ use awaken_contract::now_ms;
 use awaken_contract::state::PersistedState;
 
 use super::AgentRuntime;
-use super::run_request::RunRequest;
+use super::run_request::{RunRequest, ThreadContextSnapshot};
 
 const DEFAULT_AGENT_ID: &str = "default";
 
@@ -40,6 +40,7 @@ struct PreparedLocalRootExecution {
     messages: Vec<Message>,
     phase_runtime: crate::phase::PhaseRuntime,
     inbox: crate::inbox::InboxReceiver,
+    inbox_sender: crate::inbox::InboxSender,
 }
 
 impl AgentRuntime {
@@ -76,6 +77,25 @@ impl AgentRuntime {
         request: RunRequest,
         sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
+        self.run_inner(request, sink, None).await
+    }
+
+    #[doc(hidden)]
+    pub async fn run_with_thread_context(
+        &self,
+        request: RunRequest,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        self.run_inner(request, sink, thread_ctx).await
+    }
+
+    async fn run_inner(
+        &self,
+        request: RunRequest,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
         let RunRequest {
             messages: request_messages,
             messages_already_persisted,
@@ -99,7 +119,9 @@ impl AgentRuntime {
         } = request;
         let new_messages = request_messages.clone();
         let requested_continue_run_id = continue_run_id.clone();
-        let agent_id = self.resolve_agent_id(agent_id, &thread_id).await?;
+        let agent_id = self
+            .resolve_agent_id(agent_id, &thread_id, &thread_ctx)
+            .await?;
         let run_resolver: Arc<dyn ExecutionResolver> =
             if let Some(snapshot) = self.registry_snapshot() {
                 Arc::new(crate::registry::resolve::RegistrySetResolver::new(
@@ -120,6 +142,7 @@ impl AgentRuntime {
                 run_id_hint,
                 dispatch_id_hint,
                 matches!(&resolved_execution, ResolvedExecution::Local(_)),
+                &thread_ctx,
             )
             .await?;
         let run_origin = match req_origin {
@@ -154,42 +177,55 @@ impl AgentRuntime {
         }
 
         let mut run_inbox = run_inbox;
-        let (messages, phase_runtime, inbox, previous_non_local_state) = match &resolved_execution {
-            ResolvedExecution::Local(preflight_resolved) => {
-                let prepared = self
-                    .prepare_local_root_execution(
-                        preflight_resolved,
-                        &thread_id,
-                        request_messages,
-                        messages_already_persisted,
-                        &decisions,
-                        run_inbox.take(),
+        let (messages, phase_runtime, inbox, live_inbox_sender, previous_non_local_state) =
+            match &resolved_execution {
+                ResolvedExecution::Local(preflight_resolved) => {
+                    let prepared = self
+                        .prepare_local_root_execution(
+                            preflight_resolved,
+                            &thread_id,
+                            request_messages,
+                            messages_already_persisted,
+                            &decisions,
+                            run_inbox.take(),
+                            &thread_ctx,
+                        )
+                        .await?;
+                    (
+                        prepared.messages,
+                        Some(prepared.phase_runtime),
+                        Some(prepared.inbox),
+                        Some(prepared.inbox_sender),
+                        None,
                     )
-                    .await?;
-                (
-                    prepared.messages,
-                    Some(prepared.phase_runtime),
-                    Some(prepared.inbox),
-                    None,
-                )
-            }
-            ResolvedExecution::NonLocal(_) => (
-                self.load_non_local_messages(
-                    &thread_id,
-                    request_messages,
-                    messages_already_persisted,
-                )
-                .await?,
-                None,
-                run_inbox.take().map(|run_inbox| run_inbox.receiver),
-                self.load_non_local_state(&thread_id, requested_continue_run_id.as_deref())
-                    .await?,
-            ),
-        };
+                }
+                ResolvedExecution::NonLocal(_) => {
+                    let live_inbox_sender =
+                        run_inbox.as_ref().map(|run_inbox| run_inbox.sender.clone());
+                    (
+                        self.load_non_local_messages(
+                            &thread_id,
+                            request_messages,
+                            messages_already_persisted,
+                            &thread_ctx,
+                        )
+                        .await?,
+                        None,
+                        run_inbox.take().map(|run_inbox| run_inbox.receiver),
+                        live_inbox_sender,
+                        self.load_non_local_state(
+                            &thread_id,
+                            requested_continue_run_id.as_deref(),
+                            &thread_ctx,
+                        )
+                        .await?,
+                    )
+                }
+            };
         let run_created_at = now_ms();
 
         let (handle, cancellation_token, raw_decision_rx) =
-            self.create_run_channels(run_id.clone());
+            self.create_run_channels_with_inbox(run_id.clone(), live_inbox_sender);
         let runtime_cancellation_token = cancellation_token.clone();
         let decision_rx = if capabilities.decisions {
             Some(raw_decision_rx)
@@ -245,7 +281,7 @@ impl AgentRuntime {
         match &resolved_execution {
             ResolvedExecution::Local(_) => {
                 let result = LocalBackend::new()
-                    .execute_root(backend_request)
+                    .execute_root_with_thread_context(backend_request, thread_ctx)
                     .await
                     .map_err(local_root_execution_error)?;
                 Ok(AgentRunResult {
@@ -268,6 +304,7 @@ impl AgentRuntime {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn prepare_local_root_execution(
         &self,
         preflight_resolved: &crate::registry::ResolvedAgent,
@@ -279,6 +316,7 @@ impl AgentRuntime {
             awaken_contract::contract::suspension::ToolCallResume,
         )],
         run_inbox: Option<super::run_request::RunInbox>,
+        thread_ctx: &Option<ThreadContextSnapshot>,
     ) -> Result<PreparedLocalRootExecution, AgentLoopError> {
         let store = crate::state::StateStore::new();
         let phase_runtime =
@@ -298,7 +336,19 @@ impl AgentRuntime {
         )
         .map_err(AgentLoopError::PhaseError)?;
 
-        let mut messages = if let Some(ref ts) = self.storage {
+        let mut messages = if let Some(ctx) = thread_ctx {
+            if let Some(ref prev_run) = ctx.latest_run
+                && let Some(ref persisted) = prev_run.state
+            {
+                store
+                    .restore_thread_scoped(
+                        persisted.clone(),
+                        awaken_contract::UnknownKeyPolicy::Skip,
+                    )
+                    .map_err(AgentLoopError::PhaseError)?;
+            }
+            ctx.messages.clone()
+        } else if let Some(ref ts) = self.storage {
             if let Some(prev_run) = ts
                 .latest_run(thread_id)
                 .await
@@ -328,6 +378,7 @@ impl AgentRuntime {
             messages,
             phase_runtime,
             inbox: run_inbox.receiver,
+            inbox_sender: owner_inbox,
         })
     }
 
@@ -336,8 +387,11 @@ impl AgentRuntime {
         thread_id: &str,
         request_messages: Vec<Message>,
         messages_already_persisted: bool,
+        thread_ctx: &Option<ThreadContextSnapshot>,
     ) -> Result<Vec<Message>, AgentLoopError> {
-        let mut messages = if let Some(ref storage) = self.storage {
+        let mut messages = if let Some(ctx) = thread_ctx {
+            ctx.messages.clone()
+        } else if let Some(ref storage) = self.storage {
             storage
                 .load_messages(thread_id)
                 .await
@@ -360,8 +414,15 @@ impl AgentRuntime {
         run_id_hint: Option<String>,
         dispatch_id_hint: Option<String>,
         allow_waiting_reuse: bool,
+        thread_ctx: &Option<ThreadContextSnapshot>,
     ) -> Result<(String, bool), AgentLoopError> {
         if let Some(run_id) = continue_run_id {
+            // Check cache first for continue_run_id.
+            if let Some(ctx) = thread_ctx
+                && ctx.run_cache.contains_key(&run_id)
+            {
+                return Ok((run_id, true));
+            }
             let Some(ref ts) = self.storage else {
                 return Err(AgentLoopError::InvalidResume(format!(
                     "continue_run_id '{run_id}' requires run storage"
@@ -383,12 +444,22 @@ impl AgentRuntime {
             let trimmed = id.trim();
             (!trimmed.is_empty()).then(|| trimmed.to_string())
         }) {
-            if let Some(ref ts) = self.storage
-                && let Some(existing) = ts
-                    .load_run(&run_id)
+            // Check cache first, then store.
+            let existing = if let Some(ctx) = thread_ctx {
+                ctx.run_cache.get(&run_id).cloned()
+            } else {
+                None
+            };
+            let existing = if existing.is_some() {
+                existing
+            } else if let Some(ref ts) = self.storage {
+                ts.load_run(&run_id)
                     .await
                     .map_err(|e| AgentLoopError::StorageError(e.to_string()))?
-            {
+            } else {
+                None
+            };
+            if let Some(existing) = existing {
                 if existing.status == awaken_contract::contract::lifecycle::RunStatus::Created {
                     return Ok((run_id, false));
                 }
@@ -415,8 +486,14 @@ impl AgentRuntime {
             }
             return Ok((run_id, false));
         }
-        if allow_waiting_reuse && let Some(prev) = self.reusable_waiting_run(thread_id).await? {
-            return Ok((prev.run_id.clone(), true));
+        if allow_waiting_reuse {
+            if let Some(ctx) = thread_ctx {
+                if let Some(run) = ctx.latest_run.as_ref().filter(|r| r.is_resumable_waiting()) {
+                    return Ok((run.run_id.clone(), true));
+                }
+            } else if let Some(prev) = self.reusable_waiting_run(thread_id).await? {
+                return Ok((prev.run_id.clone(), true));
+            }
         }
         Ok((uuid::Uuid::now_v7().to_string(), false))
     }
@@ -455,12 +532,16 @@ impl AgentRuntime {
         &self,
         requested_agent_id: Option<String>,
         thread_id: &str,
+        thread_ctx: &Option<ThreadContextSnapshot>,
     ) -> Result<String, AgentLoopError> {
         if let Some(agent_id) = requested_agent_id {
             return Ok(agent_id);
         }
 
-        if let Some(inferred) = self.infer_agent_id_from_thread(thread_id).await? {
+        if let Some(inferred) = self
+            .infer_agent_id_from_thread(thread_id, thread_ctx)
+            .await?
+        {
             return Ok(inferred);
         }
 
@@ -470,7 +551,21 @@ impl AgentRuntime {
     async fn infer_agent_id_from_thread(
         &self,
         thread_id: &str,
+        thread_ctx: &Option<ThreadContextSnapshot>,
     ) -> Result<Option<String>, AgentLoopError> {
+        if let Some(ctx) = thread_ctx {
+            if let Some(ref prev_run) = ctx.latest_run {
+                if let Some(agent_id) = prev_run.state.as_ref().and_then(active_agent_from_state) {
+                    return Ok(Some(agent_id));
+                }
+                let agent_id = prev_run.agent_id.trim();
+                if !agent_id.is_empty() {
+                    return Ok(Some(agent_id.to_string()));
+                }
+            }
+            return Ok(None);
+        }
+
         let Some(storage) = &self.storage else {
             return Ok(None);
         };
@@ -499,7 +594,15 @@ impl AgentRuntime {
         &self,
         thread_id: &str,
         continue_run_id: Option<&str>,
+        thread_ctx: &Option<ThreadContextSnapshot>,
     ) -> Result<Option<PersistedState>, AgentLoopError> {
+        if let Some(ctx) = thread_ctx {
+            if let Some(run_id) = continue_run_id {
+                return Ok(ctx.run_cache.get(run_id).and_then(|r| r.state.clone()));
+            }
+            return Ok(ctx.latest_run.as_ref().and_then(|r| r.state.clone()));
+        }
+
         let Some(storage) = &self.storage else {
             return Ok(None);
         };

--- a/crates/awaken-runtime/src/runtime/mod.rs
+++ b/crates/awaken-runtime/src/runtime/mod.rs
@@ -1,3 +1,3 @@
 mod agent_runtime;
 
-pub use agent_runtime::{AgentRuntime, RunRequest};
+pub use agent_runtime::{AgentRuntime, RunRequest, ThreadContextSnapshot};

--- a/crates/awaken-runtime/tests/public_api_compat.rs
+++ b/crates/awaken-runtime/tests/public_api_compat.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use awaken_contract::contract::event_sink::NullEventSink;
+use awaken_contract::contract::identity::{RunIdentity, RunOrigin};
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::RunRequestOrigin;
+use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
+use awaken_runtime::RunRequest;
+use awaken_runtime::RuntimeError;
+use awaken_runtime::backend::{BackendControl, BackendRootRunRequest};
+use awaken_runtime::registry::{
+    AgentResolver, ExecutionResolver, ResolvedAgent, ResolvedExecution,
+};
+
+struct CompatResolver;
+
+impl AgentResolver for CompatResolver {
+    fn resolve(&self, _agent_id: &str) -> Result<ResolvedAgent, RuntimeError> {
+        unreachable!("compat test only checks struct construction")
+    }
+}
+
+impl ExecutionResolver for CompatResolver {
+    fn resolve_execution(&self, _agent_id: &str) -> Result<ResolvedExecution, RuntimeError> {
+        unreachable!("compat test only checks struct construction")
+    }
+}
+
+#[test]
+fn run_request_struct_literal_keeps_0_2_fields() {
+    let request = RunRequest {
+        messages: vec![Message::user("hello")],
+        messages_already_persisted: false,
+        thread_id: "thread-compat".to_string(),
+        agent_id: None,
+        overrides: None,
+        decisions: Vec::new(),
+        frontend_tools: Vec::new(),
+        origin: RunRequestOrigin::User,
+        run_mode: RunMode::Foreground,
+        adapter: AdapterKind::Internal,
+        parent_run_id: None,
+        parent_thread_id: None,
+        continue_run_id: None,
+        run_id_hint: None,
+        dispatch_id_hint: None,
+        dispatch_id: None,
+        session_id: None,
+        transport_request_id: None,
+        run_inbox: None,
+    };
+
+    assert_eq!(request.thread_id, "thread-compat");
+    assert_eq!(request.messages.len(), 1);
+}
+
+#[test]
+fn backend_root_run_request_struct_literal_keeps_0_2_fields() {
+    let resolver = CompatResolver;
+    let request = BackendRootRunRequest {
+        agent_id: "agent",
+        messages: vec![Message::user("hello")],
+        new_messages: vec![Message::user("hello")],
+        sink: Arc::new(NullEventSink),
+        resolver: &resolver,
+        run_identity: RunIdentity::new(
+            "thread-compat".to_string(),
+            None,
+            "run-compat".to_string(),
+            None,
+            "agent".to_string(),
+            RunOrigin::User,
+        ),
+        checkpoint_store: None,
+        control: BackendControl::default(),
+        decisions: Vec::new(),
+        overrides: None,
+        frontend_tools: Vec::new(),
+        local: None,
+        inbox: None,
+        is_continuation: false,
+    };
+
+    assert_eq!(request.agent_id, "agent");
+    assert!(!request.is_continuation);
+}

--- a/crates/awaken-runtime/tests/public_api_compat_extended.rs
+++ b/crates/awaken-runtime/tests/public_api_compat_extended.rs
@@ -1,0 +1,229 @@
+//! Extended 0.2 public-API compat lockdown.
+//!
+//! Wider than `public_api_compat.rs`: captures function-pointer signatures for
+//! the concrete public methods 0.2 users called, and exhausts every variant of
+//! every 0.2 public enum. Any SemVer-breaking change — signature drift, removed
+//! variant, renamed field, changed visibility — fails this file at compile time.
+
+#![allow(dead_code, clippy::type_complexity)]
+
+use std::sync::Arc;
+
+use awaken_contract::contract::event_sink::{EventSink, NullEventSink};
+use awaken_contract::contract::identity::{RunIdentity, RunOrigin};
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::profile_store::ProfileStore;
+use awaken_contract::contract::storage::{RunRequestOrigin, ThreadRunStore};
+use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
+use awaken_runtime::backend::{
+    BackendCapabilities, BackendControl, BackendLocalRootContext, BackendRootRunRequest,
+    ExecutionBackend, ExecutionBackendError, LocalBackend,
+};
+use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
+use awaken_runtime::registry::{
+    AgentResolver, ExecutionResolver, RegistryHandle, RegistrySet, RegistrySnapshot, ResolvedAgent,
+    ResolvedExecution,
+};
+use awaken_runtime::{AgentRuntime, RunRequest, RuntimeError};
+
+struct NopResolver;
+
+impl AgentResolver for NopResolver {
+    fn resolve(&self, _agent_id: &str) -> Result<ResolvedAgent, RuntimeError> {
+        unreachable!("compat test does not execute")
+    }
+}
+
+impl ExecutionResolver for NopResolver {
+    fn resolve_execution(&self, _agent_id: &str) -> Result<ResolvedExecution, RuntimeError> {
+        unreachable!("compat test does not execute")
+    }
+}
+
+// Force-resolve every 0.2 AgentRuntime method we promise. Any signature drift
+// turns this coercion into a compile error.
+#[test]
+fn agent_runtime_0_2_methods_resolve_at_expected_signatures() {
+    let _new: fn(Arc<dyn AgentResolver>) -> AgentRuntime = AgentRuntime::new;
+    let _new_exec: fn(Arc<dyn ExecutionResolver>) -> AgentRuntime =
+        AgentRuntime::new_with_execution_resolver;
+    let _with_reg: fn(AgentRuntime, RegistryHandle) -> AgentRuntime =
+        AgentRuntime::with_registry_handle;
+    let _with_store: fn(AgentRuntime, Arc<dyn ThreadRunStore>) -> AgentRuntime =
+        AgentRuntime::with_thread_run_store;
+    let _resolver: fn(&AgentRuntime) -> &dyn AgentResolver = AgentRuntime::resolver;
+    let _resolver_arc: fn(&AgentRuntime) -> Arc<dyn AgentResolver> = AgentRuntime::resolver_arc;
+    let _exec_resolver: fn(&AgentRuntime) -> &dyn ExecutionResolver =
+        AgentRuntime::execution_resolver;
+    let _exec_resolver_arc: fn(&AgentRuntime) -> Arc<dyn ExecutionResolver> =
+        AgentRuntime::execution_resolver_arc;
+    let _reg_handle: fn(&AgentRuntime) -> Option<RegistryHandle> = AgentRuntime::registry_handle;
+    let _reg_snap: fn(&AgentRuntime) -> Option<RegistrySnapshot> = AgentRuntime::registry_snapshot;
+    let _reg_ver: fn(&AgentRuntime) -> Option<u64> = AgentRuntime::registry_version;
+    let _reg_set: fn(&AgentRuntime) -> Option<RegistrySet> = AgentRuntime::registry_set;
+    let _replace_set: fn(&AgentRuntime, RegistrySet) -> Option<u64> =
+        AgentRuntime::replace_registry_set;
+    let _thread_store: fn(&AgentRuntime) -> Option<&dyn ThreadRunStore> =
+        AgentRuntime::thread_run_store;
+}
+
+#[test]
+fn local_backend_0_2_surface_intact() {
+    let backend: Arc<dyn ExecutionBackend> = Arc::new(LocalBackend::new());
+    let caps: BackendCapabilities = backend.capabilities();
+    // 0.2 provided `BackendCapabilities::full`.
+    let _full = BackendCapabilities::full();
+    // Compile-only: confirm the eight public fields are still accessible.
+    let _ = (
+        caps.cancellation,
+        caps.decisions,
+        caps.overrides,
+        caps.frontend_tools,
+        caps.continuation,
+        caps.waits,
+        caps.transcript,
+        caps.output,
+    );
+}
+
+#[test]
+fn run_origin_exhaustive_match_keeps_0_2_variants() {
+    fn label(origin: RunOrigin) -> &'static str {
+        match origin {
+            RunOrigin::User => "user",
+            RunOrigin::Subagent => "subagent",
+            RunOrigin::Internal => "internal",
+        }
+    }
+    assert_eq!(label(RunOrigin::User), "user");
+    assert_eq!(label(RunOrigin::Subagent), "subagent");
+    assert_eq!(label(RunOrigin::Internal), "internal");
+}
+
+#[test]
+fn run_request_origin_exhaustive_match_keeps_0_2_variants() {
+    fn label(o: RunRequestOrigin) -> &'static str {
+        match o {
+            RunRequestOrigin::User => "user",
+            RunRequestOrigin::A2A => "a2a",
+            RunRequestOrigin::Internal => "internal",
+        }
+    }
+    assert_eq!(label(RunRequestOrigin::User), "user");
+    assert_eq!(label(RunRequestOrigin::A2A), "a2a");
+    assert_eq!(label(RunRequestOrigin::Internal), "internal");
+}
+
+#[test]
+fn run_mode_exhaustive_match_keeps_0_2_variants() {
+    fn label(mode: RunMode) -> &'static str {
+        match mode {
+            RunMode::Foreground => "fg",
+            RunMode::Scheduled => "sched",
+            RunMode::Resume => "resume",
+            RunMode::InternalWake => "wake",
+        }
+    }
+    assert_eq!(label(RunMode::Foreground), "fg");
+    assert_eq!(label(RunMode::Scheduled), "sched");
+    assert_eq!(label(RunMode::Resume), "resume");
+    assert_eq!(label(RunMode::InternalWake), "wake");
+}
+
+#[test]
+fn adapter_kind_exhaustive_match_keeps_0_2_variants() {
+    fn label(kind: AdapterKind) -> &'static str {
+        match kind {
+            AdapterKind::Internal => "internal",
+            AdapterKind::Acp => "acp",
+            AdapterKind::AiSdk => "ai_sdk",
+            AdapterKind::AgUi => "ag_ui",
+            AdapterKind::A2a => "a2a",
+        }
+    }
+    assert_eq!(label(AdapterKind::Internal), "internal");
+    assert_eq!(label(AdapterKind::Acp), "acp");
+    assert_eq!(label(AdapterKind::AiSdk), "ai_sdk");
+    assert_eq!(label(AdapterKind::AgUi), "ag_ui");
+    assert_eq!(label(AdapterKind::A2a), "a2a");
+}
+
+#[test]
+fn runtime_error_keeps_0_2_variants() {
+    let _ = RuntimeError::ThreadAlreadyRunning {
+        thread_id: "t".into(),
+    };
+    let _ = RuntimeError::AgentNotFound {
+        agent_id: "a".into(),
+    };
+    let _ = RuntimeError::ResolveFailed {
+        message: "m".into(),
+    };
+}
+
+// BackendRootRunRequest must still accept 0.2 field set without ThreadContextSnapshot.
+#[test]
+fn backend_root_run_request_accepts_0_2_literal_without_thread_ctx() {
+    let resolver = NopResolver;
+    let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+    let _req = BackendRootRunRequest {
+        agent_id: "a",
+        messages: Vec::<Message>::new(),
+        new_messages: Vec::<Message>::new(),
+        sink,
+        resolver: &resolver,
+        run_identity: RunIdentity::new(
+            "t".to_string(),
+            None,
+            "r".to_string(),
+            None,
+            "a".to_string(),
+            RunOrigin::User,
+        ),
+        checkpoint_store: None,
+        control: BackendControl::default(),
+        decisions: Vec::new(),
+        overrides: None,
+        frontend_tools: Vec::new(),
+        local: Option::<BackendLocalRootContext<'_>>::None,
+        inbox: None,
+        is_continuation: false,
+    };
+}
+
+// AgentRuntime::run and AgentRuntime::cancel must keep 0.2 callable shapes.
+#[test]
+fn agent_runtime_run_cancel_signatures_intact() {
+    let _run: for<'a> fn(
+        &'a AgentRuntime,
+        RunRequest,
+        Arc<dyn EventSink>,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<AgentRunResult, AgentLoopError>> + Send + 'a>,
+    > = |rt, req, sink| Box::pin(rt.run(req, sink));
+    let _cancel: fn(&AgentRuntime, &str) -> bool = AgentRuntime::cancel;
+}
+
+// 0.2 trait-object bounds must still hold.
+#[test]
+fn runtime_store_bounds_are_still_object_safe_for_0_2_traits() {
+    fn _accept_thread_store(_: Arc<dyn ThreadRunStore>) {}
+    fn _accept_profile_store(_: Arc<dyn ProfileStore>) {}
+}
+
+#[test]
+fn agent_runtime_initialize_signature_intact() {
+    let _init: for<'a> fn(
+        &'a AgentRuntime,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<(), RuntimeError>> + Send + 'a>,
+    > = |rt| Box::pin(rt.initialize());
+}
+
+// ExecutionBackendError must retain its 0.2 public variants used by adapters.
+#[test]
+fn execution_backend_error_keeps_0_2_variants() {
+    let _ = ExecutionBackendError::AgentNotFound("x".into());
+    let _ = ExecutionBackendError::ExecutionFailed("x".into());
+    let _ = ExecutionBackendError::RemoteError("x".into());
+}

--- a/crates/awaken-server/src/mailbox.rs
+++ b/crates/awaken-server/src/mailbox.rs
@@ -21,8 +21,8 @@ use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::event_sink::EventSink;
 use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::mailbox::{
-    LiveDeliveryOutcome, LiveRunCommand, MailboxInterrupt, MailboxStore, RunDispatch,
-    RunDispatchResult, RunDispatchStatus,
+    LiveDeliveryOutcome, LiveRunCommand, LiveRunTarget, MailboxInterrupt, MailboxStore,
+    RunDispatch, RunDispatchResult, RunDispatchStatus,
 };
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::storage::{
@@ -40,8 +40,15 @@ use crate::transport::channel_sink::ReconnectableEventSink;
 /// Guard window for inline-claimed dispatches: if the process crashes between
 /// enqueue and claim, the sweep will reclaim the dispatch after this period.
 const INLINE_CLAIM_GUARD_MS: u64 = 60_000;
+#[cfg(not(test))]
 const REMOTE_CANCEL_WAIT_MS: u64 = 5_000;
+#[cfg(test)]
+const REMOTE_CANCEL_WAIT_MS: u64 = 250;
 const REMOTE_CANCEL_POLL_MS: u64 = 25;
+const DISPATCH_SIGNAL_BATCH: usize = 32;
+const DISPATCH_SIGNAL_EXPIRES: Duration = Duration::from_millis(500);
+const DISPATCH_SIGNAL_ERROR_DELAY: Duration = Duration::from_millis(250);
+const DISPATCH_SIGNAL_BLOCKED_NACK_DELAY: Duration = Duration::from_millis(500);
 
 /// Validation message returned when an inline submit loses the active-run race.
 pub(crate) const ACTIVE_RUN_CONFLICT_MESSAGE: &str =
@@ -439,12 +446,16 @@ impl MailboxLifecycleHandle {
 
 struct MailboxLifecycleTasks {
     recover_task: Option<JoinHandle<()>>,
+    dispatch_signal_task: Option<JoinHandle<()>>,
     maintenance_task: JoinHandle<()>,
 }
 
 impl MailboxLifecycleTasks {
     fn abort(self) {
         if let Some(task) = self.recover_task {
+            task.abort();
+        }
+        if let Some(task) = self.dispatch_signal_task {
             task.abort();
         }
         self.maintenance_task.abort();
@@ -454,6 +465,10 @@ impl MailboxLifecycleTasks {
         if let Some(task) = self.recover_task {
             task.abort();
             await_lifecycle_task("mailbox startup recovery", task).await?;
+        }
+        if let Some(task) = self.dispatch_signal_task {
+            task.abort();
+            await_lifecycle_task("mailbox dispatch signal loop", task).await?;
         }
         self.maintenance_task.abort();
         await_lifecycle_task("mailbox maintenance", self.maintenance_task).await
@@ -483,6 +498,20 @@ enum MailboxWorkerStatus {
         lease_handle: JoinHandle<()>,
         sink: Arc<ReconnectableEventSink>,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DispatchAttempt {
+    Claimed,
+    Busy,
+    NoEligible,
+    TransientError,
+}
+
+impl DispatchAttempt {
+    fn started_execution(self) -> bool {
+        matches!(self, DispatchAttempt::Claimed)
+    }
 }
 
 /// Cached thread state, valid for the duration of a lease.
@@ -670,18 +699,21 @@ impl Mailbox {
                     let cancelled = self
                         .cancel_active_dispatch(&thread_id, active_dispatch, true)
                         .await?;
-                    if cancelled {
-                        tracing::info!(
-                            thread_id = %thread_id,
-                            superseded = interrupt.superseded_count,
-                            "interrupted thread for new submission"
-                        );
+                    if !cancelled {
+                        return Err(MailboxError::Validation(ACTIVE_RUN_CONFLICT_MESSAGE.into()));
                     }
+                    tracing::info!(
+                        thread_id = %thread_id,
+                        superseded = interrupt.superseded_count,
+                        "interrupted thread for new submission"
+                    );
                 }
             }
             Err(e) => {
                 tracing::warn!(thread_id = %thread_id, error = %e, "interrupt failed, falling back to cancel");
-                self.executor.cancel_and_wait_by_thread(&thread_id).await;
+                if !self.executor.cancel_and_wait_by_thread(&thread_id).await {
+                    return Err(MailboxError::Validation(ACTIVE_RUN_CONFLICT_MESSAGE.into()));
+                }
             }
         }
 
@@ -808,7 +840,7 @@ impl Mailbox {
         // Dispatch via try_dispatch_next which handles Idle → Claiming atomically.
         self.get_or_create_worker(&thread_id).await;
         let claimed = self.try_dispatch_next(&thread_id).await;
-        let status = if claimed {
+        let status = if claimed.started_execution() {
             MailboxDispatchStatus::Running
         } else {
             MailboxDispatchStatus::Queued
@@ -894,7 +926,9 @@ impl Mailbox {
         if let Some(dispatch) = self.store.load_dispatch(id).await?
             && dispatch.status == RunDispatchStatus::Claimed
         {
-            return self.deliver_live_cancel(&dispatch.thread_id).await;
+            return self
+                .deliver_live_cancel(&live_target_for_dispatch(&dispatch))
+                .await;
         }
 
         let run = if let Some(run) = self.run_store.load_run(id).await? {
@@ -905,7 +939,7 @@ impl Mailbox {
         if let Some(run) = run
             && matches!(run.status, RunStatus::Running | RunStatus::Waiting)
         {
-            return self.deliver_live_cancel(&run.thread_id).await;
+            return self.deliver_live_cancel(&live_target_for_run(&run)).await;
         }
 
         Ok(false)
@@ -926,9 +960,57 @@ impl Mailbox {
         Ok(result)
     }
 
-    /// Forward a tool-call decision to an active run.
+    /// Forward a tool-call decision to an active run in this process only.
+    ///
+    /// Distributed callers should use [`Self::send_decision_live`] so remote
+    /// active runs can receive the decision through targeted live delivery.
     pub fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool {
         self.executor.send_decision(id, tool_call_id, resume)
+    }
+
+    /// Forward a tool-call decision locally or through targeted live delivery.
+    ///
+    /// Live delivery is at-least-once when the remote run accepts the decision
+    /// but the ack is lost before the durable fallback is enqueued. Consumers
+    /// must treat `(tool_call_id, decision_id)` as idempotent.
+    pub async fn send_decision_live(
+        &self,
+        id: &str,
+        tool_call_id: String,
+        resume: ToolCallResume,
+    ) -> Result<bool, MailboxError> {
+        if self
+            .executor
+            .send_decision(id, tool_call_id.clone(), resume.clone())
+        {
+            return Ok(true);
+        }
+
+        if let Some(dispatch) = self.store.load_dispatch(id).await?
+            && dispatch.status == RunDispatchStatus::Claimed
+        {
+            return self
+                .deliver_live_decision(
+                    &live_target_for_dispatch(&dispatch),
+                    vec![(tool_call_id, resume)],
+                )
+                .await;
+        }
+
+        let run = if let Some(run) = self.run_store.load_run(id).await? {
+            Some(run)
+        } else {
+            self.run_store.latest_run(id).await?
+        };
+        if let Some(run) = run
+            && matches!(run.status, RunStatus::Running | RunStatus::Waiting)
+        {
+            return self
+                .deliver_live_decision(&live_target_for_run(&run), vec![(tool_call_id, resume)])
+                .await;
+        }
+
+        Ok(false)
     }
 
     async fn cancel_active_dispatch(
@@ -939,13 +1021,27 @@ impl Mailbox {
     ) -> Result<bool, MailboxError> {
         if wait_for_release {
             if self.executor.cancel_and_wait_by_thread(thread_id).await {
-                return Ok(true);
+                if self
+                    .wait_for_dispatch_not_claimed(&active_dispatch.dispatch_id)
+                    .await?
+                {
+                    return Ok(true);
+                }
+                tracing::warn!(
+                    thread_id,
+                    dispatch_id = %active_dispatch.dispatch_id,
+                    "local cancel completed but active dispatch did not release before foreground submit"
+                );
+                return Ok(false);
             }
         } else if self.executor.cancel(thread_id) {
             return Ok(true);
         }
 
-        if !self.deliver_live_cancel(thread_id).await? {
+        if !self
+            .deliver_live_cancel(&live_target_for_dispatch(active_dispatch))
+            .await?
+        {
             return Ok(false);
         }
 
@@ -959,14 +1055,30 @@ impl Mailbox {
                 dispatch_id = %active_dispatch.dispatch_id,
                 "remote cancel delivered but active dispatch did not release before foreground submit"
             );
+            return Ok(false);
         }
         Ok(true)
     }
 
-    async fn deliver_live_cancel(&self, thread_id: &str) -> Result<bool, MailboxError> {
+    async fn deliver_live_cancel(&self, target: &LiveRunTarget) -> Result<bool, MailboxError> {
         match self
             .store
-            .deliver_live(thread_id, LiveRunCommand::Cancel)
+            .deliver_live_to(target, LiveRunCommand::Cancel)
+            .await?
+        {
+            LiveDeliveryOutcome::Delivered => Ok(true),
+            LiveDeliveryOutcome::NoSubscriber => Ok(false),
+        }
+    }
+
+    async fn deliver_live_decision(
+        &self,
+        target: &LiveRunTarget,
+        decisions: Vec<(String, ToolCallResume)>,
+    ) -> Result<bool, MailboxError> {
+        match self
+            .store
+            .deliver_live_to(target, LiveRunCommand::Decision(decisions))
             .await?
         {
             LiveDeliveryOutcome::Delivered => Ok(true),
@@ -1052,8 +1164,8 @@ impl Mailbox {
         // enqueues a durable dispatch instead of silently dropping.
         let outcome = self
             .store
-            .deliver_live(
-                thread_id,
+            .deliver_live_to(
+                &live_target_for_run(&remote_run),
                 awaken_contract::contract::mailbox::LiveRunCommand::Messages(messages),
             )
             .await?;
@@ -1272,8 +1384,19 @@ impl Mailbox {
                 .await;
         });
 
+        let dispatch_signal_task = self.store.supports_dispatch_signals().then(|| {
+            let signal_mailbox = Arc::clone(self);
+            tokio::spawn(async move {
+                if !startup_delay.is_zero() {
+                    tokio::time::sleep(startup_delay).await;
+                }
+                signal_mailbox.run_dispatch_signal_loop().await;
+            })
+        });
+
         *lifecycle = Some(MailboxLifecycleTasks {
             recover_task,
+            dispatch_signal_task,
             maintenance_task,
         });
         Ok(handle)
@@ -1395,11 +1518,87 @@ impl Mailbox {
         }
     }
 
+    /// Drain backend work-queue delivery signals and wake local workers.
+    pub async fn run_dispatch_signal_loop(self: Arc<Self>) {
+        loop {
+            match self
+                .store
+                .pull_dispatch_signals(DISPATCH_SIGNAL_BATCH, DISPATCH_SIGNAL_EXPIRES)
+                .await
+            {
+                Ok(entries) => {
+                    for entry in entries {
+                        self.get_or_create_worker(&entry.thread_id).await;
+                        let attempt = self.try_dispatch_next(&entry.thread_id).await;
+                        let nack_delay = match attempt {
+                            DispatchAttempt::TransientError => Some(None),
+                            DispatchAttempt::NoEligible => {
+                                match self.dispatch_signal_still_available(&entry).await {
+                                    Ok(true) => Some(Some(DISPATCH_SIGNAL_BLOCKED_NACK_DELAY)),
+                                    Ok(false) => None,
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            thread_id = %entry.thread_id,
+                                            dispatch_id = %entry.dispatch_id,
+                                            error = %error,
+                                            "failed to verify unclaimed dispatch signal"
+                                        );
+                                        Some(None)
+                                    }
+                                }
+                            }
+                            DispatchAttempt::Claimed | DispatchAttempt::Busy => None,
+                        };
+                        if let Some(delay) = nack_delay {
+                            let result = if let Some(delay) = delay {
+                                entry.receipt.nack_with_delay(delay).await
+                            } else {
+                                entry.receipt.nack().await
+                            };
+                            if let Err(error) = result {
+                                tracing::warn!(
+                                    thread_id = %entry.thread_id,
+                                    dispatch_id = %entry.dispatch_id,
+                                    error = %error,
+                                    "failed to nack dispatch signal after claim error"
+                                );
+                            }
+                            continue;
+                        }
+                        if let Err(error) = entry.receipt.ack().await {
+                            tracing::warn!(
+                                thread_id = %entry.thread_id,
+                                dispatch_id = %entry.dispatch_id,
+                                error = %error,
+                                "failed to ack dispatch signal"
+                            );
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "dispatch signal pull failed");
+                    tokio::time::sleep(DISPATCH_SIGNAL_ERROR_DELAY).await;
+                }
+            }
+        }
+    }
+
+    async fn dispatch_signal_still_available(
+        &self,
+        entry: &awaken_contract::contract::mailbox::DispatchSignalEntry,
+    ) -> Result<bool, StorageError> {
+        let now = now_ms();
+        let Some(dispatch) = self.store.load_dispatch(&entry.dispatch_id).await? else {
+            return Ok(false);
+        };
+        Ok(dispatch.status == RunDispatchStatus::Queued && dispatch.available_at <= now)
+    }
+
     // ── Internal: dispatch ───────────────────────────────────────────
 
     /// Claim a dispatch from the store and start execution.
     #[tracing::instrument(skip(self), fields(thread_id = %thread_id))]
-    async fn dispatch_next_claim(self: &Arc<Self>, thread_id: &str) {
+    async fn dispatch_next_claim(self: &Arc<Self>, thread_id: &str) -> DispatchAttempt {
         let now = now_ms();
         let claimed = match self
             .store
@@ -1410,14 +1609,14 @@ impl Mailbox {
             Err(e) => {
                 tracing::warn!(error = %e, thread_id, "failed to claim dispatch");
                 revert_claiming_to_idle(&self.workers, thread_id).await;
-                return;
+                return DispatchAttempt::TransientError;
             }
         };
 
         let Some(dispatch) = claimed.into_iter().next() else {
             // No dispatches to claim.
             revert_claiming_to_idle(&self.workers, thread_id).await;
-            return;
+            return DispatchAttempt::NoEligible;
         };
 
         let dispatch_id = dispatch.dispatch_id.clone();
@@ -1468,17 +1667,17 @@ impl Mailbox {
             thread_id.to_string(),
             suspended,
         );
+        DispatchAttempt::Claimed
     }
 
     /// Claim from store and execute the next dispatch for this thread.
-    /// Returns `true` if the worker transitioned to Claiming (dispatch in progress).
     #[tracing::instrument(skip(self), fields(thread_id = %thread_id))]
-    async fn try_dispatch_next(self: &Arc<Self>, thread_id: &str) -> bool {
+    async fn try_dispatch_next(self: &Arc<Self>, thread_id: &str) -> DispatchAttempt {
         let worker = {
             let workers = self.workers.read().await;
             match workers.get(thread_id) {
                 Some(w) => Arc::clone(w),
-                None => return false,
+                None => return DispatchAttempt::NoEligible,
             }
         };
 
@@ -1486,13 +1685,12 @@ impl Mailbox {
         {
             let mut w = worker.lock();
             if !matches!(w.status, MailboxWorkerStatus::Idle) {
-                return false;
+                return DispatchAttempt::Busy;
             }
             w.status = MailboxWorkerStatus::Claiming;
         }
 
-        self.dispatch_next_claim(thread_id).await;
-        true
+        self.dispatch_next_claim(thread_id).await
     }
 
     /// Spawn a lease renewal task that periodically extends the lease.
@@ -1574,6 +1772,7 @@ impl Mailbox {
                 && current_dispatch.status != RunDispatchStatus::Claimed
             {
                 tracing::info!(dispatch_id, status = ?current_dispatch.status, "dispatch no longer claimed, skipping execution");
+                this.finish_execution(&thread_id, &dispatch_id).await;
                 return;
             }
 
@@ -1613,6 +1812,7 @@ impl Mailbox {
                         .store
                         .dead_letter(&dispatch_id, &claim_token, &msg, now)
                         .await;
+                    this.finish_execution(&thread_id, &dispatch_id).await;
                     return;
                 }
             };
@@ -1735,27 +1935,31 @@ impl Mailbox {
                 }
             }
 
-            // Abort lease renewal.
-            let worker = this.get_or_create_worker(&thread_id).await;
-            {
-                let mut w = worker.lock();
-                let should_transition = matches!(
-                    &w.status,
-                    MailboxWorkerStatus::Running { dispatch_id: cid, .. } if *cid == dispatch_id
-                );
-                if should_transition {
-                    // Take ownership of the old status to abort the lease handle.
-                    let old = std::mem::replace(&mut w.status, MailboxWorkerStatus::Idle);
-                    w.thread_ctx = None;
-                    if let MailboxWorkerStatus::Running { lease_handle, .. } = old {
-                        lease_handle.abort();
-                    }
+            this.finish_execution(&thread_id, &dispatch_id).await;
+        });
+    }
+
+    async fn finish_execution(self: &Arc<Self>, thread_id: &str, dispatch_id: &str) {
+        // Abort lease renewal and return the worker to Idle.
+        let worker = self.get_or_create_worker(thread_id).await;
+        {
+            let mut w = worker.lock();
+            let should_transition = matches!(
+                &w.status,
+                MailboxWorkerStatus::Running { dispatch_id: cid, .. } if cid == dispatch_id
+            );
+            if should_transition {
+                // Take ownership of the old status to abort the lease handle.
+                let old = std::mem::replace(&mut w.status, MailboxWorkerStatus::Idle);
+                w.thread_ctx = None;
+                if let MailboxWorkerStatus::Running { lease_handle, .. } = old {
+                    lease_handle.abort();
                 }
             }
+        }
 
-            // Try to execute the next queued dispatch for this thread.
-            this.try_dispatch_next(&thread_id).await;
-        });
+        // Try to execute the next queued dispatch for this thread.
+        self.try_dispatch_next(thread_id).await;
     }
 
     /// Get or create a per-thread worker.
@@ -2331,6 +2535,19 @@ fn normalize_message_ids(messages: &[Message]) -> Vec<Message> {
         .collect()
 }
 
+fn live_target_for_dispatch(dispatch: &RunDispatch) -> LiveRunTarget {
+    LiveRunTarget::new(dispatch.thread_id.clone(), dispatch.run_id.clone())
+        .with_dispatch_id(dispatch.dispatch_id.clone())
+}
+
+fn live_target_for_run(run: &RunRecord) -> LiveRunTarget {
+    let mut target = LiveRunTarget::new(run.thread_id.clone(), run.run_id.clone());
+    if let Some(dispatch_id) = run.dispatch_id.clone() {
+        target = target.with_dispatch_id(dispatch_id);
+    }
+    target
+}
+
 fn mailbox_run_result(
     run_id: &str,
     dispatch_instance_id: &str,
@@ -2450,6 +2667,7 @@ mod tests {
     use awaken_runtime::{Plugin, ResolvedAgent};
     use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
     use serde_json::{Value, json};
+    use std::collections::VecDeque;
     use std::sync::Mutex as StdMutex;
     use std::sync::atomic::AtomicUsize;
     use tokio::time::{Duration, Instant, sleep};
@@ -2471,6 +2689,16 @@ mod tests {
 
     fn make_store() -> Arc<InMemoryMailboxStore> {
         Arc::new(InMemoryMailboxStore::new())
+    }
+
+    fn make_resume() -> ToolCallResume {
+        ToolCallResume {
+            decision_id: "d1".into(),
+            action: awaken_contract::contract::suspension::ResumeDecisionAction::Resume,
+            result: serde_json::json!({"approved": true}),
+            reason: None,
+            updated_at: 0,
+        }
     }
 
     struct RecoverFlakyMailboxStore {
@@ -2656,6 +2884,262 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct TestDispatchSignal {
+        thread_id: String,
+        dispatch_id: String,
+    }
+
+    struct TestDispatchSignalReceipt {
+        signal: TestDispatchSignal,
+        queue: Arc<tokio::sync::Mutex<VecDeque<TestDispatchSignal>>>,
+        acked_count: Arc<AtomicUsize>,
+        nacked_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl awaken_contract::contract::mailbox::DispatchSignalReceipt for TestDispatchSignalReceipt {
+        async fn ack(self: Box<Self>) -> Result<(), StorageError> {
+            self.acked_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn nack(self: Box<Self>) -> Result<(), StorageError> {
+            self.nacked_count.fetch_add(1, Ordering::SeqCst);
+            self.queue.lock().await.push_back(self.signal.clone());
+            Ok(())
+        }
+    }
+
+    struct SignalMailboxStore {
+        inner: InMemoryMailboxStore,
+        signals: Arc<tokio::sync::Mutex<VecDeque<TestDispatchSignal>>>,
+        acked_count: Arc<AtomicUsize>,
+        nacked_count: Arc<AtomicUsize>,
+        claim_failures_remaining: AtomicUsize,
+    }
+
+    impl SignalMailboxStore {
+        fn new() -> Self {
+            Self::with_claim_failures(0)
+        }
+
+        fn with_claim_failures(claim_failures: usize) -> Self {
+            Self {
+                inner: InMemoryMailboxStore::new(),
+                signals: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+                acked_count: Arc::new(AtomicUsize::new(0)),
+                nacked_count: Arc::new(AtomicUsize::new(0)),
+                claim_failures_remaining: AtomicUsize::new(claim_failures),
+            }
+        }
+
+        fn acked_signal_count(&self) -> usize {
+            self.acked_count.load(Ordering::SeqCst)
+        }
+
+        fn nacked_signal_count(&self) -> usize {
+            self.nacked_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MailboxStore for SignalMailboxStore {
+        async fn enqueue(&self, dispatch: &RunDispatch) -> Result<(), StorageError> {
+            self.inner.enqueue(dispatch).await?;
+            self.signals.lock().await.push_back(TestDispatchSignal {
+                thread_id: dispatch.thread_id.clone(),
+                dispatch_id: dispatch.dispatch_id.clone(),
+            });
+            Ok(())
+        }
+
+        async fn claim(
+            &self,
+            thread_id: &str,
+            consumer_id: &str,
+            lease_ms: u64,
+            now: u64,
+            limit: usize,
+        ) -> Result<Vec<RunDispatch>, StorageError> {
+            let remaining = self.claim_failures_remaining.load(Ordering::SeqCst);
+            if remaining > 0
+                && self
+                    .claim_failures_remaining
+                    .compare_exchange(remaining, remaining - 1, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+            {
+                return Err(StorageError::Io("injected claim failure".into()));
+            }
+            self.inner
+                .claim(thread_id, consumer_id, lease_ms, now, limit)
+                .await
+        }
+
+        async fn claim_dispatch(
+            &self,
+            dispatch_id: &str,
+            consumer_id: &str,
+            lease_ms: u64,
+            now: u64,
+        ) -> Result<Option<RunDispatch>, StorageError> {
+            self.inner
+                .claim_dispatch(dispatch_id, consumer_id, lease_ms, now)
+                .await
+        }
+
+        async fn ack(
+            &self,
+            dispatch_id: &str,
+            claim_token: &str,
+            now: u64,
+        ) -> Result<(), StorageError> {
+            self.inner.ack(dispatch_id, claim_token, now).await
+        }
+
+        async fn record_dispatch_start(
+            &self,
+            dispatch_id: &str,
+            claim_token: &str,
+            dispatch_instance_id: &str,
+            now: u64,
+        ) -> Result<(), StorageError> {
+            self.inner
+                .record_dispatch_start(dispatch_id, claim_token, dispatch_instance_id, now)
+                .await
+        }
+
+        async fn record_run_result(
+            &self,
+            dispatch_id: &str,
+            claim_token: &str,
+            result: &RunDispatchResult,
+            now: u64,
+        ) -> Result<(), StorageError> {
+            self.inner
+                .record_run_result(dispatch_id, claim_token, result, now)
+                .await
+        }
+
+        async fn nack(
+            &self,
+            dispatch_id: &str,
+            claim_token: &str,
+            retry_at: u64,
+            error: &str,
+            now: u64,
+        ) -> Result<(), StorageError> {
+            self.inner
+                .nack(dispatch_id, claim_token, retry_at, error, now)
+                .await
+        }
+
+        async fn dead_letter(
+            &self,
+            dispatch_id: &str,
+            claim_token: &str,
+            error: &str,
+            now: u64,
+        ) -> Result<(), StorageError> {
+            self.inner
+                .dead_letter(dispatch_id, claim_token, error, now)
+                .await
+        }
+
+        async fn cancel(
+            &self,
+            dispatch_id: &str,
+            now: u64,
+        ) -> Result<Option<RunDispatch>, StorageError> {
+            self.inner.cancel(dispatch_id, now).await
+        }
+
+        async fn extend_lease(
+            &self,
+            dispatch_id: &str,
+            claim_token: &str,
+            extension_ms: u64,
+            now: u64,
+        ) -> Result<bool, StorageError> {
+            self.inner
+                .extend_lease(dispatch_id, claim_token, extension_ms, now)
+                .await
+        }
+
+        async fn interrupt(
+            &self,
+            thread_id: &str,
+            now: u64,
+        ) -> Result<MailboxInterrupt, StorageError> {
+            self.inner.interrupt(thread_id, now).await
+        }
+
+        async fn load_dispatch(
+            &self,
+            dispatch_id: &str,
+        ) -> Result<Option<RunDispatch>, StorageError> {
+            self.inner.load_dispatch(dispatch_id).await
+        }
+
+        async fn list_dispatches(
+            &self,
+            thread_id: &str,
+            status_filter: Option<&[RunDispatchStatus]>,
+            limit: usize,
+            offset: usize,
+        ) -> Result<Vec<RunDispatch>, StorageError> {
+            self.inner
+                .list_dispatches(thread_id, status_filter, limit, offset)
+                .await
+        }
+
+        async fn reclaim_expired_leases(
+            &self,
+            now: u64,
+            limit: usize,
+        ) -> Result<Vec<RunDispatch>, StorageError> {
+            self.inner.reclaim_expired_leases(now, limit).await
+        }
+
+        async fn purge_terminal(&self, older_than: u64) -> Result<usize, StorageError> {
+            self.inner.purge_terminal(older_than).await
+        }
+
+        async fn queued_thread_ids(&self) -> Result<Vec<String>, StorageError> {
+            self.inner.queued_thread_ids().await
+        }
+
+        fn supports_dispatch_signals(&self) -> bool {
+            true
+        }
+
+        async fn pull_dispatch_signals(
+            &self,
+            max: usize,
+            _expires: Duration,
+        ) -> Result<Vec<awaken_contract::contract::mailbox::DispatchSignalEntry>, StorageError>
+        {
+            let mut signals = self.signals.lock().await;
+            let mut entries = Vec::new();
+            for _ in 0..max {
+                let Some(signal) = signals.pop_front() else {
+                    break;
+                };
+                entries.push(awaken_contract::contract::mailbox::DispatchSignalEntry {
+                    thread_id: signal.thread_id.clone(),
+                    dispatch_id: signal.dispatch_id.clone(),
+                    receipt: Box::new(TestDispatchSignalReceipt {
+                        signal,
+                        queue: Arc::clone(&self.signals),
+                        acked_count: Arc::clone(&self.acked_count),
+                        nacked_count: Arc::clone(&self.nacked_count),
+                    }),
+                });
+            }
+            Ok(entries)
+        }
+    }
+
     fn make_runtime() -> Arc<AgentRuntime> {
         Arc::new(AgentRuntime::new(Arc::new(StubResolver)))
     }
@@ -2713,6 +3197,35 @@ mod tests {
         }
     }
 
+    struct ImmediateLocalCancelRuntime;
+
+    #[async_trait::async_trait]
+    impl RunDispatchExecutor for ImmediateLocalCancelRuntime {
+        async fn run(
+            &self,
+            _request: RunRequest,
+            _sink: Arc<dyn EventSink>,
+        ) -> Result<AgentRunResult, AgentLoopError> {
+            panic!("local cancel test must not execute runs")
+        }
+
+        fn cancel(&self, _id: &str) -> bool {
+            true
+        }
+
+        async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+            true
+        }
+
+        fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+            false
+        }
+
+        fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+            false
+        }
+    }
+
     struct RecordedMailboxRequest {
         run_mode: RunMode,
         adapter: AdapterKind,
@@ -2723,6 +3236,68 @@ mod tests {
     #[derive(Default)]
     struct RecordingMailboxRuntime {
         requests: StdMutex<Vec<RecordedMailboxRequest>>,
+    }
+
+    struct BlockingMailboxRuntime {
+        run_count: AtomicUsize,
+        started_tx: tokio::sync::mpsc::UnboundedSender<(usize, Option<String>)>,
+        release_first: Arc<tokio::sync::Notify>,
+    }
+
+    impl BlockingMailboxRuntime {
+        fn new(
+            started_tx: tokio::sync::mpsc::UnboundedSender<(usize, Option<String>)>,
+            release_first: Arc<tokio::sync::Notify>,
+        ) -> Self {
+            Self {
+                run_count: AtomicUsize::new(0),
+                started_tx,
+                release_first,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RunDispatchExecutor for BlockingMailboxRuntime {
+        async fn run(
+            &self,
+            request: RunRequest,
+            _sink: Arc<dyn EventSink>,
+        ) -> Result<AgentRunResult, AgentLoopError> {
+            let ordinal = self.run_count.fetch_add(1, Ordering::SeqCst) + 1;
+            let _ = self.started_tx.send((ordinal, request.dispatch_id.clone()));
+            if ordinal == 1 {
+                self.release_first.notified().await;
+            }
+            let run_id = request
+                .continue_run_id
+                .clone()
+                .or(request.run_id_hint.clone())
+                .or(request.dispatch_id.clone())
+                .unwrap_or_else(|| format!("blocking-run-{ordinal}"));
+            Ok(AgentRunResult {
+                run_id,
+                response: "ok".to_string(),
+                termination: TerminationReason::NaturalEnd,
+                steps: 1,
+            })
+        }
+
+        fn cancel(&self, _id: &str) -> bool {
+            false
+        }
+
+        async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+            false
+        }
+
+        fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+            false
+        }
+
+        fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+            false
+        }
     }
 
     #[async_trait::async_trait]
@@ -3607,6 +4182,216 @@ mod tests {
         handle.shutdown().await.expect("shutdown lifecycle");
     }
 
+    #[tokio::test]
+    async fn dispatch_signal_loop_claims_and_executes_queued_dispatch() {
+        let store = Arc::new(SignalMailboxStore::new());
+        let run_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(RecordingMailboxRuntime::default());
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            store.clone(),
+            run_store.clone(),
+            "signal-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let mut request = RunRequest::new("thread-signal-loop", vec![Message::user("wake")])
+            .with_agent_id("agent");
+        let (thread_id, messages) =
+            validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false)
+                .expect("input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
+            .await
+            .expect("prepare run");
+        let dispatch = mailbox
+            .build_dispatch(&request, &thread_id)
+            .expect("build dispatch");
+        let dispatch_id = dispatch.dispatch_id.clone();
+        store.enqueue(&dispatch).await.expect("enqueue dispatch");
+
+        let signal_loop = tokio::spawn(Arc::clone(&mailbox).run_dispatch_signal_loop());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let acked = loop {
+            if let Some(dispatch) = store
+                .load_dispatch(&dispatch_id)
+                .await
+                .expect("dispatch lookup should succeed")
+                && dispatch.status == RunDispatchStatus::Acked
+            {
+                break dispatch;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for dispatch signal loop"
+            );
+            sleep(Duration::from_millis(10)).await;
+        };
+        signal_loop.abort();
+
+        assert_eq!(acked.status, RunDispatchStatus::Acked);
+        assert_eq!(store.acked_signal_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_signal_loop_nacks_and_redelivers_after_claim_error() {
+        let store = Arc::new(SignalMailboxStore::with_claim_failures(1));
+        let run_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(RecordingMailboxRuntime::default());
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            store.clone(),
+            run_store.clone(),
+            "signal-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let mut request = RunRequest::new("thread-signal-redeliver", vec![Message::user("wake")])
+            .with_agent_id("agent");
+        let (thread_id, messages) =
+            validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false)
+                .expect("input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
+            .await
+            .expect("prepare run");
+        let dispatch = mailbox
+            .build_dispatch(&request, &thread_id)
+            .expect("build dispatch");
+        let dispatch_id = dispatch.dispatch_id.clone();
+        store.enqueue(&dispatch).await.expect("enqueue dispatch");
+
+        let signal_loop = tokio::spawn(Arc::clone(&mailbox).run_dispatch_signal_loop());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let dispatch = store
+                .load_dispatch(&dispatch_id)
+                .await
+                .expect("dispatch lookup should succeed")
+                .expect("dispatch should exist");
+            if dispatch.status == RunDispatchStatus::Acked {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for redelivered dispatch signal"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+        signal_loop.abort();
+
+        assert_eq!(store.nacked_signal_count(), 1);
+        assert_eq!(store.acked_signal_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
+        let store = Arc::new(SignalMailboxStore::new());
+        let run_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(RecordingMailboxRuntime::default());
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            store.clone(),
+            run_store.clone(),
+            "signal-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let mut active = RunRequest::new("thread-signal-blocked", vec![Message::user("active")])
+            .with_agent_id("agent");
+        let (thread_id, active_messages) =
+            validate_run_inputs(active.thread_id.clone(), active.messages.clone(), false)
+                .expect("active input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut active, &thread_id, &active_messages)
+            .await
+            .expect("prepare active run");
+        let active_dispatch = mailbox
+            .build_dispatch(&active, &thread_id)
+            .expect("build active dispatch");
+        let active_dispatch_id = active_dispatch.dispatch_id.clone();
+        store
+            .enqueue(&active_dispatch)
+            .await
+            .expect("enqueue active dispatch");
+        let claimed = store
+            .claim(&thread_id, "remote-owner", 30_000, now_ms(), 1)
+            .await
+            .expect("claim active dispatch");
+        assert_eq!(claimed.len(), 1);
+        let active_claim_token = claimed[0].claim_token.clone().unwrap();
+
+        let mut queued = RunRequest::new("thread-signal-blocked", vec![Message::user("queued")])
+            .with_agent_id("agent");
+        let (_, queued_messages) =
+            validate_run_inputs(queued.thread_id.clone(), queued.messages.clone(), false)
+                .expect("queued input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut queued, &thread_id, &queued_messages)
+            .await
+            .expect("prepare queued run");
+        let queued_dispatch = mailbox
+            .build_dispatch(&queued, &thread_id)
+            .expect("build queued dispatch");
+        let queued_dispatch_id = queued_dispatch.dispatch_id.clone();
+        store
+            .enqueue(&queued_dispatch)
+            .await
+            .expect("enqueue queued dispatch");
+
+        let signal_loop = tokio::spawn(Arc::clone(&mailbox).run_dispatch_signal_loop());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if store.nacked_signal_count() > 0 {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "queued signal blocked by an active claim must be nacked for redelivery"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        let queued_before_release = store
+            .load_dispatch(&queued_dispatch_id)
+            .await
+            .expect("queued dispatch lookup")
+            .expect("queued dispatch exists");
+        assert_eq!(queued_before_release.status, RunDispatchStatus::Queued);
+
+        store
+            .ack(&active_dispatch_id, &active_claim_token, now_ms())
+            .await
+            .expect("release active claim");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let dispatch = store
+                .load_dispatch(&queued_dispatch_id)
+                .await
+                .expect("queued dispatch lookup")
+                .expect("queued dispatch exists");
+            if dispatch.status == RunDispatchStatus::Acked {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "redelivered signal should claim after active claim releases"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+        signal_loop.abort();
+
+        assert!(
+            store.nacked_signal_count() >= 1,
+            "blocked queued signal must be nacked at least once"
+        );
+        assert!(
+            store.acked_signal_count() >= 2,
+            "active signal and final queued signal should both be acked"
+        );
+    }
+
     #[test]
     fn run_request_fields() {
         let req = RunRequest::new("t-1", vec![Message::user("hello")]).with_agent_id("agent-a");
@@ -4481,6 +5266,87 @@ mod tests {
         assert!(dead.completed_at.is_some());
     }
 
+    #[tokio::test]
+    async fn reconstruct_failure_cleans_worker_and_dispatches_next_queued() {
+        let store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(RecordingMailboxRuntime::default());
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            store.clone(),
+            thread_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+        let thread_id = "thread-reconstruct-next";
+        let now = now_ms();
+
+        let missing = RunDispatch {
+            dispatch_id: "dispatch-missing-run".to_string(),
+            thread_id: thread_id.to_string(),
+            run_id: "missing-run".to_string(),
+            priority: 10,
+            dedupe_key: None,
+            dispatch_epoch: 0,
+            status: RunDispatchStatus::Queued,
+            available_at: now,
+            attempt_count: 0,
+            max_attempts: 3,
+            last_error: None,
+            claim_token: None,
+            claimed_by: None,
+            lease_until: None,
+            dispatch_instance_id: None,
+            run_status: None,
+            termination: None,
+            run_response: None,
+            run_error: None,
+            completed_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        store.enqueue(&missing).await.expect("enqueue missing run");
+
+        let mut next_request =
+            RunRequest::new(thread_id, vec![Message::user("next")]).with_agent_id("agent");
+        let (_, next_messages) = validate_run_inputs(
+            next_request.thread_id.clone(),
+            next_request.messages.clone(),
+            false,
+        )
+        .expect("next input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut next_request, thread_id, &next_messages)
+            .await
+            .expect("prepare next run");
+        let mut next = mailbox
+            .build_dispatch(&next_request, thread_id)
+            .expect("build next dispatch");
+        next.priority = 20;
+        next.created_at = now.saturating_add(1);
+        next.updated_at = next.created_at;
+        let next_dispatch_id = next.dispatch_id.clone();
+        store.enqueue(&next).await.expect("enqueue next");
+
+        mailbox.get_or_create_worker(thread_id).await;
+        assert_eq!(
+            mailbox.try_dispatch_next(thread_id).await,
+            DispatchAttempt::Claimed
+        );
+
+        let dead = wait_for_dispatch(&store, "dispatch-missing-run", |dispatch| {
+            dispatch.status == RunDispatchStatus::DeadLetter
+        })
+        .await;
+        assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+
+        let acked = wait_for_dispatch(&store, &next_dispatch_id, |dispatch| {
+            dispatch.status == RunDispatchStatus::Acked
+        })
+        .await;
+        assert_eq!(acked.status, RunDispatchStatus::Acked);
+    }
+
     // ── MailboxDispatchStatus ────────────────────────────────────────
 
     #[test]
@@ -4770,7 +5636,7 @@ mod tests {
         let active_claim_token = claimed.claim_token.clone().expect("claim token");
 
         let subscriber = mailbox_store
-            .open_live_channel(thread_id)
+            .open_live_channel_for(&live_target_for_dispatch(&active_dispatch))
             .await
             .expect("open live channel");
         let captured = Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
@@ -4817,6 +5683,220 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn foreground_submit_does_not_prepare_replacement_when_remote_cancel_times_out() {
+        use awaken_contract::contract::mailbox::LiveRunCommand;
+        use futures::StreamExt;
+
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(RecordingMailboxRuntime::default());
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "foreground-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+        let thread_id = "thread-remote-cancel-timeout";
+
+        let mut active_request =
+            RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        let (_, active_messages) = validate_run_inputs(
+            active_request.thread_id.clone(),
+            active_request.messages.clone(),
+            false,
+        )
+        .expect("active input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut active_request, thread_id, &active_messages)
+            .await
+            .expect("prepare active run");
+        let active_dispatch = mailbox
+            .build_dispatch(&active_request, thread_id)
+            .expect("build active dispatch");
+        let active_dispatch_id = active_dispatch.dispatch_id.clone();
+        mailbox_store.enqueue(&active_dispatch).await.unwrap();
+        mailbox_store
+            .claim_dispatch(&active_dispatch_id, "remote-consumer", 30_000, now_ms())
+            .await
+            .unwrap()
+            .expect("active dispatch should be claimed");
+
+        let subscriber = mailbox_store
+            .open_live_channel_for(&live_target_for_dispatch(&active_dispatch))
+            .await
+            .expect("open live channel");
+        let _forwarder = tokio::spawn(async move {
+            let mut subscriber = subscriber;
+            while let Some(entry) = subscriber.next().await {
+                if matches!(entry.command, LiveRunCommand::Cancel) {
+                    // Ack the cancel but intentionally keep the dispatch Claimed.
+                    entry.receipt.ack();
+                    break;
+                }
+                drop(entry.receipt);
+            }
+        });
+
+        let result = mailbox
+            .submit(
+                RunRequest::new(thread_id, vec![Message::user("replacement")])
+                    .with_agent_id("agent"),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(MailboxError::Validation(ref message)) if message == ACTIVE_RUN_CONFLICT_MESSAGE),
+            "foreground submit must fail before writing replacement state when old claim remains active"
+        );
+
+        let messages = thread_store
+            .load_messages(thread_id)
+            .await
+            .expect("load messages")
+            .expect("active messages should remain");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].text(), "active");
+
+        let all = mailbox_store
+            .list_dispatches(thread_id, None, 10, 0)
+            .await
+            .expect("list dispatches");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].dispatch_id, active_dispatch_id);
+        assert_eq!(all[0].status, RunDispatchStatus::Claimed);
+    }
+
+    #[tokio::test]
+    async fn foreground_submit_does_not_prepare_replacement_when_local_cancel_times_out() {
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "foreground-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+        let thread_id = "thread-local-cancel-timeout";
+
+        let mut active_request =
+            RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        let (_, active_messages) = validate_run_inputs(
+            active_request.thread_id.clone(),
+            active_request.messages.clone(),
+            false,
+        )
+        .expect("active input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut active_request, thread_id, &active_messages)
+            .await
+            .expect("prepare active run");
+        let active_dispatch = mailbox
+            .build_dispatch(&active_request, thread_id)
+            .expect("build active dispatch");
+        let active_dispatch_id = active_dispatch.dispatch_id.clone();
+        mailbox_store.enqueue(&active_dispatch).await.unwrap();
+        mailbox_store
+            .claim_dispatch(&active_dispatch_id, "foreground-consumer", 30_000, now_ms())
+            .await
+            .unwrap()
+            .expect("active dispatch should be claimed");
+
+        let result = mailbox
+            .submit(
+                RunRequest::new(thread_id, vec![Message::user("replacement")])
+                    .with_agent_id("agent"),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(MailboxError::Validation(ref message)) if message == ACTIVE_RUN_CONFLICT_MESSAGE),
+            "foreground submit must fail before writing replacement state when local cancel does not release"
+        );
+
+        let messages = thread_store
+            .load_messages(thread_id)
+            .await
+            .expect("load messages")
+            .expect("active messages should remain");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].text(), "active");
+
+        let all = mailbox_store
+            .list_dispatches(thread_id, None, 10, 0)
+            .await
+            .expect("list dispatches");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].dispatch_id, active_dispatch_id);
+        assert_eq!(all[0].status, RunDispatchStatus::Claimed);
+    }
+
+    #[tokio::test]
+    async fn foreground_submit_waits_for_local_cancelled_dispatch_to_release_claim() {
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(ImmediateLocalCancelRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "foreground-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+        let thread_id = "thread-local-cancel-claim-window";
+
+        let mut active_request =
+            RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        let (_, active_messages) = validate_run_inputs(
+            active_request.thread_id.clone(),
+            active_request.messages.clone(),
+            false,
+        )
+        .expect("active input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut active_request, thread_id, &active_messages)
+            .await
+            .expect("prepare active run");
+        let active_dispatch = mailbox
+            .build_dispatch(&active_request, thread_id)
+            .expect("build active dispatch");
+        let active_dispatch_id = active_dispatch.dispatch_id.clone();
+        mailbox_store.enqueue(&active_dispatch).await.unwrap();
+        mailbox_store
+            .claim_dispatch(&active_dispatch_id, "foreground-consumer", 30_000, now_ms())
+            .await
+            .unwrap()
+            .expect("active dispatch should be claimed");
+
+        let result = mailbox
+            .submit(
+                RunRequest::new(thread_id, vec![Message::user("replacement")])
+                    .with_agent_id("agent"),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(MailboxError::Validation(ref message)) if message == ACTIVE_RUN_CONFLICT_MESSAGE),
+            "foreground submit must fail before writing replacement state when local runtime slot released but mailbox claim remains"
+        );
+
+        let messages = thread_store
+            .load_messages(thread_id)
+            .await
+            .expect("load messages")
+            .expect("active messages should remain");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].text(), "active");
+
+        let all = mailbox_store
+            .list_dispatches(thread_id, None, 10, 0)
+            .await
+            .expect("list dispatches");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].dispatch_id, active_dispatch_id);
+        assert_eq!(all[0].status, RunDispatchStatus::Claimed);
+    }
+
     /// Cross-node live delivery: no local worker, but the thread has an
     /// active Running run recorded globally in ThreadRunStore. Mailbox must
     /// publish on the live channel (for the owning node's forwarder to
@@ -4842,7 +5922,7 @@ mod tests {
         // Simulate the remote forwarder: drain the stream and ack each
         // entry so the producer's `deliver_live` resolves as Delivered.
         let subscriber = mailbox_store
-            .open_live_channel(thread_id)
+            .open_live_channel_for(&live_target_for_run(&run))
             .await
             .expect("open live channel");
         let captured = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
@@ -4912,7 +5992,7 @@ mod tests {
         thread_store.create_run(&run).await.expect("seed run");
 
         let subscriber = mailbox_store
-            .open_live_channel(thread_id)
+            .open_live_channel_for(&live_target_for_run(&run))
             .await
             .expect("open live channel");
         // Drop every receipt — simulates forwarder that can't hand off.
@@ -4971,7 +6051,7 @@ mod tests {
         thread_store.create_run(&run).await.expect("seed run");
 
         let subscriber = mailbox_store
-            .open_live_channel(thread_id)
+            .open_live_channel_for(&live_target_for_run(&run))
             .await
             .expect("open live channel");
         // Consumer captures the command (simulates `try_send` success)
@@ -5064,6 +6144,54 @@ mod tests {
             result.run_id, "run-actual",
             "mismatched expected_run_id must not steer the stale remote run"
         );
+    }
+
+    #[tokio::test]
+    async fn send_decision_live_delivers_to_remote_waiting_run() {
+        use awaken_contract::contract::mailbox::LiveRunCommand;
+        use futures::StreamExt;
+
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let thread_id = "thread-remote-decision";
+        let run = seeded_waiting_run("run-remote-decision", thread_id, "agent");
+        thread_store.create_run(&run).await.expect("seed run");
+
+        let subscriber = mailbox_store
+            .open_live_channel_for(&live_target_for_run(&run))
+            .await
+            .expect("open targeted live channel");
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let captured_c = captured.clone();
+        let _forwarder = tokio::spawn(async move {
+            let mut subscriber = subscriber;
+            while let Some(entry) = subscriber.next().await {
+                if let LiveRunCommand::Decision(decisions) = entry.command {
+                    captured_c.lock().await.push(decisions);
+                    entry.receipt.ack();
+                    break;
+                }
+                drop(entry.receipt);
+            }
+        });
+
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store,
+            thread_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let delivered = mailbox
+            .send_decision_live(thread_id, "tool-1".to_string(), make_resume())
+            .await
+            .expect("live decision should not error");
+        assert!(delivered);
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0][0].0, "tool-1");
     }
 
     /// Cross-node live delivery when **no subscriber** is attached to the
@@ -5540,6 +6668,120 @@ mod tests {
             "at most 1 Claimed, got {}",
             dispatches.len()
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finishes() {
+        let store = Arc::new(SignalMailboxStore::new());
+        let run_store = Arc::new(InMemoryStore::new());
+        let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let release_first = Arc::new(tokio::sync::Notify::new());
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(BlockingMailboxRuntime::new(
+            started_tx,
+            Arc::clone(&release_first),
+        ));
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            store.clone(),
+            run_store,
+            "signal-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let mut first = RunRequest::new("thread-signal-busy", vec![Message::user("first")])
+            .with_agent_id("agent");
+        let (thread_id, first_messages) =
+            validate_run_inputs(first.thread_id.clone(), first.messages.clone(), false)
+                .expect("first input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut first, &thread_id, &first_messages)
+            .await
+            .expect("prepare first run");
+        let first_dispatch = mailbox
+            .build_dispatch(&first, &thread_id)
+            .expect("build first dispatch");
+        let first_dispatch_id = first_dispatch.dispatch_id.clone();
+        store.enqueue(&first_dispatch).await.expect("enqueue first");
+
+        let mut second = RunRequest::new("thread-signal-busy", vec![Message::user("second")])
+            .with_agent_id("agent");
+        let (_, second_messages) =
+            validate_run_inputs(second.thread_id.clone(), second.messages.clone(), false)
+                .expect("second input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut second, &thread_id, &second_messages)
+            .await
+            .expect("prepare second run");
+        let second_dispatch = mailbox
+            .build_dispatch(&second, &thread_id)
+            .expect("build second dispatch");
+        let second_dispatch_id = second_dispatch.dispatch_id.clone();
+        store
+            .enqueue(&second_dispatch)
+            .await
+            .expect("enqueue second");
+
+        let signal_loop = tokio::spawn(Arc::clone(&mailbox).run_dispatch_signal_loop());
+        let (ordinal, dispatch_id) =
+            tokio::time::timeout(Duration::from_secs(2), started_rx.recv())
+                .await
+                .expect("first dispatch should start")
+                .expect("runtime should report first start");
+        assert_eq!(ordinal, 1);
+        let blocked_dispatch_id = dispatch_id.expect("started dispatch should have an id");
+        assert!(
+            blocked_dispatch_id == first_dispatch_id || blocked_dispatch_id == second_dispatch_id,
+            "started dispatch must be one of the two queued dispatches"
+        );
+        let queued_dispatch_id = if blocked_dispatch_id == first_dispatch_id {
+            second_dispatch_id.as_str()
+        } else {
+            first_dispatch_id.as_str()
+        };
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while store.acked_signal_count() < 2 {
+            assert!(
+                Instant::now() < deadline,
+                "signal loop must ack the busy second signal instead of blocking"
+            );
+            sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(store.nacked_signal_count(), 0);
+        let queued_before_release = store
+            .load_dispatch(queued_dispatch_id)
+            .await
+            .expect("load queued dispatch")
+            .expect("queued dispatch exists");
+        assert_eq!(
+            queued_before_release.status,
+            RunDispatchStatus::Queued,
+            "busy signal ack must not claim the other dispatch before the first finishes"
+        );
+
+        release_first.notify_waiters();
+        let (ordinal, dispatch_id) =
+            tokio::time::timeout(Duration::from_secs(2), started_rx.recv())
+                .await
+                .expect("queued dispatch should start after first finishes")
+                .expect("runtime should report second start");
+        assert_eq!(ordinal, 2);
+        assert_eq!(dispatch_id.as_deref(), Some(queued_dispatch_id));
+
+        let first_done = wait_for_dispatch(&store.inner, &first_dispatch_id, |dispatch| {
+            dispatch.status == RunDispatchStatus::Acked
+        })
+        .await;
+        let second_done = wait_for_dispatch(&store.inner, &second_dispatch_id, |dispatch| {
+            dispatch.status == RunDispatchStatus::Acked
+        })
+        .await;
+        signal_loop.abort();
+
+        assert_eq!(first_done.status, RunDispatchStatus::Acked);
+        assert_eq!(second_done.status, RunDispatchStatus::Acked);
+        assert_eq!(store.acked_signal_count(), 2);
+        assert_eq!(store.nacked_signal_count(), 0);
     }
 
     #[tokio::test]

--- a/crates/awaken-server/src/mailbox.rs
+++ b/crates/awaken-server/src/mailbox.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use parking_lot::Mutex as SyncMutex;
 use thiserror::Error;
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio::task::JoinHandle;
@@ -20,7 +21,8 @@ use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::event_sink::EventSink;
 use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::mailbox::{
-    MailboxInterrupt, MailboxStore, RunDispatch, RunDispatchResult, RunDispatchStatus,
+    LiveDeliveryOutcome, LiveRunCommand, MailboxInterrupt, MailboxStore, RunDispatch,
+    RunDispatchResult, RunDispatchStatus,
 };
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::storage::{
@@ -31,13 +33,15 @@ use awaken_contract::contract::suspension::{ToolCallOutcome, ToolCallResume};
 use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
 use awaken_contract::now_ms;
 use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
-use awaken_runtime::{AgentRuntime, RunRequest};
+use awaken_runtime::{AgentRuntime, RunRequest, ThreadContextSnapshot};
 
 use crate::transport::channel_sink::ReconnectableEventSink;
 
 /// Guard window for inline-claimed dispatches: if the process crashes between
 /// enqueue and claim, the sweep will reclaim the dispatch after this period.
 const INLINE_CLAIM_GUARD_MS: u64 = 60_000;
+const REMOTE_CANCEL_WAIT_MS: u64 = 5_000;
+const REMOTE_CANCEL_POLL_MS: u64 = 25;
 
 /// Validation message returned when an inline submit loses the active-run race.
 pub(crate) const ACTIVE_RUN_CONFLICT_MESSAGE: &str =
@@ -150,8 +154,6 @@ impl RunRequestExtras {
 /// Implements [`OnInboxClosed`](awaken_runtime::inbox::OnInboxClosed) — when an `InboxSender::send()` fails
 /// because the receiver was dropped (agent run returned with AwaitingTasks),
 /// this enqueues a mailbox wake dispatch so the thread gets a continuation run.
-///
-/// Uses `dedupe_key` to coalesce multiple task completions into one wake dispatch.
 pub struct TaskDoneMailboxNotify {
     mailbox: Arc<Mailbox>,
     thread_id: String,
@@ -248,6 +250,17 @@ pub trait RunDispatchExecutor: Send + Sync {
         sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError>;
 
+    /// Execute a run with an optional mailbox-provided thread cache.
+    async fn run_with_thread_context(
+        &self,
+        request: RunRequest,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        let _ = thread_ctx;
+        self.run(request, sink).await
+    }
+
     /// Cancel an active run by run id or thread id.
     fn cancel(&self, id: &str) -> bool;
 
@@ -256,6 +269,12 @@ pub trait RunDispatchExecutor: Send + Sync {
 
     /// Forward one human/tool decision to an active run.
     fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool;
+
+    /// Forward direct input messages to an active run.
+    fn send_messages(&self, id: &str, messages: Vec<Message>) -> bool {
+        let _ = (id, messages);
+        false
+    }
 }
 
 #[async_trait]
@@ -268,6 +287,15 @@ impl RunDispatchExecutor for AgentRuntime {
         AgentRuntime::run(self, request, sink).await
     }
 
+    async fn run_with_thread_context(
+        &self,
+        request: RunRequest,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        AgentRuntime::run_with_thread_context(self, request, sink, thread_ctx).await
+    }
+
     fn cancel(&self, id: &str) -> bool {
         AgentRuntime::cancel(self, id)
     }
@@ -278,6 +306,10 @@ impl RunDispatchExecutor for AgentRuntime {
 
     fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool {
         AgentRuntime::send_decision(self, id, tool_call_id, resume)
+    }
+
+    fn send_messages(&self, id: &str, messages: Vec<Message>) -> bool {
+        AgentRuntime::send_messages(self, id, messages)
     }
 }
 
@@ -447,20 +479,66 @@ enum MailboxWorkerStatus {
     Claiming,
     Running {
         dispatch_id: String,
+        run_id: String,
         lease_handle: JoinHandle<()>,
         sink: Arc<ReconnectableEventSink>,
     },
 }
 
+/// Cached thread state, valid for the duration of a lease.
+struct ThreadContext {
+    messages: Vec<Message>,
+    latest_run: Option<RunRecord>,
+    run_cache: HashMap<String, RunRecord>,
+}
+
+impl ThreadContext {
+    async fn load(run_store: &dyn ThreadRunStore, thread_id: &str) -> Result<Self, MailboxError> {
+        let messages = run_store
+            .load_messages(thread_id)
+            .await?
+            .unwrap_or_default();
+        let latest_run = run_store.latest_run(thread_id).await?;
+        let mut run_cache = HashMap::new();
+        if let Some(ref run) = latest_run {
+            run_cache.insert(run.run_id.clone(), run.clone());
+        }
+        Ok(Self {
+            messages,
+            latest_run,
+            run_cache,
+        })
+    }
+
+    fn get_run(&self, run_id: &str) -> Option<&RunRecord> {
+        self.run_cache.get(run_id)
+    }
+
+    fn reusable_waiting_run_id(&self) -> Option<&str> {
+        self.latest_run
+            .as_ref()
+            .filter(|r| r.is_resumable_waiting())
+            .map(|r| r.run_id.as_str())
+    }
+
+    fn apply_checkpoint(&mut self, messages: &[Message], run: &RunRecord) {
+        self.messages = messages.to_vec();
+        self.latest_run = Some(run.clone());
+        self.run_cache.insert(run.run_id.clone(), run.clone());
+    }
+}
+
 /// Per-thread worker. Store is the sole queue authority.
 struct MailboxWorker {
     status: MailboxWorkerStatus,
+    thread_ctx: Option<ThreadContext>,
 }
 
 impl Default for MailboxWorker {
     fn default() -> Self {
         Self {
             status: MailboxWorkerStatus::Idle,
+            thread_ctx: None,
         }
     }
 }
@@ -521,7 +599,7 @@ pub struct Mailbox {
     store: Arc<dyn MailboxStore>,
     run_store: Arc<dyn ThreadRunStore>,
     consumer_id: String,
-    workers: RwLock<HashMap<String, Arc<Mutex<MailboxWorker>>>>,
+    workers: RwLock<HashMap<String, Arc<SyncMutex<MailboxWorker>>>>,
     config: MailboxConfig,
     lifecycle_tasks: Arc<StdMutex<Option<MailboxLifecycleTasks>>>,
     lifecycle_start_lock: Arc<Mutex<()>>,
@@ -588,14 +666,17 @@ impl Mailbox {
         match self.store.interrupt(&thread_id, now).await {
             Ok(interrupt) => {
                 // Step 2: Cancel active runtime run if the interrupt found one.
-                if interrupt.active_dispatch.is_some()
-                    && self.executor.cancel_and_wait_by_thread(&thread_id).await
-                {
-                    tracing::info!(
-                        thread_id = %thread_id,
-                        superseded = interrupt.superseded_count,
-                        "interrupted thread for new submission"
-                    );
+                if let Some(active_dispatch) = interrupt.active_dispatch.as_ref() {
+                    let cancelled = self
+                        .cancel_active_dispatch(&thread_id, active_dispatch, true)
+                        .await?;
+                    if cancelled {
+                        tracing::info!(
+                            thread_id = %thread_id,
+                            superseded = interrupt.superseded_count,
+                            "interrupted thread for new submission"
+                        );
+                    }
                 }
             }
             Err(e) => {
@@ -645,12 +726,23 @@ impl Mailbox {
             // Create reconnectable sink for SSE reconnection on resume.
             let reconnectable_sink = Arc::new(ReconnectableEventSink::new(event_tx.clone()));
 
+            // Pre-warm thread context cache.
+            let thread_ctx = match ThreadContext::load(self.run_store.as_ref(), &thread_id).await {
+                Ok(ctx) => Some(ctx),
+                Err(e) => {
+                    tracing::warn!(thread_id, error = %e, "failed to pre-warm thread context");
+                    None
+                }
+            };
+
             // Update worker state.
             let worker = self.get_or_create_worker(&thread_id).await;
             {
-                let mut w = worker.lock().await;
+                let mut w = worker.lock();
+                w.thread_ctx = thread_ctx;
                 w.status = MailboxWorkerStatus::Running {
                     dispatch_id: dispatch_id.clone(),
+                    run_id: run_id.clone(),
                     lease_handle,
                     sink: Arc::clone(&reconnectable_sink),
                 };
@@ -715,23 +807,11 @@ impl Mailbox {
 
         // Dispatch via try_dispatch_next which handles Idle → Claiming atomically.
         self.get_or_create_worker(&thread_id).await;
-        self.try_dispatch_next(&thread_id).await;
-
-        // Check if this dispatch was claimed (Running) or is still Queued.
-        let status = {
-            let workers = self.workers.read().await;
-            if let Some(worker) = workers.get(&thread_id) {
-                let w = worker.lock().await;
-                match &w.status {
-                    MailboxWorkerStatus::Running {
-                        dispatch_id: running_id,
-                        ..
-                    } if *running_id == dispatch_id => MailboxDispatchStatus::Running,
-                    _ => MailboxDispatchStatus::Queued,
-                }
-            } else {
-                MailboxDispatchStatus::Queued
-            }
+        let claimed = self.try_dispatch_next(&thread_id).await;
+        let status = if claimed {
+            MailboxDispatchStatus::Running
+        } else {
+            MailboxDispatchStatus::Queued
         };
 
         Ok(MailboxSubmitResult {
@@ -740,6 +820,56 @@ impl Mailbox {
             thread_id,
             status,
         })
+    }
+
+    /// Try to steer the currently active run first, then fall back to the
+    /// durable mailbox queue when live delivery is unavailable.
+    ///
+    /// # Delivery semantics
+    ///
+    /// **At-least-once** across the live + durable paths. The owning
+    /// node's forwarder acks a live command only after `InboxSender::
+    /// try_send` has returned success, so `Delivered` means the run has
+    /// the message. However — and this is the distributed edge case —
+    /// there is still a window where:
+    ///
+    /// 1. The forwarder hands the message to the run (`try_send` ok).
+    /// 2. The ack publish to the producer's reply subject drops or
+    ///    times out (network blip, broker partition).
+    /// 3. Producer observes `NoSubscriber` and falls back to
+    ///    [`Mailbox::submit_background`], which enqueues a fresh
+    ///    durable dispatch carrying the same messages.
+    /// 4. When the current run ends, the queued dispatch executes and
+    ///    the user-visible message history contains duplicates.
+    ///
+    /// `RunRequest` does not expose dispatch-level dedupe. Callers that need
+    /// exactly-once effects must drive idempotency at the application layer
+    /// (e.g., unique
+    ///   message IDs normalized via `normalize_message_ids`; agent
+    ///   state that rejects redundant inputs).
+    #[tracing::instrument(skip(self, request), fields(thread_id = %request.thread_id))]
+    pub async fn submit_live_then_queue(
+        self: &Arc<Self>,
+        mut request: RunRequest,
+        expected_run_id: Option<&str>,
+    ) -> Result<MailboxSubmitResult, MailboxError> {
+        let (thread_id, messages) = validate_run_inputs(
+            request.thread_id.clone(),
+            request.messages.clone(),
+            !request.decisions.is_empty(),
+        )?;
+        let messages = normalize_message_ids(&messages);
+
+        if let Some(result) = self
+            .try_deliver_live_messages(&thread_id, expected_run_id, messages.clone())
+            .await?
+        {
+            return Ok(result);
+        }
+
+        request.thread_id = thread_id;
+        request.messages = messages;
+        self.submit_background(request).await
     }
 
     // ── Control ──────────────────────────────────────────────────────
@@ -757,7 +887,28 @@ impl Mailbox {
         }
 
         // Try runtime cancel (for Claimed/Running dispatches).
-        Ok(self.executor.cancel(id))
+        if self.executor.cancel(id) {
+            return Ok(true);
+        }
+
+        if let Some(dispatch) = self.store.load_dispatch(id).await?
+            && dispatch.status == RunDispatchStatus::Claimed
+        {
+            return self.deliver_live_cancel(&dispatch.thread_id).await;
+        }
+
+        let run = if let Some(run) = self.run_store.load_run(id).await? {
+            Some(run)
+        } else {
+            self.run_store.latest_run(id).await?
+        };
+        if let Some(run) = run
+            && matches!(run.status, RunStatus::Running | RunStatus::Waiting)
+        {
+            return self.deliver_live_cancel(&run.thread_id).await;
+        }
+
+        Ok(false)
     }
 
     /// Interrupt a thread: bump dispatch epoch, supersede all pending,
@@ -767,8 +918,9 @@ impl Mailbox {
         let result = self.store.interrupt(thread_id, now).await?;
 
         // Cancel active runtime run if any.
-        if result.active_dispatch.is_some() {
-            self.executor.cancel(thread_id);
+        if let Some(active_dispatch) = result.active_dispatch.as_ref() {
+            self.cancel_active_dispatch(thread_id, active_dispatch, false)
+                .await?;
         }
 
         Ok(result)
@@ -777,6 +929,151 @@ impl Mailbox {
     /// Forward a tool-call decision to an active run.
     pub fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool {
         self.executor.send_decision(id, tool_call_id, resume)
+    }
+
+    async fn cancel_active_dispatch(
+        &self,
+        thread_id: &str,
+        active_dispatch: &RunDispatch,
+        wait_for_release: bool,
+    ) -> Result<bool, MailboxError> {
+        if wait_for_release {
+            if self.executor.cancel_and_wait_by_thread(thread_id).await {
+                return Ok(true);
+            }
+        } else if self.executor.cancel(thread_id) {
+            return Ok(true);
+        }
+
+        if !self.deliver_live_cancel(thread_id).await? {
+            return Ok(false);
+        }
+
+        if wait_for_release
+            && !self
+                .wait_for_dispatch_not_claimed(&active_dispatch.dispatch_id)
+                .await?
+        {
+            tracing::warn!(
+                thread_id,
+                dispatch_id = %active_dispatch.dispatch_id,
+                "remote cancel delivered but active dispatch did not release before foreground submit"
+            );
+        }
+        Ok(true)
+    }
+
+    async fn deliver_live_cancel(&self, thread_id: &str) -> Result<bool, MailboxError> {
+        match self
+            .store
+            .deliver_live(thread_id, LiveRunCommand::Cancel)
+            .await?
+        {
+            LiveDeliveryOutcome::Delivered => Ok(true),
+            LiveDeliveryOutcome::NoSubscriber => Ok(false),
+        }
+    }
+
+    async fn wait_for_dispatch_not_claimed(&self, dispatch_id: &str) -> Result<bool, MailboxError> {
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(REMOTE_CANCEL_WAIT_MS);
+        loop {
+            match self.store.load_dispatch(dispatch_id).await? {
+                Some(dispatch) if dispatch.status == RunDispatchStatus::Claimed => {}
+                _ => return Ok(true),
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Ok(false);
+            }
+            tokio::time::sleep(Duration::from_millis(REMOTE_CANCEL_POLL_MS)).await;
+        }
+    }
+
+    async fn try_deliver_live_messages(
+        &self,
+        thread_id: &str,
+        expected_run_id: Option<&str>,
+        messages: Vec<Message>,
+    ) -> Result<Option<MailboxSubmitResult>, MailboxError> {
+        if messages.is_empty() {
+            return Ok(None);
+        }
+
+        let local_active = {
+            let workers = self.workers.read().await;
+            workers.get(thread_id).and_then(|worker| {
+                let worker = worker.lock();
+                match &worker.status {
+                    MailboxWorkerStatus::Running {
+                        dispatch_id,
+                        run_id,
+                        ..
+                    } => Some((dispatch_id.clone(), run_id.clone())),
+                    MailboxWorkerStatus::Idle | MailboxWorkerStatus::Claiming => None,
+                }
+            })
+        };
+
+        if let Some((active_dispatch_id, active_run_id)) = local_active {
+            // Race guard against a run that just rolled over.
+            if expected_run_id.is_some_and(|expected| expected != active_run_id) {
+                return Ok(None);
+            }
+            // Local fast path: executor has a direct handle to the run's
+            // inbox and returns a boolean indicating whether the channel
+            // accepted the payload. A `false` here means the local run
+            // just ended — fall back to durable dispatch.
+            if !self.executor.send_messages(&active_run_id, messages) {
+                return Ok(None);
+            }
+            return Ok(Some(MailboxSubmitResult {
+                dispatch_id: active_dispatch_id,
+                run_id: active_run_id,
+                thread_id: thread_id.to_string(),
+                status: MailboxDispatchStatus::Running,
+            }));
+        }
+
+        // No local worker: check whether another node is running this
+        // thread. `ThreadRunStore::latest_run` is the global truth (every
+        // node checkpoints to the same store).
+        let Some(remote_run) = self.run_store.latest_run(thread_id).await? else {
+            return Ok(None);
+        };
+        if remote_run.status != RunStatus::Running {
+            return Ok(None);
+        }
+        if expected_run_id.is_some_and(|expected| expected != remote_run.run_id) {
+            return Ok(None);
+        }
+
+        // Cross-node: ask the store to deliver. If the owning node's
+        // forwarder isn't subscribed yet, `deliver_live` reports
+        // `NoSubscriber` and we fall through so `submit_live_then_queue`
+        // enqueues a durable dispatch instead of silently dropping.
+        let outcome = self
+            .store
+            .deliver_live(
+                thread_id,
+                awaken_contract::contract::mailbox::LiveRunCommand::Messages(messages),
+            )
+            .await?;
+        match outcome {
+            awaken_contract::contract::mailbox::LiveDeliveryOutcome::Delivered => {}
+            awaken_contract::contract::mailbox::LiveDeliveryOutcome::NoSubscriber => {
+                return Ok(None);
+            }
+        }
+
+        let dispatch_id = remote_run
+            .dispatch_id
+            .clone()
+            .unwrap_or_else(|| remote_run.run_id.clone());
+        Ok(Some(MailboxSubmitResult {
+            dispatch_id,
+            run_id: remote_run.run_id,
+            thread_id: thread_id.to_string(),
+            status: MailboxDispatchStatus::Running,
+        }))
     }
 
     /// Reconnect the event sink for an active (suspended) run.
@@ -788,7 +1085,7 @@ impl Mailbox {
         let Some(worker) = workers.get(thread_id) else {
             return false;
         };
-        let w = worker.lock().await;
+        let w = worker.lock();
         match &w.status {
             MailboxWorkerStatus::Running { sink, .. } => {
                 sink.reconnect(new_tx);
@@ -799,6 +1096,18 @@ impl Mailbox {
     }
 
     async fn reusable_waiting_run_id(&self, thread_id: &str) -> Option<String> {
+        // Fast path: check worker cache.
+        {
+            let workers = self.workers.read().await;
+            if let Some(worker) = workers.get(thread_id) {
+                let w = worker.lock();
+                if let Some(ref ctx) = w.thread_ctx {
+                    return ctx.reusable_waiting_run_id().map(|s| s.to_string());
+                }
+            }
+        }
+
+        // Slow path: fall back to store.
         if let Some(thread) = self.run_store.load_thread(thread_id).await.ok().flatten()
             && let Some(open_run_id) = thread.open_run_id.as_deref()
             && let Some(run) = self.run_store.load_run(open_run_id).await.ok().flatten()
@@ -1125,6 +1434,15 @@ impl Mailbox {
             Arc::clone(&suspended),
         );
 
+        // Pre-warm thread context cache.
+        let thread_ctx = match ThreadContext::load(self.run_store.as_ref(), thread_id).await {
+            Ok(ctx) => Some(ctx),
+            Err(e) => {
+                tracing::warn!(thread_id, error = %e, "failed to pre-warm thread context");
+                None
+            }
+        };
+
         // Create channel for background dispatch (events go nowhere unless observed).
         let (event_tx, _event_rx) = mpsc::channel(Self::EVENT_CHANNEL_CAPACITY);
         let reconnectable_sink = Arc::new(ReconnectableEventSink::new(event_tx.clone()));
@@ -1132,9 +1450,11 @@ impl Mailbox {
         // Update worker state.
         let worker = self.get_or_create_worker(thread_id).await;
         {
-            let mut w = worker.lock().await;
+            let mut w = worker.lock();
+            w.thread_ctx = thread_ctx;
             w.status = MailboxWorkerStatus::Running {
                 dispatch_id: dispatch_id.clone(),
+                run_id: dispatch.run_id.clone(),
                 lease_handle,
                 sink: Arc::clone(&reconnectable_sink),
             };
@@ -1151,26 +1471,28 @@ impl Mailbox {
     }
 
     /// Claim from store and execute the next dispatch for this thread.
+    /// Returns `true` if the worker transitioned to Claiming (dispatch in progress).
     #[tracing::instrument(skip(self), fields(thread_id = %thread_id))]
-    async fn try_dispatch_next(self: &Arc<Self>, thread_id: &str) {
+    async fn try_dispatch_next(self: &Arc<Self>, thread_id: &str) -> bool {
         let worker = {
             let workers = self.workers.read().await;
             match workers.get(thread_id) {
                 Some(w) => Arc::clone(w),
-                None => return,
+                None => return false,
             }
         };
 
         // Atomically transition Idle → Claiming to prevent TOCTOU race.
         {
-            let mut w = worker.lock().await;
+            let mut w = worker.lock();
             if !matches!(w.status, MailboxWorkerStatus::Idle) {
-                return;
+                return false;
             }
             w.status = MailboxWorkerStatus::Claiming;
         }
 
         self.dispatch_next_claim(thread_id).await;
+        true
     }
 
     /// Spawn a lease renewal task that periodically extends the lease.
@@ -1307,6 +1629,19 @@ impl Mailbox {
             {
                 tracing::warn!(dispatch_id, run_id, error = %e, "failed to record mailbox dispatch start");
             }
+            let thread_ctx = {
+                let workers = this.workers.read().await;
+                workers.get(&thread_id).and_then(|worker| {
+                    let w = worker.lock();
+                    w.thread_ctx.as_ref().map(|ctx| {
+                        ThreadContextSnapshot::new(
+                            ctx.messages.clone(),
+                            ctx.latest_run.clone(),
+                            ctx.run_cache.clone(),
+                        )
+                    })
+                })
+            };
             let continue_run_id = request.continue_run_id.clone();
             let (inbox_sender, inbox_receiver) = awaken_runtime::inbox::inbox_channel_with_fallback(
                 Arc::new(TaskDoneMailboxNotify::new(
@@ -1317,7 +1652,10 @@ impl Mailbox {
             );
             request = request.with_inbox(inbox_sender, inbox_receiver);
 
-            let result = this.executor.run(request, Arc::new(sink)).await;
+            let result = this
+                .executor
+                .run_with_thread_context(request, Arc::new(sink), thread_ctx)
+                .await;
             let now = now_ms();
             let run_result = mailbox_run_result(&run_id, &dispatch_instance_id, &result);
             if let Err(e) = this
@@ -1400,7 +1738,7 @@ impl Mailbox {
             // Abort lease renewal.
             let worker = this.get_or_create_worker(&thread_id).await;
             {
-                let mut w = worker.lock().await;
+                let mut w = worker.lock();
                 let should_transition = matches!(
                     &w.status,
                     MailboxWorkerStatus::Running { dispatch_id: cid, .. } if *cid == dispatch_id
@@ -1408,6 +1746,7 @@ impl Mailbox {
                 if should_transition {
                     // Take ownership of the old status to abort the lease handle.
                     let old = std::mem::replace(&mut w.status, MailboxWorkerStatus::Idle);
+                    w.thread_ctx = None;
                     if let MailboxWorkerStatus::Running { lease_handle, .. } = old {
                         lease_handle.abort();
                     }
@@ -1420,7 +1759,7 @@ impl Mailbox {
     }
 
     /// Get or create a per-thread worker.
-    async fn get_or_create_worker(&self, thread_id: &str) -> Arc<Mutex<MailboxWorker>> {
+    async fn get_or_create_worker(&self, thread_id: &str) -> Arc<SyncMutex<MailboxWorker>> {
         // Fast path: read lock.
         {
             let workers = self.workers.read().await;
@@ -1433,7 +1772,7 @@ impl Mailbox {
         Arc::clone(
             workers
                 .entry(thread_id.to_string())
-                .or_insert_with(|| Arc::new(Mutex::new(MailboxWorker::default()))),
+                .or_insert_with(|| Arc::new(SyncMutex::new(MailboxWorker::default()))),
         )
     }
 
@@ -1462,12 +1801,26 @@ impl Mailbox {
         }
 
         let normalized_messages = normalize_message_ids(messages);
-        let existing_messages = self
-            .run_store
-            .load_messages(thread_id)
-            .await?
-            .unwrap_or_default();
-        let previous_run = self.run_store.latest_run(thread_id).await?;
+        let (existing_messages, previous_run) = {
+            let workers = self.workers.read().await;
+            let cached = workers.get(thread_id).and_then(|w| {
+                let w = w.lock();
+                w.thread_ctx
+                    .as_ref()
+                    .map(|ctx| (ctx.messages.clone(), ctx.latest_run.clone()))
+            });
+            if let Some((msgs, run)) = cached {
+                (msgs, run)
+            } else {
+                let msgs = self
+                    .run_store
+                    .load_messages(thread_id)
+                    .await?
+                    .unwrap_or_default();
+                let run = self.run_store.latest_run(thread_id).await?;
+                (msgs, run)
+            }
+        };
         let mut appended_messages = existing_messages;
         appended_messages.extend(normalized_messages.iter().cloned());
         let input_message_ids = normalized_messages
@@ -1506,7 +1859,21 @@ impl Mailbox {
             compacted_snapshot_id: None,
         });
 
-        if let Some(mut existing) = self.run_store.load_run(&run_id).await? {
+        let cached_run = {
+            let workers = self.workers.read().await;
+            workers.get(thread_id).and_then(|w| {
+                let w = w.lock();
+                w.thread_ctx
+                    .as_ref()
+                    .and_then(|ctx| ctx.get_run(&run_id).cloned())
+            })
+        };
+        let existing_run = if let Some(run) = cached_run {
+            Some(run)
+        } else {
+            self.run_store.load_run(&run_id).await?
+        };
+        if let Some(mut existing) = existing_run {
             if existing.thread_id != thread_id {
                 return Err(MailboxError::Validation(format!(
                     "run_id '{run_id}' belongs to thread '{}', not '{thread_id}'",
@@ -1524,6 +1891,15 @@ impl Mailbox {
             self.run_store
                 .checkpoint(thread_id, &appended_messages, &existing)
                 .await?;
+            {
+                let workers = self.workers.read().await;
+                if let Some(worker) = workers.get(thread_id) {
+                    let mut w = worker.lock();
+                    if let Some(ref mut ctx) = w.thread_ctx {
+                        ctx.apply_checkpoint(&appended_messages, &existing);
+                    }
+                }
+            }
             return Ok(run_id);
         }
 
@@ -1571,6 +1947,15 @@ impl Mailbox {
         self.run_store
             .checkpoint(thread_id, &appended_messages, &record)
             .await?;
+        {
+            let workers = self.workers.read().await;
+            if let Some(worker) = workers.get(thread_id) {
+                let mut w = worker.lock();
+                if let Some(ref mut ctx) = w.thread_ctx {
+                    ctx.apply_checkpoint(&appended_messages, &record);
+                }
+            }
+        }
         Ok(run_id)
     }
 
@@ -1619,16 +2004,30 @@ impl Mailbox {
         &self,
         dispatch: &RunDispatch,
     ) -> Result<RunRequest, MailboxError> {
-        let run = self
-            .run_store
-            .load_run(&dispatch.run_id)
-            .await?
-            .ok_or_else(|| {
-                MailboxError::Validation(format!(
-                    "run '{}' not found for dispatch '{}'",
-                    dispatch.run_id, dispatch.dispatch_id
-                ))
-            })?;
+        let run = {
+            let cached = {
+                let workers = self.workers.read().await;
+                workers.get(&dispatch.thread_id).and_then(|w| {
+                    let w = w.lock();
+                    w.thread_ctx
+                        .as_ref()
+                        .and_then(|ctx| ctx.get_run(&dispatch.run_id).cloned())
+                })
+            };
+            if let Some(run) = cached {
+                run
+            } else {
+                self.run_store
+                    .load_run(&dispatch.run_id)
+                    .await?
+                    .ok_or_else(|| {
+                        MailboxError::Validation(format!(
+                            "run '{}' not found for dispatch '{}'",
+                            dispatch.run_id, dispatch.dispatch_id
+                        ))
+                    })?
+            }
+        };
         if run.thread_id != dispatch.thread_id {
             return Err(MailboxError::Validation(format!(
                 "run '{}' belongs to thread '{}', not dispatch thread '{}'",
@@ -1689,6 +2088,27 @@ impl Mailbox {
     ) -> Result<Vec<Message>, MailboxError> {
         if snapshot.input_message_ids.is_empty() {
             return self.activation_messages_from_range(run, snapshot).await;
+        }
+        // Try cache first for message lookups.
+        let cached_messages: Option<Vec<Message>> = {
+            let workers = self.workers.read().await;
+            workers.get(&run.thread_id).and_then(|w| {
+                let w = w.lock();
+                w.thread_ctx.as_ref().and_then(|ctx| {
+                    let mut msgs = Vec::with_capacity(snapshot.input_message_ids.len());
+                    for msg_id in &snapshot.input_message_ids {
+                        let found = ctx
+                            .messages
+                            .iter()
+                            .find(|m| m.id.as_deref() == Some(msg_id.as_str()));
+                        msgs.push(found?.clone());
+                    }
+                    Some(msgs)
+                })
+            })
+        };
+        if let Some(msgs) = cached_messages {
+            return Ok(msgs);
         }
         let mut messages = Vec::with_capacity(snapshot.input_message_ids.len());
         for message_id in &snapshot.input_message_ids {
@@ -1784,7 +2204,7 @@ impl Mailbox {
             let workers = self.workers.read().await;
             let mut keys = Vec::new();
             for (thread_id, worker) in workers.iter() {
-                let w = worker.lock().await;
+                let w = worker.lock();
                 if matches!(w.status, MailboxWorkerStatus::Idle) {
                     keys.push(thread_id.clone());
                 }
@@ -1802,7 +2222,7 @@ impl Mailbox {
         for thread_id in &idle_keys {
             // Re-check under write lock: status might have changed.
             let still_idle = if let Some(worker) = workers.get(thread_id) {
-                let w = worker.lock().await;
+                let w = worker.lock();
                 matches!(w.status, MailboxWorkerStatus::Idle)
             } else {
                 false
@@ -1839,12 +2259,12 @@ impl Mailbox {
 /// Revert worker from Claiming → Idle, but only if still in Claiming state.
 /// Prevents overwriting a Running state set by a concurrent dispatch.
 async fn revert_claiming_to_idle(
-    workers: &tokio::sync::RwLock<HashMap<String, Arc<tokio::sync::Mutex<MailboxWorker>>>>,
+    workers: &RwLock<HashMap<String, Arc<SyncMutex<MailboxWorker>>>>,
     thread_id: &str,
 ) {
     let workers = workers.read().await;
     if let Some(worker) = workers.get(thread_id) {
-        let mut w = worker.lock().await;
+        let mut w = worker.lock();
         if matches!(w.status, MailboxWorkerStatus::Claiming) {
             w.status = MailboxWorkerStatus::Idle;
         }
@@ -2287,6 +2707,10 @@ mod tests {
         fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
             false
         }
+
+        fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+            false
+        }
     }
 
     struct RecordedMailboxRequest {
@@ -2339,6 +2763,10 @@ mod tests {
         }
 
         fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+            false
+        }
+
+        fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
             false
         }
     }
@@ -2402,6 +2830,10 @@ mod tests {
         fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
             false
         }
+
+        fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+            false
+        }
     }
 
     struct ScriptedLlm {
@@ -2438,6 +2870,49 @@ mod tests {
 
         fn name(&self) -> &str {
             "scripted"
+        }
+    }
+
+    struct RecordingLlm {
+        responses: StdMutex<Vec<StreamResult>>,
+        requests: Arc<StdMutex<Vec<InferenceRequest>>>,
+    }
+
+    impl RecordingLlm {
+        fn new(
+            responses: Vec<StreamResult>,
+            requests: Arc<StdMutex<Vec<InferenceRequest>>>,
+        ) -> Self {
+            Self {
+                responses: StdMutex::new(responses),
+                requests,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmExecutor for RecordingLlm {
+        async fn execute(
+            &self,
+            request: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            self.requests.lock().expect("lock poisoned").push(request);
+            let mut responses = self.responses.lock().expect("lock poisoned");
+            if responses.is_empty() {
+                Ok(StreamResult {
+                    content: vec![ContentBlock::text("done")],
+                    tool_calls: vec![],
+                    usage: None,
+                    stop_reason: Some(StopReason::EndTurn),
+                    has_incomplete_tool_calls: false,
+                })
+            } else {
+                Ok(responses.remove(0))
+            }
+        }
+
+        fn name(&self) -> &str {
+            "recording"
         }
     }
 
@@ -2486,6 +2961,45 @@ mod tests {
                 .await
                 .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
             Ok(ToolResult::success("spawn_bg", json!({"spawned": true})).into())
+        }
+    }
+
+    struct BlockingTool {
+        started: StdMutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: tokio::sync::Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+    }
+
+    impl BlockingTool {
+        fn new(
+            started: tokio::sync::oneshot::Sender<()>,
+            release: tokio::sync::oneshot::Receiver<()>,
+        ) -> Self {
+            Self {
+                started: StdMutex::new(Some(started)),
+                release: tokio::sync::Mutex::new(Some(release)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn descriptor(&self) -> ToolDescriptor {
+            ToolDescriptor::new("block", "block", "wait until released")
+        }
+
+        async fn execute(
+            &self,
+            _args: Value,
+            _ctx: &ToolCallContext,
+        ) -> Result<ToolOutput, ToolError> {
+            if let Some(started) = self.started.lock().expect("lock poisoned").take() {
+                let _ = started.send(());
+            }
+            let release = self.release.lock().await.take();
+            if let Some(release) = release {
+                let _ = release.await;
+            }
+            Ok(ToolResult::success("block", json!({"released": true})).into())
         }
     }
 
@@ -3971,7 +4485,9 @@ mod tests {
 
     #[test]
     fn dispatch_status_queued_zero() {
+        let running = MailboxDispatchStatus::Running;
         let status = MailboxDispatchStatus::Queued;
+        assert!(matches!(running, MailboxDispatchStatus::Running));
         assert!(matches!(status, MailboxDispatchStatus::Queued));
     }
 
@@ -4011,6 +4527,591 @@ mod tests {
             result.status,
             MailboxDispatchStatus::Running | MailboxDispatchStatus::Queued
         ));
+    }
+
+    #[tokio::test]
+    async fn live_then_queue_steers_active_run_without_new_dispatch() {
+        let store = Arc::new(InMemoryStore::new());
+        let mailbox_store = make_store();
+        let requests = Arc::new(StdMutex::new(Vec::new()));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let llm = Arc::new(RecordingLlm::new(
+            vec![
+                StreamResult {
+                    content: vec![ContentBlock::text("start tool")],
+                    tool_calls: vec![ToolCall::new("block-1", "block", json!({}))],
+                    usage: None,
+                    stop_reason: Some(StopReason::ToolUse),
+                    has_incomplete_tool_calls: false,
+                },
+                StreamResult {
+                    content: vec![ContentBlock::text("saw live input")],
+                    tool_calls: vec![],
+                    usage: None,
+                    stop_reason: Some(StopReason::EndTurn),
+                    has_incomplete_tool_calls: false,
+                },
+            ],
+            requests.clone(),
+        ));
+        let resolver = Arc::new(FixedResolver {
+            agent: ResolvedAgent::new("agent", "m", "sys", llm)
+                .with_tool(Arc::new(BlockingTool::new(started_tx, release_rx))),
+            plugins: vec![],
+        });
+        let runtime = Arc::new(
+            AgentRuntime::new(resolver)
+                .with_thread_run_store(store.clone() as Arc<dyn ThreadRunStore>)
+                .with_mailbox_store(mailbox_store.clone()),
+        );
+        let mailbox = make_mailbox_with_run_store(
+            runtime,
+            mailbox_store.clone(),
+            store.clone() as Arc<dyn ThreadRunStore>,
+        );
+
+        let first = mailbox
+            .submit_background(
+                RunRequest::new("thread-live-steer", vec![Message::user("start")])
+                    .with_agent_id("agent"),
+            )
+            .await
+            .expect("initial submit should start");
+
+        tokio::time::timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("tool should start")
+            .expect("started signal should send");
+
+        let steered = mailbox
+            .submit_live_then_queue(
+                RunRequest::new("thread-live-steer", vec![Message::user("live steer")])
+                    .with_agent_id("agent"),
+                None,
+            )
+            .await
+            .expect("live steer should be accepted");
+        assert_eq!(steered.status, MailboxDispatchStatus::Running);
+        assert_eq!(steered.run_id, first.run_id);
+        assert_eq!(steered.dispatch_id, first.dispatch_id);
+
+        let _ = release_tx.send(());
+        let latest = wait_for_latest_run(&store, "thread-live-steer", |run| {
+            run.status == RunStatus::Done
+        })
+        .await;
+        assert_eq!(latest.run_id, first.run_id);
+
+        let live_message_seen = {
+            let recorded = requests.lock().expect("lock poisoned");
+            assert_eq!(recorded.len(), 2);
+            recorded[1].messages.iter().any(|message| {
+                message.text() == "live steer"
+                    && message.role == awaken_contract::contract::message::Role::User
+                    && message.visibility == awaken_contract::contract::message::Visibility::All
+            })
+        };
+        assert!(
+            live_message_seen,
+            "second LLM turn should receive the live user message"
+        );
+
+        let messages = store
+            .load_messages("thread-live-steer")
+            .await
+            .expect("load messages")
+            .expect("messages should be persisted");
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.text() == "live steer")
+                .count(),
+            1,
+            "live message should be persisted exactly once"
+        );
+
+        let dispatches = mailbox_store
+            .list_dispatches("thread-live-steer", None, 10, 0)
+            .await
+            .expect("list dispatches");
+        assert_eq!(
+            dispatches
+                .iter()
+                .filter(|dispatch| dispatch.run_id == first.run_id)
+                .count(),
+            1,
+            "live steering must not create an extra dispatch"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_then_queue_falls_back_to_durable_dispatch_when_receiver_unavailable() {
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+        let thread_id = "thread-live-fallback";
+        let mut active_request =
+            RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        let (_, active_messages) = validate_run_inputs(
+            active_request.thread_id.clone(),
+            active_request.messages.clone(),
+            false,
+        )
+        .expect("active input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut active_request, thread_id, &active_messages)
+            .await
+            .expect("prepare active run");
+        let active_dispatch = mailbox
+            .build_dispatch(&active_request, thread_id)
+            .expect("build active dispatch");
+        let active_dispatch_id = active_dispatch.dispatch_id.clone();
+        mailbox_store
+            .enqueue(&active_dispatch)
+            .await
+            .expect("enqueue active dispatch");
+        mailbox_store
+            .claim_dispatch(&active_dispatch_id, "test-consumer", 30_000, now_ms())
+            .await
+            .expect("claim active dispatch")
+            .expect("active dispatch should be claimed");
+        let worker = mailbox.get_or_create_worker(thread_id).await;
+        {
+            let mut worker = worker.lock();
+            worker.status = MailboxWorkerStatus::Running {
+                dispatch_id: active_dispatch_id.clone(),
+                run_id: active_dispatch.run_id.clone(),
+                lease_handle: tokio::spawn(async {}),
+                sink: Arc::new(ReconnectableEventSink::new(mpsc::channel(16).0)),
+            };
+        }
+
+        let result = mailbox
+            .submit_live_then_queue(
+                RunRequest::new(thread_id, vec![Message::user("fallback")]).with_agent_id("agent"),
+                None,
+            )
+            .await
+            .expect("fallback submit should succeed");
+
+        assert_eq!(result.status, MailboxDispatchStatus::Queued);
+        assert_ne!(result.dispatch_id, active_dispatch_id);
+        let messages = thread_store
+            .load_messages(thread_id)
+            .await
+            .expect("load messages")
+            .expect("messages should exist");
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.text() == "fallback")
+                .count(),
+            1,
+            "fallback message should be persisted once"
+        );
+        let queued = mailbox_store
+            .list_dispatches(thread_id, Some(&[RunDispatchStatus::Queued]), 10, 0)
+            .await
+            .expect("list queued");
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].dispatch_id, result.dispatch_id);
+    }
+
+    #[tokio::test]
+    async fn foreground_submit_sends_live_cancel_for_remote_active_dispatch() {
+        use awaken_contract::contract::mailbox::LiveRunCommand;
+        use futures::StreamExt;
+
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(RecordingMailboxRuntime::default());
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "foreground-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+        let thread_id = "thread-remote-foreground";
+
+        let mut active_request =
+            RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        let (_, active_messages) = validate_run_inputs(
+            active_request.thread_id.clone(),
+            active_request.messages.clone(),
+            false,
+        )
+        .expect("active input should validate");
+        mailbox
+            .prepare_run_for_dispatch(&mut active_request, thread_id, &active_messages)
+            .await
+            .expect("prepare active run");
+        let active_dispatch = mailbox
+            .build_dispatch(&active_request, thread_id)
+            .expect("build active dispatch");
+        let active_dispatch_id = active_dispatch.dispatch_id.clone();
+        mailbox_store
+            .enqueue(&active_dispatch)
+            .await
+            .expect("enqueue active dispatch");
+        let claimed = mailbox_store
+            .claim_dispatch(&active_dispatch_id, "remote-consumer", 30_000, now_ms())
+            .await
+            .expect("claim active dispatch")
+            .expect("active dispatch should be claimed");
+        let active_claim_token = claimed.claim_token.clone().expect("claim token");
+
+        let subscriber = mailbox_store
+            .open_live_channel(thread_id)
+            .await
+            .expect("open live channel");
+        let captured = Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
+        let captured_clone = captured.clone();
+        let store_clone = mailbox_store.clone();
+        let active_dispatch_id_clone = active_dispatch_id.clone();
+        let active_claim_token_clone = active_claim_token.clone();
+        let _forwarder = tokio::spawn(async move {
+            let mut subscriber = subscriber;
+            while let Some(entry) = subscriber.next().await {
+                captured_clone.lock().await.push(entry.command.clone());
+                if matches!(entry.command, LiveRunCommand::Cancel) {
+                    store_clone
+                        .ack(
+                            &active_dispatch_id_clone,
+                            &active_claim_token_clone,
+                            now_ms(),
+                        )
+                        .await
+                        .expect("remote run should release active dispatch");
+                    entry.receipt.ack();
+                    break;
+                }
+                drop(entry.receipt);
+            }
+        });
+
+        let (submitted, _events) = mailbox
+            .submit(
+                RunRequest::new(thread_id, vec![Message::user("replacement")])
+                    .with_agent_id("agent"),
+            )
+            .await
+            .expect("foreground submit should cancel remote active run and claim replacement");
+
+        assert_eq!(submitted.status, MailboxDispatchStatus::Running);
+        assert_ne!(submitted.dispatch_id, active_dispatch_id);
+        let commands = captured.lock().await;
+        assert!(
+            commands
+                .iter()
+                .any(|command| matches!(command, LiveRunCommand::Cancel)),
+            "foreground submit must deliver live Cancel to the remote active run"
+        );
+    }
+
+    /// Cross-node live delivery: no local worker, but the thread has an
+    /// active Running run recorded globally in ThreadRunStore. Mailbox must
+    /// publish on the live channel (for the owning node's forwarder to
+    /// receive) and return Running rather than falling back.
+    #[tokio::test]
+    async fn live_then_queue_publishes_for_remote_active_run() {
+        use awaken_contract::contract::mailbox::LiveRunCommand;
+        use futures::StreamExt;
+
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let thread_id = "thread-remote";
+        let remote_run_id = "run-remote";
+
+        // Seed a Running run — simulates another node owning this run.
+        let mut run = seeded_waiting_run(remote_run_id, thread_id, "agent");
+        run.status = RunStatus::Running;
+        thread_store
+            .create_run(&run)
+            .await
+            .expect("seed remote run");
+
+        // Simulate the remote forwarder: drain the stream and ack each
+        // entry so the producer's `deliver_live` resolves as Delivered.
+        let subscriber = mailbox_store
+            .open_live_channel(thread_id)
+            .await
+            .expect("open live channel");
+        let captured = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
+        let captured_clone = captured.clone();
+        let _forwarder = tokio::spawn(async move {
+            let mut subscriber = subscriber;
+            while let Some(entry) = subscriber.next().await {
+                captured_clone.lock().await.push(entry.command.clone());
+                entry.receipt.ack();
+            }
+        });
+
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let result = mailbox
+            .submit_live_then_queue(
+                RunRequest::new(thread_id, vec![Message::user("steer-remote")])
+                    .with_agent_id("agent"),
+                None,
+            )
+            .await
+            .expect("submit should succeed");
+
+        assert_eq!(result.status, MailboxDispatchStatus::Running);
+        assert_eq!(result.run_id, remote_run_id);
+
+        // The acked subscriber must have captured the message.
+        let commands = captured.lock().await;
+        assert_eq!(commands.len(), 1);
+        match &commands[0] {
+            LiveRunCommand::Messages(msgs) => assert_eq!(msgs[0].text(), "steer-remote"),
+            other => panic!("expected Messages, got {other:?}"),
+        }
+        drop(commands);
+
+        // No new dispatch should have been enqueued.
+        let queued = mailbox_store
+            .list_dispatches(thread_id, Some(&[RunDispatchStatus::Queued]), 10, 0)
+            .await
+            .expect("list queued");
+        assert!(
+            queued.is_empty(),
+            "cross-node live delivery must not create a dispatch"
+        );
+    }
+
+    /// Regression for issue #2: cross-node delivery where the subscriber
+    /// drops the receipt (simulating inbox full / forwarder failure) must
+    /// fall back to durable queue, not report `Running`.
+    #[tokio::test]
+    async fn live_then_queue_falls_back_when_subscriber_drops_receipt() {
+        use futures::StreamExt;
+
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let thread_id = "thread-dropped-receipt";
+
+        let mut run = seeded_waiting_run("run-dropped", thread_id, "agent");
+        run.status = RunStatus::Running;
+        thread_store.create_run(&run).await.expect("seed run");
+
+        let subscriber = mailbox_store
+            .open_live_channel(thread_id)
+            .await
+            .expect("open live channel");
+        // Drop every receipt — simulates forwarder that can't hand off.
+        let _rogue = tokio::spawn(async move {
+            let mut subscriber = subscriber;
+            while let Some(entry) = subscriber.next().await {
+                drop(entry.receipt);
+            }
+        });
+
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let result = mailbox
+            .submit_live_then_queue(
+                RunRequest::new(thread_id, vec![Message::user("hello?")]).with_agent_id("agent"),
+                None,
+            )
+            .await
+            .expect("submit should succeed via queue fallback");
+
+        let dispatches = mailbox_store
+            .list_dispatches(thread_id, None, 10, 0)
+            .await
+            .expect("list dispatches");
+        assert_eq!(
+            dispatches.len(),
+            1,
+            "unacked receipt must force a durable dispatch"
+        );
+        assert_eq!(result.dispatch_id, dispatches[0].dispatch_id);
+    }
+
+    /// Contract test documenting the `submit_live_then_queue` at-least-once
+    /// guarantee: a forwarder that accepts the live command but whose ack
+    /// is lost (ack publish failure / network timeout) causes the producer
+    /// to observe `NoSubscriber` and fall back to durable dispatch, even
+    /// though the run has already received the payload. Callers needing
+    /// exactly-once effects must use agent-level idempotency.
+    #[tokio::test]
+    async fn live_then_queue_is_at_least_once_when_ack_lost() {
+        use futures::StreamExt;
+
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let thread_id = "thread-ack-lost";
+
+        let mut run = seeded_waiting_run("run-ack-lost", thread_id, "agent");
+        run.status = RunStatus::Running;
+        thread_store.create_run(&run).await.expect("seed run");
+
+        let subscriber = mailbox_store
+            .open_live_channel(thread_id)
+            .await
+            .expect("open live channel");
+        // Consumer captures the command (simulates `try_send` success)
+        // but drops the receipt (simulates the ack publish failing).
+        let accepted = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<String>::new()));
+        let accepted_c = accepted.clone();
+        let _consumer = tokio::spawn(async move {
+            let mut subscriber = subscriber;
+            while let Some(entry) = subscriber.next().await {
+                if let awaken_contract::contract::mailbox::LiveRunCommand::Messages(ref msgs) =
+                    entry.command
+                {
+                    for m in msgs {
+                        accepted_c.lock().await.push(m.text());
+                    }
+                }
+                // Forwarder accepted, but ack "publish" never happens.
+                drop(entry.receipt);
+            }
+        });
+
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let result = mailbox
+            .submit_live_then_queue(
+                RunRequest::new(thread_id, vec![Message::user("steer-payload")])
+                    .with_agent_id("agent"),
+                None,
+            )
+            .await
+            .expect("submit should succeed via queue fallback");
+
+        // Contract part 1: the forwarder DID receive the payload.
+        let received = accepted.lock().await.clone();
+        assert_eq!(
+            received.as_slice(),
+            &["steer-payload".to_string()],
+            "forwarder must have observed the live command before dropping receipt"
+        );
+
+        // Contract part 2: because the ack was "lost", submit fell back
+        // to durable dispatch — the SAME payload is now queued for a
+        // future run.  This is the at-least-once window.
+        let dispatches = mailbox_store
+            .list_dispatches(thread_id, None, 10, 0)
+            .await
+            .expect("list dispatches");
+        assert_eq!(dispatches.len(), 1);
+        assert_eq!(result.dispatch_id, dispatches[0].dispatch_id);
+    }
+
+    /// expected_run_id mismatch against a remote Running run must abort
+    /// live delivery and fall back to dispatch (preventing steering the
+    /// wrong run after a rollover).
+    #[tokio::test]
+    async fn live_then_queue_rejects_remote_mismatched_expected_run_id() {
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let thread_id = "thread-mismatch";
+
+        let mut run = seeded_waiting_run("run-actual", thread_id, "agent");
+        run.status = RunStatus::Running;
+        thread_store.create_run(&run).await.expect("seed run");
+
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let result = mailbox
+            .submit_live_then_queue(
+                RunRequest::new(thread_id, vec![Message::user("wrong-run")]).with_agent_id("agent"),
+                Some("run-stale"),
+            )
+            .await
+            .expect("submit should succeed");
+
+        assert_ne!(
+            result.run_id, "run-actual",
+            "mismatched expected_run_id must not steer the stale remote run"
+        );
+    }
+
+    /// Cross-node live delivery when **no subscriber** is attached to the
+    /// live channel must fall back to `submit_background` — never report
+    /// `Running` based on a publish the owning node will never observe.
+    #[tokio::test]
+    async fn live_then_queue_falls_back_to_queue_when_no_remote_subscriber() {
+        let mailbox_store = make_store();
+        let thread_store = Arc::new(InMemoryStore::new());
+        let thread_id = "thread-no-subscriber";
+
+        // Seed a Running run on some other (imaginary) node. Crucially,
+        // we do NOT call `open_live_channel` — no one is listening.
+        let mut run = seeded_waiting_run("run-no-listener", thread_id, "agent");
+        run.status = RunStatus::Running;
+        thread_store.create_run(&run).await.expect("seed run");
+
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        let mailbox = Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let result = mailbox
+            .submit_live_then_queue(
+                RunRequest::new(thread_id, vec![Message::user("hello?")]).with_agent_id("agent"),
+                None,
+            )
+            .await
+            .expect("submit should succeed via queue fallback");
+
+        // The submit must have entered the durable queue — a new dispatch
+        // appears whether Queued or Claimed (depending on whether a worker
+        // picks it up). The key property is: a dispatch was enqueued rather
+        // than silently declared `Running` on the remote.
+        let all_dispatches = mailbox_store
+            .list_dispatches(thread_id, None, 10, 0)
+            .await
+            .expect("list dispatches");
+        assert_eq!(
+            all_dispatches.len(),
+            1,
+            "no-subscriber cross-node must fall back to durable queue"
+        );
+        assert_eq!(result.dispatch_id, all_dispatches[0].dispatch_id);
     }
 
     #[tokio::test]
@@ -4484,7 +5585,7 @@ mod tests {
         // Worker should be Running (or Claiming).
         let workers = mailbox.workers.read().await;
         if let Some(worker) = workers.get("thread-guard") {
-            let w = worker.lock().await;
+            let w = worker.lock();
             assert!(
                 !matches!(w.status, MailboxWorkerStatus::Idle),
                 "worker should not be Idle after dispatch"
@@ -4498,7 +5599,7 @@ mod tests {
         // Worker should still be Running, not reverted to Idle.
         let workers = mailbox.workers.read().await;
         if let Some(worker) = workers.get("thread-guard") {
-            let w = worker.lock().await;
+            let w = worker.lock();
             assert!(
                 !matches!(w.status, MailboxWorkerStatus::Idle),
                 "worker should still not be Idle"
@@ -4588,9 +5689,10 @@ mod tests {
         let worker = mailbox.get_or_create_worker("thread-reconnect").await;
         {
             let reconnectable = Arc::new(ReconnectableEventSink::new(mpsc::channel(16).0));
-            let mut w = worker.lock().await;
+            let mut w = worker.lock();
             w.status = MailboxWorkerStatus::Running {
                 dispatch_id: "dispatch-fake".into(),
+                run_id: "run-fake".into(),
                 lease_handle: tokio::spawn(futures::future::pending::<()>()),
                 sink: reconnectable,
             };
@@ -4742,7 +5844,7 @@ mod tests {
             let mut workers = mailbox.workers.write().await;
             workers.insert(
                 "thread-gc".to_string(),
-                Arc::new(Mutex::new(MailboxWorker::default())),
+                Arc::new(SyncMutex::new(MailboxWorker::default())),
             );
         }
 
@@ -4775,7 +5877,7 @@ mod tests {
             let mut workers = mailbox.workers.write().await;
             workers.insert(
                 "thread-gc-keep".to_string(),
-                Arc::new(Mutex::new(MailboxWorker::default())),
+                Arc::new(SyncMutex::new(MailboxWorker::default())),
             );
         }
 
@@ -4811,5 +5913,252 @@ mod tests {
         mailbox.gc_idle_workers().await;
         let workers = mailbox.workers.read().await;
         assert!(workers.is_empty());
+    }
+
+    // ── ThreadContext cache tests ───────────────────────────────────
+
+    fn make_run_record(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecord {
+        RunRecord {
+            run_id: run_id.to_string(),
+            thread_id: thread_id.to_string(),
+            agent_id: "agent".to_string(),
+            parent_run_id: None,
+            request: None,
+            input: None,
+            output: None,
+            status,
+            termination_reason: None,
+            final_output: None,
+            error_payload: None,
+            dispatch_id: None,
+            session_id: None,
+            transport_request_id: None,
+            waiting: None,
+            outcome: None,
+            created_at: 1,
+            started_at: None,
+            finished_at: None,
+            updated_at: 1,
+            steps: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            state: None,
+        }
+    }
+
+    fn make_waiting_run_record(run_id: &str, thread_id: &str) -> RunRecord {
+        let mut run = make_run_record(run_id, thread_id, RunStatus::Waiting);
+        run.waiting = Some(RunWaitingState {
+            reason: WaitingReason::BackgroundTasks,
+            ticket_ids: Vec::new(),
+            tickets: Vec::new(),
+            since_dispatch_id: None,
+            message: None,
+        });
+        run
+    }
+
+    fn make_noop_mailbox(thread_store: Arc<InMemoryStore>) -> Arc<Mailbox> {
+        let mailbox_store = make_store();
+        let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+        Arc::new(Mailbox::new_with_executor(
+            runtime,
+            mailbox_store,
+            thread_store,
+            "test-consumer".into(),
+            MailboxConfig::default(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn thread_context_cache_used_by_reusable_waiting_run_id() {
+        let thread_store = Arc::new(InMemoryStore::new());
+        let mailbox = make_noop_mailbox(thread_store.clone());
+        let thread_id = "thread-ctx-reuse";
+
+        // Create a waiting run in the store.
+        let run = make_waiting_run_record("run-waiting", thread_id);
+        thread_store
+            .checkpoint(thread_id, &[Message::user("hi")], &run)
+            .await
+            .unwrap();
+
+        // Pre-warm the cache on the worker.
+        let worker = mailbox.get_or_create_worker(thread_id).await;
+        let ctx = ThreadContext::load(thread_store.as_ref(), thread_id)
+            .await
+            .unwrap();
+        {
+            let mut w = worker.lock();
+            w.thread_ctx = Some(ctx);
+        }
+
+        let result = mailbox.reusable_waiting_run_id(thread_id).await;
+        assert_eq!(result, Some("run-waiting".to_string()));
+    }
+
+    #[tokio::test]
+    async fn thread_context_cache_updated_after_prepare_checkpoint() {
+        let thread_store = Arc::new(InMemoryStore::new());
+        let mailbox = make_noop_mailbox(thread_store.clone());
+        let thread_id = "thread-ctx-checkpoint";
+
+        // Persist initial state with a Done run.
+        let run = make_run_record("run-prev", thread_id, RunStatus::Done);
+        thread_store
+            .checkpoint(thread_id, &[Message::user("first")], &run)
+            .await
+            .unwrap();
+
+        // Pre-warm the cache.
+        let worker = mailbox.get_or_create_worker(thread_id).await;
+        let ctx = ThreadContext::load(thread_store.as_ref(), thread_id)
+            .await
+            .unwrap();
+        {
+            let mut w = worker.lock();
+            w.thread_ctx = Some(ctx);
+        }
+
+        // Prepare a new dispatch — this should update the cache.
+        let mut request =
+            RunRequest::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
+        let msgs = request.messages.clone();
+        mailbox
+            .prepare_run_for_dispatch(&mut request, thread_id, &msgs)
+            .await
+            .expect("prepare should succeed");
+
+        // Verify cache was updated with both messages and the new run.
+        let w = worker.lock();
+        let ctx = w.thread_ctx.as_ref().expect("cache should exist");
+        assert_eq!(ctx.messages.len(), 2, "cache should have 2 messages");
+        assert!(ctx.latest_run.is_some(), "cache should have latest run");
+    }
+
+    #[tokio::test]
+    async fn prepare_run_falls_back_to_store_without_cache() {
+        let thread_store = Arc::new(InMemoryStore::new());
+        let mailbox = make_noop_mailbox(thread_store.clone());
+        let thread_id = "thread-no-cache";
+
+        // Persist initial state but do NOT pre-warm the cache.
+        let run = make_run_record("run-prev", thread_id, RunStatus::Done);
+        thread_store
+            .checkpoint(thread_id, &[Message::user("first")], &run)
+            .await
+            .unwrap();
+
+        // No cache — should fall back to store.
+        let mut request =
+            RunRequest::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
+        let msgs = request.messages.clone();
+        let run_id = mailbox
+            .prepare_run_for_dispatch(&mut request, thread_id, &msgs)
+            .await
+            .expect("should succeed from store fallback");
+        assert!(!run_id.is_empty());
+
+        // Store should have both messages.
+        let stored = thread_store
+            .load_messages(thread_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn thread_context_cache_cleared_on_idle_transition() {
+        let thread_store = Arc::new(InMemoryStore::new());
+        let mailbox = make_noop_mailbox(thread_store.clone());
+        let thread_id = "thread-ctx-clear";
+
+        let run = make_run_record("r1", thread_id, RunStatus::Done);
+        thread_store
+            .checkpoint(thread_id, &[Message::user("hi")], &run)
+            .await
+            .unwrap();
+
+        // Set up worker as Running with a populated cache.
+        let worker = mailbox.get_or_create_worker(thread_id).await;
+        let ctx = ThreadContext::load(thread_store.as_ref(), thread_id)
+            .await
+            .unwrap();
+        {
+            let mut w = worker.lock();
+            w.thread_ctx = Some(ctx);
+            w.status = MailboxWorkerStatus::Running {
+                dispatch_id: "d1".into(),
+                run_id: "r1".into(),
+                lease_handle: tokio::spawn(async {}),
+                sink: Arc::new(ReconnectableEventSink::new(mpsc::channel(16).0)),
+            };
+        }
+
+        // Verify cache exists before transition.
+        assert!(worker.lock().thread_ctx.is_some());
+
+        // Simulate completion: transition to Idle and clear cache.
+        {
+            let mut w = worker.lock();
+            let old = std::mem::replace(&mut w.status, MailboxWorkerStatus::Idle);
+            w.thread_ctx = None;
+            if let MailboxWorkerStatus::Running { lease_handle, .. } = old {
+                lease_handle.abort();
+            }
+        }
+
+        assert!(
+            worker.lock().thread_ctx.is_none(),
+            "cache should be cleared on idle transition"
+        );
+    }
+
+    #[tokio::test]
+    async fn thread_context_load_populates_run_cache() {
+        let store = Arc::new(InMemoryStore::new());
+        let thread_id = "thread-load-test";
+
+        let run = make_run_record("r1", thread_id, RunStatus::Done);
+        store
+            .checkpoint(thread_id, &[Message::user("msg")], &run)
+            .await
+            .unwrap();
+
+        let ctx = ThreadContext::load(store.as_ref(), thread_id)
+            .await
+            .expect("load should succeed");
+
+        assert_eq!(ctx.messages.len(), 1);
+        assert!(ctx.latest_run.is_some());
+        assert_eq!(ctx.latest_run.as_ref().unwrap().run_id, "r1");
+        assert!(ctx.get_run("r1").is_some());
+        assert!(ctx.get_run("unknown").is_none());
+    }
+
+    #[tokio::test]
+    async fn reusable_waiting_run_id_returns_none_for_done_cached_run() {
+        let thread_store = Arc::new(InMemoryStore::new());
+        let mailbox = make_noop_mailbox(thread_store.clone());
+        let thread_id = "thread-done-run";
+
+        let run = make_run_record("run-done", thread_id, RunStatus::Done);
+        thread_store
+            .checkpoint(thread_id, &[Message::user("hi")], &run)
+            .await
+            .unwrap();
+
+        let worker = mailbox.get_or_create_worker(thread_id).await;
+        let ctx = ThreadContext::load(thread_store.as_ref(), thread_id)
+            .await
+            .unwrap();
+        {
+            let mut w = worker.lock();
+            w.thread_ctx = Some(ctx);
+        }
+
+        let result = mailbox.reusable_waiting_run_id(thread_id).await;
+        assert_eq!(result, None, "Done run should not be reusable");
     }
 }

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -391,12 +391,34 @@ async fn get_thread_messages(
     })))
 }
 
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum PushInputMode {
+    #[default]
+    Queue,
+    #[serde(alias = "steer")]
+    LiveThenQueue,
+    InterruptThenQueue,
+    ResumeOpenRun,
+}
+
+impl PushInputMode {
+    fn input_mode(self) -> Option<InputMode> {
+        match self {
+            PushInputMode::Queue => Some(InputMode::Queue),
+            PushInputMode::InterruptThenQueue => Some(InputMode::InterruptThenQueue),
+            PushInputMode::ResumeOpenRun => Some(InputMode::ResumeOpenRun),
+            PushInputMode::LiveThenQueue => None,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct PostThreadMessagesPayload {
     #[serde(rename = "agentId", alias = "agent_id", default)]
     agent_id: Option<String>,
     #[serde(default)]
-    mode: InputMode,
+    mode: PushInputMode,
     #[serde(default)]
     messages: Vec<RunMessage>,
 }
@@ -421,10 +443,20 @@ async fn post_thread_messages(
         ));
     }
 
-    let result = RunControlService::new(st)
-        .inject_user_input(&id, payload.agent_id, messages, payload.mode)
-        .await
-        .map_err(map_run_control_error)?;
+    let service = RunControlService::new(st);
+    let result = match payload.mode.input_mode() {
+        Some(mode) => {
+            service
+                .inject_user_input(&id, payload.agent_id, messages, mode)
+                .await
+        }
+        None => {
+            service
+                .inject_user_input_live_then_queue(&id, payload.agent_id, messages)
+                .await
+        }
+    }
+    .map_err(map_run_control_error)?;
 
     let body = match result.status {
         MailboxDispatchStatus::Running => json!({
@@ -607,7 +639,7 @@ async fn list_runs(
 #[derive(Debug, Deserialize)]
 struct PushRunInputsPayload {
     #[serde(default)]
-    mode: InputMode,
+    mode: PushInputMode,
     #[serde(default)]
     messages: Vec<RunMessage>,
 }
@@ -625,10 +657,16 @@ async fn push_run_inputs(
         ));
     }
 
-    let _ = RunControlService::new(st)
-        .inject_run_input(&id, messages, payload.mode)
-        .await
-        .map_err(map_run_control_error)?;
+    let service = RunControlService::new(st);
+    let result = match payload.mode.input_mode() {
+        Some(mode) => service.inject_run_input(&id, messages, mode).await,
+        None => {
+            service
+                .inject_run_input_live_then_queue(&id, messages)
+                .await
+        }
+    };
+    let _ = result.map_err(map_run_control_error)?;
 
     Ok((
         StatusCode::ACCEPTED,
@@ -980,7 +1018,7 @@ mod tests {
         let json = r#"{}"#;
         let p: PushRunInputsPayload = serde_json::from_str(json).unwrap();
         assert!(p.messages.is_empty());
-        assert_eq!(p.mode, InputMode::Queue);
+        assert_eq!(p.mode, PushInputMode::Queue);
     }
 
     #[test]
@@ -998,8 +1036,20 @@ mod tests {
         let json =
             r#"{"mode":"interrupt_then_queue","messages":[{"role":"user","content":"redirect"}]}"#;
         let p: PushRunInputsPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(p.mode, InputMode::InterruptThenQueue);
+        assert_eq!(p.mode, PushInputMode::InterruptThenQueue);
         assert_eq!(p.messages.len(), 1);
+    }
+
+    #[test]
+    fn push_run_inputs_payload_accepts_live_then_queue_mode_and_steer_alias() {
+        let json = r#"{"mode":"live_then_queue","messages":[{"role":"user","content":"steer"}]}"#;
+        let p: PushRunInputsPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(p.mode, PushInputMode::LiveThenQueue);
+        assert_eq!(p.messages.len(), 1);
+
+        let alias = r#"{"mode":"steer","messages":[{"role":"user","content":"steer"}]}"#;
+        let p: PushRunInputsPayload = serde_json::from_str(alias).unwrap();
+        assert_eq!(p.mode, PushInputMode::LiveThenQueue);
     }
 
     #[test]
@@ -1007,7 +1057,7 @@ mod tests {
         let json =
             r#"{"mode":"resume_open_run","messages":[{"role":"user","content":"continue"}]}"#;
         let p: PushRunInputsPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(p.mode, InputMode::ResumeOpenRun);
+        assert_eq!(p.mode, PushInputMode::ResumeOpenRun);
         assert_eq!(p.messages.len(), 1);
     }
 

--- a/crates/awaken-server/src/services/run_control_service.rs
+++ b/crates/awaken-server/src/services/run_control_service.rs
@@ -171,6 +171,10 @@ impl RunControlService {
     }
 
     /// Submit a tool-call decision to a waiting active run.
+    ///
+    /// Remote live delivery is at-least-once when its ack is lost before the
+    /// durable fallback is enqueued; `(tool_call_id, decision_id)` identifies
+    /// duplicate decisions.
     pub async fn decide(
         &self,
         id: &str,
@@ -180,7 +184,8 @@ impl RunControlService {
         if self
             .state
             .mailbox
-            .send_decision(id, tool_call_id.clone(), resume.clone())
+            .send_decision_live(id, tool_call_id.clone(), resume.clone())
+            .await?
         {
             Ok(())
         } else {

--- a/crates/awaken-server/src/services/run_control_service.rs
+++ b/crates/awaken-server/src/services/run_control_service.rs
@@ -288,6 +288,32 @@ impl RunControlService {
             .map_err(RunControlError::Mailbox)
     }
 
+    /// Inject messages into the active run when possible, otherwise queue them.
+    pub async fn inject_user_input_live_then_queue(
+        &self,
+        thread_id: &str,
+        agent_id: Option<String>,
+        messages: Vec<Message>,
+    ) -> Result<MailboxSubmitResult, RunControlError> {
+        let _thread = self
+            .state
+            .store
+            .load_thread(thread_id)
+            .await?
+            .ok_or_else(|| RunControlError::ThreadNotFound(thread_id.to_string()))?;
+
+        let mut request = RunRequest::new(thread_id.to_string(), messages);
+        if let Some(agent_id) = agent_id {
+            request = request.with_agent_id(agent_id);
+        }
+
+        self.state
+            .mailbox
+            .submit_live_then_queue(request, None)
+            .await
+            .map_err(RunControlError::Mailbox)
+    }
+
     /// Inject messages using an existing run as the thread and agent anchor.
     pub async fn inject_run_input(
         &self,
@@ -322,6 +348,28 @@ impl RunControlService {
 
         self.inject_user_input(&run.thread_id, Some(run.agent_id), messages, mode)
             .await
+    }
+
+    /// Inject messages using an existing run as the live-delivery anchor.
+    pub async fn inject_run_input_live_then_queue(
+        &self,
+        run_id: &str,
+        messages: Vec<Message>,
+    ) -> Result<MailboxSubmitResult, RunControlError> {
+        let run = self
+            .state
+            .store
+            .load_run(run_id)
+            .await?
+            .ok_or_else(|| RunControlError::RunNotFound(run_id.to_string()))?;
+
+        let request =
+            RunRequest::new(run.thread_id.clone(), messages).with_agent_id(run.agent_id.clone());
+        self.state
+            .mailbox
+            .submit_live_then_queue(request, Some(&run.run_id))
+            .await
+            .map_err(RunControlError::Mailbox)
     }
 
     async fn load_open_waiting_run(

--- a/crates/awaken-server/tests/http_api.rs
+++ b/crates/awaken-server/tests/http_api.rs
@@ -981,6 +981,29 @@ mod integration {
     }
 
     #[tokio::test]
+    async fn thread_messages_accepts_live_then_queue_input_mode() {
+        let test = make_test_app();
+        let thread_id = seed_thread(&test.store, Some("Live Control Thread")).await;
+
+        let (status, body) = post_json(
+            test.router.clone(),
+            &format!("/v1/threads/{thread_id}/messages"),
+            json!({
+                "mode": "live_then_queue",
+                "messages": [{"role": "user", "content": "steer softly"}]
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(body["thread_id"].as_str(), Some(thread_id.as_str()));
+        assert!(matches!(
+            body["status"].as_str(),
+            Some("running") | Some("queued")
+        ));
+    }
+
+    #[tokio::test]
     async fn thread_messages_resume_open_run_continues_projected_waiting_run() {
         let test = make_test_app();
         let thread_id = "thread-resume-open";

--- a/crates/awaken-server/tests/public_api_compat.rs
+++ b/crates/awaken-server/tests/public_api_compat.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::event_sink::EventSink;
+use awaken_contract::contract::suspension::ToolCallResume;
+use awaken_runtime::RunRequest;
+
+use awaken_server::mailbox::{MailboxDispatchStatus, RunDispatchExecutor};
+use awaken_server::services::run_control_service::InputMode;
+
+struct OldExecutorShape;
+
+#[async_trait]
+impl RunDispatchExecutor for OldExecutorShape {
+    async fn run(
+        &self,
+        _request: RunRequest,
+        _sink: Arc<dyn EventSink>,
+    ) -> Result<
+        awaken_runtime::loop_runner::AgentRunResult,
+        awaken_runtime::loop_runner::AgentLoopError,
+    > {
+        unreachable!("compat test only checks trait implementation shape")
+    }
+
+    fn cancel(&self, _id: &str) -> bool {
+        false
+    }
+
+    async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+        false
+    }
+
+    fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+        false
+    }
+}
+
+#[test]
+fn run_dispatch_executor_old_impl_shape_still_compiles() {
+    let _executor: Arc<dyn RunDispatchExecutor> = Arc::new(OldExecutorShape);
+}
+
+#[test]
+fn mailbox_dispatch_status_exhaustive_match_keeps_0_2_variants() {
+    fn label(status: MailboxDispatchStatus) -> &'static str {
+        match status {
+            MailboxDispatchStatus::Running => "running",
+            MailboxDispatchStatus::Queued => "queued",
+        }
+    }
+
+    assert_eq!(label(MailboxDispatchStatus::Running), "running");
+    assert_eq!(label(MailboxDispatchStatus::Queued), "queued");
+}
+
+#[test]
+fn input_mode_exhaustive_match_keeps_0_2_variants() {
+    fn label(mode: InputMode) -> &'static str {
+        match mode {
+            InputMode::Queue => "queue",
+            InputMode::InterruptThenQueue => "interrupt_then_queue",
+            InputMode::ResumeOpenRun => "resume_open_run",
+        }
+    }
+
+    assert_eq!(label(InputMode::Queue), "queue");
+    assert_eq!(label(InputMode::InterruptThenQueue), "interrupt_then_queue");
+    assert_eq!(label(InputMode::ResumeOpenRun), "resume_open_run");
+}

--- a/crates/awaken-server/tests/public_api_compat_extended.rs
+++ b/crates/awaken-server/tests/public_api_compat_extended.rs
@@ -1,0 +1,272 @@
+//! Extended 0.2 public-API compat lockdown for `awaken-server`.
+//!
+//! Covers every public method on `Mailbox`, `RunControlService`, every variant
+//! on `MailboxError` / `MailboxRunOutcome` / `InputMode` / `InterruptMode` /
+//! `MailboxDispatchStatus` / `RunControlError`, plus struct-literal
+//! construction for `ActiveRun` / `MailboxSubmitResult` / `MailboxConfig`.
+//!
+//! Also exercises the HTTP wire-compat surface by deserializing the three
+//! legacy `mode` values a 0.2 client would send.
+
+#![allow(dead_code, clippy::type_complexity)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use awaken_contract::contract::event::AgentEvent;
+use awaken_contract::contract::event_sink::EventSink;
+use awaken_contract::contract::lifecycle::{RunStatus, TerminationReason};
+use awaken_contract::contract::mailbox::{MailboxInterrupt, MailboxStore};
+use awaken_contract::contract::storage::{RunWaitingState, ThreadRunStore};
+use awaken_contract::contract::suspension::ToolCallResume;
+use awaken_runtime::RunRequest;
+use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
+use awaken_server::mailbox::{
+    Mailbox, MailboxConfig, MailboxDispatchStatus, MailboxError, MailboxRunOutcome,
+    MailboxSubmitResult, RunDispatchExecutor,
+};
+use awaken_server::services::run_control_service::{
+    ActiveRun, InputMode, InterruptMode, RunControlError,
+};
+
+// ── Signature lockdown for Mailbox ────────────────────────────────────────
+
+struct OldExec;
+
+#[async_trait]
+impl RunDispatchExecutor for OldExec {
+    async fn run(
+        &self,
+        _: RunRequest,
+        _: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        unreachable!()
+    }
+    fn cancel(&self, _: &str) -> bool {
+        false
+    }
+    async fn cancel_and_wait_by_thread(&self, _: &str) -> bool {
+        false
+    }
+    fn send_decision(&self, _: &str, _: String, _: ToolCallResume) -> bool {
+        false
+    }
+}
+
+#[test]
+fn mailbox_submit_signature_intact() {
+    let _submit: for<'a> fn(
+        &'a Arc<Mailbox>,
+        RunRequest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<
+                        (MailboxSubmitResult, mpsc::Receiver<AgentEvent>),
+                        MailboxError,
+                    >,
+                > + Send
+                + 'a,
+        >,
+    > = |mb, req| Box::pin(mb.submit(req));
+
+    let _submit_bg: for<'a> fn(
+        &'a Arc<Mailbox>,
+        RunRequest,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<MailboxSubmitResult, MailboxError>> + Send + 'a,
+        >,
+    > = |mb, req| Box::pin(mb.submit_background(req));
+}
+
+#[test]
+fn mailbox_methods_signature_intact() {
+    let _cancel: for<'a> fn(
+        &'a Mailbox,
+        &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<bool, MailboxError>> + Send + 'a>,
+    > = |mb, id| Box::pin(mb.cancel(id));
+
+    let _interrupt: for<'a> fn(
+        &'a Mailbox,
+        &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<MailboxInterrupt, MailboxError>> + Send + 'a>,
+    > = |mb, id| Box::pin(mb.interrupt(id));
+
+    let _send_decision: fn(&Mailbox, &str, String, ToolCallResume) -> bool = Mailbox::send_decision;
+}
+
+#[test]
+fn mailbox_new_signature_intact() {
+    let _new: fn(
+        Arc<OldExec>,
+        Arc<dyn MailboxStore>,
+        Arc<dyn ThreadRunStore>,
+        String,
+        MailboxConfig,
+    ) -> Mailbox = Mailbox::new::<OldExec>;
+
+    let _new_with: fn(
+        Arc<dyn RunDispatchExecutor>,
+        Arc<dyn MailboxStore>,
+        Arc<dyn ThreadRunStore>,
+        String,
+        MailboxConfig,
+    ) -> Mailbox = Mailbox::new_with_executor;
+}
+
+#[test]
+fn mailbox_dispatch_status_all_0_2_variants_still_exhaustive() {
+    fn label(s: MailboxDispatchStatus) -> &'static str {
+        match s {
+            MailboxDispatchStatus::Running => "running",
+            MailboxDispatchStatus::Queued => "queued",
+        }
+    }
+    assert_eq!(label(MailboxDispatchStatus::Running), "running");
+    assert_eq!(label(MailboxDispatchStatus::Queued), "queued");
+}
+
+#[test]
+fn mailbox_error_keeps_0_2_variants() {
+    // These three variants existed in 0.2; we accept that new ones may
+    // have been added (hence the trailing `_`), but the 0.2 ones must stay.
+    let _ = MailboxError::Validation("v".into());
+    fn _inspect(e: &MailboxError) -> &'static str {
+        match e {
+            MailboxError::Validation(_) => "validation",
+            MailboxError::Store(_) => "store",
+            _ => "other",
+        }
+    }
+}
+
+#[test]
+fn mailbox_run_outcome_keeps_0_2_variants() {
+    let _ = MailboxRunOutcome::Completed;
+    let _ = MailboxRunOutcome::TransientError("x".into());
+    fn _inspect(o: &MailboxRunOutcome) -> &'static str {
+        match o {
+            MailboxRunOutcome::Completed => "done",
+            MailboxRunOutcome::TransientError(_) => "transient",
+            _ => "other",
+        }
+    }
+}
+
+#[test]
+fn mailbox_submit_result_struct_literal_keeps_0_2_fields() {
+    let r = MailboxSubmitResult {
+        dispatch_id: "d".into(),
+        run_id: "r".into(),
+        thread_id: "t".into(),
+        status: MailboxDispatchStatus::Queued,
+    };
+    assert_eq!(r.thread_id, "t");
+}
+
+#[test]
+fn mailbox_config_default_constructs() {
+    let cfg = MailboxConfig::default();
+    // Fields mentioned in 0.2 docs must still exist.
+    let _ = cfg.lease_ms;
+    let _ = cfg.suspended_lease_ms;
+}
+
+// ── Signature lockdown for RunControlService ──────────────────────────────
+
+#[test]
+fn run_control_service_0_2_surface_intact() {
+    let _cancel_run: for<'a> fn(
+        &'a awaken_server::services::run_control_service::RunControlService,
+        &'a str,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<(), RunControlError>> + Send + 'a>,
+    > = |svc, id| Box::pin(svc.cancel_run(id));
+}
+
+#[test]
+fn active_run_struct_literal_keeps_0_2_fields() {
+    let _ = ActiveRun {
+        thread_id: "t".into(),
+        run_id: "r".into(),
+        agent_id: "a".into(),
+        status: RunStatus::Running,
+        termination_reason: Option::<TerminationReason>::None,
+        dispatch_id: None,
+        session_id: None,
+        waiting: Option::<RunWaitingState>::None,
+    };
+}
+
+#[test]
+fn interrupt_mode_exhaustive_match_keeps_0_2_variants() {
+    fn label(m: InterruptMode) -> &'static str {
+        match m {
+            InterruptMode::Graceful => "graceful",
+        }
+    }
+    assert_eq!(label(InterruptMode::Graceful), "graceful");
+}
+
+#[test]
+fn run_control_error_keeps_0_2_variants() {
+    let _ = RunControlError::ThreadNotFound("t".into());
+    let _ = RunControlError::RunNotFound("r".into());
+    let _ = RunControlError::DecisionTargetNotFound("d".into());
+    // Store / Mailbox variants can't be constructed without the inner error;
+    // we pattern-match instead to prove they still exist.
+    fn _inspect(e: &RunControlError) -> &'static str {
+        match e {
+            RunControlError::ThreadNotFound(_) => "thread",
+            RunControlError::RunNotFound(_) => "run",
+            RunControlError::DecisionTargetNotFound(_) => "decision",
+            RunControlError::Store(_) => "store",
+            RunControlError::Mailbox(_) => "mailbox",
+        }
+    }
+}
+
+// ── HTTP wire compat — legacy JSON `mode` values still parse ──────────────
+//
+// The 0.2 route accepted `mode: "queue" | "interrupt_then_queue" |
+// "resume_open_run"`. HEAD replaced the inner type with `PushInputMode`
+// (private) but promises identical JSON acceptance. Re-prove it from the
+// `InputMode` deserializer, which is still the public type users can embed
+// in their own request structs.
+
+#[test]
+fn input_mode_deserializes_all_0_2_strings() {
+    let q: InputMode = serde_json::from_str("\"queue\"").unwrap();
+    let iq: InputMode = serde_json::from_str("\"interrupt_then_queue\"").unwrap();
+    let ru: InputMode = serde_json::from_str("\"resume_open_run\"").unwrap();
+    assert_eq!(q, InputMode::Queue);
+    assert_eq!(iq, InputMode::InterruptThenQueue);
+    assert_eq!(ru, InputMode::ResumeOpenRun);
+}
+
+#[test]
+fn input_mode_default_matches_0_2() {
+    assert_eq!(InputMode::default(), InputMode::Queue);
+}
+
+#[test]
+fn input_mode_serialize_stays_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&InputMode::Queue).unwrap(),
+        "\"queue\""
+    );
+    assert_eq!(
+        serde_json::to_string(&InputMode::InterruptThenQueue).unwrap(),
+        "\"interrupt_then_queue\""
+    );
+    assert_eq!(
+        serde_json::to_string(&InputMode::ResumeOpenRun).unwrap(),
+        "\"resume_open_run\""
+    );
+}

--- a/crates/awaken-stores/Cargo.toml
+++ b/crates/awaken-stores/Cargo.toml
@@ -24,18 +24,22 @@ async-trait = { workspace = true }
 # Optional backends
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], default-features = false, optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+async-nats = { version = "0.38", optional = true }
+bytes = "1"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 tempfile = "3"
 proptest = { workspace = true }
 futures = { workspace = true }
+testcontainers = "0.23"
 
 [features]
 default = []
 file = []
 postgres = ["dep:sqlx"]
 sqlite = ["dep:rusqlite"]
+nats = ["dep:async-nats"]
 
 [lints]
 workspace = true

--- a/crates/awaken-stores/src/lib.rs
+++ b/crates/awaken-stores/src/lib.rs
@@ -20,6 +20,15 @@ pub mod postgres;
 #[cfg(feature = "sqlite")]
 pub mod sqlite_mailbox;
 
+#[cfg(feature = "nats")]
+mod nats_keys;
+
+#[cfg(feature = "nats")]
+pub mod nats_mailbox;
+
+#[cfg(feature = "nats")]
+pub mod nats_buffered_thread;
+
 pub use memory::InMemoryStore;
 pub use memory_mailbox::InMemoryMailboxStore;
 
@@ -31,3 +40,11 @@ pub use postgres::PostgresStore;
 
 #[cfg(feature = "sqlite")]
 pub use sqlite_mailbox::SqliteMailboxStore;
+
+#[cfg(feature = "nats")]
+pub use nats_mailbox::{NatsMailboxConfig, NatsMailboxStore};
+
+#[cfg(feature = "nats")]
+pub use nats_buffered_thread::{
+    NatsBufferedThreadConfig, NatsBufferedThreadStore, ReadConsistency,
+};

--- a/crates/awaken-stores/src/memory_mailbox.rs
+++ b/crates/awaken-stores/src/memory_mailbox.rs
@@ -1,14 +1,17 @@
 //! In-memory implementation of the new lease-based `MailboxStore`.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::mailbox::{
-    MailboxInterrupt, MailboxStore, RunDispatch, RunDispatchResult, RunDispatchStatus,
+    LiveCommandReceipt, LiveDeliveryOutcome, LiveRunCommand, LiveRunCommandEntry,
+    LiveRunCommandStream, MailboxInterrupt, MailboxStore, RunDispatch, RunDispatchResult,
+    RunDispatchStatus,
 };
 use awaken_contract::contract::storage::StorageError;
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, mpsc, oneshot};
 use uuid::Uuid;
 
 /// Per-thread dispatch epoch for interrupt semantics.
@@ -24,6 +27,25 @@ struct MailboxState {
 pub struct InMemoryMailboxStore {
     dispatches: RwLock<HashMap<String, RunDispatch>>,
     state: RwLock<HashMap<String, MailboxState>>,
+    /// Single-consumer live-channel: one forwarder per thread at a time.
+    /// Re-opening replaces the previous sender so the stale forwarder sees
+    /// the channel close.
+    live: RwLock<HashMap<String, mpsc::UnboundedSender<LiveRunCommandEntry>>>,
+}
+
+/// How long a producer waits for the consumer to ack an in-memory live
+/// command before falling back to durable dispatch. Short by design — the
+/// in-process forwarder only needs to execute a `try_send` to ack.
+const LIVE_ACK_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Oneshot-backed receipt: `ack` sends `()` on the paired receiver, which
+/// unblocks the producer's `deliver_live` await.
+struct OneshotReceipt(oneshot::Sender<()>);
+
+impl LiveCommandReceipt for OneshotReceipt {
+    fn ack(self: Box<Self>) {
+        let _ = self.0.send(());
+    }
 }
 
 impl InMemoryMailboxStore {
@@ -496,6 +518,63 @@ impl MailboxStore for InMemoryMailboxStore {
         ids.sort();
         Ok(ids)
     }
+
+    async fn deliver_live(
+        &self,
+        thread_id: &str,
+        cmd: LiveRunCommand,
+    ) -> Result<LiveDeliveryOutcome, StorageError> {
+        // Snapshot the sender without holding the map lock across await.
+        let sender = {
+            let map = self.live.read().await;
+            match map.get(thread_id) {
+                Some(sender) => sender.clone(),
+                None => return Ok(LiveDeliveryOutcome::NoSubscriber),
+            }
+        };
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let receipt: Box<dyn LiveCommandReceipt> = Box::new(OneshotReceipt(ack_tx));
+        if sender
+            .send(LiveRunCommandEntry {
+                command: cmd,
+                receipt,
+            })
+            .is_err()
+        {
+            // Receiver dropped — forwarder is gone.
+            let mut map = self.live.write().await;
+            if let Some(current) = map.get(thread_id)
+                && current.is_closed()
+            {
+                map.remove(thread_id);
+            }
+            return Ok(LiveDeliveryOutcome::NoSubscriber);
+        }
+        // Wait for the consumer to ack (i.e. to successfully hand the
+        // command off to the run). Timeout maps to `NoSubscriber` so the
+        // caller falls back to the durable queue.
+        match tokio::time::timeout(LIVE_ACK_TIMEOUT, ack_rx).await {
+            Ok(Ok(())) => Ok(LiveDeliveryOutcome::Delivered),
+            _ => Ok(LiveDeliveryOutcome::NoSubscriber),
+        }
+    }
+
+    async fn open_live_channel(
+        &self,
+        thread_id: &str,
+    ) -> Result<LiveRunCommandStream, StorageError> {
+        // Single-consumer: a fresh `open_live_channel` replaces any prior
+        // forwarder. In production there's one forwarder per thread at a
+        // time (enforced by `ActiveRunRegistry`); tests that drive multiple
+        // subscribers should be written against `NatsMailboxStore` or an
+        // intentional fanout backend.
+        let (tx, rx) = mpsc::unbounded_channel::<LiveRunCommandEntry>();
+        self.live.write().await.insert(thread_id.to_string(), tx);
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|entry| (entry, rx))
+        });
+        Ok(Box::pin(stream))
+    }
 }
 
 #[cfg(test)]
@@ -597,6 +676,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn claim_honors_batch_limit_without_active_claim() {
+        let store = InMemoryMailboxStore::new();
+        for _ in 0..3 {
+            store
+                .enqueue(&make_dispatch("m-1", "agent-1"))
+                .await
+                .unwrap();
+        }
+
+        let claimed = store
+            .claim("m-1", "consumer-1", 30_000, 1000, 2)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 2);
+        assert!(
+            claimed
+                .iter()
+                .all(|dispatch| dispatch.status == RunDispatchStatus::Claimed)
+        );
+    }
+
+    #[tokio::test]
     async fn claim_priority_ordering() {
         let store = InMemoryMailboxStore::new();
 
@@ -616,13 +717,35 @@ mod tests {
         store.enqueue(&mid).await.unwrap();
 
         let claimed = store
-            .claim("m-1", "consumer-1", 30_000, 1000, 10)
+            .claim("m-1", "consumer-1", 30_000, 1000, 1)
             .await
             .unwrap();
-        assert_eq!(claimed.len(), 3);
+        assert_eq!(claimed.len(), 1);
         assert_eq!(claimed[0].priority, 10);
-        assert_eq!(claimed[1].priority, 128);
-        assert_eq!(claimed[2].priority, 200);
+        let token = claimed[0].claim_token.clone().unwrap();
+        store
+            .ack(&claimed[0].dispatch_id, &token, 1100)
+            .await
+            .unwrap();
+
+        let claimed = store
+            .claim("m-1", "consumer-1", 30_000, 1200, 1)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].priority, 128);
+        let token = claimed[0].claim_token.clone().unwrap();
+        store
+            .ack(&claimed[0].dispatch_id, &token, 1300)
+            .await
+            .unwrap();
+
+        let claimed = store
+            .claim("m-1", "consumer-1", 30_000, 1400, 1)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].priority, 200);
     }
 
     #[tokio::test]
@@ -1362,6 +1485,201 @@ mod tests {
         // Should be claimable again.
         let reclaimed = store.claim("m-1", "c-1", 30_000, 2000, 1).await.unwrap();
         assert_eq!(reclaimed.len(), 1);
+    }
+
+    // ── Live-channel tests ──
+
+    mod live_channel {
+        use super::*;
+        use awaken_contract::contract::mailbox::{LiveDeliveryOutcome, LiveRunCommand};
+        use awaken_contract::contract::message::Message;
+        use futures::StreamExt;
+        use std::time::Duration;
+        use tokio::time::timeout;
+
+        /// Spawn a consumer task that drains the stream and auto-acks each
+        /// entry, capturing the commands for assertions.
+        fn spawn_auto_ack_consumer(
+            mut stream: LiveRunCommandStream,
+        ) -> (
+            tokio::task::JoinHandle<()>,
+            std::sync::Arc<tokio::sync::Mutex<Vec<LiveRunCommand>>>,
+        ) {
+            let captured = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            let captured_clone = captured.clone();
+            let handle = tokio::spawn(async move {
+                while let Some(entry) = stream.next().await {
+                    captured_clone.lock().await.push(entry.command.clone());
+                    entry.receipt.ack();
+                }
+            });
+            (handle, captured)
+        }
+
+        #[tokio::test]
+        async fn publish_reaches_subscriber_and_delivered_requires_ack() {
+            let store = InMemoryMailboxStore::new();
+            let stream = store.open_live_channel("t-1").await.unwrap();
+            let (_consumer, captured) = spawn_auto_ack_consumer(stream);
+
+            let outcome = store
+                .deliver_live("t-1", LiveRunCommand::Messages(vec![Message::user("hi")]))
+                .await
+                .unwrap();
+            assert_eq!(outcome, LiveDeliveryOutcome::Delivered);
+
+            let commands = captured.lock().await.clone();
+            assert_eq!(commands.len(), 1);
+            match &commands[0] {
+                LiveRunCommand::Messages(msgs) => assert_eq!(msgs[0].text(), "hi"),
+                other => panic!("expected Messages, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn publish_without_subscriber_reports_no_subscriber() {
+            let store = InMemoryMailboxStore::new();
+            let outcome = store
+                .deliver_live("t-2", LiveRunCommand::Cancel)
+                .await
+                .expect("deliver_live is infallible here");
+            assert_eq!(outcome, LiveDeliveryOutcome::NoSubscriber);
+        }
+
+        #[tokio::test]
+        async fn publish_after_subscriber_drop_reports_no_subscriber() {
+            let store = InMemoryMailboxStore::new();
+            {
+                let _stream = store.open_live_channel("t-drop").await.unwrap();
+                // subscriber dropped at scope exit
+            }
+            let outcome = store
+                .deliver_live("t-drop", LiveRunCommand::Cancel)
+                .await
+                .expect("deliver_live is infallible here");
+            assert_eq!(outcome, LiveDeliveryOutcome::NoSubscriber);
+        }
+
+        #[tokio::test]
+        async fn consumer_that_drops_receipt_triggers_no_subscriber() {
+            // Regression for issue #2: ack-after-forward guarantees that a
+            // consumer which fails to hand off the command (drops receipt)
+            // causes the producer to report NoSubscriber.
+            let store = InMemoryMailboxStore::new();
+            let mut stream = store.open_live_channel("t-nof").await.unwrap();
+
+            let producer = tokio::spawn({
+                let store = std::sync::Arc::new(store);
+                let s = store.clone();
+                async move {
+                    s.deliver_live("t-nof", LiveRunCommand::Cancel)
+                        .await
+                        .unwrap()
+                }
+            });
+
+            // Receive the entry, DO NOT ack — drop the receipt.
+            let entry = timeout(Duration::from_millis(200), stream.next())
+                .await
+                .unwrap()
+                .unwrap();
+            drop(entry.receipt);
+
+            let outcome = producer.await.unwrap();
+            assert_eq!(outcome, LiveDeliveryOutcome::NoSubscriber);
+        }
+
+        #[tokio::test]
+        async fn different_threads_isolated() {
+            let store = InMemoryMailboxStore::new();
+            let stream_a = store.open_live_channel("t-a").await.unwrap();
+            let mut stream_b = store.open_live_channel("t-b").await.unwrap();
+            let (_consumer_a, captured_a) = spawn_auto_ack_consumer(stream_a);
+
+            store
+                .deliver_live("t-a", LiveRunCommand::Cancel)
+                .await
+                .unwrap();
+            assert_eq!(captured_a.lock().await.len(), 1);
+
+            let got_b = timeout(Duration::from_millis(100), stream_b.next()).await;
+            assert!(got_b.is_err(), "t-b must not receive t-a's command");
+        }
+
+        #[tokio::test]
+        async fn reopen_replaces_previous_subscriber() {
+            // Single-consumer semantics: opening a second channel on the
+            // same thread invalidates the prior forwarder (its stream ends).
+            let store = InMemoryMailboxStore::new();
+            let mut old_stream = store.open_live_channel("t-replace").await.unwrap();
+            let new_stream = store.open_live_channel("t-replace").await.unwrap();
+            let (_consumer, captured) = spawn_auto_ack_consumer(new_stream);
+
+            store
+                .deliver_live("t-replace", LiveRunCommand::Cancel)
+                .await
+                .unwrap();
+
+            // Old stream should be closed (sender replaced).
+            let old = timeout(Duration::from_millis(100), old_stream.next()).await;
+            assert!(
+                matches!(old, Ok(None)),
+                "old stream must close, got {old:?}"
+            );
+            assert_eq!(captured.lock().await.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn order_preserved_for_single_subscriber() {
+            let store = InMemoryMailboxStore::new();
+            let stream = store.open_live_channel("t-ord").await.unwrap();
+            let (_consumer, captured) = spawn_auto_ack_consumer(stream);
+
+            for i in 0..5 {
+                store
+                    .deliver_live(
+                        "t-ord",
+                        LiveRunCommand::Messages(vec![Message::user(format!("m-{i}"))]),
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            let captured = captured.lock().await;
+            for (i, cmd) in captured.iter().enumerate() {
+                match cmd {
+                    LiveRunCommand::Messages(msgs) => {
+                        assert_eq!(msgs[0].text(), format!("m-{i}"))
+                    }
+                    other => panic!("unexpected {other:?}"),
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn cmd_variants_all_delivered() {
+            let store = InMemoryMailboxStore::new();
+            let stream = store.open_live_channel("t-var").await.unwrap();
+            let (_consumer, captured) = spawn_auto_ack_consumer(stream);
+
+            store
+                .deliver_live("t-var", LiveRunCommand::Messages(vec![Message::user("x")]))
+                .await
+                .unwrap();
+            store
+                .deliver_live("t-var", LiveRunCommand::Cancel)
+                .await
+                .unwrap();
+            store
+                .deliver_live("t-var", LiveRunCommand::Decision(vec![]))
+                .await
+                .unwrap();
+
+            let captured = captured.lock().await;
+            assert!(matches!(captured[0], LiveRunCommand::Messages(_)));
+            assert!(matches!(captured[1], LiveRunCommand::Cancel));
+            assert!(matches!(captured[2], LiveRunCommand::Decision(_)));
+        }
     }
 
     // ── Property-based tests ──

--- a/crates/awaken-stores/src/memory_mailbox.rs
+++ b/crates/awaken-stores/src/memory_mailbox.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::mailbox::{
     LiveCommandReceipt, LiveDeliveryOutcome, LiveRunCommand, LiveRunCommandEntry,
-    LiveRunCommandStream, MailboxInterrupt, MailboxStore, RunDispatch, RunDispatchResult,
-    RunDispatchStatus,
+    LiveRunCommandStream, LiveRunTarget, MailboxInterrupt, MailboxStore, RunDispatch,
+    RunDispatchResult, RunDispatchStatus,
 };
 use awaken_contract::contract::storage::StorageError;
 use tokio::sync::{RwLock, mpsc, oneshot};
@@ -52,6 +52,69 @@ impl InMemoryMailboxStore {
     /// Create a new empty in-memory mailbox store.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    fn live_key_for_thread(thread_id: &str) -> String {
+        format!("thread:{thread_id}")
+    }
+
+    fn live_key_for_target(target: &LiveRunTarget) -> String {
+        match target.dispatch_id.as_deref() {
+            Some(dispatch_id) => format!(
+                "thread:{}:run:{}:dispatch:{}",
+                target.thread_id, target.run_id, dispatch_id
+            ),
+            None => format!("thread:{}:run:{}", target.thread_id, target.run_id),
+        }
+    }
+
+    async fn deliver_live_key(
+        &self,
+        key: String,
+        cmd: LiveRunCommand,
+    ) -> Result<LiveDeliveryOutcome, StorageError> {
+        // Snapshot the sender without holding the map lock across await.
+        let sender = {
+            let map = self.live.read().await;
+            match map.get(&key) {
+                Some(sender) => sender.clone(),
+                None => return Ok(LiveDeliveryOutcome::NoSubscriber),
+            }
+        };
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let receipt: Box<dyn LiveCommandReceipt> = Box::new(OneshotReceipt(ack_tx));
+        if sender
+            .send(LiveRunCommandEntry {
+                command: cmd,
+                receipt,
+            })
+            .is_err()
+        {
+            // Receiver dropped — forwarder is gone.
+            let mut map = self.live.write().await;
+            if let Some(current) = map.get(&key)
+                && current.is_closed()
+            {
+                map.remove(&key);
+            }
+            return Ok(LiveDeliveryOutcome::NoSubscriber);
+        }
+        // Wait for the consumer to ack (i.e. to successfully hand the
+        // command off to the run). Timeout maps to `NoSubscriber` so the
+        // caller falls back to the durable queue.
+        match tokio::time::timeout(LIVE_ACK_TIMEOUT, ack_rx).await {
+            Ok(Ok(())) => Ok(LiveDeliveryOutcome::Delivered),
+            _ => Ok(LiveDeliveryOutcome::NoSubscriber),
+        }
+    }
+
+    async fn open_live_key(&self, key: String) -> Result<LiveRunCommandStream, StorageError> {
+        let (tx, rx) = mpsc::unbounded_channel::<LiveRunCommandEntry>();
+        self.live.write().await.insert(key, tx);
+        let stream = futures::stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|entry| (entry, rx))
+        });
+        Ok(Box::pin(stream))
     }
 }
 
@@ -524,39 +587,17 @@ impl MailboxStore for InMemoryMailboxStore {
         thread_id: &str,
         cmd: LiveRunCommand,
     ) -> Result<LiveDeliveryOutcome, StorageError> {
-        // Snapshot the sender without holding the map lock across await.
-        let sender = {
-            let map = self.live.read().await;
-            match map.get(thread_id) {
-                Some(sender) => sender.clone(),
-                None => return Ok(LiveDeliveryOutcome::NoSubscriber),
-            }
-        };
-        let (ack_tx, ack_rx) = oneshot::channel();
-        let receipt: Box<dyn LiveCommandReceipt> = Box::new(OneshotReceipt(ack_tx));
-        if sender
-            .send(LiveRunCommandEntry {
-                command: cmd,
-                receipt,
-            })
-            .is_err()
-        {
-            // Receiver dropped — forwarder is gone.
-            let mut map = self.live.write().await;
-            if let Some(current) = map.get(thread_id)
-                && current.is_closed()
-            {
-                map.remove(thread_id);
-            }
-            return Ok(LiveDeliveryOutcome::NoSubscriber);
-        }
-        // Wait for the consumer to ack (i.e. to successfully hand the
-        // command off to the run). Timeout maps to `NoSubscriber` so the
-        // caller falls back to the durable queue.
-        match tokio::time::timeout(LIVE_ACK_TIMEOUT, ack_rx).await {
-            Ok(Ok(())) => Ok(LiveDeliveryOutcome::Delivered),
-            _ => Ok(LiveDeliveryOutcome::NoSubscriber),
-        }
+        self.deliver_live_key(Self::live_key_for_thread(thread_id), cmd)
+            .await
+    }
+
+    async fn deliver_live_to(
+        &self,
+        target: &LiveRunTarget,
+        cmd: LiveRunCommand,
+    ) -> Result<LiveDeliveryOutcome, StorageError> {
+        self.deliver_live_key(Self::live_key_for_target(target), cmd)
+            .await
     }
 
     async fn open_live_channel(
@@ -568,12 +609,15 @@ impl MailboxStore for InMemoryMailboxStore {
         // time (enforced by `ActiveRunRegistry`); tests that drive multiple
         // subscribers should be written against `NatsMailboxStore` or an
         // intentional fanout backend.
-        let (tx, rx) = mpsc::unbounded_channel::<LiveRunCommandEntry>();
-        self.live.write().await.insert(thread_id.to_string(), tx);
-        let stream = futures::stream::unfold(rx, |mut rx| async move {
-            rx.recv().await.map(|entry| (entry, rx))
-        });
-        Ok(Box::pin(stream))
+        self.open_live_key(Self::live_key_for_thread(thread_id))
+            .await
+    }
+
+    async fn open_live_channel_for(
+        &self,
+        target: &LiveRunTarget,
+    ) -> Result<LiveRunCommandStream, StorageError> {
+        self.open_live_key(Self::live_key_for_target(target)).await
     }
 }
 

--- a/crates/awaken-stores/src/nats_buffered_thread/config.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/config.rs
@@ -1,0 +1,55 @@
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReadConsistency {
+    ReadYourWrites,
+    Strong,
+    Eventual,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct NatsBufferedThreadConfig {
+    pub url: String,
+    pub credentials: Option<String>,
+    pub stream_name: String,
+    pub consumer_name: String,
+    pub hot_bucket: String,
+    pub max_age: Duration,
+    pub flush_interval: Duration,
+    pub flush_batch_size: usize,
+    /// JetStream consumer ack-wait window. Messages pulled by a flusher that crashes
+    /// before acking are redelivered after this interval. Keep moderate in production
+    /// (e.g. 30s) so transient slow checkpoints don't trigger duplicate work; tests
+    /// may set it short to exercise crash-recovery paths quickly.
+    pub ack_wait: Duration,
+    pub read_consistency: ReadConsistency,
+}
+
+impl NatsBufferedThreadConfig {
+    #[must_use]
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for NatsBufferedThreadConfig {
+    fn default() -> Self {
+        Self {
+            url: "nats://localhost:4222".to_string(),
+            credentials: None,
+            stream_name: "THREADLOG".to_string(),
+            consumer_name: "thread-flusher".to_string(),
+            hot_bucket: "thread-hot".to_string(),
+            max_age: Duration::from_secs(24 * 3600),
+            flush_interval: Duration::from_millis(500),
+            flush_batch_size: 64,
+            ack_wait: Duration::from_secs(30),
+            read_consistency: ReadConsistency::ReadYourWrites,
+        }
+    }
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/entry.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/entry.rs
@@ -1,0 +1,74 @@
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{RunRecord, StorageError};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckpointEntry {
+    pub thread_id: String,
+    pub run: RunRecord,
+    pub messages: Vec<Message>,
+    pub thread_seq: u64,
+    pub written_at: u64,
+}
+
+pub fn encode(entry: &CheckpointEntry) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(entry)
+        .map(Bytes::from)
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn decode(bytes: &[u8]) -> Result<CheckpointEntry, StorageError> {
+    serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::lifecycle::RunStatus;
+
+    fn sample() -> CheckpointEntry {
+        CheckpointEntry {
+            thread_id: "t1".to_string(),
+            run: RunRecord {
+                run_id: "r1".to_string(),
+                thread_id: "t1".to_string(),
+                agent_id: "agent".to_string(),
+                parent_run_id: None,
+                request: None,
+                input: None,
+                output: None,
+                status: RunStatus::Done,
+                termination_reason: None,
+                final_output: None,
+                error_payload: None,
+                dispatch_id: None,
+                session_id: None,
+                transport_request_id: None,
+                waiting: None,
+                outcome: None,
+                created_at: 1,
+                started_at: None,
+                finished_at: None,
+                updated_at: 1,
+                steps: 0,
+                input_tokens: 0,
+                output_tokens: 0,
+                state: None,
+            },
+            messages: vec![Message::user("hi")],
+            thread_seq: 1,
+            written_at: 1000,
+        }
+    }
+
+    #[test]
+    fn roundtrip_preserves_fields() {
+        let entry = sample();
+        let bytes = encode(&entry).unwrap();
+        let decoded = decode(&bytes).unwrap();
+        assert_eq!(decoded.thread_id, "t1");
+        assert_eq!(decoded.thread_seq, 1);
+        assert_eq!(decoded.messages.len(), 1);
+    }
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/flusher.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/flusher.rs
@@ -1,0 +1,355 @@
+//! Background flusher: drains JetStream WAL into the inner ThreadRunStore.
+//!
+//! Uses `consumer.messages()` for a long-lived message stream (with server-side
+//! heartbeats) and batches within a `flush_interval` window to coalesce
+//! per-thread writes.
+//!
+//! # Coalescing semantics
+//!
+//! Within a single batch, for each thread:
+//! - Messages: the snapshot from the entry with the highest `thread_seq`
+//!   (checkpoint semantic is full-overwrite, so the latest snapshot subsumes
+//!   earlier ones).
+//! - Run records: one per unique `run_id` (latest version by `thread_seq`).
+//!   This preserves all distinct run records even when multiple runs complete
+//!   within a single flush window.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{RunRecord, StorageError, ThreadRunStore};
+use futures::StreamExt;
+
+use super::{config::NatsBufferedThreadConfig, entry, hot_meta};
+
+/// Accumulator for one thread within a single flush batch.
+struct ThreadBatch {
+    latest_messages: Vec<Message>,
+    latest_thread_seq: u64,
+    /// One entry per unique run_id — latest version by thread_seq.
+    runs_by_id: HashMap<String, (RunRecord, u64)>,
+    msgs_to_ack: Vec<async_nats::jetstream::Message>,
+}
+
+pub fn spawn_flusher<T: ThreadRunStore + Send + Sync + 'static>(
+    inner: Arc<T>,
+    consumer: async_nats::jetstream::consumer::PullConsumer,
+    kv_hot: async_nats::jetstream::kv::Store,
+    config: NatsBufferedThreadConfig,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut messages = match consumer.messages().await {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(error = %e, "flusher failed to open message stream");
+                return;
+            }
+        };
+
+        loop {
+            let mut by_thread: HashMap<String, ThreadBatch> = HashMap::new();
+            let window = tokio::time::sleep(config.flush_interval);
+            tokio::pin!(window);
+
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        if *shutdown_rx.borrow() {
+                            return;
+                        }
+                    }
+                    _ = &mut window => break,
+                    next = messages.next() => match next {
+                        None => return,
+                        Some(Err(e)) => {
+                            tracing::warn!(error = %e, "flusher message stream error");
+                        }
+                        Some(Ok(msg)) => {
+                            if let Some(decoded) = decode_or_ack(&msg).await {
+                                merge_entry(&mut by_thread, decoded, msg);
+                                if by_thread.len() >= config.flush_batch_size {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !by_thread.is_empty() {
+                flush_batch(&inner, &kv_hot, by_thread).await;
+            }
+        }
+    })
+}
+
+async fn decode_or_ack(msg: &async_nats::jetstream::Message) -> Option<entry::CheckpointEntry> {
+    match entry::decode(&msg.payload) {
+        Ok(e) => Some(e),
+        Err(err) => {
+            tracing::warn!(error = %err, "poison entry; acking to skip");
+            let _ = msg.ack().await;
+            None
+        }
+    }
+}
+
+fn merge_entry(
+    by_thread: &mut HashMap<String, ThreadBatch>,
+    decoded: entry::CheckpointEntry,
+    msg: async_nats::jetstream::Message,
+) {
+    let thread_id = decoded.thread_id.clone();
+    let batch = by_thread.entry(thread_id).or_insert_with(|| ThreadBatch {
+        latest_messages: Vec::new(),
+        latest_thread_seq: 0,
+        runs_by_id: HashMap::new(),
+        msgs_to_ack: Vec::new(),
+    });
+
+    if decoded.thread_seq >= batch.latest_thread_seq {
+        batch.latest_messages = decoded.messages;
+        batch.latest_thread_seq = decoded.thread_seq;
+    }
+
+    let run_id = decoded.run.run_id.clone();
+    match batch.runs_by_id.get(&run_id) {
+        Some((_, existing_seq)) if *existing_seq >= decoded.thread_seq => {}
+        _ => {
+            batch
+                .runs_by_id
+                .insert(run_id, (decoded.run, decoded.thread_seq));
+        }
+    }
+
+    batch.msgs_to_ack.push(msg);
+}
+
+/// Sort the per-run accumulator by ascending `thread_seq` so the final
+/// `inner.checkpoint` application matches the highest-seq entry and the
+/// thread projection converges to that run.
+fn order_runs_for_flush(runs_by_id: HashMap<String, (RunRecord, u64)>) -> Vec<(RunRecord, u64)> {
+    let mut ordered: Vec<(RunRecord, u64)> = runs_by_id.into_values().collect();
+    ordered.sort_by_key(|(_, seq)| *seq);
+    ordered
+}
+
+/// Apply a per-thread batch to `inner` in seq-ascending order. Returns
+/// `true` on full success, `false` if any checkpoint errored (caller is
+/// responsible for nacking the WAL messages in that case).
+async fn apply_thread_batch_ordered<T: ThreadRunStore + Send + Sync>(
+    inner: &T,
+    thread_id: &str,
+    messages: &[Message],
+    ordered_runs: &[(RunRecord, u64)],
+) -> bool {
+    for (run, _) in ordered_runs {
+        if let Err(e) = inner.checkpoint(thread_id, messages, run).await {
+            tracing::warn!(thread_id, run_id = %run.run_id, error = %e, "inner checkpoint failed");
+            return false;
+        }
+    }
+    true
+}
+
+/// Persist stale run records without touching the thread/message projection.
+async fn persist_stale_runs_without_projection<T: ThreadRunStore + Send + Sync>(
+    inner: &T,
+    thread_id: &str,
+    stale_runs: &[(RunRecord, u64)],
+) -> bool {
+    for (run, _) in stale_runs {
+        match inner.load_run(&run.run_id).await {
+            Ok(Some(_)) => {}
+            Ok(None) => match inner.create_run(run).await {
+                Ok(()) | Err(StorageError::AlreadyExists(_)) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        thread_id,
+                        run_id = %run.run_id,
+                        error = %e,
+                        "inner create_run for stale WAL entry failed"
+                    );
+                    return false;
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    thread_id,
+                    run_id = %run.run_id,
+                    error = %e,
+                    "inner load_run for stale WAL entry failed"
+                );
+                return false;
+            }
+        }
+    }
+    true
+}
+
+async fn flush_batch<T: ThreadRunStore + Send + Sync + 'static>(
+    inner: &Arc<T>,
+    kv_hot: &async_nats::jetstream::kv::Store,
+    by_thread: HashMap<String, ThreadBatch>,
+) {
+    for (thread_id, batch) in by_thread {
+        let current_flushed = match hot_meta::read_flushed_seq(kv_hot, &thread_id).await {
+            Ok(seq) => seq,
+            Err(e) => {
+                tracing::warn!(thread_id, error = %e, "read flushed_seq failed");
+                for msg in batch.msgs_to_ack {
+                    let _ = msg
+                        .ack_with(async_nats::jetstream::AckKind::Nak(None))
+                        .await;
+                }
+                continue;
+            }
+        };
+        let ordered = order_runs_for_flush(batch.runs_by_id);
+        let (stale_runs, fresh_runs): (Vec<_>, Vec<_>) = ordered
+            .into_iter()
+            .partition(|(_, seq)| *seq <= current_flushed);
+
+        if batch.latest_thread_seq <= current_flushed {
+            let stale_ok =
+                persist_stale_runs_without_projection(inner.as_ref(), &thread_id, &stale_runs)
+                    .await;
+            if stale_ok {
+                for msg in batch.msgs_to_ack {
+                    let _ = msg.ack().await;
+                }
+            } else {
+                for msg in batch.msgs_to_ack {
+                    let _ = msg
+                        .ack_with(async_nats::jetstream::AckKind::Nak(None))
+                        .await;
+                }
+            }
+            continue;
+        }
+
+        let stale_ok =
+            persist_stale_runs_without_projection(inner.as_ref(), &thread_id, &stale_runs).await;
+        let fresh_ok = if fresh_runs.is_empty() {
+            true
+        } else {
+            apply_thread_batch_ordered(
+                inner.as_ref(),
+                &thread_id,
+                &batch.latest_messages,
+                &fresh_runs,
+            )
+            .await
+        };
+        let all_ok = stale_ok && fresh_ok;
+
+        if all_ok {
+            if let Err(e) =
+                hot_meta::write_flushed_seq(kv_hot, &thread_id, batch.latest_thread_seq).await
+            {
+                tracing::warn!(thread_id, error = %e, "write flushed_seq failed");
+            }
+            for msg in batch.msgs_to_ack {
+                let _ = msg.ack().await;
+            }
+        } else {
+            for msg in batch.msgs_to_ack {
+                let _ = msg
+                    .ack_with(async_nats::jetstream::AckKind::Nak(None))
+                    .await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::InMemoryStore;
+    use awaken_contract::contract::lifecycle::RunStatus;
+    use awaken_contract::contract::storage::{RunStore, ThreadStore};
+
+    fn mk_run(run_id: &str, thread_id: &str) -> RunRecord {
+        RunRecord {
+            run_id: run_id.into(),
+            thread_id: thread_id.into(),
+            agent_id: "a".into(),
+            parent_run_id: None,
+            request: None,
+            input: None,
+            output: None,
+            status: RunStatus::Created,
+            termination_reason: None,
+            final_output: None,
+            error_payload: None,
+            dispatch_id: None,
+            session_id: None,
+            transport_request_id: None,
+            waiting: None,
+            outcome: None,
+            created_at: 1,
+            started_at: None,
+            finished_at: None,
+            updated_at: 1,
+            steps: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            state: None,
+        }
+    }
+
+    #[test]
+    fn order_runs_for_flush_sorts_by_thread_seq() {
+        let mut map: HashMap<String, (RunRecord, u64)> = HashMap::new();
+        map.insert("a".into(), (mk_run("a", "t"), 42));
+        map.insert("b".into(), (mk_run("b", "t"), 10));
+        map.insert("c".into(), (mk_run("c", "t"), 99));
+        let ordered = order_runs_for_flush(map);
+        let seqs: Vec<u64> = ordered.iter().map(|(_, s)| *s).collect();
+        assert_eq!(seqs, vec![10, 42, 99]);
+    }
+
+    /// Regression for issue #4: flushing a batch with multiple runs for the
+    /// same thread must leave the thread projection pointing at the
+    /// highest-seq run. `InMemoryStore::checkpoint` updates `latest_run_id`
+    /// on each call — applying in HashMap order could land the projection
+    /// on an older run.
+    #[tokio::test]
+    async fn flush_ordering_preserves_highest_seq_projection() {
+        let inner = InMemoryStore::new();
+
+        let older_run = mk_run("run-old", "t");
+        let newer_run = mk_run("run-new", "t");
+
+        // Deliberately insert older into the HashMap last so HashMap
+        // iteration could order it after the newer run.
+        let mut map: HashMap<String, (RunRecord, u64)> = HashMap::new();
+        map.insert("run-new".into(), (newer_run, 20));
+        map.insert("run-old".into(), (older_run, 10));
+
+        let ordered = order_runs_for_flush(map);
+        let ok = apply_thread_batch_ordered(&inner, "t", &[], &ordered).await;
+        assert!(ok);
+
+        let latest = RunStore::latest_run(&inner as &InMemoryStore, "t")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            latest.run_id, "run-new",
+            "thread projection must point at highest-seq run"
+        );
+        // `ThreadStore::load_thread` must see the same projection.
+        let thread = ThreadStore::load_thread(&inner as &InMemoryStore, "t")
+            .await
+            .unwrap()
+            .unwrap();
+        let open = thread.open_run_id.as_deref();
+        assert!(
+            open == Some("run-new") || open.is_none(),
+            "open_run_id must match highest-seq projection; got {open:?}"
+        );
+    }
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/flusher.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/flusher.rs
@@ -269,7 +269,7 @@ mod tests {
     use super::*;
     use crate::InMemoryStore;
     use awaken_contract::contract::lifecycle::RunStatus;
-    use awaken_contract::contract::storage::{RunStore, ThreadStore};
+    use awaken_contract::contract::storage::ThreadStore;
 
     fn mk_run(run_id: &str, thread_id: &str) -> RunRecord {
         RunRecord {
@@ -333,19 +333,15 @@ mod tests {
         let ok = apply_thread_batch_ordered(&inner, "t", &[], &ordered).await;
         assert!(ok);
 
-        let latest = RunStore::latest_run(&inner as &InMemoryStore, "t")
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            latest.run_id, "run-new",
-            "thread projection must point at highest-seq run"
-        );
-        // `ThreadStore::load_thread` must see the same projection.
         let thread = ThreadStore::load_thread(&inner as &InMemoryStore, "t")
             .await
             .unwrap()
             .unwrap();
+        assert_eq!(
+            thread.latest_run_id.as_deref(),
+            Some("run-new"),
+            "thread projection must point at highest-seq run"
+        );
         let open = thread.open_run_id.as_deref();
         assert!(
             open == Some("run-new") || open.is_none(),

--- a/crates/awaken-stores/src/nats_buffered_thread/hot_meta.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/hot_meta.rs
@@ -1,0 +1,344 @@
+//! Hot metadata (latest_seq, flushed_seq, cached runs) in NATS KV.
+
+// Reader/flusher (Tasks 5/6) consume these helpers; allow the gap until then.
+#![allow(dead_code)]
+
+use awaken_contract::contract::storage::{RunRecord, StorageError};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+use super::keys;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ThreadHotMetadata {
+    /// Highest `thread_seq` a writer has reserved. Incremented via CAS to
+    /// hand out unique sequences; NOT rolled back on publish failure
+    /// (dead reservations are invisible to readers).
+    #[serde(default)]
+    pub reserved_seq: u64,
+    /// Highest `thread_seq` whose WAL entry has been published and
+    /// acknowledged. This is the reader-visible watermark: the hot-cache
+    /// and WAL have a durable entry at exactly this seq.
+    pub latest_seq: u64,
+    /// JetStream stream sequence of the WAL entry corresponding to
+    /// `latest_seq`. Readers fetch by this value (not by
+    /// `get_last_raw_message_by_subject`) so concurrent writers whose
+    /// publish arrivals invert reservation order can't make a reader
+    /// observe the wrong WAL entry for the current `latest_seq`.
+    #[serde(default)]
+    pub latest_js_seq: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedRun {
+    #[serde(default)]
+    thread_seq: u64,
+    run: RunRecord,
+}
+
+pub fn encode_meta(meta: &ThreadHotMetadata) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(meta)
+        .map(Bytes::from)
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn decode_meta(bytes: &[u8]) -> Result<ThreadHotMetadata, StorageError> {
+    if bytes.is_empty() {
+        return Ok(ThreadHotMetadata::default());
+    }
+    serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn encode_run(run: &RunRecord) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(run)
+        .map(Bytes::from)
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn decode_run(bytes: &[u8]) -> Result<RunRecord, StorageError> {
+    serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+fn encode_cached_run(run: &RunRecord, thread_seq: u64) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(&CachedRun {
+        thread_seq,
+        run: run.clone(),
+    })
+    .map(Bytes::from)
+    .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+fn decode_cached_run(bytes: &[u8]) -> Result<(RunRecord, u64), StorageError> {
+    match serde_json::from_slice::<CachedRun>(bytes) {
+        Ok(cached) => Ok((cached.run, cached.thread_seq)),
+        Err(_) => decode_run(bytes).map(|run| (run, 0)),
+    }
+}
+
+pub fn encode_seq(seq: u64) -> Bytes {
+    Bytes::copy_from_slice(&seq.to_le_bytes())
+}
+
+pub fn decode_seq(bytes: &[u8]) -> Result<u64, StorageError> {
+    if bytes.len() != 8 {
+        return Err(StorageError::Serialization(format!(
+            "seq expects 8 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(bytes);
+    Ok(u64::from_le_bytes(buf))
+}
+
+const CAS_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const CAS_BACKOFF_START: std::time::Duration = std::time::Duration::from_micros(200);
+const CAS_BACKOFF_MAX: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// CAS-increment `reserved_seq`. This hands the writer a unique thread
+/// sequence BEFORE it publishes; the reservation is never rolled back on
+/// publish failure (a gap in the reserved counter is invisible to readers,
+/// which only look at `latest_seq`). Writers MUST call
+/// [`promote_latest_seq`] once the WAL publish has been acknowledged.
+pub async fn reserve_seq(
+    kv: &async_nats::jetstream::kv::Store,
+    thread_id: &str,
+    now: u64,
+) -> Result<u64, StorageError> {
+    let key = keys::hot_meta_key(thread_id);
+    let deadline = std::time::Instant::now() + CAS_TOTAL_TIMEOUT;
+    let mut backoff = CAS_BACKOFF_START;
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        let entry = kv
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let (mut meta, revision) = match entry {
+            Some(e) => (decode_meta(&e.value)?, e.revision),
+            None => (ThreadHotMetadata::default(), 0),
+        };
+        // Backfill legacy rows that only carried `latest_seq` so the two
+        // counters monotonically track.
+        if meta.reserved_seq < meta.latest_seq {
+            meta.reserved_seq = meta.latest_seq;
+        }
+        meta.reserved_seq += 1;
+        meta.updated_at = now;
+        let new_seq = meta.reserved_seq;
+        let bytes = encode_meta(&meta)?;
+        let succeeded = if revision == 0 {
+            kv.create(&key, bytes).await.is_ok()
+        } else {
+            kv.update(&key, bytes, revision).await.is_ok()
+        };
+        if succeeded {
+            return Ok(new_seq);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(StorageError::Io(format!(
+                "reserved_seq CAS timeout after {attempts} attempts (thread={thread_id})"
+            )));
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = std::cmp::min(backoff.saturating_mul(2), CAS_BACKOFF_MAX);
+    }
+}
+
+/// CAS `latest_seq = max(current, committed_seq)` and bind the
+/// JetStream sequence of the corresponding WAL entry. Called after a
+/// successful WAL publish ack. Exits without writing if another writer
+/// has already raised `latest_seq` past ours.
+pub async fn promote_latest_seq(
+    kv: &async_nats::jetstream::kv::Store,
+    thread_id: &str,
+    committed_seq: u64,
+    committed_js_seq: u64,
+    now: u64,
+) -> Result<(), StorageError> {
+    let key = keys::hot_meta_key(thread_id);
+    let deadline = std::time::Instant::now() + CAS_TOTAL_TIMEOUT;
+    let mut backoff = CAS_BACKOFF_START;
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        let entry = kv
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let (mut meta, revision) = match entry {
+            Some(e) => (decode_meta(&e.value)?, e.revision),
+            None => (ThreadHotMetadata::default(), 0),
+        };
+        if meta.latest_seq >= committed_seq {
+            return Ok(());
+        }
+        meta.latest_seq = committed_seq;
+        meta.latest_js_seq = committed_js_seq;
+        if meta.reserved_seq < meta.latest_seq {
+            meta.reserved_seq = meta.latest_seq;
+        }
+        meta.updated_at = now;
+        let bytes = encode_meta(&meta)?;
+        let succeeded = if revision == 0 {
+            kv.create(&key, bytes).await.is_ok()
+        } else {
+            kv.update(&key, bytes, revision).await.is_ok()
+        };
+        if succeeded {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(StorageError::Io(format!(
+                "latest_seq CAS timeout after {attempts} attempts (thread={thread_id})"
+            )));
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = std::cmp::min(backoff.saturating_mul(2), CAS_BACKOFF_MAX);
+    }
+}
+
+/// Read the full hot-meta record (thread_seq watermark + JS seq).
+pub async fn read_meta(
+    kv: &async_nats::jetstream::kv::Store,
+    thread_id: &str,
+) -> Result<ThreadHotMetadata, StorageError> {
+    let entry = kv
+        .entry(&keys::hot_meta_key(thread_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+    match entry {
+        Some(e) => decode_meta(&e.value),
+        None => Ok(ThreadHotMetadata::default()),
+    }
+}
+
+pub async fn read_latest_seq(
+    kv: &async_nats::jetstream::kv::Store,
+    thread_id: &str,
+) -> Result<u64, StorageError> {
+    let entry = kv
+        .entry(&keys::hot_meta_key(thread_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+    match entry {
+        Some(e) => Ok(decode_meta(&e.value)?.latest_seq),
+        None => Ok(0),
+    }
+}
+
+pub async fn read_flushed_seq(
+    kv: &async_nats::jetstream::kv::Store,
+    thread_id: &str,
+) -> Result<u64, StorageError> {
+    let entry = kv
+        .entry(&keys::flushed_seq_key(thread_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+    match entry {
+        Some(e) => decode_seq(&e.value),
+        None => Ok(0),
+    }
+}
+
+pub async fn write_flushed_seq(
+    kv: &async_nats::jetstream::kv::Store,
+    thread_id: &str,
+    seq: u64,
+) -> Result<(), StorageError> {
+    let key = keys::flushed_seq_key(thread_id);
+    let deadline = std::time::Instant::now() + CAS_TOTAL_TIMEOUT;
+    let mut backoff = CAS_BACKOFF_START;
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        let entry = kv
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry flushed_seq: {e}")))?;
+        let (current, revision) = match entry {
+            Some(e) => (decode_seq(&e.value)?, e.revision),
+            None => (0, 0),
+        };
+        if current >= seq {
+            return Ok(());
+        }
+        let bytes = encode_seq(seq);
+        let succeeded = if revision == 0 {
+            kv.create(&key, bytes).await.is_ok()
+        } else {
+            kv.update(&key, bytes, revision).await.is_ok()
+        };
+        if succeeded {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(StorageError::Io(format!(
+                "flushed_seq CAS timeout after {attempts} attempts (thread={thread_id})"
+            )));
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = std::cmp::min(backoff.saturating_mul(2), CAS_BACKOFF_MAX);
+    }
+}
+
+pub async fn cache_run_if_newer(
+    kv: &async_nats::jetstream::kv::Store,
+    run: &RunRecord,
+    thread_seq: u64,
+) -> Result<(), StorageError> {
+    let key = keys::hot_run_key(&run.run_id);
+    let deadline = std::time::Instant::now() + CAS_TOTAL_TIMEOUT;
+    let mut backoff = CAS_BACKOFF_START;
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        let entry = kv
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry run: {e}")))?;
+        let revision = match entry {
+            Some(ref e) => {
+                let (_, current_seq) = decode_cached_run(&e.value)?;
+                if current_seq >= thread_seq {
+                    return Ok(());
+                }
+                e.revision
+            }
+            None => 0,
+        };
+        let bytes = encode_cached_run(run, thread_seq)?;
+        let succeeded = if revision == 0 {
+            kv.create(&key, bytes).await.is_ok()
+        } else {
+            kv.update(&key, bytes, revision).await.is_ok()
+        };
+        if succeeded {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(StorageError::Io(format!(
+                "hot run cache CAS timeout after {attempts} attempts (run_id={})",
+                run.run_id
+            )));
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = std::cmp::min(backoff.saturating_mul(2), CAS_BACKOFF_MAX);
+    }
+}
+
+pub async fn load_cached_run(
+    kv: &async_nats::jetstream::kv::Store,
+    run_id: &str,
+) -> Result<Option<RunRecord>, StorageError> {
+    let entry = kv
+        .entry(&keys::hot_run_key(run_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+    match entry {
+        Some(e) => Ok(Some(decode_cached_run(&e.value)?.0)),
+        None => Ok(None),
+    }
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/keys.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/keys.rs
@@ -1,0 +1,39 @@
+use crate::nats_keys::encode_segment;
+
+pub fn thread_subject(thread_id: &str) -> String {
+    format!("thread.{}", encode_segment(thread_id))
+}
+
+pub fn hot_meta_key(thread_id: &str) -> String {
+    format!("meta.{}", encode_segment(thread_id))
+}
+
+pub fn hot_run_key(run_id: &str) -> String {
+    format!("run.{}", encode_segment(run_id))
+}
+
+pub fn flushed_seq_key(thread_id: &str) -> String {
+    format!("flushed.{}", encode_segment(thread_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_encode_user_controlled_segments() {
+        assert_eq!(thread_subject("t1"), "thread.h7431");
+        assert_eq!(hot_meta_key("t1"), "meta.h7431");
+        assert_eq!(hot_run_key("r1"), "run.h7231");
+        assert_eq!(flushed_seq_key("t1"), "flushed.h7431");
+    }
+
+    #[test]
+    fn subjects_do_not_expose_wildcards_or_extra_tokens() {
+        let subject = thread_subject("thread.*.>");
+
+        assert_eq!(subject.matches('.').count(), 1);
+        assert!(!subject.contains('*'));
+        assert!(!subject.contains('>'));
+    }
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/mod.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/mod.rs
@@ -1,0 +1,293 @@
+//! NATS-buffered `ThreadRunStore` decorator.
+//!
+//! Buffers `checkpoint()` writes in a JetStream WAL + KV hot state, with a
+//! background flusher that coalesces per-thread writes into the inner store.
+//! Reads serve read-your-writes consistency via a WAL overlay (DB when caught
+//! up, last WAL entry otherwise).
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use awaken_stores::{InMemoryStore, NatsBufferedThreadConfig, NatsBufferedThreadStore};
+//!
+//! # async fn wire() -> Result<(), Box<dyn std::error::Error>> {
+//! let inner = Arc::new(InMemoryStore::new());
+//! let config = NatsBufferedThreadConfig::new("nats://localhost:4222");
+//! let buffered = NatsBufferedThreadStore::connect(inner, config).await?;
+//! // Use `buffered` wherever a `ThreadRunStore` is expected.
+//! # buffered.shutdown().await?;
+//! # Ok(())
+//! # }
+//! ```
+
+mod config;
+mod entry;
+mod flusher;
+mod hot_meta;
+mod keys;
+mod reader;
+mod recovery;
+mod writer;
+
+pub use config::{NatsBufferedThreadConfig, ReadConsistency};
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{
+    RunPage, RunQuery, RunRecord, RunStore, StorageError, ThreadRunStore, ThreadStore,
+};
+use awaken_contract::thread::{Thread, ThreadMetadata};
+
+use async_nats::jetstream::{consumer, kv, stream};
+
+pub struct NatsBufferedThreadStore<T: ThreadRunStore + Send + Sync + 'static> {
+    pub(crate) inner: Arc<T>,
+    #[allow(dead_code)]
+    pub(crate) client: async_nats::Client,
+    pub(crate) jetstream: async_nats::jetstream::Context,
+    pub(crate) stream: async_nats::jetstream::stream::Stream,
+    pub(crate) kv_hot: async_nats::jetstream::kv::Store,
+    #[allow(dead_code)]
+    pub(crate) consumer: async_nats::jetstream::consumer::PullConsumer,
+    pub(crate) config: config::NatsBufferedThreadConfig,
+    pub(crate) shutdown_tx: tokio::sync::watch::Sender<bool>,
+    #[allow(dead_code)]
+    pub(crate) flusher_handle: tokio::task::JoinHandle<()>,
+}
+
+impl<T: ThreadRunStore + Send + Sync + 'static> NatsBufferedThreadStore<T> {
+    pub async fn connect(
+        inner: Arc<T>,
+        config: config::NatsBufferedThreadConfig,
+    ) -> Result<Self, StorageError> {
+        let client = async_nats::connect(&config.url)
+            .await
+            .map_err(|e| StorageError::Io(format!("connect: {e}")))?;
+        let jetstream = async_nats::jetstream::new(client.clone());
+
+        let stream_config = stream::Config {
+            name: config.stream_name.clone(),
+            subjects: vec!["thread.>".to_string()],
+            retention: stream::RetentionPolicy::Limits,
+            max_age: config.max_age,
+            storage: stream::StorageType::File,
+            ..Default::default()
+        };
+        let stream = jetstream
+            .get_or_create_stream(stream_config)
+            .await
+            .map_err(|e| StorageError::Io(format!("create stream: {e}")))?;
+
+        let consumer_config = consumer::pull::Config {
+            durable_name: Some(config.consumer_name.clone()),
+            filter_subject: "thread.>".to_string(),
+            ack_policy: consumer::AckPolicy::Explicit,
+            ack_wait: config.ack_wait,
+            ..Default::default()
+        };
+        let consumer = stream
+            .get_or_create_consumer(&config.consumer_name, consumer_config)
+            .await
+            .map_err(|e| StorageError::Io(format!("create consumer: {e}")))?;
+
+        let kv_hot = match jetstream.get_key_value(&config.hot_bucket).await {
+            Ok(s) => s,
+            Err(_) => jetstream
+                .create_key_value(kv::Config {
+                    bucket: config.hot_bucket.clone(),
+                    history: 1,
+                    ..Default::default()
+                })
+                .await
+                .map_err(|e| StorageError::Io(format!("create bucket: {e}")))?,
+        };
+
+        let (shutdown_tx, _) = tokio::sync::watch::channel(false);
+
+        let shutdown_rx = shutdown_tx.subscribe();
+        let flusher_handle = flusher::spawn_flusher(
+            Arc::clone(&inner),
+            consumer.clone(),
+            kv_hot.clone(),
+            config.clone(),
+            shutdown_rx,
+        );
+
+        Ok(Self {
+            inner,
+            client,
+            jetstream,
+            stream,
+            kv_hot,
+            consumer,
+            config,
+            shutdown_tx,
+            flusher_handle,
+        })
+    }
+
+    pub async fn shutdown(&self) -> Result<(), StorageError> {
+        let _ = self.shutdown_tx.send(true);
+        Ok(())
+    }
+
+    /// Test-only: publish a `CheckpointEntry` to the WAL with a
+    /// caller-chosen `thread_seq`, returning the JetStream stream
+    /// sequence assigned to the entry. Used to reproduce the
+    /// concurrent-writer race where JS arrival order diverges from
+    /// reservation order.
+    #[doc(hidden)]
+    pub async fn __test_plant_wal_entry(
+        &self,
+        thread_id: &str,
+        run: &RunRecord,
+        messages: &[Message],
+        thread_seq: u64,
+    ) -> Result<u64, StorageError> {
+        let wal_entry = entry::CheckpointEntry {
+            thread_id: thread_id.to_string(),
+            run: run.clone(),
+            messages: messages.to_vec(),
+            thread_seq,
+            written_at: 0,
+        };
+        let payload = entry::encode(&wal_entry)?;
+        let ack = self
+            .jetstream
+            .publish(keys::thread_subject(thread_id), payload)
+            .await
+            .map_err(|e| StorageError::Io(format!("publish: {e}")))?
+            .await
+            .map_err(|e| StorageError::Io(format!("publish ack: {e}")))?;
+        Ok(ack.sequence)
+    }
+
+    /// Test-only: force `ThreadHotMetadata` to specific values, skipping
+    /// the CAS-promote guard. Used together with `__test_plant_wal_entry`
+    /// to simulate a committed seq/JS-seq pair without running the
+    /// writer path.
+    #[doc(hidden)]
+    pub async fn __test_force_hot_meta(
+        &self,
+        thread_id: &str,
+        reserved_seq: u64,
+        latest_seq: u64,
+        latest_js_seq: u64,
+    ) -> Result<(), StorageError> {
+        let meta = hot_meta::ThreadHotMetadata {
+            reserved_seq,
+            latest_seq,
+            latest_js_seq,
+            updated_at: 0,
+        };
+        let bytes = hot_meta::encode_meta(&meta)?;
+        self.kv_hot
+            .put(keys::hot_meta_key(thread_id), bytes)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv put: {e}")))?;
+        Ok(())
+    }
+
+    #[doc(hidden)]
+    pub async fn __test_cache_run_if_newer(
+        &self,
+        run: &RunRecord,
+        thread_seq: u64,
+    ) -> Result<(), StorageError> {
+        hot_meta::cache_run_if_newer(&self.kv_hot, run, thread_seq).await
+    }
+
+    #[doc(hidden)]
+    pub async fn __test_read_flushed_seq(&self, thread_id: &str) -> Result<u64, StorageError> {
+        hot_meta::read_flushed_seq(&self.kv_hot, thread_id).await
+    }
+
+    /// Block until the flusher has drained all pending entries for the given thread.
+    pub async fn force_flush(&self, thread_id: &str) -> Result<(), StorageError> {
+        let target = hot_meta::read_latest_seq(&self.kv_hot, thread_id).await?;
+        if target == 0 {
+            return Ok(());
+        }
+        let timeout = std::time::Duration::from_secs(10);
+        let start = std::time::Instant::now();
+        loop {
+            let flushed = hot_meta::read_flushed_seq(&self.kv_hot, thread_id).await?;
+            if flushed >= target {
+                return Ok(());
+            }
+            if start.elapsed() >= timeout {
+                return Err(StorageError::Io(format!(
+                    "force_flush timeout (thread={thread_id}, target={target}, flushed={flushed})"
+                )));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+}
+
+#[async_trait]
+impl<T: ThreadRunStore + Send + Sync + 'static> ThreadStore for NatsBufferedThreadStore<T> {
+    async fn load_thread(&self, thread_id: &str) -> Result<Option<Thread>, StorageError> {
+        self.inner.load_thread(thread_id).await
+    }
+    async fn save_thread(&self, thread: &Thread) -> Result<(), StorageError> {
+        self.inner.save_thread(thread).await
+    }
+    async fn delete_thread(&self, thread_id: &str) -> Result<(), StorageError> {
+        self.inner.delete_thread(thread_id).await
+    }
+    async fn list_threads(&self, offset: usize, limit: usize) -> Result<Vec<String>, StorageError> {
+        self.inner.list_threads(offset, limit).await
+    }
+    async fn load_messages(&self, thread_id: &str) -> Result<Option<Vec<Message>>, StorageError> {
+        reader::load_messages(self, thread_id).await
+    }
+    async fn save_messages(
+        &self,
+        thread_id: &str,
+        messages: &[Message],
+    ) -> Result<(), StorageError> {
+        self.inner.save_messages(thread_id, messages).await
+    }
+    async fn delete_messages(&self, thread_id: &str) -> Result<(), StorageError> {
+        self.inner.delete_messages(thread_id).await
+    }
+    async fn update_thread_metadata(
+        &self,
+        id: &str,
+        metadata: ThreadMetadata,
+    ) -> Result<(), StorageError> {
+        self.inner.update_thread_metadata(id, metadata).await
+    }
+}
+
+#[async_trait]
+impl<T: ThreadRunStore + Send + Sync + 'static> RunStore for NatsBufferedThreadStore<T> {
+    async fn create_run(&self, record: &RunRecord) -> Result<(), StorageError> {
+        self.inner.create_run(record).await
+    }
+    async fn load_run(&self, run_id: &str) -> Result<Option<RunRecord>, StorageError> {
+        reader::load_run(self, run_id).await
+    }
+    async fn latest_run(&self, thread_id: &str) -> Result<Option<RunRecord>, StorageError> {
+        reader::latest_run(self, thread_id).await
+    }
+    async fn list_runs(&self, query: &RunQuery) -> Result<RunPage, StorageError> {
+        self.inner.list_runs(query).await
+    }
+}
+
+#[async_trait]
+impl<T: ThreadRunStore + Send + Sync + 'static> ThreadRunStore for NatsBufferedThreadStore<T> {
+    async fn checkpoint(
+        &self,
+        thread_id: &str,
+        messages: &[Message],
+        run: &RunRecord,
+    ) -> Result<(), StorageError> {
+        writer::checkpoint(self, thread_id, messages, run).await
+    }
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/reader.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/reader.rs
@@ -1,0 +1,104 @@
+//! Read path: DB + WAL overlay for read-your-writes consistency.
+
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{RunRecord, StorageError, ThreadRunStore};
+
+use super::{NatsBufferedThreadStore, config::ReadConsistency, entry, hot_meta};
+
+pub async fn load_messages<T: ThreadRunStore + Send + Sync + 'static>(
+    store: &NatsBufferedThreadStore<T>,
+    thread_id: &str,
+) -> Result<Option<Vec<Message>>, StorageError> {
+    match store.config.read_consistency {
+        ReadConsistency::Eventual => return store.inner.load_messages(thread_id).await,
+        ReadConsistency::Strong => {
+            store.force_flush(thread_id).await?;
+            return store.inner.load_messages(thread_id).await;
+        }
+        ReadConsistency::ReadYourWrites => {}
+    }
+
+    let meta = hot_meta::read_meta(&store.kv_hot, thread_id).await?;
+    let flushed_seq = hot_meta::read_flushed_seq(&store.kv_hot, thread_id).await?;
+
+    if meta.latest_seq <= flushed_seq {
+        return store.inner.load_messages(thread_id).await;
+    }
+
+    if let Some(latest_entry) = read_committed_wal_entry(store, &meta).await? {
+        return Ok(Some(latest_entry.messages));
+    }
+
+    store.inner.load_messages(thread_id).await
+}
+
+pub async fn load_run<T: ThreadRunStore + Send + Sync + 'static>(
+    store: &NatsBufferedThreadStore<T>,
+    run_id: &str,
+) -> Result<Option<RunRecord>, StorageError> {
+    if store.config.read_consistency == ReadConsistency::Eventual {
+        return store.inner.load_run(run_id).await;
+    }
+    if let Some(run) = hot_meta::load_cached_run(&store.kv_hot, run_id).await? {
+        return Ok(Some(run));
+    }
+    store.inner.load_run(run_id).await
+}
+
+pub async fn latest_run<T: ThreadRunStore + Send + Sync + 'static>(
+    store: &NatsBufferedThreadStore<T>,
+    thread_id: &str,
+) -> Result<Option<RunRecord>, StorageError> {
+    match store.config.read_consistency {
+        ReadConsistency::Eventual => return store.inner.latest_run(thread_id).await,
+        ReadConsistency::Strong => {
+            store.force_flush(thread_id).await?;
+            return store.inner.latest_run(thread_id).await;
+        }
+        ReadConsistency::ReadYourWrites => {}
+    }
+
+    let meta = hot_meta::read_meta(&store.kv_hot, thread_id).await?;
+    let flushed_seq = hot_meta::read_flushed_seq(&store.kv_hot, thread_id).await?;
+
+    if meta.latest_seq > flushed_seq
+        && let Some(latest_entry) = read_committed_wal_entry(store, &meta).await?
+    {
+        return Ok(Some(latest_entry.run));
+    }
+    store.inner.latest_run(thread_id).await
+}
+
+/// Fetch the WAL entry bound to `meta.latest_seq` via `meta.latest_js_seq`.
+///
+/// Directly addressing the JetStream stream sequence avoids the
+/// concurrent-writer race where "last message by subject" reflects
+/// publish-arrival order (which can invert reservation order). We also
+/// validate that the decoded entry's `thread_seq` matches `latest_seq`;
+/// a mismatch indicates lost bookkeeping and we conservatively fall
+/// back to the inner store rather than return unverified data.
+async fn read_committed_wal_entry<T: ThreadRunStore + Send + Sync + 'static>(
+    store: &NatsBufferedThreadStore<T>,
+    meta: &hot_meta::ThreadHotMetadata,
+) -> Result<Option<entry::CheckpointEntry>, StorageError> {
+    if meta.latest_js_seq == 0 {
+        // Legacy hot-meta row written before this field existed.
+        return Ok(None);
+    }
+    match store.stream.get_raw_message(meta.latest_js_seq).await {
+        Ok(raw) => {
+            let decoded = entry::decode(&raw.payload)?;
+            if decoded.thread_seq != meta.latest_seq {
+                tracing::warn!(
+                    thread_seq = decoded.thread_seq,
+                    latest_seq = meta.latest_seq,
+                    latest_js_seq = meta.latest_js_seq,
+                    "WAL entry at committed JS seq has mismatched thread_seq; falling back"
+                );
+                return Ok(None);
+            }
+            Ok(Some(decoded))
+        }
+        Err(_) => Ok(None),
+    }
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/reader.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/reader.rs
@@ -36,8 +36,15 @@ pub async fn load_run<T: ThreadRunStore + Send + Sync + 'static>(
     store: &NatsBufferedThreadStore<T>,
     run_id: &str,
 ) -> Result<Option<RunRecord>, StorageError> {
-    if store.config.read_consistency == ReadConsistency::Eventual {
-        return store.inner.load_run(run_id).await;
+    match store.config.read_consistency {
+        ReadConsistency::Eventual => return store.inner.load_run(run_id).await,
+        ReadConsistency::Strong => {
+            if let Some(run) = hot_meta::load_cached_run(&store.kv_hot, run_id).await? {
+                store.force_flush(&run.thread_id).await?;
+            }
+            return store.inner.load_run(run_id).await;
+        }
+        ReadConsistency::ReadYourWrites => {}
     }
     if let Some(run) = hot_meta::load_cached_run(&store.kv_hot, run_id).await? {
         return Ok(Some(run));
@@ -50,10 +57,10 @@ pub async fn latest_run<T: ThreadRunStore + Send + Sync + 'static>(
     thread_id: &str,
 ) -> Result<Option<RunRecord>, StorageError> {
     match store.config.read_consistency {
-        ReadConsistency::Eventual => return store.inner.latest_run(thread_id).await,
+        ReadConsistency::Eventual => return latest_inner_run(store, thread_id).await,
         ReadConsistency::Strong => {
             store.force_flush(thread_id).await?;
-            return store.inner.latest_run(thread_id).await;
+            return latest_inner_run(store, thread_id).await;
         }
         ReadConsistency::ReadYourWrites => {}
     }
@@ -65,6 +72,19 @@ pub async fn latest_run<T: ThreadRunStore + Send + Sync + 'static>(
         && let Some(latest_entry) = read_committed_wal_entry(store, &meta).await?
     {
         return Ok(Some(latest_entry.run));
+    }
+    latest_inner_run(store, thread_id).await
+}
+
+async fn latest_inner_run<T: ThreadRunStore + Send + Sync + 'static>(
+    store: &NatsBufferedThreadStore<T>,
+    thread_id: &str,
+) -> Result<Option<RunRecord>, StorageError> {
+    if let Some(thread) = store.inner.load_thread(thread_id).await?
+        && let Some(run_id) = thread.latest_run_id
+        && let Some(run) = store.inner.load_run(&run_id).await?
+    {
+        return Ok(Some(run));
     }
     store.inner.latest_run(thread_id).await
 }

--- a/crates/awaken-stores/src/nats_buffered_thread/recovery.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/recovery.rs
@@ -1,0 +1,1 @@
+//! Implemented in later tasks.

--- a/crates/awaken-stores/src/nats_buffered_thread/writer.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/writer.rs
@@ -1,0 +1,55 @@
+//! Checkpoint write path: KV latest_seq CAS + hot run cache + JetStream publish.
+
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{RunRecord, StorageError, ThreadRunStore};
+
+use super::{NatsBufferedThreadStore, entry, hot_meta, keys};
+
+pub async fn checkpoint<T: ThreadRunStore + Send + Sync + 'static>(
+    store: &NatsBufferedThreadStore<T>,
+    thread_id: &str,
+    messages: &[Message],
+    run: &RunRecord,
+) -> Result<(), StorageError> {
+    let now = now_millis();
+    // Reserve a unique seq but don't let readers observe it yet — that
+    // only happens after the WAL publish lands. If publish fails we
+    // abandon the reservation (gap in `reserved_seq`, harmless to
+    // readers which only consult `latest_seq`).
+    let seq = hot_meta::reserve_seq(&store.kv_hot, thread_id, now).await?;
+
+    let wal_entry = entry::CheckpointEntry {
+        thread_id: thread_id.to_string(),
+        run: run.clone(),
+        messages: messages.to_vec(),
+        thread_seq: seq,
+        written_at: now,
+    };
+    let payload = entry::encode(&wal_entry)?;
+    let publish_ack = store
+        .jetstream
+        .publish(keys::thread_subject(thread_id), payload)
+        .await
+        .map_err(|e| StorageError::Io(format!("publish: {e}")))?;
+    let ack = publish_ack
+        .await
+        .map_err(|e| StorageError::Io(format!("publish ack: {e}")))?;
+    let js_seq = ack.sequence;
+
+    // WAL is durable. Promote hot state in commit order:
+    // 1. Cache the new run so `load_run` hits the fresh copy.
+    // 2. Raise `latest_seq` AND bind it to the JS stream seq of THIS
+    //    WAL entry, so concurrent writers whose JS publish arrivals
+    //    invert reservation order don't confuse readers.
+    hot_meta::cache_run_if_newer(&store.kv_hot, run, seq).await?;
+    hot_meta::promote_latest_seq(&store.kv_hot, thread_id, seq, js_seq, now).await?;
+
+    Ok(())
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/awaken-stores/src/nats_keys.rs
+++ b/crates/awaken-stores/src/nats_keys.rs
@@ -1,0 +1,75 @@
+//! NATS subject and KV-key segment encoding.
+//!
+//! Thread IDs and run IDs can be user-controlled. Encode them before embedding
+//! in NATS subjects or KV keys so wildcard tokens and separators cannot change
+//! routing semantics.
+
+const PREFIX: char = 'h';
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+pub(crate) fn encode_segment(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = String::with_capacity(1 + bytes.len() * 2);
+    out.push(PREFIX);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+pub(crate) fn decode_segment(value: &str) -> Option<String> {
+    let encoded = value.strip_prefix(PREFIX)?;
+    if encoded.len() % 2 != 0 {
+        return None;
+    }
+
+    let mut bytes = Vec::with_capacity(encoded.len() / 2);
+    for pair in encoded.as_bytes().chunks_exact(2) {
+        let high = from_hex(pair[0])?;
+        let low = from_hex(pair[1])?;
+        bytes.push((high << 4) | low);
+    }
+    String::from_utf8(bytes).ok()
+}
+
+fn from_hex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segment_encoding_roundtrips_arbitrary_subject_chars() {
+        let raw = "thread.*.with.>.and spaces/utf8-\u{4e2d}";
+        let encoded = encode_segment(raw);
+
+        assert!(!encoded.contains('*'));
+        assert!(!encoded.contains('>'));
+        assert!(!encoded.contains('.'));
+        assert!(!encoded.contains(' '));
+        assert_eq!(decode_segment(&encoded).as_deref(), Some(raw));
+    }
+
+    #[test]
+    fn empty_segment_roundtrips_to_prefixed_token() {
+        let encoded = encode_segment("");
+
+        assert_eq!(encoded, "h");
+        assert_eq!(decode_segment(&encoded).as_deref(), Some(""));
+    }
+
+    #[test]
+    fn malformed_segments_return_none() {
+        assert!(decode_segment("raw").is_none());
+        assert!(decode_segment("h0").is_none());
+        assert!(decode_segment("hzz").is_none());
+    }
+}

--- a/crates/awaken-stores/src/nats_mailbox/claim_guard.rs
+++ b/crates/awaken-stores/src/nats_mailbox/claim_guard.rs
@@ -1,0 +1,142 @@
+//! Per-thread distributed claim guard.
+
+use awaken_contract::contract::storage::StorageError;
+
+use super::{NatsMailboxStore, codec, keys};
+
+pub(crate) struct AcquiredThreadClaim {
+    pub claim_token: String,
+    pub lease_until: u64,
+}
+
+pub(crate) async fn acquire(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    dispatch_id: &str,
+    lease_ms: u64,
+    now: u64,
+) -> Result<Option<AcquiredThreadClaim>, StorageError> {
+    let key = keys::thread_claim_key(thread_id);
+    for _ in 0..5 {
+        let entry = store
+            .kv_thread_index
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("thread claim entry: {e}")))?;
+
+        if let Some(ref entry) = entry {
+            let existing = codec::decode_thread_claim(&entry.value)?;
+            if existing.lease_until >= now {
+                return Ok(None);
+            }
+        }
+
+        let claim_token = uuid::Uuid::now_v7().to_string();
+        let lease_until = now.saturating_add(lease_ms);
+        let claim = codec::ThreadClaim {
+            dispatch_id: dispatch_id.to_string(),
+            claim_token: claim_token.clone(),
+            lease_until,
+        };
+        let bytes = codec::encode_thread_claim(&claim)?;
+
+        let result = match entry {
+            Some(entry) => store
+                .kv_thread_index
+                .update(&key, bytes, entry.revision)
+                .await
+                .map(|_| ())
+                .map_err(|e| e.to_string()),
+            None => store
+                .kv_thread_index
+                .create(&key, bytes)
+                .await
+                .map(|_| ())
+                .map_err(|e| e.to_string()),
+        };
+
+        if result.is_ok() {
+            return Ok(Some(AcquiredThreadClaim {
+                claim_token,
+                lease_until,
+            }));
+        }
+    }
+
+    Err(StorageError::Io(
+        "thread claim CAS exhausted retries".to_string(),
+    ))
+}
+
+pub(crate) async fn extend(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    dispatch_id: &str,
+    claim_token: &str,
+    lease_until: u64,
+) -> Result<bool, StorageError> {
+    let key = keys::thread_claim_key(thread_id);
+    for _ in 0..5 {
+        let entry = store
+            .kv_thread_index
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("thread claim entry: {e}")))?;
+        let Some(entry) = entry else {
+            return Ok(false);
+        };
+        let mut claim = codec::decode_thread_claim(&entry.value)?;
+        if claim.dispatch_id != dispatch_id || claim.claim_token != claim_token {
+            return Ok(false);
+        }
+        claim.lease_until = lease_until;
+        let bytes = codec::encode_thread_claim(&claim)?;
+        if store
+            .kv_thread_index
+            .update(&key, bytes, entry.revision)
+            .await
+            .is_ok()
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+pub(crate) async fn release(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    dispatch_id: &str,
+    claim_token: &str,
+) -> Result<(), StorageError> {
+    let key = keys::thread_claim_key(thread_id);
+    for _ in 0..5 {
+        let entry = store
+            .kv_thread_index
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("thread claim entry: {e}")))?;
+        let Some(entry) = entry else {
+            return Ok(());
+        };
+        let mut claim = codec::decode_thread_claim(&entry.value)?;
+        if claim.dispatch_id != dispatch_id || claim.claim_token != claim_token {
+            return Ok(());
+        }
+        claim.lease_until = 0;
+        let bytes = codec::encode_thread_claim(&claim)?;
+        if store
+            .kv_thread_index
+            .update(&key, bytes, entry.revision)
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+
+    Err(StorageError::Io(
+        "thread claim release CAS exhausted retries".to_string(),
+    ))
+}

--- a/crates/awaken-stores/src/nats_mailbox/claim_guard.rs
+++ b/crates/awaken-stores/src/nats_mailbox/claim_guard.rs
@@ -9,6 +9,28 @@ pub(crate) struct AcquiredThreadClaim {
     pub lease_until: u64,
 }
 
+pub(crate) async fn active_dispatch_id(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    now: u64,
+) -> Result<Option<String>, StorageError> {
+    let key = keys::thread_claim_key(thread_id);
+    let Some(entry) = store
+        .kv_thread_index
+        .entry(&key)
+        .await
+        .map_err(|e| StorageError::Io(format!("thread claim entry: {e}")))?
+    else {
+        return Ok(None);
+    };
+    let claim = codec::decode_thread_claim(&entry.value)?;
+    if claim.lease_until >= now {
+        Ok(Some(claim.dispatch_id))
+    } else {
+        Ok(None)
+    }
+}
+
 pub(crate) async fn acquire(
     store: &NatsMailboxStore,
     thread_id: &str,

--- a/crates/awaken-stores/src/nats_mailbox/codec.rs
+++ b/crates/awaken-stores/src/nats_mailbox/codec.rs
@@ -29,6 +29,30 @@ pub fn decode_thread_index(bytes: &[u8]) -> Result<Vec<String>, StorageError> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DedupeLockRecord {
+    pub dispatch_id: String,
+    pub created_at: u64,
+}
+
+pub(crate) fn encode_dedupe_lock(record: &DedupeLockRecord) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(record)
+        .map(Bytes::from)
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub(crate) fn decode_dedupe_lock(bytes: &[u8]) -> Result<DedupeLockRecord, StorageError> {
+    if let Ok(record) = serde_json::from_slice::<DedupeLockRecord>(bytes) {
+        return Ok(record);
+    }
+    let dispatch_id = String::from_utf8(bytes.to_vec())
+        .map_err(|e| StorageError::Serialization(format!("dedupe lock utf8: {e}")))?;
+    Ok(DedupeLockRecord {
+        dispatch_id,
+        created_at: 0,
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ThreadClaim {
     pub dispatch_id: String,
     pub claim_token: String,
@@ -126,5 +150,24 @@ mod tests {
         assert_eq!(decoded.dispatch_id, "d1");
         assert_eq!(decoded.claim_token, "token");
         assert_eq!(decoded.lease_until, 42);
+    }
+
+    #[test]
+    fn dedupe_lock_record_roundtrips() {
+        let record = DedupeLockRecord {
+            dispatch_id: "d1".to_string(),
+            created_at: 123,
+        };
+        let bytes = encode_dedupe_lock(&record).unwrap();
+        let decoded = decode_dedupe_lock(&bytes).unwrap();
+        assert_eq!(decoded.dispatch_id, "d1");
+        assert_eq!(decoded.created_at, 123);
+    }
+
+    #[test]
+    fn dedupe_lock_decodes_legacy_dispatch_id() {
+        let decoded = decode_dedupe_lock(b"legacy-dispatch").unwrap();
+        assert_eq!(decoded.dispatch_id, "legacy-dispatch");
+        assert_eq!(decoded.created_at, 0);
     }
 }

--- a/crates/awaken-stores/src/nats_mailbox/codec.rs
+++ b/crates/awaken-stores/src/nats_mailbox/codec.rs
@@ -1,0 +1,130 @@
+//! RunDispatch serialization for NATS KV values.
+
+use awaken_contract::contract::mailbox::RunDispatch;
+use awaken_contract::contract::storage::StorageError;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+pub fn encode(dispatch: &RunDispatch) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(dispatch)
+        .map(Bytes::from)
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RunDispatch, StorageError> {
+    serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn encode_thread_index(ids: &[String]) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(ids)
+        .map(Bytes::from)
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn decode_thread_index(bytes: &[u8]) -> Result<Vec<String>, StorageError> {
+    if bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ThreadClaim {
+    pub dispatch_id: String,
+    pub claim_token: String,
+    pub lease_until: u64,
+}
+
+pub(crate) fn encode_thread_claim(claim: &ThreadClaim) -> Result<Bytes, StorageError> {
+    serde_json::to_vec(claim)
+        .map(Bytes::from)
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub(crate) fn decode_thread_claim(bytes: &[u8]) -> Result<ThreadClaim, StorageError> {
+    serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+}
+
+pub fn encode_epoch(epoch: u64) -> Bytes {
+    Bytes::copy_from_slice(&epoch.to_le_bytes())
+}
+
+pub fn decode_epoch(bytes: &[u8]) -> Result<u64, StorageError> {
+    if bytes.len() != 8 {
+        return Err(StorageError::Serialization(format!(
+            "epoch expects 8 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(bytes);
+    Ok(u64::from_le_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+
+    fn sample_dispatch() -> RunDispatch {
+        RunDispatch {
+            dispatch_id: "d1".to_string(),
+            thread_id: "t1".to_string(),
+            run_id: "r1".to_string(),
+            priority: 128,
+            dedupe_key: None,
+            dispatch_epoch: 0,
+            status: RunDispatchStatus::Queued,
+            available_at: 0,
+            attempt_count: 0,
+            max_attempts: 3,
+            last_error: None,
+            claim_token: None,
+            claimed_by: None,
+            lease_until: None,
+            dispatch_instance_id: None,
+            run_status: None,
+            termination: None,
+            run_response: None,
+            run_error: None,
+            completed_at: None,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let dispatch = sample_dispatch();
+        let encoded = encode(&dispatch).unwrap();
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.dispatch_id, "d1");
+    }
+
+    #[test]
+    fn epoch_roundtrip() {
+        let bytes = encode_epoch(42);
+        assert_eq!(decode_epoch(&bytes).unwrap(), 42);
+    }
+
+    #[test]
+    fn epoch_wrong_length_errors() {
+        assert!(decode_epoch(&[1, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn thread_claim_roundtrips() {
+        let claim = ThreadClaim {
+            dispatch_id: "d1".to_string(),
+            claim_token: "token".to_string(),
+            lease_until: 42,
+        };
+
+        let bytes = encode_thread_claim(&claim).unwrap();
+        let decoded = decode_thread_claim(&bytes).unwrap();
+
+        assert_eq!(decoded.dispatch_id, "d1");
+        assert_eq!(decoded.claim_token, "token");
+        assert_eq!(decoded.lease_until, 42);
+    }
+}

--- a/crates/awaken-stores/src/nats_mailbox/config.rs
+++ b/crates/awaken-stores/src/nats_mailbox/config.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct NatsMailboxConfig {
+    pub url: String,
+    pub credentials: Option<String>,
+    pub stream_name: String,
+    pub consumer_name: String,
+    pub dispatch_bucket: String,
+    pub epoch_bucket: String,
+    pub thread_index_bucket: String,
+    pub sweeper_interval: Duration,
+    pub dedup_window: Duration,
+}
+
+impl NatsMailboxConfig {
+    #[must_use]
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for NatsMailboxConfig {
+    fn default() -> Self {
+        Self {
+            url: "nats://localhost:4222".to_string(),
+            credentials: None,
+            stream_name: "DISPATCH".to_string(),
+            consumer_name: "dispatch-worker".to_string(),
+            dispatch_bucket: "dispatch-state".to_string(),
+            epoch_bucket: "thread-epoch".to_string(),
+            thread_index_bucket: "thread-index".to_string(),
+            sweeper_interval: Duration::from_secs(5),
+            dedup_window: Duration::from_secs(120),
+        }
+    }
+}

--- a/crates/awaken-stores/src/nats_mailbox/index.rs
+++ b/crates/awaken-stores/src/nats_mailbox/index.rs
@@ -87,19 +87,6 @@ impl DispatchIndex {
         threads.into_iter().collect()
     }
 
-    pub fn claimed_with_expired_lease(&self, now: u64, limit: usize) -> Vec<RunDispatch> {
-        let Some(claimed_ids) = self.by_status.get(&status_key(RunDispatchStatus::Claimed)) else {
-            return Vec::new();
-        };
-        claimed_ids
-            .iter()
-            .filter_map(|id| self.by_id.get(id))
-            .filter(|d| d.lease_until.is_some_and(|until| until < now))
-            .take(limit)
-            .cloned()
-            .collect()
-    }
-
     pub fn terminal_older_than(&self, cutoff: u64) -> Vec<String> {
         let terminal_statuses = [
             RunDispatchStatus::Acked,

--- a/crates/awaken-stores/src/nats_mailbox/index.rs
+++ b/crates/awaken-stores/src/nats_mailbox/index.rs
@@ -1,0 +1,220 @@
+//! In-memory dispatch index, kept in sync with KV bucket via watcher.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use tokio::sync::RwLock;
+
+use super::{codec, keys};
+
+fn status_key(status: RunDispatchStatus) -> String {
+    format!("{status:?}")
+}
+
+#[derive(Default)]
+pub struct DispatchIndex {
+    by_id: HashMap<String, RunDispatch>,
+    by_thread: HashMap<String, Vec<String>>,
+    by_status: HashMap<String, HashSet<String>>,
+}
+
+impl DispatchIndex {
+    pub fn upsert(&mut self, dispatch: RunDispatch) {
+        let id = dispatch.dispatch_id.clone();
+        if let Some(prev) = self.by_id.get(&id) {
+            if let Some(set) = self.by_status.get_mut(&status_key(prev.status)) {
+                set.remove(&id);
+            }
+        } else {
+            self.by_thread
+                .entry(dispatch.thread_id.clone())
+                .or_default()
+                .push(id.clone());
+        }
+        self.by_status
+            .entry(status_key(dispatch.status))
+            .or_default()
+            .insert(id.clone());
+        self.by_id.insert(id, dispatch);
+    }
+
+    pub fn remove(&mut self, dispatch_id: &str) {
+        if let Some(dispatch) = self.by_id.remove(dispatch_id) {
+            if let Some(set) = self.by_status.get_mut(&status_key(dispatch.status)) {
+                set.remove(dispatch_id);
+            }
+            if let Some(ids) = self.by_thread.get_mut(&dispatch.thread_id) {
+                ids.retain(|id| id != dispatch_id);
+                if ids.is_empty() {
+                    self.by_thread.remove(&dispatch.thread_id);
+                }
+            }
+        }
+    }
+
+    pub fn get(&self, dispatch_id: &str) -> Option<&RunDispatch> {
+        self.by_id.get(dispatch_id)
+    }
+
+    pub fn list_by_thread(
+        &self,
+        thread_id: &str,
+        status_filter: Option<&[RunDispatchStatus]>,
+    ) -> Vec<RunDispatch> {
+        let Some(ids) = self.by_thread.get(thread_id) else {
+            return Vec::new();
+        };
+        ids.iter()
+            .filter_map(|id| self.by_id.get(id).cloned())
+            .filter(|d| match status_filter {
+                Some(filter) => filter.contains(&d.status),
+                None => true,
+            })
+            .collect()
+    }
+
+    pub fn queued_thread_ids(&self) -> Vec<String> {
+        let Some(queued_ids) = self.by_status.get(&status_key(RunDispatchStatus::Queued)) else {
+            return Vec::new();
+        };
+        let mut threads: HashSet<String> = HashSet::new();
+        for id in queued_ids {
+            if let Some(d) = self.by_id.get(id) {
+                threads.insert(d.thread_id.clone());
+            }
+        }
+        threads.into_iter().collect()
+    }
+
+    pub fn claimed_with_expired_lease(&self, now: u64, limit: usize) -> Vec<RunDispatch> {
+        let Some(claimed_ids) = self.by_status.get(&status_key(RunDispatchStatus::Claimed)) else {
+            return Vec::new();
+        };
+        claimed_ids
+            .iter()
+            .filter_map(|id| self.by_id.get(id))
+            .filter(|d| d.lease_until.is_some_and(|until| until < now))
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    pub fn terminal_older_than(&self, cutoff: u64) -> Vec<String> {
+        let terminal_statuses = [
+            RunDispatchStatus::Acked,
+            RunDispatchStatus::Cancelled,
+            RunDispatchStatus::Superseded,
+            RunDispatchStatus::DeadLetter,
+        ];
+        let mut out = Vec::new();
+        for status in terminal_statuses {
+            if let Some(ids) = self.by_status.get(&status_key(status)) {
+                for id in ids {
+                    if let Some(d) = self.by_id.get(id)
+                        && d.completed_at.is_some_and(|c| c < cutoff)
+                    {
+                        out.push(id.clone());
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    pub fn available_queued(&self, now: u64) -> Vec<RunDispatch> {
+        let Some(queued_ids) = self.by_status.get(&status_key(RunDispatchStatus::Queued)) else {
+            return Vec::new();
+        };
+        queued_ids
+            .iter()
+            .filter_map(|id| self.by_id.get(id))
+            .filter(|d| d.available_at <= now)
+            .cloned()
+            .collect()
+    }
+}
+
+/// Spawn a background task that keeps the index in sync with the KV bucket.
+pub fn spawn_watcher(
+    kv: async_nats::jetstream::kv::Store,
+    index: Arc<RwLock<DispatchIndex>>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    ready_tx: tokio::sync::oneshot::Sender<Result<(), String>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Subscribe to new events FIRST, then do a catch-up scan. Order matters:
+        // `watch_all()` uses `DeliverPolicy::New` which only reports changes made
+        // after subscription, so any `put` that lands between subscription and
+        // the catch-up scan will still arrive on the watcher stream. The reverse
+        // order (scan then subscribe) would drop puts that landed in between.
+        let mut watcher = match kv.watch_all().await {
+            Ok(w) => w,
+            Err(e) => {
+                let _ = ready_tx.send(Err(e.to_string()));
+                tracing::warn!(error = %e, "nats_mailbox watch_all failed");
+                return;
+            }
+        };
+
+        let initial_scan = initial_scan(&kv, &index).await.map_err(|e| e.to_string());
+        if let Err(ref e) = initial_scan {
+            tracing::warn!(error = %e, "nats_mailbox watcher initial scan failed");
+        }
+        let _ = ready_tx.send(initial_scan);
+
+        use futures::StreamExt;
+        loop {
+            tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() { break; }
+                }
+                entry = watcher.next() => {
+                    match entry {
+                        Some(Ok(entry)) => apply_entry(&index, entry).await,
+                        Some(Err(e)) => {
+                            tracing::warn!(error = %e, "nats_mailbox watcher error");
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+    })
+}
+
+async fn initial_scan(
+    kv: &async_nats::jetstream::kv::Store,
+    index: &Arc<RwLock<DispatchIndex>>,
+) -> Result<(), async_nats::Error> {
+    use futures::StreamExt;
+    let mut keys = kv.keys().await?;
+    while let Some(key_result) = keys.next().await {
+        let key = match key_result {
+            Ok(k) => k,
+            Err(_) => continue,
+        };
+        if let Ok(Some(entry)) = kv.entry(&key).await
+            && let Ok(dispatch) = codec::decode(&entry.value)
+        {
+            index.write().await.upsert(dispatch);
+        }
+    }
+    Ok(())
+}
+
+async fn apply_entry(index: &Arc<RwLock<DispatchIndex>>, entry: async_nats::jetstream::kv::Entry) {
+    use async_nats::jetstream::kv::Operation;
+    match entry.operation {
+        Operation::Put => {
+            if let Ok(dispatch) = codec::decode(&entry.value) {
+                index.write().await.upsert(dispatch);
+            }
+        }
+        Operation::Delete | Operation::Purge => {
+            if let Some(id) = keys::dispatch_id_from_key(&entry.key) {
+                index.write().await.remove(&id);
+            }
+        }
+    }
+}

--- a/crates/awaken-stores/src/nats_mailbox/keys.rs
+++ b/crates/awaken-stores/src/nats_mailbox/keys.rs
@@ -26,6 +26,22 @@ pub fn live_subject(thread_id: &str) -> String {
     format!("live.thread.{}", encode_segment(thread_id))
 }
 
+pub fn live_target_subject(thread_id: &str, run_id: &str, dispatch_id: Option<&str>) -> String {
+    match dispatch_id {
+        Some(dispatch_id) => format!(
+            "live.thread.{}.run.{}.dispatch.{}",
+            encode_segment(thread_id),
+            encode_segment(run_id),
+            encode_segment(dispatch_id)
+        ),
+        None => format!(
+            "live.thread.{}.run.{}",
+            encode_segment(thread_id),
+            encode_segment(run_id)
+        ),
+    }
+}
+
 pub fn dedupe_msg_id(thread_id: &str, dedupe_key: &str) -> String {
     format!(
         "{}:{}",
@@ -60,6 +76,10 @@ mod tests {
         assert_eq!(dispatch_subject("t1"), "dispatch.h7431");
         assert_eq!(thread_claim_key("t1"), "claim.h7431");
         assert_eq!(live_subject("t1"), "live.thread.h7431");
+        assert_eq!(
+            live_target_subject("t1", "r1", Some("d1")),
+            "live.thread.h7431.run.h7231.dispatch.h6431"
+        );
     }
 
     #[test]
@@ -67,13 +87,17 @@ mod tests {
         let thread_id = "tenant.*.>";
         let subject = dispatch_subject(thread_id);
         let live = live_subject(thread_id);
+        let targeted_live = live_target_subject(thread_id, "run.*.>", Some("dispatch.*.>"));
 
         assert_eq!(subject.matches('.').count(), 1);
         assert_eq!(live.matches('.').count(), 2);
+        assert_eq!(targeted_live.matches('.').count(), 6);
         assert!(!subject.contains('*'));
         assert!(!subject.contains('>'));
         assert!(!live.contains('*'));
         assert!(!live.contains('>'));
+        assert!(!targeted_live.contains('*'));
+        assert!(!targeted_live.contains('>'));
     }
 
     #[test]

--- a/crates/awaken-stores/src/nats_mailbox/keys.rs
+++ b/crates/awaken-stores/src/nats_mailbox/keys.rs
@@ -1,0 +1,85 @@
+//! KV key builders.
+
+use crate::nats_keys::{decode_segment, encode_segment};
+
+pub fn dispatch_key(dispatch_id: &str) -> String {
+    format!("dispatch.{}", encode_segment(dispatch_id))
+}
+
+pub fn epoch_key(thread_id: &str) -> String {
+    format!("epoch.{}", encode_segment(thread_id))
+}
+
+pub fn thread_index_key(thread_id: &str) -> String {
+    format!("thread.{}", encode_segment(thread_id))
+}
+
+pub fn dispatch_subject(thread_id: &str) -> String {
+    format!("dispatch.{}", encode_segment(thread_id))
+}
+
+pub fn thread_claim_key(thread_id: &str) -> String {
+    format!("claim.{}", encode_segment(thread_id))
+}
+
+pub fn live_subject(thread_id: &str) -> String {
+    format!("live.thread.{}", encode_segment(thread_id))
+}
+
+pub fn dedupe_msg_id(thread_id: &str, dedupe_key: &str) -> String {
+    format!(
+        "{}:{}",
+        encode_segment(thread_id),
+        encode_segment(dedupe_key)
+    )
+}
+
+/// KV key for the authoritative dedupe lock (one per `(thread, dedupe_key)`).
+/// `kv.create()` on this key is the race-free admission check.
+pub fn dedupe_lock_key(thread_id: &str, dedupe_key: &str) -> String {
+    format!(
+        "dedupe.{}.{}",
+        encode_segment(thread_id),
+        encode_segment(dedupe_key)
+    )
+}
+
+pub fn dispatch_id_from_key(key: &str) -> Option<String> {
+    key.strip_prefix("dispatch.").and_then(decode_segment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_encode_user_controlled_segments() {
+        assert_eq!(dispatch_key("d1"), "dispatch.h6431");
+        assert_eq!(epoch_key("t1"), "epoch.h7431");
+        assert_eq!(thread_index_key("t1"), "thread.h7431");
+        assert_eq!(dispatch_subject("t1"), "dispatch.h7431");
+        assert_eq!(thread_claim_key("t1"), "claim.h7431");
+        assert_eq!(live_subject("t1"), "live.thread.h7431");
+    }
+
+    #[test]
+    fn keys_do_not_expose_wildcards_or_extra_tokens() {
+        let thread_id = "tenant.*.>";
+        let subject = dispatch_subject(thread_id);
+        let live = live_subject(thread_id);
+
+        assert_eq!(subject.matches('.').count(), 1);
+        assert_eq!(live.matches('.').count(), 2);
+        assert!(!subject.contains('*'));
+        assert!(!subject.contains('>'));
+        assert!(!live.contains('*'));
+        assert!(!live.contains('>'));
+    }
+
+    #[test]
+    fn dispatch_id_decodes_from_dispatch_key() {
+        let key = dispatch_key("dispatch.*.1");
+        assert_eq!(dispatch_id_from_key(&key).as_deref(), Some("dispatch.*.1"));
+        assert!(dispatch_id_from_key("thread.h7431").is_none());
+    }
+}

--- a/crates/awaken-stores/src/nats_mailbox/mod.rs
+++ b/crates/awaken-stores/src/nats_mailbox/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Dispatch records live in the `dispatch-state` KV bucket (source of truth)
 //! while JetStream `DISPATCH` serves as the delivery signal. An in-memory
-//! index populated by `kv.watch_all()` answers all read-path queries with zero
-//! network I/O.
+//! index populated by `kv.watch_all()` answers list queries; point reads use
+//! the authoritative KV record so control paths are not gated on watcher lag.
 //!
 //! # Example
 //!
@@ -37,9 +37,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use awaken_contract::contract::mailbox::{
-    LiveCommandReceipt, LiveDeliveryOutcome, LiveRunCommand, LiveRunCommandEntry,
-    LiveRunCommandStream, MailboxInterrupt, MailboxStore, RunDispatch, RunDispatchResult,
-    RunDispatchStatus,
+    DispatchSignalEntry, DispatchSignalReceipt, LiveCommandReceipt, LiveDeliveryOutcome,
+    LiveRunCommand, LiveRunCommandEntry, LiveRunCommandStream, LiveRunTarget, MailboxInterrupt,
+    MailboxStore, RunDispatch, RunDispatchResult, RunDispatchStatus,
 };
 use awaken_contract::contract::storage::StorageError;
 use bytes::Bytes;
@@ -61,7 +61,6 @@ pub struct NatsMailboxStore {
     pub(crate) kv_dispatch: async_nats::jetstream::kv::Store,
     pub(crate) kv_epoch: async_nats::jetstream::kv::Store,
     pub(crate) kv_thread_index: async_nats::jetstream::kv::Store,
-    #[allow(dead_code)]
     pub(crate) consumer: async_nats::jetstream::consumer::PullConsumer,
     #[allow(dead_code)]
     pub(crate) stream_name: String,
@@ -191,6 +190,11 @@ impl NatsMailboxStore {
         self.index.read().await.get(dispatch_id).is_some()
     }
 
+    #[doc(hidden)]
+    pub async fn __test_remove_dispatch_from_index(&self, dispatch_id: &str) {
+        self.index.write().await.remove(dispatch_id);
+    }
+
     /// Test-only: force a dedupe lock into the KV bucket without going
     /// through `enqueue`, so integration tests can reproduce the
     /// crash-between-create-and-put orphan scenario.
@@ -202,7 +206,10 @@ impl NatsMailboxStore {
         holder_dispatch_id: &str,
     ) -> Result<(), StorageError> {
         let key = keys::dedupe_lock_key(thread_id, dedupe_key);
-        let value = bytes::Bytes::from(holder_dispatch_id.to_string().into_bytes());
+        let value = codec::encode_dedupe_lock(&codec::DedupeLockRecord {
+            dispatch_id: holder_dispatch_id.to_string(),
+            created_at: 0,
+        })?;
         self.kv_thread_index
             .create(&key, value)
             .await
@@ -234,7 +241,9 @@ impl NatsMailboxStore {
             .entry(&key)
             .await
             .map_err(|e| StorageError::Io(format!("dedupe lock entry: {e}")))?;
-        Ok(entry.map(|entry| String::from_utf8_lossy(&entry.value).to_string()))
+        entry
+            .map(|entry| codec::decode_dedupe_lock(&entry.value).map(|lock| lock.dispatch_id))
+            .transpose()
     }
 
     /// Test-only: plant a dispatch in the authoritative KV store WITHOUT
@@ -257,6 +266,7 @@ impl NatsMailboxStore {
             Some(entry) => codec::decode_epoch(&entry.value)?,
             None => 0,
         };
+        ops_write::append_thread_index(self, &stamped.thread_id, &stamped.dispatch_id).await?;
         let bytes = codec::encode(&stamped)?;
         self.kv_dispatch
             .put(keys::dispatch_key(&stamped.dispatch_id), bytes)
@@ -274,6 +284,7 @@ impl NatsMailboxStore {
         &self,
         dispatch: &RunDispatch,
     ) -> Result<(), StorageError> {
+        ops_write::append_thread_index(self, &dispatch.thread_id, &dispatch.dispatch_id).await?;
         let bytes = codec::encode(dispatch)?;
         self.kv_dispatch
             .put(keys::dispatch_key(&dispatch.dispatch_id), bytes)
@@ -407,6 +418,53 @@ impl MailboxStore for NatsMailboxStore {
         ops_query::queued_thread_ids(self).await
     }
 
+    fn supports_dispatch_signals(&self) -> bool {
+        true
+    }
+
+    async fn pull_dispatch_signals(
+        &self,
+        max: usize,
+        expires: std::time::Duration,
+    ) -> Result<Vec<DispatchSignalEntry>, StorageError> {
+        if max == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut messages = self
+            .consumer
+            .fetch()
+            .max_messages(max)
+            .expires(expires)
+            .messages()
+            .await
+            .map_err(|e| StorageError::Io(format!("dispatch signal fetch: {e}")))?;
+
+        let mut entries = Vec::new();
+        while let Some(next) = messages.next().await {
+            let message =
+                next.map_err(|e| StorageError::Io(format!("dispatch signal message: {e}")))?;
+            let dispatch_id = match String::from_utf8(message.payload.to_vec()) {
+                Ok(dispatch_id) if !dispatch_id.trim().is_empty() => dispatch_id,
+                _ => {
+                    let _ = message.ack().await;
+                    continue;
+                }
+            };
+            let Some(dispatch) = ops_query::load_dispatch(self, &dispatch_id).await? else {
+                let _ = message.ack().await;
+                continue;
+            };
+            self.index.write().await.upsert(dispatch.clone());
+            entries.push(DispatchSignalEntry {
+                thread_id: dispatch.thread_id,
+                dispatch_id,
+                receipt: Box::new(NatsDispatchSignalReceipt { message }),
+            });
+        }
+        Ok(entries)
+    }
+
     // Live channel uses core NATS request-reply (not JetStream). `LiveRunCommand`
     // is ephemeral by contract: no persistence, no redelivery. Request-reply
     // gives the producer a subscriber-presence signal: `NoResponders` =
@@ -419,62 +477,102 @@ impl MailboxStore for NatsMailboxStore {
         thread_id: &str,
         cmd: LiveRunCommand,
     ) -> Result<LiveDeliveryOutcome, StorageError> {
-        let payload = serde_json::to_vec(&cmd)
-            .map_err(|e| StorageError::Serialization(format!("LiveRunCommand encode: {e}")))?;
-        match self
-            .client
-            .request(keys::live_subject(thread_id), Bytes::from(payload))
-            .await
-        {
-            Ok(_) => Ok(LiveDeliveryOutcome::Delivered),
-            Err(err) => match err.kind() {
-                async_nats::client::RequestErrorKind::NoResponders
-                | async_nats::client::RequestErrorKind::TimedOut => {
-                    Ok(LiveDeliveryOutcome::NoSubscriber)
-                }
-                async_nats::client::RequestErrorKind::Other => {
-                    Err(StorageError::Io(format!("nats request: {err}")))
-                }
-            },
-        }
+        deliver_live_subject(self, keys::live_subject(thread_id), cmd).await
+    }
+
+    async fn deliver_live_to(
+        &self,
+        target: &LiveRunTarget,
+        cmd: LiveRunCommand,
+    ) -> Result<LiveDeliveryOutcome, StorageError> {
+        deliver_live_subject(
+            self,
+            keys::live_target_subject(
+                &target.thread_id,
+                &target.run_id,
+                target.dispatch_id.as_deref(),
+            ),
+            cmd,
+        )
+        .await
     }
 
     async fn open_live_channel(
         &self,
         thread_id: &str,
     ) -> Result<LiveRunCommandStream, StorageError> {
-        let subscriber = self
-            .client
-            .subscribe(keys::live_subject(thread_id))
-            .await
-            .map_err(|e| StorageError::Io(format!("nats subscribe: {e}")))?;
-        let client = self.client.clone();
-        let stream = subscriber.filter_map(move |msg| {
-            let client = client.clone();
-            async move {
-                // Decode BEFORE handing the reply subject to the consumer.
-                // Malformed payload → drop and leave the producer without
-                // an ack so its request times out and falls back to durable
-                // dispatch.
-                let command = match serde_json::from_slice::<LiveRunCommand>(&msg.payload) {
-                    Ok(cmd) => cmd,
-                    Err(err) => {
-                        tracing::warn!(
-                            error = %err,
-                            "dropping malformed LiveRunCommand payload"
-                        );
-                        return None;
-                    }
-                };
-                let receipt: Box<dyn LiveCommandReceipt> = Box::new(NatsReplyReceipt {
-                    client,
-                    reply: msg.reply.clone(),
-                });
-                Some(LiveRunCommandEntry { command, receipt })
-            }
-        });
-        Ok(Box::pin(stream))
+        open_live_subject(self, keys::live_subject(thread_id)).await
     }
+
+    async fn open_live_channel_for(
+        &self,
+        target: &LiveRunTarget,
+    ) -> Result<LiveRunCommandStream, StorageError> {
+        open_live_subject(
+            self,
+            keys::live_target_subject(
+                &target.thread_id,
+                &target.run_id,
+                target.dispatch_id.as_deref(),
+            ),
+        )
+        .await
+    }
+}
+
+async fn deliver_live_subject(
+    store: &NatsMailboxStore,
+    subject: String,
+    cmd: LiveRunCommand,
+) -> Result<LiveDeliveryOutcome, StorageError> {
+    let payload = serde_json::to_vec(&cmd)
+        .map_err(|e| StorageError::Serialization(format!("LiveRunCommand encode: {e}")))?;
+    match store.client.request(subject, Bytes::from(payload)).await {
+        Ok(_) => Ok(LiveDeliveryOutcome::Delivered),
+        Err(err) => match err.kind() {
+            async_nats::client::RequestErrorKind::NoResponders
+            | async_nats::client::RequestErrorKind::TimedOut => {
+                Ok(LiveDeliveryOutcome::NoSubscriber)
+            }
+            async_nats::client::RequestErrorKind::Other => {
+                Err(StorageError::Io(format!("nats request: {err}")))
+            }
+        },
+    }
+}
+
+async fn open_live_subject(
+    store: &NatsMailboxStore,
+    subject: String,
+) -> Result<LiveRunCommandStream, StorageError> {
+    let subscriber = store
+        .client
+        .subscribe(subject)
+        .await
+        .map_err(|e| StorageError::Io(format!("nats subscribe: {e}")))?;
+    let client = store.client.clone();
+    let stream = subscriber.filter_map(move |msg| {
+        let client = client.clone();
+        async move {
+            // Decode BEFORE handing the reply subject to the consumer.
+            // Malformed payload → drop and leave the producer without
+            // an ack so its request times out and falls back to durable
+            // dispatch.
+            let command = match serde_json::from_slice::<LiveRunCommand>(&msg.payload) {
+                Ok(cmd) => cmd,
+                Err(err) => {
+                    tracing::warn!(error = %err, "dropping malformed LiveRunCommand payload");
+                    return None;
+                }
+            };
+            let receipt: Box<dyn LiveCommandReceipt> = Box::new(NatsReplyReceipt {
+                client,
+                reply: msg.reply.clone(),
+            });
+            Some(LiveRunCommandEntry { command, receipt })
+        }
+    });
+    Ok(Box::pin(stream))
 }
 
 /// Receipt backed by a NATS reply subject. `ack` publishes an empty
@@ -497,5 +595,36 @@ impl LiveCommandReceipt for NatsReplyReceipt {
                 tracing::warn!(error = %err, "live-channel ack publish failed");
             }
         });
+    }
+}
+
+struct NatsDispatchSignalReceipt {
+    message: async_nats::jetstream::Message,
+}
+
+#[async_trait]
+impl DispatchSignalReceipt for NatsDispatchSignalReceipt {
+    async fn ack(self: Box<Self>) -> Result<(), StorageError> {
+        self.message
+            .ack()
+            .await
+            .map_err(|e| StorageError::Io(format!("dispatch signal ack: {e}")))
+    }
+
+    async fn nack(self: Box<Self>) -> Result<(), StorageError> {
+        self.message
+            .ack_with(async_nats::jetstream::AckKind::Nak(None))
+            .await
+            .map_err(|e| StorageError::Io(format!("dispatch signal nack: {e}")))
+    }
+
+    async fn nack_with_delay(
+        self: Box<Self>,
+        delay: std::time::Duration,
+    ) -> Result<(), StorageError> {
+        self.message
+            .ack_with(async_nats::jetstream::AckKind::Nak(Some(delay)))
+            .await
+            .map_err(|e| StorageError::Io(format!("dispatch signal delayed nack: {e}")))
     }
 }

--- a/crates/awaken-stores/src/nats_mailbox/mod.rs
+++ b/crates/awaken-stores/src/nats_mailbox/mod.rs
@@ -1,0 +1,501 @@
+//! NATS JetStream + KV implementation of `MailboxStore`.
+//!
+//! Dispatch records live in the `dispatch-state` KV bucket (source of truth)
+//! while JetStream `DISPATCH` serves as the delivery signal. An in-memory
+//! index populated by `kv.watch_all()` answers all read-path queries with zero
+//! network I/O.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
+//!
+//! # async fn wire() -> Result<(), Box<dyn std::error::Error>> {
+//! let config = NatsMailboxConfig::new("nats://localhost:4222");
+//! let store = NatsMailboxStore::connect(config).await?;
+//! // Use `store` wherever a `MailboxStore` is expected.
+//! # store.shutdown().await?;
+//! # Ok(())
+//! # }
+//! ```
+
+mod claim_guard;
+mod codec;
+mod config;
+mod index;
+mod keys;
+mod ops_claim;
+mod ops_interrupt;
+mod ops_maintenance;
+mod ops_query;
+mod ops_write;
+mod sweeper;
+
+pub use config::NatsMailboxConfig;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::mailbox::{
+    LiveCommandReceipt, LiveDeliveryOutcome, LiveRunCommand, LiveRunCommandEntry,
+    LiveRunCommandStream, MailboxInterrupt, MailboxStore, RunDispatch, RunDispatchResult,
+    RunDispatchStatus,
+};
+use awaken_contract::contract::storage::StorageError;
+use bytes::Bytes;
+use futures::StreamExt;
+
+use async_nats::jetstream::{consumer, kv, stream};
+
+use index::DispatchIndex;
+
+#[doc(hidden)]
+pub fn __test_encode_dispatch(dispatch: &RunDispatch) -> Vec<u8> {
+    codec::encode(dispatch).unwrap().to_vec()
+}
+
+pub struct NatsMailboxStore {
+    #[allow(dead_code)]
+    pub(crate) client: async_nats::Client,
+    pub(crate) jetstream: async_nats::jetstream::Context,
+    pub(crate) kv_dispatch: async_nats::jetstream::kv::Store,
+    pub(crate) kv_epoch: async_nats::jetstream::kv::Store,
+    pub(crate) kv_thread_index: async_nats::jetstream::kv::Store,
+    #[allow(dead_code)]
+    pub(crate) consumer: async_nats::jetstream::consumer::PullConsumer,
+    #[allow(dead_code)]
+    pub(crate) stream_name: String,
+    pub(crate) index: Arc<tokio::sync::RwLock<DispatchIndex>>,
+    pub(crate) shutdown_tx: tokio::sync::watch::Sender<bool>,
+    pub(crate) _watcher: tokio::task::JoinHandle<()>,
+    pub(crate) _sweeper: tokio::task::JoinHandle<()>,
+}
+
+impl NatsMailboxStore {
+    /// Connect to NATS, create/verify stream + buckets + consumer.
+    pub async fn connect(config: NatsMailboxConfig) -> Result<Self, StorageError> {
+        let client = async_nats::connect(&config.url)
+            .await
+            .map_err(|e| StorageError::Io(format!("connect: {e}")))?;
+        let jetstream = async_nats::jetstream::new(client.clone());
+
+        // Stream for dispatch delivery signals.
+        let stream_config = stream::Config {
+            name: config.stream_name.clone(),
+            subjects: vec!["dispatch.>".to_string()],
+            retention: stream::RetentionPolicy::WorkQueue,
+            duplicate_window: config.dedup_window,
+            ..Default::default()
+        };
+        let stream = jetstream
+            .get_or_create_stream(stream_config)
+            .await
+            .map_err(|e| StorageError::Io(format!("create stream: {e}")))?;
+
+        // Durable pull consumer.
+        let consumer_config = consumer::pull::Config {
+            durable_name: Some(config.consumer_name.clone()),
+            filter_subject: "dispatch.>".to_string(),
+            ack_policy: consumer::AckPolicy::Explicit,
+            ..Default::default()
+        };
+        let consumer = stream
+            .get_or_create_consumer(&config.consumer_name, consumer_config)
+            .await
+            .map_err(|e| StorageError::Io(format!("create consumer: {e}")))?;
+
+        let kv_dispatch = Self::get_or_create_bucket(&jetstream, &config.dispatch_bucket).await?;
+        let kv_epoch = Self::get_or_create_bucket(&jetstream, &config.epoch_bucket).await?;
+        let kv_thread_index =
+            Self::get_or_create_bucket(&jetstream, &config.thread_index_bucket).await?;
+
+        let index = Arc::new(tokio::sync::RwLock::new(DispatchIndex::default()));
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::watch::channel(false);
+
+        // Spawn KV watcher to keep index in sync.
+        let watcher_shutdown_rx = shutdown_tx.subscribe();
+        let (watcher_ready_tx, watcher_ready_rx) = tokio::sync::oneshot::channel();
+        let watcher_handle = index::spawn_watcher(
+            kv_dispatch.clone(),
+            Arc::clone(&index),
+            watcher_shutdown_rx,
+            watcher_ready_tx,
+        );
+        match watcher_ready_rx.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                return Err(StorageError::Io(format!(
+                    "mailbox index initial scan: {error}"
+                )));
+            }
+            Err(_) => {
+                return Err(StorageError::Io(
+                    "mailbox index watcher exited before initial scan".to_string(),
+                ));
+            }
+        }
+
+        let sweeper_shutdown_rx = shutdown_tx.subscribe();
+        let sweeper_handle = sweeper::spawn_sweeper(
+            jetstream.clone(),
+            Arc::clone(&index),
+            sweeper_shutdown_rx,
+            config.sweeper_interval,
+        );
+
+        Ok(Self {
+            client,
+            jetstream,
+            kv_dispatch,
+            kv_epoch,
+            kv_thread_index,
+            consumer,
+            stream_name: config.stream_name,
+            index,
+            shutdown_tx,
+            _watcher: watcher_handle,
+            _sweeper: sweeper_handle,
+        })
+    }
+
+    async fn get_or_create_bucket(
+        jetstream: &async_nats::jetstream::Context,
+        name: &str,
+    ) -> Result<kv::Store, StorageError> {
+        match jetstream.get_key_value(name).await {
+            Ok(store) => Ok(store),
+            Err(_) => jetstream
+                .create_key_value(kv::Config {
+                    bucket: name.to_string(),
+                    history: 1,
+                    ..Default::default()
+                })
+                .await
+                .map_err(|e| StorageError::Io(format!("create bucket {name}: {e}"))),
+        }
+    }
+
+    /// Signal background tasks to shut down.
+    pub async fn shutdown(&self) -> Result<(), StorageError> {
+        let _ = self.shutdown_tx.send(true);
+        Ok(())
+    }
+
+    #[doc(hidden)]
+    pub fn kv_dispatch(&self) -> &async_nats::jetstream::kv::Store {
+        &self.kv_dispatch
+    }
+
+    #[doc(hidden)]
+    pub async fn index_contains(&self, dispatch_id: &str) -> bool {
+        self.index.read().await.get(dispatch_id).is_some()
+    }
+
+    /// Test-only: force a dedupe lock into the KV bucket without going
+    /// through `enqueue`, so integration tests can reproduce the
+    /// crash-between-create-and-put orphan scenario.
+    #[doc(hidden)]
+    pub async fn __test_force_dedupe_lock(
+        &self,
+        thread_id: &str,
+        dedupe_key: &str,
+        holder_dispatch_id: &str,
+    ) -> Result<(), StorageError> {
+        let key = keys::dedupe_lock_key(thread_id, dedupe_key);
+        let value = bytes::Bytes::from(holder_dispatch_id.to_string().into_bytes());
+        self.kv_thread_index
+            .create(&key, value)
+            .await
+            .map(|_| ())
+            .map_err(|e| StorageError::Io(format!("force lock: {e}")))
+    }
+
+    /// Test-only: attempt to release a dedupe lock as a specific dispatch
+    /// owner. Used to reproduce delayed-release races.
+    #[doc(hidden)]
+    pub async fn __test_release_dedupe_lock_as(
+        &self,
+        thread_id: &str,
+        dedupe_key: &str,
+        holder_dispatch_id: &str,
+    ) {
+        ops_write::release_dedupe_lock(self, thread_id, dedupe_key, holder_dispatch_id).await;
+    }
+
+    #[doc(hidden)]
+    pub async fn __test_dedupe_lock_holder(
+        &self,
+        thread_id: &str,
+        dedupe_key: &str,
+    ) -> Result<Option<String>, StorageError> {
+        let key = keys::dedupe_lock_key(thread_id, dedupe_key);
+        let entry = self
+            .kv_thread_index
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("dedupe lock entry: {e}")))?;
+        Ok(entry.map(|entry| String::from_utf8_lossy(&entry.value).to_string()))
+    }
+
+    /// Test-only: plant a dispatch in the authoritative KV store WITHOUT
+    /// publishing the JetStream delivery signal. Reproduces the
+    /// partial-failure path where `enqueue` committed to KV but the JS
+    /// publish later failed — the sweeper should detect the missing
+    /// signal and re-publish.
+    #[doc(hidden)]
+    pub async fn __test_plant_dispatch_without_publish(
+        &self,
+        dispatch: &RunDispatch,
+    ) -> Result<(), StorageError> {
+        let mut stamped = dispatch.clone();
+        stamped.dispatch_epoch = match self
+            .kv_epoch
+            .entry(&keys::epoch_key(&stamped.thread_id))
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?
+        {
+            Some(entry) => codec::decode_epoch(&entry.value)?,
+            None => 0,
+        };
+        let bytes = codec::encode(&stamped)?;
+        self.kv_dispatch
+            .put(keys::dispatch_key(&stamped.dispatch_id), bytes)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv put: {e}")))?;
+        self.index.write().await.upsert(stamped);
+        Ok(())
+    }
+
+    /// Test-only: plant a dispatch exactly as supplied. This is used to
+    /// reproduce cross-node races where local indexes observe stale epoch
+    /// dispatches that authoritative enqueue stamping would no longer create.
+    #[doc(hidden)]
+    pub async fn __test_plant_dispatch_exact(
+        &self,
+        dispatch: &RunDispatch,
+    ) -> Result<(), StorageError> {
+        let bytes = codec::encode(dispatch)?;
+        self.kv_dispatch
+            .put(keys::dispatch_key(&dispatch.dispatch_id), bytes)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv put: {e}")))?;
+        self.index.write().await.upsert(dispatch.clone());
+        Ok(())
+    }
+
+    /// Test-only: overwrite the local in-memory index without changing KV.
+    /// This reproduces watcher-lag races where local state is older than
+    /// the authoritative dispatch record.
+    #[doc(hidden)]
+    pub async fn __test_upsert_index_only(&self, dispatch: &RunDispatch) {
+        self.index.write().await.upsert(dispatch.clone());
+    }
+}
+
+#[async_trait]
+impl MailboxStore for NatsMailboxStore {
+    async fn enqueue(&self, dispatch: &RunDispatch) -> Result<(), StorageError> {
+        ops_write::enqueue(self, dispatch).await
+    }
+    async fn claim(
+        &self,
+        thread_id: &str,
+        consumer_id: &str,
+        lease_ms: u64,
+        now: u64,
+        limit: usize,
+    ) -> Result<Vec<RunDispatch>, StorageError> {
+        ops_claim::claim(self, thread_id, consumer_id, lease_ms, now, limit).await
+    }
+    async fn claim_dispatch(
+        &self,
+        dispatch_id: &str,
+        consumer_id: &str,
+        lease_ms: u64,
+        now: u64,
+    ) -> Result<Option<RunDispatch>, StorageError> {
+        ops_claim::claim_dispatch(self, dispatch_id, consumer_id, lease_ms, now).await
+    }
+    async fn ack(
+        &self,
+        dispatch_id: &str,
+        claim_token: &str,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        ops_write::ack(self, dispatch_id, claim_token, now).await
+    }
+    async fn record_dispatch_start(
+        &self,
+        dispatch_id: &str,
+        claim_token: &str,
+        dispatch_instance_id: &str,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        ops_write::record_dispatch_start(self, dispatch_id, claim_token, dispatch_instance_id, now)
+            .await
+    }
+    async fn record_run_result(
+        &self,
+        dispatch_id: &str,
+        claim_token: &str,
+        result: &RunDispatchResult,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        ops_write::record_run_result(self, dispatch_id, claim_token, result, now).await
+    }
+    async fn nack(
+        &self,
+        dispatch_id: &str,
+        claim_token: &str,
+        retry_at: u64,
+        error: &str,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        ops_write::nack(self, dispatch_id, claim_token, retry_at, error, now).await
+    }
+    async fn dead_letter(
+        &self,
+        dispatch_id: &str,
+        claim_token: &str,
+        error: &str,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        ops_write::dead_letter(self, dispatch_id, claim_token, error, now).await
+    }
+    async fn cancel(
+        &self,
+        dispatch_id: &str,
+        now: u64,
+    ) -> Result<Option<RunDispatch>, StorageError> {
+        ops_write::cancel(self, dispatch_id, now).await
+    }
+    async fn extend_lease(
+        &self,
+        dispatch_id: &str,
+        claim_token: &str,
+        extension_ms: u64,
+        now: u64,
+    ) -> Result<bool, StorageError> {
+        ops_write::extend_lease(self, dispatch_id, claim_token, extension_ms, now).await
+    }
+    async fn interrupt(&self, thread_id: &str, now: u64) -> Result<MailboxInterrupt, StorageError> {
+        ops_interrupt::interrupt(self, thread_id, now).await
+    }
+    async fn load_dispatch(&self, dispatch_id: &str) -> Result<Option<RunDispatch>, StorageError> {
+        ops_query::load_dispatch(self, dispatch_id).await
+    }
+    async fn list_dispatches(
+        &self,
+        thread_id: &str,
+        status_filter: Option<&[RunDispatchStatus]>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<RunDispatch>, StorageError> {
+        ops_query::list_dispatches(self, thread_id, status_filter, limit, offset).await
+    }
+    async fn reclaim_expired_leases(
+        &self,
+        now: u64,
+        limit: usize,
+    ) -> Result<Vec<RunDispatch>, StorageError> {
+        ops_maintenance::reclaim_expired_leases(self, now, limit).await
+    }
+    async fn purge_terminal(&self, older_than: u64) -> Result<usize, StorageError> {
+        ops_maintenance::purge_terminal(self, older_than).await
+    }
+    async fn queued_thread_ids(&self) -> Result<Vec<String>, StorageError> {
+        ops_query::queued_thread_ids(self).await
+    }
+
+    // Live channel uses core NATS request-reply (not JetStream). `LiveRunCommand`
+    // is ephemeral by contract: no persistence, no redelivery. Request-reply
+    // gives the producer a subscriber-presence signal: `NoResponders` =
+    // nobody listening and `TimedOut` = listener couldn't ack; both map to
+    // `NoSubscriber` so callers fall back to durable dispatch. Other request
+    // errors are surfaced because they do not prove the command was unobserved.
+
+    async fn deliver_live(
+        &self,
+        thread_id: &str,
+        cmd: LiveRunCommand,
+    ) -> Result<LiveDeliveryOutcome, StorageError> {
+        let payload = serde_json::to_vec(&cmd)
+            .map_err(|e| StorageError::Serialization(format!("LiveRunCommand encode: {e}")))?;
+        match self
+            .client
+            .request(keys::live_subject(thread_id), Bytes::from(payload))
+            .await
+        {
+            Ok(_) => Ok(LiveDeliveryOutcome::Delivered),
+            Err(err) => match err.kind() {
+                async_nats::client::RequestErrorKind::NoResponders
+                | async_nats::client::RequestErrorKind::TimedOut => {
+                    Ok(LiveDeliveryOutcome::NoSubscriber)
+                }
+                async_nats::client::RequestErrorKind::Other => {
+                    Err(StorageError::Io(format!("nats request: {err}")))
+                }
+            },
+        }
+    }
+
+    async fn open_live_channel(
+        &self,
+        thread_id: &str,
+    ) -> Result<LiveRunCommandStream, StorageError> {
+        let subscriber = self
+            .client
+            .subscribe(keys::live_subject(thread_id))
+            .await
+            .map_err(|e| StorageError::Io(format!("nats subscribe: {e}")))?;
+        let client = self.client.clone();
+        let stream = subscriber.filter_map(move |msg| {
+            let client = client.clone();
+            async move {
+                // Decode BEFORE handing the reply subject to the consumer.
+                // Malformed payload → drop and leave the producer without
+                // an ack so its request times out and falls back to durable
+                // dispatch.
+                let command = match serde_json::from_slice::<LiveRunCommand>(&msg.payload) {
+                    Ok(cmd) => cmd,
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            "dropping malformed LiveRunCommand payload"
+                        );
+                        return None;
+                    }
+                };
+                let receipt: Box<dyn LiveCommandReceipt> = Box::new(NatsReplyReceipt {
+                    client,
+                    reply: msg.reply.clone(),
+                });
+                Some(LiveRunCommandEntry { command, receipt })
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Receipt backed by a NATS reply subject. `ack` publishes an empty
+/// payload to the subject the producer's `client.request()` is awaiting
+/// on. Dropping the receipt without ack leaves the request to time out →
+/// producer observes `NoSubscriber`.
+struct NatsReplyReceipt {
+    client: async_nats::Client,
+    reply: Option<async_nats::Subject>,
+}
+
+impl LiveCommandReceipt for NatsReplyReceipt {
+    fn ack(self: Box<Self>) {
+        let Some(reply) = self.reply else {
+            return;
+        };
+        let client = self.client;
+        tokio::spawn(async move {
+            if let Err(err) = client.publish(reply, Bytes::new()).await {
+                tracing::warn!(error = %err, "live-channel ack publish failed");
+            }
+        });
+    }
+}

--- a/crates/awaken-stores/src/nats_mailbox/ops_claim.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_claim.rs
@@ -1,0 +1,156 @@
+//! Claim operations: claim (by thread), claim_dispatch (by id).
+
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_contract::contract::storage::StorageError;
+
+use super::{NatsMailboxStore, claim_guard, codec, keys, ops_write};
+
+pub async fn claim_dispatch(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    consumer_id: &str,
+    lease_ms: u64,
+    now: u64,
+) -> Result<Option<RunDispatch>, StorageError> {
+    for _ in 0..5 {
+        let entry = store
+            .kv_dispatch
+            .entry(&keys::dispatch_key(dispatch_id))
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
+        let mut dispatch = codec::decode(&entry.value)?;
+
+        if dispatch.status != RunDispatchStatus::Queued {
+            return Ok(None);
+        }
+        // Note: `claim_dispatch` is the by-ID inline-claim path and
+        // must NOT honor `available_at` — that field only guards
+        // queue-scan claims (`claim()` by thread) so a foreground
+        // submit can set a future `available_at` to keep the sweeper
+        // away, then immediately claim the dispatch it just wrote.
+        // Memory and SQLite backends already have this semantic.
+
+        // Epoch check: reject dispatches whose recorded epoch is older
+        // than the thread's authoritative epoch in KV. This is the
+        // cross-node guarantee for `interrupt()` — a node whose local
+        // index hasn't caught up may see a stale Queued dispatch; the
+        // KV read here is strongly consistent and rejects it.
+        let thread_epoch = read_thread_epoch(store, &dispatch.thread_id).await?;
+        if dispatch.dispatch_epoch < thread_epoch {
+            dispatch.status = RunDispatchStatus::Superseded;
+            dispatch.dispatch_epoch = thread_epoch;
+            dispatch.completed_at = Some(now);
+            dispatch.updated_at = now;
+            let bytes = codec::encode(&dispatch)?;
+            if store
+                .kv_dispatch
+                .update(&keys::dispatch_key(dispatch_id), bytes, entry.revision)
+                .await
+                .is_ok()
+            {
+                store.index.write().await.upsert(dispatch.clone());
+                if let Some(ref dedupe_key) = dispatch.dedupe_key {
+                    ops_write::release_dedupe_lock(
+                        store,
+                        &dispatch.thread_id,
+                        dedupe_key,
+                        &dispatch.dispatch_id,
+                    )
+                    .await;
+                }
+                return Ok(None);
+            }
+            continue;
+        }
+
+        let Some(thread_claim) =
+            claim_guard::acquire(store, &dispatch.thread_id, dispatch_id, lease_ms, now).await?
+        else {
+            return Ok(None);
+        };
+
+        dispatch.status = RunDispatchStatus::Claimed;
+        dispatch.claim_token = Some(thread_claim.claim_token.clone());
+        dispatch.claimed_by = Some(consumer_id.to_string());
+        dispatch.lease_until = Some(thread_claim.lease_until);
+        dispatch.updated_at = now;
+
+        let bytes = codec::encode(&dispatch)?;
+        let result = store
+            .kv_dispatch
+            .update(&keys::dispatch_key(dispatch_id), bytes, entry.revision)
+            .await;
+        match result {
+            Ok(_) => {
+                store.index.write().await.upsert(dispatch.clone());
+                return Ok(Some(dispatch));
+            }
+            Err(_e) => {
+                claim_guard::release(
+                    store,
+                    &dispatch.thread_id,
+                    dispatch_id,
+                    &thread_claim.claim_token,
+                )
+                .await?;
+                // CAS conflict; retry.
+                continue;
+            }
+        }
+    }
+    Ok(None)
+}
+
+pub async fn claim(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    consumer_id: &str,
+    lease_ms: u64,
+    now: u64,
+    limit: usize,
+) -> Result<Vec<RunDispatch>, StorageError> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut candidates = {
+        let index = store.index.read().await;
+        index.list_by_thread(thread_id, Some(&[RunDispatchStatus::Queued]))
+    };
+    candidates.retain(|d| d.available_at <= now);
+    candidates.sort_by(|a, b| {
+        a.priority
+            .cmp(&b.priority)
+            .then(a.created_at.cmp(&b.created_at))
+    });
+
+    let mut claimed = Vec::new();
+    for candidate in candidates {
+        if let Some(d) =
+            claim_dispatch(store, &candidate.dispatch_id, consumer_id, lease_ms, now).await?
+        {
+            claimed.push(d);
+            if claimed.len() >= limit {
+                break;
+            }
+        }
+    }
+    Ok(claimed)
+}
+
+/// Read the thread's current dispatch epoch from KV. `None` → epoch 0
+/// (no epoch record yet).
+async fn read_thread_epoch(store: &NatsMailboxStore, thread_id: &str) -> Result<u64, StorageError> {
+    let entry = store
+        .kv_epoch
+        .entry(&keys::epoch_key(thread_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("kv entry epoch: {e}")))?;
+    match entry {
+        Some(e) => codec::decode_epoch(&e.value),
+        None => Ok(0),
+    }
+}

--- a/crates/awaken-stores/src/nats_mailbox/ops_claim.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_claim.rs
@@ -3,7 +3,7 @@
 use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
 use awaken_contract::contract::storage::StorageError;
 
-use super::{NatsMailboxStore, claim_guard, codec, keys, ops_write};
+use super::{NatsMailboxStore, claim_guard, codec, keys, ops_query, ops_write};
 
 pub async fn claim_dispatch(
     store: &NatsMailboxStore,
@@ -44,6 +44,9 @@ pub async fn claim_dispatch(
             dispatch.dispatch_epoch = thread_epoch;
             dispatch.completed_at = Some(now);
             dispatch.updated_at = now;
+            dispatch.claim_token = None;
+            dispatch.claimed_by = None;
+            dispatch.lease_until = None;
             let bytes = codec::encode(&dispatch)?;
             if store
                 .kv_dispatch
@@ -116,10 +119,11 @@ pub async fn claim(
         return Ok(Vec::new());
     }
 
-    let mut candidates = {
-        let index = store.index.read().await;
-        index.list_by_thread(thread_id, Some(&[RunDispatchStatus::Queued]))
-    };
+    let mut candidates = ops_query::load_thread_dispatches(store, thread_id)
+        .await?
+        .into_iter()
+        .filter(|dispatch| dispatch.status == RunDispatchStatus::Queued)
+        .collect::<Vec<_>>();
     candidates.retain(|d| d.available_at <= now);
     candidates.sort_by(|a, b| {
         a.priority

--- a/crates/awaken-stores/src/nats_mailbox/ops_interrupt.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_interrupt.rs
@@ -3,7 +3,7 @@
 use awaken_contract::contract::mailbox::{MailboxInterrupt, RunDispatchStatus};
 use awaken_contract::contract::storage::StorageError;
 
-use super::{NatsMailboxStore, codec, keys, ops_write};
+use super::{NatsMailboxStore, claim_guard, codec, keys, ops_query, ops_write};
 
 enum SupersedeOutcome {
     Superseded,
@@ -18,10 +18,26 @@ pub async fn interrupt(
 ) -> Result<MailboxInterrupt, StorageError> {
     let new_epoch = bump_epoch(store, thread_id).await?;
 
-    let dispatches = store.index.read().await.list_by_thread(thread_id, None);
+    let mut dispatches = ops_query::load_thread_dispatches(store, thread_id).await?;
 
     let mut superseded_count = 0usize;
     let mut active_dispatch = None;
+
+    let guard_active_dispatch_id = claim_guard::active_dispatch_id(store, thread_id, now).await?;
+    if let Some(active_dispatch_id) = guard_active_dispatch_id.as_deref()
+        && let Some(authoritative) = ops_query::load_dispatch(store, active_dispatch_id).await?
+        && authoritative.thread_id == thread_id
+        && authoritative.status == RunDispatchStatus::Claimed
+    {
+        store.index.write().await.upsert(authoritative.clone());
+        if !dispatches
+            .iter()
+            .any(|dispatch| dispatch.dispatch_id == authoritative.dispatch_id)
+        {
+            dispatches.push(authoritative.clone());
+        }
+        active_dispatch = Some(authoritative);
+    }
 
     for dispatch in dispatches {
         match dispatch.status {
@@ -56,7 +72,12 @@ pub async fn interrupt(
                 }
             }
             RunDispatchStatus::Claimed => {
-                active_dispatch = Some(dispatch);
+                if guard_active_dispatch_id
+                    .as_deref()
+                    .is_none_or(|active_id| active_id == dispatch.dispatch_id)
+                {
+                    active_dispatch = Some(dispatch);
+                }
             }
             _ => {}
         }
@@ -117,10 +138,16 @@ async fn supersede(
             }
             return Ok(SupersedeOutcome::NotQueued);
         }
+        if dispatch.dispatch_epoch >= new_epoch {
+            return Ok(SupersedeOutcome::NotQueued);
+        }
         dispatch.status = RunDispatchStatus::Superseded;
         dispatch.dispatch_epoch = new_epoch;
         dispatch.completed_at = Some(now);
         dispatch.updated_at = now;
+        dispatch.claim_token = None;
+        dispatch.claimed_by = None;
+        dispatch.lease_until = None;
         let bytes = codec::encode(&dispatch)?;
         if store
             .kv_dispatch

--- a/crates/awaken-stores/src/nats_mailbox/ops_interrupt.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_interrupt.rs
@@ -1,0 +1,138 @@
+//! Interrupt + dispatch epoch management.
+
+use awaken_contract::contract::mailbox::{MailboxInterrupt, RunDispatchStatus};
+use awaken_contract::contract::storage::StorageError;
+
+use super::{NatsMailboxStore, codec, keys, ops_write};
+
+enum SupersedeOutcome {
+    Superseded,
+    Claimed(Box<awaken_contract::contract::mailbox::RunDispatch>),
+    NotQueued,
+}
+
+pub async fn interrupt(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    now: u64,
+) -> Result<MailboxInterrupt, StorageError> {
+    let new_epoch = bump_epoch(store, thread_id).await?;
+
+    let dispatches = store.index.read().await.list_by_thread(thread_id, None);
+
+    let mut superseded_count = 0usize;
+    let mut active_dispatch = None;
+
+    for dispatch in dispatches {
+        match dispatch.status {
+            RunDispatchStatus::Queued => {
+                match supersede(store, &dispatch.dispatch_id, new_epoch, now).await {
+                    Ok(SupersedeOutcome::Superseded) => {
+                        superseded_count += 1;
+                        // Terminal → release any dedupe lock so a subsequent
+                        // enqueue with the same key can take over.
+                        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+                            ops_write::release_dedupe_lock(
+                                store,
+                                &dispatch.thread_id,
+                                dedupe_key,
+                                &dispatch.dispatch_id,
+                            )
+                            .await;
+                        }
+                    }
+                    Ok(SupersedeOutcome::Claimed(authoritative)) => {
+                        active_dispatch = Some(*authoritative);
+                    }
+                    Ok(SupersedeOutcome::NotQueued) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            thread_id,
+                            dispatch_id = %dispatch.dispatch_id,
+                            error = %error,
+                            "failed to supersede queued dispatch during interrupt"
+                        );
+                    }
+                }
+            }
+            RunDispatchStatus::Claimed => {
+                active_dispatch = Some(dispatch);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(MailboxInterrupt {
+        new_dispatch_epoch: new_epoch,
+        active_dispatch,
+        superseded_count,
+    })
+}
+
+async fn bump_epoch(store: &NatsMailboxStore, thread_id: &str) -> Result<u64, StorageError> {
+    let key = keys::epoch_key(thread_id);
+    for _ in 0..5 {
+        let entry = store
+            .kv_epoch
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let (current, revision) = match entry {
+            Some(e) => (codec::decode_epoch(&e.value)?, e.revision),
+            None => (0u64, 0u64),
+        };
+        let new_epoch = current + 1;
+        let bytes = codec::encode_epoch(new_epoch);
+        let ok = if revision == 0 {
+            store.kv_epoch.create(&key, bytes).await.is_ok()
+        } else {
+            store.kv_epoch.update(&key, bytes, revision).await.is_ok()
+        };
+        if ok {
+            return Ok(new_epoch);
+        }
+    }
+    Err(StorageError::Io("epoch CAS exhausted retries".to_string()))
+}
+
+async fn supersede(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    new_epoch: u64,
+    now: u64,
+) -> Result<SupersedeOutcome, StorageError> {
+    for _ in 0..5 {
+        let entry = store
+            .kv_dispatch
+            .entry(&keys::dispatch_key(dispatch_id))
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let Some(entry) = entry else {
+            return Err(StorageError::NotFound(dispatch_id.to_string()));
+        };
+        let mut dispatch = codec::decode(&entry.value)?;
+        if dispatch.status != RunDispatchStatus::Queued {
+            if dispatch.status == RunDispatchStatus::Claimed {
+                return Ok(SupersedeOutcome::Claimed(Box::new(dispatch)));
+            }
+            return Ok(SupersedeOutcome::NotQueued);
+        }
+        dispatch.status = RunDispatchStatus::Superseded;
+        dispatch.dispatch_epoch = new_epoch;
+        dispatch.completed_at = Some(now);
+        dispatch.updated_at = now;
+        let bytes = codec::encode(&dispatch)?;
+        if store
+            .kv_dispatch
+            .update(&keys::dispatch_key(dispatch_id), bytes, entry.revision)
+            .await
+            .is_ok()
+        {
+            store.index.write().await.upsert(dispatch);
+            return Ok(SupersedeOutcome::Superseded);
+        }
+    }
+    Err(StorageError::Io(
+        "supersede CAS exhausted retries".to_string(),
+    ))
+}

--- a/crates/awaken-stores/src/nats_mailbox/ops_maintenance.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_maintenance.rs
@@ -3,18 +3,22 @@
 use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
 use awaken_contract::contract::storage::StorageError;
 
-use super::{NatsMailboxStore, codec, keys};
+use super::{NatsMailboxStore, claim_guard, codec, keys, ops_query, ops_write};
 
 pub async fn reclaim_expired_leases(
     store: &NatsMailboxStore,
     now: u64,
     limit: usize,
 ) -> Result<Vec<RunDispatch>, StorageError> {
-    let candidates = store
-        .index
-        .read()
-        .await
-        .claimed_with_expired_lease(now, limit);
+    let candidates = ops_query::load_all_dispatches(store)
+        .await?
+        .into_iter()
+        .filter(|dispatch| {
+            dispatch.status == RunDispatchStatus::Claimed
+                && dispatch.lease_until.is_some_and(|until| until < now)
+        })
+        .take(limit)
+        .collect::<Vec<_>>();
     let mut reclaimed = Vec::new();
     for candidate in candidates {
         if let Some(d) = reclaim_one(store, &candidate.dispatch_id, now).await? {
@@ -45,13 +49,23 @@ async fn reclaim_one(
         if dispatch.lease_until.map(|u| u >= now).unwrap_or(true) {
             return Ok(None);
         }
-        dispatch.status = RunDispatchStatus::Queued;
-        dispatch.claim_token = None;
-        dispatch.claimed_by = None;
-        dispatch.lease_until = None;
-        dispatch.attempt_count += 1;
+        let old_claim_token = dispatch.claim_token.clone();
+        dispatch.attempt_count = dispatch.attempt_count.saturating_add(1);
         dispatch.available_at = now;
         dispatch.updated_at = now;
+        if dispatch.attempt_count >= dispatch.max_attempts {
+            dispatch.status = RunDispatchStatus::DeadLetter;
+            dispatch.last_error = Some("lease expired; max attempts reached".to_string());
+            dispatch.completed_at = Some(now);
+            dispatch.claim_token = None;
+            dispatch.claimed_by = None;
+            dispatch.lease_until = None;
+        } else {
+            dispatch.status = RunDispatchStatus::Queued;
+            dispatch.claim_token = None;
+            dispatch.claimed_by = None;
+            dispatch.lease_until = None;
+        }
         let bytes = codec::encode(&dispatch)?;
         if store
             .kv_dispatch
@@ -60,6 +74,20 @@ async fn reclaim_one(
             .is_ok()
         {
             store.index.write().await.upsert(dispatch.clone());
+            if let Some(ref claim_token) = old_claim_token {
+                claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+            }
+            if dispatch.status == RunDispatchStatus::DeadLetter
+                && let Some(ref dedupe_key) = dispatch.dedupe_key
+            {
+                ops_write::release_dedupe_lock(
+                    store,
+                    &dispatch.thread_id,
+                    dedupe_key,
+                    &dispatch.dispatch_id,
+                )
+                .await;
+            }
             return Ok(Some(dispatch));
         }
     }

--- a/crates/awaken-stores/src/nats_mailbox/ops_maintenance.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_maintenance.rs
@@ -1,0 +1,87 @@
+//! Maintenance operations: lease reclaim, terminal GC.
+
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_contract::contract::storage::StorageError;
+
+use super::{NatsMailboxStore, codec, keys};
+
+pub async fn reclaim_expired_leases(
+    store: &NatsMailboxStore,
+    now: u64,
+    limit: usize,
+) -> Result<Vec<RunDispatch>, StorageError> {
+    let candidates = store
+        .index
+        .read()
+        .await
+        .claimed_with_expired_lease(now, limit);
+    let mut reclaimed = Vec::new();
+    for candidate in candidates {
+        if let Some(d) = reclaim_one(store, &candidate.dispatch_id, now).await? {
+            reclaimed.push(d);
+        }
+    }
+    Ok(reclaimed)
+}
+
+async fn reclaim_one(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    now: u64,
+) -> Result<Option<RunDispatch>, StorageError> {
+    for _ in 0..5 {
+        let entry = store
+            .kv_dispatch
+            .entry(&keys::dispatch_key(dispatch_id))
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
+        let mut dispatch = codec::decode(&entry.value)?;
+        if dispatch.status != RunDispatchStatus::Claimed {
+            return Ok(None);
+        }
+        if dispatch.lease_until.map(|u| u >= now).unwrap_or(true) {
+            return Ok(None);
+        }
+        dispatch.status = RunDispatchStatus::Queued;
+        dispatch.claim_token = None;
+        dispatch.claimed_by = None;
+        dispatch.lease_until = None;
+        dispatch.attempt_count += 1;
+        dispatch.available_at = now;
+        dispatch.updated_at = now;
+        let bytes = codec::encode(&dispatch)?;
+        if store
+            .kv_dispatch
+            .update(&keys::dispatch_key(dispatch_id), bytes, entry.revision)
+            .await
+            .is_ok()
+        {
+            store.index.write().await.upsert(dispatch.clone());
+            return Ok(Some(dispatch));
+        }
+    }
+    Ok(None)
+}
+
+pub async fn purge_terminal(
+    store: &NatsMailboxStore,
+    older_than: u64,
+) -> Result<usize, StorageError> {
+    let ids = store.index.read().await.terminal_older_than(older_than);
+    let mut purged = 0;
+    for id in ids {
+        if store
+            .kv_dispatch
+            .delete(&keys::dispatch_key(&id))
+            .await
+            .is_ok()
+        {
+            store.index.write().await.remove(&id);
+            purged += 1;
+        }
+    }
+    Ok(purged)
+}

--- a/crates/awaken-stores/src/nats_mailbox/ops_query.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_query.rs
@@ -1,0 +1,37 @@
+//! Read-path operations served from in-memory index.
+
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_contract::contract::storage::StorageError;
+
+use super::NatsMailboxStore;
+
+pub async fn load_dispatch(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+) -> Result<Option<RunDispatch>, StorageError> {
+    Ok(store.index.read().await.get(dispatch_id).cloned())
+}
+
+pub async fn list_dispatches(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    status_filter: Option<&[RunDispatchStatus]>,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<RunDispatch>, StorageError> {
+    let mut items = store
+        .index
+        .read()
+        .await
+        .list_by_thread(thread_id, status_filter);
+    items.sort_by(|a, b| {
+        a.priority
+            .cmp(&b.priority)
+            .then(a.created_at.cmp(&b.created_at))
+    });
+    Ok(items.into_iter().skip(offset).take(limit).collect())
+}
+
+pub async fn queued_thread_ids(store: &NatsMailboxStore) -> Result<Vec<String>, StorageError> {
+    Ok(store.index.read().await.queued_thread_ids())
+}

--- a/crates/awaken-stores/src/nats_mailbox/ops_query.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_query.rs
@@ -1,15 +1,93 @@
-//! Read-path operations served from in-memory index.
+//! Read-path operations.
 
+use async_nats::jetstream::kv::Operation;
 use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
 use awaken_contract::contract::storage::StorageError;
 
-use super::NatsMailboxStore;
+use super::{NatsMailboxStore, codec, keys, ops_write};
 
 pub async fn load_dispatch(
     store: &NatsMailboxStore,
     dispatch_id: &str,
 ) -> Result<Option<RunDispatch>, StorageError> {
-    Ok(store.index.read().await.get(dispatch_id).cloned())
+    let entry = store
+        .kv_dispatch
+        .entry(&keys::dispatch_key(dispatch_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("kv dispatch entry: {e}")))?;
+    match entry {
+        Some(entry) if matches!(entry.operation, Operation::Delete | Operation::Purge) => Ok(None),
+        Some(entry) => Ok(Some(codec::decode(&entry.value)?)),
+        None => Ok(None),
+    }
+}
+
+pub(crate) async fn load_thread_dispatches(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+) -> Result<Vec<RunDispatch>, StorageError> {
+    let Some(ids) = load_thread_index_ids(store, thread_id).await? else {
+        let dispatches = load_all_dispatches(store)
+            .await?
+            .into_iter()
+            .filter(|dispatch| dispatch.thread_id == thread_id)
+            .collect::<Vec<_>>();
+        for dispatch in &dispatches {
+            ops_write::append_thread_index(store, thread_id, &dispatch.dispatch_id).await?;
+        }
+        return Ok(dispatches);
+    };
+
+    let mut dispatches = Vec::new();
+    for dispatch_id in ids {
+        let Some(dispatch) = load_dispatch(store, &dispatch_id).await? else {
+            continue;
+        };
+        if dispatch.thread_id == thread_id {
+            store.index.write().await.upsert(dispatch.clone());
+            dispatches.push(dispatch);
+        }
+    }
+    Ok(dispatches)
+}
+
+async fn load_thread_index_ids(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+) -> Result<Option<Vec<String>>, StorageError> {
+    let entry = store
+        .kv_thread_index
+        .entry(&keys::thread_index_key(thread_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("thread index entry: {e}")))?;
+    entry
+        .map(|entry| codec::decode_thread_index(&entry.value))
+        .transpose()
+}
+
+pub(crate) async fn load_all_dispatches(
+    store: &NatsMailboxStore,
+) -> Result<Vec<RunDispatch>, StorageError> {
+    use futures::StreamExt;
+
+    let mut keys = store
+        .kv_dispatch
+        .keys()
+        .await
+        .map_err(|e| StorageError::Io(format!("kv dispatch keys: {e}")))?;
+    let mut dispatches = Vec::new();
+    while let Some(key_result) = keys.next().await {
+        let key = key_result.map_err(|e| StorageError::Io(format!("kv dispatch key: {e}")))?;
+        let Some(dispatch_id) = keys::dispatch_id_from_key(&key) else {
+            continue;
+        };
+        let Some(dispatch) = load_dispatch(store, &dispatch_id).await? else {
+            continue;
+        };
+        store.index.write().await.upsert(dispatch.clone());
+        dispatches.push(dispatch);
+    }
+    Ok(dispatches)
 }
 
 pub async fn list_dispatches(

--- a/crates/awaken-stores/src/nats_mailbox/ops_write.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_write.rs
@@ -8,6 +8,8 @@ use awaken_contract::contract::storage::StorageError;
 
 use super::{NatsMailboxStore, claim_guard, codec, keys};
 
+const DEDUPE_ORPHAN_GRACE_MS: u64 = 5_000;
+
 pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result<(), StorageError> {
     // ── Stamp dispatch_epoch from authoritative KV state ──
     //
@@ -38,14 +40,29 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
         .await?;
     }
 
+    // The per-thread index is written before the dispatch record. This
+    // makes queue scans O(thread dispatches) without introducing a
+    // stranded-dispatch gap: if the later dispatch put fails, the index
+    // entry is a harmless dangling id that strong loads skip.
+    if let Err(e) = append_thread_index(store, &dispatch.thread_id, &dispatch.dispatch_id).await {
+        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+            release_dedupe_lock(
+                store,
+                &dispatch.thread_id,
+                dedupe_key,
+                &dispatch.dispatch_id,
+            )
+            .await;
+        }
+        return Err(e);
+    }
+
     // ── Commit point: KV put ──
     //
     // Once the dispatch record is durable in KV, enqueue returns Ok even
-    // if later bookkeeping steps fail. The sweeper / recovery paths
-    // reconcile: they re-publish the JetStream delivery signal, rebuild
-    // the thread-index, etc. Failing enqueue after the KV put would leave
-    // callers thinking the request was rejected while the dispatch
-    // actually proceeds — the exact partial-failure hole we're closing.
+    // if later signal publication fails. The sweeper / recovery paths
+    // reconcile by re-publishing the JetStream delivery signal for queued
+    // dispatches that still need a wakeup.
     let bytes = codec::encode(&dispatch)?;
     if let Err(e) = store
         .kv_dispatch
@@ -68,18 +85,6 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
     // Update in-memory index synchronously so later `claim()` can see it
     // without waiting for the KV watcher.
     store.index.write().await.upsert(dispatch.clone());
-
-    // Best-effort: append to the thread-index bookkeeping bucket. Failure
-    // here does NOT fail enqueue; the in-memory index (kept in sync by
-    // the watcher) already answers every query path.
-    if let Err(e) = append_thread_index(store, &dispatch.thread_id, &dispatch.dispatch_id).await {
-        tracing::warn!(
-            thread_id = dispatch.thread_id,
-            dispatch_id = dispatch.dispatch_id,
-            error = %e,
-            "append_thread_index failed; continuing (non-authoritative bookkeeping)"
-        );
-    }
 
     // Best-effort: JetStream delivery signal. Failure is recovered by the
     // sweeper, which re-publishes for every Queued dispatch still missing
@@ -138,7 +143,11 @@ async fn acquire_dedupe_lock(
 ) -> Result<(), StorageError> {
     let key = keys::dedupe_lock_key(thread_id, dedupe_key);
     for _ in 0..3 {
-        let value = bytes::Bytes::from(dispatch_id.to_string().into_bytes());
+        let record = codec::DedupeLockRecord {
+            dispatch_id: dispatch_id.to_string(),
+            created_at: current_millis(),
+        };
+        let value = codec::encode_dedupe_lock(&record)?;
         match store.kv_thread_index.create(&key, value).await {
             Ok(_) => return Ok(()),
             Err(err) => {
@@ -179,18 +188,23 @@ async fn reconcile_dedupe_lock(
         Some(entry) => entry,
         None => return Ok(true), // gone already; retry acquire
     };
-    let holder_dispatch_id = String::from_utf8_lossy(&entry.value).to_string();
-    if holder_dispatch_id.is_empty() {
+    let lock = codec::decode_dedupe_lock(&entry.value)?;
+    if lock.dispatch_id.is_empty() {
         return purge_lock_if_revision(store, &key, entry.revision).await;
     }
 
     let holder_entry = store
         .kv_dispatch
-        .entry(&keys::dispatch_key(&holder_dispatch_id))
+        .entry(&keys::dispatch_key(&lock.dispatch_id))
         .await
         .map_err(|e| StorageError::Io(format!("dedupe reconcile dispatch lookup: {e}")))?;
     let Some(holder_entry) = holder_entry else {
-        // Lock created, dispatch never materialised (crash gap).
+        // Lock created, dispatch not materialised yet. Treat young locks
+        // as in-flight enqueue owners; only purge after a short orphan
+        // grace so concurrent enqueue cannot steal the lock.
+        if !is_dedupe_orphan_expired(lock.created_at) {
+            return Ok(false);
+        }
         return purge_lock_if_revision(store, &key, entry.revision).await;
     };
     let holder = codec::decode(&holder_entry.value)?;
@@ -223,6 +237,10 @@ async fn reconcile_dedupe_lock(
         return Ok(false);
     }
     Ok(false)
+}
+
+fn is_dedupe_orphan_expired(created_at: u64) -> bool {
+    created_at == 0 || current_millis().saturating_sub(created_at) >= DEDUPE_ORPHAN_GRACE_MS
 }
 
 async fn purge_lock_if_revision(
@@ -295,8 +313,20 @@ pub(super) async fn release_dedupe_lock(
             return;
         }
     };
-    let holder_dispatch_id = String::from_utf8_lossy(&entry.value);
-    if holder_dispatch_id != dispatch_id {
+    let lock = match codec::decode_dedupe_lock(&entry.value) {
+        Ok(lock) => lock,
+        Err(err) => {
+            tracing::warn!(
+                thread_id,
+                dedupe_key,
+                dispatch_id,
+                error = %err,
+                "failed to decode dedupe lock before release"
+            );
+            return;
+        }
+    };
+    if lock.dispatch_id != dispatch_id {
         return;
     }
     if let Err(err) = store
@@ -315,7 +345,14 @@ pub(super) async fn release_dedupe_lock(
     }
 }
 
-async fn append_thread_index(
+fn current_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+pub(crate) async fn append_thread_index(
     store: &NatsMailboxStore,
     thread_id: &str,
     dispatch_id: &str,
@@ -387,6 +424,37 @@ pub async fn extend_lease(
         if dispatch.claim_token.as_deref() != Some(claim_token) {
             return Ok(false);
         }
+        let thread_epoch = current_thread_epoch(store, &dispatch.thread_id).await?;
+        if dispatch.dispatch_epoch < thread_epoch {
+            dispatch.status = RunDispatchStatus::Superseded;
+            dispatch.dispatch_epoch = thread_epoch;
+            dispatch.completed_at = Some(now);
+            dispatch.updated_at = now;
+            dispatch.claim_token = None;
+            dispatch.claimed_by = None;
+            dispatch.lease_until = None;
+            let bytes = codec::encode(&dispatch)?;
+            if store
+                .kv_dispatch
+                .update(&keys::dispatch_key(dispatch_id), bytes, entry.revision)
+                .await
+                .is_ok()
+            {
+                store.index.write().await.upsert(dispatch.clone());
+                claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+                if let Some(ref dedupe_key) = dispatch.dedupe_key {
+                    release_dedupe_lock(
+                        store,
+                        &dispatch.thread_id,
+                        dedupe_key,
+                        &dispatch.dispatch_id,
+                    )
+                    .await;
+                }
+                return Ok(false);
+            }
+            continue;
+        }
         let lease_until = now.saturating_add(extension_ms);
         if !claim_guard::extend(
             store,
@@ -452,6 +520,12 @@ where
     Err(StorageError::Io("CAS exhausted retries".to_string()))
 }
 
+fn clear_claim_fields(dispatch: &mut RunDispatch) {
+    dispatch.claim_token = None;
+    dispatch.claimed_by = None;
+    dispatch.lease_until = None;
+}
+
 pub async fn ack(
     store: &NatsMailboxStore,
     dispatch_id: &str,
@@ -473,6 +547,7 @@ pub async fn ack(
         d.status = RunDispatchStatus::Acked;
         d.completed_at = Some(now);
         d.updated_at = now;
+        clear_claim_fields(d);
         Ok(())
     })
     .await?;
@@ -575,6 +650,7 @@ pub async fn dead_letter(
         d.last_error = Some(error.to_string());
         d.completed_at = Some(now);
         d.updated_at = now;
+        clear_claim_fields(d);
         Ok(())
     })
     .await?;
@@ -611,6 +687,7 @@ pub async fn cancel(
         d.status = RunDispatchStatus::Cancelled;
         d.completed_at = Some(now);
         d.updated_at = now;
+        clear_claim_fields(d);
         Ok(())
     })
     .await

--- a/crates/awaken-stores/src/nats_mailbox/ops_write.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_write.rs
@@ -1,0 +1,702 @@
+//! Write-path operations.
+
+use async_nats::HeaderMap;
+use async_nats::jetstream::kv::CreateErrorKind;
+use awaken_contract::contract::lifecycle::RunStatus;
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchResult, RunDispatchStatus};
+use awaken_contract::contract::storage::StorageError;
+
+use super::{NatsMailboxStore, claim_guard, codec, keys};
+
+pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result<(), StorageError> {
+    // ── Stamp dispatch_epoch from authoritative KV state ──
+    //
+    // The `MailboxStore` trait contract states "sets dispatch epoch from
+    // current thread state". Without this, foreground `Mailbox::submit()`
+    // calls `interrupt()` (bumps epoch 0→N) and then enqueues a dispatch
+    // whose `dispatch_epoch` is still 0 — the epoch-safe claim path then
+    // rejects it as stale, so every foreground submit after any interrupt
+    // would fail.
+    let mut dispatch = dispatch.clone();
+    dispatch.dispatch_epoch = current_thread_epoch(store, &dispatch.thread_id).await?;
+
+    // ── Authoritative dedupe (race-free across nodes) ──
+    //
+    // `kv.create()` on the dedupe lock is an atomic admission check. If
+    // two nodes concurrently attempt the same `(thread, dedupe_key)`, at
+    // most one succeeds; the loser observes `AlreadyExists`. If a prior
+    // holder crashed between lock create and dispatch put, or if the
+    // holding dispatch has become terminal/stale-by-epoch, the acquire
+    // path reconciles by purging the orphan lock and retrying.
+    if let Some(ref dedupe_key) = dispatch.dedupe_key {
+        acquire_dedupe_lock(
+            store,
+            &dispatch.thread_id,
+            dedupe_key,
+            &dispatch.dispatch_id,
+        )
+        .await?;
+    }
+
+    // ── Commit point: KV put ──
+    //
+    // Once the dispatch record is durable in KV, enqueue returns Ok even
+    // if later bookkeeping steps fail. The sweeper / recovery paths
+    // reconcile: they re-publish the JetStream delivery signal, rebuild
+    // the thread-index, etc. Failing enqueue after the KV put would leave
+    // callers thinking the request was rejected while the dispatch
+    // actually proceeds — the exact partial-failure hole we're closing.
+    let bytes = codec::encode(&dispatch)?;
+    if let Err(e) = store
+        .kv_dispatch
+        .put(keys::dispatch_key(&dispatch.dispatch_id), bytes)
+        .await
+    {
+        // Roll back the dedupe lock so a retry isn't permanently blocked.
+        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+            release_dedupe_lock(
+                store,
+                &dispatch.thread_id,
+                dedupe_key,
+                &dispatch.dispatch_id,
+            )
+            .await;
+        }
+        return Err(StorageError::Io(format!("kv put: {e}")));
+    }
+
+    // Update in-memory index synchronously so later `claim()` can see it
+    // without waiting for the KV watcher.
+    store.index.write().await.upsert(dispatch.clone());
+
+    // Best-effort: append to the thread-index bookkeeping bucket. Failure
+    // here does NOT fail enqueue; the in-memory index (kept in sync by
+    // the watcher) already answers every query path.
+    if let Err(e) = append_thread_index(store, &dispatch.thread_id, &dispatch.dispatch_id).await {
+        tracing::warn!(
+            thread_id = dispatch.thread_id,
+            dispatch_id = dispatch.dispatch_id,
+            error = %e,
+            "append_thread_index failed; continuing (non-authoritative bookkeeping)"
+        );
+    }
+
+    // Best-effort: JetStream delivery signal. Failure is recovered by the
+    // sweeper, which re-publishes for every Queued dispatch still missing
+    // its notification.
+    let subject = keys::dispatch_subject(&dispatch.thread_id);
+    let payload = bytes::Bytes::from(dispatch.dispatch_id.clone().into_bytes());
+    let publish_result = if let Some(ref dedupe_key) = dispatch.dedupe_key {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "Nats-Msg-Id",
+            keys::dedupe_msg_id(&dispatch.thread_id, dedupe_key).as_str(),
+        );
+        store
+            .jetstream
+            .publish_with_headers(subject, headers, payload)
+            .await
+    } else {
+        store.jetstream.publish(subject, payload).await
+    };
+    match publish_result {
+        Ok(future) => {
+            if let Err(e) = future.await {
+                tracing::warn!(
+                    thread_id = dispatch.thread_id,
+                    dispatch_id = dispatch.dispatch_id,
+                    error = %e,
+                    "JetStream publish ack failed; sweeper will retry"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                thread_id = dispatch.thread_id,
+                dispatch_id = dispatch.dispatch_id,
+                error = %e,
+                "JetStream publish failed; sweeper will retry"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Create the dedupe lock KV entry. Returns `AlreadyExists` if another
+/// node legitimately holds the lock for this `(thread, dedupe_key)`.
+///
+/// Before surfacing `AlreadyExists`, reconciles the lock against the
+/// authoritative dispatch record and thread epoch so a crash between
+/// lock create and dispatch put, or a dispatch that has since become
+/// terminal / stale-by-epoch, does not permanently block the key.
+async fn acquire_dedupe_lock(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    dedupe_key: &str,
+    dispatch_id: &str,
+) -> Result<(), StorageError> {
+    let key = keys::dedupe_lock_key(thread_id, dedupe_key);
+    for _ in 0..3 {
+        let value = bytes::Bytes::from(dispatch_id.to_string().into_bytes());
+        match store.kv_thread_index.create(&key, value).await {
+            Ok(_) => return Ok(()),
+            Err(err) => {
+                if err.kind() != CreateErrorKind::AlreadyExists {
+                    return Err(StorageError::Io(format!("dedupe lock create: {err}")));
+                }
+                // Conflict → reconcile against the authoritative state.
+                if reconcile_dedupe_lock(store, thread_id, dedupe_key).await? {
+                    // Orphan/terminal/stale lock purged; retry acquire.
+                    continue;
+                }
+                return Err(StorageError::AlreadyExists(format!(
+                    "dedupe_key '{dedupe_key}' already active on thread '{thread_id}'"
+                )));
+            }
+        }
+    }
+    Err(StorageError::Io(format!(
+        "dedupe lock reconcile exhausted retries for key '{dedupe_key}' on thread '{thread_id}'"
+    )))
+}
+
+/// Inspect the holder of a dedupe lock; if its dispatch is missing,
+/// terminal, or stale-by-epoch, CAS-purge the lock and report that a
+/// retry should succeed. Returns `Ok(true)` when the lock was purged.
+async fn reconcile_dedupe_lock(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    dedupe_key: &str,
+) -> Result<bool, StorageError> {
+    let key = keys::dedupe_lock_key(thread_id, dedupe_key);
+    let entry = match store
+        .kv_thread_index
+        .entry(&key)
+        .await
+        .map_err(|e| StorageError::Io(format!("dedupe lock entry: {e}")))?
+    {
+        Some(entry) => entry,
+        None => return Ok(true), // gone already; retry acquire
+    };
+    let holder_dispatch_id = String::from_utf8_lossy(&entry.value).to_string();
+    if holder_dispatch_id.is_empty() {
+        return purge_lock_if_revision(store, &key, entry.revision).await;
+    }
+
+    let holder_entry = store
+        .kv_dispatch
+        .entry(&keys::dispatch_key(&holder_dispatch_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("dedupe reconcile dispatch lookup: {e}")))?;
+    let Some(holder_entry) = holder_entry else {
+        // Lock created, dispatch never materialised (crash gap).
+        return purge_lock_if_revision(store, &key, entry.revision).await;
+    };
+    let holder = codec::decode(&holder_entry.value)?;
+    if matches!(
+        holder.status,
+        RunDispatchStatus::Acked
+            | RunDispatchStatus::Cancelled
+            | RunDispatchStatus::DeadLetter
+            | RunDispatchStatus::Superseded
+    ) {
+        return purge_lock_if_revision(store, &key, entry.revision).await;
+    }
+    let thread_epoch = match store
+        .kv_epoch
+        .entry(&keys::epoch_key(thread_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("dedupe reconcile epoch lookup: {e}")))?
+    {
+        Some(e) => codec::decode_epoch(&e.value)?,
+        None => 0,
+    };
+    if holder.dispatch_epoch < thread_epoch {
+        // Holder wasn't seen by interrupt's local-index sweep but is
+        // stale by authoritative epoch. Queued holders can be released so a
+        // fresh enqueue can proceed; Claimed holders are still active and keep
+        // their dedupe lock until their terminal transition releases it.
+        if holder.status == RunDispatchStatus::Queued {
+            return purge_lock_if_revision(store, &key, entry.revision).await;
+        }
+        return Ok(false);
+    }
+    Ok(false)
+}
+
+async fn purge_lock_if_revision(
+    store: &NatsMailboxStore,
+    key: &str,
+    revision: u64,
+) -> Result<bool, StorageError> {
+    // Revision-guarded purge prevents a stale reconciler from deleting a
+    // newer owner that acquired the same dedupe key after our inspection.
+    match store
+        .kv_thread_index
+        .purge_expect_revision(key, Some(revision))
+        .await
+    {
+        Ok(_) => Ok(true),
+        Err(err) => {
+            if store
+                .kv_thread_index
+                .entry(key)
+                .await
+                .map_err(|e| {
+                    StorageError::Io(format!("dedupe lock entry after purge conflict: {e}"))
+                })?
+                .is_none()
+            {
+                return Ok(true);
+            }
+            tracing::warn!(key, revision, error = %err, "dedupe lock purge failed");
+            Ok(false)
+        }
+    }
+}
+
+async fn current_thread_epoch(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+) -> Result<u64, StorageError> {
+    match store
+        .kv_epoch
+        .entry(&keys::epoch_key(thread_id))
+        .await
+        .map_err(|e| StorageError::Io(format!("kv entry epoch: {e}")))?
+    {
+        Some(e) => codec::decode_epoch(&e.value),
+        None => Ok(0),
+    }
+}
+
+/// Delete the dedupe lock. Idempotent — failures are logged and swallowed
+/// because a stale lock is recoverable (manual purge or TTL sweep) while
+/// a panicking release would strand a whole terminal transition.
+pub(super) async fn release_dedupe_lock(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    dedupe_key: &str,
+    dispatch_id: &str,
+) {
+    let key = keys::dedupe_lock_key(thread_id, dedupe_key);
+    let entry = match store.kv_thread_index.entry(&key).await {
+        Ok(Some(entry)) => entry,
+        Ok(None) => return,
+        Err(err) => {
+            tracing::warn!(
+                thread_id,
+                dedupe_key,
+                dispatch_id,
+                error = %err,
+                "failed to read dedupe lock before release"
+            );
+            return;
+        }
+    };
+    let holder_dispatch_id = String::from_utf8_lossy(&entry.value);
+    if holder_dispatch_id != dispatch_id {
+        return;
+    }
+    if let Err(err) = store
+        .kv_thread_index
+        .purge_expect_revision(&key, Some(entry.revision))
+        .await
+    {
+        tracing::warn!(
+            thread_id,
+            dedupe_key,
+            dispatch_id,
+            revision = entry.revision,
+            error = %err,
+            "failed to release dedupe lock (idempotent; sweeper may reconcile)"
+        );
+    }
+}
+
+async fn append_thread_index(
+    store: &NatsMailboxStore,
+    thread_id: &str,
+    dispatch_id: &str,
+) -> Result<(), StorageError> {
+    let key = keys::thread_index_key(thread_id);
+    for _ in 0..5 {
+        let entry = store
+            .kv_thread_index
+            .entry(&key)
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let (mut ids, revision) = match entry {
+            Some(e) => (codec::decode_thread_index(&e.value)?, e.revision),
+            None => (Vec::new(), 0),
+        };
+        if ids.contains(&dispatch_id.to_string()) {
+            return Ok(());
+        }
+        ids.push(dispatch_id.to_string());
+        let bytes = codec::encode_thread_index(&ids)?;
+        let result: Result<(), String> = if revision == 0 {
+            store
+                .kv_thread_index
+                .create(&key, bytes)
+                .await
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        } else {
+            store
+                .kv_thread_index
+                .update(&key, bytes, revision)
+                .await
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        };
+        match result {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                tracing::debug!(error = %e, "thread_index CAS retry");
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        }
+    }
+    Err(StorageError::Io(
+        "thread_index CAS exhausted retries".to_string(),
+    ))
+}
+
+pub async fn extend_lease(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    claim_token: &str,
+    extension_ms: u64,
+    now: u64,
+) -> Result<bool, StorageError> {
+    for _ in 0..5 {
+        let entry = store
+            .kv_dispatch
+            .entry(&keys::dispatch_key(dispatch_id))
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let Some(entry) = entry else {
+            return Ok(false);
+        };
+        let mut dispatch = codec::decode(&entry.value)?;
+        if dispatch.status != RunDispatchStatus::Claimed {
+            return Ok(false);
+        }
+        if dispatch.claim_token.as_deref() != Some(claim_token) {
+            return Ok(false);
+        }
+        let lease_until = now.saturating_add(extension_ms);
+        if !claim_guard::extend(
+            store,
+            &dispatch.thread_id,
+            dispatch_id,
+            claim_token,
+            lease_until,
+        )
+        .await?
+        {
+            return Ok(false);
+        }
+        dispatch.lease_until = Some(lease_until);
+        dispatch.updated_at = now;
+        let bytes = codec::encode(&dispatch)?;
+        if store
+            .kv_dispatch
+            .update(&keys::dispatch_key(dispatch_id), bytes, entry.revision)
+            .await
+            .is_ok()
+        {
+            store.index.write().await.upsert(dispatch);
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Load, mutate via closure, CAS write back. Returns the updated `RunDispatch`.
+///
+/// Returns `Ok(None)` if the dispatch doesn't exist.
+/// Returns `Err(StorageError::NotFound)` if the mutate closure rejects.
+async fn cas_update<F>(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    mutate: F,
+) -> Result<Option<RunDispatch>, StorageError>
+where
+    F: Fn(&mut RunDispatch) -> Result<(), StorageError>,
+{
+    for _ in 0..5 {
+        let entry = store
+            .kv_dispatch
+            .entry(&keys::dispatch_key(dispatch_id))
+            .await
+            .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?;
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
+        let mut dispatch = codec::decode(&entry.value)?;
+        mutate(&mut dispatch)?;
+        let bytes = codec::encode(&dispatch)?;
+        if store
+            .kv_dispatch
+            .update(&keys::dispatch_key(dispatch_id), bytes, entry.revision)
+            .await
+            .is_ok()
+        {
+            store.index.write().await.upsert(dispatch.clone());
+            return Ok(Some(dispatch));
+        }
+    }
+    Err(StorageError::Io("CAS exhausted retries".to_string()))
+}
+
+pub async fn ack(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    claim_token: &str,
+    now: u64,
+) -> Result<(), StorageError> {
+    let result = cas_update(store, dispatch_id, |d| {
+        if d.status != RunDispatchStatus::Claimed {
+            return Err(StorageError::NotFound(format!(
+                "dispatch {dispatch_id} not claimed (status={:?})",
+                d.status
+            )));
+        }
+        if d.claim_token.as_deref() != Some(claim_token) {
+            return Err(StorageError::NotFound(format!(
+                "claim_token mismatch for {dispatch_id}"
+            )));
+        }
+        d.status = RunDispatchStatus::Acked;
+        d.completed_at = Some(now);
+        d.updated_at = now;
+        Ok(())
+    })
+    .await?;
+    if result.is_none() {
+        return Err(StorageError::NotFound(dispatch_id.to_string()));
+    }
+    if let Some(dispatch) = result {
+        claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+        // Terminal state — release the dedupe lock so a future request
+        // with the same key can succeed.
+        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+            release_dedupe_lock(
+                store,
+                &dispatch.thread_id,
+                dedupe_key,
+                &dispatch.dispatch_id,
+            )
+            .await;
+        }
+    }
+    Ok(())
+}
+
+pub async fn nack(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    claim_token: &str,
+    retry_at: u64,
+    error: &str,
+    now: u64,
+) -> Result<(), StorageError> {
+    let result = cas_update(store, dispatch_id, |d| {
+        if d.status != RunDispatchStatus::Claimed {
+            return Err(StorageError::NotFound(format!(
+                "dispatch {dispatch_id} not claimed"
+            )));
+        }
+        if d.claim_token.as_deref() != Some(claim_token) {
+            return Err(StorageError::NotFound(format!(
+                "claim_token mismatch for {dispatch_id}"
+            )));
+        }
+        d.attempt_count += 1;
+        d.last_error = Some(error.to_string());
+        d.updated_at = now;
+        d.claim_token = None;
+        d.claimed_by = None;
+        d.lease_until = None;
+        if d.attempt_count >= d.max_attempts {
+            d.status = RunDispatchStatus::DeadLetter;
+            d.completed_at = Some(now);
+        } else {
+            d.status = RunDispatchStatus::Queued;
+            d.available_at = retry_at;
+        }
+        Ok(())
+    })
+    .await?;
+    if result.is_none() {
+        return Err(StorageError::NotFound(dispatch_id.to_string()));
+    }
+    if let Some(dispatch) = result {
+        claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+        // Only release the dedupe lock if THIS attempt was actually
+        // terminal (nack can either retry-queue or dead-letter).
+        if dispatch.status == RunDispatchStatus::DeadLetter
+            && let Some(ref dedupe_key) = dispatch.dedupe_key
+        {
+            release_dedupe_lock(
+                store,
+                &dispatch.thread_id,
+                dedupe_key,
+                &dispatch.dispatch_id,
+            )
+            .await;
+        }
+    }
+    Ok(())
+}
+
+pub async fn dead_letter(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    claim_token: &str,
+    error: &str,
+    now: u64,
+) -> Result<(), StorageError> {
+    let result = cas_update(store, dispatch_id, |d| {
+        if d.status != RunDispatchStatus::Claimed {
+            return Err(StorageError::NotFound(format!(
+                "dispatch {dispatch_id} not claimed"
+            )));
+        }
+        if d.claim_token.as_deref() != Some(claim_token) {
+            return Err(StorageError::NotFound(format!(
+                "claim_token mismatch for {dispatch_id}"
+            )));
+        }
+        d.status = RunDispatchStatus::DeadLetter;
+        d.last_error = Some(error.to_string());
+        d.completed_at = Some(now);
+        d.updated_at = now;
+        Ok(())
+    })
+    .await?;
+    if result.is_none() {
+        return Err(StorageError::NotFound(dispatch_id.to_string()));
+    }
+    if let Some(dispatch) = result {
+        claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+            release_dedupe_lock(
+                store,
+                &dispatch.thread_id,
+                dedupe_key,
+                &dispatch.dispatch_id,
+            )
+            .await;
+        }
+    }
+    Ok(())
+}
+
+pub async fn cancel(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    now: u64,
+) -> Result<Option<RunDispatch>, StorageError> {
+    let result = match cas_update(store, dispatch_id, |d| {
+        if d.status != RunDispatchStatus::Queued {
+            return Err(StorageError::NotFound(format!(
+                "dispatch {dispatch_id} not cancellable (status={:?})",
+                d.status
+            )));
+        }
+        d.status = RunDispatchStatus::Cancelled;
+        d.completed_at = Some(now);
+        d.updated_at = now;
+        Ok(())
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(StorageError::NotFound(_)) => return Ok(None),
+        Err(other) => return Err(other),
+    };
+    if let Some(ref dispatch) = result
+        && let Some(ref dedupe_key) = dispatch.dedupe_key
+    {
+        release_dedupe_lock(
+            store,
+            &dispatch.thread_id,
+            dedupe_key,
+            &dispatch.dispatch_id,
+        )
+        .await;
+    }
+    Ok(result)
+}
+
+pub async fn record_dispatch_start(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    claim_token: &str,
+    dispatch_instance_id: &str,
+    now: u64,
+) -> Result<(), StorageError> {
+    let result = cas_update(store, dispatch_id, |d| {
+        if d.claim_token.as_deref() != Some(claim_token) {
+            return Err(StorageError::NotFound(format!(
+                "claim_token mismatch for {dispatch_id}"
+            )));
+        }
+        if d.status != RunDispatchStatus::Claimed {
+            return Err(StorageError::NotFound(format!(
+                "dispatch {dispatch_id} not claimed"
+            )));
+        }
+        d.dispatch_instance_id = Some(dispatch_instance_id.to_string());
+        d.run_status = Some(RunStatus::Running);
+        d.termination = None;
+        d.run_response = None;
+        d.run_error = None;
+        d.completed_at = None;
+        d.updated_at = now;
+        Ok(())
+    })
+    .await?;
+    if result.is_none() {
+        return Err(StorageError::NotFound(dispatch_id.to_string()));
+    }
+    Ok(())
+}
+
+pub async fn record_run_result(
+    store: &NatsMailboxStore,
+    dispatch_id: &str,
+    claim_token: &str,
+    result: &RunDispatchResult,
+    now: u64,
+) -> Result<(), StorageError> {
+    let updated = cas_update(store, dispatch_id, |d| {
+        if d.claim_token.as_deref() != Some(claim_token) {
+            return Err(StorageError::NotFound(format!(
+                "claim_token mismatch for {dispatch_id}"
+            )));
+        }
+        if d.status != RunDispatchStatus::Claimed {
+            return Err(StorageError::NotFound(format!(
+                "dispatch {dispatch_id} not claimed"
+            )));
+        }
+        d.dispatch_instance_id = Some(result.dispatch_instance_id.clone());
+        d.run_status = Some(result.status);
+        d.termination = result.termination.clone();
+        d.run_response = result.response.clone();
+        d.run_error = result.error.clone();
+        d.completed_at = Some(now);
+        d.updated_at = now;
+        Ok(())
+    })
+    .await?;
+    if updated.is_none() {
+        return Err(StorageError::NotFound(dispatch_id.to_string()));
+    }
+    Ok(())
+}

--- a/crates/awaken-stores/src/nats_mailbox/sweeper.rs
+++ b/crates/awaken-stores/src/nats_mailbox/sweeper.rs
@@ -1,0 +1,90 @@
+//! Background sweeper: re-publishes available Queued dispatches.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use tokio::sync::RwLock;
+
+use super::{index::DispatchIndex, keys};
+
+#[derive(Default)]
+struct SweeperState {
+    already_published: std::collections::HashSet<String>,
+}
+
+pub fn spawn_sweeper(
+    jetstream: async_nats::jetstream::Context,
+    index: Arc<RwLock<DispatchIndex>>,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let state = Arc::new(RwLock::new(SweeperState::default()));
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // skip initial immediate tick
+
+        loop {
+            tokio::select! {
+                changed = shutdown_rx.changed() => {
+                    if changed.is_err() || *shutdown_rx.borrow() { break; }
+                }
+                _ = ticker.tick() => {
+                    let now = current_millis();
+                    tick(&jetstream, &index, &state, now).await;
+                }
+            }
+        }
+    })
+}
+
+async fn tick(
+    jetstream: &async_nats::jetstream::Context,
+    index: &Arc<RwLock<DispatchIndex>>,
+    state: &Arc<RwLock<SweeperState>>,
+    now: u64,
+) {
+    let candidates = index.read().await.available_queued(now);
+    for candidate in candidates {
+        let already = state
+            .read()
+            .await
+            .already_published
+            .contains(&candidate.dispatch_id);
+        if already {
+            continue;
+        }
+        if publish(jetstream, &candidate).await {
+            state
+                .write()
+                .await
+                .already_published
+                .insert(candidate.dispatch_id);
+        }
+    }
+    // Clean up tracking for dispatches no longer Queued.
+    let mut state_w = state.write().await;
+    let idx = index.read().await;
+    state_w.already_published.retain(|id| {
+        idx.get(id)
+            .is_some_and(|d| d.status == RunDispatchStatus::Queued)
+    });
+}
+
+async fn publish(jetstream: &async_nats::jetstream::Context, dispatch: &RunDispatch) -> bool {
+    let payload = bytes::Bytes::from(dispatch.dispatch_id.clone().into_bytes());
+    match jetstream
+        .publish(keys::dispatch_subject(&dispatch.thread_id), payload)
+        .await
+    {
+        Ok(ack_future) => ack_future.await.is_ok(),
+        Err(_) => false,
+    }
+}
+
+fn current_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/awaken-stores/src/sqlite_mailbox.rs
+++ b/crates/awaken-stores/src/sqlite_mailbox.rs
@@ -1293,6 +1293,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn claim_honors_batch_limit_without_active_claim() {
+        let store = SqliteMailboxStore::open_memory().unwrap();
+        for id in ["dispatch-1", "dispatch-2", "dispatch-3"] {
+            store.enqueue(&make_dispatch(id, "thread-a")).await.unwrap();
+        }
+
+        let claimed = store
+            .claim("thread-a", "consumer-1", 30_000, 2000, 2)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 2);
+        assert!(
+            claimed
+                .iter()
+                .all(|dispatch| dispatch.status == RunDispatchStatus::Claimed)
+        );
+    }
+
+    #[tokio::test]
     async fn nack_increments_attempt_and_requeues() {
         let store = SqliteMailboxStore::open_memory().unwrap();
         let mut dispatch = make_dispatch("dispatch-1", "thread-a");

--- a/crates/awaken-stores/tests/mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/mailbox_conformance.rs
@@ -448,6 +448,29 @@ pub async fn reclaim_expired_leases_requeues<S: MailboxStore>(store: &S) {
     assert!(loaded.claim_token.is_none());
 }
 
+/// Expired lease reclaim follows `max_attempts` and dead-letters instead of
+/// retrying forever.
+pub async fn reclaim_expired_leases_dead_letters_at_max_attempts<S: MailboxStore>(store: &S) {
+    let mut dispatch = make_dispatch("d1", "t-reclaim-max", "r1", 128, 1000);
+    dispatch.max_attempts = 1;
+    store.enqueue(&dispatch).await.unwrap();
+
+    store
+        .claim("t-reclaim-max", "consumer-1", 100, 1000, 1)
+        .await
+        .unwrap();
+
+    let reclaimed = store.reclaim_expired_leases(2000, 10).await.unwrap();
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].dispatch_id, "d1");
+    assert_eq!(reclaimed[0].status, RunDispatchStatus::DeadLetter);
+    assert_eq!(reclaimed[0].attempt_count, 1);
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(loaded.attempt_count, 1);
+}
+
 /// `purge_terminal()` removes terminal dispatches older than the cutoff.
 pub async fn purge_terminal_removes_old<S: MailboxStore>(store: &S) {
     let dispatch = make_dispatch("d1", "t-purge", "r1", 128, 1000);

--- a/crates/awaken-stores/tests/mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/mailbox_conformance.rs
@@ -1,0 +1,684 @@
+//! Shared semantic conformance tests for [`MailboxStore`] implementations.
+//!
+//! Each `pub async fn` in this module exercises one semantic behavior of the
+//! trait against a `&S: MailboxStore`. Backend-specific test binaries (e.g.
+//! `memory_mailbox_conformance.rs`) include this file via `mod
+//! mailbox_conformance;` and dispatch each test against a fresh store
+//! instance.
+//!
+//! No `#[test]` / `#[tokio::test]` attributes live here on purpose: when cargo
+//! compiles this file as its own integration test binary it simply produces a
+//! binary with zero tests. `#![allow(dead_code)]` silences warnings in that
+//! standalone compilation mode, since each backend binary only calls a subset
+//! of these functions through its macro expansion.
+
+#![allow(dead_code)]
+
+use awaken_contract::contract::mailbox::{MailboxStore, RunDispatch, RunDispatchStatus};
+use uuid::Uuid;
+
+/// Construct a `RunDispatch` with sensible defaults for conformance tests.
+pub fn make_dispatch(
+    dispatch_id: &str,
+    thread_id: &str,
+    run_id: &str,
+    priority: u8,
+    available_at: u64,
+) -> RunDispatch {
+    RunDispatch {
+        dispatch_id: dispatch_id.to_string(),
+        thread_id: thread_id.to_string(),
+        run_id: run_id.to_string(),
+        priority,
+        dedupe_key: None,
+        dispatch_epoch: 0,
+        status: RunDispatchStatus::Queued,
+        available_at,
+        attempt_count: 0,
+        max_attempts: 5,
+        last_error: None,
+        claim_token: None,
+        claimed_by: None,
+        lease_until: None,
+        dispatch_instance_id: None,
+        run_status: None,
+        termination: None,
+        run_response: None,
+        run_error: None,
+        completed_at: None,
+        created_at: available_at,
+        updated_at: available_at,
+    }
+}
+
+/// Enqueue a single dispatch and verify it is returned by `list_dispatches`.
+pub async fn enqueue_and_list<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-enqueue", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let listed = store
+        .list_dispatches("t-enqueue", None, 100, 0)
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].dispatch_id, "d1");
+    assert_eq!(listed[0].status, RunDispatchStatus::Queued);
+}
+
+/// `claim()` returns a previously queued dispatch with status Claimed and a
+/// populated `claim_token`.
+pub async fn claim_returns_queued_dispatch<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-claim", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-claim", "consumer-1", 30_000, 1000, 10)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "d1");
+    assert_eq!(claimed[0].status, RunDispatchStatus::Claimed);
+    assert!(claimed[0].claim_token.is_some());
+    assert_eq!(claimed[0].claimed_by.as_deref(), Some("consumer-1"));
+}
+
+/// `claim()` must skip dispatches whose `available_at` is in the future.
+pub async fn claim_respects_available_at<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-avail", "r1", 128, 5000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-avail", "consumer-1", 30_000, 1000, 10)
+        .await
+        .unwrap();
+    assert!(claimed.is_empty());
+
+    // Advance beyond available_at: dispatch must now be claimable.
+    let claimed = store
+        .claim("t-avail", "consumer-1", 30_000, 5000, 10)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "d1");
+}
+
+/// Lower numeric priority wins before `created_at` ordering.
+pub async fn claim_respects_priority_before_created_at<S: MailboxStore>(store: &S) {
+    let mut older_low_priority = make_dispatch("d-low", "t-priority", "r-low", 200, 1000);
+    older_low_priority.created_at = 10;
+    store.enqueue(&older_low_priority).await.unwrap();
+
+    let mut newer_high_priority = make_dispatch("d-high", "t-priority", "r-high", 10, 1000);
+    newer_high_priority.created_at = 20;
+    store.enqueue(&newer_high_priority).await.unwrap();
+
+    let claimed = store
+        .claim("t-priority", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "d-high");
+    assert_eq!(claimed[0].priority, 10);
+}
+
+/// A second claim must not bypass same-thread execution ownership while a
+/// dispatch is already active.
+pub async fn claim_limit_preserves_thread_exclusivity<S: MailboxStore>(store: &S) {
+    let older = make_dispatch("d-one", "t-claim-limit", "r-one", 10, 1000);
+    store.enqueue(&older).await.unwrap();
+
+    let mut newer = make_dispatch("d-two", "t-claim-limit", "r-two", 10, 1000);
+    newer.created_at = 2000;
+    store.enqueue(&newer).await.unwrap();
+
+    let claimed = store
+        .claim("t-claim-limit", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "d-one");
+
+    let blocked = store
+        .claim("t-claim-limit", "consumer-2", 30_000, 1100, 10)
+        .await
+        .unwrap();
+    assert!(
+        blocked.is_empty(),
+        "same thread must not claim a second dispatch while one is active"
+    );
+
+    let token = claimed[0].claim_token.clone().unwrap();
+    store.ack("d-one", &token, 1200).await.unwrap();
+
+    let next = store
+        .claim("t-claim-limit", "consumer-2", 30_000, 1300, 1)
+        .await
+        .unwrap();
+    assert_eq!(next.len(), 1);
+    assert_eq!(next[0].dispatch_id, "d-two");
+}
+
+/// `list_dispatches()` must use the same priority/FIFO ordering as `claim()`.
+pub async fn list_dispatches_orders_by_priority_then_created_at<S: MailboxStore>(store: &S) {
+    let mut low = make_dispatch("d-low", "t-list-order", "r-low", 200, 1000);
+    low.created_at = 10;
+    store.enqueue(&low).await.unwrap();
+
+    let mut high_newer = make_dispatch("d-high-newer", "t-list-order", "r-high-newer", 10, 1000);
+    high_newer.created_at = 30;
+    store.enqueue(&high_newer).await.unwrap();
+
+    let mut high_older = make_dispatch("d-high-older", "t-list-order", "r-high-older", 10, 1000);
+    high_older.created_at = 20;
+    store.enqueue(&high_older).await.unwrap();
+
+    let listed = store
+        .list_dispatches("t-list-order", None, 10, 0)
+        .await
+        .unwrap();
+    let ids = listed
+        .iter()
+        .map(|dispatch| dispatch.dispatch_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["d-high-older", "d-high-newer", "d-low"]);
+}
+
+/// `ack()` transitions a Claimed dispatch to Acked.
+pub async fn ack_transitions_to_acked<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-ack", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-ack", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    let token = claimed[0].claim_token.clone().unwrap();
+
+    store.ack("d1", &token, 2000).await.unwrap();
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Acked);
+}
+
+/// `ack()` with a claim_token that does not match the active lease must fail.
+pub async fn ack_rejects_wrong_claim_token<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-ack-wrong", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    store
+        .claim("t-ack-wrong", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+
+    let result = store.ack("d1", "wrong-token", 2000).await;
+    assert!(result.is_err(), "ack with wrong token must error");
+
+    // Dispatch stays Claimed.
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
+}
+
+/// `nack()` with attempts remaining returns the dispatch to Queued, bumping
+/// `attempt_count` and rescheduling with `available_at == retry_at`.
+pub async fn nack_returns_to_queued<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-nack", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-nack", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    let token = claimed[0].claim_token.clone().unwrap();
+
+    store
+        .nack("d1", &token, 3000, "transient error", 2000)
+        .await
+        .unwrap();
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Queued);
+    assert_eq!(loaded.attempt_count, 1);
+    assert_eq!(loaded.available_at, 3000);
+    assert!(loaded.claim_token.is_none());
+    assert!(loaded.claimed_by.is_none());
+    assert!(loaded.lease_until.is_none());
+    assert_eq!(loaded.last_error.as_deref(), Some("transient error"));
+}
+
+/// `nack()` dead-letters a dispatch once `attempt_count` reaches `max_attempts`.
+pub async fn nack_dead_letters_after_max_attempts<S: MailboxStore>(store: &S) {
+    let mut dispatch = make_dispatch("d1", "t-dead", "r1", 128, 1000);
+    dispatch.max_attempts = 2;
+    store.enqueue(&dispatch).await.unwrap();
+
+    // First nack: attempt_count=1, back to Queued.
+    let claimed = store
+        .claim("t-dead", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    let token = claimed[0].claim_token.clone().unwrap();
+    store.nack("d1", &token, 1500, "retry", 1100).await.unwrap();
+    let after_first = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(after_first.status, RunDispatchStatus::Queued);
+    assert_eq!(after_first.attempt_count, 1);
+
+    // Second nack: attempt_count=2 == max_attempts → DeadLetter.
+    let claimed = store
+        .claim("t-dead", "consumer-1", 30_000, 1500, 1)
+        .await
+        .unwrap();
+    let token = claimed[0].claim_token.clone().unwrap();
+    store
+        .nack("d1", &token, 2500, "final error", 2000)
+        .await
+        .unwrap();
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(loaded.attempt_count, 2);
+}
+
+/// `cancel()` on a Queued dispatch transitions it to Cancelled.
+pub async fn cancel_queued_dispatch<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-cancel", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let cancelled = store.cancel("d1", 2000).await.unwrap();
+    assert!(cancelled.is_some());
+    assert_eq!(cancelled.unwrap().status, RunDispatchStatus::Cancelled);
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Cancelled);
+}
+
+/// `cancel()` is only for Queued dispatches; Claimed dispatches remain owned by
+/// the runtime cancellation path.
+pub async fn cancel_claimed_dispatch_returns_none<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-cancel-claimed", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-cancel-claimed", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+
+    let cancelled = store.cancel("d1", 2000).await.unwrap();
+    assert!(cancelled.is_none());
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
+}
+
+/// `extend_lease()` with the right claim_token updates `lease_until`.
+pub async fn extend_lease_success<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-extend", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-extend", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    let token = claimed[0].claim_token.clone().unwrap();
+
+    let ok = store
+        .extend_lease("d1", &token, 60_000, 15_000)
+        .await
+        .unwrap();
+    assert!(ok);
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.lease_until, Some(75_000));
+}
+
+/// `extend_lease()` with a mismatched claim_token must return `false` and
+/// leave the dispatch untouched.
+pub async fn extend_lease_wrong_token<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-extend-wrong", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-extend-wrong", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    let original_lease = claimed[0].lease_until;
+
+    let ok = store
+        .extend_lease("d1", "wrong-token", 60_000, 15_000)
+        .await
+        .unwrap();
+    assert!(!ok);
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.lease_until, original_lease);
+}
+
+/// `interrupt()` supersedes all Queued dispatches in the thread.
+pub async fn interrupt_supersedes_queued<S: MailboxStore>(store: &S) {
+    store
+        .enqueue(&make_dispatch("d1", "t-interrupt", "r1", 128, 1000))
+        .await
+        .unwrap();
+    store
+        .enqueue(&make_dispatch("d2", "t-interrupt", "r2", 128, 1000))
+        .await
+        .unwrap();
+
+    let result = store.interrupt("t-interrupt", 2000).await.unwrap();
+    assert_eq!(result.superseded_count, 2);
+    assert!(result.active_dispatch.is_none());
+    assert!(result.new_dispatch_epoch >= 1);
+
+    let listed = store
+        .list_dispatches(
+            "t-interrupt",
+            Some(&[RunDispatchStatus::Superseded]),
+            100,
+            0,
+        )
+        .await
+        .unwrap();
+    assert_eq!(listed.len(), 2);
+}
+
+/// `interrupt()` returns the currently Claimed dispatch as `active_dispatch`
+/// and supersedes the remaining Queued dispatches.
+pub async fn interrupt_returns_active_claimed<S: MailboxStore>(store: &S) {
+    store
+        .enqueue(&make_dispatch("d1", "t-interrupt-active", "r1", 128, 1000))
+        .await
+        .unwrap();
+
+    // Claim the first dispatch → Claimed.
+    let claimed = store
+        .claim("t-interrupt-active", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    let claimed_id = claimed[0].dispatch_id.clone();
+
+    // Enqueue another dispatch (will be Queued).
+    store
+        .enqueue(&make_dispatch("d2", "t-interrupt-active", "r2", 128, 1000))
+        .await
+        .unwrap();
+
+    let result = store.interrupt("t-interrupt-active", 2000).await.unwrap();
+    let active = result
+        .active_dispatch
+        .expect("interrupt must return active claimed dispatch");
+    assert_eq!(active.dispatch_id, claimed_id);
+    assert_eq!(active.status, RunDispatchStatus::Claimed);
+    assert_eq!(result.superseded_count, 1);
+}
+
+/// `enqueue()` rejects a second dispatch that reuses a non-terminal
+/// dispatch's `dedupe_key`.
+pub async fn dedupe_key_rejects_duplicate<S: MailboxStore>(store: &S) {
+    let mut first = make_dispatch("d1", "t-dedupe", "r1", 128, 1000);
+    first.dedupe_key = Some("unique-key".to_string());
+    store.enqueue(&first).await.unwrap();
+
+    let mut second = make_dispatch("d2", "t-dedupe", "r2", 128, 1000);
+    second.dedupe_key = Some("unique-key".to_string());
+    let result = store.enqueue(&second).await;
+    assert!(result.is_err(), "duplicate dedupe_key must be rejected");
+}
+
+/// `reclaim_expired_leases()` returns orphaned Claimed dispatches to Queued.
+pub async fn reclaim_expired_leases_requeues<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-reclaim", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    // Claim with a short lease ending at 1100.
+    store
+        .claim("t-reclaim", "consumer-1", 100, 1000, 1)
+        .await
+        .unwrap();
+
+    // Advance past lease expiry.
+    let reclaimed = store.reclaim_expired_leases(2000, 10).await.unwrap();
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].dispatch_id, "d1");
+    assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
+    assert_eq!(reclaimed[0].attempt_count, 1);
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Queued);
+    assert!(loaded.claim_token.is_none());
+}
+
+/// `purge_terminal()` removes terminal dispatches older than the cutoff.
+pub async fn purge_terminal_removes_old<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-purge", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    // Cancel → Cancelled (terminal) with updated_at=1500.
+    store.cancel("d1", 1500).await.unwrap();
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Cancelled);
+
+    // Cutoff > 1500 must purge the terminal dispatch.
+    let purged = store.purge_terminal(2000).await.unwrap();
+    assert_eq!(purged, 1);
+
+    let gone = store.load_dispatch("d1").await.unwrap();
+    assert!(gone.is_none(), "purged dispatch must be removed");
+}
+
+/// `queued_thread_ids()` lists every thread that currently holds at least one
+/// Queued dispatch.
+pub async fn queued_thread_ids_returns_active_threads<S: MailboxStore>(store: &S) {
+    store
+        .enqueue(&make_dispatch("d1", "thread-a", "r1", 128, 1000))
+        .await
+        .unwrap();
+    store
+        .enqueue(&make_dispatch("d2", "thread-b", "r2", 128, 1000))
+        .await
+        .unwrap();
+
+    let ids = store.queued_thread_ids().await.unwrap();
+    assert!(ids.contains(&"thread-a".to_string()));
+    assert!(ids.contains(&"thread-b".to_string()));
+    assert_eq!(ids.len(), 2);
+}
+
+/// `claim_dispatch()` targets a specific dispatch_id and transitions it to
+/// Claimed.
+pub async fn claim_dispatch_by_id<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-claim-id", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim_dispatch("d1", "consumer-1", 30_000, 1000)
+        .await
+        .unwrap()
+        .expect("claim_dispatch should return the dispatch");
+    assert_eq!(claimed.dispatch_id, "d1");
+    assert_eq!(claimed.status, RunDispatchStatus::Claimed);
+    assert!(claimed.claim_token.is_some());
+}
+
+/// `claim_dispatch(id)` MUST ignore `available_at` — it is the by-ID
+/// inline-claim path used by `Mailbox::submit()` to claim the dispatch
+/// it just wrote, where a future `available_at` keeps the sweeper away.
+/// The queue-scan path (`claim()`) must still respect the guard.
+pub async fn claim_dispatch_ignores_available_at<S: MailboxStore>(store: &S) {
+    // Submit with available_at far in the future.
+    let mut dispatch = make_dispatch("d-guarded", "t-guarded", "r1", 128, 1000);
+    dispatch.available_at = 1_000_000;
+    store.enqueue(&dispatch).await.unwrap();
+
+    // Queue scan at t=1000 must skip it (future available_at).
+    let scanned = store
+        .claim("t-guarded", "consumer-1", 30_000, 1000, 10)
+        .await
+        .unwrap();
+    assert!(
+        scanned.is_empty(),
+        "claim() by thread must respect available_at"
+    );
+
+    // By-id claim at the same time must succeed regardless of available_at.
+    let claimed = store
+        .claim_dispatch("d-guarded", "consumer-1", 30_000, 1000)
+        .await
+        .unwrap()
+        .expect("claim_dispatch must ignore available_at");
+    assert_eq!(claimed.dispatch_id, "d-guarded");
+    assert_eq!(claimed.status, RunDispatchStatus::Claimed);
+}
+
+/// `record_dispatch_start()` sets the active runtime projection and clears any
+/// stale terminal result fields from previous attempts.
+pub async fn record_dispatch_start_marks_running<S: MailboxStore>(store: &S) {
+    let dispatch = make_dispatch("d1", "t-start", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-start", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    let token = claimed[0].claim_token.clone().unwrap();
+
+    store
+        .record_dispatch_start("d1", &token, "attempt-1", 1500)
+        .await
+        .unwrap();
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.dispatch_instance_id.as_deref(), Some("attempt-1"));
+    assert_eq!(
+        loaded.run_status,
+        Some(awaken_contract::contract::lifecycle::RunStatus::Running)
+    );
+    assert!(loaded.termination.is_none());
+    assert!(loaded.run_response.is_none());
+    assert!(loaded.run_error.is_none());
+    assert!(loaded.completed_at.is_none());
+}
+
+/// `record_run_result()` requires the active claim and persists the full runtime
+/// result projection.
+pub async fn record_run_result_sets_terminal_projection<S: MailboxStore>(store: &S) {
+    use awaken_contract::contract::lifecycle::{RunStatus, TerminationReason};
+    use awaken_contract::contract::mailbox::RunDispatchResult;
+
+    let dispatch = make_dispatch("d1", "t-result", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-result", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    let token = claimed[0].claim_token.clone().unwrap();
+    let result = RunDispatchResult {
+        run_id: "r1".to_string(),
+        dispatch_instance_id: "attempt-1".to_string(),
+        status: RunStatus::Done,
+        termination: Some(TerminationReason::NaturalEnd),
+        response: Some("ok".to_string()),
+        error: None,
+    };
+
+    store
+        .record_run_result("d1", &token, &result, 2000)
+        .await
+        .unwrap();
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.dispatch_instance_id.as_deref(), Some("attempt-1"));
+    assert_eq!(loaded.run_status, Some(RunStatus::Done));
+    assert_eq!(loaded.termination, Some(TerminationReason::NaturalEnd));
+    assert_eq!(loaded.run_response.as_deref(), Some("ok"));
+    assert!(loaded.run_error.is_none());
+    assert_eq!(loaded.completed_at, Some(2000));
+}
+
+/// Runtime projection writes must require an existing claimed dispatch.
+pub async fn record_projection_rejects_missing_or_unclaimed_dispatch<S: MailboxStore>(store: &S) {
+    use awaken_contract::contract::lifecycle::RunStatus;
+    use awaken_contract::contract::mailbox::RunDispatchResult;
+
+    let result = RunDispatchResult {
+        run_id: "r-missing".to_string(),
+        dispatch_instance_id: "attempt-missing".to_string(),
+        status: RunStatus::Done,
+        termination: None,
+        response: None,
+        error: None,
+    };
+
+    assert!(
+        store
+            .record_dispatch_start("missing", "token", "attempt-missing", 1000)
+            .await
+            .is_err()
+    );
+    assert!(
+        store
+            .record_run_result("missing", "token", &result, 1000)
+            .await
+            .is_err()
+    );
+
+    let dispatch = make_dispatch("d1", "t-projection-reject", "r1", 128, 1000);
+    store.enqueue(&dispatch).await.unwrap();
+
+    assert!(
+        store
+            .record_dispatch_start("d1", "token", "attempt-1", 1100)
+            .await
+            .is_err()
+    );
+    assert!(
+        store
+            .record_run_result("d1", "token", &result, 1100)
+            .await
+            .is_err()
+    );
+
+    let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
+    assert_eq!(loaded.status, RunDispatchStatus::Queued);
+    assert!(loaded.run_status.is_none());
+    assert!(loaded.dispatch_instance_id.is_none());
+}
+
+/// For dispatches that share a priority, `claim()` must return them in
+/// `created_at` ascending order (FIFO).
+pub async fn fifo_ordering_within_same_priority<S: MailboxStore>(store: &S) {
+    // Use unique dispatch IDs to survive any cross-test bleed (not expected,
+    // but cheap insurance against non-isolated backends).
+    let older_id = format!("older-{}", Uuid::now_v7());
+    let newer_id = format!("newer-{}", Uuid::now_v7());
+
+    let mut older = make_dispatch(&older_id, "t-fifo", "r1", 128, 1000);
+    older.created_at = 100;
+    store.enqueue(&older).await.unwrap();
+
+    let mut newer = make_dispatch(&newer_id, "t-fifo", "r2", 128, 1000);
+    newer.created_at = 200;
+    store.enqueue(&newer).await.unwrap();
+
+    // Claim them one at a time; the older dispatch must come first.
+    let first = store
+        .claim("t-fifo", "consumer-1", 30_000, 1000, 1)
+        .await
+        .unwrap();
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].dispatch_id, older_id);
+
+    let token = first[0].claim_token.clone().unwrap();
+    store
+        .ack(&first[0].dispatch_id, &token, 1100)
+        .await
+        .unwrap();
+
+    let second = store
+        .claim("t-fifo", "consumer-1", 30_000, 1100, 1)
+        .await
+        .unwrap();
+    assert_eq!(second.len(), 1);
+    assert_eq!(second[0].dispatch_id, newer_id);
+}

--- a/crates/awaken-stores/tests/memory_mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/memory_mailbox_conformance.rs
@@ -33,6 +33,7 @@ conformance_test!(interrupt_supersedes_queued);
 conformance_test!(interrupt_returns_active_claimed);
 conformance_test!(dedupe_key_rejects_duplicate);
 conformance_test!(reclaim_expired_leases_requeues);
+conformance_test!(reclaim_expired_leases_dead_letters_at_max_attempts);
 conformance_test!(purge_terminal_removes_old);
 conformance_test!(queued_thread_ids_returns_active_threads);
 conformance_test!(claim_dispatch_by_id);

--- a/crates/awaken-stores/tests/memory_mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/memory_mailbox_conformance.rs
@@ -1,0 +1,43 @@
+//! Conformance test binary wiring the shared `mailbox_conformance` harness to
+//! the in-memory `InMemoryMailboxStore` backend.
+
+mod mailbox_conformance;
+
+use awaken_stores::InMemoryMailboxStore;
+
+macro_rules! conformance_test {
+    ($name:ident) => {
+        #[tokio::test]
+        async fn $name() {
+            let store = InMemoryMailboxStore::new();
+            mailbox_conformance::$name(&store).await;
+        }
+    };
+}
+
+conformance_test!(enqueue_and_list);
+conformance_test!(claim_returns_queued_dispatch);
+conformance_test!(claim_respects_available_at);
+conformance_test!(claim_respects_priority_before_created_at);
+conformance_test!(claim_limit_preserves_thread_exclusivity);
+conformance_test!(list_dispatches_orders_by_priority_then_created_at);
+conformance_test!(ack_transitions_to_acked);
+conformance_test!(ack_rejects_wrong_claim_token);
+conformance_test!(nack_returns_to_queued);
+conformance_test!(nack_dead_letters_after_max_attempts);
+conformance_test!(cancel_queued_dispatch);
+conformance_test!(cancel_claimed_dispatch_returns_none);
+conformance_test!(extend_lease_success);
+conformance_test!(extend_lease_wrong_token);
+conformance_test!(interrupt_supersedes_queued);
+conformance_test!(interrupt_returns_active_claimed);
+conformance_test!(dedupe_key_rejects_duplicate);
+conformance_test!(reclaim_expired_leases_requeues);
+conformance_test!(purge_terminal_removes_old);
+conformance_test!(queued_thread_ids_returns_active_threads);
+conformance_test!(claim_dispatch_by_id);
+conformance_test!(claim_dispatch_ignores_available_at);
+conformance_test!(record_dispatch_start_marks_running);
+conformance_test!(record_run_result_sets_terminal_projection);
+conformance_test!(record_projection_rejects_missing_or_unclaimed_dispatch);
+conformance_test!(fifo_ordering_within_same_priority);

--- a/crates/awaken-stores/tests/memory_thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/memory_thread_store_conformance.rs
@@ -1,0 +1,22 @@
+#[path = "thread_store_conformance.rs"]
+mod thread_store_conformance;
+
+use awaken_stores::InMemoryStore;
+
+macro_rules! conformance_test {
+    ($name:ident) => {
+        #[tokio::test]
+        async fn $name() {
+            let store = InMemoryStore::new();
+            thread_store_conformance::$name(&store).await;
+        }
+    };
+}
+
+conformance_test!(checkpoint_persists_messages_and_run);
+conformance_test!(load_messages_returns_none_for_unknown_thread);
+conformance_test!(latest_run_returns_most_recent);
+conformance_test!(checkpoint_overwrites_messages);
+conformance_test!(load_thread_reflects_checkpoint);
+conformance_test!(append_message_records_assigns_seq);
+conformance_test!(load_run_returns_none_for_unknown);

--- a/crates/awaken-stores/tests/nats_buffered_thread_adversarial.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_adversarial.rs
@@ -27,7 +27,7 @@ use awaken_contract::contract::storage::{
     RunPage, RunQuery, RunRecord, RunStore, StorageError, ThreadRunStore, ThreadStore,
 };
 use awaken_contract::thread::{Thread, ThreadMetadata};
-use awaken_stores::{InMemoryStore, NatsBufferedThreadStore};
+use awaken_stores::{InMemoryStore, NatsBufferedThreadStore, ReadConsistency};
 use fixture::{NatsFixture, unique_config};
 
 // ── Test doubles ────────────────────────────────────────────────────
@@ -346,6 +346,50 @@ async fn out_of_order_wal_publish_does_not_rewind_projection_or_flushed_seq() {
         probe.count(),
         1,
         "stale seq should be acked/skipped, not checkpointed to inner"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn strong_latest_run_uses_thread_projection_when_run_timestamps_tie() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(100);
+    config.read_consistency = ReadConsistency::Strong;
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let older = mk_run("run-old-tie", "t-projection-tie", 1);
+    let newer = mk_run("run-new-tie", "t-projection-tie", 1);
+    store
+        .checkpoint(
+            "t-projection-tie",
+            &[Message::user("old projection")],
+            &older,
+        )
+        .await
+        .unwrap();
+    store
+        .checkpoint(
+            "t-projection-tie",
+            &[Message::user("new projection")],
+            &newer,
+        )
+        .await
+        .unwrap();
+
+    store.force_flush("t-projection-tie").await.unwrap();
+    let latest = store
+        .latest_run("t-projection-tie")
+        .await
+        .unwrap()
+        .expect("latest run");
+    assert_eq!(
+        latest.run_id, "run-new-tie",
+        "Strong latest_run must follow the flushed thread projection, not updated_at tie order"
     );
 
     store.shutdown().await.unwrap();

--- a/crates/awaken-stores/tests/nats_buffered_thread_adversarial.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_adversarial.rs
@@ -1,0 +1,799 @@
+//! Adversarial/stress tests for `NatsBufferedThreadStore`.
+//!
+//! These exercise failure modes and concurrency that the happy-path conformance
+//! suite does not:
+//!
+//! - Concurrent checkpoints racing on a single thread (CAS + coalescing)
+//! - Many-thread fanout (per-thread isolation under interleaving)
+//! - Transient inner-store failures (JetStream NAK + redelivery)
+//! - `force_flush` timeout when the inner store stalls
+//! - Large payloads near JetStream's 1 MiB message limit
+//! - Mid-flight crash + recovery coalescing (store1 drops with N unacked
+//!   entries for one thread; store2 must drain to a consistent final state)
+
+#![cfg(feature = "nats")]
+
+#[path = "nats_buffered_thread_fixture.rs"]
+mod fixture;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use awaken_contract::contract::lifecycle::RunStatus;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{
+    RunPage, RunQuery, RunRecord, RunStore, StorageError, ThreadRunStore, ThreadStore,
+};
+use awaken_contract::thread::{Thread, ThreadMetadata};
+use awaken_stores::{InMemoryStore, NatsBufferedThreadStore};
+use fixture::{NatsFixture, unique_config};
+
+// ── Test doubles ────────────────────────────────────────────────────
+
+/// Wraps `InMemoryStore`, counting checkpoint invocations.
+struct CountingStore {
+    inner: InMemoryStore,
+    checkpoint_count: AtomicUsize,
+}
+
+impl CountingStore {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryStore::new(),
+            checkpoint_count: AtomicUsize::new(0),
+        }
+    }
+    fn count(&self) -> usize {
+        self.checkpoint_count.load(Ordering::SeqCst)
+    }
+}
+
+/// Checkpoint fails for the first `fail_first` calls (Io error), then succeeds.
+struct FlakyStore {
+    inner: InMemoryStore,
+    fail_first: AtomicUsize,
+    observed_calls: AtomicUsize,
+}
+
+impl FlakyStore {
+    fn new(fail_first: usize) -> Self {
+        Self {
+            inner: InMemoryStore::new(),
+            fail_first: AtomicUsize::new(fail_first),
+            observed_calls: AtomicUsize::new(0),
+        }
+    }
+    fn observed_calls(&self) -> usize {
+        self.observed_calls.load(Ordering::SeqCst)
+    }
+}
+
+/// Checkpoint blocks forever so the flusher cannot advance `flushed_seq`.
+struct BlockedStore {
+    inner: InMemoryStore,
+}
+
+impl BlockedStore {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryStore::new(),
+        }
+    }
+}
+
+// Macro to forward ThreadStore + RunStore methods to inner InMemoryStore.
+macro_rules! forward_thread_run {
+    ($ty:ty) => {
+        #[async_trait]
+        impl ThreadStore for $ty {
+            async fn load_thread(&self, id: &str) -> Result<Option<Thread>, StorageError> {
+                self.inner.load_thread(id).await
+            }
+            async fn save_thread(&self, thread: &Thread) -> Result<(), StorageError> {
+                self.inner.save_thread(thread).await
+            }
+            async fn delete_thread(&self, id: &str) -> Result<(), StorageError> {
+                self.inner.delete_thread(id).await
+            }
+            async fn list_threads(
+                &self,
+                offset: usize,
+                limit: usize,
+            ) -> Result<Vec<String>, StorageError> {
+                self.inner.list_threads(offset, limit).await
+            }
+            async fn load_messages(&self, id: &str) -> Result<Option<Vec<Message>>, StorageError> {
+                self.inner.load_messages(id).await
+            }
+            async fn save_messages(
+                &self,
+                id: &str,
+                messages: &[Message],
+            ) -> Result<(), StorageError> {
+                self.inner.save_messages(id, messages).await
+            }
+            async fn delete_messages(&self, id: &str) -> Result<(), StorageError> {
+                self.inner.delete_messages(id).await
+            }
+            async fn update_thread_metadata(
+                &self,
+                id: &str,
+                metadata: ThreadMetadata,
+            ) -> Result<(), StorageError> {
+                self.inner.update_thread_metadata(id, metadata).await
+            }
+        }
+
+        #[async_trait]
+        impl RunStore for $ty {
+            async fn create_run(&self, record: &RunRecord) -> Result<(), StorageError> {
+                self.inner.create_run(record).await
+            }
+            async fn load_run(&self, run_id: &str) -> Result<Option<RunRecord>, StorageError> {
+                self.inner.load_run(run_id).await
+            }
+            async fn latest_run(&self, thread_id: &str) -> Result<Option<RunRecord>, StorageError> {
+                self.inner.latest_run(thread_id).await
+            }
+            async fn list_runs(&self, query: &RunQuery) -> Result<RunPage, StorageError> {
+                self.inner.list_runs(query).await
+            }
+        }
+    };
+}
+
+forward_thread_run!(CountingStore);
+forward_thread_run!(FlakyStore);
+forward_thread_run!(BlockedStore);
+
+#[async_trait]
+impl ThreadRunStore for CountingStore {
+    async fn checkpoint(
+        &self,
+        thread_id: &str,
+        messages: &[Message],
+        run: &RunRecord,
+    ) -> Result<(), StorageError> {
+        self.checkpoint_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.checkpoint(thread_id, messages, run).await
+    }
+}
+
+#[async_trait]
+impl ThreadRunStore for FlakyStore {
+    async fn checkpoint(
+        &self,
+        thread_id: &str,
+        messages: &[Message],
+        run: &RunRecord,
+    ) -> Result<(), StorageError> {
+        self.observed_calls.fetch_add(1, Ordering::SeqCst);
+        if self
+            .fail_first
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                if n > 0 { Some(n - 1) } else { None }
+            })
+            .is_ok()
+        {
+            return Err(StorageError::Io("flaky: transient".into()));
+        }
+        self.inner.checkpoint(thread_id, messages, run).await
+    }
+}
+
+#[async_trait]
+impl ThreadRunStore for BlockedStore {
+    async fn checkpoint(
+        &self,
+        _thread_id: &str,
+        _messages: &[Message],
+        _run: &RunRecord,
+    ) -> Result<(), StorageError> {
+        // Park forever — flusher never advances flushed_seq, so force_flush must time out.
+        std::future::pending::<()>().await;
+        unreachable!()
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn mk_run(id: &str, thread: &str, updated_at: u64) -> RunRecord {
+    RunRecord {
+        run_id: id.into(),
+        thread_id: thread.into(),
+        agent_id: "a".into(),
+        parent_run_id: None,
+        request: None,
+        input: None,
+        output: None,
+        status: RunStatus::Created,
+        termination_reason: None,
+        final_output: None,
+        error_payload: None,
+        dispatch_id: None,
+        session_id: None,
+        transport_request_id: None,
+        waiting: None,
+        outcome: None,
+        created_at: 1,
+        started_at: None,
+        finished_at: None,
+        updated_at,
+        steps: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        state: None,
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+/// 20 writers race on one thread. Every checkpoint must return Ok (no CAS
+/// deadlocks, no lost errors), force_flush must converge within the 10s
+/// internal timeout, and the surviving run/messages must be from the same
+/// checkpoint call (coalescer keeps the highest-seq entry consistently).
+#[tokio::test]
+async fn concurrent_checkpoints_same_thread_converge() {
+    const N: usize = 20;
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(100);
+    let store = Arc::new(
+        NatsBufferedThreadStore::connect(Arc::clone(&inner), config)
+            .await
+            .expect("connect"),
+    );
+
+    let mut handles = Vec::with_capacity(N);
+    for i in 0..N {
+        let s = Arc::clone(&store);
+        handles.push(tokio::spawn(async move {
+            let run = mk_run(&format!("r{i}"), "t-race", i as u64 + 1);
+            s.checkpoint("t-race", &[Message::user(format!("msg-{i}"))], &run)
+                .await
+        }));
+    }
+    for h in handles {
+        h.await.unwrap().expect("checkpoint ok under contention");
+    }
+
+    store.force_flush("t-race").await.expect("force_flush");
+
+    let latest = inner
+        .latest_run("t-race")
+        .await
+        .unwrap()
+        .expect("some run persisted");
+    // Coalescing keeps the entry with the highest thread_seq; the run &
+    // messages in that entry must match (they were written by the same call).
+    let winner_idx: usize = latest
+        .run_id
+        .trim_start_matches('r')
+        .parse()
+        .expect("run_id parseable");
+    assert!(winner_idx < N);
+    let msgs = inner.load_messages("t-race").await.unwrap().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(
+        msgs[0].text(),
+        format!("msg-{winner_idx}"),
+        "winning run's messages must match winning run_id (no cross-entry tearing)"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: if logical thread_seq publish order is inverted, a later
+/// stale WAL entry must not roll the inner projection or flushed watermark
+/// back after a higher seq has already flushed.
+#[tokio::test]
+async fn out_of_order_wal_publish_does_not_rewind_projection_or_flushed_seq() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(CountingStore::new());
+    let probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(100);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let newer = mk_run("run-newer", "t-out-of-order", 2);
+    let newer_js_seq = store
+        .__test_plant_wal_entry("t-out-of-order", &newer, &[Message::user("newer")], 2)
+        .await
+        .expect("plant newer wal");
+    store
+        .__test_force_hot_meta("t-out-of-order", 2, 2, newer_js_seq)
+        .await
+        .expect("force hot meta");
+    store
+        .force_flush("t-out-of-order")
+        .await
+        .expect("flush newer");
+
+    let older = mk_run("run-older", "t-out-of-order", 1);
+    store
+        .__test_plant_wal_entry("t-out-of-order", &older, &[Message::user("older")], 1)
+        .await
+        .expect("plant older wal");
+
+    tokio::time::sleep(Duration::from_millis(350)).await;
+
+    let latest = probe
+        .latest_run("t-out-of-order")
+        .await
+        .unwrap()
+        .expect("latest run");
+    assert_eq!(latest.run_id, "run-newer");
+    let messages = probe
+        .load_messages("t-out-of-order")
+        .await
+        .unwrap()
+        .expect("messages");
+    assert_eq!(messages[0].text(), "newer");
+    assert_eq!(
+        store
+            .__test_read_flushed_seq("t-out-of-order")
+            .await
+            .unwrap(),
+        2,
+        "flushed_seq must not regress when stale seq is redelivered later"
+    );
+    assert_eq!(
+        probe.count(),
+        1,
+        "stale seq should be acked/skipped, not checkpointed to inner"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: hot run cache is keyed by run_id, so same-run checkpoints
+/// must carry their logical thread_seq and reject older overwrites.
+#[tokio::test]
+async fn hot_run_cache_ignores_older_same_run_sequence() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_secs(60);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let newer = mk_run("same-run", "t-cache", 2);
+    store
+        .__test_cache_run_if_newer(&newer, 2)
+        .await
+        .expect("cache newer");
+    let older = mk_run("same-run", "t-cache", 1);
+    store
+        .__test_cache_run_if_newer(&older, 1)
+        .await
+        .expect("cache older no-op");
+
+    let cached = store
+        .load_run("same-run")
+        .await
+        .unwrap()
+        .expect("cached run");
+    assert_eq!(cached.updated_at, 2);
+
+    store.shutdown().await.unwrap();
+}
+
+/// M threads × K checkpoints on the SAME run_id per thread (iterative agent-loop
+/// pattern). Per-thread `latest_run` must be that thread's last write (no
+/// cross-thread interference), and coalescing must reduce inner writes below
+/// M*K because repeated writes to the same run_id collapse to one per batch.
+#[tokio::test]
+async fn many_threads_fanout_isolated() {
+    const M: usize = 8;
+    const K: usize = 5;
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(CountingStore::new());
+    let probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(150);
+    let store = Arc::new(
+        NatsBufferedThreadStore::connect(inner, config)
+            .await
+            .expect("connect"),
+    );
+
+    let mut handles = Vec::new();
+    for t in 0..M {
+        let s = Arc::clone(&store);
+        handles.push(tokio::spawn(async move {
+            let tid = format!("t-fan-{t}");
+            // Same run_id checkpointed K times — realistic agent-step scenario.
+            let run_id = format!("t{t}-r0");
+            for k in 0..K {
+                let run = mk_run(&run_id, &tid, (k + 1) as u64);
+                s.checkpoint(&tid, &[Message::user(format!("t{t}-k{k}"))], &run)
+                    .await
+                    .unwrap();
+            }
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    for t in 0..M {
+        let tid = format!("t-fan-{t}");
+        store.force_flush(&tid).await.unwrap();
+    }
+
+    for t in 0..M {
+        let tid = format!("t-fan-{t}");
+        let latest = probe.latest_run(&tid).await.unwrap().expect("run");
+        assert_eq!(
+            latest.run_id,
+            format!("t{t}-r0"),
+            "each thread's latest_run must be its own final write"
+        );
+    }
+    assert!(
+        probe.count() < M * K,
+        "same-run-id coalescing should reduce inner writes below {} got {}",
+        M * K,
+        probe.count()
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// First 3 inner checkpoints fail; flusher NAKs, JetStream redelivers, and
+/// state eventually converges. Verifies the NAK/redelivery loop isn't broken.
+#[tokio::test]
+async fn transient_inner_failure_redelivers_until_success() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(FlakyStore::new(3));
+    let probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(100);
+    // Short ack_wait ⇒ NAK'd messages redeliver quickly.
+    config.ack_wait = Duration::from_secs(1);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let run = mk_run("r-retry", "t-flaky", 1);
+    store
+        .checkpoint("t-flaky", &[Message::user("will-retry")], &run)
+        .await
+        .unwrap();
+
+    let mut converged = false;
+    for _ in 0..100 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if probe.load_run("r-retry").await.unwrap().is_some() {
+            converged = true;
+            break;
+        }
+    }
+    assert!(
+        converged,
+        "inner state must converge after transient errors"
+    );
+    assert!(
+        probe.observed_calls() >= 4,
+        "flaky store should have been invoked at least 4 times (3 fails + 1 success), got {}",
+        probe.observed_calls()
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// Inner store blocks forever ⇒ flusher cannot advance `flushed_seq` ⇒
+/// `force_flush` must surface a timeout error rather than hang.
+#[tokio::test]
+async fn force_flush_times_out_when_flusher_stalls() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(BlockedStore::new());
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(100);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let run = mk_run("r-stuck", "t-stuck", 1);
+    store
+        .checkpoint("t-stuck", &[Message::user("never-lands")], &run)
+        .await
+        .unwrap();
+
+    let t0 = std::time::Instant::now();
+    let err = store
+        .force_flush("t-stuck")
+        .await
+        .expect_err("force_flush must time out");
+    let elapsed = t0.elapsed();
+
+    match err {
+        StorageError::Io(msg) => {
+            assert!(
+                msg.contains("force_flush timeout"),
+                "expected timeout message, got: {msg}"
+            );
+        }
+        other => panic!("expected StorageError::Io, got {other:?}"),
+    }
+    assert!(
+        elapsed >= Duration::from_secs(9),
+        "force_flush should have waited ~10s before timing out, got {:?}",
+        elapsed
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// ~800 KiB message payload — below JetStream's 1 MiB default but well above
+/// anything the unit tests touch. Round-trips through WAL + flush.
+#[tokio::test]
+async fn large_payload_round_trip() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(150);
+    let store = NatsBufferedThreadStore::connect(Arc::clone(&inner), config)
+        .await
+        .expect("connect");
+
+    let big = "x".repeat(800 * 1024);
+    let run = mk_run("r-big", "t-big", 1);
+    store
+        .checkpoint("t-big", &[Message::user(big.clone())], &run)
+        .await
+        .unwrap();
+
+    store.force_flush("t-big").await.expect("force_flush");
+    let msgs = probe.load_messages("t-big").await.unwrap().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].text().len(), big.len());
+
+    store.shutdown().await.unwrap();
+}
+
+/// store1 publishes 5 checkpoints for one thread with a long flush interval
+/// (so its flusher never runs), then is dropped. store2 joins the same
+/// durable consumer; the 5 unacked entries redeliver and must coalesce —
+/// the inner store ends up with the highest-seq entry's run, not multiple
+/// competing writes.
+#[tokio::test]
+async fn inflight_crash_recovery_coalesces_same_thread() {
+    const N: usize = 5;
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(CountingStore::new());
+    let probe = Arc::clone(&inner);
+
+    let stream_name = format!("THREADLOG_{}", uuid::Uuid::now_v7().simple());
+    let consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    let hot_bucket = format!("hot_{}", uuid::Uuid::now_v7().simple());
+    let mut store1_cfg = awaken_stores::NatsBufferedThreadConfig::new(fixture.url.clone());
+    store1_cfg.stream_name = stream_name.clone();
+    store1_cfg.consumer_name = consumer_name.clone();
+    store1_cfg.hot_bucket = hot_bucket.clone();
+    // Very long so store1's flusher never drains before drop.
+    store1_cfg.flush_interval = Duration::from_secs(60);
+    store1_cfg.ack_wait = Duration::from_secs(1);
+    let store1 = NatsBufferedThreadStore::connect(Arc::clone(&inner), store1_cfg)
+        .await
+        .expect("connect 1");
+
+    for i in 0..N {
+        let run = mk_run(&format!("r{i}"), "t-crash", (i + 1) as u64);
+        store1
+            .checkpoint("t-crash", &[Message::user(format!("m{i}"))], &run)
+            .await
+            .unwrap();
+    }
+    assert_eq!(probe.count(), 0, "store1 must not have flushed yet");
+    drop(store1);
+
+    let mut store2_cfg = awaken_stores::NatsBufferedThreadConfig::new(fixture.url.clone());
+    store2_cfg.stream_name = stream_name.clone();
+    store2_cfg.consumer_name = consumer_name.clone();
+    store2_cfg.hot_bucket = hot_bucket.clone();
+    store2_cfg.flush_interval = Duration::from_millis(200);
+    store2_cfg.ack_wait = Duration::from_secs(1);
+    let store2 = NatsBufferedThreadStore::connect(Arc::clone(&inner), store2_cfg)
+        .await
+        .expect("connect 2");
+
+    // Wait until the final checkpoint lands (run "r{N-1}" has highest seq
+    // ⇒ coalescer's chosen entry).
+    let mut converged = false;
+    for _ in 0..80 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if let Some(run) = probe.latest_run("t-crash").await.unwrap()
+            && run.run_id == format!("r{}", N - 1)
+        {
+            converged = true;
+            break;
+        }
+    }
+    assert!(converged, "store2 must drain to highest-seq entry");
+    assert!(
+        probe.count() <= N,
+        "coalescing should cap inner writes at {N}, got {}",
+        probe.count()
+    );
+    // Most redeliveries should share a single batch ⇒ well below N.
+    // (Not a hard bound — timing-dependent — but count < N is the meaningful check.)
+
+    store2.shutdown().await.unwrap();
+}
+
+/// Drain-in-progress: store1 leaves N unacked entries, store2 connects and
+/// *while it is still draining those*, M new checkpoints arrive via store2's
+/// write path. Final state must reflect the highest-seq entry across both
+/// generations — no partial drain, no lost writes, no stale winner.
+#[tokio::test]
+async fn drain_in_progress_accepts_new_writes() {
+    const OLD: usize = 5;
+    const NEW: usize = 5;
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(CountingStore::new());
+    let probe = Arc::clone(&inner);
+
+    let stream_name = format!("THREADLOG_{}", uuid::Uuid::now_v7().simple());
+    let consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    let hot_bucket = format!("hot_{}", uuid::Uuid::now_v7().simple());
+    let mk_cfg = |flush: Duration| {
+        let mut config = awaken_stores::NatsBufferedThreadConfig::new(fixture.url.clone());
+        config.stream_name = stream_name.clone();
+        config.consumer_name = consumer_name.clone();
+        config.hot_bucket = hot_bucket.clone();
+        config.flush_interval = flush;
+        config.ack_wait = Duration::from_secs(1);
+        config
+    };
+
+    // store1: publish OLD entries but never flush (long interval + drop).
+    let store1 =
+        NatsBufferedThreadStore::connect(Arc::clone(&inner), mk_cfg(Duration::from_secs(60)))
+            .await
+            .expect("connect 1");
+    for i in 0..OLD {
+        let run = mk_run(&format!("old-{i}"), "t-mix", (i + 1) as u64);
+        store1
+            .checkpoint("t-mix", &[Message::user(format!("old-{i}"))], &run)
+            .await
+            .unwrap();
+    }
+    drop(store1);
+
+    // store2 takes over. Fire NEW checkpoints immediately — before the flusher
+    // has had a chance to drain the inherited OLD entries — so both cohorts
+    // contend in the same coalescing window(s).
+    let store2 =
+        NatsBufferedThreadStore::connect(Arc::clone(&inner), mk_cfg(Duration::from_millis(150)))
+            .await
+            .expect("connect 2");
+    for i in 0..NEW {
+        let updated_at = (OLD + i + 1) as u64; // strictly above every OLD entry
+        let run = mk_run(&format!("new-{i}"), "t-mix", updated_at);
+        store2
+            .checkpoint("t-mix", &[Message::user(format!("new-{i}"))], &run)
+            .await
+            .unwrap();
+    }
+
+    // Highest thread_seq wins. Since store2's checkpoints run after store1's
+    // (CAS seq is monotonic across the shared KV), the winner is the last NEW.
+    store2.force_flush("t-mix").await.expect("force_flush");
+    let latest = probe.latest_run("t-mix").await.unwrap().expect("run");
+    assert_eq!(
+        latest.run_id,
+        format!("new-{}", NEW - 1),
+        "drain-in-progress must honour highest-seq across mixed cohorts"
+    );
+    let msgs = probe.load_messages("t-mix").await.unwrap().unwrap();
+    assert_eq!(msgs[0].text(), format!("new-{}", NEW - 1));
+    assert!(
+        probe.count() <= OLD + NEW,
+        "coalescing should cap inner writes at {}; got {}",
+        OLD + NEW,
+        probe.count()
+    );
+
+    store2.shutdown().await.unwrap();
+}
+
+/// Two active stores share one stream + durable consumer + hot bucket.
+/// Writers are split across disjoint thread_id sets (so no CAS contention),
+/// but both stores' flushers compete to pull from the same JetStream
+/// consumer. JetStream's pull-consumer semantics must ensure each WAL entry
+/// is applied exactly once to `inner`, and every thread's final state must
+/// match its single writer.
+#[tokio::test]
+async fn two_active_stores_share_consumer_no_double_apply() {
+    const PER_STORE: usize = 10;
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(CountingStore::new());
+    let probe = Arc::clone(&inner);
+
+    let stream_name = format!("THREADLOG_{}", uuid::Uuid::now_v7().simple());
+    let consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    let hot_bucket = format!("hot_{}", uuid::Uuid::now_v7().simple());
+    let mk_cfg = || {
+        let mut config = awaken_stores::NatsBufferedThreadConfig::new(fixture.url.clone());
+        config.stream_name = stream_name.clone();
+        config.consumer_name = consumer_name.clone();
+        config.hot_bucket = hot_bucket.clone();
+        config.flush_interval = Duration::from_millis(100);
+        config.ack_wait = Duration::from_secs(5);
+        config
+    };
+
+    let store_a = Arc::new(
+        NatsBufferedThreadStore::connect(Arc::clone(&inner), mk_cfg())
+            .await
+            .expect("connect A"),
+    );
+    let store_b = Arc::new(
+        NatsBufferedThreadStore::connect(Arc::clone(&inner), mk_cfg())
+            .await
+            .expect("connect B"),
+    );
+
+    let a = Arc::clone(&store_a);
+    let writer_a = tokio::spawn(async move {
+        for i in 0..PER_STORE {
+            let tid = format!("A-{i}");
+            let run = mk_run(&format!("ra-{i}"), &tid, 1);
+            a.checkpoint(&tid, &[Message::user(format!("a-{i}"))], &run)
+                .await
+                .unwrap();
+        }
+    });
+    let b = Arc::clone(&store_b);
+    let writer_b = tokio::spawn(async move {
+        for i in 0..PER_STORE {
+            let tid = format!("B-{i}");
+            let run = mk_run(&format!("rb-{i}"), &tid, 1);
+            b.checkpoint(&tid, &[Message::user(format!("b-{i}"))], &run)
+                .await
+                .unwrap();
+        }
+    });
+    writer_a.await.unwrap();
+    writer_b.await.unwrap();
+
+    for i in 0..PER_STORE {
+        store_a.force_flush(&format!("A-{i}")).await.unwrap();
+        store_b.force_flush(&format!("B-{i}")).await.unwrap();
+    }
+
+    for i in 0..PER_STORE {
+        let a_run = probe
+            .latest_run(&format!("A-{i}"))
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("A-{i} missing"));
+        assert_eq!(a_run.run_id, format!("ra-{i}"));
+        let b_run = probe
+            .latest_run(&format!("B-{i}"))
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("B-{i} missing"));
+        assert_eq!(b_run.run_id, format!("rb-{i}"));
+    }
+    // Each unique thread has exactly one entry in the WAL and no intra-thread
+    // coalescing is possible ⇒ each entry must be applied exactly once.
+    // If JetStream double-delivered to both flushers, count would exceed 2N.
+    assert_eq!(
+        probe.count(),
+        2 * PER_STORE,
+        "expected exactly one inner.checkpoint per thread (no double-apply, no drops); got {}",
+        probe.count()
+    );
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_buffered_thread_behavior.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_behavior.rs
@@ -1,0 +1,300 @@
+#![cfg(feature = "nats")]
+
+#[path = "nats_buffered_thread_fixture.rs"]
+mod fixture;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use awaken_contract::contract::lifecycle::RunStatus;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{
+    RunPage, RunQuery, RunRecord, RunStore, StorageError, ThreadRunStore, ThreadStore,
+};
+use awaken_contract::thread::{Thread, ThreadMetadata};
+use awaken_stores::{InMemoryStore, NatsBufferedThreadStore};
+use fixture::{NatsFixture, unique_config};
+
+/// A ThreadRunStore that wraps InMemoryStore and counts checkpoint calls.
+struct CountingStore {
+    inner: InMemoryStore,
+    checkpoint_count: AtomicUsize,
+}
+
+impl CountingStore {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryStore::new(),
+            checkpoint_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn checkpoint_count(&self) -> usize {
+        self.checkpoint_count.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ThreadStore for CountingStore {
+    async fn load_thread(&self, id: &str) -> Result<Option<Thread>, StorageError> {
+        self.inner.load_thread(id).await
+    }
+    async fn save_thread(&self, thread: &Thread) -> Result<(), StorageError> {
+        self.inner.save_thread(thread).await
+    }
+    async fn delete_thread(&self, id: &str) -> Result<(), StorageError> {
+        self.inner.delete_thread(id).await
+    }
+    async fn list_threads(&self, offset: usize, limit: usize) -> Result<Vec<String>, StorageError> {
+        self.inner.list_threads(offset, limit).await
+    }
+    async fn load_messages(&self, id: &str) -> Result<Option<Vec<Message>>, StorageError> {
+        self.inner.load_messages(id).await
+    }
+    async fn save_messages(&self, id: &str, messages: &[Message]) -> Result<(), StorageError> {
+        self.inner.save_messages(id, messages).await
+    }
+    async fn delete_messages(&self, id: &str) -> Result<(), StorageError> {
+        self.inner.delete_messages(id).await
+    }
+    async fn update_thread_metadata(
+        &self,
+        id: &str,
+        metadata: ThreadMetadata,
+    ) -> Result<(), StorageError> {
+        self.inner.update_thread_metadata(id, metadata).await
+    }
+}
+
+#[async_trait]
+impl RunStore for CountingStore {
+    async fn create_run(&self, record: &RunRecord) -> Result<(), StorageError> {
+        self.inner.create_run(record).await
+    }
+    async fn load_run(&self, run_id: &str) -> Result<Option<RunRecord>, StorageError> {
+        self.inner.load_run(run_id).await
+    }
+    async fn latest_run(&self, thread_id: &str) -> Result<Option<RunRecord>, StorageError> {
+        self.inner.latest_run(thread_id).await
+    }
+    async fn list_runs(&self, query: &RunQuery) -> Result<RunPage, StorageError> {
+        self.inner.list_runs(query).await
+    }
+}
+
+#[async_trait]
+impl ThreadRunStore for CountingStore {
+    async fn checkpoint(
+        &self,
+        thread_id: &str,
+        messages: &[Message],
+        run: &RunRecord,
+    ) -> Result<(), StorageError> {
+        self.checkpoint_count.fetch_add(1, Ordering::SeqCst);
+        self.inner.checkpoint(thread_id, messages, run).await
+    }
+}
+
+fn mk_run(id: &str, thread: &str) -> RunRecord {
+    RunRecord {
+        run_id: id.into(),
+        thread_id: thread.into(),
+        agent_id: "a".into(),
+        parent_run_id: None,
+        request: None,
+        input: None,
+        output: None,
+        status: RunStatus::Created,
+        termination_reason: None,
+        final_output: None,
+        error_payload: None,
+        dispatch_id: None,
+        session_id: None,
+        transport_request_id: None,
+        waiting: None,
+        outcome: None,
+        created_at: 1,
+        started_at: None,
+        finished_at: None,
+        updated_at: 1,
+        steps: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        state: None,
+    }
+}
+
+#[tokio::test]
+async fn coalescing_reduces_inner_checkpoint_count() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(CountingStore::new());
+    let inner_probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(300);
+    config.flush_batch_size = 64;
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    // Simulate an agent loop: SAME run_id checkpointed across 10 steps.
+    let run = mk_run("r1", "t-coalesce");
+    for _ in 0..10 {
+        store
+            .checkpoint("t-coalesce", &[Message::user("msg")], &run)
+            .await
+            .unwrap();
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    store.force_flush("t-coalesce").await.unwrap();
+
+    let count = inner_probe.checkpoint_count();
+    assert!(
+        count < 10,
+        "expected coalescing to reduce DB writes below 10, got {}",
+        count
+    );
+    assert!(count >= 1, "at least one DB write expected");
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn read_your_writes_without_waiting() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_secs(60);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let run = mk_run("r1", "t1");
+    store
+        .checkpoint("t1", &[Message::user("fresh")], &run)
+        .await
+        .unwrap();
+
+    let msgs = store.load_messages("t1").await.unwrap().unwrap();
+    assert_eq!(msgs.len(), 1);
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn recovery_drains_wal_on_reconnect() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let inner_probe = Arc::clone(&inner);
+
+    let stream_name = format!("THREADLOG_{}", uuid::Uuid::now_v7().simple());
+    let consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    let hot_bucket = format!("hot_{}", uuid::Uuid::now_v7().simple());
+    let mk_cfg = || {
+        let mut config = awaken_stores::NatsBufferedThreadConfig::new(fixture.url.clone());
+        config.stream_name = stream_name.clone();
+        config.consumer_name = consumer_name.clone();
+        config.hot_bucket = hot_bucket.clone();
+        config.flush_interval = Duration::from_millis(100);
+        // Short ack_wait so an unacked in-flight message from the dropped store1
+        // is redelivered to store2 quickly.
+        config.ack_wait = Duration::from_secs(1);
+        config
+    };
+
+    // store1: connect, publish a checkpoint, then drop *immediately* — with no
+    // explicit shutdown — to simulate a crashed instance. The WAL entry is durable
+    // in the JetStream stream; whether store1's flusher acked it before dropping
+    // is a race, but in either case the data must end up in the inner store.
+    let store1 = NatsBufferedThreadStore::connect(Arc::clone(&inner), mk_cfg())
+        .await
+        .expect("connect 1");
+    let run = mk_run("r1", "t-recover");
+    store1
+        .checkpoint("t-recover", &[Message::user("durable")], &run)
+        .await
+        .unwrap();
+    drop(store1);
+
+    let store2 = NatsBufferedThreadStore::connect(Arc::clone(&inner), mk_cfg())
+        .await
+        .expect("connect 2");
+    // Same durable consumer + unacked message → JetStream redelivers to store2's
+    // flusher once ack_wait expires.
+    let mut recovered = false;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if inner_probe.load_run("r1").await.unwrap().is_some() {
+            recovered = true;
+            break;
+        }
+    }
+    assert!(recovered, "second instance should drain WAL within 5s");
+    store2.shutdown().await.unwrap();
+}
+
+/// Regression for the concurrent-writer WAL race: when two writers
+/// reserve seqs in order (A=20, B=10) but their JetStream publishes
+/// arrive in the opposite order (B lands first, A lands second), a
+/// reader relying on `get_last_raw_message_by_subject` would return B's
+/// content while `latest_seq` is 20 — off-by-one content for the
+/// watermark. The fix binds `latest_seq` to the JS stream seq of its
+/// own WAL entry; the reader fetches by that JS seq and verifies
+/// `thread_seq` matches.
+#[tokio::test]
+async fn read_your_writes_binds_to_committed_js_seq_not_subject_tail() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let cfg = unique_config(&fixture);
+    let store = NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg)
+        .await
+        .expect("connect");
+
+    let thread_id = "t-race";
+    let run_a = mk_run("run-a", thread_id);
+    let run_b = mk_run("run-b", thread_id);
+
+    // Plant entry A (committed thread_seq=20) FIRST so its JS seq is
+    // lower, then plant entry B (thread_seq=10) AFTER so it becomes the
+    // JS subject-latest. Reader must NOT follow subject-latest.
+    let js_seq_a = store
+        .__test_plant_wal_entry(thread_id, &run_a, &[Message::user("A-content")], 20)
+        .await
+        .unwrap();
+    let js_seq_b = store
+        .__test_plant_wal_entry(thread_id, &run_b, &[Message::user("B-content")], 10)
+        .await
+        .unwrap();
+    assert!(
+        js_seq_b > js_seq_a,
+        "precondition: B is JS-latest (got A={js_seq_a}, B={js_seq_b})"
+    );
+
+    // Force hot_meta to point at A's commit (latest_seq=20 bound to
+    // A's JS stream sequence). This is what `promote_latest_seq` would
+    // write when A committed "latest".
+    store
+        .__test_force_hot_meta(thread_id, 20, 20, js_seq_a)
+        .await
+        .unwrap();
+
+    let messages = store
+        .load_messages(thread_id)
+        .await
+        .unwrap()
+        .expect("read-your-writes must return overlay content");
+    assert_eq!(
+        messages[0].text(),
+        "A-content",
+        "reader must return the WAL entry bound to latest_seq's JS seq, \
+         not the subject-latest entry"
+    );
+    let latest = store
+        .latest_run(thread_id)
+        .await
+        .unwrap()
+        .expect("latest_run must return overlay run");
+    assert_eq!(latest.run_id, "run-a");
+
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_buffered_thread_behavior.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_behavior.rs
@@ -14,7 +14,7 @@ use awaken_contract::contract::storage::{
     RunPage, RunQuery, RunRecord, RunStore, StorageError, ThreadRunStore, ThreadStore,
 };
 use awaken_contract::thread::{Thread, ThreadMetadata};
-use awaken_stores::{InMemoryStore, NatsBufferedThreadStore};
+use awaken_stores::{InMemoryStore, NatsBufferedThreadStore, ReadConsistency};
 use fixture::{NatsFixture, unique_config};
 
 /// A ThreadRunStore that wraps InMemoryStore and counts checkpoint calls.
@@ -178,6 +178,31 @@ async fn read_your_writes_without_waiting() {
 
     let msgs = store.load_messages("t1").await.unwrap().unwrap();
     assert_eq!(msgs.len(), 1);
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn strong_load_run_does_not_return_unflushed_hot_cache() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut config = unique_config(&fixture);
+    config.read_consistency = ReadConsistency::Strong;
+    config.flush_interval = Duration::from_secs(60);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let run = mk_run("r-hot-only", "t-hot-only");
+    store
+        .__test_cache_run_if_newer(&run, 1)
+        .await
+        .expect("cache hot run");
+
+    let loaded = store.load_run("r-hot-only").await.unwrap();
+    assert!(
+        loaded.is_none(),
+        "Strong load_run must not expose a run that only exists in hot cache"
+    );
     store.shutdown().await.unwrap();
 }
 

--- a/crates/awaken-stores/tests/nats_buffered_thread_conformance.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_conformance.rs
@@ -1,0 +1,87 @@
+#![cfg(feature = "nats")]
+
+#[path = "nats_buffered_thread_fixture.rs"]
+mod fixture;
+#[path = "thread_store_conformance.rs"]
+mod thread_store_conformance;
+
+use std::sync::Arc;
+
+use awaken_stores::{InMemoryStore, NatsBufferedThreadStore};
+use fixture::{NatsFixture, unique_config};
+
+async fn make_store(fixture: &NatsFixture) -> NatsBufferedThreadStore<InMemoryStore> {
+    let inner = Arc::new(InMemoryStore::new());
+    NatsBufferedThreadStore::connect(inner, unique_config(fixture))
+        .await
+        .expect("connect")
+}
+
+#[tokio::test]
+async fn nats_checkpoint_persists_messages_and_run() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::checkpoint_persists_messages_and_run(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_load_messages_returns_none_for_unknown_thread() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::load_messages_returns_none_for_unknown_thread(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_latest_run_returns_most_recent() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::latest_run_returns_most_recent(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_checkpoint_overwrites_messages() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::checkpoint_overwrites_messages(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_load_thread_reflects_checkpoint() {
+    // load_thread goes through to inner; we need force_flush first.
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    let thread_id = "t-meta";
+    let run = thread_store_conformance::make_run(
+        "r1",
+        thread_id,
+        awaken_contract::contract::lifecycle::RunStatus::Done,
+    );
+    use awaken_contract::contract::storage::ThreadRunStore;
+    store.checkpoint(thread_id, &[], &run).await.unwrap();
+    store.force_flush(thread_id).await.unwrap();
+    use awaken_contract::contract::storage::ThreadStore;
+    let thread = store.load_thread(thread_id).await.unwrap();
+    assert!(thread.is_some());
+    assert_eq!(thread.unwrap().id, thread_id);
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_append_message_records_assigns_seq() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::append_message_records_assigns_seq(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_load_run_returns_none_for_unknown() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::load_run_returns_none_for_unknown(&store).await;
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_buffered_thread_connect.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_connect.rs
@@ -1,0 +1,165 @@
+#![cfg(feature = "nats")]
+
+#[path = "nats_buffered_thread_fixture.rs"]
+mod fixture;
+
+use std::sync::Arc;
+
+use awaken_stores::{InMemoryStore, NatsBufferedThreadStore};
+use fixture::{NatsFixture, unique_config};
+
+#[tokio::test]
+async fn connect_and_shutdown() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let store = NatsBufferedThreadStore::connect(inner, unique_config(&fixture))
+        .await
+        .expect("connect");
+    store.shutdown().await.expect("shutdown");
+}
+
+use awaken_contract::contract::lifecycle::RunStatus;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{RunRecord, RunStore, ThreadRunStore};
+
+fn mk_run(id: &str, thread: &str) -> RunRecord {
+    RunRecord {
+        run_id: id.into(),
+        thread_id: thread.into(),
+        agent_id: "a".into(),
+        parent_run_id: None,
+        request: None,
+        input: None,
+        output: None,
+        status: RunStatus::Created,
+        termination_reason: None,
+        final_output: None,
+        error_payload: None,
+        dispatch_id: None,
+        session_id: None,
+        transport_request_id: None,
+        waiting: None,
+        outcome: None,
+        created_at: 1,
+        started_at: None,
+        finished_at: None,
+        updated_at: 1,
+        steps: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        state: None,
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_writes_wal_without_db_write() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let inner_probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    // Effectively disable the flusher so the inner store stays empty.
+    config.flush_interval = std::time::Duration::from_secs(60);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    store
+        .checkpoint("t1", &[Message::user("hi")], &mk_run("r1", "t1"))
+        .await
+        .unwrap();
+
+    // No flusher spawned yet (Task 4); DB stays empty.
+    let loaded = inner_probe.load_run("r1").await.unwrap();
+    assert!(loaded.is_none(), "inner store should not have the run yet");
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn read_your_writes_via_wal_overlay() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut config = unique_config(&fixture);
+    // Effectively disable the flusher so the read must hit the WAL overlay.
+    config.flush_interval = std::time::Duration::from_secs(60);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let run = mk_run("r1", "t1");
+    store
+        .checkpoint("t1", &[Message::user("hello")], &run)
+        .await
+        .unwrap();
+
+    // flush_interval is 60s so WAL overlay must serve the read without waiting for DB.
+    use awaken_contract::contract::storage::ThreadStore;
+    let msgs = store.load_messages("t1").await.unwrap().unwrap();
+    assert_eq!(msgs.len(), 1);
+
+    let loaded_run = store.load_run("r1").await.unwrap().unwrap();
+    assert_eq!(loaded_run.run_id, "r1");
+
+    let latest = store.latest_run("t1").await.unwrap().unwrap();
+    assert_eq!(latest.run_id, "r1");
+
+    store.shutdown().await.unwrap();
+}
+
+use std::time::Duration;
+
+#[tokio::test]
+async fn flusher_writes_to_inner_db() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let inner_probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(100);
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let run = mk_run("r1", "t-flush");
+    store
+        .checkpoint("t-flush", &[Message::user("hi")], &run)
+        .await
+        .unwrap();
+
+    // Wait for flusher to catch up.
+    let mut flushed = false;
+    for _ in 0..30 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if inner_probe.load_run("r1").await.unwrap().is_some() {
+            flushed = true;
+            break;
+        }
+    }
+    assert!(flushed, "flusher should have written to inner DB within 3s");
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn force_flush_blocks_until_drained() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let inner_probe = Arc::clone(&inner);
+    let mut config = unique_config(&fixture);
+    config.flush_interval = Duration::from_millis(500); // slow flush
+    let store = NatsBufferedThreadStore::connect(inner, config)
+        .await
+        .expect("connect");
+
+    let run = mk_run("r1", "t-force");
+    store
+        .checkpoint("t-force", &[Message::user("hi")], &run)
+        .await
+        .unwrap();
+
+    // Without waiting the full interval, inner DB may not have it.
+    // (Flusher may or may not have run yet; that's ok — force_flush will wait.)
+    store.force_flush("t-force").await.expect("force flush");
+    assert!(
+        inner_probe.load_run("r1").await.unwrap().is_some(),
+        "flushed after force_flush"
+    );
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_buffered_thread_distributed.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_distributed.rs
@@ -1,0 +1,238 @@
+#![cfg(feature = "nats")]
+
+#[path = "nats_buffered_thread_fixture.rs"]
+mod fixture;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use awaken_contract::contract::lifecycle::RunStatus;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{RunRecord, RunStore, ThreadRunStore, ThreadStore};
+use awaken_stores::{InMemoryStore, NatsBufferedThreadConfig, NatsBufferedThreadStore};
+use fixture::NatsFixture;
+
+fn shared_config(fixture: &NatsFixture) -> NatsBufferedThreadConfig {
+    let suffix = uuid::Uuid::now_v7().simple().to_string();
+    let mut config = NatsBufferedThreadConfig::new(fixture.url.clone());
+    config.stream_name = format!("THREADLOG_{suffix}");
+    config.consumer_name = format!("c_{suffix}");
+    config.hot_bucket = format!("hot_{suffix}");
+    config.flush_interval = Duration::from_millis(100);
+    config
+}
+
+fn mk_run(id: &str, thread: &str) -> RunRecord {
+    RunRecord {
+        run_id: id.into(),
+        thread_id: thread.into(),
+        agent_id: "a".into(),
+        parent_run_id: None,
+        request: None,
+        input: None,
+        output: None,
+        status: RunStatus::Created,
+        termination_reason: None,
+        final_output: None,
+        error_payload: None,
+        dispatch_id: None,
+        session_id: None,
+        transport_request_id: None,
+        waiting: None,
+        outcome: None,
+        created_at: 1,
+        started_at: None,
+        finished_at: None,
+        updated_at: 1,
+        steps: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        state: None,
+    }
+}
+
+/// Write from instance A visible to instance B via shared JetStream WAL overlay
+/// even before the inner DB is flushed.
+#[tokio::test]
+async fn read_your_writes_across_instances() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut cfg = shared_config(&fixture);
+    cfg.flush_interval = Duration::from_secs(60); // effectively disable flusher
+
+    let store_a = NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg.clone())
+        .await
+        .expect("a");
+    let store_b = NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg)
+        .await
+        .expect("b");
+
+    let run = mk_run("r1", "t1");
+    store_a
+        .checkpoint("t1", &[Message::user("from A")], &run)
+        .await
+        .unwrap();
+
+    // B reads via WAL overlay (latest_seq > flushed_seq).
+    let msgs = store_b.load_messages("t1").await.unwrap().unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].text(), "from A");
+
+    let latest = store_b.latest_run("t1").await.unwrap().unwrap();
+    assert_eq!(latest.run_id, "r1");
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}
+
+/// Shared inner DB: exactly one instance's flusher drains each WAL entry; both
+/// instances eventually see data in the shared inner store.
+#[tokio::test]
+async fn shared_inner_store_observes_flushed_writes_from_either_instance() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let cfg = shared_config(&fixture);
+
+    let store_a = NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg.clone())
+        .await
+        .expect("a");
+    let store_b = NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg)
+        .await
+        .expect("b");
+
+    // A writes multiple runs.
+    for i in 0..5 {
+        store_a
+            .checkpoint(
+                "t1",
+                &[Message::user(format!("m{i}"))],
+                &mk_run(&format!("r{i}"), "t1"),
+            )
+            .await
+            .unwrap();
+    }
+
+    // Eventually all writes land in the shared inner DB.
+    let start = std::time::Instant::now();
+    let mut seen = 0;
+    while start.elapsed() < Duration::from_secs(5) {
+        seen = 0;
+        for i in 0..5 {
+            if inner.load_run(&format!("r{i}")).await.unwrap().is_some() {
+                seen += 1;
+            }
+        }
+        if seen == 5 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(seen, 5, "all 5 runs should be in shared inner DB within 5s");
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}
+
+/// Concurrent writers to the same thread produce monotonic unique thread_seq via
+/// KV CAS on latest_seq.
+#[tokio::test]
+async fn concurrent_writes_same_thread_produce_unique_monotonic_seq() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let cfg = shared_config(&fixture);
+
+    let store_a = Arc::new(
+        NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg.clone())
+            .await
+            .expect("a"),
+    );
+    let store_b = Arc::new(
+        NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg)
+            .await
+            .expect("b"),
+    );
+
+    // Fire 10 concurrent checkpoints from each instance on the same thread.
+    let mut handles = Vec::new();
+    for i in 0..10 {
+        let s = Arc::clone(&store_a);
+        handles.push(tokio::spawn(async move {
+            s.checkpoint(
+                "t-concurrent",
+                &[Message::user(format!("a{i}"))],
+                &mk_run(&format!("ra{i}"), "t-concurrent"),
+            )
+            .await
+            .unwrap();
+        }));
+    }
+    for i in 0..10 {
+        let s = Arc::clone(&store_b);
+        handles.push(tokio::spawn(async move {
+            s.checkpoint(
+                "t-concurrent",
+                &[Message::user(format!("b{i}"))],
+                &mk_run(&format!("rb{i}"), "t-concurrent"),
+            )
+            .await
+            .unwrap();
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    // All 20 writes eventually reach the shared DB.
+    store_a.force_flush("t-concurrent").await.unwrap();
+
+    let mut total = 0;
+    for prefix in ["ra", "rb"] {
+        for i in 0..10 {
+            if inner
+                .load_run(&format!("{prefix}{i}"))
+                .await
+                .unwrap()
+                .is_some()
+            {
+                total += 1;
+            }
+        }
+    }
+    assert_eq!(total, 20, "all 20 concurrent writes should land in DB");
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}
+
+/// Hot KV run cache visible across instances — A writes, B's `load_run` sees it
+/// immediately (before DB flush).
+#[tokio::test]
+async fn hot_run_cache_shared_across_instances() {
+    let fixture = NatsFixture::start().await;
+    let inner = Arc::new(InMemoryStore::new());
+    let mut cfg = shared_config(&fixture);
+    cfg.flush_interval = Duration::from_secs(60); // block flusher so only KV is fresh
+
+    let store_a = NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg.clone())
+        .await
+        .expect("a");
+    let store_b = NatsBufferedThreadStore::connect(Arc::clone(&inner), cfg)
+        .await
+        .expect("b");
+
+    store_a
+        .checkpoint("t1", &[], &mk_run("r1", "t1"))
+        .await
+        .unwrap();
+
+    // B reads from shared KV hot cache.
+    let loaded = store_b.load_run("r1").await.unwrap();
+    assert!(loaded.is_some());
+    assert_eq!(loaded.unwrap().run_id, "r1");
+
+    // Inner DB should still be empty (flush is blocked).
+    assert!(inner.load_run("r1").await.unwrap().is_none());
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_buffered_thread_fixture.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_fixture.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "nats")]
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use testcontainers::{ContainerAsync, GenericImage, ImageExt, core::WaitFor, runners::AsyncRunner};
+
+pub struct NatsFixture {
+    _container: ContainerAsync<GenericImage>,
+    pub url: String,
+}
+
+impl NatsFixture {
+    pub async fn start() -> Self {
+        let image = GenericImage::new("nats", "2.10-alpine")
+            .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+            .with_cmd(vec!["-js"]);
+        let container = image.start().await.expect("failed to start nats container");
+        let host_port = container.get_host_port_ipv4(4222).await.expect("port");
+        let url = format!("nats://127.0.0.1:{host_port}");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Self {
+            _container: container,
+            url,
+        }
+    }
+}
+
+pub fn unique_config(fixture: &NatsFixture) -> awaken_stores::NatsBufferedThreadConfig {
+    let mut config = awaken_stores::NatsBufferedThreadConfig::new(fixture.url.clone());
+    config.stream_name = format!("THREADLOG_{}", uuid::Uuid::now_v7().simple());
+    config.consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    config.hot_bucket = format!("hot_{}", uuid::Uuid::now_v7().simple());
+    config
+}

--- a/crates/awaken-stores/tests/nats_fixture.rs
+++ b/crates/awaken-stores/tests/nats_fixture.rs
@@ -1,0 +1,30 @@
+//! Test fixture: launches a NATS server in a testcontainer.
+
+#![cfg(feature = "nats")]
+#![allow(dead_code)]
+
+use std::time::Duration;
+
+use testcontainers::{ContainerAsync, GenericImage, ImageExt, core::WaitFor, runners::AsyncRunner};
+
+pub struct NatsFixture {
+    _container: ContainerAsync<GenericImage>,
+    pub url: String,
+}
+
+impl NatsFixture {
+    pub async fn start() -> Self {
+        let image = GenericImage::new("nats", "2.10-alpine")
+            .with_wait_for(WaitFor::message_on_stderr("Server is ready"))
+            .with_cmd(vec!["-js"]);
+        let container = image.start().await.expect("failed to start nats container");
+        let host_port = container.get_host_port_ipv4(4222).await.expect("nats port");
+        let url = format!("nats://127.0.0.1:{host_port}");
+        // Give JetStream a moment to initialize.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Self {
+            _container: container,
+            url,
+        }
+    }
+}

--- a/crates/awaken-stores/tests/nats_mailbox_behavior.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_behavior.rs
@@ -1,0 +1,475 @@
+#![cfg(feature = "nats")]
+
+mod nats_fixture;
+
+use std::time::Duration;
+
+use awaken_contract::contract::mailbox::{MailboxStore, RunDispatch, RunDispatchStatus};
+use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
+use nats_fixture::NatsFixture;
+
+fn test_dispatch(id: &str, thread_id: &str) -> RunDispatch {
+    RunDispatch {
+        dispatch_id: id.to_string(),
+        thread_id: thread_id.to_string(),
+        run_id: format!("{id}-run"),
+        priority: 128,
+        dedupe_key: None,
+        dispatch_epoch: 0,
+        status: RunDispatchStatus::Queued,
+        available_at: 0,
+        attempt_count: 0,
+        max_attempts: 3,
+        last_error: None,
+        claim_token: None,
+        claimed_by: None,
+        lease_until: None,
+        dispatch_instance_id: None,
+        run_status: None,
+        termination: None,
+        run_response: None,
+        run_error: None,
+        completed_at: None,
+        created_at: 0,
+        updated_at: 0,
+    }
+}
+
+async fn make_store(fixture: &NatsFixture) -> NatsMailboxStore {
+    let mut config = NatsMailboxConfig::new(fixture.url.clone());
+    config.stream_name = format!("DISPATCH_{}", uuid::Uuid::now_v7().simple());
+    config.consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    config.dispatch_bucket = format!("d_{}", uuid::Uuid::now_v7().simple());
+    config.epoch_bucket = format!("e_{}", uuid::Uuid::now_v7().simple());
+    config.thread_index_bucket = format!("ti_{}", uuid::Uuid::now_v7().simple());
+    config.sweeper_interval = Duration::from_millis(100);
+    NatsMailboxStore::connect(config).await.expect("connect")
+}
+
+#[tokio::test]
+async fn index_rebuilds_from_kv_on_restart() {
+    let fixture = NatsFixture::start().await;
+
+    // Shared config so the second instance reuses the same buckets.
+    let stream_name = format!("DISPATCH_{}", uuid::Uuid::now_v7().simple());
+    let dispatch_bucket = format!("d_{}", uuid::Uuid::now_v7().simple());
+    let epoch_bucket = format!("e_{}", uuid::Uuid::now_v7().simple());
+    let ti_bucket = format!("ti_{}", uuid::Uuid::now_v7().simple());
+    let consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    let mk_config = || {
+        let mut config = NatsMailboxConfig::new(fixture.url.clone());
+        config.stream_name = stream_name.clone();
+        config.consumer_name = consumer_name.clone();
+        config.dispatch_bucket = dispatch_bucket.clone();
+        config.epoch_bucket = epoch_bucket.clone();
+        config.thread_index_bucket = ti_bucket.clone();
+        config
+    };
+
+    let store1 = NatsMailboxStore::connect(mk_config())
+        .await
+        .expect("connect 1");
+    store1.enqueue(&test_dispatch("d1", "t1")).await.unwrap();
+    store1.shutdown().await.unwrap();
+    drop(store1);
+
+    // Second store connects to same buckets; index must rebuild.
+    let store2 = NatsMailboxStore::connect(mk_config())
+        .await
+        .expect("connect 2");
+
+    let loaded = store2.load_dispatch("d1").await.unwrap();
+    assert!(loaded.is_some(), "second store should see d1 from KV");
+    store2.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn sweeper_republishes_available_dispatch() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    let d = test_dispatch("d1", "t1");
+    store.enqueue(&d).await.unwrap();
+    let claimed = store.claim("t1", "c1", 30_000, 100, 1).await.unwrap();
+    assert_eq!(claimed.len(), 1);
+    let token = claimed[0].claim_token.clone().unwrap();
+
+    // Nack with retry_at in the past so sweeper picks it up on next tick.
+    store
+        .nack("d1", &token, 50, "transient error", 150)
+        .await
+        .unwrap();
+
+    // Wait for sweeper to tick (sweeper_interval = 100ms).
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    // Dispatch should be Queued and claimable again.
+    let reclaim = store.claim("t1", "c1", 30_000, 500, 1).await.unwrap();
+    assert_eq!(
+        reclaim.len(),
+        1,
+        "sweeper should have re-queued the dispatch"
+    );
+    store.shutdown().await.unwrap();
+}
+
+/// Regression for the foreground-submit Blocker: `Mailbox::submit()`
+/// interrupts (epoch 0→1) and then inline-claims the dispatch it just
+/// wrote. `enqueue` must stamp the dispatch with the current thread
+/// epoch so the epoch-safe claim path doesn't reject it as stale.
+#[tokio::test]
+async fn enqueue_stamps_current_thread_epoch_after_interrupt() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    // Bump the thread epoch via interrupt (nothing to supersede yet).
+    store.interrupt("t-epoch", 1_000).await.unwrap();
+
+    // Caller passes dispatch_epoch=0 (Mailbox::build_dispatch default);
+    // enqueue must override it to the current thread epoch so claim
+    // succeeds.
+    let dispatch = test_dispatch("d-stamp", "t-epoch");
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim_dispatch("d-stamp", "consumer", 30_000, 2_000)
+        .await
+        .unwrap();
+    assert!(
+        claimed.is_some(),
+        "dispatch written after interrupt must be claimable — \
+         enqueue should stamp current thread epoch"
+    );
+    assert!(
+        claimed.unwrap().dispatch_epoch >= 1,
+        "stamped dispatch_epoch must be >= the post-interrupt epoch"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: background dispatch enqueued after an interrupt must
+/// also be claimable via queue-scan `claim()`.
+#[tokio::test]
+async fn background_enqueue_after_interrupt_is_claimable_via_scan() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    store.interrupt("t-bg", 1_000).await.unwrap();
+
+    let mut dispatch = test_dispatch("d-bg", "t-bg");
+    dispatch.available_at = 0; // claimable immediately
+    store.enqueue(&dispatch).await.unwrap();
+
+    let claimed = store
+        .claim("t-bg", "consumer", 30_000, 2_000, 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        claimed.len(),
+        1,
+        "background dispatch must be claimable after interrupt"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: a stale queued dispatch missed by interrupt must not block
+/// the queue head. Claim-time epoch validation should terminalize the stale
+/// dispatch, release its dedupe lock, and continue to the next valid
+/// candidate even when `limit = 1`.
+#[tokio::test]
+async fn claim_skips_and_supersedes_stale_epoch_queue_head() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    store.interrupt("t-stale-head", 1_000).await.unwrap();
+
+    let mut old = test_dispatch("d-old-stale", "t-stale-head");
+    old.dedupe_key = Some("stale-key".to_string());
+    old.dispatch_epoch = 0;
+    old.created_at = 1;
+    store.__test_plant_dispatch_exact(&old).await.unwrap();
+    store
+        .__test_force_dedupe_lock("t-stale-head", "stale-key", "d-old-stale")
+        .await
+        .unwrap();
+
+    let mut new = test_dispatch("d-new-valid", "t-stale-head");
+    new.created_at = 2;
+    store.enqueue(&new).await.unwrap();
+
+    let claimed = store
+        .claim("t-stale-head", "consumer", 30_000, 2_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "d-new-valid");
+
+    let old_after = store
+        .load_dispatch("d-old-stale")
+        .await
+        .unwrap()
+        .expect("old dispatch should remain inspectable");
+    assert_eq!(old_after.status, RunDispatchStatus::Superseded);
+
+    let mut fresh = test_dispatch("d-fresh-dedupe", "t-stale-head");
+    fresh.dedupe_key = Some("stale-key".to_string());
+    store
+        .enqueue(&fresh)
+        .await
+        .expect("stale head dedupe lock must be released");
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: if interrupt's local index still says a dispatch is Queued
+/// but authoritative KV has already moved it to Claimed, interrupt must not
+/// count it as superseded or release its dedupe lock.
+#[tokio::test]
+async fn interrupt_does_not_release_dedupe_for_claimed_dispatch_from_stale_index() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    let mut indexed = test_dispatch("d-authoritative-claimed", "t-interrupt-race");
+    indexed.dedupe_key = Some("race-key".to_string());
+    store
+        .__test_force_dedupe_lock("t-interrupt-race", "race-key", "d-authoritative-claimed")
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .__test_dedupe_lock_holder("t-interrupt-race", "race-key")
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("d-authoritative-claimed")
+    );
+
+    let mut claimed = indexed.clone();
+    claimed.status = RunDispatchStatus::Claimed;
+    claimed.claim_token = Some("claim-token".to_string());
+    claimed.claimed_by = Some("remote-consumer".to_string());
+    claimed.lease_until = Some(60_000);
+    store
+        .__test_plant_dispatch_exact(&claimed)
+        .await
+        .expect("plant authoritative claimed dispatch");
+
+    store.__test_upsert_index_only(&indexed).await;
+    assert_eq!(
+        store
+            .__test_dedupe_lock_holder("t-interrupt-race", "race-key")
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("d-authoritative-claimed")
+    );
+
+    let mut before_interrupt = test_dispatch("d-before-interrupt", "t-interrupt-race");
+    before_interrupt.dedupe_key = Some("race-key".to_string());
+    assert!(
+        store.enqueue(&before_interrupt).await.is_err(),
+        "dedupe lock should be held before interrupt"
+    );
+
+    let interrupted = store.interrupt("t-interrupt-race", 1_000).await.unwrap();
+    assert_eq!(
+        interrupted.superseded_count, 0,
+        "claimed authoritative dispatch must not be counted as superseded"
+    );
+    assert_eq!(
+        interrupted
+            .active_dispatch
+            .as_ref()
+            .map(|dispatch| dispatch.dispatch_id.as_str()),
+        Some("d-authoritative-claimed"),
+        "interrupt should return the authoritative active dispatch"
+    );
+
+    let mut next = test_dispatch("d-next-same-key", "t-interrupt-race");
+    next.dedupe_key = Some("race-key".to_string());
+    let result = store.enqueue(&next).await;
+    assert!(
+        result.is_err(),
+        "dedupe lock for active claimed dispatch must remain held"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression for the dedupe-lock orphan case: if a prior acquirer
+/// crashed between lock create and dispatch put, the next enqueue with
+/// the same key must reconcile (purge the orphan) and succeed.
+#[tokio::test]
+async fn dedupe_lock_orphan_is_reconciled_by_next_enqueue() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    // Simulate a crash leaving only the dedupe lock behind.
+    store
+        .__test_force_dedupe_lock("t-orphan", "ghost-key", "never-materialised-d")
+        .await
+        .unwrap();
+
+    let mut d1 = test_dispatch("d-recovers", "t-orphan");
+    d1.dedupe_key = Some("ghost-key".to_string());
+    store
+        .enqueue(&d1)
+        .await
+        .expect("next enqueue must reconcile the orphan lock");
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: once a dispatch reaches a terminal state (cancelled
+/// here), the dedupe lock MUST be released so a fresh request with the
+/// same key can proceed.
+#[tokio::test]
+async fn dedupe_key_reusable_after_cancel() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    let mut first = test_dispatch("d-first", "t-reuse");
+    first.dedupe_key = Some("reuse-key".to_string());
+    store.enqueue(&first).await.unwrap();
+
+    store.cancel("d-first", 1_000).await.unwrap();
+
+    let mut second = test_dispatch("d-second", "t-reuse");
+    second.dedupe_key = Some("reuse-key".to_string());
+    store
+        .enqueue(&second)
+        .await
+        .expect("dedupe_key must be reusable after terminal");
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: a delayed terminal release by an old owner must not delete
+/// the dedupe lock acquired by a newer dispatch with the same key.
+#[tokio::test]
+async fn delayed_old_owner_release_does_not_delete_new_dedupe_lock() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    let mut first = test_dispatch("d-release-old", "t-release-race");
+    first.dedupe_key = Some("race-key".to_string());
+    store.enqueue(&first).await.unwrap();
+    store.cancel("d-release-old", 1_000).await.unwrap();
+
+    let mut second = test_dispatch("d-release-new", "t-release-race");
+    second.dedupe_key = Some("race-key".to_string());
+    store.enqueue(&second).await.unwrap();
+
+    store
+        .__test_release_dedupe_lock_as("t-release-race", "race-key", "d-release-old")
+        .await;
+
+    let mut third = test_dispatch("d-release-third", "t-release-race");
+    third.dedupe_key = Some("race-key".to_string());
+    let result = store.enqueue(&third).await;
+    assert!(
+        result.is_err(),
+        "old owner release must not remove the new owner's active dedupe lock"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression: two concurrent reconcilers racing to clean one orphan lock
+/// must still admit exactly one new dispatch for the dedupe key.
+#[tokio::test]
+async fn concurrent_orphan_reconcile_admits_exactly_one_owner() {
+    let fixture = NatsFixture::start().await;
+    let store = std::sync::Arc::new(make_store(&fixture).await);
+
+    store
+        .__test_force_dedupe_lock("t-reconcile-race", "race-key", "missing-owner")
+        .await
+        .unwrap();
+
+    let mut first = test_dispatch("d-race-a", "t-reconcile-race");
+    first.dedupe_key = Some("race-key".to_string());
+    let mut second = test_dispatch("d-race-b", "t-reconcile-race");
+    second.dedupe_key = Some("race-key".to_string());
+
+    let store_a = store.clone();
+    let store_b = store.clone();
+    let (a, b) = tokio::join!(async move { store_a.enqueue(&first).await }, async move {
+        store_b.enqueue(&second).await
+    },);
+    let success_count = usize::from(a.is_ok()) + usize::from(b.is_ok());
+    assert_eq!(
+        success_count, 1,
+        "exactly one enqueue should win orphan-lock reconciliation"
+    );
+
+    let dispatches = store
+        .list_dispatches("t-reconcile-race", None, 10, 0)
+        .await
+        .unwrap();
+    assert_eq!(dispatches.len(), 1);
+
+    store.shutdown().await.unwrap();
+}
+
+/// Regression for the partial-failure recovery contract: when `enqueue`
+/// commits the dispatch to KV but the subsequent JetStream publish drops
+/// (KV put succeeds, publish fails), the sweeper must re-publish the
+/// delivery signal and the dispatch must become claimable — not stay
+/// stranded. We reproduce this with a test-only helper that plants the
+/// dispatch in KV without publishing, then drive the sweeper.
+#[tokio::test]
+async fn partial_failure_kv_put_without_publish_is_recovered_by_sweeper() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    // Simulate the partial-failure hole: dispatch committed to KV,
+    // JS publish ack never happened.
+    let dispatch = test_dispatch("d-partial", "t-partial");
+    store
+        .__test_plant_dispatch_without_publish(&dispatch)
+        .await
+        .expect("plant dispatch");
+
+    // Immediately after: no JS delivery signal, but the dispatch should
+    // still be visible in the index (so `claim()` could theoretically
+    // pick it up directly).
+    assert!(store.index_contains("d-partial").await);
+
+    // Give the sweeper time to tick (it re-publishes dispatches whose
+    // JS delivery signal is missing).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Regardless of whether the sweeper re-published, a direct claim
+    // must succeed — the KV record is authoritative.
+    let claimed = store
+        .claim_dispatch("d-partial", "consumer", 30_000, 1_000)
+        .await
+        .expect("claim must not error")
+        .expect("dispatch must be claimable after KV-only commit");
+    assert_eq!(claimed.dispatch_id, "d-partial");
+
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn dedup_rejects_duplicate_key_on_same_thread() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    let mut d1 = test_dispatch("d1", "t1");
+    d1.dedupe_key = Some("dup-key".to_string());
+    store.enqueue(&d1).await.expect("first enqueue");
+
+    let mut d2 = test_dispatch("d2", "t1");
+    d2.dedupe_key = Some("dup-key".to_string());
+    let result = store.enqueue(&d2).await;
+    assert!(
+        result.is_err(),
+        "second enqueue with same dedupe_key must fail"
+    );
+
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_mailbox_behavior.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_behavior.rs
@@ -2,7 +2,7 @@
 
 mod nats_fixture;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use awaken_contract::contract::mailbox::{MailboxStore, RunDispatch, RunDispatchStatus};
 use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
@@ -44,6 +44,32 @@ async fn make_store(fixture: &NatsFixture) -> NatsMailboxStore {
     config.thread_index_bucket = format!("ti_{}", uuid::Uuid::now_v7().simple());
     config.sweeper_interval = Duration::from_millis(100);
     NatsMailboxStore::connect(config).await.expect("connect")
+}
+
+async fn make_shared_stores(fixture: &NatsFixture) -> (NatsMailboxStore, NatsMailboxStore) {
+    let stream_name = format!("DISPATCH_{}", uuid::Uuid::now_v7().simple());
+    let dispatch_bucket = format!("d_{}", uuid::Uuid::now_v7().simple());
+    let epoch_bucket = format!("e_{}", uuid::Uuid::now_v7().simple());
+    let ti_bucket = format!("ti_{}", uuid::Uuid::now_v7().simple());
+    let consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    let mk_config = || {
+        let mut config = NatsMailboxConfig::new(fixture.url.clone());
+        config.stream_name = stream_name.clone();
+        config.consumer_name = consumer_name.clone();
+        config.dispatch_bucket = dispatch_bucket.clone();
+        config.epoch_bucket = epoch_bucket.clone();
+        config.thread_index_bucket = ti_bucket.clone();
+        config.sweeper_interval = Duration::from_secs(60);
+        config
+    };
+
+    let store1 = NatsMailboxStore::connect(mk_config())
+        .await
+        .expect("connect 1");
+    let store2 = NatsMailboxStore::connect(mk_config())
+        .await
+        .expect("connect 2");
+    (store1, store2)
 }
 
 #[tokio::test]
@@ -111,6 +137,417 @@ async fn sweeper_republishes_available_dispatch() {
         "sweeper should have re-queued the dispatch"
     );
     store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn load_dispatch_reads_authoritative_kv_not_stale_index() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    let dispatch = test_dispatch("d-strong-load", "t-strong-load");
+    store.enqueue(&dispatch).await.unwrap();
+    let claimed = store
+        .claim("t-strong-load", "consumer", 30_000, 1_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+
+    let mut stale = dispatch;
+    stale.status = RunDispatchStatus::Queued;
+    store.__test_upsert_index_only(&stale).await;
+
+    let loaded = store
+        .load_dispatch("d-strong-load")
+        .await
+        .unwrap()
+        .expect("authoritative dispatch");
+    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
+    assert_eq!(loaded.claimed_by.as_deref(), Some("consumer"));
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn dispatch_signal_can_wake_a_different_store_instance() {
+    let fixture = NatsFixture::start().await;
+    let (store1, store2) = make_shared_stores(&fixture).await;
+
+    store2.shutdown().await.unwrap();
+
+    store1
+        .enqueue(&test_dispatch("d-signal", "t-signal"))
+        .await
+        .unwrap();
+    store2.__test_remove_dispatch_from_index("d-signal").await;
+    assert!(
+        !store2.index_contains("d-signal").await,
+        "test requires store2's watcher index to be stale before pulling the signal"
+    );
+
+    let signals = store2
+        .pull_dispatch_signals(8, Duration::from_secs(2))
+        .await
+        .unwrap();
+    let signal = signals
+        .into_iter()
+        .find(|entry| entry.dispatch_id == "d-signal")
+        .expect("dispatch signal");
+    assert_eq!(signal.thread_id, "t-signal");
+    assert!(
+        store2.index_contains("d-signal").await,
+        "pull_dispatch_signals must upsert the authoritative dispatch before acking the signal"
+    );
+
+    let claimed = store2
+        .claim("t-signal", "consumer-2", 30_000, 1_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "d-signal");
+    signal.receipt.ack().await.unwrap();
+
+    store1.shutdown().await.unwrap();
+    store2.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn interrupt_detects_authoritative_active_dispatch_when_local_index_is_stale() {
+    let fixture = NatsFixture::start().await;
+    let (store1, store2) = make_shared_stores(&fixture).await;
+    store2.shutdown().await.unwrap();
+
+    store1
+        .enqueue(&test_dispatch(
+            "d-active-authoritative",
+            "t-active-authoritative",
+        ))
+        .await
+        .unwrap();
+    let claimed = store1
+        .claim("t-active-authoritative", "consumer-1", 30_000, 1_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    let claim_token = claimed[0].claim_token.clone().unwrap();
+
+    store2
+        .__test_remove_dispatch_from_index("d-active-authoritative")
+        .await;
+    assert!(
+        !store2.index_contains("d-active-authoritative").await,
+        "test requires the interrupting node's local index to miss the active dispatch"
+    );
+
+    let interrupted = store2
+        .interrupt("t-active-authoritative", 2_000)
+        .await
+        .unwrap();
+    assert_eq!(
+        interrupted
+            .active_dispatch
+            .as_ref()
+            .map(|dispatch| dispatch.dispatch_id.as_str()),
+        Some("d-active-authoritative")
+    );
+
+    let extended = store1
+        .extend_lease("d-active-authoritative", &claim_token, 30_000, 3_000)
+        .await
+        .unwrap();
+    assert!(
+        !extended,
+        "epoch-stale active dispatch must not keep extending its lease after interrupt"
+    );
+    let stale = store1
+        .load_dispatch("d-active-authoritative")
+        .await
+        .unwrap()
+        .expect("dispatch remains recorded");
+    assert_eq!(stale.status, RunDispatchStatus::Superseded);
+
+    store1.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn interrupt_keeps_claim_guard_active_dispatch_over_stale_claimed_records() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    let thread_id = "t-active-override";
+
+    store
+        .enqueue(&test_dispatch("a-current-active", thread_id))
+        .await
+        .unwrap();
+    let claimed = store
+        .claim(thread_id, "current-consumer", 60_000, 1_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "a-current-active");
+
+    let mut stale = test_dispatch("z-stale-claimed", thread_id);
+    stale.status = RunDispatchStatus::Claimed;
+    stale.claim_token = Some("stale-token".to_string());
+    stale.claimed_by = Some("stale-consumer".to_string());
+    stale.lease_until = Some(500);
+    store
+        .__test_plant_dispatch_exact(&stale)
+        .await
+        .expect("plant stale claimed dispatch");
+
+    let interrupted = store.interrupt(thread_id, 2_000).await.unwrap();
+    assert_eq!(
+        interrupted
+            .active_dispatch
+            .as_ref()
+            .map(|dispatch| dispatch.dispatch_id.as_str()),
+        Some("a-current-active"),
+        "claim-guard active dispatch must not be overwritten by stale claimed scan results"
+    );
+
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn claim_uses_authoritative_ordering_when_local_index_only_has_later_dispatch() {
+    let fixture = NatsFixture::start().await;
+    let (store1, store2) = make_shared_stores(&fixture).await;
+    store2.shutdown().await.unwrap();
+
+    let mut high = test_dispatch("d-high-priority", "t-authoritative-order");
+    high.priority = 10;
+    high.created_at = 1;
+    let mut low = test_dispatch("d-low-priority", "t-authoritative-order");
+    low.priority = 128;
+    low.created_at = 2;
+
+    store1.enqueue(&high).await.unwrap();
+    store1.enqueue(&low).await.unwrap();
+
+    store2.__test_upsert_index_only(&low).await;
+    store2
+        .__test_remove_dispatch_from_index("d-high-priority")
+        .await;
+    assert!(
+        !store2.index_contains("d-high-priority").await,
+        "test requires local index to miss the higher-priority dispatch"
+    );
+    assert!(
+        store2.index_contains("d-low-priority").await,
+        "test requires local index to contain only the later dispatch"
+    );
+
+    let claimed = store2
+        .claim("t-authoritative-order", "consumer-2", 30_000, 1_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(
+        claimed[0].dispatch_id, "d-high-priority",
+        "claim must use authoritative ordering instead of the incomplete local watcher index"
+    );
+
+    store1.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn reclaim_expired_leases_uses_authoritative_kv_and_clears_terminal_claim_fields() {
+    let fixture = NatsFixture::start().await;
+    let (store1, store2) = make_shared_stores(&fixture).await;
+    store2.shutdown().await.unwrap();
+
+    let mut dispatch = test_dispatch("d-expired-authoritative", "t-expired-authoritative");
+    dispatch.max_attempts = 1;
+    store1.enqueue(&dispatch).await.unwrap();
+    let claimed = store1
+        .claim("t-expired-authoritative", "consumer-1", 100, 1_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+
+    store2
+        .__test_remove_dispatch_from_index("d-expired-authoritative")
+        .await;
+    assert!(
+        !store2.index_contains("d-expired-authoritative").await,
+        "test requires reclaiming node's local index to miss the expired claim"
+    );
+
+    let reclaimed = store2.reclaim_expired_leases(2_000, 10).await.unwrap();
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].dispatch_id, "d-expired-authoritative");
+    assert_eq!(reclaimed[0].status, RunDispatchStatus::DeadLetter);
+    assert!(reclaimed[0].claim_token.is_none());
+    assert!(reclaimed[0].claimed_by.is_none());
+    assert!(reclaimed[0].lease_until.is_none());
+
+    let loaded = store1
+        .load_dispatch("d-expired-authoritative")
+        .await
+        .unwrap()
+        .expect("dispatch remains inspectable");
+    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
+    assert!(loaded.claim_token.is_none());
+    assert!(loaded.claimed_by.is_none());
+    assert!(loaded.lease_until.is_none());
+
+    store1.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn dispatch_signal_nack_redelivers_same_dispatch() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+
+    store
+        .enqueue(&test_dispatch("d-signal-redeliver", "t-signal-redeliver"))
+        .await
+        .unwrap();
+
+    let mut signals = store
+        .pull_dispatch_signals(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+    assert_eq!(signals.len(), 1);
+    let signal = signals.pop().unwrap();
+    assert_eq!(signal.dispatch_id, "d-signal-redeliver");
+    signal.receipt.nack().await.unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let redelivered = loop {
+        let mut signals = store
+            .pull_dispatch_signals(1, Duration::from_millis(250))
+            .await
+            .unwrap();
+        if let Some(signal) = signals.pop() {
+            if signal.dispatch_id == "d-signal-redeliver" {
+                break signal;
+            }
+            signal.receipt.ack().await.unwrap();
+        }
+        assert!(
+            Instant::now() < deadline,
+            "nacked dispatch signal must redeliver before the wakeup is lost"
+        );
+    };
+
+    let dispatch = store
+        .load_dispatch("d-signal-redeliver")
+        .await
+        .unwrap()
+        .expect("dispatch should still exist after signal nack");
+    assert_eq!(dispatch.status, RunDispatchStatus::Queued);
+    redelivered.receipt.ack().await.unwrap();
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn dispatch_signal_delayed_nack_does_not_hot_loop() {
+    let fixture = NatsFixture::start().await;
+    let (store, other) = make_shared_stores(&fixture).await;
+    other.shutdown().await.unwrap();
+
+    store
+        .enqueue(&test_dispatch("d-delayed-nack", "t-delayed-nack"))
+        .await
+        .unwrap();
+
+    let mut signals = store
+        .pull_dispatch_signals(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+    assert_eq!(signals.len(), 1);
+    let signal = signals.pop().unwrap();
+    assert_eq!(signal.dispatch_id, "d-delayed-nack");
+
+    let start = Instant::now();
+    signal
+        .receipt
+        .nack_with_delay(Duration::from_millis(500))
+        .await
+        .unwrap();
+
+    let early = store
+        .pull_dispatch_signals(1, Duration::from_millis(150))
+        .await
+        .unwrap();
+    assert!(
+        early.is_empty(),
+        "delayed nack must not immediately redeliver and spin while a thread is blocked"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let redelivered = loop {
+        let mut signals = store
+            .pull_dispatch_signals(1, Duration::from_millis(250))
+            .await
+            .unwrap();
+        if let Some(signal) = signals.pop() {
+            if signal.dispatch_id == "d-delayed-nack" {
+                break signal;
+            }
+            signal.receipt.ack().await.unwrap();
+        }
+        assert!(
+            Instant::now() < deadline,
+            "delayed nacked dispatch signal must redeliver after the delay"
+        );
+    };
+    assert!(
+        start.elapsed() >= Duration::from_millis(400),
+        "redelivery happened too quickly for a delayed nack"
+    );
+    redelivered.receipt.ack().await.unwrap();
+
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn dispatch_signal_nack_redelivers_to_other_store_instance() {
+    let fixture = NatsFixture::start().await;
+    let (store1, store2) = make_shared_stores(&fixture).await;
+
+    store1
+        .enqueue(&test_dispatch("d-cross-redeliver", "t-cross-redeliver"))
+        .await
+        .unwrap();
+
+    let mut signals = store1
+        .pull_dispatch_signals(1, Duration::from_secs(2))
+        .await
+        .unwrap();
+    assert_eq!(signals.len(), 1);
+    let signal = signals.pop().unwrap();
+    assert_eq!(signal.dispatch_id, "d-cross-redeliver");
+    signal.receipt.nack().await.unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let redelivered = loop {
+        let mut signals = store2
+            .pull_dispatch_signals(1, Duration::from_millis(250))
+            .await
+            .unwrap();
+        if let Some(signal) = signals.pop() {
+            if signal.dispatch_id == "d-cross-redeliver" {
+                break signal;
+            }
+            signal.receipt.ack().await.unwrap();
+        }
+        assert!(
+            Instant::now() < deadline,
+            "nacked dispatch signal must be claimable by another store instance"
+        );
+    };
+
+    let claimed = store2
+        .claim("t-cross-redeliver", "consumer-2", 30_000, 1_000, 1)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].dispatch_id, "d-cross-redeliver");
+    redelivered.receipt.ack().await.unwrap();
+
+    store1.shutdown().await.unwrap();
+    store2.shutdown().await.unwrap();
 }
 
 /// Regression for the foreground-submit Blocker: `Mailbox::submit()`

--- a/crates/awaken-stores/tests/nats_mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_conformance.rs
@@ -1,0 +1,226 @@
+#![cfg(feature = "nats")]
+
+#[path = "mailbox_conformance.rs"]
+mod mailbox_conformance;
+mod nats_fixture;
+
+use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
+use nats_fixture::NatsFixture;
+
+async fn make_store(fixture: &NatsFixture) -> NatsMailboxStore {
+    let mut config = NatsMailboxConfig::new(fixture.url.clone());
+    config.stream_name = format!("DISPATCH_{}", uuid::Uuid::now_v7().simple());
+    config.consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    config.dispatch_bucket = format!("d_{}", uuid::Uuid::now_v7().simple());
+    config.epoch_bucket = format!("e_{}", uuid::Uuid::now_v7().simple());
+    config.thread_index_bucket = format!("ti_{}", uuid::Uuid::now_v7().simple());
+    NatsMailboxStore::connect(config).await.expect("connect")
+}
+
+#[tokio::test]
+async fn nats_enqueue_and_list() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::enqueue_and_list(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_dedupe_key_rejects_duplicate() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::dedupe_key_rejects_duplicate(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_queued_thread_ids_returns_active_threads() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::queued_thread_ids_returns_active_threads(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_claim_returns_queued_dispatch() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::claim_returns_queued_dispatch(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_claim_respects_available_at() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::claim_respects_available_at(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_claim_respects_priority_before_created_at() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::claim_respects_priority_before_created_at(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_claim_limit_preserves_thread_exclusivity() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::claim_limit_preserves_thread_exclusivity(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_list_dispatches_orders_by_priority_then_created_at() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::list_dispatches_orders_by_priority_then_created_at(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_extend_lease_success() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::extend_lease_success(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_extend_lease_wrong_token() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::extend_lease_wrong_token(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_claim_dispatch_by_id() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::claim_dispatch_by_id(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_claim_dispatch_ignores_available_at() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::claim_dispatch_ignores_available_at(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_record_dispatch_start_marks_running() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::record_dispatch_start_marks_running(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_record_run_result_sets_terminal_projection() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::record_run_result_sets_terminal_projection(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_record_projection_rejects_missing_or_unclaimed_dispatch() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::record_projection_rejects_missing_or_unclaimed_dispatch(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_fifo_ordering_within_same_priority() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::fifo_ordering_within_same_priority(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_ack_transitions_to_acked() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::ack_transitions_to_acked(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_ack_rejects_wrong_claim_token() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::ack_rejects_wrong_claim_token(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_nack_returns_to_queued() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::nack_returns_to_queued(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_nack_dead_letters_after_max_attempts() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::nack_dead_letters_after_max_attempts(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_cancel_queued_dispatch() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::cancel_queued_dispatch(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_cancel_claimed_dispatch_returns_none() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::cancel_claimed_dispatch_returns_none(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_interrupt_supersedes_queued() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::interrupt_supersedes_queued(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_interrupt_returns_active_claimed() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::interrupt_returns_active_claimed(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_reclaim_expired_leases_requeues() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::reclaim_expired_leases_requeues(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_purge_terminal_removes_old() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::purge_terminal_removes_old(&store).await;
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_conformance.rs
@@ -218,6 +218,14 @@ async fn nats_reclaim_expired_leases_requeues() {
 }
 
 #[tokio::test]
+async fn nats_reclaim_expired_leases_dead_letters_at_max_attempts() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    mailbox_conformance::reclaim_expired_leases_dead_letters_at_max_attempts(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
 async fn nats_purge_terminal_removes_old() {
     let fixture = NatsFixture::start().await;
     let store = make_store(&fixture).await;

--- a/crates/awaken-stores/tests/nats_mailbox_connect.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_connect.rs
@@ -1,0 +1,81 @@
+#![cfg(feature = "nats")]
+
+mod nats_fixture;
+
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
+use nats_fixture::NatsFixture;
+
+fn test_dispatch(id: &str, thread_id: &str) -> RunDispatch {
+    RunDispatch {
+        dispatch_id: id.to_string(),
+        thread_id: thread_id.to_string(),
+        run_id: format!("{id}-run"),
+        priority: 128,
+        dedupe_key: None,
+        dispatch_epoch: 0,
+        status: RunDispatchStatus::Queued,
+        available_at: 0,
+        attempt_count: 0,
+        max_attempts: 3,
+        last_error: None,
+        claim_token: None,
+        claimed_by: None,
+        lease_until: None,
+        dispatch_instance_id: None,
+        run_status: None,
+        termination: None,
+        run_response: None,
+        run_error: None,
+        completed_at: None,
+        created_at: 0,
+        updated_at: 0,
+    }
+}
+
+fn unique_config(fixture: &NatsFixture) -> NatsMailboxConfig {
+    let mut config = NatsMailboxConfig::new(fixture.url.clone());
+    config.stream_name = format!("DISPATCH_{}", uuid::Uuid::now_v7().simple());
+    config.consumer_name = format!("c_{}", uuid::Uuid::now_v7().simple());
+    config.dispatch_bucket = format!("d_{}", uuid::Uuid::now_v7().simple());
+    config.epoch_bucket = format!("e_{}", uuid::Uuid::now_v7().simple());
+    config.thread_index_bucket = format!("ti_{}", uuid::Uuid::now_v7().simple());
+    config
+}
+
+#[tokio::test]
+async fn connect_creates_stream_and_buckets() {
+    let fixture = NatsFixture::start().await;
+    let store = NatsMailboxStore::connect(unique_config(&fixture))
+        .await
+        .expect("connect");
+    store.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn watcher_populates_index_on_kv_put() {
+    let fixture = NatsFixture::start().await;
+    let store = NatsMailboxStore::connect(unique_config(&fixture))
+        .await
+        .expect("connect");
+
+    let dispatch = test_dispatch("d1", "t1");
+    let bytes = awaken_stores::nats_mailbox::__test_encode_dispatch(&dispatch);
+    store
+        .kv_dispatch()
+        .put("dispatch.d1", bytes.into())
+        .await
+        .expect("kv put");
+
+    // Wait up to 1s for watcher to observe.
+    let mut found = false;
+    for _ in 0..20 {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        if store.index_contains("d1").await {
+            found = true;
+            break;
+        }
+    }
+    assert!(found, "watcher did not populate index");
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_mailbox_distributed.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_distributed.rs
@@ -1,0 +1,303 @@
+#![cfg(feature = "nats")]
+
+#[path = "nats_fixture.rs"]
+mod nats_fixture;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use awaken_contract::contract::mailbox::{MailboxStore, RunDispatch, RunDispatchStatus};
+use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
+use nats_fixture::NatsFixture;
+
+fn shared_config(fixture: &NatsFixture) -> (String, NatsMailboxConfig) {
+    let suffix = uuid::Uuid::now_v7().simple().to_string();
+    let stream = format!("DISPATCH_{suffix}");
+    let consumer = format!("c_{suffix}");
+    let dispatch_b = format!("d_{suffix}");
+    let epoch_b = format!("e_{suffix}");
+    let ti_b = format!("ti_{suffix}");
+    let mut cfg = NatsMailboxConfig::new(fixture.url.clone());
+    cfg.stream_name = stream.clone();
+    cfg.consumer_name = consumer;
+    cfg.dispatch_bucket = dispatch_b;
+    cfg.epoch_bucket = epoch_b;
+    cfg.thread_index_bucket = ti_b;
+    (suffix, cfg)
+}
+
+fn test_dispatch(id: &str, thread_id: &str) -> RunDispatch {
+    RunDispatch {
+        dispatch_id: id.to_string(),
+        thread_id: thread_id.to_string(),
+        run_id: format!("{id}-run"),
+        priority: 128,
+        dedupe_key: None,
+        dispatch_epoch: 0,
+        status: RunDispatchStatus::Queued,
+        available_at: 0,
+        attempt_count: 0,
+        max_attempts: 3,
+        last_error: None,
+        claim_token: None,
+        claimed_by: None,
+        lease_until: None,
+        dispatch_instance_id: None,
+        run_status: None,
+        termination: None,
+        run_response: None,
+        run_error: None,
+        completed_at: None,
+        created_at: 0,
+        updated_at: 0,
+    }
+}
+
+async fn wait_for_index(store: &NatsMailboxStore, dispatch_id: &str, timeout_ms: u64) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < Duration::from_millis(timeout_ms) {
+        if store.load_dispatch(dispatch_id).await.unwrap().is_some() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    false
+}
+
+/// Two instances competing to claim the same dispatch — only one wins.
+#[tokio::test]
+async fn concurrent_claim_same_dispatch_only_one_wins() {
+    let fixture = NatsFixture::start().await;
+    let (_, cfg) = shared_config(&fixture);
+
+    let store_a = Arc::new(NatsMailboxStore::connect(cfg.clone()).await.expect("a"));
+    let store_b = Arc::new(NatsMailboxStore::connect(cfg).await.expect("b"));
+
+    // Enqueue via A, wait for B's index to see it.
+    store_a.enqueue(&test_dispatch("d1", "t1")).await.unwrap();
+    assert!(wait_for_index(&store_b, "d1", 2_000).await);
+
+    // Both try to claim concurrently.
+    let a = Arc::clone(&store_a);
+    let b = Arc::clone(&store_b);
+    let (r_a, r_b) = tokio::join!(
+        async move {
+            a.claim_dispatch("d1", "consumer-a", 30_000, 1000)
+                .await
+                .unwrap()
+        },
+        async move {
+            b.claim_dispatch("d1", "consumer-b", 30_000, 1000)
+                .await
+                .unwrap()
+        },
+    );
+
+    let won_a = r_a.is_some();
+    let won_b = r_b.is_some();
+    assert!(
+        won_a ^ won_b,
+        "exactly one should win (a={won_a}, b={won_b})"
+    );
+
+    // Verify winner's claim_token is unique.
+    let winner_token = match (r_a, r_b) {
+        (Some(d), None) | (None, Some(d)) => d.claim_token.expect("claim_token set"),
+        _ => unreachable!("exactly one winner verified above"),
+    };
+    assert!(!winner_token.is_empty());
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}
+
+/// Two instances competing to claim different dispatches on the same thread:
+/// the per-thread guard must still allow only one active claim globally.
+#[tokio::test]
+async fn concurrent_claim_different_dispatches_same_thread_only_one_wins() {
+    let fixture = NatsFixture::start().await;
+    let (_, cfg) = shared_config(&fixture);
+
+    let store_a = Arc::new(NatsMailboxStore::connect(cfg.clone()).await.expect("a"));
+    let store_b = Arc::new(NatsMailboxStore::connect(cfg).await.expect("b"));
+
+    store_a.enqueue(&test_dispatch("d1", "t1")).await.unwrap();
+    store_a.enqueue(&test_dispatch("d2", "t1")).await.unwrap();
+    assert!(wait_for_index(&store_b, "d1", 2_000).await);
+    assert!(wait_for_index(&store_b, "d2", 2_000).await);
+
+    let a = Arc::clone(&store_a);
+    let b = Arc::clone(&store_b);
+    let (r_a, r_b) = tokio::join!(
+        async move {
+            a.claim_dispatch("d1", "consumer-a", 30_000, 1000)
+                .await
+                .unwrap()
+        },
+        async move {
+            b.claim_dispatch("d2", "consumer-b", 30_000, 1000)
+                .await
+                .unwrap()
+        },
+    );
+
+    let won_a = r_a.is_some();
+    let won_b = r_b.is_some();
+    assert!(
+        won_a ^ won_b,
+        "same-thread claims must be globally exclusive (a={won_a}, b={won_b})"
+    );
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}
+
+/// Instance A crashes holding a claim; Instance B reclaims after lease expiry.
+#[tokio::test]
+async fn expired_lease_reclaimable_by_other_instance() {
+    let fixture = NatsFixture::start().await;
+    let (_, cfg) = shared_config(&fixture);
+
+    let store_a = NatsMailboxStore::connect(cfg.clone()).await.expect("a");
+    store_a.enqueue(&test_dispatch("d1", "t1")).await.unwrap();
+
+    // A claims with 100ms lease.
+    let claimed = store_a
+        .claim_dispatch("d1", "consumer-a", 100, 1000)
+        .await
+        .unwrap();
+    assert!(claimed.is_some());
+
+    // A "crashes" — drop without ack.
+    drop(store_a);
+
+    // B connects, waits for lease to expire, reclaims.
+    let store_b = NatsMailboxStore::connect(cfg).await.expect("b");
+    assert!(wait_for_index(&store_b, "d1", 2_000).await);
+
+    // After lease expiry (100ms + guard), reclaim should succeed.
+    let now_after_expiry = 1000 + 1000; // 1 sec later > 100ms lease
+    let reclaimed = store_b
+        .reclaim_expired_leases(now_after_expiry, 10)
+        .await
+        .unwrap();
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].dispatch_id, "d1");
+
+    // Now B can claim the re-queued dispatch.
+    let b_claim = store_b
+        .claim_dispatch("d1", "consumer-b", 30_000, now_after_expiry + 1)
+        .await
+        .unwrap();
+    assert!(b_claim.is_some());
+    assert_eq!(b_claim.unwrap().claimed_by.as_deref(), Some("consumer-b"));
+
+    store_b.shutdown().await.unwrap();
+}
+
+/// Interrupt from one instance is seen by another's index via KV watch.
+#[tokio::test]
+async fn interrupt_supersedes_across_instances() {
+    let fixture = NatsFixture::start().await;
+    let (_, cfg) = shared_config(&fixture);
+
+    let store_a = NatsMailboxStore::connect(cfg.clone()).await.expect("a");
+    let store_b = NatsMailboxStore::connect(cfg).await.expect("b");
+
+    // A enqueues 3 dispatches on t1.
+    for i in 0..3 {
+        store_a
+            .enqueue(&test_dispatch(&format!("d{i}"), "t1"))
+            .await
+            .unwrap();
+    }
+
+    // Wait for B to see them in its index.
+    assert!(wait_for_index(&store_b, "d2", 2_000).await);
+
+    // B interrupts t1.
+    let result = store_b.interrupt("t1", 2000).await.unwrap();
+    assert_eq!(result.superseded_count, 3);
+
+    // A should eventually see all 3 as Superseded via watcher.
+    let start = std::time::Instant::now();
+    let mut all_superseded = false;
+    while start.elapsed() < Duration::from_secs(3) {
+        let queued = store_a
+            .list_dispatches("t1", Some(&[RunDispatchStatus::Queued]), 10, 0)
+            .await
+            .unwrap();
+        if queued.is_empty() {
+            all_superseded = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(all_superseded, "A's index should see superseded dispatches");
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}
+
+/// Regression for issue #3: two instances concurrently enqueueing the same
+/// `(thread_id, dedupe_key)` must produce exactly ONE accepted dispatch —
+/// the local-index dedupe check was racy; the KV-backed dedupe lock makes
+/// it authoritative.
+#[tokio::test]
+async fn concurrent_enqueue_same_dedupe_key_only_one_wins() {
+    let fixture = NatsFixture::start().await;
+    let (_, cfg) = shared_config(&fixture);
+
+    let store_a = Arc::new(NatsMailboxStore::connect(cfg.clone()).await.expect("a"));
+    let store_b = Arc::new(NatsMailboxStore::connect(cfg).await.expect("b"));
+
+    let mut d1 = test_dispatch("dedupe-a", "t-dedupe-race");
+    d1.dedupe_key = Some("same-key".into());
+    let mut d2 = test_dispatch("dedupe-b", "t-dedupe-race");
+    d2.dedupe_key = Some("same-key".into());
+
+    let a = Arc::clone(&store_a);
+    let b = Arc::clone(&store_b);
+    let (r_a, r_b) = tokio::join!(async move { a.enqueue(&d1).await }, async move {
+        b.enqueue(&d2).await
+    },);
+    let won_a = r_a.is_ok();
+    let won_b = r_b.is_ok();
+    assert!(
+        won_a ^ won_b,
+        "exactly one enqueue must succeed for a given dedupe_key (a={won_a}, b={won_b})"
+    );
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}
+
+/// queued_thread_ids converges across instances.
+#[tokio::test]
+async fn queued_thread_ids_converges_across_instances() {
+    let fixture = NatsFixture::start().await;
+    let (_, cfg) = shared_config(&fixture);
+
+    let store_a = NatsMailboxStore::connect(cfg.clone()).await.expect("a");
+    let store_b = NatsMailboxStore::connect(cfg).await.expect("b");
+
+    store_a.enqueue(&test_dispatch("d1", "t1")).await.unwrap();
+    store_b.enqueue(&test_dispatch("d2", "t2")).await.unwrap();
+
+    // Wait for both indices to converge.
+    let start = std::time::Instant::now();
+    let mut converged = false;
+    while start.elapsed() < Duration::from_secs(3) {
+        let ids_a = store_a.queued_thread_ids().await.unwrap();
+        let ids_b = store_b.queued_thread_ids().await.unwrap();
+        if ids_a.len() == 2 && ids_b.len() == 2 {
+            converged = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(converged, "both instances should see both threads");
+
+    store_a.shutdown().await.unwrap();
+    store_b.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_mailbox_live.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_live.rs
@@ -1,0 +1,292 @@
+//! Cross-node live-channel integration tests for `NatsMailboxStore`.
+//!
+//! Two independent store instances share a single NATS server — the closest
+//! mirror of a multi-node deployment where different processes own a
+//! thread's active run at different times. Verifies that:
+//!
+//! - A publish from store A is observed by a subscriber on store B.
+//! - All `LiveRunCommand` variants round-trip without truncation.
+//! - Disjoint threads are isolated (no cross-talk at the subject level).
+//! - Publishing with no subscriber is a silent no-op (best-effort).
+//! - Multiple subscribers to the same subject all receive each publish
+//!   (core NATS pub-sub semantics).
+
+#![cfg(feature = "nats")]
+
+mod nats_fixture;
+
+use std::time::Duration;
+
+use awaken_contract::contract::mailbox::{LiveRunCommand, MailboxStore};
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::suspension::{ResumeDecisionAction, ToolCallResume};
+use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
+use futures::StreamExt;
+use nats_fixture::NatsFixture;
+use serde_json::Value;
+use tokio::time::timeout;
+
+/// Config that is unique per test (so tests can run in parallel on the
+/// same fixture) but shared between the two store instances in a single
+/// test — they simulate two nodes attached to the same production NATS
+/// deployment, so they must reuse the same stream and KV buckets.
+fn shared_config(fixture: &NatsFixture) -> NatsMailboxConfig {
+    let tag = uuid::Uuid::now_v7().simple().to_string();
+    let mut config = NatsMailboxConfig::new(fixture.url.clone());
+    config.stream_name = format!("DISPATCH_{tag}");
+    config.consumer_name = format!("c_{tag}");
+    config.dispatch_bucket = format!("d_{tag}");
+    config.epoch_bucket = format!("e_{tag}");
+    config.thread_index_bucket = format!("ti_{tag}");
+    config
+}
+
+fn mk_resume() -> ToolCallResume {
+    ToolCallResume {
+        decision_id: "d1".into(),
+        action: ResumeDecisionAction::Resume,
+        result: Value::Null,
+        reason: None,
+        updated_at: 0,
+    }
+}
+
+/// Publish on one store, subscribe on another, verify cross-instance delivery.
+/// This is the minimum "multi-node" scenario: two `NatsMailboxStore` instances
+/// connected to the same NATS URL act as two different server processes.
+#[tokio::test]
+async fn cross_node_messages_delivery() {
+    let fixture = NatsFixture::start().await;
+    let config = shared_config(&fixture);
+    let publisher = NatsMailboxStore::connect(config.clone())
+        .await
+        .expect("publisher connect");
+    let subscriber_store = NatsMailboxStore::connect(config)
+        .await
+        .expect("subscriber connect");
+
+    let stream = subscriber_store
+        .open_live_channel("thread-x")
+        .await
+        .expect("open channel");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let captured = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
+    let captured_c = captured.clone();
+    let _consumer = tokio::spawn(async move {
+        let mut stream = stream;
+        while let Some(entry) = stream.next().await {
+            captured_c.lock().await.push(entry.command.clone());
+            entry.receipt.ack();
+        }
+    });
+
+    publisher
+        .deliver_live(
+            "thread-x",
+            LiveRunCommand::Messages(vec![Message::user("cross-node")]),
+        )
+        .await
+        .expect("publish");
+
+    // Allow forwarder to capture + ack.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let cmds = captured.lock().await;
+    match &cmds[0] {
+        LiveRunCommand::Messages(msgs) => {
+            assert_eq!(msgs.len(), 1);
+            assert_eq!(msgs[0].text(), "cross-node");
+        }
+        other => panic!("expected Messages, got {other:?}"),
+    }
+    drop(cmds);
+
+    publisher.shutdown().await.unwrap();
+    subscriber_store.shutdown().await.unwrap();
+}
+
+/// All three `LiveRunCommand` variants round-trip across stores.
+#[tokio::test]
+async fn cross_node_all_variants() {
+    let fixture = NatsFixture::start().await;
+    let config = shared_config(&fixture);
+    let publisher = NatsMailboxStore::connect(config.clone())
+        .await
+        .expect("publisher connect");
+    let subscriber_store = NatsMailboxStore::connect(config)
+        .await
+        .expect("subscriber connect");
+
+    let stream = subscriber_store
+        .open_live_channel("t-all")
+        .await
+        .expect("open channel");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let captured = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
+    let captured_c = captured.clone();
+    let _consumer = tokio::spawn(async move {
+        let mut stream = stream;
+        while let Some(entry) = stream.next().await {
+            captured_c.lock().await.push(entry.command.clone());
+            entry.receipt.ack();
+        }
+    });
+
+    publisher
+        .deliver_live("t-all", LiveRunCommand::Messages(vec![Message::user("m")]))
+        .await
+        .unwrap();
+    publisher
+        .deliver_live("t-all", LiveRunCommand::Cancel)
+        .await
+        .unwrap();
+    publisher
+        .deliver_live(
+            "t-all",
+            LiveRunCommand::Decision(vec![("tc-1".into(), mk_resume())]),
+        )
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let cmds = captured.lock().await;
+    assert!(matches!(cmds[0], LiveRunCommand::Messages(_)));
+    assert!(matches!(cmds[1], LiveRunCommand::Cancel));
+    match &cmds[2] {
+        LiveRunCommand::Decision(d) => {
+            assert_eq!(d.len(), 1);
+            assert_eq!(d[0].0, "tc-1");
+        }
+        other => panic!("expected Decision, got {other:?}"),
+    }
+    drop(cmds);
+
+    publisher.shutdown().await.unwrap();
+    subscriber_store.shutdown().await.unwrap();
+}
+
+/// Disjoint threads must not cross-talk — the subject carries `thread_id`
+/// so publishes on one subject never reach subscribers of another.
+#[tokio::test]
+async fn cross_node_thread_isolation() {
+    let fixture = NatsFixture::start().await;
+    let config = shared_config(&fixture);
+    let publisher = NatsMailboxStore::connect(config.clone())
+        .await
+        .expect("publisher connect");
+    let subscriber_store = NatsMailboxStore::connect(config)
+        .await
+        .expect("subscriber connect");
+
+    let stream_a = subscriber_store
+        .open_live_channel("t-a")
+        .await
+        .expect("open a");
+    let mut stream_b = subscriber_store
+        .open_live_channel("t-b")
+        .await
+        .expect("open b");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let captured_a = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
+    let captured_a_c = captured_a.clone();
+    let _consumer_a = tokio::spawn(async move {
+        let mut stream_a = stream_a;
+        while let Some(entry) = stream_a.next().await {
+            captured_a_c.lock().await.push(entry.command.clone());
+            entry.receipt.ack();
+        }
+    });
+
+    publisher
+        .deliver_live("t-a", LiveRunCommand::Cancel)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let cmds = captured_a.lock().await;
+    assert!(matches!(cmds[0], LiveRunCommand::Cancel));
+    drop(cmds);
+
+    let got_b = timeout(Duration::from_millis(200), stream_b.next()).await;
+    assert!(got_b.is_err(), "t-b must not receive t-a's command");
+
+    publisher.shutdown().await.unwrap();
+    subscriber_store.shutdown().await.unwrap();
+}
+
+/// Publishing with no subscriber is a silent no-op — messages drop, no
+/// error surfaces. This is the contract for ephemeral `LiveRunCommand` delivery.
+#[tokio::test]
+async fn cross_node_publish_without_subscriber_silently_drops() {
+    let fixture = NatsFixture::start().await;
+    let publisher = NatsMailboxStore::connect(shared_config(&fixture))
+        .await
+        .expect("publisher connect");
+
+    let outcome = publisher
+        .deliver_live("ghost-thread", LiveRunCommand::Cancel)
+        .await
+        .expect("publish without subscriber must return Ok");
+    assert_eq!(
+        outcome,
+        awaken_contract::contract::mailbox::LiveDeliveryOutcome::NoSubscriber,
+        "no-subscriber ⇒ NoSubscriber so the caller falls back to durable queue"
+    );
+
+    publisher.shutdown().await.unwrap();
+}
+
+/// Two subscribers on the same subject both receive each publish
+/// (core NATS pub-sub fan-out semantics).
+#[tokio::test]
+async fn cross_node_multiple_subscribers_fanout() {
+    let fixture = NatsFixture::start().await;
+    let config = shared_config(&fixture);
+    let publisher = NatsMailboxStore::connect(config.clone())
+        .await
+        .expect("publisher connect");
+    let sub_a = NatsMailboxStore::connect(config.clone())
+        .await
+        .expect("sub a connect");
+    let sub_b = NatsMailboxStore::connect(config)
+        .await
+        .expect("sub b connect");
+
+    let stream_a = sub_a.open_live_channel("fanout").await.expect("open a");
+    let stream_b = sub_b.open_live_channel("fanout").await.expect("open b");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let captured_a = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
+    let captured_b = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<LiveRunCommand>::new()));
+    let a_c = captured_a.clone();
+    let b_c = captured_b.clone();
+    let _ca = tokio::spawn(async move {
+        let mut stream_a = stream_a;
+        while let Some(entry) = stream_a.next().await {
+            a_c.lock().await.push(entry.command.clone());
+            entry.receipt.ack();
+        }
+    });
+    let _cb = tokio::spawn(async move {
+        let mut stream_b = stream_b;
+        while let Some(entry) = stream_b.next().await {
+            b_c.lock().await.push(entry.command.clone());
+            entry.receipt.ack();
+        }
+    });
+
+    publisher
+        .deliver_live("fanout", LiveRunCommand::Cancel)
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(matches!(captured_a.lock().await[0], LiveRunCommand::Cancel));
+    assert!(matches!(captured_b.lock().await[0], LiveRunCommand::Cancel));
+
+    publisher.shutdown().await.unwrap();
+    sub_a.shutdown().await.unwrap();
+    sub_b.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_mailbox_live.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_live.rs
@@ -17,7 +17,7 @@ mod nats_fixture;
 
 use std::time::Duration;
 
-use awaken_contract::contract::mailbox::{LiveRunCommand, MailboxStore};
+use awaken_contract::contract::mailbox::{LiveRunCommand, LiveRunTarget, MailboxStore};
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::suspension::{ResumeDecisionAction, ToolCallResume};
 use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
@@ -166,6 +166,68 @@ async fn cross_node_all_variants() {
     subscriber_store.shutdown().await.unwrap();
 }
 
+#[tokio::test]
+async fn targeted_live_delivery_does_not_ack_stale_same_thread_subscriber() {
+    let fixture = NatsFixture::start().await;
+    let config = shared_config(&fixture);
+    let publisher = NatsMailboxStore::connect(config.clone())
+        .await
+        .expect("publisher connect");
+    let subscriber_store = NatsMailboxStore::connect(config)
+        .await
+        .expect("subscriber connect");
+
+    let stale_target = LiveRunTarget::new("thread-target", "run-old").with_dispatch_id("d-old");
+    let current_target = LiveRunTarget::new("thread-target", "run-new").with_dispatch_id("d-new");
+
+    let stale_stream = subscriber_store
+        .open_live_channel_for(&stale_target)
+        .await
+        .expect("open stale channel");
+    let current_stream = subscriber_store
+        .open_live_channel_for(&current_target)
+        .await
+        .expect("open current channel");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let stale_seen = std::sync::Arc::new(tokio::sync::Mutex::new(0usize));
+    let current_seen = std::sync::Arc::new(tokio::sync::Mutex::new(0usize));
+    let stale_seen_c = stale_seen.clone();
+    let current_seen_c = current_seen.clone();
+    let _stale_consumer = tokio::spawn(async move {
+        let mut stream = stale_stream;
+        while let Some(entry) = stream.next().await {
+            *stale_seen_c.lock().await += 1;
+            entry.receipt.ack();
+        }
+    });
+    let _current_consumer = tokio::spawn(async move {
+        let mut stream = current_stream;
+        while let Some(entry) = stream.next().await {
+            if matches!(entry.command, LiveRunCommand::Cancel) {
+                *current_seen_c.lock().await += 1;
+            }
+            entry.receipt.ack();
+        }
+    });
+
+    let delivered = publisher
+        .deliver_live_to(&current_target, LiveRunCommand::Cancel)
+        .await
+        .expect("targeted deliver");
+    assert_eq!(
+        delivered,
+        awaken_contract::contract::mailbox::LiveDeliveryOutcome::Delivered
+    );
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    assert_eq!(*current_seen.lock().await, 1);
+    assert_eq!(*stale_seen.lock().await, 0);
+
+    publisher.shutdown().await.unwrap();
+    subscriber_store.shutdown().await.unwrap();
+}
+
 /// Disjoint threads must not cross-talk — the subject carries `thread_id`
 /// so publishes on one subject never reach subscribers of another.
 #[tokio::test]
@@ -236,6 +298,45 @@ async fn cross_node_publish_without_subscriber_silently_drops() {
     );
 
     publisher.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn targeted_live_channel_drop_removes_subscriber() {
+    let fixture = NatsFixture::start().await;
+    let config = shared_config(&fixture);
+    let publisher = NatsMailboxStore::connect(config.clone())
+        .await
+        .expect("publisher connect");
+    let subscriber_store = NatsMailboxStore::connect(config)
+        .await
+        .expect("subscriber connect");
+    let target = LiveRunTarget::new("thread-drop", "run-drop").with_dispatch_id("dispatch-drop");
+
+    let stream = subscriber_store
+        .open_live_channel_for(&target)
+        .await
+        .expect("open targeted channel");
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    drop(stream);
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        let outcome = publisher
+            .deliver_live_to(&target, LiveRunCommand::Cancel)
+            .await
+            .expect("publish after subscription drop");
+        if outcome == awaken_contract::contract::mailbox::LiveDeliveryOutcome::NoSubscriber {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "dropping a targeted live stream must remove its NATS subscription"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    publisher.shutdown().await.unwrap();
+    subscriber_store.shutdown().await.unwrap();
 }
 
 /// Two subscribers on the same subject both receive each publish

--- a/crates/awaken-stores/tests/sqlite_mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/sqlite_mailbox_conformance.rs
@@ -32,6 +32,7 @@ conformance_test!(interrupt_supersedes_queued);
 conformance_test!(interrupt_returns_active_claimed);
 conformance_test!(dedupe_key_rejects_duplicate);
 conformance_test!(reclaim_expired_leases_requeues);
+conformance_test!(reclaim_expired_leases_dead_letters_at_max_attempts);
 conformance_test!(purge_terminal_removes_old);
 conformance_test!(queued_thread_ids_returns_active_threads);
 conformance_test!(claim_dispatch_by_id);

--- a/crates/awaken-stores/tests/sqlite_mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/sqlite_mailbox_conformance.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "sqlite")]
+
+mod mailbox_conformance;
+
+use awaken_stores::SqliteMailboxStore;
+
+macro_rules! conformance_test {
+    ($name:ident) => {
+        #[tokio::test]
+        async fn $name() {
+            let store = SqliteMailboxStore::open_memory().unwrap();
+            mailbox_conformance::$name(&store).await;
+        }
+    };
+}
+
+conformance_test!(enqueue_and_list);
+conformance_test!(claim_returns_queued_dispatch);
+conformance_test!(claim_respects_available_at);
+conformance_test!(claim_respects_priority_before_created_at);
+conformance_test!(claim_limit_preserves_thread_exclusivity);
+conformance_test!(list_dispatches_orders_by_priority_then_created_at);
+conformance_test!(ack_transitions_to_acked);
+conformance_test!(ack_rejects_wrong_claim_token);
+conformance_test!(nack_returns_to_queued);
+conformance_test!(nack_dead_letters_after_max_attempts);
+conformance_test!(cancel_queued_dispatch);
+conformance_test!(cancel_claimed_dispatch_returns_none);
+conformance_test!(extend_lease_success);
+conformance_test!(extend_lease_wrong_token);
+conformance_test!(interrupt_supersedes_queued);
+conformance_test!(interrupt_returns_active_claimed);
+conformance_test!(dedupe_key_rejects_duplicate);
+conformance_test!(reclaim_expired_leases_requeues);
+conformance_test!(purge_terminal_removes_old);
+conformance_test!(queued_thread_ids_returns_active_threads);
+conformance_test!(claim_dispatch_by_id);
+conformance_test!(claim_dispatch_ignores_available_at);
+conformance_test!(record_dispatch_start_marks_running);
+conformance_test!(record_run_result_sets_terminal_projection);
+conformance_test!(record_projection_rejects_missing_or_unclaimed_dispatch);
+conformance_test!(fifo_ordering_within_same_priority);

--- a/crates/awaken-stores/tests/thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/thread_store_conformance.rs
@@ -1,0 +1,114 @@
+#![allow(dead_code)]
+
+use awaken_contract::contract::lifecycle::RunStatus;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{RunRecord, ThreadRunStore};
+
+pub fn make_run(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecord {
+    RunRecord {
+        run_id: run_id.to_string(),
+        thread_id: thread_id.to_string(),
+        agent_id: "agent".to_string(),
+        parent_run_id: None,
+        request: None,
+        input: None,
+        output: None,
+        status,
+        termination_reason: None,
+        final_output: None,
+        error_payload: None,
+        dispatch_id: None,
+        session_id: None,
+        transport_request_id: None,
+        waiting: None,
+        outcome: None,
+        created_at: 1,
+        started_at: None,
+        finished_at: None,
+        updated_at: 1,
+        steps: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        state: None,
+    }
+}
+
+pub async fn checkpoint_persists_messages_and_run<S: ThreadRunStore>(store: &S) {
+    let thread_id = "t-ckpt";
+    let messages = vec![Message::user("hello"), Message::assistant("hi there")];
+    let run = make_run("r1", thread_id, RunStatus::Done);
+    store.checkpoint(thread_id, &messages, &run).await.unwrap();
+
+    let loaded_msgs = store.load_messages(thread_id).await.unwrap().unwrap();
+    assert_eq!(loaded_msgs.len(), 2);
+    let loaded_run = store.load_run("r1").await.unwrap().unwrap();
+    assert_eq!(loaded_run.run_id, "r1");
+    assert_eq!(loaded_run.thread_id, thread_id);
+}
+
+pub async fn load_messages_returns_none_for_unknown_thread<S: ThreadRunStore>(store: &S) {
+    let result = store.load_messages("unknown-thread").await.unwrap();
+    assert!(result.is_none() || result.unwrap().is_empty());
+}
+
+pub async fn latest_run_returns_most_recent<S: ThreadRunStore>(store: &S) {
+    let thread_id = "t-latest";
+    let r1 = RunRecord {
+        created_at: 100,
+        updated_at: 100,
+        ..make_run("r1", thread_id, RunStatus::Done)
+    };
+    let r2 = RunRecord {
+        created_at: 200,
+        updated_at: 200,
+        ..make_run("r2", thread_id, RunStatus::Done)
+    };
+    store.checkpoint(thread_id, &[], &r1).await.unwrap();
+    store.checkpoint(thread_id, &[], &r2).await.unwrap();
+    let latest = store.latest_run(thread_id).await.unwrap().unwrap();
+    assert_eq!(latest.run_id, "r2");
+}
+
+pub async fn checkpoint_overwrites_messages<S: ThreadRunStore>(store: &S) {
+    let thread_id = "t-overwrite";
+    let r = make_run("r1", thread_id, RunStatus::Created);
+    store
+        .checkpoint(thread_id, &[Message::user("first")], &r)
+        .await
+        .unwrap();
+    store
+        .checkpoint(
+            thread_id,
+            &[Message::user("first"), Message::assistant("second")],
+            &r,
+        )
+        .await
+        .unwrap();
+    let msgs = store.load_messages(thread_id).await.unwrap().unwrap();
+    assert_eq!(msgs.len(), 2);
+    assert_eq!(msgs[1].text(), "second");
+}
+
+pub async fn load_thread_reflects_checkpoint<S: ThreadRunStore>(store: &S) {
+    let thread_id = "t-meta";
+    let r = make_run("r1", thread_id, RunStatus::Done);
+    store.checkpoint(thread_id, &[], &r).await.unwrap();
+    let thread = store.load_thread(thread_id).await.unwrap();
+    assert!(thread.is_some());
+    assert_eq!(thread.unwrap().id, thread_id);
+}
+
+pub async fn append_message_records_assigns_seq<S: ThreadRunStore>(store: &S) {
+    let thread_id = "t-append";
+    let records = store
+        .append_message_records(thread_id, &[Message::user("a"), Message::user("b")])
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 2);
+    assert_eq!(records[0].seq, 1);
+    assert_eq!(records[1].seq, 2);
+}
+
+pub async fn load_run_returns_none_for_unknown<S: ThreadRunStore>(store: &S) {
+    assert!(store.load_run("nonexistent-run").await.unwrap().is_none());
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -34,6 +34,7 @@
 - [State & Storage](./state-and-storage.md)
 - [Use File Store](./how-to/use-file-store.md)
 - [Use Postgres Store](./how-to/use-postgres-store.md)
+- [Use NATS Stores](./how-to/use-nats-stores.md)
 - [Optimize Context Window](./how-to/optimize-context-window.md)
 - [State Keys](./reference/state-keys.md)
 - [Thread Model](./reference/thread-model.md)

--- a/docs/book/src/how-to/use-nats-stores.md
+++ b/docs/book/src/how-to/use-nats-stores.md
@@ -1,0 +1,136 @@
+# Use NATS Stores
+
+Use these when you need a durable, horizontally-scalable message queue backend
+for mailbox dispatches or a buffered write path for thread checkpoints.
+
+Two backends live in the `nats` feature of `awaken-stores`:
+
+- **`NatsMailboxStore`** — `MailboxStore` implementation using JetStream for
+  delivery signals and NATS KV as source of truth for dispatch state.
+- **`NatsBufferedThreadStore<T>`** — `ThreadRunStore` decorator that buffers
+  `checkpoint()` writes in JetStream + KV and asynchronously flushes to an
+  inner store (e.g. `InMemoryStore`, `PostgresStore`). Coalesces per-thread
+  writes to reduce DB load.
+
+## Prerequisites
+
+- `awaken-stores` with `nats` feature enabled
+- A running NATS server with JetStream (`nats-server -js`)
+- `tokio` runtime
+
+## Enable the feature
+
+```toml
+[dependencies]
+awaken-stores = { version = "0.2", features = ["nats"] }
+```
+
+## NatsMailboxStore
+
+```rust,ignore
+use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
+
+let config = NatsMailboxConfig::new("nats://localhost:4222");
+let store = NatsMailboxStore::connect(config).await?;
+// Use wherever a `MailboxStore` is expected.
+```
+
+Defaults create:
+
+- Stream `DISPATCH` (subjects `dispatch.*`, WorkQueue retention)
+- KV bucket `dispatch-state` (source of truth), `thread-epoch`, `thread-index`
+- Durable consumer `dispatch-worker`
+
+An in-memory index populated by `kv.watch_all()` serves all read paths with
+zero network I/O.
+
+## NatsBufferedThreadStore
+
+Wrap any existing `ThreadRunStore` to buffer writes:
+
+```rust,ignore
+use std::sync::Arc;
+use awaken_stores::{InMemoryStore, NatsBufferedThreadConfig, NatsBufferedThreadStore};
+
+let inner = Arc::new(InMemoryStore::new());
+let config = NatsBufferedThreadConfig::new("nats://localhost:4222");
+let buffered = NatsBufferedThreadStore::connect(inner, config).await?;
+```
+
+The store implements `ThreadRunStore`, so it plugs into any location accepting
+that trait.
+
+Defaults create:
+
+- Stream `THREADLOG` (subjects `thread.>`, file storage, 24h retention)
+- KV bucket `thread-hot` (latest_seq, flushed_seq, cached run records)
+- Durable consumer `thread-flusher` with 30s ack_wait
+
+The background flusher coalesces checkpoints per thread into the inner store
+every `flush_interval` (default 500ms).
+
+### Read consistency
+
+Configure via `NatsBufferedThreadConfig::read_consistency`:
+
+- `ReadYourWrites` (default) — reads overlay WAL tail on top of DB when
+  `latest_seq > flushed_seq`
+- `Strong` — reads trigger `force_flush()` before querying DB
+- `Eventual` — reads go directly to DB, ignoring WAL
+
+### Explicit flush
+
+```rust,ignore
+store.force_flush("thread-123").await?;
+```
+
+Blocks until the background flusher has drained every WAL entry for the given
+thread into the inner store. Use for admin operations or critical reads.
+
+## When to choose which
+
+| Need | Use |
+|------|-----|
+| Multi-instance mailbox with distributed claim | `NatsMailboxStore` |
+| Reduce DB write amplification for hot threads | `NatsBufferedThreadStore` over Postgres |
+| Maintain pagination via DB indices while buffering writes | `NatsBufferedThreadStore` |
+| Single-instance, no NATS available | `InMemoryMailboxStore` + `InMemoryStore` |
+
+## Distributed deployment
+
+### Shared NATS, shared DB
+
+When running multiple awaken-server instances, every instance must connect to:
+
+- The **same NATS cluster** with identical `stream_name`, `consumer_name`, and
+  bucket names. Durable consumers ensure exactly-one-delivery semantics across
+  instances.
+- The **same inner `ThreadRunStore`** (e.g. shared PostgreSQL). Only one
+  instance's flusher processes each WAL entry; the resulting DB write must be
+  visible to all instances.
+
+Pointing two instances at separate inner stores leads to divergent DB contents.
+
+### Guarantees verified under multi-instance load
+
+The distributed test suite (`tests/nats_*_distributed.rs`) verifies:
+
+- **Mailbox claim exclusivity**: concurrent `claim_dispatch` calls from
+  multiple instances on the same dispatch have exactly one winner (KV CAS).
+- **Lease recovery**: when an instance holding a claim crashes, another
+  instance reclaims the dispatch after lease expiry via
+  `reclaim_expired_leases`.
+- **Interrupt propagation**: interrupt from instance A is observed by instance
+  B's in-memory index via `kv.watch_all()` within the flush window.
+- **Write visibility**: checkpoint from instance A is readable from instance B
+  via the WAL overlay (read-your-writes) before DB flush completes.
+- **Concurrent writers**: parallel `checkpoint()` calls on the same thread
+  from different instances produce monotonic unique `thread_seq` (KV CAS on
+  `latest_seq`) and all distinct runs land in the shared DB.
+
+### Consumer naming
+
+All instances sharing a mailbox or buffered thread store must use identical
+`consumer_name`. Different consumer names create independent consumers that
+each receive a full copy of every message — this breaks coalescing and
+duplicates DB writes.

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -35,6 +35,13 @@ and `crates/awaken-server/src/config_routes.rs`.
 | `GET` | `/v1/threads/:id/runs` | List runs for the thread |
 | `GET` | `/v1/threads/:id/runs/latest` | Get the latest run for the thread |
 
+`POST /v1/threads/:id/messages` and `POST /v1/runs/:id/inputs` accept an
+optional `mode` field. `queue` appends a durable mailbox dispatch,
+`live_then_queue` first tries to deliver the messages to the active run and
+queues only when live delivery is unavailable, `steer` is an alias for
+`live_then_queue`, `interrupt_then_queue` cancels the active run before
+queueing, and `resume_open_run` continues a resumable waiting run.
+
 ## Runs
 
 | Method | Path | Description |

--- a/docs/book/src/state-and-storage.md
+++ b/docs/book/src/state-and-storage.md
@@ -17,7 +17,9 @@ This path is for teams moving beyond stateless demos.
 
 Current built-in stores cover memory, file, and PostgreSQL for thread/run data;
 memory, file, and PostgreSQL for config; memory and file for profile/shared
-state; and memory or SQLite for mailbox jobs.
+state; and memory, SQLite, or NATS JetStream for mailbox jobs. A
+`NatsBufferedThreadStore` decorator can also wrap any thread/run backend to
+coalesce checkpoint writes through a JetStream WAL.
 
 ## Related internals
 

--- a/docs/book/src/zh-CN/reference/http-api.md
+++ b/docs/book/src/zh-CN/reference/http-api.md
@@ -33,6 +33,12 @@
 | `GET` | `/v1/threads/:id/runs` | 列出该 thread 的 runs |
 | `GET` | `/v1/threads/:id/runs/latest` | 获取最新 run |
 
+`POST /v1/threads/:id/messages` 与 `POST /v1/runs/:id/inputs` 支持可选的
+`mode` 字段。`queue` 会追加持久化 mailbox dispatch；`live_then_queue` 会先
+尝试把消息投递给活动 run，live 投递不可用时再排队；`steer` 是
+`live_then_queue` 的别名；`interrupt_then_queue` 会先取消活动 run 再排队；
+`resume_open_run` 会继续可恢复的等待中 run。
+
 ## Runs
 
 | 方法 | 路径 | 说明 |


### PR DESCRIPTION
## Summary

Ship distributed run steering for 0.2.1 on top of a NATS-backed mailbox + thread store, without breaking the 0.2.0 public API.

- **NATS mailbox store** (`feat` in `awaken-stores`): lease-based claim, atomic epoch interrupt, background sweeper, KV-watched dispatch index. New optional `nats` feature.
- **NATS buffered thread store** (`feat` in `awaken-stores`): WAL overlay on read, coalescing flusher, strong-consistency `force_flush`, adversarial/distributed test suites.
- **Live-steering for active runs** (`feat` in `awaken-mailbox`): `LiveRunCommand` + per-run forwarder on the owning node, cross-node `submit_live_then_queue` with `LiveDeliveryOutcome::{Delivered, NoSubscriber}` to guarantee durable-queue fallback when no subscriber observes the command. NATS transport uses request-reply for subscriber-presence signal.
- **Thread context cache** (`perf` in `awaken-runtime`): mailbox pre-warms `ThreadContextSnapshot` (messages + latest_run + run_cache) once per lease; runtime checkpoint hot path consumes it, eliminating redundant `load_messages` / `latest_run` / `load_run` reads per step.
- **Mailbox claim hardening** (`fix` in `awaken-stores`): claim-guard + encoded NATS subjects; closes edge cases in the distributed conformance suite.
- **0.2 compat preservation** (`fix` in `awaken-compat`): restores `AgentLoopParams` to its 0.2 shape (routes `thread_ctx` through a crate-internal helper), fixes the pre-existing `--no-default-features` build in `awaken-runtime`, and locks the full 0.2 public surface (runtime + server) with 32 compile-time compat tests.

### SemVer status

`cargo-semver-checks` across all 14 crates: **no semver update required** — every crate is source-compatible with v0.2.0.

### Commits

- ✨ feat(stores): NATS mailbox store with lease-based claim
- ⚡ perf(runtime): thread context cache for live steering
- ✨ feat(stores): NATS buffered thread store with WAL overlay
- ✨ feat(mailbox): live-steering for active runs
- 🐛 fix(stores): harden mailbox claim semantics
- 🐛 fix(compat): preserve 0.2 public API surface

## Test plan

- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets` — 0 warnings, 0 errors
- [x] `cargo test --workspace --tests` — 4497 passed / 0 failed / 26 ignored
- [x] `cargo test --workspace --doc` — 56 passed / 236 ignored
- [x] `cargo check -p awaken-runtime --no-default-features` — clean (was broken before)
- [x] `cargo check -p awaken-stores --no-default-features --features {nats,sqlite,postgres,file}` — clean per-feature
- [x] `cargo semver-checks check-release -p <crate> --baseline-root v0.2.0` — 14/14 crates clean
- [x] 32 public-API compat lockdown tests (`public_api_compat` + `_extended` × runtime/server) — 32/32 pass
- [x] Live-channel `NoSubscriber` fallback — new `live_then_queue_falls_back_to_queue_when_no_remote_subscriber` test + 7 `InMemoryMailboxStore::live_channel` tests
- [ ] Live NATS smoke tests (require broker) — run locally with `cargo test -p awaken-stores -- --ignored`