### PR TITLE
✨ feat(runtime): mid-stream R1-R4 recovery + parallel tool hint (2/3)

### DIFF
--- a/crates/awaken-contract/src/contract/event.rs
+++ b/crates/awaken-contract/src/contract/event.rs
@@ -92,6 +92,24 @@ pub enum AgentEvent {
     /// Tool call resumed from suspension.
     ToolCallResumed { target_id: String, result: Value },
 
+    /// A previously-started tool call was cancelled mid-stream before its
+    /// argument JSON closed. Emitted during stream-interruption recovery so
+    /// downstream consumers can drop any partial delta they buffered.
+    ToolCallCancel {
+        id: String,
+        name: String,
+        /// Human-readable reason (e.g. `"connection reset"`, `"idle stall"`).
+        reason: String,
+    },
+
+    /// The entire stream was restarted after a mid-stream interruption that
+    /// could not be recovered via continuation — all previously-emitted
+    /// deltas in this assistant turn should be discarded by consumers.
+    StreamReset {
+        /// Human-readable cause.
+        reason: String,
+    },
+
     /// Step started.
     StepStart {
         #[serde(default)]
@@ -283,6 +301,14 @@ mod tests {
                 snapshot: json!({}),
             },
             AgentEvent::StateDelta { delta: vec![] },
+            AgentEvent::ToolCallCancel {
+                id: "c1".into(),
+                name: "search".into(),
+                reason: "connection reset".into(),
+            },
+            AgentEvent::StreamReset {
+                reason: "connection reset".into(),
+            },
         ];
 
         for event in non_terminal_events {
@@ -291,6 +317,48 @@ mod tests {
                 "event should not be terminal: {event:?}"
             );
         }
+    }
+
+    #[test]
+    fn tool_call_cancel_serde_roundtrip() {
+        let event = AgentEvent::ToolCallCancel {
+            id: "c3".into(),
+            name: "fetch".into(),
+            reason: "connection reset".into(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: AgentEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            AgentEvent::ToolCallCancel { id, name, reason }
+            if id == "c3" && name == "fetch" && reason == "connection reset"
+        ));
+    }
+
+    #[test]
+    fn stream_reset_serde_roundtrip() {
+        let event = AgentEvent::StreamReset {
+            reason: "idle stall".into(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: AgentEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            AgentEvent::StreamReset { reason } if reason == "idle stall"
+        ));
+    }
+
+    #[test]
+    fn tool_call_cancel_and_stream_reset_are_not_terminal() {
+        let cancel = AgentEvent::ToolCallCancel {
+            id: "c1".into(),
+            name: "x".into(),
+            reason: "r".into(),
+        };
+        assert!(!cancel.is_terminal());
+
+        let reset = AgentEvent::StreamReset { reason: "r".into() };
+        assert!(!reset.is_terminal());
     }
 
     #[test]

--- a/crates/awaken-runtime/src/engine/streaming.rs
+++ b/crates/awaken-runtime/src/engine/streaming.rs
@@ -1,10 +1,12 @@
 //! Streaming response collector: accumulates genai ChatStreamEvents into a StreamResult.
 
 use std::collections::{HashMap, VecDeque};
+use std::time::Instant;
 
 use genai::chat::{ChatStreamEvent, StreamEnd};
 use serde_json::Value;
 
+use awaken_contract::contract::executor::{InFlightTool, InterruptSnapshot};
 use awaken_contract::contract::inference::{StreamResult, TokenUsage};
 use awaken_contract::contract::message::ToolCall;
 
@@ -34,6 +36,13 @@ pub struct StreamCollector {
     pending_outputs: VecDeque<StreamOutput>,
     /// Set to true after `ChatStreamEvent::End` is processed.
     end_seen: bool,
+    /// Timestamp of the most recent delta (text / reasoning / tool-call)
+    /// processed. Used by the stream-level recovery loop to detect idle
+    /// stalls. Updated within `process` when an event yields content.
+    last_delta_at: Option<Instant>,
+    /// Approximate running total of the byte-size of received deltas —
+    /// surfaced on `InterruptSnapshot` for telemetry.
+    bytes_received: usize,
 }
 
 struct PartialToolCall {
@@ -59,6 +68,73 @@ impl StreamCollector {
             usage: None,
             stop_reason: None,
             pending_outputs: VecDeque::new(),
+            last_delta_at: None,
+            bytes_received: 0,
+        }
+    }
+
+    /// Timestamp of the most recent delta processed, if any.
+    pub fn last_delta_at(&self) -> Option<Instant> {
+        self.last_delta_at
+    }
+
+    /// Accumulated text so far — useful to construct a continuation prompt
+    /// without having to finalize the collector.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Capture a snapshot of accumulated state as of "now" for use when a
+    /// stream interruption triggers recovery. Does not consume the
+    /// collector; the caller typically discards it and opens a fresh one.
+    pub fn interrupt_snapshot(&self) -> InterruptSnapshot {
+        let mut completed: Vec<ToolCall> = Vec::new();
+        let mut in_flight: Option<InFlightTool> = None;
+
+        for id in &self.tool_call_order {
+            let Some(p) = self.tool_calls.get(id) else {
+                continue;
+            };
+            if p.name.is_empty() {
+                // Name has not been observed yet — treat as in-flight but
+                // keep scanning in case a later entry is valid. Rare.
+                in_flight = Some(InFlightTool {
+                    id: p.id.clone(),
+                    name: String::new(),
+                    partial_args: p.arguments.clone(),
+                });
+                continue;
+            }
+            let parsed = serde_json::from_str::<Value>(&p.arguments);
+            match parsed {
+                Ok(arguments) if !(arguments.is_null() && !p.arguments.is_empty()) => {
+                    completed.push(ToolCall::new(p.id.clone(), p.name.clone(), arguments));
+                }
+                // Args present but unparseable → in-flight. If multiple
+                // unclosed tools race to be "in flight" only the most recent
+                // is retained (Anthropic/OpenAI emit at most one at a time
+                // per assistant turn; the last one wins).
+                _ => {
+                    in_flight = Some(InFlightTool {
+                        id: p.id.clone(),
+                        name: p.name.clone(),
+                        partial_args: p.arguments.clone(),
+                    });
+                }
+            }
+        }
+
+        let text = if self.text.is_empty() {
+            None
+        } else {
+            Some(self.text.clone())
+        };
+
+        InterruptSnapshot {
+            text,
+            completed_tool_calls: completed,
+            in_flight_tool: in_flight,
+            bytes_received: self.bytes_received,
         }
     }
 
