### PR TITLE
📐 feat(runtime): LLM error taxonomy split + Retry-After honored (1/3)

### DIFF
--- a/crates/awaken-contract/src/contract/executor.rs
+++ b/crates/awaken-contract/src/contract/executor.rs
@@ -1,8 +1,10 @@
 //! LLM executor trait and tool execution strategy.
 
+use std::time::Duration;
+
 use super::content::ContentBlock;
 use super::inference::{InferenceOverride, StreamResult};
-use super::message::Message;
+use super::message::{Message, ToolCall};
 use super::tool::ToolDescriptor;
 use async_trait::async_trait;
 use thiserror::Error;
@@ -25,17 +27,219 @@ pub struct InferenceRequest {
     pub enable_prompt_cache: bool,
 }
 
+/// Cause of a mid-stream interruption.
+#[derive(Debug, Clone)]
+pub enum InterruptCause {
+    /// Underlying socket reset (TCP RST, ECONNRESET) while receiving events.
+    ConnectionReset,
+    /// No delta received within the configured idle window.
+    IdleStall,
+    /// HTTP/2 GOAWAY or equivalent server-initiated disconnect.
+    GoAway,
+    /// Provider returned a 5xx status after headers had been sent.
+    Provider5xxMidStream(u16),
+}
+
+impl std::fmt::Display for InterruptCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionReset => f.write_str("connection reset"),
+            Self::IdleStall => f.write_str("idle stall"),
+            Self::GoAway => f.write_str("goaway"),
+            Self::Provider5xxMidStream(s) => write!(f, "provider {s} mid-stream"),
+        }
+    }
+}
+
+/// A tool_use block observed mid-stream whose argument JSON did not close.
+#[derive(Debug, Clone)]
+pub struct InFlightTool {
+    pub id: String,
+    pub name: String,
+    /// Raw accumulated argument JSON fragment (unparseable as-is).
+    pub partial_args: String,
+}
+
+/// Snapshot of everything a `StreamCollector` had accumulated at the moment
+/// the stream was interrupted. Used by the loop runner to pick a
+/// [`RecoveryPlan`](crate::contract::executor::RecoveryPlan).
+#[derive(Debug, Clone)]
+pub struct InterruptSnapshot {
+    /// Assistant text accumulated before the interruption. `None` if no text
+    /// was received.
+    pub text: Option<String>,
+    /// Tool calls whose argument JSON parsed successfully before interruption.
+    pub completed_tool_calls: Vec<ToolCall>,
+    /// The tool_use block (if any) that was open but not yet closed.
+    pub in_flight_tool: Option<InFlightTool>,
+    /// Total bytes of events processed (telemetry).
+    pub bytes_received: usize,
+}
+
+/// Chosen recovery path for a mid-stream interruption. Computed from
+/// [`InterruptSnapshot::plan`].
+#[derive(Debug, Clone)]
+pub enum RecoveryPlan {
+    /// Only text accumulated. Retry the whole request with the accumulated
+    /// text injected as an assistant prefix followed by a continuation
+    /// prompt.
+    ContinueText { assistant_prefix: String },
+    /// At least one tool_use arrived intact. Synthesize a
+    /// `StopReason::ToolUse` terminal state so the loop runner executes the
+    /// completed tools. Any in-flight tool is surfaced as a hint for the
+    /// next user message.
+    SynthesizeToolUse {
+        completed: Vec<ToolCall>,
+        cancelled_tool_hint: Option<InFlightTool>,
+    },
+    /// There was text plus a single unclosed tool_use. Truncate before the
+    /// tool, emit a cancel event for consumers, then continue with the text
+    /// prefix.
+    TruncateBeforeTool {
+        assistant_prefix: String,
+        cancelled_tool_id: String,
+        cancelled_tool_name: String,
+    },
+    /// Nothing salvageable: retry the entire request fresh.
+    WholeRestart,
+}
+
+impl InterruptSnapshot {
+    /// Decide which recovery plan applies to this snapshot.
+    pub fn plan(&self) -> RecoveryPlan {
+        let text = self.text.as_deref().unwrap_or("");
+        let has_text = !text.is_empty();
+        let has_completed = !self.completed_tool_calls.is_empty();
+
+        // R2: any completed tool → synthesize ToolUse regardless of text/in-flight.
+        if has_completed {
+            return RecoveryPlan::SynthesizeToolUse {
+                completed: self.completed_tool_calls.clone(),
+                cancelled_tool_hint: self.in_flight_tool.clone(),
+            };
+        }
+
+        // R3: text with an in-flight tool → truncate to the text prefix.
+        if has_text {
+            if let Some(p) = &self.in_flight_tool {
+                return RecoveryPlan::TruncateBeforeTool {
+                    assistant_prefix: text.to_string(),
+                    cancelled_tool_id: p.id.clone(),
+                    cancelled_tool_name: p.name.clone(),
+                };
+            }
+            // R1: text only.
+            return RecoveryPlan::ContinueText {
+                assistant_prefix: text.to_string(),
+            };
+        }
+
+        // R4: nothing usable (no text and no completed tools).
+        RecoveryPlan::WholeRestart
+    }
+}
+
 /// Errors from LLM inference.
-#[derive(Debug, Error)]
+///
+/// Variants split into three recoverability classes:
+/// - **Transient** (retryable, count toward circuit breaker): `RateLimited`,
+///   `Overloaded`, `Timeout`, `Provider`, `StreamInterrupted`.
+/// - **Permanent** (not retryable, do NOT count toward circuit breaker):
+///   `ContextOverflow`, `InvalidRequest`, `Unauthorized`, `ModelNotFound`,
+///   `ContentFiltered`.
+/// - **Fail-fast**: `AllModelsUnavailable`, `Cancelled`.
+///
+/// Use [`InferenceExecutionError::is_retryable`] and
+/// [`InferenceExecutionError::counts_toward_circuit_breaker`] for policy
+/// decisions instead of pattern-matching variants directly where possible.
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum InferenceExecutionError {
     #[error("provider error: {0}")]
     Provider(String),
-    #[error("rate limited: {0}")]
-    RateLimited(String),
+    #[error("rate limited: {message}")]
+    RateLimited {
+        message: String,
+        /// Duration from the provider's `Retry-After` header, if any.
+        retry_after: Option<Duration>,
+    },
+    #[error("provider overloaded: {message}")]
+    Overloaded {
+        message: String,
+        retry_after: Option<Duration>,
+    },
     #[error("timeout: {0}")]
     Timeout(String),
+    #[error("stream interrupted ({cause})")]
+    StreamInterrupted {
+        cause: InterruptCause,
+        snapshot: Box<InterruptSnapshot>,
+    },
+    #[error("context overflow: {0}")]
+    ContextOverflow(String),
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+    #[error("model not found: {0}")]
+    ModelNotFound(String),
+    #[error("content filtered: {0}")]
+    ContentFiltered(String),
+    #[error("all models unavailable (circuit breakers open)")]
+    AllModelsUnavailable,
     #[error("cancelled")]
     Cancelled,
+}
+
+impl InferenceExecutionError {
+    /// Short constructor for a rate-limit error with no `Retry-After`.
+    pub fn rate_limited(message: impl Into<String>) -> Self {
+        Self::RateLimited {
+            message: message.into(),
+            retry_after: None,
+        }
+    }
+
+    /// Short constructor for an overloaded error with no `Retry-After`.
+    pub fn overloaded(message: impl Into<String>) -> Self {
+        Self::Overloaded {
+            message: message.into(),
+            retry_after: None,
+        }
+    }
+
+    /// Whether the retry subsystem should try this request again.
+    ///
+    /// Transient errors return `true`; permanent and fail-fast errors
+    /// (including `Cancelled`) return `false`.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Provider(_)
+                | Self::RateLimited { .. }
+                | Self::Overloaded { .. }
+                | Self::Timeout(_)
+                | Self::StreamInterrupted { .. }
+        )
+    }
+
+    /// Whether this failure should increment the per-model circuit-breaker
+    /// failure counter. Permanent errors (bad auth, bad schema, context
+    /// overflow) must not trip the breaker — they would have failed with the
+    /// same error on any model.
+    pub fn counts_toward_circuit_breaker(&self) -> bool {
+        self.is_retryable()
+    }
+
+    /// If this error carries a `Retry-After` hint from the provider, return it.
+    pub fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::RateLimited { retry_after, .. } | Self::Overloaded { retry_after, .. } => {
+                *retry_after
+            }
+            _ => None,
+        }
+    }
 }
 
 /// A token-level streaming event from the LLM.
@@ -294,13 +498,203 @@ mod tests {
             "provider error: provider failed"
         );
         assert_eq!(
-            InferenceExecutionError::RateLimited("too many requests".into()).to_string(),
+            InferenceExecutionError::rate_limited("too many requests").to_string(),
             "rate limited: too many requests"
+        );
+        assert_eq!(
+            InferenceExecutionError::overloaded("server overloaded").to_string(),
+            "provider overloaded: server overloaded"
         );
         assert_eq!(
             InferenceExecutionError::Timeout("slow backend".into()).to_string(),
             "timeout: slow backend"
         );
+        assert_eq!(
+            InferenceExecutionError::ContextOverflow("prompt too long".into()).to_string(),
+            "context overflow: prompt too long"
+        );
+        assert_eq!(
+            InferenceExecutionError::InvalidRequest("bad schema".into()).to_string(),
+            "invalid request: bad schema"
+        );
+        assert_eq!(
+            InferenceExecutionError::Unauthorized("bad key".into()).to_string(),
+            "unauthorized: bad key"
+        );
+        assert_eq!(
+            InferenceExecutionError::ModelNotFound("no such model".into()).to_string(),
+            "model not found: no such model"
+        );
+        assert_eq!(
+            InferenceExecutionError::AllModelsUnavailable.to_string(),
+            "all models unavailable (circuit breakers open)"
+        );
         assert_eq!(InferenceExecutionError::Cancelled.to_string(), "cancelled");
