### PR TITLE
🔖 chore(release): prepare 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 Development work lands here before the next versioned release.
 
+## [0.2.1] - 2026-04-21
+
+### Added
+
+- NATS-backed `MailboxStore` and `ThreadRunStore` implementations through the
+  `awaken-stores/nats` feature, including JetStream dispatch wakeups, KV-backed
+  dispatch state, buffered checkpoint WAL, and read-your-writes overlays.
+- Live mailbox steering for active runs, with durable dispatch fallback when no
+  live subscriber acknowledges the command.
+- NATS mailbox operational metrics, delayed dispatch-signal NAK backoff,
+  sweeper republish TTL, configurable signal-loop tuning, and stress coverage
+  for multi-node contention and large KV buckets.
+
+### Fixed
+
+- Preserved 0.2.0 public API compatibility for mailbox and server-facing types
+  while keeping new dispatch signal behavior additive.
+- Hardened distributed mailbox scheduling around thread claim guards,
+  `available_at` retry windows, dispatch epoch checks, stale claim rejection,
+  dedupe lock reconciliation, and terminal claim-field cleanup.
+- Fixed NATS buffered thread flushing so WAL messages are ACKed only after both
+  the inner checkpoint and `flushed_seq` watermark write succeed.
+- Wired NATS credentials config into both mailbox and buffered thread store
+  connections.
+- Normalized NATS KV Delete/Purge tombstones across claim guards, dedupe locks,
+  thread indexes, epochs, and dispatch control paths.
+- Made terminal dispatch GC authoritative and changed expired-lease reclaim to
+  use thread-claim guard records instead of scanning all dispatch records.
+
+### Changed
+
+- Updated `genai` to `0.6.0-beta.17`.
+- Aligned Rust toolchain metadata with the current workspace MSRV.
+
+### Compatibility
+
+- `cargo semver-checks` passes against `v0.2.0`; this release is intended as a
+  non-breaking 0.2 patch release.
+- The NATS backend is additive and behind the `awaken-stores/nats` feature.
+
 ## [0.2.0] - 2026-04-11
 
 ### Breaking Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "awaken-examples",
  "clap",
@@ -267,7 +267,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awaken-agent"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-contract"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-doctest"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-agent",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-examples"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-deferred-tools"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-generative-ui"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-mcp"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-observability"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-permission"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-reminder"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-skills"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-protocol-a2a"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-stores"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-tool-pattern"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "glob-match",
  "regex",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.2.1-dev"
