### PR TITLE
🔖 chore(release): start 0.2.2-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "awaken-examples",
  "clap",
@@ -267,7 +267,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awaken-agent"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-contract"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "futures",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-doctest"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-agent",
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-examples"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-deferred-tools"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-generative-ui"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-mcp"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-observability"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-permission"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-reminder"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-skills"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-protocol-a2a"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-stores"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-tool-pattern"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "glob-match",
  "regex",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.2.1"
+version = "0.2.2-dev"
 dependencies = [
  "awaken-examples",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
@@ -31,19 +31,19 @@ keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-awaken-contract = { version = "0.2.1", path = "crates/awaken-contract" }
-awaken-protocol-a2a = { version = "0.2.1", path = "crates/awaken-protocol-a2a" }
-awaken-stores = { version = "0.2.1", path = "crates/awaken-stores" }
-awaken-runtime = { version = "0.2.1", path = "crates/awaken-runtime" }
-awaken-ext-permission = { version = "0.2.1", path = "crates/awaken-ext-permission" }
-awaken-ext-observability = { version = "0.2.1", path = "crates/awaken-ext-observability" }
-awaken-ext-mcp = { version = "0.2.1", path = "crates/awaken-ext-mcp" }
-awaken-ext-skills = { version = "0.2.1", path = "crates/awaken-ext-skills" }
-awaken-ext-reminder = { version = "0.2.1", path = "crates/awaken-ext-reminder" }
-awaken-ext-generative-ui = { version = "0.2.1", path = "crates/awaken-ext-generative-ui" }
-awaken-ext-deferred-tools = { version = "0.2.1", path = "crates/awaken-ext-deferred-tools" }
-awaken-tool-pattern = { version = "0.2.1", path = "crates/awaken-tool-pattern" }
-awaken-server = { version = "0.2.1", path = "crates/awaken-server" }
+awaken-contract = { version = "0.2.2-dev", path = "crates/awaken-contract" }
+awaken-protocol-a2a = { version = "0.2.2-dev", path = "crates/awaken-protocol-a2a" }
+awaken-stores = { version = "0.2.2-dev", path = "crates/awaken-stores" }
+awaken-runtime = { version = "0.2.2-dev", path = "crates/awaken-runtime" }
+awaken-ext-permission = { version = "0.2.2-dev", path = "crates/awaken-ext-permission" }
+awaken-ext-observability = { version = "0.2.2-dev", path = "crates/awaken-ext-observability" }
+awaken-ext-mcp = { version = "0.2.2-dev", path = "crates/awaken-ext-mcp" }
+awaken-ext-skills = { version = "0.2.2-dev", path = "crates/awaken-ext-skills" }
+awaken-ext-reminder = { version = "0.2.2-dev", path = "crates/awaken-ext-reminder" }
+awaken-ext-generative-ui = { version = "0.2.2-dev", path = "crates/awaken-ext-generative-ui" }
+awaken-ext-deferred-tools = { version = "0.2.2-dev", path = "crates/awaken-ext-deferred-tools" }
+awaken-tool-pattern = { version = "0.2.2-dev", path = "crates/awaken-tool-pattern" }
+awaken-server = { version = "0.2.2-dev", path = "crates/awaken-server" }
 glob-match = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-awaken = { package = "awaken-agent", version = "0.2.1", path = "../awaken", features = ["full"] }
+awaken = { package = "awaken-agent", version = "0.2.2-dev", path = "../awaken", features = ["full"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
- bump workspace version to 0.2.2-dev after the 0.2.1 release
- update internal workspace dependency versions
- refresh Cargo.lock package versions

## Validation
- cargo check --workspace
- pre-push validation