### PR TITLE
fix(background): make task persistence failures observable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,8 @@ dependencies = [
  "futures",
  "genai",
  "jsonschema",
+ "metrics",
+ "metrics-util 0.20.1",
  "parking_lot",
  "proptest",
  "reqwest 0.13.2",
@@ -1288,6 +1290,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -2445,7 +2453,7 @@ dependencies = [
  "indexmap 2.13.0",
  "ipnet",
  "metrics",
- "metrics-util",
+ "metrics-util 0.19.1",
  "quanta",
  "thiserror 1.0.69",
  "tokio",
@@ -2463,6 +2471,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "metrics",
  "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "metrics",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
@@ -2545,6 +2573,15 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -2842,6 +2879,15 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3172,6 +3218,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/crates/awaken-runtime/Cargo.toml
+++ b/crates/awaken-runtime/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { workspace = true }
 schemars = { workspace = true }
 jsonschema = { workspace = true }
 parking_lot = { workspace = true }
+metrics = "0.24"
 
 [features]
 default = ["a2a", "handoff", "background"]
@@ -41,6 +42,7 @@ awaken-runtime = { path = ".", features = ["test-utils"] }
 awaken-stores = { workspace = true }
 tokio = { workspace = true }
 proptest = { workspace = true }
+metrics-util = "0.20"
 
 [lints]
 workspace = true

--- a/crates/awaken-runtime/src/extensions/background/manager.rs
+++ b/crates/awaken-runtime/src/extensions/background/manager.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use awaken_contract::StateError;
+use parking_lot::RwLock;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -55,24 +57,39 @@ impl std::error::Error for SendError {}
 const RESERVED_NAMES: &[&str] = &["parent", "self", "all", "broadcast"];
 
 /// Errors from task spawn operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum SpawnError {
     /// The name is reserved by the system.
+    #[error("'{0}' is a reserved name")]
     ReservedName(String),
     /// Another running task on this thread already has this name.
+    #[error("a running task named '{0}' already exists")]
     DuplicateName(String),
+    /// No state store has been configured for the manager.
+    #[error("background task state store is not configured")]
+    StoreNotConfigured,
+    /// Commit to the state store failed.
+    #[error(transparent)]
+    State(#[from] StateError),
 }
 
-impl std::fmt::Display for SpawnError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ReservedName(n) => write!(f, "'{n}' is a reserved name"),
-            Self::DuplicateName(n) => write!(f, "a running task named '{n}' already exists"),
+#[derive(Debug, thiserror::Error)]
+enum MetaCommitError {
+    #[error("background task state store is not configured")]
+    StoreUnavailable,
+    #[error(transparent)]
+    State(#[from] StateError),
+}
+
+impl From<MetaCommitError> for SpawnError {
+    fn from(err: MetaCommitError) -> Self {
+        match err {
+            MetaCommitError::StoreUnavailable => Self::StoreNotConfigured,
+            MetaCommitError::State(e) => Self::State(e),
         }
     }
 }
-
-impl std::error::Error for SpawnError {}
 
 /// Runtime-only handle for a live background task.
 ///
@@ -97,7 +114,7 @@ struct TaskHandle {
 pub struct BackgroundTaskManager {
     handles: Mutex<HashMap<TaskId, TaskHandle>>,
     counter: AtomicU64,
-    owner_inbox: std::sync::RwLock<Option<InboxSender>>,
+    owner_inbox: RwLock<Option<InboxSender>>,
     store: std::sync::OnceLock<StateStore>,
 }
 
@@ -106,7 +123,7 @@ impl BackgroundTaskManager {
         Self {
             handles: Mutex::new(HashMap::new()),
             counter: AtomicU64::new(0),
-            owner_inbox: std::sync::RwLock::new(None),
+            owner_inbox: RwLock::new(None),
             store: std::sync::OnceLock::new(),
         }
     }
@@ -114,7 +131,7 @@ impl BackgroundTaskManager {
     /// Set the inbox sender that background tasks receive for pushing
     /// messages to the owner thread.
     pub fn set_owner_inbox(&self, inbox: InboxSender) {
-        *self.owner_inbox.write().expect("owner_inbox poisoned") = Some(inbox);
+        *self.owner_inbox.write() = Some(inbox);
     }
 
     /// Provide the state store for metadata persistence.
@@ -152,10 +169,18 @@ impl BackgroundTaskManager {
     }
 
     fn owner_inbox(&self) -> Option<InboxSender> {
-        self.owner_inbox
-            .read()
-            .expect("owner_inbox poisoned")
-            .clone()
+        self.owner_inbox.read().clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn panic_while_holding_owner_inbox_lock_for_test(&self) {
+        let _guard = self.owner_inbox.write();
+        panic!("owner_inbox lock test panic");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_owner_inbox_for_test(&self) -> bool {
+        self.owner_inbox().is_some()
     }
 
     fn next_task_id(&self) -> TaskId {
@@ -188,13 +213,51 @@ impl BackgroundTaskManager {
         parent_context
     }
 
-    /// Commit a state update to the store (if available).
-    fn commit_meta(&self, action: BackgroundTaskStateAction) {
-        if let Some(store) = self.store() {
-            let mut batch = MutationBatch::new();
-            batch.update::<BackgroundTaskStateKey>(action);
-            // Ignore commit errors (e.g. key not registered in test setups)
-            let _ = store.commit(batch);
+    /// Commit a state update to the store.
+    fn commit_meta(&self, action: BackgroundTaskStateAction) -> Result<u64, MetaCommitError> {
+        let Some(store) = self.store() else {
+            return Err(MetaCommitError::StoreUnavailable);
+        };
+
+        let mut batch = MutationBatch::new();
+        batch.update::<BackgroundTaskStateKey>(action);
+        store.commit(batch).map_err(Into::into)
+    }
+
+    fn commit_meta_or_warn(
+        &self,
+        action: BackgroundTaskStateAction,
+        operation: &'static str,
+        task_id: &str,
+    ) {
+        if let Err(error) = self.commit_meta(action) {
+            metrics::counter!(
+                "awaken_background_task_state_commit_failures_total",
+                "operation" => operation
+            )
+            .increment(1);
+            tracing::warn!(
+                operation,
+                task_id,
+                error = %error,
+                "background task metadata commit failed"
+            );
+        }
+    }
+
+    fn terminal_event(task_id: &str, result: &TaskResult) -> TaskEvent {
+        match result {
+            TaskResult::Success(val) => TaskEvent::Completed {
+                task_id: task_id.to_string(),
+                result: Some(val.clone()),
+            },
+            TaskResult::Failed(err) => TaskEvent::Failed {
+                task_id: task_id.to_string(),
+                error: err.clone(),
+            },
+            TaskResult::Cancelled => TaskEvent::Cancelled {
+                task_id: task_id.to_string(),
+            },
         }
     }
 
@@ -250,7 +313,8 @@ impl BackgroundTaskManager {
                 completed_at_ms: None,
                 parent_context: parent_context.clone(),
             },
-        )));
+        )))
+        .map_err(SpawnError::from)?;
 
         let manager = Arc::clone(self);
         let tid = task_id.clone();
@@ -278,8 +342,8 @@ impl BackgroundTaskManager {
                 TaskResult::Cancelled => (TaskStatus::Cancelled, None, None),
             };
 
-            manager.commit_meta(BackgroundTaskStateAction::Upsert(Box::new(
-                PersistedTaskMeta {
+            manager.commit_meta_or_warn(
+                BackgroundTaskStateAction::Upsert(Box::new(PersistedTaskMeta {
                     task_id: tid.clone(),
                     owner_thread_id: owner,
                     task_type: ttype,
@@ -291,25 +355,17 @@ impl BackgroundTaskManager {
                     created_at_ms: now,
                     completed_at_ms: Some(completed_at),
                     parent_context,
-                },
-            )));
+                })),
+                "task_completion",
+                &tid,
+            );
 
             // Notify owner via inbox (terminal event).
             if let Some(ref inbox) = owner_inbox {
-                let event = match &result {
-                    TaskResult::Success(val) => TaskEvent::Completed {
-                        task_id: tid.clone(),
-                        result: Some(val.clone()),
-                    },
-                    TaskResult::Failed(err) => TaskEvent::Failed {
-                        task_id: tid.clone(),
-                        error: err.clone(),
-                    },
-                    TaskResult::Cancelled => TaskEvent::Cancelled {
-                        task_id: tid.clone(),
-                    },
-                };
-                inbox.send(serde_json::to_value(&event).unwrap_or_default());
+                let event = Self::terminal_event(&tid, &result);
+                inbox.send(
+                    serde_json::to_value(&event).expect("TaskEvent serialization is infallible"),
+                );
             }
         });
 
@@ -474,7 +530,11 @@ impl BackgroundTaskManager {
                         Some("task orphaned: runtime restarted while running".to_string());
                 }
 
-                self.commit_meta(BackgroundTaskStateAction::Upsert(Box::new(to_store)));
+                self.commit_meta_or_warn(
+                    BackgroundTaskStateAction::Upsert(Box::new(to_store)),
+                    "restore_task_metadata",
+                    task_id,
+                );
             }
         }
     }