@@ -73,15 +149,22 @@ impl StreamCollector {
             ChatStreamEvent::Start => StreamOutput::None,
 
             ChatStreamEvent::Chunk(chunk) => {
+                self.bytes_received += chunk.content.len();
+                self.last_delta_at = Some(Instant::now());
                 self.text.push_str(&chunk.content);
                 StreamOutput::TextDelta(chunk.content)
             }
 
-            ChatStreamEvent::ReasoningChunk(chunk) => StreamOutput::ReasoningDelta(chunk.content),
+            ChatStreamEvent::ReasoningChunk(chunk) => {
+                self.bytes_received += chunk.content.len();
+                self.last_delta_at = Some(Instant::now());
+                StreamOutput::ReasoningDelta(chunk.content)
+            }
 
             ChatStreamEvent::ThoughtSignatureChunk(_) => StreamOutput::None,
 
             ChatStreamEvent::ToolCallChunk(tool_chunk) => {
+                self.last_delta_at = Some(Instant::now());
                 let call = &tool_chunk.tool_call;
                 let id = call.call_id.clone();
 
@@ -115,6 +198,7 @@ impl StreamCollector {
                     String::new()
                 };
                 entry.arguments = args_str;
+                self.bytes_received += delta.len();
 
                 let should_emit_start = !entry.start_emitted && !entry.name.is_empty();
                 if should_emit_start {
@@ -688,6 +772,112 @@ mod tests {
             result.tool_calls[0].arguments["prompt"],
             "build a dashboard"
         );
+    }
+
+    // -- interrupt_snapshot tests --------------------------------------------
+
+    #[test]
+    fn interrupt_snapshot_empty_when_nothing_received() {
+        let c = StreamCollector::new();
+        let snap = c.interrupt_snapshot();
+        assert!(snap.text.is_none());
+        assert!(snap.completed_tool_calls.is_empty());
+        assert!(snap.in_flight_tool.is_none());
+        assert_eq!(snap.bytes_received, 0);
+    }
+
+    #[test]
+    fn interrupt_snapshot_captures_text_only() {
+        let mut c = StreamCollector::new();
+        c.process(ChatStreamEvent::Chunk(StreamChunk {
+            content: "hello ".into(),
+        }));
+        c.process(ChatStreamEvent::Chunk(StreamChunk {
+            content: "world".into(),
+        }));
+
+        let snap = c.interrupt_snapshot();
+        assert_eq!(snap.text.as_deref(), Some("hello world"));
+        assert!(snap.completed_tool_calls.is_empty());
+        assert!(snap.in_flight_tool.is_none());
+        assert_eq!(snap.bytes_received, "hello world".len());
+        assert!(c.last_delta_at().is_some());
+    }
+
+    #[test]
+    fn interrupt_snapshot_captures_completed_and_in_flight_tool() {
+        use genai::chat::ToolCall as GToolCall;
+
+        let mut c = StreamCollector::new();
+
+        // Completed tool: arrives in one chunk with valid JSON args.
+        c.process(ChatStreamEvent::ToolCallChunk(ToolChunk {
+            tool_call: GToolCall {
+                call_id: "c1".into(),
+                fn_name: "search".into(),
+                fn_arguments: serde_json::json!({"q": "rust"}),
+                thought_signatures: None,
+            },
+        }));
+
+        // In-flight tool: invalid JSON fragment.
+        c.process(ChatStreamEvent::ToolCallChunk(ToolChunk {
+            tool_call: GToolCall {
+                call_id: "c2".into(),
+                fn_name: "fetch".into(),
+                fn_arguments: Value::String(r#"{"url":"#.into()),
+                thought_signatures: None,
+            },
+        }));
+
+        let snap = c.interrupt_snapshot();
+        assert_eq!(snap.completed_tool_calls.len(), 1);
+        assert_eq!(snap.completed_tool_calls[0].name, "search");
+        let p = snap.in_flight_tool.expect("expected in-flight tool");
+        assert_eq!(p.id, "c2");
+        assert_eq!(p.name, "fetch");
+        assert_eq!(p.partial_args, r#"{"url":"#);
+    }
+
+    #[test]
+    fn interrupt_snapshot_truncated_only_becomes_in_flight_with_empty_completed() {
+        use genai::chat::ToolCall as GToolCall;
+
+        let mut c = StreamCollector::new();
+        c.process(ChatStreamEvent::ToolCallChunk(ToolChunk {
+            tool_call: GToolCall {
+                call_id: "c1".into(),
+                fn_name: "calc".into(),
+                fn_arguments: Value::String(r#"{"expr":"2+"#.into()),
+                thought_signatures: None,
+            },
+        }));
+
+        let snap = c.interrupt_snapshot();
+        assert!(snap.completed_tool_calls.is_empty());
+        let p = snap.in_flight_tool.expect("expected in-flight");
+        assert_eq!(p.name, "calc");
+    }
+
+    #[test]
+    fn last_delta_at_only_updates_on_deltas_not_start_or_end() {
+        use genai::chat::StreamEnd;
+
+        let mut c = StreamCollector::new();
+        // Start event alone does not count.
+        c.process(ChatStreamEvent::Start);
+        assert!(c.last_delta_at().is_none());
+
+        // Chunk updates last_delta_at.
+        c.process(ChatStreamEvent::Chunk(StreamChunk {
+            content: "x".into(),
+        }));
+        let t1 = c.last_delta_at().expect("should have timestamp");
+
+        // End does not overwrite last_delta_at (it's not a delta).
+        c.process(ChatStreamEvent::End(StreamEnd::default()));
+        let t2 = c.last_delta_at().expect("preserved across end");
+        assert_eq!(t1, t2);
     }
 
     #[test]

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -40,7 +40,7 @@ pub(super) async fn execute_streaming(
     cancellation_token: Option<&CancellationToken>,
     total_input_tokens: &mut u64,
     total_output_tokens: &mut u64,
-) -> Result<StreamResult, AgentLoopError> {
+) -> Result<(StreamResult, Option<InFlightTool>), AgentLoopError> {
     let policy = stream_retry_policy_for(agent);
     let idle_timeout = idle_timeout_for(&request, &policy);
     let max_retries = policy.max_stream_retries;
@@ -60,7 +60,7 @@ pub(super) async fn execute_streaming(
 
         match outcome {
             DriveOutcome::Completed(result) | DriveOutcome::Cancelled(result) => {
-                return Ok(result);
+                return Ok((result, None));
             }
             DriveOutcome::Error(err) => return Err(err),
             DriveOutcome::Interrupted { cause, snapshot } => {
@@ -80,7 +80,9 @@ pub(super) async fn execute_streaming(
                 }
 
                 match apply_recovery_plan(&mut request, sink, &cause, &snapshot).await {
-                    RecoveryOutcome::SynthesizedToolUse(result) => return Ok(result),
+                    RecoveryOutcome::SynthesizedToolUse { result, hint } => {
+                        return Ok((result, hint));
+                    }
                     RecoveryOutcome::RetryAfterPlan => {
                         let delay = stream_retry_backoff(&cause, attempt, &policy);
                         if !delay.is_zero() {
@@ -126,8 +128,13 @@ enum DriveOutcome {
 
 enum RecoveryOutcome {
     /// R2 path: return the synthesized tool-use stream result directly to
-    /// the caller without another inference round-trip.
-    SynthesizedToolUse(StreamResult),
+    /// the caller without another inference round-trip. The in-flight
+    /// tool (if any) is surfaced as a hint so the caller can append a
+    /// note to the next turn's user message.
+    SynthesizedToolUse {
+        result: StreamResult,
+        hint: Option<InFlightTool>,
+    },
     /// R1/R3/R4 paths: `request` has been mutated (R1/R3) or left as-is
     /// (R4); control flow loops back and opens a fresh stream.
     RetryAfterPlan,
@@ -171,13 +178,16 @@ async fn apply_recovery_plan(
                 Some(t) if !t.is_empty() => vec![ContentBlock::text(t.clone())],
                 _ => Vec::new(),
             };
-            RecoveryOutcome::SynthesizedToolUse(StreamResult {
-                content,
-                tool_calls: completed,
-                usage: None,
-                stop_reason: Some(StopReason::ToolUse),
-                has_incomplete_tool_calls: false,
-            })
+            RecoveryOutcome::SynthesizedToolUse {
+                result: StreamResult {
+                    content,
+                    tool_calls: completed,
+                    usage: None,
+                    stop_reason: Some(StopReason::ToolUse),
+                    has_incomplete_tool_calls: false,
+                },
+                hint: cancelled_tool_hint,
+            }
         }
         RecoveryPlan::TruncateBeforeTool {
             assistant_prefix,
@@ -682,6 +692,30 @@ mod tests {
         )
     }
 
+    /// Thin adapter that discards the in-flight tool hint. Used by
+    /// legacy tests that only care about the `StreamResult`; new tests
+    /// that exercise the hint path (Phase E) call `execute_streaming`
+    /// directly and destructure the tuple.
+    async fn stream_only(
+        agent: &ResolvedAgent,
+        request: InferenceRequest,
+        sink: &dyn EventSink,
+        cancellation_token: Option<&CancellationToken>,
+        total_input_tokens: &mut u64,
+        total_output_tokens: &mut u64,
+    ) -> Result<StreamResult, AgentLoopError> {
+        execute_streaming(
+            agent,
+            request,
+            sink,
+            cancellation_token,
+            total_input_tokens,
+            total_output_tokens,
+        )
+        .await
+        .map(|(result, _hint)| result)
+    }
+
     fn make_request() -> InferenceRequest {
         InferenceRequest {
             upstream_model: "test-model".into(),
@@ -707,7 +741,7 @@ mod tests {
         let mut input_tokens = 0u64;
         let mut output_tokens = 0u64;
 
-        let result = execute_streaming(
+        let result = stream_only(
             &agent,
             make_request(),
             &sink,
@@ -736,7 +770,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -766,7 +800,7 @@ mod tests {
         let mut input_tokens = 10u64;
         let mut output_tokens = 5u64;
 
-        let result = execute_streaming(
+        let result = stream_only(
             &agent,
             make_request(),
             &sink,
@@ -793,7 +827,7 @@ mod tests {
         let mut input_tokens = 100u64;
         let mut output_tokens = 50u64;
 
-        execute_streaming(
+        stream_only(
             &agent,
             make_request(),
             &sink,
@@ -833,7 +867,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -860,7 +894,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -895,7 +929,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -931,7 +965,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -967,7 +1001,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(
+        let result = stream_only(
             &agent,
             make_request(),
             &sink,
@@ -994,7 +1028,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -1016,7 +1050,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -1036,7 +1070,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -1059,7 +1093,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -1087,7 +1121,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1121,7 +1155,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap();
 
@@ -1198,7 +1232,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1228,7 +1262,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1297,7 +1331,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1324,7 +1358,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1350,7 +1384,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1424,7 +1458,7 @@ mod tests {
             token_clone.cancel();
         });
 
-        let result = execute_streaming(
+        let result = stream_only(
             &agent,
             make_request(),
             &sink,
@@ -1465,7 +1499,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1584,7 +1618,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .expect("R1 should succeed after one retry");
 
@@ -1645,7 +1679,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .expect("R2 short-circuits to synthesized tool_use");
 
@@ -1700,7 +1734,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .expect("R3 recovers after truncation");
 
@@ -1741,7 +1775,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let result = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .expect("R4 recovers after whole restart");
 
@@ -1772,7 +1806,7 @@ mod tests {
         let mut it = 0u64;
         let mut ot = 0u64;
 
-        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+        let err = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot)
             .await
             .unwrap_err();
 
@@ -1867,7 +1901,7 @@ mod tests {
 
         // Drive the streaming call concurrently so we can advance paused
         // time past the idle-stall threshold (60s by default).
-        let exec_fut = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot);
+        let exec_fut = stream_only(&agent, make_request(), &sink, None, &mut it, &mut ot);
         let drive = async {
             // Wait for the first TextDelta to be emitted, then advance
             // past the idle threshold to trigger the stall.

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -1,17 +1,29 @@
 //! LLM inference execution and context compaction.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::cancellation::CancellationToken;
+use awaken_contract::contract::content::ContentBlock;
 use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::event_sink::EventSink;
-use awaken_contract::contract::executor::{InferenceRequest, LlmStreamEvent};
+use awaken_contract::contract::executor::{
+    InFlightTool, InferenceExecutionError, InferenceRequest, InterruptCause, InterruptSnapshot,
+    LlmStreamEvent, RecoveryPlan,
+};
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::contract::message::{Message, ToolCall};
 use futures::StreamExt;
 
 use super::AgentLoopError;
+use crate::engine::retry::LlmRetryPolicy;
 use crate::registry::ResolvedAgent;
+
+/// Continuation prompt injected after a mid-stream interruption to nudge
+/// the model to pick up where its partial response left off. Intentionally
+/// short — long prompts dilute the assistant prefix context.
+const CONTINUATION_PROMPT: &str =
+    "Your previous response was interrupted mid-stream. Continue from where you left off.";
 
 /// Execute LLM inference with streaming, emitting delta events via sink.
 ///
@@ -23,52 +35,258 @@ use crate::registry::ResolvedAgent;
 /// result is returned with `StopReason::EndTurn` (graceful cancel — no error).
 pub(super) async fn execute_streaming(
     agent: &ResolvedAgent,
-    request: InferenceRequest,
+    mut request: InferenceRequest,
     sink: &dyn EventSink,
     cancellation_token: Option<&CancellationToken>,
     total_input_tokens: &mut u64,
     total_output_tokens: &mut u64,
 ) -> Result<StreamResult, AgentLoopError> {
-    use awaken_contract::contract::content::ContentBlock;
-
-    let mut token_stream = agent.llm_executor.execute_stream(request).await?;
-
-    let mut content_blocks: Vec<ContentBlock> = Vec::new();
-    let mut tool_calls: Vec<ToolCall> = Vec::new();
-    let mut usage: Option<TokenUsage> = None;
-    let mut stop_reason: Option<StopReason> = None;
-    let mut current_text = String::new();
-    let mut current_tool_args: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    let mut tool_names: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    // Track insertion order so tool_calls preserves the LLM's declared order.
-    let mut tool_order: Vec<String> = Vec::new();
-    let mut cancelled = false;
+    let policy = stream_retry_policy_for(agent);
+    let idle_timeout = idle_timeout_for(&request, &policy);
+    let max_retries = policy.max_stream_retries;
+    let mut attempt: u32 = 0;
 
     loop {
+        let outcome = drive_one_stream(
+            agent,
+            request.clone(),
+            sink,
+            cancellation_token,
+            total_input_tokens,
+            total_output_tokens,
+            idle_timeout,
+        )
+        .await;
+
+        match outcome {
+            DriveOutcome::Completed(result) | DriveOutcome::Cancelled(result) => {
+                return Ok(result);
+            }
+            DriveOutcome::Error(err) => return Err(err),
+            DriveOutcome::Interrupted { cause, snapshot } => {
+                if attempt >= max_retries {
+                    tracing::warn!(
+                        attempts = attempt,
+                        cause = %cause,
+                        bytes_received = snapshot.bytes_received,
+                        "stream retry budget exhausted; surfacing StreamInterrupted",
+                    );
+                    return Err(AgentLoopError::from(
+                        InferenceExecutionError::StreamInterrupted {
+                            cause,
+                            snapshot: Box::new(snapshot),
+                        },
+                    ));
+                }
+
+                match apply_recovery_plan(&mut request, sink, &cause, &snapshot).await {
+                    RecoveryOutcome::SynthesizedToolUse(result) => return Ok(result),
+                    RecoveryOutcome::RetryAfterPlan => {
+                        let delay = stream_retry_backoff(&cause, attempt, &policy);
+                        if !delay.is_zero() {
+                            if let Some(token) = cancellation_token {
+                                tokio::select! {
+                                    biased;
+                                    _ = token.cancelled() => {
+                                        return Err(AgentLoopError::from(
+                                            InferenceExecutionError::Cancelled,
+                                        ));
+                                    }
+                                    _ = tokio::time::sleep(delay) => {}
+                                }
+                            } else {
+                                tokio::time::sleep(delay).await;
+                            }
+                        }
+                        attempt += 1;
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Result of driving a single stream attempt to completion.
+enum DriveOutcome {
+    /// Stream finished naturally.
+    Completed(StreamResult),
+    /// Cancellation token fired; partial state returned with
+    /// `StopReason::EndTurn` (graceful).
+    Cancelled(StreamResult),
+    /// Mid-stream transport/idle failure; caller decides whether to retry.
+    Interrupted {
+        cause: InterruptCause,
+        snapshot: InterruptSnapshot,
+    },
+    /// Non-recoverable runtime error (stream open failed with permanent
+    /// error, sink emit failed, etc.).
+    Error(AgentLoopError),
+}
+
+enum RecoveryOutcome {
+    /// R2 path: return the synthesized tool-use stream result directly to
+    /// the caller without another inference round-trip.
+    SynthesizedToolUse(StreamResult),
+    /// R1/R3/R4 paths: `request` has been mutated (R1/R3) or left as-is
+    /// (R4); control flow loops back and opens a fresh stream.
+    RetryAfterPlan,
+}
+
+async fn apply_recovery_plan(
+    request: &mut InferenceRequest,
+    sink: &dyn EventSink,
+    cause: &InterruptCause,
+    snapshot: &InterruptSnapshot,
+) -> RecoveryOutcome {
+    match snapshot.plan() {
+        RecoveryPlan::ContinueText { assistant_prefix } => {
+            push_continuation(request, assistant_prefix);
+            RecoveryOutcome::RetryAfterPlan
+        }
+        RecoveryPlan::SynthesizeToolUse {
+            completed,
+            cancelled_tool_hint,
+        } => {
+            if let Some(hint) = &cancelled_tool_hint {
+                sink.emit(AgentEvent::ToolCallCancel {
+                    id: hint.id.clone(),
+                    name: hint.name.clone(),
+                    reason: cause.to_string(),
+                })
+                .await;
+            }
+            // Emit ToolCallReady for each completed tool so downstream
+            // consumers (UI, telemetry) see the same sequence they would
+            // have on a normal `StopReason::ToolUse` termination.
+            for call in &completed {
+                sink.emit(AgentEvent::ToolCallReady {
+                    id: call.id.clone(),
+                    name: call.name.clone(),
+                    arguments: call.arguments.clone(),
+                })
+                .await;
+            }
+            let content = match snapshot.text.as_ref() {
+                Some(t) if !t.is_empty() => vec![ContentBlock::text(t.clone())],
+                _ => Vec::new(),
+            };
+            RecoveryOutcome::SynthesizedToolUse(StreamResult {
+                content,
+                tool_calls: completed,
+                usage: None,
+                stop_reason: Some(StopReason::ToolUse),
+                has_incomplete_tool_calls: false,
+            })
+        }
+        RecoveryPlan::TruncateBeforeTool {
+            assistant_prefix,
+            cancelled_tool_id,
+            cancelled_tool_name,
+        } => {
+            sink.emit(AgentEvent::ToolCallCancel {
+                id: cancelled_tool_id,
+                name: cancelled_tool_name,
+                reason: cause.to_string(),
+            })
+            .await;
+            push_continuation(request, assistant_prefix);
+            RecoveryOutcome::RetryAfterPlan
+        }
+        RecoveryPlan::WholeRestart => {
+            sink.emit(AgentEvent::StreamReset {
+                reason: cause.to_string(),
+            })
+            .await;
+            RecoveryOutcome::RetryAfterPlan
+        }
+    }
+}
+
+fn push_continuation(request: &mut InferenceRequest, assistant_prefix: String) {
+    if !assistant_prefix.is_empty() {
+        request.messages.push(Message::assistant(assistant_prefix));
+    }
+    request.messages.push(Message::user(CONTINUATION_PROMPT));
+}
+
+/// Drive a single `execute_stream` call to completion, returning one of
+/// three outcomes. The mid-stream error-to-`InterruptCause` classification
+/// lives here.
+async fn drive_one_stream(
+    agent: &ResolvedAgent,
+    request: InferenceRequest,
+    sink: &dyn EventSink,
+    cancellation_token: Option<&CancellationToken>,
+    total_input_tokens: &mut u64,
+    total_output_tokens: &mut u64,
+    idle_timeout: Duration,
+) -> DriveOutcome {
+    let mut token_stream = match agent.llm_executor.execute_stream(request).await {
+        Ok(s) => s,
+        Err(err) => {
+            // `err` here comes from the executor (including `RetryingExecutor`)
+            // and has already exhausted its own retries. Surface it.
+            return DriveOutcome::Error(AgentLoopError::from(err));
+        }
+    };
+
+    let mut acc = StreamingAccumulator::default();
+
+    loop {
+        let next_fut = async { tokio::time::timeout(idle_timeout, token_stream.next()).await };
+
         let event = if let Some(token) = cancellation_token {
             tokio::select! {
                 biased;
                 _ = token.cancelled() => {
-                    cancelled = true;
+                    acc.cancelled = true;
                     break;
                 }
-                next = token_stream.next() => next,
+                r = next_fut => r,
             }
         } else {
-            token_stream.next().await
+            next_fut.await
         };
 
-        let Some(event_result) = event else {
-            break; // stream ended
+        let poll = match event {
+            Ok(p) => p,
+            Err(_) => {
+                // Idle stall — no delta in `idle_timeout`.
+                let snapshot = acc.interrupt_snapshot();
+                return DriveOutcome::Interrupted {
+                    cause: InterruptCause::IdleStall,
+                    snapshot,
+                };
+            }
         };
 
-        let event = event_result?;
+        let Some(event_result) = poll else {
+            break; // stream ended cleanly
+        };
+
+        let event = match event_result {
+            Ok(ev) => ev,
+            Err(err) => {
+                // Mid-stream transport error. Classify and surface.
+                let snapshot = acc.interrupt_snapshot();
+                match classify_mid_stream(&err) {
+                    Some(cause) => {
+                        tracing::debug!(
+                            cause = %cause,
+                            bytes_received = snapshot.bytes_received,
+                            "mid-stream error captured, entering recovery"
+                        );
+                        return DriveOutcome::Interrupted { cause, snapshot };
+                    }
+                    None => return DriveOutcome::Error(AgentLoopError::from(err)),
+                }
+            }
+        };
 
         match event {
             LlmStreamEvent::TextDelta(delta) => {
-                current_text.push_str(&delta);
+                acc.current_text.push_str(&delta);
                 sink.emit(AgentEvent::TextDelta { delta }).await;
             }
             LlmStreamEvent::ReasoningDelta(delta) => {
@@ -80,20 +298,21 @@ pub(super) async fn execute_streaming(
                     name: name.clone(),
                 })
                 .await;
-                tool_names.insert(id.clone(), name);
-                current_tool_args.insert(id.clone(), String::new());
-                tool_order.push(id);
+                acc.tool_names.insert(id.clone(), name);
+                acc.current_tool_args.insert(id.clone(), String::new());
+                acc.tool_order.push(id);
             }
             LlmStreamEvent::ToolCallDelta { id, args_delta } => {
-                if let Some(buf) = current_tool_args.get_mut(&id) {
+                if let Some(buf) = acc.current_tool_args.get_mut(&id) {
                     buf.push_str(&args_delta);
                 }
                 sink.emit(AgentEvent::ToolCallDelta { id, args_delta })
                     .await;
             }
             LlmStreamEvent::ContentBlockStop => {
-                if !current_text.is_empty() {
-                    content_blocks.push(ContentBlock::text(std::mem::take(&mut current_text)));
+                if !acc.current_text.is_empty() {
+                    acc.content_blocks
+                        .push(ContentBlock::text(std::mem::take(&mut acc.current_text)));
                 }
             }
             LlmStreamEvent::Usage(u) => {
@@ -103,51 +322,195 @@ pub(super) async fn execute_streaming(
                 if let Some(v) = u.completion_tokens {
                     *total_output_tokens = total_output_tokens.saturating_add(v.max(0) as u64);
                 }
-                usage = Some(u);
+                acc.usage = Some(u);
             }
             LlmStreamEvent::Stop(reason) => {
-                stop_reason = Some(reason);
+                acc.stop_reason = Some(reason);
             }
         }
     }
 
-    // Flush remaining text
-    if !current_text.is_empty() {
-        content_blocks.push(ContentBlock::text(current_text));
+    // Stream drained cleanly (or cancelled): finalize.
+    let result = acc.finalize(sink).await;
+    if acc.cancelled {
+        DriveOutcome::Cancelled(result)
+    } else {
+        DriveOutcome::Completed(result)
     }
+}
 
-    // Collect tool calls from accumulated args in LLM-declared order (drop incomplete on cancel)
-    let mut has_incomplete_tool_calls = false;
-    if !cancelled {
-        for id in &tool_order {
-            let args_json = current_tool_args.get(id).cloned().unwrap_or_default();
-            let name = tool_names.get(id).cloned().unwrap_or_default();
-            let arguments = serde_json::from_str(&args_json).unwrap_or(serde_json::Value::Null);
-            if arguments.is_null() && !args_json.is_empty() {
-                has_incomplete_tool_calls = true;
-                continue; // truncated JSON, skip
+#[derive(Default)]
+struct StreamingAccumulator {
+    content_blocks: Vec<ContentBlock>,
+    usage: Option<TokenUsage>,
+    stop_reason: Option<StopReason>,
+    current_text: String,
+    current_tool_args: std::collections::HashMap<String, String>,
+    tool_names: std::collections::HashMap<String, String>,
+    tool_order: Vec<String>,
+    bytes_received: usize,
+    cancelled: bool,
+}
+
+impl StreamingAccumulator {
+    /// Build an [`InterruptSnapshot`] reflecting the current accumulator
+    /// state. Preserves text (may be empty), marks tool calls with valid
+    /// JSON as completed and the most-recent unparseable one as in-flight.
+    fn interrupt_snapshot(&self) -> InterruptSnapshot {
+        let mut completed: Vec<ToolCall> = Vec::new();
+        let mut in_flight: Option<InFlightTool> = None;
+
+        for id in &self.tool_order {
+            let args_json = self.current_tool_args.get(id).cloned().unwrap_or_default();
+            let name = self.tool_names.get(id).cloned().unwrap_or_default();
+
+            if name.is_empty() {
+                in_flight = Some(InFlightTool {
+                    id: id.clone(),
+                    name: String::new(),
+                    partial_args: args_json,
+                });
+                continue;
             }
-            tool_calls.push(ToolCall::new(id.clone(), name.clone(), arguments.clone()));
-            sink.emit(AgentEvent::ToolCallReady {
-                id: id.clone(),
-                name,
-                arguments,
-            })
-            .await;
-        }
-    }
 
-    Ok(StreamResult {
-        content: content_blocks,
-        tool_calls,
-        usage,
-        stop_reason: if cancelled {
-            Some(StopReason::EndTurn)
+            match serde_json::from_str::<serde_json::Value>(&args_json) {
+                Ok(arguments) if !(arguments.is_null() && !args_json.is_empty()) => {
+                    completed.push(ToolCall::new(id.clone(), name, arguments));
+                }
+                _ => {
+                    in_flight = Some(InFlightTool {
+                        id: id.clone(),
+                        name,
+                        partial_args: args_json,
+                    });
+                }
+            }
+        }
+
+        let text = if self.current_text.is_empty() {
+            self.content_blocks
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Text { text } if !text.is_empty() => Some(text.clone()),
+                    _ => None,
+                })
+                .reduce(|a, b| a + &b)
         } else {
-            stop_reason
-        },
-        has_incomplete_tool_calls,
-    })
+            Some(self.current_text.clone())
+        };
+
+        InterruptSnapshot {
+            text,
+            completed_tool_calls: completed,
+            in_flight_tool: in_flight,
+            bytes_received: self.bytes_received,
+        }
+    }
+
+    async fn finalize(&mut self, sink: &dyn EventSink) -> StreamResult {
+        // Flush remaining text into a content block.
+        if !self.current_text.is_empty() {
+            self.content_blocks
+                .push(ContentBlock::text(std::mem::take(&mut self.current_text)));
+        }
+
+        let mut tool_calls = Vec::new();
+        let mut has_incomplete_tool_calls = false;
+
+        if !self.cancelled {
+            for id in &self.tool_order {
+                let args_json = self.current_tool_args.get(id).cloned().unwrap_or_default();
+                let name = self.tool_names.get(id).cloned().unwrap_or_default();
+                let arguments = serde_json::from_str(&args_json).unwrap_or(serde_json::Value::Null);
+                if arguments.is_null() && !args_json.is_empty() {
+                    has_incomplete_tool_calls = true;
+                    continue;
+                }
+                tool_calls.push(ToolCall::new(id.clone(), name.clone(), arguments.clone()));
+                sink.emit(AgentEvent::ToolCallReady {
+                    id: id.clone(),
+                    name,
+                    arguments,
+                })
+                .await;
+            }
+        }
+
+        StreamResult {
+            content: std::mem::take(&mut self.content_blocks),
+            tool_calls,
+            usage: self.usage.take(),
+            stop_reason: if self.cancelled {
+                Some(StopReason::EndTurn)
+            } else {
+                self.stop_reason.take()
+            },
+            has_incomplete_tool_calls,
+        }
+    }
+}
+
+/// Classify a mid-stream error into an `InterruptCause`. Returns `None`
+/// when the error is of a kind that should NOT enter the recovery loop
+/// (e.g. `ContextOverflow`, `Unauthorized`, `Cancelled`) — those propagate
+/// as a regular `Error` outcome.
+fn classify_mid_stream(err: &InferenceExecutionError) -> Option<InterruptCause> {
+    match err {
+        // Recoverable — transport-ish failures.
+        InferenceExecutionError::Provider(_)
+        | InferenceExecutionError::Timeout(_)
+        | InferenceExecutionError::RateLimited { .. }
+        | InferenceExecutionError::Overloaded { .. } => Some(InterruptCause::ConnectionReset),
+
+        // Already-classified stream interruption — preserve cause.
+        InferenceExecutionError::StreamInterrupted { cause, .. } => Some(cause.clone()),
+
+        // Permanent / lifecycle — surface to caller, not a mid-stream retry.
+        _ => None,
+    }
+}
+
+/// Fetch the active retry policy. Falls back to defaults for agents that
+/// do not configure one. The agent-level override plumbing lives in
+/// `engine::retry::RetryConfigKey`; for now, treat missing config as
+/// "use defaults".
+fn stream_retry_policy_for(_agent: &ResolvedAgent) -> LlmRetryPolicy {
+    LlmRetryPolicy::default()
+}
+
+/// Model-aware idle-stall threshold. Thinking / reasoning models receive
+/// a 2× window to accommodate long silent reasoning phases.
+fn idle_timeout_for(request: &InferenceRequest, policy: &LlmRetryPolicy) -> Duration {
+    let base = Duration::from_secs(policy.stream_idle_timeout_secs);
+    let model = request.upstream_model.as_str();
+    let name_hits = model.contains("thinking")
+        || model.contains("reasoning")
+        || model.starts_with("o1")
+        || model.starts_with("o3")
+        || model.starts_with("o4");
+    let options_hits = request
+        .overrides
+        .as_ref()
+        .and_then(|o| o.reasoning_effort.as_ref())
+        .is_some();
+    if name_hits || options_hits {
+        base * 2
+    } else {
+        base
+    }
+}
+
+fn stream_retry_backoff(cause: &InterruptCause, attempt: u32, policy: &LlmRetryPolicy) -> Duration {
+    // Mid-stream retries use the normal backoff; Overloaded-style
+    // surges propagate through `RetryingExecutor` on stream open, not
+    // here. For idle stalls, use a short delay to probe quickly.
+    match cause {
+        InterruptCause::IdleStall => Duration::from_millis(200),
+        _ => policy.delay_before_retry(
+            &InferenceExecutionError::Provider("mid-stream".into()),
+            attempt,
+        ),
+    }
 }
 
 /// Compact messages using the configured ContextSummarizer.
@@ -252,14 +615,25 @@ mod tests {
 
     // -- Streaming LLM executor that yields explicit stream events --
 
+    /// Mock LLM executor that yields a fixed scripted event sequence on
+    /// EVERY call to `execute_stream`. Cloning the script per attempt means
+    /// stream-level retries in `execute_streaming` observe the same
+    /// behavior across attempts — useful when asserting retry budgets.
     struct StreamingMockExecutor {
-        events: std::sync::Mutex<Option<Vec<Result<LlmStreamEvent, InferenceExecutionError>>>>,
+        script: Vec<ClonedEvent>,
     }
+
+    /// Serializable-as-needed twin of the scripted events. `LlmStreamEvent`
+    /// itself is Clone via Copy/String fields; `InferenceExecutionError` is
+    /// now Clone as of the Phase-A refactor — so a straightforward clone
+    /// works, but we normalize to owned values here for clarity.
+    #[derive(Clone)]
+    struct ClonedEvent(Result<LlmStreamEvent, InferenceExecutionError>);
 
     impl StreamingMockExecutor {
         fn new(events: Vec<Result<LlmStreamEvent, InferenceExecutionError>>) -> Self {
             Self {
-                events: std::sync::Mutex::new(Some(events)),
+                script: events.into_iter().map(ClonedEvent).collect(),
             }
         }
     }
@@ -289,7 +663,8 @@ mod tests {
                     + '_,
             >,
         > {
-            let events = self.events.lock().unwrap().take().unwrap_or_default();
+            let events: Vec<Result<LlmStreamEvent, InferenceExecutionError>> =
+                self.script.iter().map(|e| e.0.clone()).collect();
             Box::pin(async move { Ok(Box::pin(futures::stream::iter(events)) as InferenceStream) })
         }
 
@@ -700,6 +1075,10 @@ mod tests {
 
     #[tokio::test]
     async fn stream_error_propagated_as_agent_loop_error() {
+        // Mid-stream provider error after accumulated text. Under the
+        // Phase-D recovery flow this enters R1 (ContinueText), retries up
+        // to the stream-retry budget, and finally surfaces a
+        // StreamInterrupted error when every attempt reproduces the fault.
         let agent = make_agent(vec![
             Ok(LlmStreamEvent::TextDelta("before error".into())),
             Err(InferenceExecutionError::Provider("rate limited".into())),
@@ -714,7 +1093,10 @@ mod tests {
 
         match err {
             AgentLoopError::InferenceFailed(msg) => {
-                assert!(msg.contains("rate limited"));
+                assert!(
+                    msg.contains("stream interrupted"),
+                    "expected stream-interrupt message, got: {msg}"
+                );
             }
             other => panic!("expected InferenceFailed, got: {other:?}"),
         }
@@ -808,6 +1190,9 @@ mod tests {
 
     #[tokio::test]
     async fn error_after_zero_events_returns_inference_failed() {
+        // 0 successful events + error → R4 (WholeRestart). The recovery
+        // loop emits `StreamReset` for each retry then surfaces
+        // `StreamInterrupted` once the budget exhausts.
         let agent = make_failing_agent(0);
         let sink = VecEventSink::new();
         let mut it = 0u64;
@@ -819,13 +1204,21 @@ mod tests {
 
         match err {
             AgentLoopError::InferenceFailed(msg) => {
-                assert!(msg.contains("injected mid-stream failure"));
+                assert!(
+                    msg.contains("stream interrupted"),
+                    "expected stream-interrupt message, got: {msg}"
+                );
             }
             other => panic!("expected InferenceFailed, got: {other:?}"),
         }
 
-        // No events should have been emitted
-        assert!(sink.take().is_empty());
+        let events = sink.take();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::StreamReset { .. })),
+            "expected at least one StreamReset event, got: {events:?}"
+        );
     }
 
     #[tokio::test]
@@ -841,13 +1234,20 @@ mod tests {
 
         assert!(matches!(err, AgentLoopError::InferenceFailed(_)));
 
-        // 3 TextDelta events should have been emitted before the error
+        // At least 3 TextDelta events should have been emitted before the
+        // first error. Retries under the R1 recovery plan may emit more
+        // duplicated deltas across attempts; we assert the floor rather
+        // than an exact count so the test stays agnostic to retry budget.
         let events = sink.take();
         let text_deltas: Vec<_> = events
             .iter()
             .filter(|e| matches!(e, AgentEvent::TextDelta { .. }))
             .collect();
-        assert_eq!(text_deltas.len(), 3);
+        assert!(
+            text_deltas.len() >= 3,
+            "expected >=3 text deltas (with possible retries), got {}",
+            text_deltas.len()
+        );
     }
 
     // -- Executor that immediately fails at execute_stream level --
@@ -913,6 +1313,10 @@ mod tests {
 
     #[tokio::test]
     async fn rate_limited_error_surfaces_correctly() {
+        // Rate-limit mid-stream retries through R4 (WholeRestart) since no
+        // deltas are accumulated yet when the error fires. After the
+        // stream retry budget is exhausted the caller sees a
+        // stream-interrupted error.
         let agent = make_agent(vec![Err(InferenceExecutionError::rate_limited(
             "429 too many requests",
         ))]);
@@ -926,7 +1330,10 @@ mod tests {
 
         match err {
             AgentLoopError::InferenceFailed(msg) => {
-                assert!(msg.contains("429 too many requests"));
+                assert!(
+                    msg.contains("stream interrupted"),
+                    "expected stream-interrupt message, got: {msg}"
+                );
             }
             other => panic!("expected InferenceFailed, got: {other:?}"),
         }
@@ -934,6 +1341,8 @@ mod tests {
 
     #[tokio::test]
     async fn timeout_error_surfaces_correctly() {
+        // Timeout mid-stream routes through the recovery loop and
+        // surfaces as `stream interrupted` after the budget exhausts.
         let agent = make_agent(vec![Err(InferenceExecutionError::Timeout(
             "30s exceeded".into(),
         ))]);
@@ -947,7 +1356,12 @@ mod tests {
 
         match err {
             AgentLoopError::InferenceFailed(msg) => {
-                assert!(msg.contains("30s exceeded"));
+                assert!(
+                    msg.contains("stream interrupted"),
+                    "expected stream-interrupt message, got: {msg}"
+                );
+                // original classifier info is preserved in snapshot cause (connection reset for mapped Timeout).
+                let _ = "30s exceeded"; // keep literal for test discoverability
             }
             other => panic!("expected InferenceFailed, got: {other:?}"),
         }
@@ -1031,6 +1445,11 @@ mod tests {
 
     #[tokio::test]
     async fn error_mid_tool_call_returns_inference_error() {
+        // ToolCallStart + partial ToolCallDelta + mid-stream error →
+        // snapshot has an in-flight tool but no completed tools and no
+        // text. That's R4 (WholeRestart): emit StreamReset, retry. All
+        // retries reproduce the same failure and the stream retry budget
+        // exhausts into a stream-interrupt error.
         let agent = make_agent(vec![
             Ok(LlmStreamEvent::ToolCallStart {
                 id: "tc1".into(),
@@ -1052,17 +1471,26 @@ mod tests {
 
         match err {
             AgentLoopError::InferenceFailed(msg) => {
-                assert!(msg.contains("connection reset"));
+                assert!(
+                    msg.contains("stream interrupted"),
+                    "expected stream-interrupt message, got: {msg}"
+                );
             }
             other => panic!("expected InferenceFailed, got: {other:?}"),
         }
 
-        // Events before the error should still have been emitted
+        // Events before the error should still have been emitted, and
+        // a StreamReset event should appear from the R4 recovery path.
         let events = sink.take();
         assert!(
             events
                 .iter()
                 .any(|e| matches!(e, AgentEvent::ToolCallStart { .. }))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::StreamReset { .. }))
         );
     }
 }

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -1493,4 +1493,429 @@ mod tests {
                 .any(|e| matches!(e, AgentEvent::StreamReset { .. }))
         );
     }
+
+    // ========================================================================
+    // Phase-F failure-injection harness + R1-R4 matrix
+    //
+    // These tests exercise the stream-level retry loop introduced in Phase D.
+    // A per-attempt scripted executor lets us express "first attempt fails
+    // like X, second attempt succeeds like Y" without resorting to time or
+    // real transport. Each recovery plan (R1/R2/R3/R4), the idle-stall path,
+    // and the retry-budget exhaustion path has its own test.
+    // ========================================================================
+
+    /// Scripted streaming executor keyed by attempt number. On the Nth call
+    /// to `execute_stream`, yields `scripts[min(N, scripts.len()-1)]` so
+    /// short scripts naturally repeat the last attempt's script forever.
+    struct ScriptedPerAttemptExecutor {
+        scripts: Vec<Vec<Result<LlmStreamEvent, InferenceExecutionError>>>,
+        attempt: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ScriptedPerAttemptExecutor {
+        fn new(scripts: Vec<Vec<Result<LlmStreamEvent, InferenceExecutionError>>>) -> Self {
+            assert!(!scripts.is_empty(), "need at least one attempt script");
+            Self {
+                scripts,
+                attempt: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn attempts(&self) -> usize {
+            self.attempt.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl awaken_contract::contract::executor::LlmExecutor for ScriptedPerAttemptExecutor {
+        async fn execute(
+            &self,
+            _r: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            Err(InferenceExecutionError::Provider("unused".into()))
+        }
+
+        fn execute_stream(
+            &self,
+            _request: InferenceRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<InferenceStream, InferenceExecutionError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            let n = self
+                .attempt
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let idx = n.min(self.scripts.len() - 1);
+            let events = self.scripts[idx].clone();
+            Box::pin(async move { Ok(Box::pin(futures::stream::iter(events)) as InferenceStream) })
+        }
+
+        fn name(&self) -> &str {
+            "scripted-per-attempt"
+        }
+    }
+
+    fn agent_with(exec: Arc<ScriptedPerAttemptExecutor>) -> ResolvedAgent {
+        ResolvedAgent::new("test-agent", "test-model", "system prompt", exec)
+    }
+
+    // --- R1: pure text interruption → continuation retry succeeds --------
+
+    #[tokio::test]
+    async fn r1_text_only_interruption_recovers_via_continuation() {
+        let exec = Arc::new(ScriptedPerAttemptExecutor::new(vec![
+            // Attempt 1: partial text + mid-stream failure
+            vec![
+                Ok(LlmStreamEvent::TextDelta("Hello, ".into())),
+                Ok(LlmStreamEvent::TextDelta("this is".into())),
+                Err(InferenceExecutionError::Provider("connection reset".into())),
+            ],
+            // Attempt 2: fresh completion (model picks up from continuation)
+            vec![
+                Ok(LlmStreamEvent::TextDelta(" the second half.".into())),
+                Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+            ],
+        ]));
+        let agent = agent_with(exec.clone());
+        let sink = VecEventSink::new();
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+            .await
+            .expect("R1 should succeed after one retry");
+
+        assert_eq!(exec.attempts(), 2, "expected exactly two attempts");
+        // The second attempt's deltas are preserved in the returned result.
+        assert_eq!(result.text(), " the second half.");
+        assert_eq!(result.stop_reason, Some(StopReason::EndTurn));
+
+        // No StreamReset / ToolCallCancel on the R1 path.
+        let events = sink.take();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::StreamReset { .. })),
+            "R1 must not emit StreamReset"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ToolCallCancel { .. })),
+            "R1 must not emit ToolCallCancel"
+        );
+    }
+
+    // --- R2: completed tool + partial tool → synthesize tool_use ---------
+
+    #[tokio::test]
+    async fn r2_completed_tool_synthesizes_tool_use_without_another_round_trip() {
+        let exec = Arc::new(ScriptedPerAttemptExecutor::new(vec![
+            // Attempt 1: completed tool A + partial tool B + failure.
+            vec![
+                Ok(LlmStreamEvent::ToolCallStart {
+                    id: "a".into(),
+                    name: "search".into(),
+                }),
+                Ok(LlmStreamEvent::ToolCallDelta {
+                    id: "a".into(),
+                    args_delta: r#"{"q":"rust"}"#.into(),
+                }),
+                Ok(LlmStreamEvent::ToolCallStart {
+                    id: "b".into(),
+                    name: "fetch".into(),
+                }),
+                Ok(LlmStreamEvent::ToolCallDelta {
+                    id: "b".into(),
+                    args_delta: r#"{"url":"#.into(), // unclosed
+                }),
+                Err(InferenceExecutionError::Provider("connection reset".into())),
+            ],
+            // If R2 is correct we should never see attempt 2: synthesize
+            // tool_use short-circuits the retry loop. Put an obvious trap.
+            vec![Err(InferenceExecutionError::Provider(
+                "R2 should not retry".into(),
+            ))],
+        ]));
+        let agent = agent_with(exec.clone());
+        let sink = VecEventSink::new();
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+            .await
+            .expect("R2 short-circuits to synthesized tool_use");
+
+        assert_eq!(exec.attempts(), 1, "R2 must not trigger a retry");
+        assert_eq!(result.stop_reason, Some(StopReason::ToolUse));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].id, "a");
+        assert_eq!(result.tool_calls[0].name, "search");
+
+        let events = sink.take();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ToolCallCancel { id, name, .. }
+                    if id == "b" && name == "fetch")),
+            "expected ToolCallCancel for the in-flight tool"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ToolCallReady { id, .. } if id == "a")),
+            "expected ToolCallReady for the completed tool"
+        );
+    }
+
+    // --- R3: text + unclosed tool → truncate + continuation --------------
+
+    #[tokio::test]
+    async fn r3_text_plus_partial_tool_truncates_and_continues() {
+        let exec = Arc::new(ScriptedPerAttemptExecutor::new(vec![
+            // Attempt 1: text prefix + unclosed tool + failure
+            vec![
+                Ok(LlmStreamEvent::TextDelta("Looking it up: ".into())),
+                Ok(LlmStreamEvent::ToolCallStart {
+                    id: "t1".into(),
+                    name: "lookup".into(),
+                }),
+                Ok(LlmStreamEvent::ToolCallDelta {
+                    id: "t1".into(),
+                    args_delta: r#"{"id":"#.into(),
+                }),
+                Err(InferenceExecutionError::Provider("connection reset".into())),
+            ],
+            // Attempt 2: model continues with a different plan (just text).
+            vec![
+                Ok(LlmStreamEvent::TextDelta("done.".into())),
+                Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+            ],
+        ]));
+        let agent = agent_with(exec.clone());
+        let sink = VecEventSink::new();
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+            .await
+            .expect("R3 recovers after truncation");
+
+        assert_eq!(exec.attempts(), 2);
+        assert_eq!(result.text(), "done.");
+
+        let events = sink.take();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ToolCallCancel { id, name, .. }
+                    if id == "t1" && name == "lookup")),
+            "R3 must emit ToolCallCancel for the unclosed tool"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::StreamReset { .. })),
+            "R3 must NOT emit StreamReset"
+        );
+    }
+
+    // --- R4: nothing salvageable → whole restart + StreamReset -----------
+
+    #[tokio::test]
+    async fn r4_empty_snapshot_whole_restarts_and_emits_stream_reset() {
+        let exec = Arc::new(ScriptedPerAttemptExecutor::new(vec![
+            // Attempt 1: immediate failure, no accumulated state
+            vec![Err(InferenceExecutionError::Provider("reset".into()))],
+            // Attempt 2: succeeds cleanly
+            vec![
+                Ok(LlmStreamEvent::TextDelta("fresh start".into())),
+                Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+            ],
+        ]));
+        let agent = agent_with(exec.clone());
+        let sink = VecEventSink::new();
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        let result = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+            .await
+            .expect("R4 recovers after whole restart");
+
+        assert_eq!(exec.attempts(), 2);
+        assert_eq!(result.text(), "fresh start");
+
+        let events = sink.take();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::StreamReset { .. })),
+            "R4 must emit StreamReset"
+        );
+    }
+
+    // --- Budget exhaustion → StreamInterrupted ---------------------------
+
+    #[tokio::test]
+    async fn retry_budget_exhausted_surfaces_stream_interrupted() {
+        // Every attempt fails. Default max_stream_retries = 2, so we expect
+        // 3 total attempts (1 initial + 2 retries) before the error
+        // surfaces.
+        let exec = Arc::new(ScriptedPerAttemptExecutor::new(vec![vec![Err(
+            InferenceExecutionError::Provider("reset".into()),
+        )]]));
+        let agent = agent_with(exec.clone());
+        let sink = VecEventSink::new();
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        let err = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            exec.attempts(),
+            3,
+            "expected 1 initial + 2 retries = 3 attempts"
+        );
+        match err {
+            AgentLoopError::InferenceFailed(msg) => {
+                assert!(
+                    msg.contains("stream interrupted"),
+                    "expected stream-interrupt message, got: {msg}"
+                );
+            }
+            other => panic!("expected InferenceFailed, got: {other:?}"),
+        }
+    }
+
+    // --- Idle-stall: hung stream triggers IdleStall cause ---------------
+
+    /// Executor that returns a stream which yields one event and then
+    /// never yields again, exercising the idle-stall timeout branch in
+    /// `drive_one_stream`. We use `tokio::time::advance` under
+    /// `tokio::test(start_paused = true)` to avoid wall-clock waits.
+    struct StallingExecutor {
+        attempt: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl awaken_contract::contract::executor::LlmExecutor for StallingExecutor {
+        async fn execute(
+            &self,
+            _r: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            Err(InferenceExecutionError::Provider("unused".into()))
+        }
+
+        fn execute_stream(
+            &self,
+            _request: InferenceRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<InferenceStream, InferenceExecutionError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            let n = self
+                .attempt
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move {
+                if n == 0 {
+                    // Attempt 1: one text delta then hang forever.
+                    let hung = futures::stream::unfold((), |()| async move {
+                        // Never yields — the select! / timeout in
+                        // drive_one_stream is responsible for noticing.
+                        futures::future::pending::<()>().await;
+                        None
+                    });
+                    let prefix: Vec<Result<LlmStreamEvent, InferenceExecutionError>> =
+                        vec![Ok(LlmStreamEvent::TextDelta("partial".into()))];
+                    let combined = futures::stream::iter(prefix)
+                        .chain(hung)
+                        .map(|r: Result<LlmStreamEvent, InferenceExecutionError>| r);
+                    Ok(Box::pin(combined) as InferenceStream)
+                } else {
+                    // Attempt 2: clean finish.
+                    let events: Vec<Result<LlmStreamEvent, InferenceExecutionError>> = vec![
+                        Ok(LlmStreamEvent::TextDelta(" done.".into())),
+                        Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+                    ];
+                    Ok(Box::pin(futures::stream::iter(events)) as InferenceStream)
+                }
+            })
+        }
+
+        fn name(&self) -> &str {
+            "stalling"
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_stall_triggers_recovery_and_second_attempt_succeeds() {
+        let exec = Arc::new(StallingExecutor {
+            attempt: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let agent = ResolvedAgent::new("test-agent", "test-model", "system prompt", exec.clone());
+        let sink = VecEventSink::new();
+        let mut it = 0u64;
+        let mut ot = 0u64;
+
+        // Drive the streaming call concurrently so we can advance paused
+        // time past the idle-stall threshold (60s by default).
+        let exec_fut = execute_streaming(&agent, make_request(), &sink, None, &mut it, &mut ot);
+        let drive = async {
+            // Wait for the first TextDelta to be emitted, then advance
+            // past the idle threshold to trigger the stall.
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            tokio::time::advance(Duration::from_secs(70)).await;
+        };
+
+        let (result, ()) = tokio::join!(exec_fut, drive);
+        let result = result.expect("idle-stall should recover");
+        assert_eq!(
+            exec.attempt.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "expected 2 attempts after stall recovery"
+        );
+        assert!(result.text().contains("done"));
+    }
+
+    #[test]
+    fn idle_timeout_for_doubles_on_thinking_model_names() {
+        let policy = LlmRetryPolicy::default().with_stream_idle_timeout_secs(30);
+        let base = Duration::from_secs(30);
+
+        let plain = InferenceRequest {
+            upstream_model: "gpt-4o-mini".into(),
+            messages: vec![],
+            tools: vec![],
+            system: vec![],
+            overrides: None,
+            enable_prompt_cache: false,
+        };
+        assert_eq!(idle_timeout_for(&plain, &policy), base);
+
+        let thinking = InferenceRequest {
+            upstream_model: "claude-opus-4-7-thinking".into(),
+            ..plain.clone()
+        };
+        assert_eq!(idle_timeout_for(&thinking, &policy), base * 2);
+
+        let reasoning = InferenceRequest {
+            upstream_model: "o1-mini".into(),
+            ..plain.clone()
+        };
+        assert_eq!(idle_timeout_for(&reasoning, &policy), base * 2);
+
+        let o3 = InferenceRequest {
+            upstream_model: "o3-preview".into(),
+            ..plain.clone()
+        };
+        assert_eq!(idle_timeout_for(&o3, &policy), base * 2);
+    }
 }

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -35,6 +35,18 @@ use crate::agent::state::{
 
 const INTERRUPTED_TOOL_MESSAGE: &str = "[Tool execution was interrupted]";
 
+/// Format a user-visible note that surfaces a cancelled parallel tool
+/// call after mid-stream recovery. Centralized so telemetry and docs can
+/// reason about the exact wording.
+fn format_tool_cancel_hint(hint: &awaken_contract::contract::executor::InFlightTool) -> String {
+    format!(
+        "Note: your parallel call to tool `{}` was interrupted mid-stream due to a transient \
+         upstream error. The other tool calls completed normally. You may re-issue the call if \
+         still needed.",
+        hint.name,
+    )
+}
+
 /// Outcome of a single step.
 pub(super) enum StepOutcome {
     /// The LLM responded with text only; run ends naturally.
@@ -263,7 +275,11 @@ async fn recover_truncation(
             enable_prompt_cache: false,
         };
 
-        stream_result = execute_streaming(
+        // Truncation recovery happens after any stream-interruption
+        // recovery, so the `cancelled_tool_hint` from mid-stream retry is
+        // no longer meaningful at this layer — it was consumed on the
+        // first call. Discard it here.
+        let (next_result, _hint) = execute_streaming(
             ctx.agent,
             cont_request,
             ctx.sink.as_ref(),
@@ -272,6 +288,7 @@ async fn recover_truncation(
             ctx.total_output_tokens,
         )
         .await?;
+        stream_result = next_result;
     }
     Ok(stream_result)
 }
@@ -395,6 +412,12 @@ struct InferencePhaseOutput {
     stream_result: StreamResult,
     duration_ms: u64,
     upstream_model: String,
+    /// Set when the mid-stream recovery loop synthesized a
+    /// `StopReason::ToolUse` terminal state that dropped an in-flight
+    /// tool call (R2 plan). The loop runner appends a user-visible note
+    /// to the next `user` message after the completed tools execute,
+    /// telling the model which call was lost so it can choose to retry.
+    cancelled_tool_hint: Option<awaken_contract::contract::executor::InFlightTool>,
 }
 
 /// Run the inference phase: compaction, request building, streaming.
@@ -455,7 +478,7 @@ async fn run_inference_phase(
     };
 
     // Inference
-    let stream_result = execute_streaming(
+    let (stream_result, cancelled_tool_hint) = execute_streaming(
         ctx.agent,
         request,
         ctx.sink.as_ref(),
@@ -481,6 +504,7 @@ async fn run_inference_phase(
         stream_result,
         duration_ms,
         upstream_model: request_upstream_model,
+        cancelled_tool_hint,
     })
 }
 
@@ -1142,6 +1166,7 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
         stream_result,
         duration_ms,
         upstream_model,
+        cancelled_tool_hint,
     } = inference;
 
     // --- Post-inference cancellation check ---
@@ -1223,6 +1248,14 @@ pub(super) async fn execute_step(ctx: &mut StepContext<'_>) -> Result<StepOutcom
     // Messages stay step-local until the batch has complete visible outputs.
     let (blocked_reason, suspended) =
         execute_tools_with_interception(ctx, &mut transcript, &stream_result.tool_calls).await?;
+
+    // If the mid-stream recovery dropped an in-flight parallel tool call,
+    // inject a user-visible note after the surviving tool_result messages
+    // so the model can decide whether to retry the cancelled call.
+    if let Some(hint) = cancelled_tool_hint.as_ref() {
+        transcript.push_tool_message(Arc::new(Message::user(format_tool_cancel_hint(hint))));
+    }
+
     transcript.commit_into(ctx.messages);
 
     if ctx.cancellation_token.is_some_and(|t| t.is_cancelled()) {

--- a/crates/awaken-runtime/tests/event_lifecycle.rs
+++ b/crates/awaken-runtime/tests/event_lifecycle.rs
@@ -206,6 +206,8 @@ fn event_type(e: &AgentEvent) -> &'static str {
         AgentEvent::ActivityDelta { .. } => "activity_delta",
         AgentEvent::ToolCallResumed { .. } => "tool_call_resumed",
         AgentEvent::ToolCallStreamDelta { .. } => "tool_call_stream_delta",
+        AgentEvent::ToolCallCancel { .. } => "tool_call_cancel",
+        AgentEvent::StreamReset { .. } => "stream_reset",
         AgentEvent::Error { .. } => "error",
     }
 }

--- a/crates/awaken-server/src/protocols/acp/encoder.rs
+++ b/crates/awaken-server/src/protocols/acp/encoder.rs
@@ -232,7 +232,9 @@ impl AcpEncoder {
             | AgentEvent::InferenceComplete { .. }
             | AgentEvent::ReasoningEncryptedValue { .. }
             | AgentEvent::MessagesSnapshot { .. }
-            | AgentEvent::ToolCallStreamDelta { .. } => Vec::new(),
+            | AgentEvent::ToolCallStreamDelta { .. }
+            | AgentEvent::ToolCallCancel { .. }
+            | AgentEvent::StreamReset { .. } => Vec::new(),
         }
     }
 }

--- a/crates/awaken-server/src/protocols/ag_ui/encoder.rs
+++ b/crates/awaken-server/src/protocols/ag_ui/encoder.rs
@@ -325,6 +325,10 @@ impl AgUiEncoder {
             }
 
             AgentEvent::InferenceComplete { .. } => Vec::new(),
+
+            // Mid-stream recovery is a runtime concern; AG-UI consumers can
+            // ignore these events without losing correctness.
+            AgentEvent::ToolCallCancel { .. } | AgentEvent::StreamReset { .. } => Vec::new(),
         }
     }
 }

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/encoder.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/encoder.rs
@@ -398,6 +398,9 @@ impl AiSdkEncoder {
                     }),
                 )]
             }
+
+            // Mid-stream recovery events have no AI SDK equivalent — swallow.
+            AgentEvent::ToolCallCancel { .. } | AgentEvent::StreamReset { .. } => Vec::new(),
         }
     }
 }

--- a/crates/awaken/tests/agent_loop.rs
+++ b/crates/awaken/tests/agent_loop.rs
@@ -11324,3 +11324,263 @@ async fn inbox_messages_injected_before_natural_end() {
     // Clean up
     manager.cancel_all("thread-1").await;
 }
+
+// ---------------------------------------------------------------------------
+// Phase-E end-to-end: mid-stream R2 recovery injects a user note for the
+// cancelled parallel tool call, and the next turn's LLM request observes it.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn mid_stream_r2_recovery_injects_cancelled_tool_hint_into_next_turn() {
+    use awaken::contract::executor::{InferenceStream, LlmStreamEvent};
+
+    struct R2Llm {
+        call_count: Mutex<usize>,
+        captured_requests: Arc<Mutex<Vec<InferenceRequest>>>,
+    }
+
+    impl R2Llm {
+        fn new(captured: Arc<Mutex<Vec<InferenceRequest>>>) -> Self {
+            Self {
+                call_count: Mutex::new(0),
+                captured_requests: captured,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmExecutor for R2Llm {
+        async fn execute(
+            &self,
+            _req: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            unreachable!("streaming path only");
+        }
+
+        fn execute_stream(
+            &self,
+            request: InferenceRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<InferenceStream, InferenceExecutionError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            self.captured_requests.lock().unwrap().push(request);
+            let mut count = self.call_count.lock().unwrap();
+            *count += 1;
+            let call_num = *count;
+            drop(count);
+
+            Box::pin(async move {
+                let events: Vec<Result<LlmStreamEvent, InferenceExecutionError>> = match call_num {
+                    1 => vec![
+                        Ok(LlmStreamEvent::ToolCallStart {
+                            id: "echo-1".into(),
+                            name: "echo".into(),
+                        }),
+                        Ok(LlmStreamEvent::ToolCallDelta {
+                            id: "echo-1".into(),
+                            args_delta: r#"{"message":"hello"}"#.into(),
+                        }),
+                        Ok(LlmStreamEvent::ToolCallStart {
+                            id: "calc-1".into(),
+                            name: "calc".into(),
+                        }),
+                        Ok(LlmStreamEvent::ToolCallDelta {
+                            id: "calc-1".into(),
+                            args_delta: r#"{"result":"#.into(),
+                        }),
+                        Err(InferenceExecutionError::Provider("connection reset".into())),
+                    ],
+                    _ => vec![
+                        Ok(LlmStreamEvent::TextDelta("all done".into())),
+                        Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+                    ],
+                };
+                Ok(Box::pin(futures::stream::iter(events)) as InferenceStream)
+            })
+        }
+
+        fn name(&self) -> &str {
+            "r2-llm"
+        }
+    }
+
+    let captured: Arc<Mutex<Vec<InferenceRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm = Arc::new(R2Llm::new(captured.clone()));
+
+    let agent = ResolvedAgent::new("test", "gpt-4o", "sys", llm)
+        .with_tool(Arc::new(EchoTool))
+        .with_tool(Arc::new(CalcTool));
+    let runtime = make_runtime();
+    let resolver = FixedResolver::new(agent);
+
+    let sink = Arc::new(VecEventSink::new());
+    let result = run_agent_loop(AgentLoopParams {
+        resolver: &resolver,
+        agent_id: "test",
+        runtime: &runtime,
+        sink: sink.clone(),
+        checkpoint_store: None,
+        messages: vec![Message::user("go")],
+        run_identity: test_identity(),
+        cancellation_token: None,
+        decision_rx: None,
+        overrides: None,
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: false,
+    })
+    .await
+    .unwrap();
+
+    assert!(matches!(result.termination, TerminationReason::NaturalEnd));
+
+    let requests = captured.lock().unwrap().clone();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected 2 LLM calls, got {}",
+        requests.len()
+    );
+
+    let hint_msg = requests[1].messages.iter().find(|m| {
+        m.role == Role::User
+            && m.text()
+                .contains("call to tool `calc` was interrupted mid-stream")
+    });
+    assert!(
+        hint_msg.is_some(),
+        "expected cancelled-tool hint in turn 2's request, got messages: {:#?}",
+        requests[1]
+            .messages
+            .iter()
+            .map(|m| (m.role, m.text()))
+            .collect::<Vec<_>>()
+    );
+
+    let events = sink.events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCallCancel { id, name, .. }
+            if id == "calc-1" && name == "calc"
+        )),
+        "expected ToolCallCancel{{ id=calc-1, name=calc }} in emitted events"
+    );
+
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCallDone { id, .. } if id == "echo-1"
+        )),
+        "expected ToolCallDone for the surviving echo tool"
+    );
+}
+
+#[tokio::test]
+async fn mid_stream_recovery_without_parallel_tools_does_not_inject_hint() {
+    use awaken::contract::executor::{InferenceStream, LlmStreamEvent};
+
+    struct R1Llm {
+        call_count: Mutex<usize>,
+        captured_requests: Arc<Mutex<Vec<InferenceRequest>>>,
+    }
+
+    #[async_trait]
+    impl LlmExecutor for R1Llm {
+        async fn execute(
+            &self,
+            _req: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            unreachable!();
+        }
+
+        fn execute_stream(
+            &self,
+            request: InferenceRequest,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<InferenceStream, InferenceExecutionError>>
+                    + Send
+                    + '_,
+            >,
+        > {
+            self.captured_requests.lock().unwrap().push(request);
+            let mut count = self.call_count.lock().unwrap();
+            *count += 1;
+            let call_num = *count;
+            drop(count);
+
+            Box::pin(async move {
+                let events: Vec<Result<LlmStreamEvent, InferenceExecutionError>> = match call_num {
+                    1 => vec![
+                        Ok(LlmStreamEvent::TextDelta("partial ".into())),
+                        Err(InferenceExecutionError::Provider("reset".into())),
+                    ],
+                    _ => vec![
+                        Ok(LlmStreamEvent::TextDelta("answer".into())),
+                        Ok(LlmStreamEvent::Stop(StopReason::EndTurn)),
+                    ],
+                };
+                Ok(Box::pin(futures::stream::iter(events)) as InferenceStream)
+            })
+        }
+
+        fn name(&self) -> &str {
+            "r1-llm"
+        }
+    }
+
+    let captured: Arc<Mutex<Vec<InferenceRequest>>> = Arc::new(Mutex::new(Vec::new()));
+    let llm = Arc::new(R1Llm {
+        call_count: Mutex::new(0),
+        captured_requests: captured.clone(),
+    });
+
+    let agent = ResolvedAgent::new("test", "gpt-4o", "sys", llm);
+    let runtime = make_runtime();
+    let resolver = FixedResolver::new(agent);
+
+    let sink = Arc::new(VecEventSink::new());
+    let _result = run_agent_loop(AgentLoopParams {
+        resolver: &resolver,
+        agent_id: "test",
+        runtime: &runtime,
+        sink: sink.clone(),
+        checkpoint_store: None,
+        messages: vec![Message::user("go")],
+        run_identity: test_identity(),
+        cancellation_token: None,
+        decision_rx: None,
+        overrides: None,
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: false,
+    })
+    .await
+    .unwrap();
+
+    // Scan every request's messages — none should contain the
+    // cancelled-tool hint (distinct from the R1 continuation prompt).
+    let requests = captured.lock().unwrap().clone();
+    for (i, req) in requests.iter().enumerate() {
+        for msg in &req.messages {
+            assert!(
+                !msg.text().contains("parallel call to tool"),
+                "request {i} unexpectedly contained cancelled-tool hint: {}",
+                msg.text()
+            );
+        }
+    }
+
+    let events = sink.events();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ToolCallCancel { .. })),
+        "R1 recovery must not emit ToolCallCancel"
+    );
+}


### PR DESCRIPTION
## Summary

> Re-opened replacement for #133, which was auto-closed when its base branch (`pr/llm-error-taxonomy`) was deleted after PR #132 merged.

Second PR in the LLM stream error handling series. Builds on top of #132 (now in `main`). Adds the in-process retry loop, the four-plan recovery dispatch, and the cancelled-tool hint that flows back to the next user message.

- **`StreamCollector::interrupt_snapshot`**: extracts in-flight accumulator state for recovery.
- **`AgentEvent::ToolCallCancel`** + **`StreamReset`**: new sink-visible events for downstream consumers.
- **`execute_streaming` retry loop**: drives one stream at a time via `drive_one_stream`, classifies mid-stream errors via `classify_mid_stream`, dispatches `InterruptSnapshot::plan()` to one of four recovery plans:
  - **R1 ContinueText**: assistant prefix + continuation prompt, retry
  - **R2 SynthesizeToolUse**: completed tools become a synthesized `StopReason::ToolUse`, in-flight tool surfaces as a hint
  - **R3 TruncateBeforeTool**: truncate to text before unclosed tool, emit `ToolCallCancel`, retry
  - **R4 WholeRestart**: emit `StreamReset`, retry without state injection
- **Idle-stall detection**: `tokio::time::timeout` per `stream.next()`; thinking/reasoning models get 2× threshold.
- **Cancelled parallel tool hint**: R2 surfaces the dropped tool name; `step.rs` injects a user note after the tool_results so the model can decide whether to retry the call.

## Failure-injection test matrix (new)

| Scenario | Test |
|---|---|
| R1: text only → continuation | `r1_text_only_interruption_recovers_via_continuation` |
| R2: completed tool short-circuits | `r2_completed_tool_synthesizes_tool_use_without_another_round_trip` |
| R3: text + partial tool truncates | `r3_text_plus_partial_tool_truncates_and_continues` |
| R4: empty snapshot whole-restart | `r4_empty_snapshot_whole_restarts_and_emits_stream_reset` |
| Retry budget exhaustion | `retry_budget_exhausted_surfaces_stream_interrupted` |
| Idle stall + recovery (`tokio::time::advance`) | `idle_stall_triggers_recovery_and_second_attempt_succeeds` |
| Thinking model 2× threshold | `idle_timeout_for_doubles_on_thinking_model_names` |
| End-to-end hint injection through step.rs | `mid_stream_r2_recovery_injects_cancelled_tool_hint_into_next_turn` |
| Negative control: no hint without parallel tools | `mid_stream_recovery_without_parallel_tools_does_not_inject_hint` |

## Out of scope (PR #134)

- HTTP/2 GOAWAY classification, ContentFiltered string-match
- Malformed tool args (non-MaxTokens) hint
- Cross-process resume (`StreamCheckpointStore`)
- Refactor passes that polish duplication observed across this PR + #134

## Test plan

- [x] `cargo test -p awaken-runtime --lib loop_runner::inference` — 22 tests including R1-R4 matrix
- [x] `cargo test -p awaken --test agent_loop` — full e2e suite green
- [x] AG-UI / ACP / AI-SDK encoders updated for new `AgentEvent` variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)