+version = "0.2.1"
 dependencies = [
  "awaken-examples",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1-dev"
+version = "0.2.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
@@ -31,19 +31,19 @@ keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-awaken-contract = { version = "0.2.1-dev", path = "crates/awaken-contract" }
-awaken-protocol-a2a = { version = "0.2.1-dev", path = "crates/awaken-protocol-a2a" }
-awaken-stores = { version = "0.2.1-dev", path = "crates/awaken-stores" }
-awaken-runtime = { version = "0.2.1-dev", path = "crates/awaken-runtime" }
-awaken-ext-permission = { version = "0.2.1-dev", path = "crates/awaken-ext-permission" }
-awaken-ext-observability = { version = "0.2.1-dev", path = "crates/awaken-ext-observability" }
-awaken-ext-mcp = { version = "0.2.1-dev", path = "crates/awaken-ext-mcp" }
-awaken-ext-skills = { version = "0.2.1-dev", path = "crates/awaken-ext-skills" }
-awaken-ext-reminder = { version = "0.2.1-dev", path = "crates/awaken-ext-reminder" }
-awaken-ext-generative-ui = { version = "0.2.1-dev", path = "crates/awaken-ext-generative-ui" }
-awaken-ext-deferred-tools = { version = "0.2.1-dev", path = "crates/awaken-ext-deferred-tools" }
-awaken-tool-pattern = { version = "0.2.1-dev", path = "crates/awaken-tool-pattern" }
-awaken-server = { version = "0.2.1-dev", path = "crates/awaken-server" }
+awaken-contract = { version = "0.2.1", path = "crates/awaken-contract" }
+awaken-protocol-a2a = { version = "0.2.1", path = "crates/awaken-protocol-a2a" }
+awaken-stores = { version = "0.2.1", path = "crates/awaken-stores" }
+awaken-runtime = { version = "0.2.1", path = "crates/awaken-runtime" }
+awaken-ext-permission = { version = "0.2.1", path = "crates/awaken-ext-permission" }
+awaken-ext-observability = { version = "0.2.1", path = "crates/awaken-ext-observability" }
+awaken-ext-mcp = { version = "0.2.1", path = "crates/awaken-ext-mcp" }
+awaken-ext-skills = { version = "0.2.1", path = "crates/awaken-ext-skills" }
+awaken-ext-reminder = { version = "0.2.1", path = "crates/awaken-ext-reminder" }
+awaken-ext-generative-ui = { version = "0.2.1", path = "crates/awaken-ext-generative-ui" }
+awaken-ext-deferred-tools = { version = "0.2.1", path = "crates/awaken-ext-deferred-tools" }
+awaken-tool-pattern = { version = "0.2.1", path = "crates/awaken-tool-pattern" }
+awaken-server = { version = "0.2.1", path = "crates/awaken-server" }
 glob-match = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.2.1-dev", path = "../awaken", features = ["full"] }
+awaken = { package = "awaken-agent", version = "0.2.1", path = "../awaken", features = ["full"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/docs/adr/0019-mailbox-architecture.md
+++ b/docs/adr/0019-mailbox-architecture.md
@@ -55,7 +55,9 @@ Normal path: `enqueue` triggers immediate dispatch if the thread's `MailboxWorke
 ### D7: Crate placement
 
 - `awaken-contract` — `RunDispatch`, `RunDispatchStatus`, `RunRequestOrigin`, `MailboxStore` trait.
-- `awaken-stores` — `InMemoryMailboxStore`, `FileMailboxStore`, `PostgresMailboxStore`. (**Note**: only `InMemoryMailboxStore` is implemented; `FileMailboxStore` and `PostgresMailboxStore` are not yet implemented.)
+- `awaken-stores` — mailbox backend implementations. Current built-in
+  implementations are `InMemoryMailboxStore`, `SqliteMailboxStore`, and
+  `NatsMailboxStore`.
 - `awaken-server` — `Mailbox` service, `MailboxConfig`, handler integration.
 
 ### D8: Mailbox is the control plane; AgentRuntime is the execution plane

--- a/docs/book/src/state-and-storage.md
+++ b/docs/book/src/state-and-storage.md
@@ -21,6 +21,21 @@ state; and memory, SQLite, or NATS JetStream for mailbox jobs. A
 `NatsBufferedThreadStore` decorator can also wrap any thread/run backend to
 coalesce checkpoint writes through a JetStream WAL.
 
+## Mailbox backend choice
+
+Mailbox jobs are run-dispatch control-plane records. They are separate from
+the thread/run checkpoint store, so a deployment can combine, for example,
+PostgreSQL thread storage with a NATS mailbox.
+
+| Backend | Use when | Boundary |
+| --- | --- | --- |
+| `InMemoryMailboxStore` | Tests, local development, and embedded single-process runs. | Process-local only; queued dispatches are lost when the process exits. |
+| `SqliteMailboxStore` | A single-node server needs durable mailbox jobs without running NATS. | Durable on local storage, but not the horizontally-scaled mailbox backend. |
+| `NatsMailboxStore` | Multiple server instances need shared dispatch ownership, wakeups, and lease recovery. | Requires JetStream and KV; all instances must share the same stream, buckets, and durable consumer. |
+
+See [Use NATS Stores](./how-to/use-nats-stores.md) for distributed mailbox
+configuration and operations.
+
 ## Related internals
 
 - [State and Snapshot Model](./explanation/state-and-snapshot-model.md)

--- a/docs/book/src/zh-CN/state-and-storage.md
+++ b/docs/book/src/zh-CN/state-and-storage.md
@@ -15,7 +15,17 @@
 2. 阅读 [状态键](./reference/state-keys.md) 和 [线程模型](./reference/thread-model.md)，理解状态布局和生命周期。
 3. 当上下文规模开始成为问题时，再阅读 [优化上下文窗口](./how-to/optimize-context-window.md)。
 
-当前内置 store 覆盖：thread/run 的内存、文件、PostgreSQL；config 的内存、文件、PostgreSQL；profile/shared state 的内存和文件；以及 mailbox job 的内存或 SQLite。
+当前内置 store 覆盖：thread/run 的内存、文件、PostgreSQL；config 的内存、文件、PostgreSQL；profile/shared state 的内存和文件；以及 mailbox job 的内存、SQLite 或 NATS JetStream。`NatsBufferedThreadStore` 还可以包裹任意 thread/run 后端，通过 JetStream WAL 合并 checkpoint 写入。
+
+## Mailbox 后端选择
+
+Mailbox job 是 run-dispatch 控制面记录，和 thread/run checkpoint store 是两套边界。因此可以组合使用，例如 PostgreSQL 保存 thread/run 数据，同时用 NATS mailbox 负责分布式调度。
+
+| 后端 | 适用场景 | 边界 |
+| --- | --- | --- |
+| `InMemoryMailboxStore` | 测试、本地开发、嵌入式单进程运行。 | 只在进程内有效；进程退出后 queued dispatch 会丢失。 |
+| `SqliteMailboxStore` | 单节点服务需要持久 mailbox job，但不想运行 NATS。 | 使用本地存储持久化，但不是水平扩展 mailbox 后端。 |
+| `NatsMailboxStore` | 多个 server 实例需要共享 dispatch 所有权、wakeup 和 lease recovery。 | 需要 JetStream 和 KV；所有实例必须使用同一组 stream、bucket 和 durable consumer。 |
 
 ## 相关内部机制
 


### PR DESCRIPTION
## Summary
- set workspace and internal dependency versions to 0.2.1
- update Cargo.lock and doctest dependency version
- add 0.2.1 changelog entry with compatibility and release notes
- document mailbox backend selection across in-memory, SQLite, and NATS stores
- correct ADR-0019 current mailbox backend implementation list

## Validation
- cargo check --workspace
- cargo fmt --all -- --check
- cargo clippy --workspace --lib --bins --examples --locked -- -D clippy::correctness
- cargo test --workspace --locked
- bash scripts/test-book.sh
- cargo semver-checks --workspace --baseline-rev v0.2.0 --color never
- NATS mailbox behavior/conformance tests
- NATS buffered thread behavior/adversarial/distributed/conformance/connect tests
- NATS mailbox stress tests with AWAKEN_NATS_STRESS_RECORDS=16
- cargo publish --dry-run for awaken-contract, awaken-protocol-a2a, awaken-tool-pattern

## Notes
- Full dry-run for dependent workspace crates is blocked until 0.2.1 dependency crates are published to crates.io in release order.