### PR TITLE
fix(background): support self-cancel cascade across runs

### DIFF
--- a/crates/awaken-runtime/src/backend/local.rs
+++ b/crates/awaken-runtime/src/backend/local.rs
@@ -14,6 +14,47 @@ use super::{
     BackendRunStatus, ExecutionBackend, ExecutionBackendError,
 };
 
+#[cfg(feature = "background")]
+struct BackgroundControlResolver<'a> {
+    inner: &'a dyn crate::registry::ExecutionResolver,
+    context: Option<crate::extensions::background::BackgroundTaskExecutionContext>,
+}
+
+#[cfg(feature = "background")]
+impl<'a> BackgroundControlResolver<'a> {
+    fn new(
+        inner: &'a dyn crate::registry::ExecutionResolver,
+        context: Option<crate::extensions::background::BackgroundTaskExecutionContext>,
+    ) -> Self {
+        Self { inner, context }
+    }
+}
+
+#[cfg(feature = "background")]
+impl crate::registry::AgentResolver for BackgroundControlResolver<'_> {
+    fn resolve(&self, agent_id: &str) -> Result<ResolvedAgent, crate::RuntimeError> {
+        let mut resolved = self.inner.resolve(agent_id)?;
+        if let Some(context) = &self.context {
+            LocalBackend::ensure_background_cancel_tool(&mut resolved, context);
+        }
+        Ok(resolved)
+    }
+
+    fn agent_ids(&self) -> Vec<String> {
+        self.inner.agent_ids()
+    }
+}
+
+#[cfg(feature = "background")]
+impl crate::registry::ExecutionResolver for BackgroundControlResolver<'_> {
+    fn resolve_execution(
+        &self,
+        agent_id: &str,
+    ) -> Result<crate::registry::ResolvedExecution, crate::RuntimeError> {
+        self.inner.resolve_execution(agent_id)
+    }
+}
+
 /// Local runtime backend for executing the standard loop in-process.
 pub struct LocalBackend;
 