@@ -562,7 +622,8 @@ impl BackgroundTaskManager {
                 completed_at_ms: None,
                 parent_context: parent_context.clone(),
             },
-        )));
+        )))
+        .map_err(SpawnError::from)?;
 
         let manager = Arc::clone(self);
         let tid = task_id.clone();
@@ -593,8 +654,8 @@ impl BackgroundTaskManager {
                 TaskResult::Cancelled => (TaskStatus::Cancelled, None, None),
             };
 
-            manager.commit_meta(BackgroundTaskStateAction::Upsert(Box::new(
-                PersistedTaskMeta {
+            manager.commit_meta_or_warn(
+                BackgroundTaskStateAction::Upsert(Box::new(PersistedTaskMeta {
                     task_id: tid.clone(),
                     owner_thread_id: owner,
                     task_type: "sub_agent".to_string(),
@@ -606,24 +667,16 @@ impl BackgroundTaskManager {
                     created_at_ms: now,
                     completed_at_ms: Some(completed_at),
                     parent_context,
-                },
-            )));
+                })),
+                "sub_agent_completion",
+                &tid,
+            );
 
-            let event = match &result {
-                TaskResult::Success(val) => TaskEvent::Completed {
-                    task_id: tid.clone(),
-                    result: Some(val.clone()),
-                },
-                TaskResult::Failed(err) => TaskEvent::Failed {
-                    task_id: tid.clone(),
-                    error: err.clone(),
-                },
-                TaskResult::Cancelled => TaskEvent::Cancelled {
-                    task_id: tid.clone(),
-                },
-            };
+            let event = Self::terminal_event(&tid, &result);
             if let Some(ref inbox) = owner_inbox {
-                inbox.send(serde_json::to_value(&event).unwrap_or_default());
+                inbox.send(
+                    serde_json::to_value(&event).expect("TaskEvent serialization is infallible"),
+                );
             }
         });
 