+
+        let stream_err = InferenceExecutionError::StreamInterrupted {
+            cause: InterruptCause::ConnectionReset,
+            snapshot: Box::new(InterruptSnapshot {
+                text: None,
+                completed_tool_calls: vec![],
+                in_flight_tool: None,
+                bytes_received: 0,
+            }),
+        };
+        assert_eq!(
+            stream_err.to_string(),
+            "stream interrupted (connection reset)"
+        );
+    }
+
+    #[test]
+    fn is_retryable_partitions_variants() {
+        use InferenceExecutionError::*;
+        let partial_snapshot = || {
+            Box::new(InterruptSnapshot {
+                text: None,
+                completed_tool_calls: vec![],
+                in_flight_tool: None,
+                bytes_received: 0,
+            })
+        };
+
+        // Retryable
+        assert!(Provider("x".into()).is_retryable());
+        assert!(InferenceExecutionError::rate_limited("x").is_retryable());
+        assert!(InferenceExecutionError::overloaded("x").is_retryable());
+        assert!(Timeout("x".into()).is_retryable());
+        assert!(
+            StreamInterrupted {
+                cause: InterruptCause::ConnectionReset,
+                snapshot: partial_snapshot(),
+            }
+            .is_retryable()
+        );
+
+        // Permanent
+        assert!(!ContextOverflow("x".into()).is_retryable());
+        assert!(!InvalidRequest("x".into()).is_retryable());
+        assert!(!Unauthorized("x".into()).is_retryable());
+        assert!(!ModelNotFound("x".into()).is_retryable());
+        assert!(!ContentFiltered("x".into()).is_retryable());
+
+        // Fail-fast / lifecycle
+        assert!(!AllModelsUnavailable.is_retryable());
+        assert!(!Cancelled.is_retryable());
+    }
+
+    #[test]
+    fn retry_after_is_only_exposed_for_rate_limit_variants() {
+        use std::time::Duration;
+
+        let rl = InferenceExecutionError::RateLimited {
+            message: "429".into(),
+            retry_after: Some(Duration::from_secs(5)),
+        };
+        assert_eq!(rl.retry_after(), Some(Duration::from_secs(5)));
+
+        let ov = InferenceExecutionError::Overloaded {
+            message: "529".into(),
+            retry_after: Some(Duration::from_secs(10)),
+        };
+        assert_eq!(ov.retry_after(), Some(Duration::from_secs(10)));
+
+        assert_eq!(
+            InferenceExecutionError::Timeout("slow".into()).retry_after(),
+            None
+        );
+    }
+
+    #[test]
+    fn plan_returns_continue_text_when_only_text_present() {
+        let snap = InterruptSnapshot {
+            text: Some("hello".into()),
+            completed_tool_calls: vec![],
+            in_flight_tool: None,
+            bytes_received: 5,
+        };
+        match snap.plan() {
+            RecoveryPlan::ContinueText { assistant_prefix } => {
+                assert_eq!(assistant_prefix, "hello");
+            }
+            other => panic!("expected ContinueText, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_returns_synthesize_tool_use_when_completed_tool_present() {
+        use serde_json::json;
+        let snap = InterruptSnapshot {
+            text: Some("I'll search.".into()),
+            completed_tool_calls: vec![ToolCall::new("c1", "search", json!({"q": "rust"}))],
+            in_flight_tool: Some(InFlightTool {
+                id: "c2".into(),
+                name: "fetch".into(),
+                partial_args: r#"{"url":"#.into(),
+            }),
+            bytes_received: 64,
+        };
+        match snap.plan() {
+            RecoveryPlan::SynthesizeToolUse {
+                completed,
+                cancelled_tool_hint,
+            } => {
+                assert_eq!(completed.len(), 1);
+                assert_eq!(completed[0].name, "search");
+                let hint = cancelled_tool_hint.expect("in-flight tool becomes hint");
+                assert_eq!(hint.name, "fetch");
+            }
+            other => panic!("expected SynthesizeToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_returns_truncate_before_tool_when_text_and_in_flight_only() {
+        let snap = InterruptSnapshot {
+            text: Some("let me think".into()),
+            completed_tool_calls: vec![],
+            in_flight_tool: Some(InFlightTool {
+                id: "c1".into(),
+                name: "calc".into(),
+                partial_args: r#"{"expr":"#.into(),
+            }),
+            bytes_received: 24,
+        };
+        match snap.plan() {
+            RecoveryPlan::TruncateBeforeTool {
+                assistant_prefix,
+                cancelled_tool_id,
+                cancelled_tool_name,
+            } => {
+                assert_eq!(assistant_prefix, "let me think");
+                assert_eq!(cancelled_tool_id, "c1");
+                assert_eq!(cancelled_tool_name, "calc");
+            }
+            other => panic!("expected TruncateBeforeTool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_returns_whole_restart_when_nothing_salvageable() {
+        let snap = InterruptSnapshot {
+            text: None,
+            completed_tool_calls: vec![],
+            in_flight_tool: None,
+            bytes_received: 0,
+        };
+        assert!(matches!(snap.plan(), RecoveryPlan::WholeRestart));
+
+        // Also: only an in-flight tool, no text → whole restart.
+        let snap2 = InterruptSnapshot {
+            text: None,
+            completed_tool_calls: vec![],
+            in_flight_tool: Some(InFlightTool {
+                id: "c1".into(),
+                name: "x".into(),
+                partial_args: "{".into(),
+            }),
+            bytes_received: 1,
+        };
+        assert!(matches!(snap2.plan(), RecoveryPlan::WholeRestart));
     }
 }

--- a/crates/awaken-runtime/src/engine/executor.rs
+++ b/crates/awaken-runtime/src/engine/executor.rs
@@ -144,29 +144,25 @@ impl GenaiExecutor {
     fn map_error(e: genai::Error) -> InferenceExecutionError {
         tracing::warn!(error = ?e, "LLM inference error");
 
-        // Try structured matching on status codes first.
-        if let Some(status) = Self::extract_status_code(&e) {
-            let msg = format!("{e:#}");
-            return match status.as_u16() {
-                429 => InferenceExecutionError::RateLimited(msg),
-                408 | 504 => InferenceExecutionError::Timeout(msg),
-                500 | 502 | 503 => InferenceExecutionError::Provider(msg),
-                _ => InferenceExecutionError::Provider(msg),
-            };
+        let parts = Self::extract_structured_parts(&e);
+        let msg = format!("{e:#}");
+
+        if let Some((status, body, retry_after)) = parts {
+            return Self::classify_status(status, &msg, body.as_deref(), retry_after);
         }
 
         // Fall back to string matching for errors without structured status codes.
-        let msg = format!("{e:#}");
         let lower = msg.to_lowercase();
-        if lower.contains("rate") || lower.contains("429") || lower.contains("too many requests") {
-            InferenceExecutionError::RateLimited(msg)
+        if lower.contains("overloaded") {
+            InferenceExecutionError::overloaded(msg)
+        } else if lower.contains("rate")
+            || lower.contains("429")
+            || lower.contains("too many requests")
+        {
+            InferenceExecutionError::rate_limited(msg)
         } else if lower.contains("timeout") || lower.contains("timed out") {
             InferenceExecutionError::Timeout(msg)
-        } else if lower.contains("overloaded")
-            || lower.contains("503")
-            || lower.contains("502")
-            || lower.contains("500")
-        {
+        } else if lower.contains("503") || lower.contains("502") || lower.contains("500") {
             InferenceExecutionError::Provider(msg)
         } else {
             tracing::warn!(error_msg = %msg, "unclassified LLM error — consider adding a pattern");
@@ -174,21 +170,96 @@ impl GenaiExecutor {
         }
     }
 
-    /// Extract an HTTP status code from structured `genai::Error` variants.
-    fn extract_status_code(e: &genai::Error) -> Option<StatusCode> {
-        match e {
-            genai::Error::HttpError { status, .. } => Some(*status),
-            genai::Error::WebAdapterCall { webc_error, .. }
-            | genai::Error::WebModelCall { webc_error, .. } => {
-                if let genai::webc::Error::ResponseFailedStatus { status, .. } = webc_error {
-                    Some(*status)
+    /// Classify a structured HTTP status into an `InferenceExecutionError`.
+    ///
+    /// `body` is inspected for status 400 to distinguish `ContextOverflow`
+    /// (prompt too long / token limit exceeded) from generic `InvalidRequest`.
+    fn classify_status(
+        status: StatusCode,
+        msg: &str,
+        body: Option<&str>,
+        retry_after: Option<Duration>,
+    ) -> InferenceExecutionError {
+        match status.as_u16() {
+            429 => InferenceExecutionError::RateLimited {
+                message: msg.to_string(),
+                retry_after,
+            },
+            529 | 503 => InferenceExecutionError::Overloaded {
+                message: msg.to_string(),
+                retry_after,
+            },
+            408 | 504 => InferenceExecutionError::Timeout(msg.to_string()),
+            500 | 502 => InferenceExecutionError::Provider(msg.to_string()),
+            400 => {
+                if Self::looks_like_context_overflow(body, msg) {
+                    InferenceExecutionError::ContextOverflow(msg.to_string())
                 } else {
-                    None
+                    InferenceExecutionError::InvalidRequest(msg.to_string())
                 }
             }
+            401 | 403 => InferenceExecutionError::Unauthorized(msg.to_string()),
+            404 => InferenceExecutionError::ModelNotFound(msg.to_string()),
+            413 => InferenceExecutionError::ContextOverflow(msg.to_string()),
+            422 => InferenceExecutionError::InvalidRequest(msg.to_string()),
+            _ => InferenceExecutionError::Provider(msg.to_string()),
+        }
+    }
+
+    /// Match provider error bodies that signal a context-length problem.
+    ///
+    /// Patterns are drawn from Anthropic, OpenAI, and Azure OpenAI error
+    /// messages. Matching is substring-based and case-insensitive.
+    fn looks_like_context_overflow(body: Option<&str>, msg: &str) -> bool {
+        const NEEDLES: &[&str] = &[
+            "prompt is too long",
+            "context_length_exceeded",
+            "context length",
+            "input is too long",
+            "maximum context length",
+            "reduce the length",
+            "too many tokens",
+            "request too large",
+        ];
+        let haystack_lower = match body {
+            Some(b) if !b.is_empty() => b.to_lowercase(),
+            _ => msg.to_lowercase(),
+        };
+        NEEDLES.iter().any(|needle| haystack_lower.contains(needle))
+    }
+
+    /// Extract `(status, body, Retry-After)` from structured `genai::Error`
+    /// variants when available. `HttpError` only yields a status.
+    fn extract_structured_parts(
+        e: &genai::Error,
+    ) -> Option<(StatusCode, Option<String>, Option<Duration>)> {
+        match e {
+            genai::Error::HttpError { status, .. } => Some((*status, None, None)),
+            genai::Error::WebAdapterCall { webc_error, .. }
+            | genai::Error::WebModelCall { webc_error, .. } => match webc_error {
+                genai::webc::Error::ResponseFailedStatus {
+                    status,
+                    body,
+                    headers,
+                } => {
+                    let retry = parse_retry_after(headers);
+                    Some((*status, Some(body.clone()), retry))
+                }
+                _ => None,
+            },
             _ => None,
         }
     }
+}
+
+/// Parse an HTTP `Retry-After` header as a `Duration`. Only the
+/// delta-seconds form (RFC 9110 §10.2.3 form 1) is supported; HTTP-date
+/// form is rare in LLM provider responses and yields `None`.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let value = headers.get(reqwest::header::RETRY_AFTER)?;
+    let text = value.to_str().ok()?.trim();
+    let seconds: u64 = text.parse().ok()?;
+    Some(Duration::from_secs(seconds))
 }
 
 impl Default for GenaiExecutor {
@@ -564,7 +635,7 @@ mod tests {
         let err = genai::Error::Internal("server returned 429".into());
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::RateLimited(_)),
+            matches!(mapped, InferenceExecutionError::RateLimited { .. }),
             "expected RateLimited, got {mapped:?}"
         );
     }
@@ -574,7 +645,7 @@ mod tests {
         let err = genai::Error::Internal("rate limit exceeded".into());
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::RateLimited(_)),
+            matches!(mapped, InferenceExecutionError::RateLimited { .. }),
             "expected RateLimited, got {mapped:?}"
         );
     }
@@ -614,7 +685,7 @@ mod tests {
         let err = genai::Error::Internal("Too Many Requests".into());
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::RateLimited(_)),
+            matches!(mapped, InferenceExecutionError::RateLimited { .. }),
             "expected RateLimited, got {mapped:?}"
         );
     }
@@ -624,8 +695,8 @@ mod tests {
         let err = genai::Error::Internal("server overloaded".into());
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::Provider(_)),
-            "expected Provider, got {mapped:?}"
+            matches!(mapped, InferenceExecutionError::Overloaded { .. }),
+            "expected Overloaded, got {mapped:?}"
         );
     }
 
@@ -648,7 +719,7 @@ mod tests {
         };
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::RateLimited(_)),
+            matches!(mapped, InferenceExecutionError::RateLimited { .. }),
             "expected RateLimited, got {mapped:?}"
         );
     }
@@ -686,7 +757,7 @@ mod tests {
         let err = genai::Error::Internal("rate limit exceeded".into());
         let mapped = GenaiExecutor::map_error(err);
         let msg = match mapped {
-            InferenceExecutionError::RateLimited(m) => m,
+            InferenceExecutionError::RateLimited { message, .. } => message,
             other => panic!("expected RateLimited, got {other:?}"),
         };
         // format!("{e:#}") should give us the full chain
@@ -793,7 +864,7 @@ mod tests {
         };
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::RateLimited(_)),
+            matches!(mapped, InferenceExecutionError::RateLimited { .. }),
             "expected RateLimited, got {mapped:?}"
         );
     }