@@ -121,9 +162,9 @@ impl LocalBackend {
         match (request.policy.persistence, request.policy.continuation) {
             (BackendDelegatePersistence::Ephemeral, BackendDelegateContinuation::Disabled) => {}
         }
-        let resolved = request
-            .resolver
-            .resolve(request.agent_id)
+        #[cfg(feature = "background")]
+        let background_context = crate::extensions::background::current_background_task_context();
+        let resolved = crate::registry::AgentResolver::resolve(request.resolver, request.agent_id)
             .map_err(|error| {
                 ExecutionBackendError::AgentNotFound(format!(
                     "failed to resolve agent '{}': {error}",
@@ -174,6 +215,12 @@ impl LocalBackend {
                 .map_err(|error| ExecutionBackendError::ExecutionFailed(error.to_string()))?;
         }
 
+        #[cfg(feature = "background")]
+        let background_resolver =
+            BackgroundControlResolver::new(request.resolver, background_context.clone());
+        #[cfg(not(feature = "background"))]
+        let background_resolver = request.resolver;
+
         let sub_run_id = uuid::Uuid::now_v7().to_string();
         let mut run_identity = RunIdentity::new(
             sub_run_id.clone(),
@@ -188,7 +235,7 @@ impl LocalBackend {
         }
 
         let result = run_agent_loop(AgentLoopParams {
-            resolver: request.resolver,
+            resolver: &background_resolver,
             agent_id: request.agent_id,
             runtime: &phase_runtime,
             sink: request.sink,
@@ -222,6 +269,34 @@ impl LocalBackend {
             inbox: owner_inbox,
             state: None,
         })
+    }
+
+    #[cfg(feature = "background")]
+    fn ensure_background_cancel_tool(
+        resolved: &mut ResolvedAgent,
+        context: &crate::extensions::background::BackgroundTaskExecutionContext,
+    ) {
+        if resolved
+            .tools
+            .contains_key(crate::extensions::background::CANCEL_TASK_TOOL_ID)
+        {
+            return;
+        }
+
+        let tool: std::sync::Arc<dyn awaken_contract::contract::tool::Tool> = std::sync::Arc::new(
+            crate::extensions::background::CancelTaskTool::with_current_task(
+                context.manager.clone(),
+                context.task_id.clone(),
+            ),
+        );
+        resolved.tools.insert(
+            crate::extensions::background::CANCEL_TASK_TOOL_ID.into(),
+            tool.clone(),
+        );
+        resolved.env.tools.insert(
+            crate::extensions::background::CANCEL_TASK_TOOL_ID.into(),
+            tool,
+        );
     }
 
     pub(crate) fn bind_local_execution_env(
@@ -278,10 +353,18 @@ mod tests {
 
     use crate::backend::{
         BackendControl, BackendDelegatePolicy, BackendDelegateRunRequest, BackendParentContext,
+        BackendRunStatus,
+    };
+    #[cfg(feature = "background")]
+    use crate::extensions::background::{
+        BackgroundTaskManager, BackgroundTaskPlugin, TaskParentContext, TaskResult as BgTaskResult,
+        TaskStatus,
     };
     use crate::loop_runner::build_agent_env;
     use crate::plugins::{Plugin, PluginDescriptor};
     use crate::registry::{AgentResolver, ExecutionResolver, ResolvedExecution};
+    #[cfg(feature = "background")]
+    use crate::state::StateStore;
 
     struct ScriptedLlm {
         responses: Mutex<Vec<StreamResult>>,
@@ -345,6 +428,31 @@ mod tests {
             _ctx: &ToolCallContext,
         ) -> Result<ToolOutput, ToolError> {
             Ok(ToolResult::success_with_message("echo", args, "tool result should not win").into())
+        }
+    }
+
+    #[cfg(feature = "background")]
+    struct CustomCancelTool {
+        called: Arc<AtomicUsize>,
+    }
+
+    #[cfg(feature = "background")]
+    #[async_trait]
+    impl Tool for CustomCancelTool {
+        fn descriptor(&self) -> ToolDescriptor {
+            ToolDescriptor::new("cancel_task", "cancel_task", "custom cancel task tool")
+        }
+
+        async fn execute(
+            &self,
+            args: Value,
+            _ctx: &ToolCallContext,
+        ) -> Result<ToolOutput, ToolError> {
+            self.called.fetch_add(1, Ordering::SeqCst);
+            Ok(
+                ToolResult::success_with_message("cancel_task", args, "custom cancel handled")
+                    .into(),
+            )
         }
     }
 
@@ -471,5 +579,236 @@ mod tests {
         assert_eq!(result.response.as_deref(), Some("final child answer"));
         assert_eq!(result.output.text.as_deref(), Some("final child answer"));
         assert_eq!(result.steps, 2);
+    }
+
+    #[cfg(feature = "background")]
+    #[tokio::test]
+    async fn execute_delegate_in_background_task_can_self_cancel_and_cascade() {
+        let store = StateStore::new();
+        let manager = Arc::new(BackgroundTaskManager::new());
+        manager.set_store(store.clone());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager.clone()));
+        let env = crate::phase::ExecutionEnv::from_plugins(&[plugin], &Default::default())
+            .expect("background plugin env");
+        store
+            .register_keys(&env.key_registrations)
+            .expect("background keys should register");
+
+        let resolver = FixedResolver {
+            agent: ResolvedAgent::new(
+                "delegate",
+                "m",
+                "sys",
+                Arc::new(ScriptedLlm::new(vec![
+                    tool_call_response(
+                        "cancel self",
+                        "cancel_task",
+                        "call-1",
+                        json!({"target": {"relation": "self"}}),
+                    ),
+                    text_response("should not be reached after cancellation"),
+                ])),
+            ),
+            plugins: Vec::new(),
+        };
+
+        let child_task_id = Arc::new(tokio::sync::Mutex::new(None::<String>));
+        let child_task_id_seen = child_task_id.clone();
+        let resolver = Arc::new(resolver);
+        let task_id = manager
+            .spawn_agent_with_context(
+                "thread-1",
+                Some("worker"),
+                "worker agent",
+                TaskParentContext::default(),
+                {
+                    let manager = manager.clone();
+                    move |ctx| {
+                        let manager = manager.clone();
+                        let child_task_id_seen = child_task_id_seen.clone();
+                        let resolver = resolver.clone();
+                        async move {
+                            assert!(
+                                crate::extensions::background::current_background_task_context()
+                                    .is_some(),
+                                "background task context should be visible inside spawned task"
+                            );
+                            let child_id = manager
+                                .spawn(
+                                    "thread-1",
+                                    "child",
+                                    Some("leaf"),
+                                    "child task",
+                                    TaskParentContext {
+                                        task_id: Some(ctx.task_id.clone()),
+                                        ..TaskParentContext::default()
+                                    },
+                                    |child_ctx| async move {
+                                        child_ctx.cancelled().await;
+                                        BgTaskResult::Cancelled
+                                    },
+                                )
+                                .await
+                                .expect("child task should spawn");
+                            *child_task_id_seen.lock().await = Some(child_id);
+
+                            let result = LocalBackend::new()
+                                .execute_delegate(BackendDelegateRunRequest {
+                                    agent_id: "delegate",
+                                    messages: vec![Message::user("cancel yourself")],
+                                    new_messages: vec![Message::user("cancel yourself")],
+                                    sink: Arc::new(NullEventSink),
+                                    resolver: resolver.as_ref(),
+                                    parent: BackendParentContext {
+                                        parent_run_id: Some("parent-run".into()),
+                                        parent_thread_id: Some("parent-thread".into()),
+                                        parent_tool_call_id: Some("tool-1".into()),
+                                    },
+                                    control: BackendControl {
+                                        cancellation_token: Some(ctx.cancel_token.clone()),
+                                        decision_rx: None,
+                                    },
+                                    policy: BackendDelegatePolicy::default(),
+                                })
+                                .await
+                                .expect("delegate should run");
+
+                            match result.status {
+                                BackendRunStatus::Cancelled => BgTaskResult::Cancelled,
+                                other => BgTaskResult::Failed(format!(
+                                    "expected cancelled delegate status, got {other}; response={:?}; output={:?}",
+                                    result.response,
+                                    result.output
+                                )),
+                            }
+                        }
+                    }
+                },
+            )
+            .await
+            .expect("background sub-agent should spawn");
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let child_id = child_task_id
+            .lock()
+            .await
+            .clone()
+            .expect("child task id should be recorded");
+        let task_summary = manager
+            .get(&task_id)
+            .await
+            .expect("root task should still be queryable");
+        let child_summary = manager
+            .get(&child_id)
+            .await
+            .expect("child task should still be queryable");
+
+        assert_eq!(
+            task_summary.status,
+            TaskStatus::Cancelled,
+            "task={task_summary:?} child={child_summary:?}"
+        );
+        assert_eq!(
+            child_summary.status,
+            TaskStatus::Cancelled,
+            "task={task_summary:?} child={child_summary:?}"
+        );
+    }
+
+    #[cfg(feature = "background")]
+    #[tokio::test]
+    async fn execute_delegate_preserves_existing_cancel_task_tool_in_background_context() {
+        let store = StateStore::new();
+        let manager = Arc::new(BackgroundTaskManager::new());
+        manager.set_store(store.clone());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager.clone()));
+        let env = crate::phase::ExecutionEnv::from_plugins(&[plugin], &Default::default())
+            .expect("background plugin env");
+        store
+            .register_keys(&env.key_registrations)
+            .expect("background keys should register");
+
+        let cancel_calls = Arc::new(AtomicUsize::new(0));
+        let resolver = Arc::new(FixedResolver {
+            agent: ResolvedAgent::new(
+                "delegate",
+                "m",
+                "sys",
+                Arc::new(ScriptedLlm::new(vec![
+                    tool_call_response(
+                        "use custom cancel",
+                        "cancel_task",
+                        "call-1",
+                        json!({"target": {"relation": "self"}}),
+                    ),
+                    text_response("custom tool won"),
+                ])),
+            )
+            .with_tool(Arc::new(CustomCancelTool {
+                called: cancel_calls.clone(),
+            })),
+            plugins: Vec::new(),
+        });
+
+        let task_id = manager
+            .spawn_agent_with_context(
+                "thread-1",
+                Some("worker"),
+                "worker agent",
+                TaskParentContext::default(),
+                move |ctx| {
+                    let resolver = resolver.clone();
+                    async move {
+                        let result = LocalBackend::new()
+                            .execute_delegate(BackendDelegateRunRequest {
+                                agent_id: "delegate",
+                                messages: vec![Message::user("use custom cancel")],
+                                new_messages: vec![Message::user("use custom cancel")],
+                                sink: Arc::new(NullEventSink),
+                                resolver: resolver.as_ref(),
+                                parent: BackendParentContext {
+                                    parent_run_id: Some("parent-run".into()),
+                                    parent_thread_id: Some("parent-thread".into()),
+                                    parent_tool_call_id: Some("tool-1".into()),
+                                },
+                                control: BackendControl {
+                                    cancellation_token: Some(ctx.cancel_token),
+                                    decision_rx: None,
+                                },
+                                policy: BackendDelegatePolicy::default(),
+                            })
+                            .await
+                            .expect("delegate should run");
+
+                        match result.status {
+                            BackendRunStatus::Completed
+                                if result.response.as_deref() == Some("custom tool won") =>
+                            {
+                                BgTaskResult::Success(json!({
+                                    "response": result.response,
+                                    "steps": result.steps,
+                                }))
+                            }
+                            other => BgTaskResult::Failed(format!(
+                                "expected completed delegate status, got {other}; response={:?}; output={:?}",
+                                result.response,
+                                result.output
+                            )),
+                        }
+                    }
+                },
+            )
+            .await
+            .expect("background sub-agent should spawn");
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(cancel_calls.load(Ordering::SeqCst), 1);
+        let summary = manager
+            .get(&task_id)
+            .await
+            .expect("root task should be queryable");
+        assert_eq!(summary.status, TaskStatus::Completed, "task={summary:?}");
     }
 }

--- a/crates/awaken-runtime/src/execution/executor.rs
+++ b/crates/awaken-runtime/src/execution/executor.rs
@@ -9,6 +9,9 @@ use awaken_contract::contract::suspension::ToolCallOutcome;
 use awaken_contract::contract::tool::{Tool, ToolCallContext, ToolOutput, ToolResult};
 use awaken_contract::state::StateCommand;
 
+#[cfg(feature = "background")]
+use crate::extensions::background::{ToolLineageContext, scope_tool_lineage_context};
+
 /// Result of executing a single tool call.
 pub struct ToolExecutionResult {
     pub call: ToolCall,
@@ -216,10 +219,36 @@ pub(crate) async fn execute_single_tool(
         return ToolResult::error(&call.name, e.to_string()).into();
     }
 
-    match tool.execute(call.arguments.clone(), ctx).await {
+    match execute_tool_with_runtime_context(tool, call, ctx).await {
         Ok(output) => output,
         Err(e) => ToolResult::error(&call.name, e.to_string()).into(),
     }
+}
+
+#[cfg(feature = "background")]
+async fn execute_tool_with_runtime_context(
+    tool: &Arc<dyn Tool>,
+    call: &ToolCall,
+    ctx: &ToolCallContext,
+) -> Result<ToolOutput, awaken_contract::contract::tool::ToolError> {
+    scope_tool_lineage_context(
+        ToolLineageContext {
+            run_id: ctx.run_identity.run_id.clone(),
+            call_id: ctx.call_id.clone(),
+            agent_id: ctx.run_identity.agent_id.clone(),
+        },
+        tool.execute(call.arguments.clone(), ctx),
+    )
+    .await
+}
+
+#[cfg(not(feature = "background"))]
+async fn execute_tool_with_runtime_context(
+    tool: &Arc<dyn Tool>,
+    call: &ToolCall,
+    ctx: &ToolCallContext,
+) -> Result<ToolOutput, awaken_contract::contract::tool::ToolError> {
+    tool.execute(call.arguments.clone(), ctx).await
 }
 
 #[cfg(test)]
@@ -227,6 +256,19 @@ mod tests {
     use super::*;
     use awaken_contract::contract::tool::{ToolDescriptor, ToolError, ToolOutput};
     use serde_json::{Value, json};
+
+    #[cfg(feature = "background")]
+    use crate::extensions::background::{
+        BackgroundTaskManager, BackgroundTaskPlugin, TaskParentContext, TaskResult,
+    };
+    #[cfg(feature = "background")]
+    use crate::phase::ExecutionEnv;
+    #[cfg(feature = "background")]
+    use crate::plugins::Plugin;
+    #[cfg(feature = "background")]
+    use crate::state::StateStore;
+    #[cfg(feature = "background")]
+    use awaken_contract::contract::identity::{RunIdentity, RunOrigin};
 
     struct EchoTool;
 
@@ -973,5 +1015,93 @@ mod tests {
         let output = execute_single_tool(&tools, &call, &ctx).await;
         assert!(output.result.is_success());
         assert_eq!(output.result.tool_name, "echo");
+    }
+
+    #[cfg(feature = "background")]
+    struct SpawnBackgroundTaskTool {
+        manager: Arc<BackgroundTaskManager>,
+        spawned_task_id: Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    #[cfg(feature = "background")]
+    #[async_trait]
+    impl Tool for SpawnBackgroundTaskTool {
+        fn descriptor(&self) -> ToolDescriptor {
+            ToolDescriptor::new(
+                "spawn_background",
+                "spawn_background",
+                "Spawns a background task",
+            )
+        }
+
+        async fn execute(
+            &self,
+            _args: Value,
+            _ctx: &ToolCallContext,
+        ) -> Result<ToolOutput, ToolError> {
+            let task_id = self
+                .manager
+                .spawn(
+                    "thread-1",
+                    "background",
+                    None,
+                    "spawned from tool",
+                    TaskParentContext::default(),
+                    |_| async { TaskResult::Success(json!({"ok": true})) },
+                )
+                .await
+                .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+            *self.spawned_task_id.lock().unwrap() = Some(task_id.clone());
+            Ok(ToolResult::success("spawn_background", json!({"task_id": task_id})).into())
+        }
+    }
+
+    #[cfg(feature = "background")]
+    #[tokio::test]
+    async fn execute_single_tool_scopes_tool_lineage_for_background_spawns() {
+        let store = StateStore::new();
+        let manager = Arc::new(BackgroundTaskManager::new());
+        manager.set_store(store.clone());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager.clone()));
+        let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
+        store.register_keys(&env.key_registrations).unwrap();
+
+        let spawned_task_id = Arc::new(std::sync::Mutex::new(None::<String>));
+        let tools = tool_map(vec![Arc::new(SpawnBackgroundTaskTool {
+            manager: manager.clone(),
+            spawned_task_id: spawned_task_id.clone(),
+        }) as Arc<dyn Tool>]);
+        let executor = SequentialToolExecutor;
+        let calls = vec![ToolCall::new("call-77", "spawn_background", json!({}))];
+
+        let mut ctx = ToolCallContext::test_default();
+        ctx.run_identity = RunIdentity::new(
+            "thread-1".into(),
+            None,
+            "run-77".into(),
+            None,
+            "agent-77".into(),
+            RunOrigin::User,
+        );
+        ctx.cancellation_token = Some(crate::cancellation::CancellationToken::new());
+
+        let results = executor.execute(&tools, &calls, &ctx).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].result.is_success());
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let task_id = spawned_task_id
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("spawned task id should be recorded");
+        let summary = manager
+            .get(&task_id)
+            .await
+            .expect("spawned background task should be queryable");
+        assert_eq!(summary.parent_context.run_id.as_deref(), Some("run-77"));
+        assert_eq!(summary.parent_context.call_id.as_deref(), Some("call-77"));
+        assert_eq!(summary.parent_context.agent_id.as_deref(), Some("agent-77"));
     }
 }

--- a/crates/awaken-runtime/src/extensions/background/cancel_task_tool.rs
+++ b/crates/awaken-runtime/src/extensions/background/cancel_task_tool.rs
@@ -1,0 +1,484 @@
+//! `cancel_task` tool for self/child background task cancellation.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use awaken_contract::contract::tool::{
+    Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
+};
+
+use super::manager::BackgroundTaskManager;
+
+pub const CANCEL_TASK_TOOL_ID: &str = "cancel_task";
+
+/// Structured cancel receipt returned to the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelTaskReceipt {
+    pub status: &'static str,
+    pub root_task_id: String,
+    pub cancelled_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CancelTaskError {
+    CurrentTaskUnavailable,
+    TaskNotFound,
+}
+
+impl std::fmt::Display for CancelTaskError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CurrentTaskUnavailable => write!(f, "current_task_unavailable"),
+            Self::TaskNotFound => write!(f, "task_not_found"),
+        }
+    }
+}
+
+/// Tool exposed to agents for cancelling their own background task tree.
+pub struct CancelTaskTool {
+    manager: Arc<BackgroundTaskManager>,
+    current_task_id_override: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum CancelScope {
+    Task(String),
+    Run(String),
+}
+
+impl CancelTaskTool {
+    pub fn new(manager: Arc<BackgroundTaskManager>) -> Self {
+        Self {
+            manager,
+            current_task_id_override: None,
+        }
+    }
+
+    pub(crate) fn with_current_task(
+        manager: Arc<BackgroundTaskManager>,
+        task_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            manager,
+            current_task_id_override: Some(task_id.into()),
+        }
+    }
+
+    fn current_task_id(&self, _ctx: &ToolCallContext) -> Option<String> {
+        self.current_task_id_override
+            .clone()
+            .or_else(|| super::current_background_task_context().map(|context| context.task_id))
+    }
+
+    fn current_scope(&self, ctx: &ToolCallContext) -> Option<CancelScope> {
+        if let Some(task_id) = self.current_task_id(ctx) {
+            return Some(CancelScope::Task(task_id));
+        }
+
+        if ctx.cancellation_token.is_some() && !ctx.run_identity.run_id.trim().is_empty() {
+            return Some(CancelScope::Run(ctx.run_identity.run_id.clone()));
+        }
+
+        None
+    }
+
+    fn resolve_child(&self, scope: &CancelScope, name: &str) -> Option<String> {
+        match scope {
+            CancelScope::Task(task_id) => self.manager.resolve_live_child_task(task_id, name),
+            CancelScope::Run(run_id) => self.manager.resolve_live_child_run(run_id, name),
+        }
+    }
+
+    fn make_receipt(root_task_id: String, cancelled_count: usize) -> CancelTaskReceipt {
+        CancelTaskReceipt {
+            status: "accepted",
+            root_task_id,
+            cancelled_count,
+            error: None,
+        }
+    }
+
+    fn make_error(root_task_id: String, error: CancelTaskError) -> CancelTaskReceipt {
+        CancelTaskReceipt {
+            status: "failed",
+            root_task_id,
+            cancelled_count: 0,
+            error: Some(error.to_string()),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for CancelTaskTool {
+    fn descriptor(&self) -> ToolDescriptor {
+        ToolDescriptor::new(
+            CANCEL_TASK_TOOL_ID,
+            CANCEL_TASK_TOOL_ID,
+            "Cancel the current background task or one of its child tasks. Descendant tasks are cancelled together.",
+        )
+        .with_parameters(json!({
+            "type": "object",
+            "properties": {
+                "target": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "relation": { "const": "self" }
+                            },
+                            "required": ["relation"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "relation": { "const": "child" },
+                                "name": { "type": "string", "description": "Direct child task name or task_id" }
+                            },
+                            "required": ["relation", "name"]
+                        }
+                    ]
+                }
+            },
+            "required": ["target"]
+        }))
+    }
+
+    fn validate_args(&self, args: &Value) -> Result<(), ToolError> {
+        let target = args
+            .get("target")
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'target'".into()))?;
+        let relation = target
+            .get("relation")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'target.relation'".into()))?;
+
+        match relation {
+            "self" => Ok(()),
+            "child" => {
+                if target.get("name").and_then(Value::as_str).is_none() {
+                    Err(ToolError::InvalidArguments("child requires 'name'".into()))
+                } else {
+                    Ok(())
+                }
+            }
+            other => Err(ToolError::InvalidArguments(format!(
+                "unknown relation '{other}'"
+            ))),
+        }
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+        let current_scope = self.current_scope(ctx);
+        let relation = args["target"]["relation"].as_str().unwrap_or_default();
+        let (root_task_id, cancelled_count) = match relation {
+            "self" => {
+                let scope = current_scope.clone().ok_or_else(|| {
+                    ToolError::ExecutionFailed(CancelTaskError::CurrentTaskUnavailable.to_string())
+                })?;
+                let cancelled_count = match &scope {
+                    CancelScope::Task(task_id) => self.manager.cancel_tree(task_id).await,
+                    CancelScope::Run(run_id) => {
+                        let descendant_count =
+                            self.manager.cancel_descendants_for_run(run_id).await;
+                        descendant_count + usize::from(ctx.cancellation_token.is_some())
+                    }
+                };
+                let root_id = match scope {
+                    CancelScope::Task(task_id) => task_id,
+                    CancelScope::Run(run_id) => run_id,
+                };
+
+                if let Some(cancellation_token) = &ctx.cancellation_token {
+                    cancellation_token.cancel();
+                }
+
+                (root_id, cancelled_count)
+            }
+            "child" => {
+                let scope = current_scope.clone().ok_or_else(|| {
+                    ToolError::ExecutionFailed(CancelTaskError::CurrentTaskUnavailable.to_string())
+                })?;
+                let name = args["target"]["name"].as_str().unwrap_or_default();
+                let Some(child_task_id) = self.resolve_child(&scope, name) else {
+                    let receipt = Self::make_error(name.to_string(), CancelTaskError::TaskNotFound);
+                    return Ok(ToolResult::success(
+                        CANCEL_TASK_TOOL_ID,
+                        serde_json::to_value(receipt).unwrap_or_default(),
+                    )
+                    .into());
+                };
+                let cancelled_count = self.manager.cancel_tree(&child_task_id).await;
+                (child_task_id, cancelled_count)
+            }
+            _ => {
+                return Err(ToolError::InvalidArguments(
+                    "unknown cancellation relation".into(),
+                ));
+            }
+        };
+
+        let receipt = if cancelled_count == 0 {
+            Self::make_error(root_task_id, CancelTaskError::TaskNotFound)
+        } else {
+            Self::make_receipt(root_task_id, cancelled_count)
+        };
+
+        Ok(ToolResult::success(
+            CANCEL_TASK_TOOL_ID,
+            serde_json::to_value(receipt).unwrap_or_default(),
+        )
+        .into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::background::{BackgroundTaskPlugin, TaskParentContext, TaskResult};
+    use crate::phase::ExecutionEnv;
+    use crate::plugins::Plugin;
+    use crate::state::StateStore;
+    use awaken_contract::contract::identity::RunIdentity;
+    use awaken_contract::registry_spec::AgentSpec;
+
+    fn make_manager_and_store() -> (Arc<BackgroundTaskManager>, StateStore) {
+        let store = StateStore::new();
+        let manager = Arc::new(BackgroundTaskManager::new());
+        manager.set_store(store.clone());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager.clone()));
+        let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
+        store.register_keys(&env.key_registrations).unwrap();
+        (manager, store)
+    }
+
+    fn make_ctx_with_store_and_task(
+        thread_id: &str,
+        agent_id: &str,
+        store: &StateStore,
+        task_id: Option<&str>,
+    ) -> ToolCallContext {
+        make_ctx_with_store_and_task_and_token(
+            thread_id,
+            agent_id,
+            store,
+            task_id,
+            Some(crate::cancellation::CancellationToken::new()),
+        )
+    }
+
+    fn make_ctx_with_store_and_task_and_token(
+        thread_id: &str,
+        agent_id: &str,
+        store: &StateStore,
+        _task_id: Option<&str>,
+        cancellation_token: Option<crate::cancellation::CancellationToken>,
+    ) -> ToolCallContext {
+        ToolCallContext {
+            call_id: "call-1".into(),
+            tool_name: CANCEL_TASK_TOOL_ID.into(),
+            run_identity: RunIdentity::new(
+                thread_id.to_string(),
+                None,
+                "run-1".to_string(),
+                None,
+                agent_id.to_string(),
+                awaken_contract::contract::identity::RunOrigin::Subagent,
+            ),
+            agent_spec: Arc::new(AgentSpec::default()),
+            snapshot: store.snapshot(),
+            activity_sink: None,
+            cancellation_token,
+            resume_input: None,
+            suspension_id: None,
+            suspension_reason: None,
+        }
+    }
+
+    #[test]
+    fn accepts_self_target() {
+        let (manager, _store) = make_manager_and_store();
+        let tool = CancelTaskTool::new(manager);
+        assert!(
+            tool.validate_args(&json!({"target": {"relation": "self"}}))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_child_without_name() {
+        let (manager, _store) = make_manager_and_store();
+        let tool = CancelTaskTool::new(manager);
+        assert!(
+            tool.validate_args(&json!({"target": {"relation": "child"}}))
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn self_cancel_cascades_to_descendants() {
+        let (manager, store) = make_manager_and_store();
+
+        let parent_id = manager
+            .spawn(
+                "thread-1",
+                "root_task",
+                Some("root-task"),
+                "parent task",
+                TaskParentContext::default(),
+                |ctx| async move {
+                    ctx.cancelled().await;
+                    TaskResult::Cancelled
+                },
+            )
+            .await
+            .unwrap();
+
+        let child_id = manager
+            .spawn(
+                "thread-1",
+                "child",
+                Some("child"),
+                "child task",
+                TaskParentContext {
+                    task_id: Some(parent_id.clone()),
+                    ..TaskParentContext::default()
+                },
+                |ctx| async move {
+                    ctx.cancelled().await;
+                    TaskResult::Cancelled
+                },
+            )
+            .await
+            .unwrap();
+
+        let grandchild_id = manager
+            .spawn(
+                "thread-1",
+                "grandchild",
+                Some("grandchild"),
+                "grandchild task",
+                TaskParentContext {
+                    task_id: Some(child_id.clone()),
+                    ..TaskParentContext::default()
+                },
+                |ctx| async move {
+                    ctx.cancelled().await;
+                    TaskResult::Cancelled
+                },
+            )
+            .await
+            .unwrap();
+
+        let tool = CancelTaskTool::with_current_task(manager.clone(), parent_id.clone());
+        let ctx = make_ctx_with_store_and_task("thread-1", "agent", &store, None);
+        let result = tool
+            .execute(json!({"target": {"relation": "self"}}), &ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(result.result.data["status"], "accepted");
+        assert_eq!(result.result.data["root_task_id"], parent_id);
+        assert_eq!(result.result.data["cancelled_count"], 3);
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            manager.get(&child_id).await.unwrap().status,
+            super::super::types::TaskStatus::Cancelled
+        );
+        assert_eq!(
+            manager.get(&grandchild_id).await.unwrap().status,
+            super::super::types::TaskStatus::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn self_cancel_from_run_context_cascades_run_children() {
+        let (manager, store) = make_manager_and_store();
+
+        let child_id = manager
+            .spawn(
+                "thread-1",
+                "child",
+                Some("child"),
+                "child task",
+                TaskParentContext {
+                    run_id: Some("run-1".into()),
+                    ..TaskParentContext::default()
+                },
+                |ctx| async move {
+                    ctx.cancelled().await;
+                    TaskResult::Cancelled
+                },
+            )
+            .await
+            .unwrap();
+
+        let grandchild_id = manager
+            .spawn(
+                "thread-1",
+                "grandchild",
+                Some("grandchild"),
+                "grandchild task",
+                TaskParentContext {
+                    task_id: Some(child_id.clone()),
+                    ..TaskParentContext::default()
+                },
+                |ctx| async move {
+                    ctx.cancelled().await;
+                    TaskResult::Cancelled
+                },
+            )
+            .await
+            .unwrap();
+
+        let tool = CancelTaskTool::new(manager.clone());
+        let cancellation_token = crate::cancellation::CancellationToken::new();
+        let ctx = make_ctx_with_store_and_task_and_token(
+            "thread-1",
+            "agent",
+            &store,
+            None,
+            Some(cancellation_token.clone()),
+        );
+        let result = tool
+            .execute(json!({"target": {"relation": "self"}}), &ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(result.result.data["status"], "accepted");
+        assert_eq!(result.result.data["root_task_id"], "run-1");
+        assert_eq!(result.result.data["cancelled_count"], 3);
+        assert!(cancellation_token.is_cancelled());
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            manager.get(&child_id).await.unwrap().status,
+            super::super::types::TaskStatus::Cancelled
+        );
+        assert_eq!(
+            manager.get(&grandchild_id).await.unwrap().status,
+            super::super::types::TaskStatus::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn self_cancel_without_task_context_fails() {
+        let (manager, store) = make_manager_and_store();
+        let tool = CancelTaskTool::new(manager);
+        let ctx = make_ctx_with_store_and_task_and_token("thread-1", "agent", &store, None, None);
+        let err = tool
+            .execute(json!({"target": {"relation": "self"}}), &ctx)
+            .await
+            .expect_err("missing current task context should fail");
+        assert!(
+            err.to_string()
+                .contains(CancelTaskError::CurrentTaskUnavailable.to_string().as_str())
+        );
+    }
+}

--- a/crates/awaken-runtime/src/extensions/background/execution_context.rs
+++ b/crates/awaken-runtime/src/extensions/background/execution_context.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use super::{BackgroundTaskManager, TaskId};
+
+tokio::task_local! {
+    static CURRENT_BACKGROUND_TASK_CONTEXT: BackgroundTaskExecutionContext;
+}
+
+tokio::task_local! {
+    static CURRENT_TOOL_LINEAGE_CONTEXT: ToolLineageContext;
+}
+
+#[derive(Clone)]
+pub(crate) struct BackgroundTaskExecutionContext {
+    pub(crate) manager: Arc<BackgroundTaskManager>,
+    pub(crate) task_id: TaskId,
+}
+
+#[derive(Clone)]
+pub(crate) struct ToolLineageContext {
+    pub(crate) run_id: String,
+    pub(crate) call_id: String,
+    pub(crate) agent_id: String,
+}
+
+pub(crate) async fn scope_background_task_context<Fut>(
+    context: BackgroundTaskExecutionContext,
+    future: Fut,
+) -> Fut::Output
+where
+    Fut: std::future::Future,
+{
+    CURRENT_BACKGROUND_TASK_CONTEXT.scope(context, future).await
+}
+
+pub(crate) fn current_background_task_context() -> Option<BackgroundTaskExecutionContext> {
+    CURRENT_BACKGROUND_TASK_CONTEXT.try_with(Clone::clone).ok()
+}
+
+pub(crate) async fn scope_tool_lineage_context<Fut>(
+    context: ToolLineageContext,
+    future: Fut,
+) -> Fut::Output
+where
+    Fut: std::future::Future,
+{
+    CURRENT_TOOL_LINEAGE_CONTEXT.scope(context, future).await
+}
+
+pub(crate) fn current_tool_lineage_context() -> Option<ToolLineageContext> {
+    CURRENT_TOOL_LINEAGE_CONTEXT.try_with(Clone::clone).ok()
+}

--- a/crates/awaken-runtime/src/extensions/background/manager.rs
+++ b/crates/awaken-runtime/src/extensions/background/manager.rs
@@ -14,7 +14,12 @@ use super::state::{
     PersistedTaskMeta,
 };
 use super::types::{
-    TaskContext, TaskEvent, TaskId, TaskParentContext, TaskResult, TaskStatus, TaskSummary,
+    AgentTaskContext, TaskContext, TaskEvent, TaskId, TaskParentContext, TaskResult, TaskStatus,
+    TaskSummary,
+};
+use super::{
+    BackgroundTaskExecutionContext, current_background_task_context, current_tool_lineage_context,
+    scope_background_task_context,
 };
 
 /// Errors from [`BackgroundTaskManager::send_task_inbox_message`].
@@ -158,6 +163,31 @@ impl BackgroundTaskManager {
         format!("bg_{n}")
     }
 
+    fn merge_ambient_parent_context(
+        &self,
+        mut parent_context: TaskParentContext,
+    ) -> TaskParentContext {
+        if parent_context.task_id.is_none()
+            && let Some(context) = current_background_task_context()
+        {
+            parent_context.task_id = Some(context.task_id);
+        }
+
+        if let Some(context) = current_tool_lineage_context() {
+            if parent_context.run_id.is_none() {
+                parent_context.run_id = Some(context.run_id);
+            }
+            if parent_context.call_id.is_none() && !context.call_id.is_empty() {
+                parent_context.call_id = Some(context.call_id);
+            }
+            if parent_context.agent_id.is_none() && !context.agent_id.is_empty() {
+                parent_context.agent_id = Some(context.agent_id);
+            }
+        }
+
+        parent_context
+    }
+
     /// Commit a state update to the store (if available).
     fn commit_meta(&self, action: BackgroundTaskStateAction) {
         if let Some(store) = self.store() {
@@ -189,6 +219,7 @@ impl BackgroundTaskManager {
         F: FnOnce(TaskContext) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = TaskResult> + Send + 'static,
     {
+        let parent_context = self.merge_ambient_parent_context(parent_context);
         if let Some(n) = name {
             self.validate_name(n, owner_thread_id)?;
         }
@@ -230,7 +261,14 @@ impl BackgroundTaskManager {
         let desc = description.to_string();
 
         let join_handle = tokio::spawn(async move {
-            let result = task_fn(ctx).await;
+            let result = scope_background_task_context(
+                BackgroundTaskExecutionContext {
+                    manager: manager.clone(),
+                    task_id: tid.clone(),
+                },
+                task_fn(ctx),
+            )
+            .await;
             let completed_at = now_ms();
 
             // Update metadata in the store
@@ -303,6 +341,37 @@ impl BackgroundTaskManager {
             return true;
         }
         false
+    }
+
+    /// Cancel a task and every known descendant task in the same manager.
+    ///
+    /// Descendants are discovered through `TaskParentContext.task_id`.
+    /// Returns the number of live tasks whose cancellation token was signalled.
+    pub async fn cancel_tree(&self, task_id: &str) -> usize {
+        let Some(task_ids) = self.task_tree_ids(task_id) else {
+            return 0;
+        };
+
+        let handles = self.handles.lock().await;
+        let store_snap = self
+            .store()
+            .and_then(|s| s.read::<BackgroundTaskStateKey>());
+        let mut count = 0;
+        for task_id in task_ids {
+            let Some(handle) = handles.get(&task_id) else {
+                continue;
+            };
+            let is_terminal = store_snap
+                .as_ref()
+                .and_then(|snap| snap.tasks.get(&task_id))
+                .map(|meta| meta.status.is_terminal())
+                .unwrap_or(false);
+            if !is_terminal {
+                handle.cancel_handle.cancel();
+                count += 1;
+            }
+        }
+        count
     }
 
     /// Cancel all running tasks for a given thread.
@@ -445,6 +514,27 @@ impl BackgroundTaskManager {
             + 'static,
         Fut: std::future::Future<Output = TaskResult> + Send + 'static,
     {
+        self.spawn_agent_with_context(owner_thread_id, name, description, parent_context, |ctx| {
+            task_fn(ctx.cancel_token, ctx.inbox_sender, ctx.inbox_receiver)
+        })
+        .await
+    }
+
+    /// Spawn a sub-agent as a background task while exposing the spawned task
+    /// ID to the closure for lineage-aware coordination.
+    pub async fn spawn_agent_with_context<F, Fut>(
+        self: &Arc<Self>,
+        owner_thread_id: &str,
+        name: Option<&str>,
+        description: &str,
+        parent_context: TaskParentContext,
+        task_fn: F,
+    ) -> Result<TaskId, SpawnError>
+    where
+        F: FnOnce(AgentTaskContext) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = TaskResult> + Send + 'static,
+    {
+        let parent_context = self.merge_ambient_parent_context(parent_context);
         if let Some(n) = name {
             self.validate_name(n, owner_thread_id)?;
         }
@@ -482,7 +572,19 @@ impl BackgroundTaskManager {
         let desc = description.to_string();
 
         let join_handle = tokio::spawn(async move {
-            let result = task_fn(cancel_token, child_inbox_tx, child_inbox_rx).await;
+            let result = scope_background_task_context(
+                BackgroundTaskExecutionContext {
+                    manager: manager.clone(),
+                    task_id: tid.clone(),
+                },
+                task_fn(AgentTaskContext {
+                    task_id: tid.clone(),
+                    cancel_token,
+                    inbox_sender: child_inbox_tx,
+                    inbox_receiver: child_inbox_rx,
+                }),
+            )
+            .await;
             let completed_at = now_ms();
 
             let (status, error, result_val) = match &result {
@@ -582,6 +684,97 @@ impl BackgroundTaskManager {
         } else {
             Err(SendError::InboxClosed)
         }
+    }
+
+    pub(crate) fn task_tree_ids(&self, task_id: &str) -> Option<Vec<TaskId>> {
+        let snapshot = self
+            .store()
+            .and_then(|store| store.read::<BackgroundTaskStateKey>())?;
+        if !snapshot.tasks.contains_key(task_id) {
+            return None;
+        }
+
+        let mut ordered = Vec::new();
+        let mut stack = vec![task_id.to_string()];
+        while let Some(current) = stack.pop() {
+            if ordered.iter().any(|seen| seen == &current) {
+                continue;
+            }
+            ordered.push(current.clone());
+            for meta in snapshot.tasks.values() {
+                if meta.parent_context.task_id.as_deref() == Some(current.as_str()) {
+                    stack.push(meta.task_id.clone());
+                }
+            }
+        }
+        Some(ordered)
+    }
+
+    pub(crate) fn resolve_live_child_task(
+        &self,
+        parent_task_id: &str,
+        name_or_task_id: &str,
+    ) -> Option<TaskId> {
+        let snapshot = self.store()?.read::<BackgroundTaskStateKey>()?;
+        for meta in snapshot.tasks.values() {
+            if meta.status.is_terminal() {
+                continue;
+            }
+            if meta.parent_context.task_id.as_deref() != Some(parent_task_id) {
+                continue;
+            }
+            if meta.task_id == name_or_task_id || meta.name.as_deref() == Some(name_or_task_id) {
+                return Some(meta.task_id.clone());
+            }
+        }
+        None
+    }
+
+    pub(crate) fn resolve_live_child_run(
+        &self,
+        parent_run_id: &str,
+        name_or_task_id: &str,
+    ) -> Option<TaskId> {
+        let snapshot = self.store()?.read::<BackgroundTaskStateKey>()?;
+        for meta in snapshot.tasks.values() {
+            if meta.status.is_terminal() {
+                continue;
+            }
+            if meta.parent_context.run_id.as_deref() != Some(parent_run_id)
+                || meta.parent_context.task_id.is_some()
+            {
+                continue;
+            }
+            if meta.task_id == name_or_task_id || meta.name.as_deref() == Some(name_or_task_id) {
+                return Some(meta.task_id.clone());
+            }
+        }
+        None
+    }
+
+    pub async fn cancel_descendants_for_run(&self, parent_run_id: &str) -> usize {
+        let root_task_ids = self
+            .store()
+            .and_then(|store| store.read::<BackgroundTaskStateKey>())
+            .map(|snapshot| {
+                snapshot
+                    .tasks
+                    .values()
+                    .filter(|meta| {
+                        !meta.status.is_terminal()
+                            && meta.parent_context.run_id.as_deref() == Some(parent_run_id)
+                            && meta.parent_context.task_id.is_none()
+                    })
+                    .map(|meta| meta.task_id.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let mut cancelled = 0usize;
+        for task_id in root_task_ids {
+            cancelled += self.cancel_tree(&task_id).await;
+        }
+        cancelled
     }
 
     #[cfg(test)]

--- a/crates/awaken-runtime/src/extensions/background/mod.rs
+++ b/crates/awaken-runtime/src/extensions/background/mod.rs
@@ -3,6 +3,8 @@
 //! Provides a system for spawning, tracking, cancelling, and querying
 //! background tasks. Tasks are tracked in-memory and outlive individual runs.
 
+mod cancel_task_tool;
+mod execution_context;
 mod hook;
 mod manager;
 mod plugin;
@@ -10,12 +12,19 @@ mod send_message_tool;
 pub(crate) mod state;
 mod types;
 
+pub(crate) use cancel_task_tool::CANCEL_TASK_TOOL_ID;
+pub use cancel_task_tool::CancelTaskTool;
+pub(crate) use execution_context::{
+    BackgroundTaskExecutionContext, ToolLineageContext, current_background_task_context,
+    current_tool_lineage_context, scope_background_task_context, scope_tool_lineage_context,
+};
 pub use manager::{BackgroundTaskManager, SendError, SpawnError};
 pub use plugin::BackgroundTaskPlugin;
 pub use send_message_tool::SendMessageTool;
 pub use state::{BackgroundTaskViewKey, PersistedTaskMeta};
 pub use types::{
-    TaskContext, TaskEvent, TaskId, TaskParentContext, TaskResult, TaskStatus, TaskSummary,
+    AgentTaskContext, TaskContext, TaskEvent, TaskId, TaskParentContext, TaskResult, TaskStatus,
+    TaskSummary,
 };
 
 #[cfg(test)]

--- a/crates/awaken-runtime/src/extensions/background/plugin.rs
+++ b/crates/awaken-runtime/src/extensions/background/plugin.rs
@@ -1,12 +1,12 @@
-use std::sync::Arc;
-
 use awaken_contract::StateError;
 use awaken_contract::model::Phase;
 use awaken_contract::registry_spec::AgentSpec;
+use std::sync::Arc;
 
 use crate::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
 use crate::state::{KeyScope, MutationBatch, StateKeyOptions, StateStore};
 
+use super::cancel_task_tool::{CANCEL_TASK_TOOL_ID, CancelTaskTool};
 use super::hook::BackgroundTaskSyncHook;
 use super::manager::BackgroundTaskManager;
 use super::state::{BackgroundTaskStateKey, BackgroundTaskViewKey};
@@ -60,6 +60,10 @@ impl Plugin for BackgroundTaskPlugin {
             scope: KeyScope::Thread,
             ..StateKeyOptions::default()
         })?;
+        registrar.register_tool(
+            CANCEL_TASK_TOOL_ID,
+            Arc::new(CancelTaskTool::new(self.manager.clone())),
+        )?;
 
         // Sync task metadata into persisted state at run boundaries.
         registrar.register_phase_hook(

--- a/crates/awaken-runtime/src/extensions/background/tests.rs
+++ b/crates/awaken-runtime/src/extensions/background/tests.rs
@@ -197,6 +197,14 @@ fn plugin_registers_key() {
     assert!(registry.keys_by_name.contains_key("background_task_state"));
 }
 
+#[test]
+fn plugin_registers_cancel_task_tool() {
+    let manager = Arc::new(BackgroundTaskManager::new());
+    let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager));
+    let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
+    assert!(env.tools.contains_key("cancel_task"));
+}
+
 #[tokio::test]
 async fn run_start_restores_persisted_metadata_into_manager() {
     let store = StateStore::new();

--- a/crates/awaken-runtime/src/extensions/background/tests.rs
+++ b/crates/awaken-runtime/src/extensions/background/tests.rs
@@ -184,6 +184,104 @@ async fn manager_cancel_nonexistent() {
     assert!(!manager.cancel("nonexistent").await);
 }
 
+#[tokio::test]
+async fn manager_cancel_tree_cascades_to_descendants() {
+    let (manager, _store) = manager_with_store();
+    let parent_id = manager
+        .spawn(
+            "thread-1",
+            "root_task",
+            Some("root-task"),
+            "parent task",
+            TaskParentContext::default(),
+            |ctx| async move {
+                ctx.cancelled().await;
+                TaskResult::Cancelled
+            },
+        )
+        .await
+        .unwrap();
+    let child_id = manager
+        .spawn(
+            "thread-1",
+            "child",
+            Some("child"),
+            "child task",
+            TaskParentContext {
+                task_id: Some(parent_id.clone()),
+                ..TaskParentContext::default()
+            },
+            |ctx| async move {
+                ctx.cancelled().await;
+                TaskResult::Cancelled
+            },
+        )
+        .await
+        .unwrap();
+    let grandchild_id = manager
+        .spawn(
+            "thread-1",
+            "grandchild",
+            Some("grandchild"),
+            "grandchild task",
+            TaskParentContext {
+                task_id: Some(child_id.clone()),
+                ..TaskParentContext::default()
+            },
+            |ctx| async move {
+                ctx.cancelled().await;
+                TaskResult::Cancelled
+            },
+        )
+        .await
+        .unwrap();
+
+    let cancelled = manager.cancel_tree(&parent_id).await;
+    assert_eq!(cancelled, 3);
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        manager.get(&parent_id).await.unwrap().status,
+        TaskStatus::Cancelled
+    );
+    assert_eq!(
+        manager.get(&child_id).await.unwrap().status,
+        TaskStatus::Cancelled
+    );
+    assert_eq!(
+        manager.get(&grandchild_id).await.unwrap().status,
+        TaskStatus::Cancelled
+    );
+}
+
+#[tokio::test]
+async fn spawn_agent_with_context_exposes_task_id() {
+    let (manager, _store) = manager_with_store();
+    let seen = Arc::new(tokio::sync::Mutex::new(None::<String>));
+    let seen_clone = Arc::clone(&seen);
+
+    let task_id = manager
+        .spawn_agent_with_context(
+            "thread-1",
+            Some("worker"),
+            "worker",
+            TaskParentContext::default(),
+            move |ctx| {
+                let seen = Arc::clone(&seen_clone);
+                async move {
+                    *seen.lock().await = Some(ctx.task_id.clone());
+                    ctx.cancel_token.cancel();
+                    TaskResult::Cancelled
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(seen.lock().await.as_deref(), Some(task_id.as_str()));
+}
+
 #[test]
 fn plugin_registers_key() {
     let store = StateStore::new();
@@ -1000,6 +1098,7 @@ fn task_summary_serde_roundtrip() {
 async fn spawn_with_parent_context_preserves_lineage() {
     let (manager, _store) = manager_with_store();
     let ctx = TaskParentContext {
+        task_id: None,
         run_id: Some("run-abc".into()),
         call_id: Some("call-xyz".into()),
         agent_id: Some("agent-007".into()),
@@ -1040,6 +1139,126 @@ async fn spawn_with_parent_context_preserves_lineage() {
     assert_eq!(meta.parent_context.agent_id.as_deref(), Some("agent-007"));
 }
 
+#[tokio::test]
+async fn spawn_with_default_parent_context_inherits_ambient_tool_lineage() {
+    let (manager, _store) = manager_with_store();
+
+    let task_id = super::scope_tool_lineage_context(
+        super::ToolLineageContext {
+            run_id: "run-ambient".into(),
+            call_id: "call-ambient".into(),
+            agent_id: "agent-ambient".into(),
+        },
+        async {
+            manager
+                .spawn(
+                    "thread-1",
+                    "test",
+                    None,
+                    "ambient lineage task",
+                    TaskParentContext::default(),
+                    |_| async { TaskResult::Success(serde_json::json!({"ok": true})) },
+                )
+                .await
+                .unwrap()
+        },
+    )
+    .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let summary = manager.get(&task_id).await.unwrap();
+    assert_eq!(
+        summary.parent_context.run_id.as_deref(),
+        Some("run-ambient")
+    );
+    assert_eq!(
+        summary.parent_context.call_id.as_deref(),
+        Some("call-ambient")
+    );
+    assert_eq!(
+        summary.parent_context.agent_id.as_deref(),
+        Some("agent-ambient")
+    );
+}
+
+#[tokio::test]
+async fn nested_spawn_inherits_parent_task_id_from_ambient_task_context() {
+    let (manager, _store) = manager_with_store();
+    let child_task_id = Arc::new(tokio::sync::Mutex::new(None::<String>));
+    let child_task_id_seen = child_task_id.clone();
+
+    let root_id = manager
+        .spawn(
+            "thread-1",
+            "root",
+            Some("root"),
+            "root task",
+            TaskParentContext::default(),
+            {
+                let manager = manager.clone();
+                move |ctx| {
+                    let manager = manager.clone();
+                    let child_task_id_seen = child_task_id_seen.clone();
+                    async move {
+                        let current = super::current_background_task_context()
+                            .expect("plain background task should expose current task context");
+                        assert_eq!(current.task_id, ctx.task_id);
+
+                        let child_id = manager
+                            .spawn(
+                                "thread-1",
+                                "child",
+                                Some("child"),
+                                "child task",
+                                TaskParentContext::default(),
+                                |child_ctx| async move {
+                                    child_ctx.cancelled().await;
+                                    TaskResult::Cancelled
+                                },
+                            )
+                            .await
+                            .unwrap();
+                        *child_task_id_seen.lock().await = Some(child_id);
+
+                        ctx.cancelled().await;
+                        TaskResult::Cancelled
+                    }
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let child_id = child_task_id
+        .lock()
+        .await
+        .clone()
+        .expect("child task id should be recorded");
+    let child_summary = manager
+        .get(&child_id)
+        .await
+        .expect("child task should be queryable");
+    assert_eq!(
+        child_summary.parent_context.task_id.as_deref(),
+        Some(root_id.as_str())
+    );
+
+    assert_eq!(manager.cancel_tree(&root_id).await, 2);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    assert_eq!(
+        manager.get(&root_id).await.unwrap().status,
+        TaskStatus::Cancelled
+    );
+    assert_eq!(
+        manager.get(&child_id).await.unwrap().status,
+        TaskStatus::Cancelled
+    );
+}
+
 #[test]
 fn persisted_task_meta_with_parent_context_serde_roundtrip() {
     let meta = PersistedTaskMeta {
@@ -1054,6 +1273,7 @@ fn persisted_task_meta_with_parent_context_serde_roundtrip() {
         created_at_ms: 500,
         completed_at_ms: Some(600),
         parent_context: TaskParentContext {
+            task_id: None,
             run_id: Some("run-123".into()),
             call_id: None,
             agent_id: Some("agent-a".into()),
@@ -1130,6 +1350,13 @@ fn task_parent_context_is_empty() {
     assert!(TaskParentContext::default().is_empty());
     assert!(
         !TaskParentContext {
+            task_id: Some("t".into()),
+            ..Default::default()
+        }
+        .is_empty()
+    );
+    assert!(
+        !TaskParentContext {
             run_id: Some("r".into()),
             ..Default::default()
         }
@@ -1180,6 +1407,7 @@ fn task_summary_with_parent_context_includes_field_in_json() {
         created_at_ms: 100,
         completed_at_ms: None,
         parent_context: TaskParentContext {
+            task_id: None,
             run_id: Some("run-1".into()),
             call_id: None,
             agent_id: None,
@@ -1770,6 +1998,7 @@ async fn full_lifecycle_sub_agent_with_child_tasks() {
             None,
             "worker-agent",
             TaskParentContext {
+                task_id: None,
                 run_id: Some("run-1".into()),
                 call_id: None,
                 agent_id: Some("parent".into()),

--- a/crates/awaken-runtime/src/extensions/background/types.rs
+++ b/crates/awaken-runtime/src/extensions/background/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::cancellation::CancellationToken;
-use crate::inbox::InboxSender;
+use crate::inbox::{InboxReceiver, InboxSender};
 
 /// Unique identifier for a background task.
 pub type TaskId = String;
@@ -55,10 +55,16 @@ impl TaskResult {
 /// Optional parent execution context for background task lineage tracking.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TaskParentContext {
+    /// Parent background task ID when this task is spawned from another task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    /// Parent run ID when this task is spawned from an agent run/tool call.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
+    /// Parent tool call ID that created this task, when available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
+    /// Parent agent ID that created this task, when available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
 }
@@ -66,8 +72,27 @@ pub struct TaskParentContext {
 impl TaskParentContext {
     /// Returns `true` when no lineage fields are set.
     pub fn is_empty(&self) -> bool {
-        self.run_id.is_none() && self.call_id.is_none() && self.agent_id.is_none()
+        self.task_id.is_none()
+            && self.run_id.is_none()
+            && self.call_id.is_none()
+            && self.agent_id.is_none()
     }
+}
+
+/// Runtime context passed to sub-agent task closures.
+///
+/// Exposes the spawned task's stable `task_id` so nested agent execution can
+/// publish lineage metadata (for example, self-cancel and cascading child
+/// cancellation).
+pub struct AgentTaskContext {
+    /// Unique identifier of the spawned background task.
+    pub task_id: TaskId,
+    /// Shared cancellation token for the task.
+    pub cancel_token: CancellationToken,
+    /// Inbox sender used by nested children to deliver live events/messages.
+    pub inbox_sender: InboxSender,
+    /// Inbox receiver consumed by the task's inner agent loop.
+    pub inbox_receiver: InboxReceiver,
 }
 
 /// Context provided to every background task closure.

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -1225,6 +1225,17 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
         execute_tools_with_interception(ctx, &mut transcript, &stream_result.tool_calls).await?;
     transcript.commit_into(ctx.messages);
 
+    if ctx.cancellation_token.is_some_and(|t| t.is_cancelled()) {
+        commit_update::<RunLifecycle>(
+            store,
+            RunLifecycleUpdate::Done {
+                done_reason: "cancelled".into(),
+                updated_at: now_ms(),
+            },
+        )?;
+        return Ok(StepOutcome::Cancelled);
+    }
+
     if let Some(reason) = blocked_reason {
         commit_update::<RunLifecycle>(
             store,

--- a/crates/awaken-runtime/tests/background_task_lifecycle.rs
+++ b/crates/awaken-runtime/tests/background_task_lifecycle.rs
@@ -449,6 +449,7 @@ async fn parent_child_message_roundtrip() {
             Some("worker"),
             "long-running worker agent",
             TaskParentContext {
+                task_id: None,
                 run_id: Some("run-parent".into()),
                 call_id: None,
                 agent_id: Some("parent-agent".into()),

--- a/crates/awaken-server/tests/a2a_http.rs
+++ b/crates/awaken-server/tests/a2a_http.rs
@@ -4,13 +4,21 @@ use async_trait::async_trait;
 use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::contract::lifecycle::RunStatus;
-use awaken_contract::contract::message::Message;
+use awaken_contract::contract::lifecycle::TerminationReason;
+use awaken_contract::contract::message::{Message, ToolCall};
 use awaken_contract::contract::storage::{
     RunRecord, RunStore, RunWaitingState, ThreadRunStore, ThreadStore, WaitingReason,
+};
+use awaken_contract::contract::tool::{
+    Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
 };
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_contract::thread::Thread;
 use awaken_runtime::builder::AgentRuntimeBuilder;
+use awaken_runtime::extensions::background::{
+    BackgroundTaskManager, BackgroundTaskPlugin, TaskParentContext,
+    TaskResult as BackgroundTaskResult, TaskStatus,
+};
 use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::routes::build_router;
@@ -18,7 +26,7 @@ use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
 use axum::http::{Request, StatusCode};
 use serde_json::{Value, json};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tower::ServiceExt;
 
@@ -64,6 +72,95 @@ impl LlmExecutor for DelayedExecutor {
 
     fn name(&self) -> &str {
         "delayed"
+    }
+}
+
+struct ScriptedLlm {
+    responses: Mutex<Vec<StreamResult>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<StreamResult>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+
+    fn tool_call_response(calls: Vec<ToolCall>) -> StreamResult {
+        StreamResult {
+            content: vec![],
+            tool_calls: calls,
+            usage: Some(TokenUsage::default()),
+            stop_reason: Some(StopReason::ToolUse),
+            has_incomplete_tool_calls: false,
+        }
+    }
+}
+
+#[async_trait]
+impl LlmExecutor for ScriptedLlm {
+    async fn execute(
+        &self,
+        _request: InferenceRequest,
+    ) -> Result<StreamResult, InferenceExecutionError> {
+        let mut responses = self.responses.lock().expect("responses lock");
+        Ok(if responses.is_empty() {
+            StreamResult {
+                content: vec![],
+                tool_calls: vec![],
+                usage: Some(TokenUsage::default()),
+                stop_reason: Some(StopReason::EndTurn),
+                has_incomplete_tool_calls: false,
+            }
+        } else {
+            responses.remove(0)
+        })
+    }
+
+    fn name(&self) -> &str {
+        "scripted"
+    }
+}
+
+struct SpawnBackgroundChildTool {
+    manager: Arc<BackgroundTaskManager>,
+}
+
+#[async_trait]
+impl Tool for SpawnBackgroundChildTool {
+    fn descriptor(&self) -> ToolDescriptor {
+        ToolDescriptor::new(
+            "spawn_bg_child",
+            "spawn_bg_child",
+            "Spawn a cancellable background child task",
+        )
+        .with_parameters(json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            }
+        }))
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+        let name = args.get("name").and_then(Value::as_str).unwrap_or("leaf");
+        let task_id = self
+            .manager
+            .spawn(
+                &ctx.run_identity.thread_id,
+                "background_child",
+                Some(name),
+                "child spawned from A2A test",
+                TaskParentContext::default(),
+                |task_ctx| async move {
+                    task_ctx.cancelled().await;
+                    BackgroundTaskResult::Cancelled
+                },
+            )
+            .await
+            .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+
+        Ok(ToolResult::success("spawn_bg_child", json!({"task_id": task_id})).into())
     }
 }
 
@@ -129,6 +226,71 @@ fn make_test_app(agent_ids: &[&str]) -> axum::Router {
         Arc::new(ImmediateExecutor),
         ServerConfig::default(),
     )
+}
+
+fn build_background_cancel_fixture()
+-> (axum::Router, Arc<InMemoryStore>, Arc<BackgroundTaskManager>) {
+    let manager = Arc::new(BackgroundTaskManager::new());
+    let executor = Arc::new(ScriptedLlm::new(vec![ScriptedLlm::tool_call_response(
+        vec![
+            ToolCall::new("call-spawn", "spawn_bg_child", json!({"name": "leaf"})),
+            ToolCall::new(
+                "call-cancel",
+                "cancel_task",
+                json!({"target": {"relation": "self"}}),
+            ),
+        ],
+    )]));
+
+    let store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_model_binding(
+                "test-model",
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
+                },
+            )
+            .with_provider("mock", executor)
+            .with_agent_spec(AgentSpec {
+                id: "alpha".into(),
+                model_id: "test-model".into(),
+                system_prompt: "cancel yourself after spawning a child".into(),
+                max_rounds: 2,
+                plugin_ids: vec!["background".into()],
+                ..Default::default()
+            })
+            .with_tool(
+                "spawn_bg_child",
+                Arc::new(SpawnBackgroundChildTool {
+                    manager: manager.clone(),
+                }),
+            )
+            .with_plugin(
+                "background",
+                Arc::new(BackgroundTaskPlugin::new(manager.clone())),
+            )
+            .with_thread_run_store(store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    let mailbox_store = Arc::new(awaken_stores::InMemoryMailboxStore::new());
+    let mailbox = Arc::new(awaken_server::mailbox::Mailbox::new(
+        runtime.clone(),
+        mailbox_store,
+        store.clone(),
+        "test".to_string(),
+        awaken_server::mailbox::MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime.clone(),
+        mailbox,
+        store.clone(),
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+    (build_router().with_state(state), store, manager)
 }
 
 async fn request_json(
@@ -309,6 +471,69 @@ async fn message_send_returns_task_wrapper_and_task_is_retrievable() {
                 && message["role"].as_str() == Some("ROLE_USER")
         }),
         "user message missing from history: {task}"
+    );
+}
+
+#[tokio::test]
+async fn a2a_message_send_self_cancel_cascades_background_run_children() {
+    let (app, store, manager) = build_background_cancel_fixture();
+    let task_id = "task-a2a-self-cancel";
+    let context_id = "thread-a2a-self-cancel";
+
+    let (status, body) = request_json(
+        &app,
+        "POST",
+        "/v1/a2a/message:send",
+        &[("content-type", "application/json")],
+        Some(send_message_payload(
+            task_id,
+            context_id,
+            "msg-a2a-self-cancel",
+            "spawn a child and then cancel yourself",
+        )),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "unexpected body: {body}");
+    assert_eq!(body["task"]["id"].as_str(), Some(task_id));
+    assert_eq!(body["task"]["contextId"].as_str(), Some(context_id));
+    assert_eq!(
+        body["task"]["status"]["state"].as_str(),
+        Some("TASK_STATE_CANCELED"),
+        "expected cancelled A2A task body: {body}"
+    );
+
+    let run = store
+        .load_run(task_id)
+        .await
+        .expect("load run")
+        .expect("run should exist");
+    assert_eq!(run.status, RunStatus::Done);
+    assert_eq!(run.termination_reason, Some(TerminationReason::Cancelled));
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let tasks = manager.list(context_id).await;
+    assert_eq!(tasks.len(), 1, "expected one spawned child task: {tasks:?}");
+    assert_eq!(tasks[0].status, TaskStatus::Cancelled);
+    assert_eq!(tasks[0].task_type, "background_child");
+    assert_eq!(
+        tasks[0].parent_context.run_id.as_deref(),
+        Some(task_id),
+        "background child should be linked to the A2A run for cascade cancel"
+    );
+
+    let (status, task) = request_json(
+        &app,
+        "GET",
+        &format!("/v1/a2a/tasks/{task_id}?historyLength=10"),
+        &[],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        task["status"]["state"].as_str(),
+        Some("TASK_STATE_CANCELED")
     );
 }
 

--- a/crates/awaken-server/tests/a2a_loopback.rs
+++ b/crates/awaken-server/tests/a2a_loopback.rs
@@ -13,12 +13,26 @@
 //! Run with:
 //!   cargo test -p awaken-server --test a2a_loopback -- --ignored
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use async_trait::async_trait;
+use awaken_contract::contract::content::ContentBlock;
+use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
+use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+use awaken_contract::contract::lifecycle::{RunStatus, TerminationReason};
+use awaken_contract::contract::message::ToolCall;
+use awaken_contract::contract::storage::{RunQuery, RunStore};
+use awaken_contract::contract::tool::{
+    Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
+};
 use awaken_contract::registry_spec::{AgentSpec, RemoteEndpoint};
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::engine::executor::GenaiExecutor;
+use awaken_runtime::extensions::background::{
+    BackgroundTaskManager, BackgroundTaskPlugin, TaskParentContext,
+    TaskResult as BackgroundTaskResult, TaskStatus,
+};
 use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
@@ -126,9 +140,607 @@ async fn get_json(client: &reqwest::Client, url: &str) -> Value {
     serde_json::from_str(&text).expect("valid JSON response")
 }
 
+struct ScriptedLlm {
+    responses: Mutex<Vec<StreamResult>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<StreamResult>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+
+    fn tool_call_response(calls: Vec<ToolCall>) -> StreamResult {
+        StreamResult {
+            content: vec![],
+            tool_calls: calls,
+            usage: Some(TokenUsage::default()),
+            stop_reason: Some(StopReason::ToolUse),
+            has_incomplete_tool_calls: false,
+        }
+    }
+
+    fn text_response(text: &str) -> StreamResult {
+        StreamResult {
+            content: vec![ContentBlock::text(text)],
+            tool_calls: vec![],
+            usage: Some(TokenUsage::default()),
+            stop_reason: Some(StopReason::EndTurn),
+            has_incomplete_tool_calls: false,
+        }
+    }
+}
+
+#[async_trait]
+impl LlmExecutor for ScriptedLlm {
+    async fn execute(
+        &self,
+        _request: InferenceRequest,
+    ) -> Result<StreamResult, InferenceExecutionError> {
+        let mut responses = self.responses.lock().expect("responses lock");
+        Ok(if responses.is_empty() {
+            ScriptedLlm::text_response("")
+        } else {
+            responses.remove(0)
+        })
+    }
+
+    fn name(&self) -> &str {
+        "scripted"
+    }
+}
+
+struct SpawnBackgroundChildTool {
+    manager: Arc<BackgroundTaskManager>,
+}
+
+#[async_trait]
+impl Tool for SpawnBackgroundChildTool {
+    fn descriptor(&self) -> ToolDescriptor {
+        ToolDescriptor::new(
+            "spawn_bg_child",
+            "spawn_bg_child",
+            "Spawn a cancellable background child task",
+        )
+    }
+
+    async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+        let name = args.get("name").and_then(Value::as_str).unwrap_or("leaf");
+        let task_id = self
+            .manager
+            .spawn(
+                &ctx.run_identity.thread_id,
+                "background_child",
+                Some(name),
+                "child spawned from loopback worker",
+                TaskParentContext::default(),
+                |task_ctx| async move {
+                    task_ctx.cancelled().await;
+                    BackgroundTaskResult::Cancelled
+                },
+            )
+            .await
+            .map_err(|error| ToolError::ExecutionFailed(error.to_string()))?;
+
+        Ok(ToolResult::success("spawn_bg_child", serde_json::json!({ "task_id": task_id })).into())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a2a_loopback_remote_self_cancel_cascades_background_children() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind to random port");
+    let addr = listener.local_addr().expect("local addr");
+    let base_url = format!("http://127.0.0.1:{}", addr.port());
+    let manager = Arc::new(BackgroundTaskManager::new());
+
+    let orchestrator_executor = Arc::new(ScriptedLlm::new(vec![
+        ScriptedLlm::tool_call_response(vec![ToolCall::new(
+            "delegate-1",
+            "agent_run_worker-remote",
+            serde_json::json!({"prompt": "spawn a child and cancel yourself"}),
+        )]),
+        ScriptedLlm::text_response("observed remote cancellation"),
+    ]));
+    let worker_executor = Arc::new(ScriptedLlm::new(vec![ScriptedLlm::tool_call_response(
+        vec![
+            ToolCall::new(
+                "spawn-1",
+                "spawn_bg_child",
+                serde_json::json!({"name": "leaf"}),
+            ),
+            ToolCall::new(
+                "cancel-1",
+                "cancel_task",
+                serde_json::json!({"target": {"relation": "self"}}),
+            ),
+        ],
+    )]));
+
+    let orchestrator_spec = AgentSpec {
+        id: "orchestrator".into(),
+        model_id: "orchestrator-model".into(),
+        system_prompt: "delegate to the remote worker".into(),
+        max_rounds: 2,
+        delegates: vec!["worker-remote".into()],
+        ..Default::default()
+    };
+    let worker_local = AgentSpec {
+        id: "worker".into(),
+        model_id: "worker-model".into(),
+        system_prompt: "spawn a child and cancel yourself".into(),
+        max_rounds: 2,
+        plugin_ids: vec!["background".into()],
+        ..Default::default()
+    };
+    let worker_remote = AgentSpec {
+        id: "worker-remote".into(),
+        model_id: "worker-model".into(),
+        system_prompt: "remote worker".into(),
+        endpoint: Some(RemoteEndpoint {
+            backend: "a2a".into(),
+            base_url: format!("{base_url}/v1/a2a"),
+            auth: None,
+            target: Some("worker".into()),
+            timeout_ms: 5_000,
+            options: std::collections::BTreeMap::from([(
+                "poll_interval_ms".into(),
+                serde_json::json!(10_u64),
+            )]),
+        }),
+        ..Default::default()
+    };
+
+    let store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("orchestrator", orchestrator_executor)
+            .with_provider("worker", worker_executor)
+            .with_model_binding(
+                "orchestrator-model",
+                ModelBinding {
+                    provider_id: "orchestrator".into(),
+                    upstream_model: "mock-orchestrator".into(),
+                },
+            )
+            .with_model_binding(
+                "worker-model",
+                ModelBinding {
+                    provider_id: "worker".into(),
+                    upstream_model: "mock-worker".into(),
+                },
+            )
+            .with_tool(
+                "spawn_bg_child",
+                Arc::new(SpawnBackgroundChildTool {
+                    manager: manager.clone(),
+                }),
+            )
+            .with_plugin(
+                "background",
+                Arc::new(BackgroundTaskPlugin::new(manager.clone())),
+            )
+            .with_agent_spec(orchestrator_spec)
+            .with_agent_spec(worker_local)
+            .with_agent_spec(worker_remote)
+            .with_thread_run_store(store.clone())
+            .build_unchecked()
+            .expect("build runtime"),
+    );
+
+    let mailbox_store = Arc::new(InMemoryMailboxStore::new());
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        mailbox_store,
+        store.clone(),
+        "loopback-test".to_string(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime.clone(),
+        mailbox,
+        store.clone(),
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+
+    let router = build_router().with_state(state);
+    let server_handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let http = reqwest::Client::new();
+    let task_id = format!("loopback-cancel-{}", uuid::Uuid::now_v7());
+    let submit_resp = post_json(
+        &http,
+        &format!("{base_url}/v1/a2a/orchestrator/message:send"),
+        serde_json::json!({
+            "message": {
+                "taskId": task_id,
+                "contextId": task_id,
+                "messageId": format!("msg-{task_id}"),
+                "role": "ROLE_USER",
+                "parts": [{"text": "spawn a child and cancel yourself"}]
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(submit_resp["task"]["id"].as_str(), Some(task_id.as_str()));
+    assert_eq!(
+        submit_resp["task"]["status"]["state"].as_str(),
+        Some("TASK_STATE_COMPLETED"),
+        "orchestrator task should complete after observing remote cancellation: {submit_resp}"
+    );
+
+    let orchestrator_run = store
+        .load_run(&task_id)
+        .await
+        .expect("load orchestrator run")
+        .expect("orchestrator run should exist");
+    assert_eq!(orchestrator_run.status, RunStatus::Done);
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let worker_run = loop {
+        let page = store
+            .list_runs(&RunQuery {
+                limit: 20,
+                ..RunQuery::default()
+            })
+            .await
+            .expect("list runs");
+        let worker_runs = page
+            .items
+            .into_iter()
+            .filter(|run| run.agent_id == "worker")
+            .collect::<Vec<_>>();
+        if let Some(run) = worker_runs
+            .iter()
+            .find(|run| run.termination_reason == Some(TerminationReason::Cancelled))
+            .cloned()
+        {
+            break run;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "cancelled worker run did not appear before deadline: {worker_runs:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+
+    assert_eq!(worker_run.status, RunStatus::Done);
+    assert_eq!(
+        worker_run.termination_reason,
+        Some(TerminationReason::Cancelled)
+    );
+
+    let tasks = manager.list(&worker_run.thread_id).await;
+    assert_eq!(
+        tasks.len(),
+        1,
+        "expected one background child task: {tasks:?}"
+    );
+    assert_eq!(tasks[0].status, TaskStatus::Cancelled);
+    assert_eq!(tasks[0].task_type, "background_child");
+    assert_eq!(
+        tasks[0].parent_context.run_id.as_deref(),
+        Some(worker_run.run_id.as_str())
+    );
+
+    let runs = get_json(&http, &format!("{base_url}/v1/runs")).await;
+    let worker_statuses = runs["items"]
+        .as_array()
+        .expect("runs items")
+        .iter()
+        .filter(|item| item["agent_id"].as_str() == Some("worker"))
+        .filter_map(|item| item["status"].as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        worker_statuses.contains(&"done"),
+        "expected worker run to be visible in run listing: {runs}"
+    );
+
+    server_handle.abort();
+}
+
+/// Dual-server A2A loopback: orchestrator server delegates over HTTP to a
+/// separate worker server, where the remote worker self-cancels and cascades
+/// cancellation to its background descendants.
+#[tokio::test]
+async fn a2a_dual_server_remote_self_cancel_cascades_background_children() {
+    let worker_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind worker listener");
+    let worker_addr = worker_listener.local_addr().expect("worker local addr");
+    let worker_base_url = format!("http://127.0.0.1:{}", worker_addr.port());
+    let worker_manager = Arc::new(BackgroundTaskManager::new());
+    let worker_store = Arc::new(InMemoryStore::new());
+    let worker_runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider(
+                "worker",
+                Arc::new(ScriptedLlm::new(vec![ScriptedLlm::tool_call_response(
+                    vec![
+                        ToolCall::new(
+                            "spawn-1",
+                            "spawn_bg_child",
+                            serde_json::json!({"name": "leaf"}),
+                        ),
+                        ToolCall::new(
+                            "cancel-1",
+                            "cancel_task",
+                            serde_json::json!({"target": {"relation": "self"}}),
+                        ),
+                    ],
+                )])),
+            )
+            .with_model_binding(
+                "worker-model",
+                ModelBinding {
+                    provider_id: "worker".into(),
+                    upstream_model: "mock-worker".into(),
+                },
+            )
+            .with_tool(
+                "spawn_bg_child",
+                Arc::new(SpawnBackgroundChildTool {
+                    manager: worker_manager.clone(),
+                }),
+            )
+            .with_plugin(
+                "background",
+                Arc::new(BackgroundTaskPlugin::new(worker_manager.clone())),
+            )
+            .with_agent_spec(AgentSpec {
+                id: "worker".into(),
+                model_id: "worker-model".into(),
+                system_prompt: "spawn a child and cancel yourself".into(),
+                max_rounds: 2,
+                plugin_ids: vec!["background".into()],
+                ..Default::default()
+            })
+            .with_thread_run_store(worker_store.clone())
+            .build()
+            .expect("build worker runtime"),
+    );
+    let worker_mailbox = Arc::new(Mailbox::new(
+        worker_runtime.clone(),
+        Arc::new(InMemoryMailboxStore::new()),
+        worker_store.clone(),
+        "dual-loopback-worker".to_string(),
+        MailboxConfig::default(),
+    ));
+    let worker_state = AppState::new(
+        worker_runtime.clone(),
+        worker_mailbox,
+        worker_store.clone(),
+        worker_runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+    let worker_router = build_router().with_state(worker_state);
+    let worker_handle = tokio::spawn(async move {
+        axum::serve(worker_listener, worker_router).await.ok();
+    });
+
+    let orchestrator_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind orchestrator listener");
+    let orchestrator_addr = orchestrator_listener
+        .local_addr()
+        .expect("orchestrator local addr");
+    let orchestrator_base_url = format!("http://127.0.0.1:{}", orchestrator_addr.port());
+    let orchestrator_store = Arc::new(InMemoryStore::new());
+    let orchestrator_runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider(
+                "orchestrator",
+                Arc::new(ScriptedLlm::new(vec![
+                    ScriptedLlm::tool_call_response(vec![ToolCall::new(
+                        "delegate-1",
+                        "agent_run_worker-remote",
+                        serde_json::json!({"prompt": "spawn a child and cancel yourself"}),
+                    )]),
+                    ScriptedLlm::text_response("observed remote cancellation"),
+                ])),
+            )
+            .with_model_binding(
+                "orchestrator-model",
+                ModelBinding {
+                    provider_id: "orchestrator".into(),
+                    upstream_model: "mock-orchestrator".into(),
+                },
+            )
+            .with_model_binding(
+                "worker-remote-model",
+                ModelBinding {
+                    provider_id: "orchestrator".into(),
+                    upstream_model: "mock-worker-remote".into(),
+                },
+            )
+            .with_agent_spec(AgentSpec {
+                id: "orchestrator".into(),
+                model_id: "orchestrator-model".into(),
+                system_prompt: "delegate to the remote worker".into(),
+                max_rounds: 2,
+                delegates: vec!["worker-remote".into()],
+                ..Default::default()
+            })
+            .with_agent_spec(AgentSpec {
+                id: "worker-remote".into(),
+                model_id: "worker-remote-model".into(),
+                system_prompt: "remote worker".into(),
+                endpoint: Some(RemoteEndpoint {
+                    backend: "a2a".into(),
+                    base_url: format!("{worker_base_url}/v1/a2a"),
+                    auth: None,
+                    target: Some("worker".into()),
+                    timeout_ms: 5_000,
+                    options: std::collections::BTreeMap::from([(
+                        "poll_interval_ms".into(),
+                        serde_json::json!(10_u64),
+                    )]),
+                }),
+                ..Default::default()
+            })
+            .with_thread_run_store(orchestrator_store.clone())
+            .build_unchecked()
+            .expect("build orchestrator runtime"),
+    );
+    let orchestrator_mailbox = Arc::new(Mailbox::new(
+        orchestrator_runtime.clone(),
+        Arc::new(InMemoryMailboxStore::new()),
+        orchestrator_store.clone(),
+        "dual-loopback-orchestrator".to_string(),
+        MailboxConfig::default(),
+    ));
+    let orchestrator_state = AppState::new(
+        orchestrator_runtime.clone(),
+        orchestrator_mailbox,
+        orchestrator_store.clone(),
+        orchestrator_runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+    let orchestrator_router = build_router().with_state(orchestrator_state);
+    let orchestrator_handle = tokio::spawn(async move {
+        axum::serve(orchestrator_listener, orchestrator_router)
+            .await
+            .ok();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let http = reqwest::Client::new();
+    let task_id = format!("dual-loopback-cancel-{}", uuid::Uuid::now_v7());
+    let submit_resp = post_json(
+        &http,
+        &format!("{orchestrator_base_url}/v1/a2a/orchestrator/message:send"),
+        serde_json::json!({
+            "message": {
+                "taskId": task_id,
+                "contextId": task_id,
+                "messageId": format!("msg-{task_id}"),
+                "role": "ROLE_USER",
+                "parts": [{"text": "spawn a child and cancel yourself"}]
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(submit_resp["task"]["id"].as_str(), Some(task_id.as_str()));
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut task_state = submit_resp["task"]["status"]["state"]
+        .as_str()
+        .unwrap_or("unknown")
+        .to_string();
+    while task_state != "TASK_STATE_COMPLETED" {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "orchestrator task did not complete before deadline; last state: {task_state}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        let snapshot = get_json(
+            &http,
+            &format!("{orchestrator_base_url}/v1/a2a/orchestrator/tasks/{task_id}"),
+        )
+        .await;
+        task_state = snapshot["status"]["state"]
+            .as_str()
+            .unwrap_or("unknown")
+            .to_string();
+    }
+
+    let orchestrator_run = orchestrator_store
+        .load_run(&task_id)
+        .await
+        .expect("load orchestrator run")
+        .expect("orchestrator run should exist");
+    assert_eq!(orchestrator_run.status, RunStatus::Done);
+    assert_eq!(orchestrator_run.agent_id, "orchestrator");
+
+    let worker_run = loop {
+        let page = worker_store
+            .list_runs(&RunQuery {
+                limit: 20,
+                ..RunQuery::default()
+            })
+            .await
+            .expect("list worker runs");
+        let worker_runs = page
+            .items
+            .into_iter()
+            .filter(|run| run.agent_id == "worker")
+            .collect::<Vec<_>>();
+        if let Some(run) = worker_runs
+            .iter()
+            .find(|run| run.termination_reason == Some(TerminationReason::Cancelled))
+            .cloned()
+        {
+            break run;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "cancelled worker run did not appear before deadline: {worker_runs:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+
+    assert_eq!(worker_run.status, RunStatus::Done);
+    assert_eq!(
+        worker_run.termination_reason,
+        Some(TerminationReason::Cancelled)
+    );
+
+    let worker_tasks = worker_manager.list(&worker_run.thread_id).await;
+    assert_eq!(
+        worker_tasks.len(),
+        1,
+        "expected one background child task on worker server: {worker_tasks:?}"
+    );
+    assert_eq!(worker_tasks[0].status, TaskStatus::Cancelled);
+    assert_eq!(worker_tasks[0].task_type, "background_child");
+    assert_eq!(
+        worker_tasks[0].parent_context.run_id.as_deref(),
+        Some(worker_run.run_id.as_str())
+    );
+
+    let orchestrator_runs = get_json(&http, &format!("{orchestrator_base_url}/v1/runs")).await;
+    let orchestrator_agents = orchestrator_runs["items"]
+        .as_array()
+        .expect("orchestrator runs items")
+        .iter()
+        .filter_map(|item| item["agent_id"].as_str())
+        .collect::<Vec<_>>();
+    assert!(orchestrator_agents.contains(&"orchestrator"));
+    assert!(
+        !orchestrator_agents.contains(&"worker"),
+        "worker run should not be persisted on orchestrator server: {orchestrator_runs}"
+    );
+
+    let worker_runs = get_json(&http, &format!("{worker_base_url}/v1/runs")).await;
+    let worker_statuses = worker_runs["items"]
+        .as_array()
+        .expect("worker runs items")
+        .iter()
+        .filter(|item| item["agent_id"].as_str() == Some("worker"))
+        .filter_map(|item| item["status"].as_str())
+        .collect::<Vec<_>>();
+    assert!(
+        worker_statuses.contains(&"done"),
+        "expected worker run to be visible on worker server: {worker_runs}"
+    );
+
+    orchestrator_handle.abort();
+    worker_handle.abort();
+}
 
 /// Full A2A loopback: orchestrator → HTTP A2A → worker (same server) → done.
 ///


### PR DESCRIPTION
## Summary
- allow agents to cancel their own background task from task scope or run scope
- cascade cancellation across background task descendants and delegate runs
- add A2A regressions covering HTTP, single-server loopback, and dual-server loopback flows

## Validation
- cargo test -p awaken-runtime background
- cargo test -p awaken-runtime --test public_api_compat --test public_api_compat_extended
- cargo test -p awaken-server --test a2a_http
- cargo test -p awaken-server --test a2a_loopback
- cargo clippy -p awaken-runtime --all-targets -- -D warnings
- cargo clippy -p awaken-server --test a2a_http --test a2a_loopback --no-deps -- -D warnings
