### PR TITLE
🐛 fix(docs): avoid rustdoc output collision for awaken-agent

### DIFF
--- a/crates/awaken-agent/Cargo.toml
+++ b/crates/awaken-agent/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["artificial-intelligence", "asynchronous"]
 
 [lib]
 name = "awaken"
+doc = false
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
## Summary
- skip rustdoc generation for the `awaken-agent` compatibility shim
- keep doctests disabled for the shim crate
- unblock the `Docs` workflow on `main` by avoiding duplicate `awaken` doc output paths

## Verification
- `cargo doc --workspace --no-deps`
- `bash scripts/build-docs.sh`