@@ -814,13 +885,13 @@ mod tests {
         };
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::RateLimited(_)),
+            matches!(mapped, InferenceExecutionError::RateLimited { .. }),
             "expected RateLimited, got {mapped:?}"
         );
     }
 
     #[test]
-    fn map_error_web_adapter_call_503() {
+    fn map_error_web_adapter_call_503_is_overloaded() {
         use genai::adapter::AdapterKind;
         use reqwest::header::HeaderMap;
 
@@ -834,9 +905,247 @@ mod tests {
         };
         let mapped = GenaiExecutor::map_error(err);
         assert!(
-            matches!(mapped, InferenceExecutionError::Provider(_)),
-            "expected Provider, got {mapped:?}"
+            matches!(mapped, InferenceExecutionError::Overloaded { .. }),
+            "expected Overloaded, got {mapped:?}"
         );
+    }
+
+    #[test]
+    fn map_error_web_adapter_call_529_is_overloaded() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::Anthropic,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::from_u16(529).unwrap(),
+                body: r#"{"type":"error","error":{"type":"overloaded_error"}}"#.into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::Overloaded { .. }),
+            "expected Overloaded, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_http_400_prompt_too_long_is_context_overflow() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::Anthropic,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::BAD_REQUEST,
+                body: r#"{"error":{"message":"prompt is too long: 210000 tokens"}}"#.into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::ContextOverflow(_)),
+            "expected ContextOverflow, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_http_400_context_length_exceeded_is_context_overflow() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebModelCall {
+            model_iden: genai::ModelIden::new(AdapterKind::OpenAI, "gpt-4o"),
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::BAD_REQUEST,
+                body: r#"{"error":{"code":"context_length_exceeded"}}"#.into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::ContextOverflow(_)),
+            "expected ContextOverflow, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_http_400_generic_is_invalid_request() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::OpenAI,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::BAD_REQUEST,
+                body: r#"{"error":"messages must be a non-empty array"}"#.into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::InvalidRequest(_)),
+            "expected InvalidRequest, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_http_401_is_unauthorized() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::OpenAI,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::UNAUTHORIZED,
+                body: "bad api key".into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::Unauthorized(_)),
+            "expected Unauthorized, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_http_404_is_model_not_found() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::OpenAI,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::NOT_FOUND,
+                body: "no such model".into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::ModelNotFound(_)),
+            "expected ModelNotFound, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_http_413_is_context_overflow() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::OpenAI,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::PAYLOAD_TOO_LARGE,
+                body: "too big".into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::ContextOverflow(_)),
+            "expected ContextOverflow, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_http_422_is_invalid_request() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::OpenAI,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                body: "schema violation".into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::InvalidRequest(_)),
+            "expected InvalidRequest, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_retry_after_seconds_header_is_parsed() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("42"));
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::Anthropic,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                body: "slow down".into(),
+                headers: Box::new(headers),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        match mapped {
+            InferenceExecutionError::RateLimited { retry_after, .. } => {
+                assert_eq!(retry_after, Some(Duration::from_secs(42)));
+            }
+            other => panic!("expected RateLimited with retry_after, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_error_retry_after_absent_yields_none() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::HeaderMap;
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::Anthropic,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::TOO_MANY_REQUESTS,
+                body: "no header".into(),
+                headers: Box::new(HeaderMap::new()),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(matches!(
+            mapped,
+            InferenceExecutionError::RateLimited {
+                retry_after: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn map_error_retry_after_non_numeric_yields_none() {
+        use genai::adapter::AdapterKind;
+        use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+
+        let mut headers = HeaderMap::new();
+        // HTTP-date form is intentionally NOT supported in Phase 1.
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_static("Fri, 31 Dec 1999 23:59:59 GMT"),
+        );
+
+        let err = genai::Error::WebAdapterCall {
+            adapter_kind: AdapterKind::Anthropic,
+            webc_error: genai::webc::Error::ResponseFailedStatus {
+                status: StatusCode::from_u16(529).unwrap(),
+                body: "overloaded".into(),
+                headers: Box::new(headers),
+            },
+        };
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(matches!(
+            mapped,
+            InferenceExecutionError::Overloaded {
+                retry_after: None,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/awaken-runtime/src/engine/retry.rs
+++ b/crates/awaken-runtime/src/engine/retry.rs
@@ -31,10 +31,38 @@ pub struct LlmRetryPolicy {
     /// Actual delay = min(base_ms * 2^attempt, 8000ms). Set to 0 to disable backoff.
     #[serde(default = "default_backoff_base_ms")]
     pub backoff_base_ms: u64,
+    /// Base delay for `Overloaded` errors, which signal provider-wide surges.
+    /// Uses the same exponential curve and cap as `backoff_base_ms` but a
+    /// longer base to give the provider more headroom.
+    #[serde(default = "default_overloaded_backoff_base_ms")]
+    pub overloaded_backoff_base_ms: u64,
+    /// Maximum number of mid-stream retries (independent of `max_retries`).
+    /// Applies only when a stream interruption is recovered by
+    /// `execute_streaming`; the initial open of a stream is still governed
+    /// by `max_retries`.
+    #[serde(default = "default_max_stream_retries")]
+    pub max_stream_retries: u32,
+    /// Per-event idle window during streaming. If no delta arrives within
+    /// this window the current attempt is treated as a stall and the
+    /// recovery path is entered. Doubles for thinking/reasoning models.
+    #[serde(default = "default_stream_idle_timeout_secs")]
+    pub stream_idle_timeout_secs: u64,
 }
 
 fn default_backoff_base_ms() -> u64 {
     500
+}
+
+fn default_overloaded_backoff_base_ms() -> u64 {
+    2_000
+}
+
+fn default_max_stream_retries() -> u32 {
+    2
+}
+
+fn default_stream_idle_timeout_secs() -> u64 {
+    60
 }
 
 impl Default for LlmRetryPolicy {
@@ -43,6 +71,9 @@ impl Default for LlmRetryPolicy {
             max_retries: 2,
             fallback_upstream_models: Vec::new(),
             backoff_base_ms: default_backoff_base_ms(),
+            overloaded_backoff_base_ms: default_overloaded_backoff_base_ms(),
+            max_stream_retries: default_max_stream_retries(),
+            stream_idle_timeout_secs: default_stream_idle_timeout_secs(),
         }
     }
 }
@@ -74,30 +105,62 @@ impl LlmRetryPolicy {
         self
     }
 
+    /// Set the backoff base delay for `Overloaded` errors in milliseconds.
+    pub fn with_overloaded_backoff_base_ms(mut self, ms: u64) -> Self {
+        self.overloaded_backoff_base_ms = ms;
+        self
+    }
+
+    /// Set the maximum number of mid-stream retries.
+    pub fn with_max_stream_retries(mut self, n: u32) -> Self {
+        self.max_stream_retries = n;
+        self
+    }
+
+    /// Set the per-event stream idle timeout in seconds.
+    pub fn with_stream_idle_timeout_secs(mut self, secs: u64) -> Self {
+        self.stream_idle_timeout_secs = secs;
+        self
+    }
+
     /// Compute the backoff delay for a given retry attempt (0-indexed).
     fn backoff_delay(&self, attempt: u32) -> Duration {
-        if self.backoff_base_ms == 0 {
+        Self::backoff_delay_with_base(self.backoff_base_ms, attempt)
+    }
+
+    /// Compute the backoff delay for an `Overloaded` error.
+    fn overloaded_backoff_delay(&self, attempt: u32) -> Duration {
+        Self::backoff_delay_with_base(self.overloaded_backoff_base_ms, attempt)
+    }
+
+    fn backoff_delay_with_base(base_ms: u64, attempt: u32) -> Duration {
+        if base_ms == 0 {
             return Duration::ZERO;
         }
-        let delay_ms = self
-            .backoff_base_ms
+        let delay_ms = base_ms
             .saturating_mul(1u64 << attempt.min(16))
             .min(MAX_BACKOFF_MS);
         Duration::from_millis(delay_ms)
     }
+
+    /// Select the delay to wait before the next retry attempt. Picks the
+    /// larger of the error-type-specific exponential backoff and any
+    /// provider-supplied `Retry-After` hint.
+    pub fn delay_before_retry(&self, err: &InferenceExecutionError, attempt: u32) -> Duration {
+        let base = match err {
+            InferenceExecutionError::Overloaded { .. } => self.overloaded_backoff_delay(attempt),
+            _ => self.backoff_delay(attempt),
+        };
+        match err.retry_after() {
+            Some(hint) if hint > base => hint,
+            _ => base,
+        }
+    }
 }
 
-/// Whether an error is retryable.
-///
-/// Transient errors (rate limits, timeouts, provider errors) are retryable.
-/// Terminal errors (cancellation) are not.
+/// Whether an error is retryable by the retry subsystem.
 fn is_retryable(err: &InferenceExecutionError) -> bool {
-    matches!(
-        err,
-        InferenceExecutionError::RateLimited(_)
-            | InferenceExecutionError::Timeout(_)
-            | InferenceExecutionError::Provider(_)
-    )
+    err.is_retryable()
 }
 
 /// An [`LlmExecutor`] wrapper that applies a [`LlmRetryPolicy`].
@@ -148,18 +211,21 @@ impl RetryingExecutor {
                     return Ok(result);
                 }
                 Err(err) => {
-                    if let Some(ref cb) = self.circuit_breaker {
-                        cb.record_failure(&request.upstream_model);
+                    if err.counts_toward_circuit_breaker() {
+                        if let Some(ref cb) = self.circuit_breaker {
+                            cb.record_failure(&request.upstream_model);
+                        }
                     }
                     if !is_retryable(&err) {
                         return Err(err);
                     }
-                    last_error = Some(err);
                     if attempt == self.policy.max_retries {
+                        last_error = Some(err);
                         break;
                     }
                     // Exponential backoff between retries (not before the first attempt).
-                    let delay = self.policy.backoff_delay(attempt);
+                    let delay = self.policy.delay_before_retry(&err, attempt);
+                    last_error = Some(err);
                     if !delay.is_zero() {
                         tokio::time::sleep(delay).await;
                     }
@@ -181,8 +247,8 @@ impl RetryingExecutor {
     /// Attempt to open a streaming response with retries for one model variant.
     ///
     /// Retries apply only while creating the stream. Once a provider has returned
-    /// a stream, retrying later stream-item errors would duplicate already
-    /// emitted deltas, so those errors are surfaced to the caller.
+    /// a stream, mid-stream errors are recovered by `execute_streaming` (see
+    /// `loop_runner::inference`), not here.
     async fn try_stream_with_retries(
         &self,
         request: &InferenceRequest,
@@ -202,17 +268,20 @@ impl RetryingExecutor {
                     return Ok(stream);
                 }
                 Err(err) => {
-                    if let Some(ref cb) = self.circuit_breaker {
-                        cb.record_failure(&request.upstream_model);
+                    if err.counts_toward_circuit_breaker() {
+                        if let Some(ref cb) = self.circuit_breaker {
+                            cb.record_failure(&request.upstream_model);
+                        }
                     }
                     if !is_retryable(&err) {
                         return Err(err);
                     }
-                    last_error = Some(err);
                     if attempt == self.policy.max_retries {
+                        last_error = Some(err);
                         break;
                     }
-                    let delay = self.policy.backoff_delay(attempt);
+                    let delay = self.policy.delay_before_retry(&err, attempt);
+                    last_error = Some(err);
                     if !delay.is_zero() {
                         tokio::time::sleep(delay).await;
                     }
@@ -221,6 +290,24 @@ impl RetryingExecutor {
         }
 
         Err(last_error.expect("at least one stream attempt was made"))
+    }
+
+    /// Return `AllModelsUnavailable` iff a circuit breaker is attached and
+    /// every candidate model (primary + fallbacks) is currently open.
+    fn all_models_blocked(
+        &self,
+        request: &InferenceRequest,
+        fallback_upstream_models: &[String],
+    ) -> bool {
+        let Some(ref cb) = self.circuit_breaker else {
+            return false;
+        };
+        if cb.check(&request.upstream_model).is_ok() {
+            return false;
+        }
+        fallback_upstream_models
+            .iter()
+            .all(|m| cb.check(m).is_err())
     }
 }
 
@@ -231,6 +318,10 @@ impl LlmExecutor for RetryingExecutor {
         request: InferenceRequest,
     ) -> Result<StreamResult, InferenceExecutionError> {
         let fallback_upstream_models = self.fallback_upstream_models_for_request(&request);
+
+        if self.all_models_blocked(&request, &fallback_upstream_models) {
+            return Err(InferenceExecutionError::AllModelsUnavailable);
+        }
 
         // Try primary model.
         match self.try_with_retries(&request).await {
@@ -275,6 +366,10 @@ impl LlmExecutor for RetryingExecutor {
     > {
         Box::pin(async move {
             let fallback_upstream_models = self.fallback_upstream_models_for_request(&request);
+
+            if self.all_models_blocked(&request, &fallback_upstream_models) {
+                return Err(InferenceExecutionError::AllModelsUnavailable);
+            }
 
             match self.try_stream_with_retries(&request).await {
                 Ok(stream) => return Ok(stream),
@@ -432,18 +527,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(request.upstream_model.clone());
-            match &self.error {
-                InferenceExecutionError::Provider(s) => {
-                    Err(InferenceExecutionError::Provider(s.clone()))
-                }
-                InferenceExecutionError::RateLimited(s) => {
-                    Err(InferenceExecutionError::RateLimited(s.clone()))
-                }
-                InferenceExecutionError::Timeout(s) => {
-                    Err(InferenceExecutionError::Timeout(s.clone()))
-                }
-                InferenceExecutionError::Cancelled => Err(InferenceExecutionError::Cancelled),
-            }
+            Err(self.error.clone())
         }
 
         fn name(&self) -> &str {
@@ -502,7 +586,7 @@ mod tests {
     #[tokio::test]
     async fn fallback_upstream_model_used_after_primary_exhausts_retries() {
         let inner = Arc::new(ModelRecorder::always_fail_with(
-            InferenceExecutionError::RateLimited("overloaded".into()),
+            InferenceExecutionError::rate_limited("overloaded"),
         ));
         let policy = test_policy()
             .with_max_retries(1)
@@ -529,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn request_override_fallback_upstream_models_replace_policy_fallbacks() {
         let inner = Arc::new(ModelRecorder::always_fail_with(
-            InferenceExecutionError::RateLimited("overloaded".into()),
+            InferenceExecutionError::rate_limited("overloaded"),
         ));
         let policy = test_policy()
             .with_max_retries(0)
@@ -565,7 +649,7 @@ mod tests {
     #[tokio::test]
     async fn execute_stream_uses_request_override_fallback_upstream_models() {
         let inner = Arc::new(ModelRecorder::always_fail_with(
-            InferenceExecutionError::RateLimited("overloaded".into()),
+            InferenceExecutionError::rate_limited("overloaded"),
         ));
         let policy = test_policy()
             .with_max_retries(0)
@@ -667,6 +751,9 @@ mod tests {
         assert_eq!(policy.max_retries, 2);
         assert!(policy.fallback_upstream_models.is_empty());
         assert_eq!(policy.backoff_base_ms, 500);
+        assert_eq!(policy.overloaded_backoff_base_ms, 2_000);
+        assert_eq!(policy.max_stream_retries, 2);
+        assert_eq!(policy.stream_idle_timeout_secs, 60);
     }
 
     #[test]
@@ -678,9 +765,47 @@ mod tests {
 
     #[test]
     fn rate_limit_error_is_retryable() {
-        assert!(is_retryable(&InferenceExecutionError::RateLimited(
-            "429".into()
+        assert!(is_retryable(&InferenceExecutionError::rate_limited("429")));
+    }
+
+    #[test]
+    fn overloaded_error_is_retryable() {
+        assert!(is_retryable(&InferenceExecutionError::overloaded("529")));
+    }
+
+    #[test]
+    fn context_overflow_is_not_retryable() {
+        assert!(!is_retryable(&InferenceExecutionError::ContextOverflow(
+            "too long".into()
         )));
+    }
+
+    #[test]
+    fn context_overflow_does_not_count_toward_breaker() {
+        let err = InferenceExecutionError::ContextOverflow("too long".into());
+        assert!(!err.counts_toward_circuit_breaker());
+    }
+
+    #[test]
+    fn invalid_request_does_not_count_toward_breaker() {
+        assert!(
+            !InferenceExecutionError::InvalidRequest("schema".into())
+                .counts_toward_circuit_breaker()
+        );
+    }
+
+    #[test]
+    fn unauthorized_does_not_count_toward_breaker() {
+        assert!(
+            !InferenceExecutionError::Unauthorized("key".into()).counts_toward_circuit_breaker()
+        );
+    }
+
+    #[test]
+    fn all_models_unavailable_is_fail_fast() {
+        let err = InferenceExecutionError::AllModelsUnavailable;
+        assert!(!err.is_retryable());
+        assert!(!err.counts_toward_circuit_breaker());
     }
 
     #[test]
@@ -805,7 +930,7 @@ mod tests {
     async fn retry_on_rate_limit_then_succeed() {
         let inner = Arc::new(
             FailNThenSucceed::new(2)
-                .with_error(|_| InferenceExecutionError::RateLimited("rate limited".into())),
+                .with_error(|_| InferenceExecutionError::rate_limited("rate limited")),
         );
         let policy = test_policy().with_max_retries(3);
         let executor = RetryingExecutor::new(inner.clone(), policy);
@@ -858,7 +983,7 @@ mod tests {
     async fn all_error_types_handled() {
         for error_fn in [
             (|_: u32| InferenceExecutionError::Provider("down".into())) as fn(u32) -> _,
-            |_| InferenceExecutionError::RateLimited("429".into()),
+            |_| InferenceExecutionError::rate_limited("429"),
             |_| InferenceExecutionError::Timeout("timeout".into()),
         ] {
             let inner = Arc::new(FailNThenSucceed::new(1).with_error(error_fn));
@@ -908,7 +1033,10 @@ mod tests {
             .with_max_retries(5)
             .with_fallback_upstream_model("fallback-a")
             .with_fallback_upstream_model("fallback-b")
-            .with_backoff_base_ms(200);
+            .with_backoff_base_ms(200)
+            .with_overloaded_backoff_base_ms(4_000)
+            .with_max_stream_retries(3)
+            .with_stream_idle_timeout_secs(90);
         let json = serde_json::to_string(&policy).unwrap();
         let parsed: LlmRetryPolicy = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.max_retries, 5);
@@ -917,14 +1045,20 @@ mod tests {
             vec!["fallback-a", "fallback-b"]
         );
         assert_eq!(parsed.backoff_base_ms, 200);
+        assert_eq!(parsed.overloaded_backoff_base_ms, 4_000);
+        assert_eq!(parsed.max_stream_retries, 3);
+        assert_eq!(parsed.stream_idle_timeout_secs, 90);
     }
 
     #[test]
     fn retry_policy_serde_default_backoff() {
-        // Deserializing without backoff_base_ms should use the default.
+        // Deserializing without optional fields should use defaults.
         let json = r#"{"max_retries":2,"fallback_upstream_models":[]}"#;
         let parsed: LlmRetryPolicy = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.backoff_base_ms, 500);
+        assert_eq!(parsed.overloaded_backoff_base_ms, 2_000);
+        assert_eq!(parsed.max_stream_retries, 2);
+        assert_eq!(parsed.stream_idle_timeout_secs, 60);
     }
 
     #[test]
@@ -1011,6 +1145,147 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 1: Retry-After, Overloaded base, AllModelsUnavailable, permanent
+    //          errors bypass the circuit breaker.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn delay_before_retry_respects_retry_after_when_longer() {
+        let policy = LlmRetryPolicy::default().with_backoff_base_ms(100);
+        let err = InferenceExecutionError::RateLimited {
+            message: "slow".into(),
+            retry_after: Some(Duration::from_secs(5)),
+        };
+        // 100ms exp backoff at attempt 0 < 5s hint → hint wins.
+        assert_eq!(policy.delay_before_retry(&err, 0), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn delay_before_retry_uses_exponential_when_longer_than_retry_after() {
+        let policy = LlmRetryPolicy::default().with_backoff_base_ms(10_000);
+        let err = InferenceExecutionError::RateLimited {
+            message: "fast hint".into(),
+            retry_after: Some(Duration::from_millis(100)),
+        };
+        // 10s base capped at 8s at attempt 0, still > 100ms hint.
+        assert_eq!(
+            policy.delay_before_retry(&err, 0),
+            Duration::from_millis(MAX_BACKOFF_MS)
+        );
+    }
+
+    #[test]
+    fn delay_before_retry_uses_overloaded_base_for_overloaded_errors() {
+        let policy = LlmRetryPolicy::default()
+            .with_backoff_base_ms(500)
+            .with_overloaded_backoff_base_ms(2_000);
+        let overloaded = InferenceExecutionError::overloaded("surge");
+        // At attempt 0 the overloaded base dominates: 2000ms vs 500ms.
+        assert_eq!(
+            policy.delay_before_retry(&overloaded, 0),
+            Duration::from_millis(2_000)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limited_retry_after_waits_hint_duration() {
+        let inner = Arc::new(FailNThenSucceed::new(1).with_error(|_| {
+            InferenceExecutionError::RateLimited {
+                message: "slow down".into(),
+                retry_after: Some(Duration::from_secs(3)),
+            }
+        }));
+        let policy = LlmRetryPolicy::default()
+            .with_max_retries(2)
+            .with_backoff_base_ms(10); // short base so Retry-After dominates
+        let executor = RetryingExecutor::new(inner.clone(), policy);
+
+        let start = tokio::time::Instant::now();
+        let result = executor.execute(test_request()).await;
+        assert!(result.is_ok());
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_secs(3),
+            "expected >=3s retry-after wait, got {elapsed:?}"
+        );
+        assert_eq!(inner.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn context_overflow_error_is_not_retried() {
+        let inner =
+            Arc::new(FailNThenSucceed::new(5).with_error(|_| {
+                InferenceExecutionError::ContextOverflow("prompt too long".into())
+            }));
+        let policy = test_policy().with_max_retries(3);
+        let executor = RetryingExecutor::new(inner.clone(), policy);
+
+        let result = executor.execute(test_request()).await;
+        assert!(matches!(
+            result,
+            Err(InferenceExecutionError::ContextOverflow(_))
+        ));
+        assert_eq!(inner.call_count(), 1, "permanent error must not retry");
+    }
+
+    #[tokio::test]
+    async fn context_overflow_does_not_trip_circuit_breaker() {
+        use crate::engine::circuit_breaker::CircuitBreakerConfig;
+
+        let inner = Arc::new(
+            FailNThenSucceed::new(100)
+                .with_error(|_| InferenceExecutionError::ContextOverflow("too long".into())),
+        );
+        let cb = Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 2,
+            cooldown: Duration::from_secs(60),
+            half_open_max: 1,
+        }));
+
+        let policy = test_policy().with_max_retries(0);
+        let executor =
+            RetryingExecutor::new(inner.clone(), policy).with_circuit_breaker(cb.clone());
+
+        // Five independent calls: none should trip the breaker.
+        for _ in 0..5 {
+            let _ = executor.execute(test_request()).await;
+        }
+        assert!(
+            cb.check("primary-model").is_ok(),
+            "ContextOverflow must not increment the breaker"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_models_blocked_short_circuits_with_all_models_unavailable() {
+        use crate::engine::circuit_breaker::CircuitBreakerConfig;
+
+        let cb = Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 1,
+            cooldown: Duration::from_secs(60),
+            half_open_max: 1,
+        }));
+        cb.record_failure("primary-model");
+        cb.record_failure("fallback-a");
+        cb.record_failure("fallback-b");
+
+        let inner = Arc::new(FailNThenSucceed::new(0)); // would succeed if called
+        let policy = test_policy()
+            .with_max_retries(2)
+            .with_fallback_upstream_model("fallback-a")
+            .with_fallback_upstream_model("fallback-b");
+        let executor =
+            RetryingExecutor::new(inner.clone(), policy).with_circuit_breaker(cb.clone());
+
+        let result = executor.execute(test_request()).await;
+        assert!(
+            matches!(result, Err(InferenceExecutionError::AllModelsUnavailable)),
+            "expected AllModelsUnavailable, got {result:?}"
+        );
+        assert_eq!(inner.call_count(), 0, "no inner call should be made");
+    }
+
+    // -----------------------------------------------------------------------
     // Backoff sleep verification with paused time
     // -----------------------------------------------------------------------
 
@@ -1048,17 +1323,26 @@ mod tests {
             fn llm_retry_policy_serde_roundtrip(
                 max_retries in 0u32..10,
                 backoff_base_ms in 0u64..10000,
+                overloaded_backoff_base_ms in 0u64..10000,
+                max_stream_retries in 0u32..10,
+                stream_idle_timeout_secs in 1u64..300,
                 num_fallbacks in 0usize..5,
             ) {
                 let policy = LlmRetryPolicy {
                     max_retries,
                     fallback_upstream_models: (0..num_fallbacks).map(|i| format!("model-{i}")).collect(),
                     backoff_base_ms,
+                    overloaded_backoff_base_ms,
+                    max_stream_retries,
+                    stream_idle_timeout_secs,
                 };
                 let json = serde_json::to_string(&policy).unwrap();
                 let parsed: LlmRetryPolicy = serde_json::from_str(&json).unwrap();
                 prop_assert_eq!(parsed.max_retries, max_retries);
                 prop_assert_eq!(parsed.backoff_base_ms, backoff_base_ms);
+                prop_assert_eq!(parsed.overloaded_backoff_base_ms, overloaded_backoff_base_ms);
+                prop_assert_eq!(parsed.max_stream_retries, max_stream_retries);
+                prop_assert_eq!(parsed.stream_idle_timeout_secs, stream_idle_timeout_secs);
                 prop_assert_eq!(parsed.fallback_upstream_models.len(), num_fallbacks);
             }
 

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -913,8 +913,8 @@ mod tests {
 
     #[tokio::test]
     async fn rate_limited_error_surfaces_correctly() {
-        let agent = make_agent(vec![Err(InferenceExecutionError::RateLimited(
-            "429 too many requests".into(),
+        let agent = make_agent(vec![Err(InferenceExecutionError::rate_limited(
+            "429 too many requests",
         ))]);
         let sink = VecEventSink::new();
         let mut it = 0u64;

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -99,7 +99,7 @@ impl LlmExecutor for RecordingFallbackExecutor {
             .push(request.upstream_model.clone());
 
         if request.upstream_model == self.retryable_model {
-            return Err(InferenceExecutionError::RateLimited("test retry".into()));
+            return Err(InferenceExecutionError::rate_limited("test retry"));
         }
 
         Ok(StreamResult {

--- a/docs/superpowers/specs/2026-04-24-llm-stream-error-handling-design.md
+++ b/docs/superpowers/specs/2026-04-24-llm-stream-error-handling-design.md
@@ -1,0 +1,572 @@
+# LLM Stream Error Handling & Mid-Stream Recovery — Design
+
+## Problem
+
+The inference pipeline (`awaken-runtime::engine::executor::GenaiExecutor`,
+`awaken-runtime::engine::retry::RetryingExecutor`, and
+`awaken-runtime::loop_runner::inference::execute_streaming`) retries whole
+requests that fail *before* streaming starts, and already recovers from
+`stop_reason == MaxTokens` via `awaken-runtime::context::truncation`. It does
+not, however, recover from failures that occur **after streaming has begun**.
+The current classification also conflates permanent errors (context overflow,
+auth, invalid request) with transient ones, causing retry loops that make
+outages worse.
+
+Concretely, the following failure modes are handled poorly or not at all:
+
+1. Mid-stream disconnects (`ECONNRESET`, HTTP/2 GOAWAY, proxy 5xx after
+   headers): error is surfaced immediately, already-emitted deltas are
+   discarded, accumulated state is thrown away.
+2. Idle stalls (TCP half-open, provider hang): only bounded by the 120 s total
+   request timeout; a stalled stream blocks a turn for the full window.
+3. `400 "prompt is too long"` / `413 Payload Too Large`: classified as
+   `Provider` and retried, amplifying the failure.
+4. `529 overloaded_error` (Anthropic) is indistinguishable from generic 5xx,
+   retried at the same cadence rather than backing off harder or failing over.
+5. `Retry-After` header is ignored; retries use pure exponential backoff.
+6. Partial tool_use JSON on mid-stream disconnect is dropped with no path to
+   tell the model which tools succeeded and which were interrupted.
+7. All-circuit-open state surfaces as a generic provider error.
+
+## Goals
+
+In scope for this spec:
+
+- Split `InferenceExecutionError` into retryable / permanent variants, with
+  per-variant policy (backoff base, retry count, circuit-breaker accounting).
+- Honor `Retry-After` headers for `RateLimited` and `Overloaded`.
+- Detect mid-stream interruptions and idle-stalls, capture accumulated state,
+  and resume via one of four plans (R1–R4 below) that reuse existing loop
+  runner machinery rather than inventing a new resume protocol.
+- For parallel tool_use interruptions, deliver complete tool calls to the
+  existing `StopReason::ToolUse` path and inject a user-visible note for the
+  cancelled partial tool, so the model can decide whether to retry it.
+- Add failure-injection tests covering each recovery path and each
+  classification change.
+
+### Explicit non-goals
+
+- Cross-process / cross-crash resume of in-flight streams. Depends on
+  `NatsBufferedThreadStore` (design WIP, not yet on `main`); tracked as a
+  separate follow-up change once that store lands.
+- Tool argument "repair prompting" for non-truncated malformed JSON. Tracked
+  as a follow-up change.
+- `ContentFiltered` surfacing. A variant is reserved in the enum but
+  `map_error` keeps current behavior; the follow-up change wires provider
+  classification and telemetry.
+- Changes to the `genai` dependency or provider-specific SDK behavior.
+
+## Architecture
+
+### Error taxonomy
+
+`awaken-contract::contract::executor::InferenceExecutionError` becomes:
+
+```rust
+#[derive(Debug, Error)]
+pub enum InferenceExecutionError {
+    // Transient — retryable. Counts toward circuit breaker.
+    #[error("rate limited: {message}")]
+    RateLimited {
+        message: String,
+        retry_after: Option<Duration>,
+    },
+
+    #[error("provider overloaded: {0}")]
+    Overloaded(String),
+
+    #[error("upstream timeout: {0}")]
+    Timeout(String),
+
+    #[error("transient provider error: {0}")]
+    Provider(String),
+
+    #[error("stream interrupted ({cause})")]
+    StreamInterrupted {
+        cause: InterruptCause,
+        snapshot: Box<InterruptSnapshot>,
+    },
+
+    // Permanent — NOT retryable. Does NOT count toward circuit breaker.
+    #[error("context overflow: {0}")]
+    ContextOverflow(String),
+
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+
+    #[error("model not found: {0}")]
+    ModelNotFound(String),
+
+    #[error("content filtered: {0}")]
+    ContentFiltered(String),
+
+    // Fail-fast when the retry subsystem has nothing left.
+    #[error("all models unavailable (circuit breakers open)")]
+    AllModelsUnavailable,
+
+    // Lifecycle.
+    #[error("cancelled")]
+    Cancelled,
+}
+
+pub enum InterruptCause {
+    ConnectionReset,
+    IdleStall,
+    GoAway,
+    Provider5xxMidStream(u16),
+}
+```
+
+`RetryingExecutor::is_retryable` returns `true` for `RateLimited | Overloaded
+| Timeout | Provider | StreamInterrupted`; `false` for everything else.
+`CircuitBreaker::record_failure` is only called for the retryable set.
+`ContextOverflow`, `InvalidRequest`, `Unauthorized`, `ModelNotFound`,
+`AllModelsUnavailable`, `ContentFiltered`, `Cancelled` bypass the breaker.
+
+### `GenaiExecutor::map_error` classification
+
+- Status 429 → `RateLimited { retry_after: parse_retry_after(headers) }`.
+- Status 529 → `Overloaded`. Status 503 also maps to `Overloaded` (Anthropic
+  and many proxies emit 503 under overload).
+- Status 408, 504, client-side read timeout → `Timeout`.
+- Status 500, 502 → `Provider`.
+- Status 400:
+  - Body or message contains any of `"prompt is too long"`,
+    `"context_length_exceeded"`, `"reduce the length"`, `"input is too long"`
+    (case-insensitive) → `ContextOverflow`.
+  - Otherwise → `InvalidRequest`.
+- Status 413 → `ContextOverflow`.
+- Status 401, 403 → `Unauthorized`.
+- Status 404 → `ModelNotFound`.
+- Status 422 → `InvalidRequest`.
+- No status + string-match fallback preserves today's heuristics but routes
+  `"overloaded"` to `Overloaded` (was `Provider`).
+
+`parse_retry_after` accepts either an integer seconds value or an HTTP-date,
+per RFC 9110 §10.2.3. Unparseable values fall back to `None`.
+
+### Backoff policy
+
+Two defaults and one rule change in `RetryingExecutor`:
+
+- Existing `backoff_base_ms` (default 500, cap 8000) stays for `Timeout`,
+  `Provider`, and `StreamInterrupted`.
+- New `overloaded_backoff_base_ms` (default 2000, same cap) for `Overloaded`,
+  to give the provider more room.
+- For `RateLimited { retry_after: Some(d) }` and `Overloaded` carrying a
+  `Retry-After` header, the wait is `max(retry_after, computed_backoff)`.
+- `AllModelsUnavailable` is raised when every `fallback_upstream_models` entry
+  has an open breaker; the error is returned immediately without waiting.
+
+### Stream-level recovery: where it lives
+
+Mid-stream retry logic lives in
+`awaken-runtime::loop_runner::inference::execute_streaming`, not in
+`RetryingExecutor`. Rationale:
+
+| Responsibility                                     | Executor layer | loop_runner |
+| -------------------------------------------------- | :------------: | :---------: |
+| Mutate the `messages` field of `InferenceRequest` for continuation |   ✗   |   ✓   |
+| Emit `ToolCallCancel` / `StreamReset` to `EventSink` |     ✗        |      ✓      |
+| Inspect `ChatOptions.reasoning` for idle threshold |       ✗        |      ✓      |
+| Synthesize `StopReason::ToolUse` to upstream caller|       ✗        |      ✓      |
+
+`RetryingExecutor` keeps its current semantics: retry the *call* to
+`execute_stream` on errors raised before the stream yields. Mid-stream errors
+propagate up to `execute_streaming`, which owns recovery.
+
+### `StreamCollector` snapshot
+
+`awaken-runtime::engine::streaming::StreamCollector` gains:
+
+```rust
+pub struct InterruptSnapshot {
+    pub text: Option<String>,
+    pub completed_tool_calls: Vec<ToolCall>,
+    pub in_flight_tool: Option<InFlightTool>,
+    pub bytes_received: usize,
+    pub last_delta_at: Instant,
+}
+
+pub struct InFlightTool {
+    pub id: String,
+    pub name: String,
+    pub partial_args: String,
+}
+
+impl StreamCollector {
+    pub fn last_delta_at(&self) -> Instant;
+    pub fn interrupt_snapshot(&self) -> InterruptSnapshot;
+}
+```
+
+`last_delta_at` is updated inside `process()` after every yielded `Text`,
+`Reasoning`, or `ToolCallDelta`. A tool call moves from `in_flight_tool` to
+`completed_tool_calls` when its accumulated JSON parses successfully. Only
+one tool can be `in_flight` at a time per Anthropic / OpenAI streaming
+semantics; if a second `ToolCallStart` arrives while one is in flight, the
+previous one is finalized (and if JSON is invalid, dropped).
+
+### Recovery plans
+
+```rust
+pub enum RecoveryPlan {
+    ContinueText {
+        assistant_prefix: String,
+    },
+    SynthesizeToolUse {
+        completed: Vec<ToolCall>,
+        cancelled_tool_hint: Option<InFlightTool>,
+    },
+    TruncateBeforeTool {
+        assistant_prefix: String,
+        cancelled_tool_id: String,
+        cancelled_tool_name: String,
+    },
+    WholeRestart,
+}
+
+impl InterruptSnapshot {
+    pub fn plan(&self) -> RecoveryPlan {
+        match (self.text.as_deref(), self.completed_tool_calls.as_slice(),
+               self.in_flight_tool.as_ref()) {
+            // R1: text only
+            (Some(t), [], None) if !t.is_empty() =>
+                RecoveryPlan::ContinueText { assistant_prefix: t.into() },
+
+            // R2: ≥1 completed tool, partial tool (if any) becomes a hint
+            (_, completed @ [_, ..], in_flight) =>
+                RecoveryPlan::SynthesizeToolUse {
+                    completed: completed.to_vec(),
+                    cancelled_tool_hint: in_flight.cloned(),
+                },
+
+            // R3: only one partial tool, but we have text before it
+            (Some(t), [], Some(p)) if !t.is_empty() =>
+                RecoveryPlan::TruncateBeforeTool {
+                    assistant_prefix: t.into(),
+                    cancelled_tool_id: p.id.clone(),
+                    cancelled_tool_name: p.name.clone(),
+                },
+
+            // R4: only a partial tool, no text, no completed tools
+            _ => RecoveryPlan::WholeRestart,
+        }
+    }
+}
+```
+
+### `execute_streaming` loop
+
+```rust
+pub async fn execute_streaming(
+    agent: &ActiveAgent,
+    mut req: InferenceRequest,
+    sink: &mut dyn EventSink,
+    cancel: &CancellationToken,
+    policy: &StreamRetryPolicy,
+) -> Result<StreamResult, InferenceExecutionError> {
+    let idle_timeout = idle_timeout_for(&req, policy.stream_idle_timeout);
+    let mut attempt: u32 = 0;
+
+    loop {
+        let executor = &agent.llm_executor;
+        let stream = executor.execute_stream(req.clone()).await?;
+        let mut collector = StreamCollector::new();
+
+        match run_stream_with_idle_timeout(
+            stream, &mut collector, sink, cancel, idle_timeout,
+        ).await {
+            Ok(()) => return Ok(collector.finish()),
+
+            Err(DriveError::Cancelled) => return Err(Cancelled),
+
+            Err(DriveError::Interrupted(cause))
+                if attempt >= policy.max_stream_retries =>
+            {
+                return Err(StreamInterrupted {
+                    cause,
+                    snapshot: Box::new(collector.interrupt_snapshot()),
+                });
+            }
+
+            Err(DriveError::Interrupted(cause)) => {
+                let snapshot = collector.interrupt_snapshot();
+                match snapshot.plan() {
+                    RecoveryPlan::ContinueText { assistant_prefix } => {
+                        push_continuation(&mut req, assistant_prefix);
+                    }
+                    RecoveryPlan::SynthesizeToolUse { completed, cancelled_tool_hint } => {
+                        return Ok(StreamResult::synthesized_tool_use(
+                            collector.text(),
+                            completed,
+                            cancelled_tool_hint,
+                        ));
+                    }
+                    RecoveryPlan::TruncateBeforeTool {
+                        assistant_prefix, cancelled_tool_id, cancelled_tool_name: _,
+                    } => {
+                        sink.emit(StreamEvent::ToolCallCancel {
+                            id: cancelled_tool_id,
+                        });
+                        push_continuation(&mut req, assistant_prefix);
+                    }
+                    RecoveryPlan::WholeRestart => {
+                        sink.emit(StreamEvent::StreamReset { reason: cause });
+                    }
+                }
+
+                backoff_for_stream(&cause, attempt, policy).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+fn push_continuation(req: &mut InferenceRequest, assistant_prefix: String) {
+    let msgs = req.messages_mut();
+    msgs.push(Message::assistant_text(assistant_prefix));
+    msgs.push(Message::user_text(CONTINUATION_PROMPT));
+}
+```
+
+`run_stream_with_idle_timeout` wraps each `stream.next()` call in
+`tokio::time::timeout(idle_timeout, …)`. On timeout it returns
+`Interrupted(IdleStall)`. On transport errors it returns
+`Interrupted(ConnectionReset | GoAway | Provider5xxMidStream(n))` based on
+the underlying error source.
+
+`StreamResult::synthesized_tool_use` constructs a `StreamResult` with
+`stop_reason = StopReason::ToolUse`, the completed tool calls, any pre-tool
+text, and — if `cancelled_tool_hint` is `Some` — stores the hint in a new
+`pending_tool_cancel_hint: Option<ToolCancelHint>` field on the returned
+`StreamResult` (and copied onto the run's turn state so the next
+`user`-role message can carry it).
+
+### Model-aware idle threshold
+
+```rust
+fn idle_timeout_for(req: &InferenceRequest, base: Duration) -> Duration {
+    let model = req.upstream_model.as_str();
+    let name_hits_thinking =
+        model.contains("thinking")
+        || model.contains("reasoning")
+        || model.starts_with("o1")
+        || model.starts_with("o3")
+        || model.starts_with("o4");
+    let options_hits_thinking = req.overrides.thinking_enabled();
+    if name_hits_thinking || options_hits_thinking { base * 2 } else { base }
+}
+```
+
+`InferenceOverrides` gains a new `thinking_enabled: Option<bool>` field (
+serde default `None`, which behaves as `false`). The field is populated by the
+caller (agent config, tool-use setup) when the request uses extended thinking
+or any reasoning-effort knob. `thinking_enabled()` returns
+`self.thinking_enabled.unwrap_or(false)`. The field is additive on the
+`InferenceOverrides` struct; existing configs deserialize unchanged.
+
+### Parallel tool_use: the `cancelled_tool_hint` injection
+
+The R2 recovery path returns a `StreamResult` to the caller without any
+further LLM round trip. Loop runner proceeds as it does for any
+`StopReason::ToolUse`: the completed tool calls are executed via
+`execute_ready_tool_calls`, and their results are assembled into a `user`
+message containing `tool_result` content blocks.
+
+A new optional payload on that `user` message — a trailing `text` content
+block — is emitted iff `pending_tool_cancel_hint` is set:
+
+```text
+Note: your parallel call to tool `<name>` was interrupted mid-stream due to a
+transient upstream error. The other tool calls completed normally. You may
+re-issue the call if still needed.
+```
+
+The hint is consumed (cleared) when the next `assistant` turn is drafted.
+No changes to the API contract with upstream providers: the injected block
+is a standard `text` content block, legal on `user` messages in both
+Anthropic and OpenAI schemas.
+
+### Configuration
+
+New fields on `awaken-contract::contract::executor::LlmRetryPolicy`:
+
+```rust
+pub struct LlmRetryPolicy {
+    // existing fields ...
+    pub max_stream_retries: u32,              // default 2, independent of max_retries
+    pub stream_idle_timeout_secs: u64,        // default 60
+    pub overloaded_backoff_base_ms: u64,      // default 2000
+}
+```
+
+Defaults live in `Default for LlmRetryPolicy`. Agent-level overrides are
+already plumbed through `AgentConfig`.
+
+### Telemetry
+
+Counters, registered through the existing `metrics` pattern used by
+`circuit_breaker.rs`:
+
+- `llm_stream_interrupted_total{cause, recovery_plan}`
+- `llm_stream_idle_stall_total{model}`
+- `llm_context_overflow_total{model}`
+- `llm_overloaded_total{model}`
+- `llm_retry_after_respected_total`
+- `llm_all_models_unavailable_total`
+
+Existing logs in `map_error` gain the classified variant in their structured
+fields.
+
+## Testing
+
+All new tests live adjacent to the code they cover and use the existing mock
+executor patterns from `awaken-runtime::engine::mock` and
+`awaken-runtime::engine::retry` tests.
+
+### Failure-injection harness
+
+A new helper, `MockStreamInjector`, feeds scripted `ChatStreamEvent` sequences
+with inline faults:
+
+```rust
+pub enum Injected {
+    Event(ChatStreamEvent),
+    Fault(InjectFault),
+    IdleFor(Duration),
+}
+
+pub enum InjectFault {
+    ConnectionReset,
+    GoAway,
+    Provider5xxMidStream(u16),
+    EndWithoutStopReason,
+}
+
+pub struct MockStreamInjector {
+    scripts: Vec<Vec<Injected>>,   // one script per attempt
+    attempt: AtomicUsize,
+}
+```
+
+Each call to `execute_stream` consumes the script at index
+`min(attempt, scripts.len() - 1)` and increments `attempt`. If fewer scripts
+than attempts are provided, the last script repeats, which models a steady
+failure mode across retries. `IdleFor` is rendered via
+`tokio::time::advance` under `tokio::test(start_paused = true)` to exercise
+the idle-timeout path without wall-clock waits.
+
+`Message::assistant_text` and `Message::user_text` are convenience
+constructors on `awaken-contract::contract::message::Message` that wrap a
+single-element `content` vector with a `Text` block. They are added as part
+of this change if not already present.
+
+### Unit tests (per module)
+
+`crates/awaken-runtime/src/engine/executor.rs` — classification:
+
+- `map_error_429_populates_retry_after_from_header`
+- `map_error_529_maps_to_overloaded`
+- `map_error_503_maps_to_overloaded`
+- `map_error_400_prompt_too_long_maps_to_context_overflow`
+- `map_error_400_schema_maps_to_invalid_request`
+- `map_error_413_maps_to_context_overflow`
+- `map_error_401_maps_to_unauthorized`
+- `map_error_404_maps_to_model_not_found`
+
+`crates/awaken-runtime/src/engine/retry.rs` — backoff & breaker:
+
+- `retry_after_header_overrides_exponential_backoff`
+- `overloaded_uses_longer_base_backoff`
+- `context_overflow_bypasses_retry_and_breaker`
+- `invalid_request_bypasses_retry_and_breaker`
+- `all_models_open_returns_all_models_unavailable_without_wait`
+
+`crates/awaken-runtime/src/engine/streaming.rs` — snapshot:
+
+- `interrupt_snapshot_captures_text_only_state` → R1 plan
+- `interrupt_snapshot_captures_completed_and_in_flight_tool` → R2 plan
+- `interrupt_snapshot_truncates_before_in_flight_when_no_completed_tool` → R3
+- `interrupt_snapshot_wholerestart_when_partial_tool_no_text` → R4
+- `last_delta_at_updates_on_every_delta`
+
+`crates/awaken-runtime/src/loop_runner/inference.rs` — stream loop:
+
+- `mid_stream_connection_reset_with_text_retries_via_continuation` (R1)
+- `mid_stream_reset_with_two_complete_tools_and_one_partial_synthesizes_tool_use_and_queues_hint` (R2)
+- `mid_stream_reset_with_text_then_partial_tool_truncates_and_emits_cancel_event` (R3)
+- `mid_stream_reset_with_only_partial_tool_whole_restart_emits_reset_event` (R4)
+- `idle_stall_triggers_recovery_at_configured_threshold`
+- `thinking_model_idle_threshold_doubled`
+- `stream_retry_budget_exhausted_returns_last_snapshot`
+- `cancellation_during_backoff_aborts_loop`
+
+### Integration test
+
+`crates/awaken/tests/llm_stream_recovery.rs` — end-to-end through the full
+loop runner with `MockStreamInjector`:
+
+- `parallel_tools_interrupted_midway_model_gets_hint_and_final_answer`
+  Scripts attempt 1 to emit two complete `tool_use` blocks plus a partial
+  third, then `ConnectionReset`. Tools A and B execute via mock handlers.
+  Attempt 2's `user` message contains the injected hint text block. Attempt
+  2 returns a clean final answer. Assert: A and B were called once each,
+  the partial tool was never executed, the final `assistant` content matches
+  the scripted answer.
+
+- `context_overflow_triggers_compaction_then_succeeds`
+  First `execute_stream` call returns `ContextOverflow`. Loop runner invokes
+  `compact_with_llm`, replaces the message tail with the summary, and
+  re-dispatches. Assert: no breaker failure recorded; second call
+  succeeds.
+
+- `stream_retries_bounded_and_final_snapshot_surfaced`
+  Injector fails mid-stream on every attempt. After `max_stream_retries + 1`
+  attempts, the run terminates with `StreamInterrupted` whose snapshot
+  carries the last attempt's accumulated state.
+
+## Migration and compatibility
+
+- `InferenceExecutionError` additions are source-incompatible with external
+  consumers that `match` exhaustively on the enum. The only in-tree
+  exhaustive matches are in `RetryingExecutor`, `map_error`, and tests;
+  these are updated in the same change. The enum is not `#[non_exhaustive]`
+  today but becomes so as part of this spec so future variants (wired
+  `ContentFiltered` handling, resume-id for cross-process recovery) are
+  additive without breaking downstream code.
+- `LlmRetryPolicy` gains fields with `Default` values; serde defaults cover
+  deserialization of older configs.
+- `StreamEvent` variants `ToolCallCancel` and `StreamReset` are additive.
+  Existing `EventSink` implementations must pattern-match exhaustively; the
+  trait adds default no-op methods for the new variants to keep implementors
+  compiling without mandatory changes.
+
+## Risks
+
+- **R2 hint wording drift.** The injected hint is natural-language; models
+  may react to its phrasing differently. The text is centralized as a
+  `const` so it can be tuned from telemetry.
+- **Idle threshold false positives on thinking models.** `2×` is a coarse
+  rule. If we observe stalls on `claude-opus-4-7` with extended thinking
+  beyond 120 s, the policy can be made per-model via
+  `LlmRetryPolicy::per_model_overrides`.
+- **Alignment with `codex/max-tokens-text-continuation` branch.** That
+  in-flight branch touches the same continuation path. The implementation
+  plan must rebase on top of it (or merge it first) to avoid divergent
+  continuation prompts.
+- **Breaker accounting change.** Moving permanent errors off the breaker
+  changes observed failure counts; dashboards that read the breaker metric
+  will see lower counts after rollout. Acceptable — those errors should
+  never have been counted in the first place.
+
+## Follow-up changes (separate specs)
+
+| Change                                                          | Depends on              |
+| --------------------------------------------------------------- | ----------------------- |
+| Malformed-JSON tool args repair; `stop_reason`-missing recovery | This spec               |
+| `ContentFiltered` surfacing and policy telemetry                | This spec               |
+| Cross-process stream resume via `NatsBufferedThreadStore` WAL   | NATS store store design |


### PR DESCRIPTION
## Summary

First PR in a 3-PR series implementing comprehensive LLM stream error handling. This PR establishes the contract layer: error taxonomy and the spec.

- Splits `InferenceExecutionError` into transient / permanent / fail-fast classes (`RateLimited` / `Overloaded` / `ContextOverflow` / `InvalidRequest` / `Unauthorized` / `ModelNotFound` / `ContentFiltered` / `AllModelsUnavailable` / `StreamInterrupted`).
- HTTP-status classification (`map_error`) reads `body` for 400 (`prompt too long` → `ContextOverflow` vs generic → `InvalidRequest`); 529/503 → `Overloaded` with longer backoff base; 401/403 → `Unauthorized`; 404 → `ModelNotFound`.
- `Retry-After` header (delta-seconds form) parsed and respected in `RetryingExecutor::delay_before_retry` — honors the larger of header hint and exponential backoff.
- Permanent errors bypass the circuit breaker (no false trips on schema bugs / context overflow).
- `AllModelsUnavailable` short-circuits when every fallback model has an open breaker.

## In scope (this PR)

- `InferenceExecutionError` taxonomy + `is_retryable` / `counts_toward_circuit_breaker` policy helpers
- `LlmRetryPolicy` extensions: `overloaded_backoff_base_ms`, `max_stream_retries`, `stream_idle_timeout_secs`
- Spec doc at `docs/superpowers/specs/2026-04-24-llm-stream-error-handling-design.md`

## Out of scope (later PRs)

- PR 2: mid-stream R1-R4 recovery loop, idle stall, parallel tool hint injection
- PR 3: cross-process resume via `StreamCheckpointStore`, GOAWAY / `ContentFiltered` / malformed-args extensions

## Test plan

- [x] `cargo test -p awaken-contract --lib` (511 → 514, +3 tests for new variants & `is_retryable` partition)
- [x] `cargo test -p awaken-runtime --lib engine::executor` (10 → 22, +12 tests for HTTP-status classification + `Retry-After` parsing)
- [x] `cargo test -p awaken-runtime --lib engine::retry` (45 → 60, +15 tests for `delay_before_retry`, breaker bypass, `AllModelsUnavailable`)
- [x] No behavioral change to existing call sites — string-form `RateLimited` constructions migrated mechanically via `InferenceExecutionError::rate_limited()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)