@@ -679,7 +732,8 @@ impl BackgroundTaskManager {
             }),
         };
 
-        if inbox.send(serde_json::to_value(&event).unwrap_or_default()) {
+        if inbox.send(serde_json::to_value(&event).expect("TaskEvent serialization is infallible"))
+        {
             Ok(())
         } else {
             Err(SendError::InboxClosed)

--- a/crates/awaken-runtime/src/extensions/background/tests.rs
+++ b/crates/awaken-runtime/src/extensions/background/tests.rs
@@ -2005,9 +2005,15 @@ async fn full_lifecycle_sub_agent_with_child_tasks() {
             },
             |_cancel, child_inbox_sender, mut child_inbox_receiver| async move {
                 // Sub-agent creates its own background task manager
+                let child_store = StateStore::new();
                 let child_manager = BackgroundTaskManager::new();
                 child_manager.set_owner_inbox(child_inbox_sender);
                 let child_manager = Arc::new(child_manager);
+                child_manager.set_store(child_store.clone());
+                let plugin: Arc<dyn Plugin> =
+                    Arc::new(BackgroundTaskPlugin::new(child_manager.clone()));
+                let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
+                child_store.register_keys(&env.key_registrations).unwrap();
 
                 // Sub-agent spawns a background task
                 child_manager
@@ -2596,6 +2602,232 @@ async fn spawn_rejects_duplicate_name() {
     ));
 
     manager.cancel(&_id).await;
+}
+
+#[tokio::test]
+async fn spawn_fails_when_background_store_is_not_configured() {
+    let manager = Arc::new(BackgroundTaskManager::new());
+
+    let result = manager
+        .spawn(
+            "thread-1",
+            "test",
+            None,
+            "desc",
+            TaskParentContext::default(),
+            |_ctx| async { TaskResult::Success(serde_json::json!(null)) },
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(super::manager::SpawnError::StoreNotConfigured)
+    ));
+}
+
+#[tokio::test]
+async fn spawn_agent_fails_when_background_keys_are_not_registered() {
+    use awaken_contract::StateError;
+
+    let store = StateStore::new();
+    let manager = Arc::new(BackgroundTaskManager::new());
+    manager.set_store(store);
+
+    let result = manager
+        .spawn_agent(
+            "thread-1",
+            Some("worker"),
+            "desc",
+            TaskParentContext::default(),
+            |_cancel, _tx, _rx| async { TaskResult::Success(serde_json::json!(null)) },
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(super::manager::SpawnError::State(
+            StateError::UnknownKey { .. }
+        ))
+    ));
+}
+
+#[test]
+fn owner_inbox_lock_recovers_after_panicking_holder() {
+    let manager = BackgroundTaskManager::new();
+    let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        manager.panic_while_holding_owner_inbox_lock_for_test();
+    }));
+    assert!(panic_result.is_err());
+
+    let (tx, _rx) = inbox_channel();
+    manager.set_owner_inbox(tx);
+    assert!(manager.has_owner_inbox_for_test());
+}
+
+/// Exposes the asymmetry flagged in PR review: spawn-time commit failure is
+/// returned as `SpawnError::State(_)`, but completion-time commit failure is
+/// only logged via `tracing::warn!`. The task genuinely runs and terminates,
+/// yet the store still shows `TaskStatus::Running` with no `completed_at_ms`,
+/// so downstream consumers of the persisted metadata see a permanent zombie.
+#[tokio::test]
+async fn completion_metadata_commit_failure_leaves_store_stuck_at_running() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    // Install via `install_plugin` so we can later `uninstall_plugin` to rip
+    // the key registration out from under the completion-time commit.
+    let store = StateStore::new();
+    let manager = Arc::new(BackgroundTaskManager::new());
+    manager.set_store(store.clone());
+    store
+        .install_plugin(BackgroundTaskPlugin::new(manager.clone()))
+        .unwrap();
+
+    let gate = Arc::new(Notify::new());
+    let gate_for_task = gate.clone();
+    let ran = Arc::new(AtomicBool::new(false));
+    let ran_for_task = ran.clone();
+
+    let task_id = manager
+        .spawn(
+            "thread-zombie",
+            "worker",
+            None,
+            "desc",
+            TaskParentContext::default(),
+            move |_ctx| async move {
+                gate_for_task.notified().await;
+                ran_for_task.store(true, Ordering::SeqCst);
+                TaskResult::Success(serde_json::json!("done"))
+            },
+        )
+        .await
+        .expect("spawn succeeds while the store is healthy");
+
+    let running_snap = store
+        .read::<BackgroundTaskStateKey>()
+        .expect("spawn commit must have populated the key");
+    let running_meta = running_snap
+        .tasks
+        .get(&task_id)
+        .expect("spawn-time metadata must be visible");
+    assert_eq!(running_meta.status, TaskStatus::Running);
+    assert!(running_meta.completed_at_ms.is_none());
+
+    // Break the commit path: uninstall clears the key state AND unregisters
+    // the key, so subsequent commit_meta calls hit `StateError::UnknownKey`.
+    store
+        .uninstall_plugin::<BackgroundTaskPlugin>()
+        .expect("uninstall clears registration and snapshot state");
+
+    gate.notify_one();
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while !ran.load(Ordering::SeqCst) {
+        if std::time::Instant::now() >= deadline {
+            panic!("task body never ran");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    // Give the completion branch a moment to *attempt* its commit.
+    tokio::time::sleep(Duration::from_millis(75)).await;
+
+    // The task visibly completed (it set `ran = true` and its tokio body
+    // returned), yet the store has no Completed record. Observability of
+    // the divergence is covered by tracing::warn! plus the
+    // `awaken_background_task_state_commit_failures_total` counter (see
+    // `completion_metadata_commit_failure_increments_observability_metric`).
+    assert!(ran.load(Ordering::SeqCst), "task ran to completion");
+    let still_running_or_absent = match store.read::<BackgroundTaskStateKey>() {
+        None => true,
+        Some(snap) => match snap.tasks.get(&task_id) {
+            None => true,
+            Some(meta) => meta.status == TaskStatus::Running,
+        },
+    };
+    assert!(
+        still_running_or_absent,
+        "completion-time commit failure is silent: store does not reflect the task's real outcome"
+    );
+}
+
+/// Companion to `completion_metadata_commit_failure_leaves_store_stuck_at_running`:
+/// proves that the silent commit failure is now also exposed through a
+/// low-cardinality counter (`awaken_background_task_state_commit_failures_total`
+/// labelled by `operation`). This is the signal ops can alert on.
+#[test]
+fn completion_metadata_commit_failure_increments_observability_metric() {
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+    use tokio::sync::Notify;
+
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    metrics::with_local_recorder(&recorder, || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            let store = StateStore::new();
+            let manager = Arc::new(BackgroundTaskManager::new());
+            manager.set_store(store.clone());
+            store
+                .install_plugin(BackgroundTaskPlugin::new(manager.clone()))
+                .unwrap();
+
+            let gate = Arc::new(Notify::new());
+            let gate_for_task = gate.clone();
+            let ran = Arc::new(AtomicBool::new(false));
+            let ran_for_task = ran.clone();
+
+            manager
+                .spawn(
+                    "thread-metric",
+                    "worker",
+                    None,
+                    "desc",
+                    TaskParentContext::default(),
+                    move |_ctx| async move {
+                        gate_for_task.notified().await;
+                        ran_for_task.store(true, Ordering::SeqCst);
+                        TaskResult::Success(serde_json::json!(null))
+                    },
+                )
+                .await
+                .expect("spawn");
+
+            store.uninstall_plugin::<BackgroundTaskPlugin>().unwrap();
+            gate.notify_one();
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            while !ran.load(Ordering::SeqCst) {
+                assert!(std::time::Instant::now() < deadline, "task body never ran");
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            tokio::time::sleep(Duration::from_millis(75)).await;
+        });
+    });
+
+    let snapshot = snapshotter.snapshot().into_vec();
+    let entry = snapshot
+        .iter()
+        .find(|(ck, _, _, _)| {
+            ck.key().name() == "awaken_background_task_state_commit_failures_total"
+                && ck
+                    .key()
+                    .labels()
+                    .any(|label| label.key() == "operation" && label.value() == "task_completion")
+        })
+        .expect("counter awaken_background_task_state_commit_failures_total{operation=task_completion} must be emitted");
+    match entry.3 {
+        DebugValue::Counter(n) => assert!(
+            n >= 1,
+            "counter should have incremented at least once, got {n}"
+        ),
+        ref other => panic!("expected Counter, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/awaken-runtime/src/extensions/background/types.rs
+++ b/crates/awaken-runtime/src/extensions/background/types.rs
@@ -122,7 +122,9 @@ impl TaskContext {
             payload,
         };
         match &self.inbox {
-            Some(s) => s.send(serde_json::to_value(&event).unwrap_or_default()),
+            Some(s) => {
+                s.send(serde_json::to_value(&event).expect("TaskEvent serialization is infallible"))
+            }
             None => false,
         }
     }


### PR DESCRIPTION
## Summary

### Behavior
- Make `commit_meta` failures observable instead of silent:
  - Spawn-time failures return an explicit `SpawnError` variant (no more `.ok()`).
  - Completion-time failures emit a low-cardinality counter `awaken_background_task_state_commit_failures_total{operation}` alongside the existing `tracing::warn!`.
- Replace the `std::sync::RwLock` on `owner_inbox` with `parking_lot::RwLock` so a panicking writer no longer poisons the lock.
- Drop the handwritten `TaskEvent::to_json_value` helper (duplicated the `#[serde(tag = "kind")]` derive); call sites now use `serde_json::to_value(..).expect("TaskEvent serialization is infallible")`, removing the silent `unwrap_or_default` fallback.

### API surface
- `SpawnError` marked `#[non_exhaustive]` and re-shaped:
  - `StoreNotConfigured` (was `StatePersistence(String)` when store was missing).
  - `State(#[from] StateError)` (was `StatePersistence(String)` — now carries the structured `StateError` so callers can pattern-match on the cause).
- Internal `MetaCommitError` kept as a private helper with `From<MetaCommitError> for SpawnError`.

### Tests
- `completion_metadata_commit_failure_leaves_store_stuck_at_running`: demonstrates the pre-fix divergence (task completed but store stuck at `Running`).
- `completion_metadata_commit_failure_increments_observability_metric`: confirms the new counter increments via `metrics-util::debugging::DebuggingRecorder` + `metrics::with_local_recorder`.
- `owner_inbox_lock_recovers_after_panicking_holder`: verifies the `parking_lot` switch.
- `spawn_fails_when_background_store_is_not_configured` / `spawn_agent_fails_when_background_keys_are_not_registered`: updated to match the structured `SpawnError` variants.

### Dependencies
- Added `metrics = "0.24"` to `awaken-runtime` (first metric in this crate, unlocks runtime-side observability going forward).
- Added `metrics-util = "0.20"` as a dev-dep for counter assertions.

## Testing
- `cargo test -p awaken-runtime --lib extensions::background`
- `cargo test -p awaken-runtime --locked`
- `cargo clippy -p awaken-runtime --all-targets --locked -- -D warnings`
