### PR TITLE
✨ feat(runtime): cross-process resume + failure-mode coverage + dedup (3/3)

### DIFF
--- a/crates/awaken-contract/src/contract/executor.rs
+++ b/crates/awaken-contract/src/contract/executor.rs
@@ -38,6 +38,10 @@ pub enum InterruptCause {
     GoAway,
     /// Provider returned a 5xx status after headers had been sent.
     Provider5xxMidStream(u16),
+    /// Synthetic cause used when a stream is being resumed from a
+    /// persisted checkpoint (no real interruption happened in this
+    /// process — the previous process crashed or restarted).
+    ResumedFromCheckpoint,
 }
 
 impl std::fmt::Display for InterruptCause {
@@ -47,6 +51,7 @@ impl std::fmt::Display for InterruptCause {
             Self::IdleStall => f.write_str("idle stall"),
             Self::GoAway => f.write_str("goaway"),
             Self::Provider5xxMidStream(s) => write!(f, "provider {s} mid-stream"),
+            Self::ResumedFromCheckpoint => f.write_str("resumed from checkpoint"),
         }
     }
 }

--- a/crates/awaken-contract/src/contract/executor.rs
+++ b/crates/awaken-contract/src/contract/executor.rs
@@ -105,6 +105,53 @@ pub enum RecoveryPlan {
 }
 
 impl InterruptSnapshot {
+    /// Build an `InterruptSnapshot` from a stream of `(id, name, args_json)`
+    /// triples in declaration order, plus the accumulated text.
+    ///
+    /// Tools whose `name` is empty or whose `args_json` does not parse as
+    /// JSON become the `in_flight_tool` (last-write-wins if multiple);
+    /// the rest land in `completed_tool_calls`. This is the single source
+    /// of truth for partials → snapshot translation; the multiple
+    /// stream-collector implementations across the runtime delegate to
+    /// it instead of reimplementing.
+    pub fn from_partials<I>(text: Option<String>, partials: I, bytes_received: usize) -> Self
+    where
+        I: IntoIterator<Item = (String, String, String)>,
+    {
+        let mut completed: Vec<ToolCall> = Vec::new();
+        let mut in_flight: Option<InFlightTool> = None;
+
+        for (id, name, args_json) in partials {
+            if name.is_empty() {
+                in_flight = Some(InFlightTool {
+                    id,
+                    name: String::new(),
+                    partial_args: args_json,
+                });
+                continue;
+            }
+            match serde_json::from_str::<serde_json::Value>(&args_json) {
+                Ok(arguments) if !(arguments.is_null() && !args_json.is_empty()) => {
+                    completed.push(ToolCall::new(id, name, arguments));
+                }
+                _ => {
+                    in_flight = Some(InFlightTool {
+                        id,
+                        name,
+                        partial_args: args_json,
+                    });
+                }
+            }
+        }
+
+        Self {
+            text,
+            completed_tool_calls: completed,
+            in_flight_tool: in_flight,
+            bytes_received,
+        }
+    }
+
     /// Decide which recovery plan applies to this snapshot.
     pub fn plan(&self) -> RecoveryPlan {
         let text = self.text.as_deref().unwrap_or("");

--- a/crates/awaken-contract/src/contract/executor.rs
+++ b/crates/awaken-contract/src/contract/executor.rs
@@ -52,7 +52,7 @@ impl std::fmt::Display for InterruptCause {
 }
 
 /// A tool_use block observed mid-stream whose argument JSON did not close.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct InFlightTool {
     pub id: String,
     pub name: String,

--- a/crates/awaken-contract/src/contract/mod.rs
+++ b/crates/awaken-contract/src/contract/mod.rs
@@ -15,6 +15,7 @@ pub mod profile_store;
 pub mod progress;
 pub mod shared_state;
 pub mod storage;
+pub mod stream_checkpoint;
 pub mod suspension;
 pub mod tool;
 pub mod tool_intercept;

--- a/crates/awaken-contract/src/contract/stream_checkpoint.rs
+++ b/crates/awaken-contract/src/contract/stream_checkpoint.rs
@@ -58,13 +58,13 @@ pub struct StreamCheckpoint {
     pub updated_at_ms: u64,
 }
 
-/// Errors returned by `StreamCheckpointStore` operations.
+/// Backend-level failure (IO, network, serialization). The contract is a
+/// newtype rather than a multi-variant enum because every checkpoint
+/// backend collapses its native error to a string at this boundary —
+/// callers never branch on the cause.
 #[derive(Debug, Error)]
-pub enum StreamCheckpointError {
-    /// Backend-level failure (IO, network, serialization).
-    #[error("stream checkpoint backend error: {0}")]
-    Backend(String),
-}
+#[error("stream checkpoint backend error: {0}")]
+pub struct StreamCheckpointError(pub String);
 
 /// Persistence for stream checkpoints.
 ///

--- a/crates/awaken-contract/src/contract/stream_checkpoint.rs
+++ b/crates/awaken-contract/src/contract/stream_checkpoint.rs
@@ -1,0 +1,204 @@
+//! Cross-process stream resume: persist mid-stream accumulated state so a
+//! new process (or a retry after a hard crash) can pick up where the
+//! previous attempt left off, instead of re-inferring the whole turn.
+//!
+//! ## Semantics
+//!
+//! A `StreamCheckpoint` is a *snapshot of accumulated deltas* scoped to a
+//! single `run_id`. Writers (the loop runner's `drive_one_stream`) flush
+//! the snapshot periodically as deltas arrive. Readers (the start of a
+//! new `execute_streaming` call) look up any stored checkpoint for the
+//! active `run_id` and, if present, mutate the request to include the
+//! previously-accumulated text as an assistant prefix + a continuation
+//! prompt — mechanically identical to the in-process R1 recovery path.
+//!
+//! ## Non-goals
+//!
+//! - The checkpoint is **not** a full conversation log. Committed
+//!   messages are still owned by `ThreadRunStore`. The checkpoint only
+//!   captures the in-flight delta accumulator.
+//! - The contract does **not** prescribe a retention policy. Production
+//!   implementations may bound the checkpoint TTL; the in-memory store
+//!   keeps everything until explicitly deleted.
+//! - The contract is provider-agnostic. A NATS JetStream-backed impl,
+//!   a filesystem impl, or a Redis impl all satisfy this trait.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::executor::InFlightTool;
+use super::message::ToolCall;
+
+/// A persisted snapshot of in-flight stream accumulator state for a run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamCheckpoint {
+    /// Identifier of the run this checkpoint belongs to. Uniquely keys
+    /// the checkpoint in storage.
+    pub run_id: String,
+    /// Identifier of the containing thread. Carried for operator
+    /// inspection and for scoped bulk deletion (per-thread cleanup).
+    pub thread_id: String,
+    /// Upstream model the interrupted attempt targeted.
+    pub upstream_model: String,
+    /// Text content accumulated before interruption.
+    pub partial_text: String,
+    /// Tool calls whose arguments parsed cleanly before interruption.
+    /// On resume these are replayed as completed; the model does not
+    /// re-emit them.
+    pub completed_tool_calls: Vec<ToolCall>,
+    /// The open tool whose arguments had not finished arriving. Used to
+    /// surface a cancelled-tool hint on resume, same as R2.
+    pub in_flight_tool: Option<InFlightTool>,
+    /// Wall-clock millis when the writer last updated the checkpoint.
+    /// Used to bound staleness on read.
+    pub updated_at_ms: u64,
+}
+
+/// Errors returned by `StreamCheckpointStore` operations.
+#[derive(Debug, Error)]
+pub enum StreamCheckpointError {
+    /// Backend-level failure (IO, network, serialization).
+    #[error("stream checkpoint backend error: {0}")]
+    Backend(String),
+}
+
+/// Persistence for stream checkpoints.
+///
+/// The trait is deliberately small: implementations are free to batch,
+/// buffer, or shard under the hood. Callers assume sub-millisecond
+/// latency for the in-memory path and bounded (single-digit ms) latency
+/// for production backends.
+#[async_trait]
+pub trait StreamCheckpointStore: Send + Sync {
+    /// Upsert a checkpoint for `checkpoint.run_id`.
+    async fn put(&self, checkpoint: StreamCheckpoint) -> Result<(), StreamCheckpointError>;
+
+    /// Look up the most recent checkpoint for `run_id`, if any.
+    async fn get(&self, run_id: &str) -> Result<Option<StreamCheckpoint>, StreamCheckpointError>;
+
+    /// Remove the checkpoint for `run_id`. Idempotent: removing a
+    /// nonexistent key is not an error.
+    async fn delete(&self, run_id: &str) -> Result<(), StreamCheckpointError>;
+}
+
+/// Reference in-memory implementation. Suitable for tests and for
+/// single-process operation where cross-process resume is not needed
+/// but the in-process retry loop still benefits from the same
+/// checkpoint interface.
+pub struct InMemoryStreamCheckpointStore {
+    data: Mutex<HashMap<String, StreamCheckpoint>>,
+}
+
+impl Default for InMemoryStreamCheckpointStore {
+    fn default() -> Self {
+        Self {
+            data: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl InMemoryStreamCheckpointStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Count stored checkpoints (test-only helper).
+    pub fn len(&self) -> usize {
+        self.data.lock().unwrap().len()
+    }
+
+    /// True when no checkpoints are stored.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[async_trait]
+impl StreamCheckpointStore for InMemoryStreamCheckpointStore {
+    async fn put(&self, checkpoint: StreamCheckpoint) -> Result<(), StreamCheckpointError> {
+        let mut guard = self.data.lock().unwrap();
+        guard.insert(checkpoint.run_id.clone(), checkpoint);
+        Ok(())
+    }
+
+    async fn get(&self, run_id: &str) -> Result<Option<StreamCheckpoint>, StreamCheckpointError> {
+        Ok(self.data.lock().unwrap().get(run_id).cloned())
+    }
+
+    async fn delete(&self, run_id: &str) -> Result<(), StreamCheckpointError> {
+        self.data.lock().unwrap().remove(run_id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(run_id: &str) -> StreamCheckpoint {
+        StreamCheckpoint {
+            run_id: run_id.into(),
+            thread_id: "thread-1".into(),
+            upstream_model: "test-model".into(),
+            partial_text: "hello".into(),
+            completed_tool_calls: vec![],
+            in_flight_tool: None,
+            updated_at_ms: 1_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn in_memory_put_get_delete_roundtrip() {
+        let store = InMemoryStreamCheckpointStore::new();
+        assert!(store.is_empty());
+
+        store.put(sample("run-a")).await.unwrap();
+        store.put(sample("run-b")).await.unwrap();
+        assert_eq!(store.len(), 2);
+
+        let got = store.get("run-a").await.unwrap().unwrap();
+        assert_eq!(got.run_id, "run-a");
+        assert_eq!(got.partial_text, "hello");
+
+        store.delete("run-a").await.unwrap();
+        assert_eq!(store.len(), 1);
+        assert!(store.get("run-a").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_is_not_an_error() {
+        let store = InMemoryStreamCheckpointStore::new();
+        store.delete("no-such-run").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn put_overwrites_existing_entry() {
+        let store = InMemoryStreamCheckpointStore::new();
+        store.put(sample("run-a")).await.unwrap();
+
+        let updated = StreamCheckpoint {
+            partial_text: "updated text".into(),
+            updated_at_ms: 2_000,
+            ..sample("run-a")
+        };
+        store.put(updated).await.unwrap();
+
+        let got = store.get("run-a").await.unwrap().unwrap();
+        assert_eq!(got.partial_text, "updated text");
+        assert_eq!(got.updated_at_ms, 2_000);
+    }
+
+    #[test]
+    fn checkpoint_serde_roundtrip() {
+        let checkpoint = sample("run-1");
+        let json = serde_json::to_string(&checkpoint).unwrap();
+        let parsed: StreamCheckpoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.run_id, "run-1");
+        assert_eq!(parsed.partial_text, "hello");
+    }
+}

--- a/crates/awaken-runtime/src/engine/executor.rs
+++ b/crates/awaken-runtime/src/engine/executor.rs
@@ -153,7 +153,13 @@ impl GenaiExecutor {
 
         // Fall back to string matching for errors without structured status codes.
         let lower = msg.to_lowercase();
-        if lower.contains("overloaded") {
+        if lower.contains("content_filter")
+            || lower.contains("content policy")
+            || lower.contains("content_policy_violation")
+            || lower.contains("blocked by safety")
+        {
+            InferenceExecutionError::ContentFiltered(msg)
+        } else if lower.contains("overloaded") {
             InferenceExecutionError::overloaded(msg)
         } else if lower.contains("rate")
             || lower.contains("429")
@@ -1116,6 +1122,50 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn map_error_content_filter_string_maps_to_content_filtered() {
+        let err =
+            genai::Error::Internal("response blocked by content_filter policy violation".into());
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::ContentFiltered(_)),
+            "expected ContentFiltered, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_content_policy_string_maps_to_content_filtered() {
+        let err = genai::Error::Internal("content policy triggered".into());
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::ContentFiltered(_)),
+            "expected ContentFiltered, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn map_error_safety_string_maps_to_content_filtered() {
+        let err = genai::Error::Internal("blocked by safety filter".into());
+        let mapped = GenaiExecutor::map_error(err);
+        assert!(
+            matches!(mapped, InferenceExecutionError::ContentFiltered(_)),
+            "expected ContentFiltered, got {mapped:?}"
+        );
+    }
+
+    #[test]
+    fn content_filtered_is_not_retryable_and_does_not_count_toward_breaker() {
+        let err = InferenceExecutionError::ContentFiltered("policy".into());
+        assert!(
+            !err.is_retryable(),
+            "ContentFiltered must be permanent (no retry)"
+        );
+        assert!(
+            !err.counts_toward_circuit_breaker(),
+            "ContentFiltered must not increment the breaker"
+        );
     }
 
     #[test]

--- a/crates/awaken-runtime/src/engine/streaming.rs
+++ b/crates/awaken-runtime/src/engine/streaming.rs
@@ -840,6 +840,56 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_tool_use_id_is_deduplicated_to_single_entry() {
+        use genai::chat::ToolCall as GToolCall;
+
+        let mut c = StreamCollector::new();
+
+        // First ToolCallStart establishes the id/name.
+        c.process(ChatStreamEvent::ToolCallChunk(ToolChunk {
+            tool_call: GToolCall {
+                call_id: "dup-1".into(),
+                fn_name: "search".into(),
+                fn_arguments: serde_json::json!({"q": "a"}),
+                thought_signatures: None,
+            },
+        }));
+
+        // Second event reuses the same id with richer args — collector
+        // extends the existing entry rather than creating a duplicate.
+        c.process(ChatStreamEvent::ToolCallChunk(ToolChunk {
+            tool_call: GToolCall {
+                call_id: "dup-1".into(),
+                fn_name: "search".into(),
+                fn_arguments: serde_json::json!({"q": "abc"}),
+                thought_signatures: None,
+            },
+        }));
+
+        // A semantically duplicate "start" emission of the same id that
+        // actually provides FULLY new args (edge case some providers
+        // emit on retry) is also folded into the same entry.
+        c.process(ChatStreamEvent::ToolCallChunk(ToolChunk {
+            tool_call: GToolCall {
+                call_id: "dup-1".into(),
+                fn_name: "search".into(),
+                fn_arguments: serde_json::json!({"q": "abcdef"}),
+                thought_signatures: None,
+            },
+        }));
+
+        let result = c.finish();
+        assert_eq!(
+            result.tool_calls.len(),
+            1,
+            "duplicate ids must collapse to one entry, got: {:?}",
+            result.tool_calls
+        );
+        assert_eq!(result.tool_calls[0].id, "dup-1");
+        assert_eq!(result.tool_calls[0].arguments["q"], "abcdef");
+    }
+
+    #[test]
     fn interrupt_snapshot_truncated_only_becomes_in_flight_with_empty_completed() {
         use genai::chat::ToolCall as GToolCall;
 

--- a/crates/awaken-runtime/src/engine/streaming.rs
+++ b/crates/awaken-runtime/src/engine/streaming.rs
@@ -88,54 +88,13 @@ impl StreamCollector {
     /// stream interruption triggers recovery. Does not consume the
     /// collector; the caller typically discards it and opens a fresh one.
     pub fn interrupt_snapshot(&self) -> InterruptSnapshot {
-        let mut completed: Vec<ToolCall> = Vec::new();
-        let mut in_flight: Option<InFlightTool> = None;
-
-        for id in &self.tool_call_order {
-            let Some(p) = self.tool_calls.get(id) else {
-                continue;
-            };
-            if p.name.is_empty() {
-                // Name has not been observed yet — treat as in-flight but
-                // keep scanning in case a later entry is valid. Rare.
-                in_flight = Some(InFlightTool {
-                    id: p.id.clone(),
-                    name: String::new(),
-                    partial_args: p.arguments.clone(),
-                });
-                continue;
-            }
-            let parsed = serde_json::from_str::<Value>(&p.arguments);
-            match parsed {
-                Ok(arguments) if !(arguments.is_null() && !p.arguments.is_empty()) => {
-                    completed.push(ToolCall::new(p.id.clone(), p.name.clone(), arguments));
-                }
-                // Args present but unparseable → in-flight. If multiple
-                // unclosed tools race to be "in flight" only the most recent
-                // is retained (Anthropic/OpenAI emit at most one at a time
-                // per assistant turn; the last one wins).
-                _ => {
-                    in_flight = Some(InFlightTool {
-                        id: p.id.clone(),
-                        name: p.name.clone(),
-                        partial_args: p.arguments.clone(),
-                    });
-                }
-            }
-        }
-
-        let text = if self.text.is_empty() {
-            None
-        } else {
-            Some(self.text.clone())
-        };
-
-        InterruptSnapshot {
-            text,
-            completed_tool_calls: completed,
-            in_flight_tool: in_flight,
-            bytes_received: self.bytes_received,
-        }
+        let text = (!self.text.is_empty()).then(|| self.text.clone());
+        let partials = self.tool_call_order.iter().filter_map(|id| {
+            self.tool_calls
+                .get(id)
+                .map(|p| (p.id.clone(), p.name.clone(), p.arguments.clone()))
+        });
+        InterruptSnapshot::from_partials(text, partials, self.bytes_received)
     }
 
     /// Take the next deferred output produced by the previous provider event, if any.

--- a/crates/awaken-runtime/src/engine/streaming.rs
+++ b/crates/awaken-runtime/src/engine/streaming.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use genai::chat::{ChatStreamEvent, StreamEnd};
 use serde_json::Value;
 
-use awaken_contract::contract::executor::{InFlightTool, InterruptSnapshot};
+use awaken_contract::contract::executor::InterruptSnapshot;
 use awaken_contract::contract::inference::{StreamResult, TokenUsage};
 use awaken_contract::contract::message::ToolCall;
 

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -558,39 +558,9 @@ struct StreamingAccumulator {
 
 impl StreamingAccumulator {
     /// Build an [`InterruptSnapshot`] reflecting the current accumulator
-    /// state. Preserves text (may be empty), marks tool calls with valid
-    /// JSON as completed and the most-recent unparseable one as in-flight.
+    /// state. Delegates partials → snapshot translation to the contract
+    /// helper so the two stream collectors in this crate stay in lockstep.
     fn interrupt_snapshot(&self) -> InterruptSnapshot {
-        let mut completed: Vec<ToolCall> = Vec::new();
-        let mut in_flight: Option<InFlightTool> = None;
-
-        for id in &self.tool_order {
-            let args_json = self.current_tool_args.get(id).cloned().unwrap_or_default();
-            let name = self.tool_names.get(id).cloned().unwrap_or_default();
-
-            if name.is_empty() {
-                in_flight = Some(InFlightTool {
-                    id: id.clone(),
-                    name: String::new(),
-                    partial_args: args_json,
-                });
-                continue;
-            }
-
-            match serde_json::from_str::<serde_json::Value>(&args_json) {
-                Ok(arguments) if !(arguments.is_null() && !args_json.is_empty()) => {
-                    completed.push(ToolCall::new(id.clone(), name, arguments));
-                }
-                _ => {
-                    in_flight = Some(InFlightTool {
-                        id: id.clone(),
-                        name,
-                        partial_args: args_json,
-                    });
-                }
-            }
-        }
-
         let text = if self.current_text.is_empty() {
             self.content_blocks
                 .iter()
@@ -602,13 +572,14 @@ impl StreamingAccumulator {
         } else {
             Some(self.current_text.clone())
         };
-
-        InterruptSnapshot {
-            text,
-            completed_tool_calls: completed,
-            in_flight_tool: in_flight,
-            bytes_received: self.bytes_received,
-        }
+        let partials = self.tool_order.iter().map(|id| {
+            (
+                id.clone(),
+                self.tool_names.get(id).cloned().unwrap_or_default(),
+                self.current_tool_args.get(id).cloned().unwrap_or_default(),
+            )
+        });
+        InterruptSnapshot::from_partials(text, partials, self.bytes_received)
     }
 
     async fn finalize(&mut self, sink: &dyn EventSink) -> StreamResult {

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -98,125 +98,60 @@ pub(super) async fn execute_streaming(
     let max_retries = policy.max_stream_retries;
     let mut attempt: u32 = 0;
 
-    // Cross-process resume: if a checkpoint exists for this run id, apply
-    // its state as if we had just hit a mid-stream interruption. This
-    // pushes an assistant prefix + continuation prompt onto the request
-    // mechanically identical to the in-process R1/R2/R3 paths. The
-    // checkpoint is NOT deleted here — it is only cleared after the new
-    // attempt finalizes cleanly, so a crash during recovery doesn't lose
-    // the state.
-    let mut restored_hint: Option<InFlightTool> = None;
-    if let Some(handle) = checkpoint.as_ref() {
-        match handle.store.get(handle.run_id).await {
-            Ok(Some(saved)) => {
-                tracing::info!(
-                    run_id = %handle.run_id,
-                    partial_text_len = saved.partial_text.len(),
-                    completed_tools = saved.completed_tool_calls.len(),
-                    has_in_flight = saved.in_flight_tool.is_some(),
-                    "restoring stream checkpoint"
-                );
-                let snapshot = InterruptSnapshot {
-                    text: if saved.partial_text.is_empty() {
-                        None
-                    } else {
-                        Some(saved.partial_text.clone())
-                    },
-                    completed_tool_calls: saved.completed_tool_calls.clone(),
-                    in_flight_tool: saved.in_flight_tool.clone(),
-                    bytes_received: saved.partial_text.len(),
-                };
-                match snapshot.plan() {
-                    RecoveryPlan::ContinueText { assistant_prefix } => {
-                        push_continuation(&mut request, assistant_prefix);
-                    }
-                    RecoveryPlan::SynthesizeToolUse {
-                        completed,
-                        cancelled_tool_hint,
-                    } => {
-                        // The previous process had already observed fully
-                        // formed tool_use(s). Return the synthesized result
-                        // immediately; the loop runner will execute the
-                        // tools in this process.
-                        for call in &completed {
-                            sink.emit(AgentEvent::ToolCallReady {
-                                id: call.id.clone(),
-                                name: call.name.clone(),
-                                arguments: call.arguments.clone(),
-                            })
-                            .await;
-                        }
-                        if let Some(hint) = &cancelled_tool_hint {
-                            sink.emit(AgentEvent::ToolCallCancel {
-                                id: hint.id.clone(),
-                                name: hint.name.clone(),
-                                reason: "resumed from checkpoint".into(),
-                            })
-                            .await;
-                        }
-                        // Clear the checkpoint — we are consuming it.
-                        let _ = handle.store.delete(handle.run_id).await;
-                        let content = match &snapshot.text {
-                            Some(t) if !t.is_empty() => {
-                                vec![ContentBlock::text(t.clone())]
-                            }
-                            _ => Vec::new(),
-                        };
-                        return Ok((
-                            StreamResult {
-                                content,
-                                tool_calls: completed,
-                                usage: None,
-                                stop_reason: Some(StopReason::ToolUse),
-                                has_incomplete_tool_calls: false,
-                            },
-                            cancelled_tool_hint,
-                        ));
-                    }
-                    RecoveryPlan::TruncateBeforeTool {
-                        assistant_prefix,
-                        cancelled_tool_id,
-                        cancelled_tool_name,
-                    } => {
-                        sink.emit(AgentEvent::ToolCallCancel {
-                            id: cancelled_tool_id,
-                            name: cancelled_tool_name,
-                            reason: "resumed from checkpoint".into(),
-                        })
-                        .await;
-                        restored_hint = saved.in_flight_tool.clone();
-                        push_continuation(&mut request, assistant_prefix);
-                    }
-                    RecoveryPlan::WholeRestart => {
-                        // Nothing salvageable — proceed with the original
-                        // request unchanged but clear the stale checkpoint.
-                        let _ = handle.store.delete(handle.run_id).await;
-                    }
-                }
-            }
-            Ok(None) => {}
-            Err(e) => {
-                tracing::warn!(
-                    run_id = %handle.run_id,
-                    error = %e,
-                    "checkpoint read failed; continuing without restore"
-                );
-            }
-        }
+    // Cross-process resume: if a checkpoint exists for this run id,
+    // synthesize a `DriveOutcome::Interrupted` and feed it through the
+    // same recovery dispatch the in-process retry loop uses. This means
+    // crash-resume reuses every R1-R4 code path verbatim — there is no
+    // separate "restore" code path to keep in sync.
+    let mut pending_resume: Option<DriveOutcome> = None;
+    if let Some(handle) = checkpoint.as_ref()
+        && let Some(saved) = read_checkpoint(handle).await
+    {
+        let snapshot = InterruptSnapshot::from_partials(
+            (!saved.partial_text.is_empty()).then(|| saved.partial_text.clone()),
+            saved
+                .completed_tool_calls
+                .into_iter()
+                .map(|c| {
+                    (
+                        c.id,
+                        c.name,
+                        serde_json::to_string(&c.arguments).unwrap_or_default(),
+                    )
+                })
+                .chain(
+                    saved
+                        .in_flight_tool
+                        .into_iter()
+                        .map(|p| (p.id, p.name, p.partial_args)),
+                ),
+            saved.partial_text.len(),
+        );
+        pending_resume = Some(DriveOutcome::Interrupted {
+            cause: InterruptCause::ResumedFromCheckpoint,
+            snapshot,
+        });
     }
 
     loop {
-        let outcome = drive_one_stream(
-            agent,
-            request.clone(),
-            sink,
-            cancellation_token,
-            total_input_tokens,
-            total_output_tokens,
-            idle_timeout,
-            checkpoint.as_ref(),
-        )
-        .await;
+        // Consume the synthetic resume outcome on the first iteration,
+        // then fall through to driving real streams on subsequent ones.
+        let outcome = match pending_resume.take() {
+            Some(o) => o,
+            None => {
+                drive_one_stream(
+                    agent,
+                    request.clone(),
+                    sink,
+                    cancellation_token,
+                    total_input_tokens,
+                    total_output_tokens,
+                    idle_timeout,
+                    checkpoint.as_ref(),
+                )
+                .await
+            }
+        };
 
         match outcome {
             DriveOutcome::Completed(result) | DriveOutcome::Cancelled(result) => {
@@ -225,11 +160,15 @@ pub(super) async fn execute_streaming(
                 if let Some(handle) = checkpoint.as_ref() {
                     let _ = handle.store.delete(handle.run_id).await;
                 }
-                return Ok((result, restored_hint));
+                return Ok((result, None));
             }
             DriveOutcome::Error(err) => return Err(err),
             DriveOutcome::Interrupted { cause, snapshot } => {
-                if attempt >= max_retries {
+                // Resume-from-checkpoint never counts against the retry
+                // budget — it is a "free" first attempt that mutates the
+                // request, then proceeds to drive a real stream.
+                let counts_against_budget = !matches!(cause, InterruptCause::ResumedFromCheckpoint);
+                if counts_against_budget && attempt >= max_retries {
                     tracing::warn!(
                         attempts = attempt,
                         cause = %cause,
@@ -249,30 +188,58 @@ pub(super) async fn execute_streaming(
                         if let Some(handle) = checkpoint.as_ref() {
                             let _ = handle.store.delete(handle.run_id).await;
                         }
-                        return Ok((result, hint.or(restored_hint)));
+                        return Ok((result, hint));
                     }
                     RecoveryOutcome::RetryAfterPlan => {
-                        let delay = stream_retry_backoff(&cause, attempt, &policy);
-                        if !delay.is_zero() {
-                            if let Some(token) = cancellation_token {
-                                tokio::select! {
-                                    biased;
-                                    _ = token.cancelled() => {
-                                        return Err(AgentLoopError::from(
-                                            InferenceExecutionError::Cancelled,
-                                        ));
+                        if counts_against_budget {
+                            let delay = stream_retry_backoff(&cause, attempt, &policy);
+                            if !delay.is_zero() {
+                                if let Some(token) = cancellation_token {
+                                    tokio::select! {
+                                        biased;
+                                        _ = token.cancelled() => {
+                                            return Err(AgentLoopError::from(
+                                                InferenceExecutionError::Cancelled,
+                                            ));
+                                        }
+                                        _ = tokio::time::sleep(delay) => {}
                                     }
-                                    _ = tokio::time::sleep(delay) => {}
+                                } else {
+                                    tokio::time::sleep(delay).await;
                                 }
-                            } else {
-                                tokio::time::sleep(delay).await;
                             }
+                            attempt += 1;
                         }
-                        attempt += 1;
                         continue;
                     }
                 }
             }
+        }
+    }
+}
+
+/// Best-effort checkpoint read. Logs and swallows backend errors so a
+/// failing store can never block forward progress.
+async fn read_checkpoint(handle: &CheckpointHandle<'_>) -> Option<StreamCheckpoint> {
+    match handle.store.get(handle.run_id).await {
+        Ok(Some(saved)) => {
+            tracing::info!(
+                run_id = %handle.run_id,
+                partial_text_len = saved.partial_text.len(),
+                completed_tools = saved.completed_tool_calls.len(),
+                has_in_flight = saved.in_flight_tool.is_some(),
+                "restoring stream checkpoint"
+            );
+            Some(saved)
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!(
+                run_id = %handle.run_id,
+                error = %e,
+                "checkpoint read failed; continuing without restore"
+            );
+            None
         }
     }
 }

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -467,16 +467,53 @@ impl StreamingAccumulator {
 fn classify_mid_stream(err: &InferenceExecutionError) -> Option<InterruptCause> {
     match err {
         // Recoverable — transport-ish failures.
-        InferenceExecutionError::Provider(_)
-        | InferenceExecutionError::Timeout(_)
-        | InferenceExecutionError::RateLimited { .. }
-        | InferenceExecutionError::Overloaded { .. } => Some(InterruptCause::ConnectionReset),
+        InferenceExecutionError::Provider(msg) | InferenceExecutionError::Timeout(msg) => {
+            Some(interpret_transport_message(msg))
+        }
+        InferenceExecutionError::RateLimited { message, .. }
+        | InferenceExecutionError::Overloaded { message, .. } => {
+            Some(interpret_transport_message(message))
+        }
 
         // Already-classified stream interruption — preserve cause.
         InferenceExecutionError::StreamInterrupted { cause, .. } => Some(cause.clone()),
 
         // Permanent / lifecycle — surface to caller, not a mid-stream retry.
         _ => None,
+    }
+}
+
+/// Heuristic substring match to distinguish HTTP/2 GOAWAY — which is a
+/// graceful server-initiated disconnect — from a raw TCP reset. The
+/// difference matters for telemetry (GOAWAY is benign, TCP reset is not)
+/// and for future policy (GOAWAY often warrants immediate fallback to a
+/// different endpoint rather than a naive retry).
+///
+/// `genai` surfaces these through error messages whose contents are
+/// provider- / reqwest-dependent, so string matching is the pragmatic
+/// contract. Keep patterns case-insensitive.
+fn interpret_transport_message(msg: &str) -> InterruptCause {
+    let lower = msg.to_lowercase();
+    if lower.contains("goaway")
+        || lower.contains("go_away")
+        || lower.contains("http/2 going away")
+        || lower.contains("connection: close")
+    {
+        InterruptCause::GoAway
+    } else if lower.contains("connection reset") || lower.contains("econnreset") {
+        InterruptCause::ConnectionReset
+    } else if lower.starts_with("502")
+        || lower.starts_with("503")
+        || lower.contains("502 bad gateway")
+        || lower.contains("503 service unavailable")
+    {
+        // Gateway-level 5xx that reaches us after the stream opened is
+        // treated as a mid-stream provider fault. The actual status
+        // code is typically available in `msg`, but for
+        // classification we only need the shape.
+        InterruptCause::Provider5xxMidStream(503)
+    } else {
+        InterruptCause::ConnectionReset
     }
 }
 
@@ -1951,5 +1988,125 @@ mod tests {
             ..plain.clone()
         };
         assert_eq!(idle_timeout_for(&o3, &policy), base * 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // GOAWAY / transport-message classification
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_mid_stream_maps_goaway_substring_to_goaway_cause() {
+        let err = InferenceExecutionError::Provider("HTTP/2 GOAWAY frame received".into());
+        assert!(matches!(
+            classify_mid_stream(&err),
+            Some(InterruptCause::GoAway)
+        ));
+    }
+
+    #[test]
+    fn classify_mid_stream_maps_connection_reset_substring_to_connection_reset() {
+        let err = InferenceExecutionError::Provider("ECONNRESET: connection reset by peer".into());
+        assert!(matches!(
+            classify_mid_stream(&err),
+            Some(InterruptCause::ConnectionReset)
+        ));
+    }
+
+    #[test]
+    fn classify_mid_stream_maps_503_substring_to_provider_5xx() {
+        let err = InferenceExecutionError::Provider("503 Service Unavailable".into());
+        assert!(matches!(
+            classify_mid_stream(&err),
+            Some(InterruptCause::Provider5xxMidStream(_))
+        ));
+    }
+
+    #[test]
+    fn classify_mid_stream_preserves_cause_from_stream_interrupted() {
+        let err = InferenceExecutionError::StreamInterrupted {
+            cause: InterruptCause::IdleStall,
+            snapshot: Box::new(InterruptSnapshot {
+                text: None,
+                completed_tool_calls: vec![],
+                in_flight_tool: None,
+                bytes_received: 0,
+            }),
+        };
+        assert!(matches!(
+            classify_mid_stream(&err),
+            Some(InterruptCause::IdleStall)
+        ));
+    }
+
+    #[test]
+    fn classify_mid_stream_refuses_permanent_errors() {
+        assert!(
+            classify_mid_stream(&InferenceExecutionError::ContextOverflow("x".into())).is_none()
+        );
+        assert!(classify_mid_stream(&InferenceExecutionError::Unauthorized("x".into())).is_none());
+        assert!(
+            classify_mid_stream(&InferenceExecutionError::ContentFiltered("x".into())).is_none()
+        );
+        assert!(classify_mid_stream(&InferenceExecutionError::Cancelled).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // J: Cancellation during retry backoff aborts the retry loop
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(start_paused = true)]
+    async fn cancellation_during_backoff_aborts_retry_loop_with_cancelled_error() {
+        use crate::cancellation::CancellationToken;
+
+        // R4-path executor: first attempt fails immediately with no
+        // accumulated state. With default policy the retry loop sleeps
+        // before attempt 2; the cancellation token fires during that
+        // sleep and the error surfaces as `Cancelled`, not as
+        // `StreamInterrupted`.
+        let exec = Arc::new(ScriptedPerAttemptExecutor::new(vec![
+            vec![Err(InferenceExecutionError::Provider("reset".into()))],
+            vec![Err(InferenceExecutionError::Provider(
+                "should-not-be-reached".into(),
+            ))],
+        ]));
+        let agent = agent_with(exec.clone());
+        let sink = VecEventSink::new();
+        let token = CancellationToken::new();
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        // Kick off the streaming call and cancel mid-backoff.
+        let exec_fut = stream_only(
+            &agent,
+            make_request(),
+            &sink,
+            Some(&token),
+            &mut it,
+            &mut ot,
+        );
+        let drive = async {
+            // Let the first attempt open and fail.
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            // Cancel before the backoff sleep completes. The default
+            // stream retry backoff for ConnectionReset ends up using
+            // the general `delay_before_retry` path, so sleeping any
+            // paused duration >= 1s guarantees we're inside it.
+            token.cancel();
+            tokio::time::advance(Duration::from_secs(30)).await;
+        };
+
+        let (result, ()) = tokio::join!(exec_fut, drive);
+        let err = result.expect_err("cancellation must abort the retry loop");
+        match err {
+            AgentLoopError::InferenceFailed(msg) => {
+                assert!(
+                    msg.contains("cancelled"),
+                    "expected cancellation message, got: {msg}"
+                );
+            }
+            other => panic!("expected InferenceFailed(cancelled), got: {other:?}"),
+        }
+        // Only the first attempt should have run.
+        assert_eq!(exec.attempts(), 1, "retry must not proceed after cancel");
     }
 }

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -13,11 +13,62 @@ use awaken_contract::contract::executor::{
 };
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::contract::message::{Message, ToolCall};
+use awaken_contract::contract::stream_checkpoint::{StreamCheckpoint, StreamCheckpointStore};
 use futures::StreamExt;
 
 use super::AgentLoopError;
 use crate::engine::retry::LlmRetryPolicy;
 use crate::registry::ResolvedAgent;
+
+/// Identifies a run for stream-checkpoint purposes. Passed into
+/// `execute_streaming` by the caller that actually knows the run
+/// identity (the loop runner's step driver); tests that don't care
+/// about cross-process resume pass `None`.
+pub(super) struct CheckpointHandle<'a> {
+    pub store: &'a dyn StreamCheckpointStore,
+    pub run_id: &'a str,
+    pub thread_id: &'a str,
+}
+
+/// Minimum delta interval between checkpoint flushes. Prevents one
+/// flush per tokenized chunk at the cost of losing up to this many
+/// deltas on a hard crash.
+const CHECKPOINT_FLUSH_DELTAS: usize = 4;
+
+/// Write the current accumulator state to the checkpoint store. Logs and
+/// suppresses backend errors — a failing checkpoint store must never
+/// disrupt the in-flight stream.
+async fn flush_checkpoint(
+    acc: &StreamingAccumulator,
+    upstream_model: &str,
+    handle: &CheckpointHandle<'_>,
+) {
+    let snapshot = acc.interrupt_snapshot();
+    let checkpoint = StreamCheckpoint {
+        run_id: handle.run_id.to_string(),
+        thread_id: handle.thread_id.to_string(),
+        upstream_model: upstream_model.to_string(),
+        partial_text: snapshot.text.clone().unwrap_or_default(),
+        completed_tool_calls: snapshot.completed_tool_calls,
+        in_flight_tool: snapshot.in_flight_tool,
+        updated_at_ms: now_ms(),
+    };
+    if let Err(e) = handle.store.put(checkpoint).await {
+        tracing::warn!(
+            run_id = %handle.run_id,
+            error = %e,
+            "stream checkpoint flush failed — continuing without persistence",
+        );
+    }
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
 
 /// Continuation prompt injected after a mid-stream interruption to nudge
 /// the model to pick up where its partial response left off. Intentionally
@@ -35,16 +86,149 @@ const CONTINUATION_PROMPT: &str =
 /// result is returned with `StopReason::EndTurn` (graceful cancel — no error).
 pub(super) async fn execute_streaming(
     agent: &ResolvedAgent,
-    mut request: InferenceRequest,
+    request: InferenceRequest,
     sink: &dyn EventSink,
     cancellation_token: Option<&CancellationToken>,
     total_input_tokens: &mut u64,
     total_output_tokens: &mut u64,
 ) -> Result<(StreamResult, Option<InFlightTool>), AgentLoopError> {
+    execute_streaming_with_checkpoint(
+        agent,
+        request,
+        sink,
+        cancellation_token,
+        total_input_tokens,
+        total_output_tokens,
+        None,
+    )
+    .await
+}
+
+/// Core streaming executor with an optional cross-process resume handle.
+/// `execute_streaming` is the tests-friendly wrapper that passes `None`
+/// for the checkpoint handle; production callers in step.rs use this
+/// function directly when they have a run identity and the agent has
+/// a `stream_checkpoint_store` configured.
+pub(super) async fn execute_streaming_with_checkpoint(
+    agent: &ResolvedAgent,
+    mut request: InferenceRequest,
+    sink: &dyn EventSink,
+    cancellation_token: Option<&CancellationToken>,
+    total_input_tokens: &mut u64,
+    total_output_tokens: &mut u64,
+    checkpoint: Option<CheckpointHandle<'_>>,
+) -> Result<(StreamResult, Option<InFlightTool>), AgentLoopError> {
     let policy = stream_retry_policy_for(agent);
     let idle_timeout = idle_timeout_for(&request, &policy);
     let max_retries = policy.max_stream_retries;
     let mut attempt: u32 = 0;
+
+    // Cross-process resume: if a checkpoint exists for this run id, apply
+    // its state as if we had just hit a mid-stream interruption. This
+    // pushes an assistant prefix + continuation prompt onto the request
+    // mechanically identical to the in-process R1/R2/R3 paths. The
+    // checkpoint is NOT deleted here — it is only cleared after the new
+    // attempt finalizes cleanly, so a crash during recovery doesn't lose
+    // the state.
+    let mut restored_hint: Option<InFlightTool> = None;
+    if let Some(handle) = checkpoint.as_ref() {
+        match handle.store.get(handle.run_id).await {
+            Ok(Some(saved)) => {
+                tracing::info!(
+                    run_id = %handle.run_id,
+                    partial_text_len = saved.partial_text.len(),
+                    completed_tools = saved.completed_tool_calls.len(),
+                    has_in_flight = saved.in_flight_tool.is_some(),
+                    "restoring stream checkpoint"
+                );
+                let snapshot = InterruptSnapshot {
+                    text: if saved.partial_text.is_empty() {
+                        None
+                    } else {
+                        Some(saved.partial_text.clone())
+                    },
+                    completed_tool_calls: saved.completed_tool_calls.clone(),
+                    in_flight_tool: saved.in_flight_tool.clone(),
+                    bytes_received: saved.partial_text.len(),
+                };
+                match snapshot.plan() {
+                    RecoveryPlan::ContinueText { assistant_prefix } => {
+                        push_continuation(&mut request, assistant_prefix);
+                    }
+                    RecoveryPlan::SynthesizeToolUse {
+                        completed,
+                        cancelled_tool_hint,
+                    } => {
+                        // The previous process had already observed fully
+                        // formed tool_use(s). Return the synthesized result
+                        // immediately; the loop runner will execute the
+                        // tools in this process.
+                        for call in &completed {
+                            sink.emit(AgentEvent::ToolCallReady {
+                                id: call.id.clone(),
+                                name: call.name.clone(),
+                                arguments: call.arguments.clone(),
+                            })
+                            .await;
+                        }
+                        if let Some(hint) = &cancelled_tool_hint {
+                            sink.emit(AgentEvent::ToolCallCancel {
+                                id: hint.id.clone(),
+                                name: hint.name.clone(),
+                                reason: "resumed from checkpoint".into(),
+                            })
+                            .await;
+                        }
+                        // Clear the checkpoint — we are consuming it.
+                        let _ = handle.store.delete(handle.run_id).await;
+                        let content = match &snapshot.text {
+                            Some(t) if !t.is_empty() => {
+                                vec![ContentBlock::text(t.clone())]
+                            }
+                            _ => Vec::new(),
+                        };
+                        return Ok((
+                            StreamResult {
+                                content,
+                                tool_calls: completed,
+                                usage: None,
+                                stop_reason: Some(StopReason::ToolUse),
+                                has_incomplete_tool_calls: false,
+                            },
+                            cancelled_tool_hint,
+                        ));
+                    }
+                    RecoveryPlan::TruncateBeforeTool {
+                        assistant_prefix,
+                        cancelled_tool_id,
+                        cancelled_tool_name,
+                    } => {
+                        sink.emit(AgentEvent::ToolCallCancel {
+                            id: cancelled_tool_id,
+                            name: cancelled_tool_name,
+                            reason: "resumed from checkpoint".into(),
+                        })
+                        .await;
+                        restored_hint = saved.in_flight_tool.clone();
+                        push_continuation(&mut request, assistant_prefix);
+                    }
+                    RecoveryPlan::WholeRestart => {
+                        // Nothing salvageable — proceed with the original
+                        // request unchanged but clear the stale checkpoint.
+                        let _ = handle.store.delete(handle.run_id).await;
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(
+                    run_id = %handle.run_id,
+                    error = %e,
+                    "checkpoint read failed; continuing without restore"
+                );
+            }
+        }
+    }
 
     loop {
         let outcome = drive_one_stream(
@@ -55,12 +239,18 @@ pub(super) async fn execute_streaming(
             total_input_tokens,
             total_output_tokens,
             idle_timeout,
+            checkpoint.as_ref(),
         )
         .await;
 
         match outcome {
             DriveOutcome::Completed(result) | DriveOutcome::Cancelled(result) => {
-                return Ok((result, None));
+                // On clean completion delete the checkpoint — it has been
+                // fully consumed and should not leak across runs.
+                if let Some(handle) = checkpoint.as_ref() {
+                    let _ = handle.store.delete(handle.run_id).await;
+                }
+                return Ok((result, restored_hint));
             }
             DriveOutcome::Error(err) => return Err(err),
             DriveOutcome::Interrupted { cause, snapshot } => {
@@ -81,7 +271,10 @@ pub(super) async fn execute_streaming(
 
                 match apply_recovery_plan(&mut request, sink, &cause, &snapshot).await {
                     RecoveryOutcome::SynthesizedToolUse { result, hint } => {
-                        return Ok((result, hint));
+                        if let Some(handle) = checkpoint.as_ref() {
+                            let _ = handle.store.delete(handle.run_id).await;
+                        }
+                        return Ok((result, hint.or(restored_hint)));
                     }
                     RecoveryOutcome::RetryAfterPlan => {
                         let delay = stream_retry_backoff(&cause, attempt, &policy);
@@ -231,7 +424,9 @@ async fn drive_one_stream(
     total_input_tokens: &mut u64,
     total_output_tokens: &mut u64,
     idle_timeout: Duration,
+    checkpoint: Option<&CheckpointHandle<'_>>,
 ) -> DriveOutcome {
+    let upstream_model = request.upstream_model.clone();
     let mut token_stream = match agent.llm_executor.execute_stream(request).await {
         Ok(s) => s,
         Err(err) => {
@@ -242,6 +437,7 @@ async fn drive_one_stream(
     };
 
     let mut acc = StreamingAccumulator::default();
+    let mut deltas_since_last_flush: usize = 0;
 
     loop {
         let next_fut = async { tokio::time::timeout(idle_timeout, token_stream.next()).await };
@@ -262,7 +458,11 @@ async fn drive_one_stream(
         let poll = match event {
             Ok(p) => p,
             Err(_) => {
-                // Idle stall — no delta in `idle_timeout`.
+                // Idle stall — no delta in `idle_timeout`. Flush
+                // whatever we had before surrendering to recovery.
+                if let Some(handle) = checkpoint {
+                    flush_checkpoint(&acc, &upstream_model, handle).await;
+                }
                 let snapshot = acc.interrupt_snapshot();
                 return DriveOutcome::Interrupted {
                     cause: InterruptCause::IdleStall,
@@ -278,7 +478,12 @@ async fn drive_one_stream(
         let event = match event_result {
             Ok(ev) => ev,
             Err(err) => {
-                // Mid-stream transport error. Classify and surface.
+                // Mid-stream transport error. Flush accumulator state
+                // for cross-process resume before surfacing to the
+                // in-process recovery loop.
+                if let Some(handle) = checkpoint {
+                    flush_checkpoint(&acc, &upstream_model, handle).await;
+                }
                 let snapshot = acc.interrupt_snapshot();
                 match classify_mid_stream(&err) {
                     Some(cause) => {
@@ -294,8 +499,10 @@ async fn drive_one_stream(
             }
         };
 
+        let mut saw_delta = false;
         match event {
             LlmStreamEvent::TextDelta(delta) => {
+                saw_delta = true;
                 acc.current_text.push_str(&delta);
                 sink.emit(AgentEvent::TextDelta { delta }).await;
             }
@@ -303,6 +510,7 @@ async fn drive_one_stream(
                 sink.emit(AgentEvent::ReasoningDelta { delta }).await;
             }
             LlmStreamEvent::ToolCallStart { id, name } => {
+                saw_delta = true;
                 sink.emit(AgentEvent::ToolCallStart {
                     id: id.clone(),
                     name: name.clone(),
@@ -313,6 +521,7 @@ async fn drive_one_stream(
                 acc.tool_order.push(id);
             }
             LlmStreamEvent::ToolCallDelta { id, args_delta } => {
+                saw_delta = true;
                 if let Some(buf) = acc.current_tool_args.get_mut(&id) {
                     buf.push_str(&args_delta);
                 }
@@ -336,6 +545,16 @@ async fn drive_one_stream(
             }
             LlmStreamEvent::Stop(reason) => {
                 acc.stop_reason = Some(reason);
+            }
+        }
+
+        if saw_delta {
+            deltas_since_last_flush += 1;
+            if deltas_since_last_flush >= CHECKPOINT_FLUSH_DELTAS {
+                deltas_since_last_flush = 0;
+                if let Some(handle) = checkpoint {
+                    flush_checkpoint(&acc, &upstream_model, handle).await;
+                }
             }
         }
     }
@@ -2053,6 +2272,297 @@ mod tests {
     // -----------------------------------------------------------------------
     // J: Cancellation during retry backoff aborts the retry loop
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // L: Cross-process stream resume via `StreamCheckpointStore`
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn checkpoint_is_flushed_on_mid_stream_interruption() {
+        use awaken_contract::contract::stream_checkpoint::{
+            InMemoryStreamCheckpointStore, StreamCheckpointStore,
+        };
+
+        // Attempt 1 emits 8 text deltas then fails. With
+        // CHECKPOINT_FLUSH_DELTAS = 4 the writer must flush at least
+        // twice (after delta #4 and after delta #8). On mid-stream
+        // error we also flush once more before surfacing.
+        let deltas: Vec<Result<LlmStreamEvent, InferenceExecutionError>> = (0..8)
+            .map(|i| Ok(LlmStreamEvent::TextDelta(format!("d{i}"))))
+            .chain(std::iter::once(Err(InferenceExecutionError::Provider(
+                "reset".into(),
+            ))))
+            .collect();
+        let exec = Arc::new(ScriptedPerAttemptExecutor::new(vec![
+            deltas.clone(),
+            deltas,
+        ]));
+        let agent = agent_with(exec.clone());
+        let sink = VecEventSink::new();
+        let store: Arc<InMemoryStreamCheckpointStore> =
+            Arc::new(InMemoryStreamCheckpointStore::new());
+        let handle = CheckpointHandle {
+            store: store.as_ref(),
+            run_id: "run-checkpoint-flush",
+            thread_id: "thread-1",
+        };
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        // Budget 0: exhaust on first attempt so the failure surfaces
+        // and we can assert on the persisted checkpoint.
+        let _ = execute_streaming_with_checkpoint(
+            &agent,
+            make_request(),
+            &sink,
+            None,
+            &mut it,
+            &mut ot,
+            Some(handle),
+        )
+        .await;
+
+        let saved = store
+            .get("run-checkpoint-flush")
+            .await
+            .unwrap()
+            .expect("checkpoint must have been persisted before failure");
+        assert_eq!(saved.run_id, "run-checkpoint-flush");
+        assert_eq!(saved.thread_id, "thread-1");
+        assert!(
+            saved.partial_text.contains("d0") && saved.partial_text.contains("d7"),
+            "partial_text should contain all 8 deltas, got: {}",
+            saved.partial_text
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_process_resume_injects_continuation_from_checkpoint() {
+        use awaken_contract::contract::stream_checkpoint::{
+            InMemoryStreamCheckpointStore, StreamCheckpoint, StreamCheckpointStore,
+        };
+
+        // Pre-populate a checkpoint as though a prior process crashed
+        // mid-stream. The executor records every InferenceRequest it
+        // receives so we can assert the continuation prompt was
+        // injected.
+        let store: Arc<InMemoryStreamCheckpointStore> =
+            Arc::new(InMemoryStreamCheckpointStore::new());
+        store
+            .put(StreamCheckpoint {
+                run_id: "run-resumed".into(),
+                thread_id: "thread-1".into(),
+                upstream_model: "test-model".into(),
+                partial_text: "half-written answer".into(),
+                completed_tool_calls: vec![],
+                in_flight_tool: None,
+                updated_at_ms: 1_000,
+            })
+            .await
+            .unwrap();
+
+        // Capturing executor: records each request, returns a clean
+        // terminal stream so the resumed call completes immediately.
+        struct CapturingExec {
+            captured: Arc<std::sync::Mutex<Vec<InferenceRequest>>>,
+        }
+
+        #[async_trait]
+        impl awaken_contract::contract::executor::LlmExecutor for CapturingExec {
+            async fn execute(
+                &self,
+                _r: InferenceRequest,
+            ) -> Result<StreamResult, InferenceExecutionError> {
+                Err(InferenceExecutionError::Provider("unused".into()))
+            }
+
+            fn execute_stream(
+                &self,
+                request: InferenceRequest,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = Result<InferenceStream, InferenceExecutionError>,
+                        > + Send
+                        + '_,
+                >,
+            > {
+                self.captured.lock().unwrap().push(request);
+                Box::pin(async move {
+                    let events: Vec<Result<LlmStreamEvent, InferenceExecutionError>> = vec![
+                        Ok(LlmStreamEvent::TextDelta(" — conclusion.".into())),
+                        Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+                    ];
+                    Ok(Box::pin(futures::stream::iter(events)) as InferenceStream)
+                })
+            }
+
+            fn name(&self) -> &str {
+                "capturing"
+            }
+        }
+
+        let captured: Arc<std::sync::Mutex<Vec<InferenceRequest>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let exec = Arc::new(CapturingExec {
+            captured: captured.clone(),
+        });
+        let agent = ResolvedAgent::new("test", "test-model", "sys", exec);
+        let sink = VecEventSink::new();
+        let handle = CheckpointHandle {
+            store: store.as_ref(),
+            run_id: "run-resumed",
+            thread_id: "thread-1",
+        };
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        let (result, _hint) = execute_streaming_with_checkpoint(
+            &agent,
+            make_request(),
+            &sink,
+            None,
+            &mut it,
+            &mut ot,
+            Some(handle),
+        )
+        .await
+        .expect("resume should succeed");
+
+        // The executor was called exactly once, with a request whose
+        // messages end in `assistant("half-written answer")` +
+        // `user(<continuation prompt>)` — the R1 restore pattern.
+        let reqs = captured.lock().unwrap();
+        assert_eq!(reqs.len(), 1);
+        let last_two: Vec<_> = reqs[0]
+            .messages
+            .iter()
+            .rev()
+            .take(2)
+            .rev()
+            .cloned()
+            .collect();
+        assert_eq!(last_two.len(), 2);
+        assert_eq!(
+            last_two[0].text(),
+            "half-written answer",
+            "assistant prefix must carry saved partial text"
+        );
+        assert!(
+            last_two[1].text().contains("interrupted mid-stream"),
+            "user continuation prompt must follow the prefix, got: {}",
+            last_two[1].text()
+        );
+
+        // The fresh attempt's output wins: the text is whatever the
+        // resumed attempt produced.
+        assert_eq!(result.text(), " — conclusion.");
+        assert_eq!(result.stop_reason, Some(StopReason::EndTurn));
+
+        // Checkpoint must be cleared on clean completion — otherwise
+        // subsequent runs would incorrectly restore it.
+        assert!(
+            store.get("run-resumed").await.unwrap().is_none(),
+            "checkpoint must be deleted after successful resume"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_process_resume_with_completed_tool_checkpoint_short_circuits_to_tool_use() {
+        use awaken_contract::contract::stream_checkpoint::{
+            InMemoryStreamCheckpointStore, StreamCheckpoint, StreamCheckpointStore,
+        };
+        use serde_json::json;
+
+        let store: Arc<InMemoryStreamCheckpointStore> =
+            Arc::new(InMemoryStreamCheckpointStore::new());
+        store
+            .put(StreamCheckpoint {
+                run_id: "run-r2-resumed".into(),
+                thread_id: "thread-1".into(),
+                upstream_model: "test-model".into(),
+                partial_text: "thinking...".into(),
+                completed_tool_calls: vec![ToolCall::new("tc-1", "search", json!({"q": "rust"}))],
+                in_flight_tool: None,
+                updated_at_ms: 1_000,
+            })
+            .await
+            .unwrap();
+
+        // An executor that PANICS if called — the R2 short-circuit
+        // must not reopen a stream.
+        struct NeverCallMe;
+
+        #[async_trait]
+        impl awaken_contract::contract::executor::LlmExecutor for NeverCallMe {
+            async fn execute(
+                &self,
+                _r: InferenceRequest,
+            ) -> Result<StreamResult, InferenceExecutionError> {
+                panic!("R2 checkpoint resume must not reopen a stream");
+            }
+
+            fn execute_stream(
+                &self,
+                _r: InferenceRequest,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = Result<InferenceStream, InferenceExecutionError>,
+                        > + Send
+                        + '_,
+                >,
+            > {
+                panic!("R2 checkpoint resume must not reopen a stream");
+            }
+
+            fn name(&self) -> &str {
+                "never-call"
+            }
+        }
+
+        let agent = ResolvedAgent::new("test", "test-model", "sys", Arc::new(NeverCallMe));
+        let sink = VecEventSink::new();
+        let handle = CheckpointHandle {
+            store: store.as_ref(),
+            run_id: "run-r2-resumed",
+            thread_id: "thread-1",
+        };
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        let (result, _hint) = execute_streaming_with_checkpoint(
+            &agent,
+            make_request(),
+            &sink,
+            None,
+            &mut it,
+            &mut ot,
+            Some(handle),
+        )
+        .await
+        .expect("R2 resume should short-circuit successfully");
+
+        assert_eq!(result.stop_reason, Some(StopReason::ToolUse));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "search");
+        assert_eq!(result.text(), "thinking...");
+
+        // Checkpoint cleared on R2 resume (consumed).
+        assert!(store.get("run-r2-resumed").await.unwrap().is_none());
+
+        // Sink should have observed the ToolCallReady event for the
+        // resumed tool so downstream consumers see the same sequence
+        // as a normal `StopReason::ToolUse` termination.
+        let events = sink.events();
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                AgentEvent::ToolCallReady { id, .. } if id == "tc-1"
+            )),
+            "expected ToolCallReady for the resumed tool"
+        );
+    }
 
     #[tokio::test(start_paused = true)]
     async fn cancellation_during_backoff_aborts_retry_loop_with_cancelled_error() {

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -16,7 +16,7 @@ use awaken_contract::contract::message::{Message, ToolCall};
 use awaken_contract::contract::stream_checkpoint::{StreamCheckpoint, StreamCheckpointStore};
 use futures::StreamExt;
 
-use super::AgentLoopError;
+use super::{AgentLoopError, now_ms};
 use crate::engine::retry::LlmRetryPolicy;
 use crate::registry::ResolvedAgent;
 
@@ -60,14 +60,6 @@ async fn flush_checkpoint(
             "stream checkpoint flush failed — continuing without persistence",
         );
     }
-}
-
-fn now_ms() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
 }
 
 /// Continuation prompt injected after a mid-stream interruption to nudge

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -70,38 +70,21 @@ const CONTINUATION_PROMPT: &str =
 
 /// Execute LLM inference with streaming, emitting delta events via sink.
 ///
-/// Consumes the token stream from `execute_stream()`, forwards deltas to sink,
-/// and collects the final `StreamResult`.
+/// Consumes the token stream from `execute_stream()`, forwards deltas to
+/// sink, and collects the final `StreamResult`. Drives the in-process R1-R4
+/// retry loop on mid-stream interruption and, when a `CheckpointHandle` is
+/// supplied, persists / restores accumulator state for cross-process resume.
 ///
-/// Supports mid-stream cancellation: if the `CancellationToken` is signalled while
-/// waiting for the next token, the stream is dropped and the partially accumulated
-/// result is returned with `StopReason::EndTurn` (graceful cancel — no error).
+/// Supports mid-stream cancellation: if the `CancellationToken` is signalled
+/// while waiting for the next token, the stream is dropped and the partially
+/// accumulated result is returned with `StopReason::EndTurn` (graceful
+/// cancel — no error).
+///
+/// Returns `(stream_result, cancelled_tool_hint)`. `cancelled_tool_hint`
+/// is `Some` only when an in-flight parallel tool was dropped during
+/// recovery; the loop runner uses it to inject a user-visible note in
+/// the next turn.
 pub(super) async fn execute_streaming(
-    agent: &ResolvedAgent,
-    request: InferenceRequest,
-    sink: &dyn EventSink,
-    cancellation_token: Option<&CancellationToken>,
-    total_input_tokens: &mut u64,
-    total_output_tokens: &mut u64,
-) -> Result<(StreamResult, Option<InFlightTool>), AgentLoopError> {
-    execute_streaming_with_checkpoint(
-        agent,
-        request,
-        sink,
-        cancellation_token,
-        total_input_tokens,
-        total_output_tokens,
-        None,
-    )
-    .await
-}
-
-/// Core streaming executor with an optional cross-process resume handle.
-/// `execute_streaming` is the tests-friendly wrapper that passes `None`
-/// for the checkpoint handle; production callers in step.rs use this
-/// function directly when they have a run identity and the agent has
-/// a `stream_checkpoint_store` configured.
-pub(super) async fn execute_streaming_with_checkpoint(
     agent: &ResolvedAgent,
     mut request: InferenceRequest,
     sink: &dyn EventSink,
@@ -871,44 +854,39 @@ mod tests {
     use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
     use awaken_contract::contract::message::Message;
 
-    // -- Streaming LLM executor that yields explicit stream events --
+    // -- Scripted LLM executor used by every test in this module --
 
-    /// Mock LLM executor that yields a fixed scripted event sequence on
-    /// EVERY call to `execute_stream`. Cloning the script per attempt means
-    /// stream-level retries in `execute_streaming` observe the same
-    /// behavior across attempts — useful when asserting retry budgets.
-    struct StreamingMockExecutor {
-        script: Vec<ClonedEvent>,
+    /// Mock LLM executor that yields scripted events keyed by attempt
+    /// number. On the Nth call to `execute_stream`, yields
+    /// `scripts[min(N, scripts.len() - 1)]` so a single-element script
+    /// repeats forever (legacy use case) and a multi-element script
+    /// drives different per-attempt behavior (R1-R4 retry tests).
+    struct ScriptedPerAttemptExecutor {
+        scripts: Vec<Vec<Result<LlmStreamEvent, InferenceExecutionError>>>,
+        attempt: std::sync::atomic::AtomicUsize,
     }
 
-    /// Serializable-as-needed twin of the scripted events. `LlmStreamEvent`
-    /// itself is Clone via Copy/String fields; `InferenceExecutionError` is
-    /// now Clone as of the Phase-A refactor — so a straightforward clone
-    /// works, but we normalize to owned values here for clarity.
-    #[derive(Clone)]
-    struct ClonedEvent(Result<LlmStreamEvent, InferenceExecutionError>);
-
-    impl StreamingMockExecutor {
-        fn new(events: Vec<Result<LlmStreamEvent, InferenceExecutionError>>) -> Self {
+    impl ScriptedPerAttemptExecutor {
+        fn new(scripts: Vec<Vec<Result<LlmStreamEvent, InferenceExecutionError>>>) -> Self {
+            assert!(!scripts.is_empty(), "need at least one attempt script");
             Self {
-                script: events.into_iter().map(ClonedEvent).collect(),
+                scripts,
+                attempt: std::sync::atomic::AtomicUsize::new(0),
             }
+        }
+
+        fn attempts(&self) -> usize {
+            self.attempt.load(std::sync::atomic::Ordering::SeqCst)
         }
     }
 
     #[async_trait]
-    impl awaken_contract::contract::executor::LlmExecutor for StreamingMockExecutor {
+    impl awaken_contract::contract::executor::LlmExecutor for ScriptedPerAttemptExecutor {
         async fn execute(
             &self,
-            _request: InferenceRequest,
+            _r: InferenceRequest,
         ) -> Result<StreamResult, InferenceExecutionError> {
-            Ok(StreamResult {
-                content: vec![],
-                tool_calls: vec![],
-                usage: None,
-                stop_reason: None,
-                has_incomplete_tool_calls: false,
-            })
+            Err(InferenceExecutionError::Provider("unused".into()))
         }
 
         fn execute_stream(
@@ -921,47 +899,27 @@ mod tests {
                     + '_,
             >,
         > {
-            let events: Vec<Result<LlmStreamEvent, InferenceExecutionError>> =
-                self.script.iter().map(|e| e.0.clone()).collect();
+            let n = self
+                .attempt
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let idx = n.min(self.scripts.len() - 1);
+            let events = self.scripts[idx].clone();
             Box::pin(async move { Ok(Box::pin(futures::stream::iter(events)) as InferenceStream) })
         }
 
         fn name(&self) -> &str {
-            "streaming-mock"
+            "scripted-per-attempt"
         }
     }
 
+    /// Build an agent backed by a single-script executor (the script
+    /// repeats on every attempt).
     fn make_agent(events: Vec<Result<LlmStreamEvent, InferenceExecutionError>>) -> ResolvedAgent {
-        ResolvedAgent::new(
-            "test-agent",
-            "test-model",
-            "system prompt",
-            Arc::new(StreamingMockExecutor::new(events)),
-        )
+        agent_with(Arc::new(ScriptedPerAttemptExecutor::new(vec![events])))
     }
 
-    /// Thin adapter that discards the in-flight tool hint. Used by
-    /// legacy tests that only care about the `StreamResult`; new tests
-    /// that exercise the hint path (Phase E) call `execute_streaming`
-    /// directly and destructure the tuple.
-    async fn stream_only(
-        agent: &ResolvedAgent,
-        request: InferenceRequest,
-        sink: &dyn EventSink,
-        cancellation_token: Option<&CancellationToken>,
-        total_input_tokens: &mut u64,
-        total_output_tokens: &mut u64,
-    ) -> Result<StreamResult, AgentLoopError> {
-        execute_streaming(
-            agent,
-            request,
-            sink,
-            cancellation_token,
-            total_input_tokens,
-            total_output_tokens,
-        )
-        .await
-        .map(|(result, _hint)| result)
+    fn agent_with(exec: Arc<ScriptedPerAttemptExecutor>) -> ResolvedAgent {
+        ResolvedAgent::new("test-agent", "test-model", "system prompt", exec)
     }
 
     fn make_request() -> InferenceRequest {
@@ -989,13 +947,14 @@ mod tests {
         let mut input_tokens = 0u64;
         let mut output_tokens = 0u64;
 
-        let result = stream_only(
+        let (result, _hint) = execute_streaming(
             &agent,
             make_request(),
             &sink,
             None,
             &mut input_tokens,
             &mut output_tokens,
+            None,
         )
         .await
         .unwrap();
@@ -1018,7 +977,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap();
 
@@ -1048,13 +1007,14 @@ mod tests {
         let mut input_tokens = 10u64;
         let mut output_tokens = 5u64;
 
-        let result = stream_only(
+        let (result, _hint) = execute_streaming(
             &agent,
             make_request(),
             &sink,
             None,
             &mut input_tokens,
             &mut output_tokens,
+            None,
         )
         .await
         .unwrap();
@@ -1075,13 +1035,14 @@ mod tests {
         let mut input_tokens = 100u64;
         let mut output_tokens = 50u64;
 
-        stream_only(
+        execute_streaming(
             &agent,
             make_request(),
             &sink,
             None,
             &mut input_tokens,
             &mut output_tokens,
+            None,
         )
         .await
         .unwrap();
@@ -1115,9 +1076,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .unwrap();
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .unwrap();
 
         assert_eq!(result.tool_calls.len(), 1);
         assert_eq!(result.tool_calls[0].name, "get_weather");
@@ -1142,7 +1104,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap();
 
@@ -1177,9 +1139,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .unwrap();
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .unwrap();
 
         // Truncated tool call is skipped, but has_incomplete_tool_calls is flagged
         assert!(result.tool_calls.is_empty());
@@ -1213,9 +1176,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .unwrap();
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .unwrap();
 
         assert_eq!(result.tool_calls.len(), 2);
         assert_eq!(result.tool_calls[0].name, "tool_a");
@@ -1249,13 +1213,14 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(
+        let (result, _hint) = execute_streaming(
             &agent,
             make_request(),
             &sink,
             Some(&token),
             &mut it,
             &mut ot,
+            None,
         )
         .await
         .unwrap();
@@ -1276,9 +1241,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .unwrap();
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .unwrap();
 
         assert_eq!(result.content.len(), 1);
         assert_eq!(result.stop_reason, Some(StopReason::EndTurn));
@@ -1298,7 +1264,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap();
 
@@ -1318,9 +1284,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .unwrap();
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .unwrap();
 
         assert!(result.content.is_empty());
         assert!(result.tool_calls.is_empty());
@@ -1341,9 +1308,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .unwrap();
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .unwrap();
 
         // Text should still be flushed
         assert_eq!(result.content.len(), 1);
@@ -1369,7 +1337,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -1403,7 +1371,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap();
 
@@ -1480,7 +1448,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -1510,7 +1478,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -1579,7 +1547,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -1606,7 +1574,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -1632,7 +1600,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -1706,13 +1674,14 @@ mod tests {
             token_clone.cancel();
         });
 
-        let result = stream_only(
+        let (result, _hint) = execute_streaming(
             &agent,
             make_request(),
             &sink,
             Some(&token),
             &mut it,
             &mut ot,
+            None,
         )
         .await
         .unwrap();
@@ -1747,7 +1716,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -1786,64 +1755,6 @@ mod tests {
     // and the retry-budget exhaustion path has its own test.
     // ========================================================================
 
-    /// Scripted streaming executor keyed by attempt number. On the Nth call
-    /// to `execute_stream`, yields `scripts[min(N, scripts.len()-1)]` so
-    /// short scripts naturally repeat the last attempt's script forever.
-    struct ScriptedPerAttemptExecutor {
-        scripts: Vec<Vec<Result<LlmStreamEvent, InferenceExecutionError>>>,
-        attempt: std::sync::atomic::AtomicUsize,
-    }
-
-    impl ScriptedPerAttemptExecutor {
-        fn new(scripts: Vec<Vec<Result<LlmStreamEvent, InferenceExecutionError>>>) -> Self {
-            assert!(!scripts.is_empty(), "need at least one attempt script");
-            Self {
-                scripts,
-                attempt: std::sync::atomic::AtomicUsize::new(0),
-            }
-        }
-
-        fn attempts(&self) -> usize {
-            self.attempt.load(std::sync::atomic::Ordering::SeqCst)
-        }
-    }
-
-    #[async_trait]
-    impl awaken_contract::contract::executor::LlmExecutor for ScriptedPerAttemptExecutor {
-        async fn execute(
-            &self,
-            _r: InferenceRequest,
-        ) -> Result<StreamResult, InferenceExecutionError> {
-            Err(InferenceExecutionError::Provider("unused".into()))
-        }
-
-        fn execute_stream(
-            &self,
-            _request: InferenceRequest,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<InferenceStream, InferenceExecutionError>>
-                    + Send
-                    + '_,
-            >,
-        > {
-            let n = self
-                .attempt
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            let idx = n.min(self.scripts.len() - 1);
-            let events = self.scripts[idx].clone();
-            Box::pin(async move { Ok(Box::pin(futures::stream::iter(events)) as InferenceStream) })
-        }
-
-        fn name(&self) -> &str {
-            "scripted-per-attempt"
-        }
-    }
-
-    fn agent_with(exec: Arc<ScriptedPerAttemptExecutor>) -> ResolvedAgent {
-        ResolvedAgent::new("test-agent", "test-model", "system prompt", exec)
-    }
-
     // --- R1: pure text interruption → continuation retry succeeds --------
 
     #[tokio::test]
@@ -1866,9 +1777,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .expect("R1 should succeed after one retry");
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .expect("R1 should succeed after one retry");
 
         assert_eq!(exec.attempts(), 2, "expected exactly two attempts");
         // The second attempt's deltas are preserved in the returned result.
@@ -1927,9 +1839,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .expect("R2 short-circuits to synthesized tool_use");
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .expect("R2 short-circuits to synthesized tool_use");
 
         assert_eq!(exec.attempts(), 1, "R2 must not trigger a retry");
         assert_eq!(result.stop_reason, Some(StopReason::ToolUse));
@@ -1982,9 +1895,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .expect("R3 recovers after truncation");
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .expect("R3 recovers after truncation");
 
         assert_eq!(exec.attempts(), 2);
         assert_eq!(result.text(), "done.");
@@ -2023,9 +1937,10 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
-            .await
-            .expect("R4 recovers after whole restart");
+        let (result, _hint) =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
+                .await
+                .expect("R4 recovers after whole restart");
 
         assert_eq!(exec.attempts(), 2);
         assert_eq!(result.text(), "fresh start");
@@ -2054,7 +1969,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None)
             .await
             .unwrap_err();
 
@@ -2149,7 +2064,8 @@ mod tests {
 
         // Drive the streaming call concurrently so we can advance paused
         // time past the idle-stall threshold (60s by default).
-        let exec_fut = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot);
+        let exec_fut =
+            execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot, None);
         let drive = async {
             // Wait for the first TextDelta to be emitted, then advance
             // past the idle threshold to trigger the stall.
@@ -2157,8 +2073,8 @@ mod tests {
             tokio::time::advance(Duration::from_secs(70)).await;
         };
 
-        let (result, ()) = tokio::join!(exec_fut, drive);
-        let result = result.expect("idle-stall should recover");
+        let (outcome, ()) = tokio::join!(exec_fut, drive);
+        let (result, _hint) = outcome.expect("idle-stall should recover");
         assert_eq!(
             exec.attempt.load(std::sync::atomic::Ordering::SeqCst),
             2,
@@ -2303,7 +2219,7 @@ mod tests {
 
         // Budget 0: exhaust on first attempt so the failure surfaces
         // and we can assert on the persisted checkpoint.
-        let _ = execute_streaming_with_checkpoint(
+        let _ = execute_streaming(
             &agent,
             make_request(),
             &sink,
@@ -2409,7 +2325,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let (result, _hint) = execute_streaming_with_checkpoint(
+        let (result, _hint) = execute_streaming(
             &agent,
             make_request(),
             &sink,
@@ -2523,7 +2439,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let (result, _hint) = execute_streaming_with_checkpoint(
+        let (result, _hint) = execute_streaming(
             &agent,
             make_request(),
             &sink,
@@ -2578,13 +2494,14 @@ mod tests {
         let mut ot = 0u64;
 
         // Kick off the streaming call and cancel mid-backoff.
-        let exec_fut = stream_only(
+        let exec_fut = execute_streaming(
             &agent,
             make_request(),
             &sink,
             Some(&token),
             &mut it,
             &mut ot,
+            None,
         );
         let drive = async {
             // Let the first attempt open and fail.

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -60,8 +60,11 @@ fn format_tool_cancel_hint(hint: &awaken_contract::contract::executor::InFlightT
 /// tool_use blocks that actually had valid JSON. Naming is unnecessary
 /// — the main model has full conversation context and will identify
 /// which call to retry.
-const MALFORMED_TOOL_ARGS_HINT: &str = "Note: one or more of your tool calls had malformed arguments and were not executed. \
-     Please re-issue any affected calls with valid JSON if still needed.";
+const MALFORMED_TOOL_ARGS_HINT: &str = concat!(
+    "Note: one or more of your tool calls had malformed arguments ",
+    "and were not executed. Please re-issue any affected calls with ",
+    "valid JSON if still needed.",
+);
 
 /// Outcome of a single step.
 pub(super) enum StepOutcome {

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -28,7 +28,9 @@ use super::actions::{
     resolve_intercept_payloads, take_context_messages,
 };
 use super::checkpoint::{StepCompletion, check_termination, complete_step};
-use super::inference::{compact_with_llm, execute_streaming};
+use super::inference::{
+    CheckpointHandle, compact_with_llm, execute_streaming, execute_streaming_with_checkpoint,
+};
 use super::{AgentLoopError, commit_update, now_ms, tool_result_to_content};
 use crate::agent::state::{
     InferenceOverrideState, InferenceOverrideStateAction, RunLifecycle, RunLifecycleUpdate,
@@ -491,14 +493,27 @@ async fn run_inference_phase(
         enable_prompt_cache,
     };
 
-    // Inference
-    let (stream_result, cancelled_tool_hint) = execute_streaming(
+    // Inference. Wire the agent's stream checkpoint store (if any) so
+    // mid-stream accumulator snapshots are flushed for cross-process
+    // resume. The `run_identity` supplies the keying — `run_id` is the
+    // primary key; `thread_id` is carried for operator inspection.
+    let checkpoint_handle =
+        ctx.agent
+            .stream_checkpoint_store
+            .as_ref()
+            .map(|store| CheckpointHandle {
+                store: store.as_ref(),
+                run_id: &ctx.run_identity.run_id,
+                thread_id: &ctx.run_identity.thread_id,
+            });
+    let (stream_result, cancelled_tool_hint) = execute_streaming_with_checkpoint(
         ctx.agent,
         request,
         ctx.sink.as_ref(),
         ctx.cancellation_token,
         ctx.total_input_tokens,
         ctx.total_output_tokens,
+        checkpoint_handle,
     )
     .await?;
 

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -28,9 +28,7 @@ use super::actions::{
     resolve_intercept_payloads, take_context_messages,
 };
 use super::checkpoint::{StepCompletion, check_termination, complete_step};
-use super::inference::{
-    CheckpointHandle, compact_with_llm, execute_streaming, execute_streaming_with_checkpoint,
-};
+use super::inference::{CheckpointHandle, compact_with_llm, execute_streaming};
 use super::{AgentLoopError, commit_update, now_ms, tool_result_to_content};
 use crate::agent::state::{
     InferenceOverrideState, InferenceOverrideStateAction, RunLifecycle, RunLifecycleUpdate,
@@ -297,7 +295,9 @@ async fn recover_truncation(
         // Truncation recovery happens after any stream-interruption
         // recovery, so the `cancelled_tool_hint` from mid-stream retry is
         // no longer meaningful at this layer — it was consumed on the
-        // first call. Discard it here.
+        // first call. Pass `None` for checkpoint: continuation requests
+        // are mid-turn retries that share the run id with the in-flight
+        // attempt and should not race the same checkpoint key.
         let (next_result, _hint) = execute_streaming(
             ctx.agent,
             cont_request,
@@ -305,6 +305,7 @@ async fn recover_truncation(
             ctx.cancellation_token,
             ctx.total_input_tokens,
             ctx.total_output_tokens,
+            None,
         )
         .await?;
         stream_result = next_result;
@@ -509,7 +510,7 @@ async fn run_inference_phase(
                 run_id: &ctx.run_identity.run_id,
                 thread_id: &ctx.run_identity.thread_id,
             });
-    let (stream_result, cancelled_tool_hint) = execute_streaming_with_checkpoint(
+    let (stream_result, cancelled_tool_hint) = execute_streaming(
         ctx.agent,
         request,
         ctx.sink.as_ref(),

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -12,7 +12,9 @@ use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::event_sink::EventSink;
 use awaken_contract::contract::executor::InferenceRequest;
 use awaken_contract::contract::identity::RunIdentity;
-use awaken_contract::contract::inference::{InferenceOverride, LLMResponse, StreamResult};
+use awaken_contract::contract::inference::{
+    InferenceOverride, LLMResponse, StopReason, StreamResult,
+};
 use awaken_contract::contract::lifecycle::TerminationReason;
 use awaken_contract::contract::message::{Message, ToolCall};
 use awaken_contract::contract::storage::ThreadRunStore;
@@ -46,6 +48,18 @@ fn format_tool_cancel_hint(hint: &awaken_contract::contract::executor::InFlightT
         hint.name,
     )
 }
+
+/// Note injected when one or more tool calls were dropped because their
+/// argument JSON was malformed and no further recovery path applied.
+///
+/// The message is intentionally generic: by the time the loop runner
+/// sees a dropped tool the accumulator has already lost the id/name
+/// mapping, and the API-level `assistant` message can only carry the
+/// tool_use blocks that actually had valid JSON. Naming is unnecessary
+/// — the main model has full conversation context and will identify
+/// which call to retry.
+const MALFORMED_TOOL_ARGS_HINT: &str = "Note: one or more of your tool calls had malformed arguments and were not executed. \
+     Please re-issue any affected calls with valid JSON if still needed.";
 
 /// Outcome of a single step.
 pub(super) enum StepOutcome {
@@ -1219,7 +1233,17 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
     }
 
     // --- No tools needed: natural end ---
-    if !stream_result.needs_tools() {
+    //
+    // If every tool call in the stream was dropped due to malformed
+    // argument JSON on a *non-MaxTokens* stop, we want to continue the
+    // loop so the hint can surface on the next turn. MaxTokens with
+    // incomplete tools is already handled by `recover_truncation` above
+    // — by the time we reach this point, that path has either retried
+    // successfully or exhausted its budget and we treat the result as
+    // text-only natural end (preserving prior behavior).
+    let malformed_non_max_tokens = stream_result.has_incomplete_tool_calls
+        && stream_result.stop_reason != Some(StopReason::MaxTokens);
+    if !stream_result.needs_tools() && !malformed_non_max_tokens {
         ctx.messages
             .push(Arc::new(Message::assistant(stream_result.text())));
         complete_step(StepCompletion {
@@ -1254,6 +1278,17 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
     // so the model can decide whether to retry the cancelled call.
     if let Some(hint) = cancelled_tool_hint.as_ref() {
         transcript.push_tool_message(Arc::new(Message::user(format_tool_cancel_hint(hint))));
+    }
+
+    // If the stream contained malformed tool-call argument JSON that we
+    // could NOT recover via truncation retry (non-MaxTokens case, or
+    // MaxTokens retries exhausted), surface a user note so the model
+    // can fix its output on the next turn instead of silently losing
+    // the call. `recover_truncation` runs before tool execution and
+    // only retries on MaxTokens; any lingering `has_incomplete_tool_calls`
+    // at this point is unrecoverable at the stream level.
+    if stream_result.has_incomplete_tool_calls {
+        transcript.push_tool_message(Arc::new(Message::user(MALFORMED_TOOL_ARGS_HINT)));
     }
 
     transcript.commit_into(ctx.messages);

--- a/crates/awaken-runtime/src/registry/resolve/pipeline.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline.rs
@@ -80,6 +80,7 @@ pub(crate) fn resolve_registry_set(
         llm_executor: executor,
         tool_executor: Arc::new(SequentialToolExecutor),
         context_summarizer: None,
+        stream_checkpoint_store: None,
         env,
     })
 }
@@ -149,6 +150,7 @@ fn resolve_local_spec(
         llm_executor: executor,
         tool_executor: Arc::new(SequentialToolExecutor),
         context_summarizer: None,
+        stream_checkpoint_store: None,
         env,
     })
 }

--- a/crates/awaken-runtime/src/registry/resolver.rs
+++ b/crates/awaken-runtime/src/registry/resolver.rs
@@ -3,6 +3,7 @@
 use crate::backend::{ExecutionBackend, ExecutionBackendError, ExecutionBackendFactory};
 use awaken_contract::contract::executor::LlmExecutor;
 use awaken_contract::contract::inference::ContextWindowPolicy;
+use awaken_contract::contract::stream_checkpoint::StreamCheckpointStore;
 use awaken_contract::contract::tool::Tool;
 use awaken_contract::registry_spec::{AgentSpec, RemoteEndpoint};
 use std::collections::HashMap;
@@ -28,6 +29,12 @@ pub struct ResolvedAgent {
     /// Context summarizer for LLM-based compaction. `None` disables LLM compaction
     /// (hard truncation still works if `context_policy` is set).
     pub context_summarizer: Option<Arc<dyn crate::context::ContextSummarizer>>,
+    /// Optional store for cross-process stream resume. When `Some`, the
+    /// loop runner flushes mid-stream accumulator snapshots to this
+    /// store and restores from it on the next `execute_streaming` call
+    /// that targets the same run. `None` disables cross-process resume
+    /// entirely (in-process retry still works via the normal R1-R4 loop).
+    pub stream_checkpoint_store: Option<Arc<dyn StreamCheckpointStore>>,
     /// Plugin-provided behavior (hooks, handlers, transforms).
     pub env: ExecutionEnv,
 }
@@ -65,8 +72,18 @@ impl ResolvedAgent {
             llm_executor,
             tool_executor: Arc::new(SequentialToolExecutor),
             context_summarizer: None,
+            stream_checkpoint_store: None,
             env: ExecutionEnv::empty(),
         }
+    }
+
+    /// Attach a stream checkpoint store (builder-style). Enables cross-process
+    /// resume: mid-stream accumulator snapshots will be flushed here and
+    /// restored by the next `execute_streaming` call for the same `run_id`.
+    #[must_use]
+    pub fn with_stream_checkpoint_store(mut self, store: Arc<dyn StreamCheckpointStore>) -> Self {
+        self.stream_checkpoint_store = Some(store);
+        self
     }
 
     // -- delegation accessors -------------------------------------------------

--- a/crates/awaken/tests/agent_loop.rs
+++ b/crates/awaken/tests/agent_loop.rs
@@ -11584,3 +11584,187 @@ async fn mid_stream_recovery_without_parallel_tools_does_not_inject_hint() {
         "R1 recovery must not emit ToolCallCancel"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Phase-G end-to-end: malformed tool args (non-MaxTokens) → user hint
+// injected so the main model can retry the call with valid JSON.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn malformed_tool_args_on_end_turn_injects_user_hint_for_next_turn() {
+    use awaken::contract::executor::{InferenceStream, LlmStreamEvent};
+
+    struct MalformedArgsLlm {
+        call_count: Mutex<usize>,
+        captured_requests: Arc<Mutex<Vec<InferenceRequest>>>,
+    }
+
+    #[async_trait]
+    impl LlmExecutor for MalformedArgsLlm {
+        async fn execute(
+            &self,
+            _req: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            unreachable!("streaming path only");
+        }
+
+        fn execute_stream(
+            &self,
+            request: InferenceRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<InferenceStream, InferenceExecutionError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            self.captured_requests.lock().unwrap().push(request);
+            let mut count = self.call_count.lock().unwrap();
+            *count += 1;
+            let call_num = *count;
+            drop(count);
+
+            Box::pin(async move {
+                // Turn 1: model emits a tool_use with TRUNCATED/BROKEN JSON
+                // args but terminates with end_turn (NOT MaxTokens). The
+                // accumulator drops the tool because its JSON is invalid,
+                // setting has_incomplete_tool_calls=true. Because the stop
+                // reason is not MaxTokens, truncation recovery does NOT
+                // retry. step.rs should surface the generic hint.
+                //
+                // Turn 2: model returns final text once it's been told.
+                let events: Vec<Result<LlmStreamEvent, InferenceExecutionError>> = match call_num {
+                    1 => vec![
+                        Ok(LlmStreamEvent::TextDelta("checking".into())),
+                        Ok(LlmStreamEvent::ToolCallStart {
+                            id: "bad-1".into(),
+                            name: "calc".into(),
+                        }),
+                        Ok(LlmStreamEvent::ToolCallDelta {
+                            id: "bad-1".into(),
+                            args_delta: r#"{"result": not-json"#.into(),
+                        }),
+                        Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+                    ],
+                    _ => vec![
+                        Ok(LlmStreamEvent::TextDelta("got it".into())),
+                        Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+                    ],
+                };
+                Ok(Box::pin(futures::stream::iter(events)) as InferenceStream)
+            })
+        }
+
+        fn name(&self) -> &str {
+            "malformed-args-llm"
+        }
+    }
+
+    let captured: Arc<Mutex<Vec<InferenceRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm = Arc::new(MalformedArgsLlm {
+        call_count: Mutex::new(0),
+        captured_requests: captured.clone(),
+    });
+
+    let agent = ResolvedAgent::new("test", "gpt-4o", "sys", llm).with_tool(Arc::new(CalcTool));
+    let runtime = make_runtime();
+    let resolver = FixedResolver::new(agent);
+
+    let sink = Arc::new(VecEventSink::new());
+    let _ = run_agent_loop(AgentLoopParams {
+        resolver: &resolver,
+        agent_id: "test",
+        runtime: &runtime,
+        sink,
+        checkpoint_store: None,
+        messages: vec![Message::user("go")],
+        run_identity: test_identity(),
+        cancellation_token: None,
+        decision_rx: None,
+        overrides: None,
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: false,
+    })
+    .await
+    .unwrap();
+
+    let requests = captured.lock().unwrap().clone();
+    // The first request is turn 1. If the hint is injected correctly the
+    // loop should proceed to turn 2 and we'll see an additional request.
+    assert!(
+        requests.len() >= 2,
+        "expected at least 2 LLM calls (turn 2 sees the hint), got {}",
+        requests.len()
+    );
+
+    // Turn 2's request must contain the malformed-args hint.
+    let hint_found = requests[1].messages.iter().any(|m| {
+        m.role == Role::User
+            && m.text()
+                .contains("one or more of your tool calls had malformed arguments")
+    });
+    assert!(
+        hint_found,
+        "expected malformed-args user hint in turn 2's request; \
+         got messages: {:#?}",
+        requests[1]
+            .messages
+            .iter()
+            .map(|m| (m.role, m.text()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn malformed_tool_args_hint_absent_when_all_tools_have_valid_json() {
+    // Negative-control: a clean turn with valid tool args must NOT
+    // trigger the malformed-args hint.
+    let llm = Arc::new(ScriptedLlm::new(vec![
+        StreamResult {
+            content: vec![ContentBlock::text("calling")],
+            tool_calls: vec![ToolCall::new("c1", "calc", json!({"result": 42}))],
+            usage: None,
+            stop_reason: Some(StopReason::ToolUse),
+            has_incomplete_tool_calls: false,
+        },
+        StreamResult {
+            content: vec![ContentBlock::text("done")],
+            tool_calls: vec![],
+            usage: None,
+            stop_reason: Some(StopReason::EndTurn),
+            has_incomplete_tool_calls: false,
+        },
+    ]));
+
+    let agent = ResolvedAgent::new("test", "gpt-4o", "sys", llm).with_tool(Arc::new(CalcTool));
+    let runtime = make_runtime();
+    let resolver = FixedResolver::new(agent);
+
+    let sink = Arc::new(VecEventSink::new());
+    let result = run_agent_loop(AgentLoopParams {
+        resolver: &resolver,
+        agent_id: "test",
+        runtime: &runtime,
+        sink,
+        checkpoint_store: None,
+        messages: vec![Message::user("go")],
+        run_identity: test_identity(),
+        cancellation_token: None,
+        decision_rx: None,
+        overrides: None,
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: false,
+    })
+    .await
+    .unwrap();
+
+    assert!(matches!(result.termination, TerminationReason::NaturalEnd));
+    // The response text should NOT contain the malformed-args hint.
+    assert!(
+        !result.response.contains("malformed arguments"),
+        "unexpected malformed-args hint leaked into response: {}",
+        result.response
+    );
+}


### PR DESCRIPTION
## Summary

Final PR in the LLM stream error handling series. Builds on top of #133 (mid-stream recovery — set as the base of this PR). Adds cross-process stream resume via a `StreamCheckpointStore` trait, broadens failure-mode classification (GOAWAY / ContentFiltered / malformed tool args), and follows up with refactor passes that eliminate duplication between the in-loop recovery path and the checkpoint-restore path.

> ⚠️ **Stacked PR**: base is `pr/llm-stream-recovery` (PR #133). When PRs #132 + #133 merge, GitHub will auto-rebase this PR's base to `main`.

## What's new

### Failure-mode breadth (commit 35289b435)

- **`InterruptCause::GoAway`** + `Provider5xxMidStream`: `interpret_transport_message` substring-matches HTTP/2 GOAWAY, ECONNRESET, 502/503 in transport error messages. Test: `classify_mid_stream_maps_goaway_substring_to_goaway_cause` + 4 sibling tests.
- **`ContentFiltered`** classification: `map_error` recognizes `content_filter` / `content policy` / `blocked by safety` substrings; the variant is non-retryable and bypasses the breaker. Tests: `map_error_content_filter_string_maps_to_content_filtered` + 3 sibling tests.
- **Malformed tool args (non-MaxTokens)**: when a stream ends with `EndTurn` but `has_incomplete_tool_calls == true`, `step.rs` continues the loop instead of natural-end and injects a `MALFORMED_TOOL_ARGS_HINT` user message so the model can retry with valid JSON. Tests: `malformed_tool_args_on_end_turn_injects_user_hint_for_next_turn` + negative control.
- **Cancellation during backoff race**: explicit test `cancellation_during_backoff_aborts_retry_loop_with_cancelled_error` (existing code, was untested).
- **Duplicate tool_use id**: explicit test `duplicate_tool_use_id_is_deduplicated_to_single_entry` (existing code, was untested).

### Cross-process resume (commit 507a47ed1)

- **`StreamCheckpointStore`** trait + `StreamCheckpoint` type in a new `awaken-contract::contract::stream_checkpoint` module. Single newtype error (`StreamCheckpointError(String)`).
- **`InMemoryStreamCheckpointStore`** as reference impl + test fixture.
- **`ResolvedAgent::with_stream_checkpoint_store`** builder — opt-in: `None` by default, completely zero-cost when not configured.
- **`drive_one_stream`** flushes accumulator state every `CHECKPOINT_FLUSH_DELTAS` (=4) deltas + before idle-stall + before transport error.
- **`execute_streaming`** restores at start by feeding the saved snapshot through the **same** R1-R4 dispatch the in-loop retry uses (see refactor below).
- Cleared on clean completion / R2 short-circuit / stale R4.

### Refactor pass (commits 74fc6d2e7, f6f4a9e5a, a3ae060cd, c22ecaa95)

After both #133 and the resume code landed, several duplication patterns became obvious; they are removed here in dedicated refactor commits so the diff stays reviewable:

- **\`InterruptSnapshot::from_partials\`** — single source of truth for partials → snapshot translation, replacing two ~50-line near-identical implementations across the two stream collectors. (commit \`a3ae060cd\`)
- **Single \`execute_streaming\` entry point** with \`Option<CheckpointHandle>\` parameter — was \`execute_streaming\` + \`execute_streaming_with_checkpoint\` wrapper. (commit \`f6f4a9e5a\`)
- **One scripted mock executor** — was \`StreamingMockExecutor\` + \`ScriptedPerAttemptExecutor\` (the former is a special case of the latter). (commit \`f6f4a9e5a\`)
- **\`InterruptCause::ResumedFromCheckpoint\`** — checkpoint restore synthesizes a \`DriveOutcome::Interrupted\` and feeds it through the same recovery dispatch the in-loop path uses. The two parallel match-on-\`RecoveryPlan\` blocks (~70 lines duplicate) collapsed to one. (commit \`c22ecaa95\`)
- **Misc**: `concat!` for `MALFORMED_TOOL_ARGS_HINT` (fixes whitespace bug), `super::now_ms` reuse, `StreamCheckpointError` simplified to newtype. (commit \`74fc6d2e7\`)

Net of refactor commits: **−138 lines** of production code while keeping all 4877 tests green.

## Test plan

- [x] `cargo test --workspace --all-targets` — **4877 passing / 0 failing**
- [x] `cargo clippy --workspace --all-targets` — zero warnings on touched files
- [x] Pre-commit hooks (format + doc-content + secrets) green on every commit
- [x] Cross-process resume failure injection: `checkpoint_is_flushed_on_mid_stream_interruption`, `cross_process_resume_injects_continuation_from_checkpoint`, `cross_process_resume_with_completed_tool_checkpoint_short_circuits_to_tool_use`

## Failure-mode coverage matrix (final)

| Mode | Status |
|---|---|
| Mid-stream R1/R2/R3/R4 | ✅ tested |
| Idle stall + thinking-model threshold | ✅ tested |
| HTTP 4xx/5xx/529 classification + Retry-After | ✅ tested |
| HTTP/2 GOAWAY / ECONNRESET / 502-503 mid-stream | ✅ tested |
| ContentFiltered classification | ✅ tested |
| Malformed tool args (non-MaxTokens) | ✅ tested |
| Cancellation during backoff | ✅ tested |
| Duplicate tool_use id dedup | ✅ tested |
| Cross-process resume (R1 + R2 paths) | ✅ tested |
| Stop-reason `None` truncation | ❌ deferred (design ambiguity) |
| Retry-After HTTP-date format | ❌ deferred (no LLM provider uses it) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)