### PR TITLE
feat(runtime): non-blocking background context compaction

### DIFF
--- a/crates/awaken-runtime/src/context/compaction.rs
+++ b/crates/awaken-runtime/src/context/compaction.rs
@@ -7,7 +7,14 @@ use awaken_contract::contract::inference::ContextWindowPolicy;
 use awaken_contract::contract::message::{Message, Role, Visibility};
 use awaken_contract::contract::transform::estimate_message_tokens;
 
+use super::plugin::{CompactionAction, CompactionBoundary, CompactionInFlight, CompactionStateKey};
 use super::summarizer::{MIN_COMPACTION_GAIN_TOKENS, extract_previous_summary, render_transcript};
+use crate::state::{MutationBatch, StateStore};
+
+/// Custom event type emitted by a successful background compaction task.
+pub const COMPACTION_COMPLETED_EVENT: &str = "context.compacted";
+/// Custom event type emitted when a background compaction task fails.
+pub const COMPACTION_FAILED_EVENT: &str = "context.compaction_failed";
 
 /// Find a safe compaction boundary in the message history.
 ///
@@ -142,6 +149,127 @@ pub fn plan_compaction(
         boundary_message_id,
         pre_tokens,
     })
+}
+
+/// Mark a background compaction pass as in-flight in the state store.
+/// Used by the spawn helper after a task has been queued.
+pub fn record_compaction_in_flight(in_flight: CompactionInFlight) -> CompactionAction {
+    CompactionAction::SetInFlight(in_flight)
+}
+
+/// Clear the in-flight marker. Called from the inbox-event router on both
+/// success and failure of the background pass.
+pub fn clear_compaction_in_flight() -> CompactionAction {
+    CompactionAction::ClearInFlight
+}
+
+/// Detect and handle a context-compaction event arriving via the inbox.
+///
+/// Returns `true` when `payload` was a compaction event — in that case the
+/// caller MUST NOT also push it as a regular Internal user message. The
+/// success path performs the message swap by stable id and records the
+/// boundary; both success and failure paths clear the in-flight marker
+/// so future compactions can be triggered.
+///
+/// Returns `false` for any payload that is not a compaction event; the
+/// caller should fall back to the normal inbox handling.
+pub fn try_consume_compaction_event(
+    messages: &mut Vec<Arc<Message>>,
+    payload: &serde_json::Value,
+    store: &StateStore,
+) -> bool {
+    let Some(event_type) = compaction_event_type(payload) else {
+        return false;
+    };
+    let inner = payload.get("payload");
+
+    match event_type {
+        e if e == COMPACTION_COMPLETED_EVENT => {
+            let boundary_id = inner
+                .and_then(|p| p.get("boundary_message_id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let summary = inner
+                .and_then(|p| p.get("summary"))
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            let reported_pre_tokens = inner
+                .and_then(|p| p.get("pre_tokens"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as usize;
+
+            let mut batch = MutationBatch::new();
+            if !boundary_id.is_empty()
+                && !summary.is_empty()
+                && let Some(applied) = apply_summary(messages, boundary_id, summary)
+            {
+                batch.update::<CompactionStateKey>(CompactionAction::RecordBoundary(
+                    CompactionBoundary {
+                        summary: summary.to_string(),
+                        pre_tokens: applied.pre_tokens.max(reported_pre_tokens),
+                        post_tokens: applied.post_tokens,
+                        timestamp_ms: now_ms(),
+                    },
+                ));
+                tracing::info!(
+                    pre_tokens = applied.pre_tokens,
+                    post_tokens = applied.post_tokens,
+                    boundary_index = applied.boundary_index,
+                    "background_compaction_swap_applied"
+                );
+            } else {
+                tracing::warn!(
+                    boundary_message_id = boundary_id,
+                    "background compaction completed but boundary message no longer present; skipping swap"
+                );
+            }
+            batch.update::<CompactionStateKey>(CompactionAction::ClearInFlight);
+            if let Err(error) = store.commit(batch) {
+                tracing::warn!(
+                    error = %error,
+                    "failed to commit compaction completion state"
+                );
+            }
+        }
+        e if e == COMPACTION_FAILED_EVENT => {
+            let error_text = inner
+                .and_then(|p| p.get("error"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            tracing::warn!(
+                error = error_text,
+                "background compaction failed; clearing in-flight marker"
+            );
+            let mut batch = MutationBatch::new();
+            batch.update::<CompactionStateKey>(CompactionAction::ClearInFlight);
+            if let Err(error) = store.commit(batch) {
+                tracing::warn!(
+                    error = %error,
+                    "failed to clear in-flight marker after compaction failure"
+                );
+            }
+        }
+        _ => {}
+    }
+    true
+}
+
+fn compaction_event_type(payload: &serde_json::Value) -> Option<&str> {
+    if payload.get("kind").and_then(|k| k.as_str()) != Some("custom") {
+        return None;
+    }
+    payload
+        .get("event_type")
+        .and_then(|t| t.as_str())
+        .filter(|t| *t == COMPACTION_COMPLETED_EVENT || *t == COMPACTION_FAILED_EVENT)
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 /// Apply a freshly produced summary to the live message list. Locates the

--- a/crates/awaken-runtime/src/context/compaction.rs
+++ b/crates/awaken-runtime/src/context/compaction.rs
@@ -313,6 +313,164 @@ mod tests {
         Arc::new(Message::user(text.repeat(copies)))
     }
 
+    fn store_with_compaction_plugin() -> StateStore {
+        let store = StateStore::new();
+        store
+            .install_plugin(super::super::plugin::CompactionPlugin::default())
+            .unwrap();
+        store
+    }
+
+    fn completed_event(boundary_id: &str, summary: &str, pre_tokens: u64) -> serde_json::Value {
+        json!({
+            "kind": "custom",
+            "task_id": "bg_99",
+            "event_type": COMPACTION_COMPLETED_EVENT,
+            "payload": {
+                "boundary_message_id": boundary_id,
+                "summary": summary,
+                "pre_tokens": pre_tokens,
+            },
+        })
+    }
+
+    fn failed_event(boundary_id: &str, error_text: &str) -> serde_json::Value {
+        json!({
+            "kind": "custom",
+            "task_id": "bg_99",
+            "event_type": COMPACTION_FAILED_EVENT,
+            "payload": {
+                "boundary_message_id": boundary_id,
+                "error": error_text,
+            },
+        })
+    }
+
+    fn mark_in_flight(store: &StateStore, boundary_id: &str) {
+        let mut batch = MutationBatch::new();
+        batch.update::<CompactionStateKey>(record_compaction_in_flight(CompactionInFlight {
+            task_id: "bg_99".into(),
+            boundary_message_id: boundary_id.into(),
+            started_at_ms: 1,
+        }));
+        store.commit(batch).unwrap();
+    }
+
+    #[test]
+    fn try_consume_compaction_event_swaps_messages_and_records_boundary() {
+        let store = store_with_compaction_plugin();
+        let mut messages: Vec<Arc<Message>> = vec![
+            Arc::new(Message::user("OLD-1")),
+            Arc::new(Message::assistant("OLD-2")),
+            Arc::new(Message::user("BOUNDARY")),
+            Arc::new(Message::assistant("AFTER")),
+            // simulates a user message that arrived during the compaction window
+            Arc::new(Message::user("RACE-NEW")),
+        ];
+        let boundary_id = messages[2].id.clone().unwrap();
+        mark_in_flight(&store, &boundary_id);
+
+        let consumed = try_consume_compaction_event(
+            &mut messages,
+            &completed_event(&boundary_id, "the summary", 4321),
+            &store,
+        );
+        assert!(consumed, "must report the event was consumed");
+
+        // Swap happened: summary at front, race-new message preserved.
+        assert!(
+            messages[0]
+                .text()
+                .contains("<conversation-summary>\nthe summary"),
+            "summary not at front: {}",
+            messages[0].text()
+        );
+        assert_eq!(messages[1].text(), "AFTER");
+        assert_eq!(messages[2].text(), "RACE-NEW");
+        assert_eq!(messages.len(), 3);
+
+        let state = store.read::<CompactionStateKey>().unwrap();
+        assert!(!state.is_compacting(), "in-flight must be cleared");
+        assert_eq!(state.boundaries.len(), 1, "boundary must be recorded");
+        assert_eq!(state.boundaries[0].summary, "the summary");
+    }
+
+    #[test]
+    fn try_consume_compaction_event_skips_swap_when_boundary_no_longer_present() {
+        let store = store_with_compaction_plugin();
+        let mut messages: Vec<Arc<Message>> = vec![
+            Arc::new(Message::user("only-msg")),
+            Arc::new(Message::assistant("only-reply")),
+        ];
+        mark_in_flight(&store, "ghost-boundary-id");
+
+        let consumed = try_consume_compaction_event(
+            &mut messages,
+            &completed_event("ghost-boundary-id", "irrelevant", 0),
+            &store,
+        );
+        assert!(consumed);
+
+        // No mutation: skip is benign.
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].text(), "only-msg");
+
+        let state = store.read::<CompactionStateKey>().unwrap();
+        assert!(
+            !state.is_compacting(),
+            "in-flight must clear even on benign skip"
+        );
+        assert!(
+            state.boundaries.is_empty(),
+            "no boundary should be recorded when swap was skipped"
+        );
+    }
+
+    #[test]
+    fn try_consume_compaction_event_clears_in_flight_on_failure() {
+        let store = store_with_compaction_plugin();
+        let mut messages: Vec<Arc<Message>> = vec![Arc::new(Message::user("x"))];
+        mark_in_flight(&store, "any");
+
+        let consumed =
+            try_consume_compaction_event(&mut messages, &failed_event("any", "boom"), &store);
+        assert!(consumed);
+
+        let state = store.read::<CompactionStateKey>().unwrap();
+        assert!(!state.is_compacting());
+        assert!(
+            state.boundaries.is_empty(),
+            "failure must not record a boundary"
+        );
+    }
+
+    #[test]
+    fn try_consume_compaction_event_passes_through_unrelated_payloads() {
+        let store = store_with_compaction_plugin();
+        let mut messages: Vec<Arc<Message>> = vec![Arc::new(Message::user("x"))];
+
+        // Other Custom event: not for compaction.
+        let other = json!({
+            "kind": "custom",
+            "task_id": "bg_42",
+            "event_type": "task.heartbeat",
+            "payload": {"pct": 50},
+        });
+        assert!(!try_consume_compaction_event(&mut messages, &other, &store));
+
+        // Plain non-Custom payload.
+        let task_completed = json!({
+            "kind": "completed",
+            "task_id": "bg_43",
+            "result": null,
+        });
+        assert!(!try_consume_compaction_event(
+            &mut messages,
+            &task_completed,
+            &store
+        ));
+    }
+
     #[test]
     fn plan_compaction_returns_none_when_savings_below_threshold() {
         let messages: Vec<Arc<Message>> = vec![

--- a/crates/awaken-runtime/src/context/compaction.rs
+++ b/crates/awaken-runtime/src/context/compaction.rs
@@ -1,9 +1,13 @@
-//! Compaction boundary discovery and load-time trimming.
+//! Compaction boundary discovery, plan/apply helpers, and load-time trimming.
 
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use awaken_contract::contract::inference::ContextWindowPolicy;
 use awaken_contract::contract::message::{Message, Role, Visibility};
+use awaken_contract::contract::transform::estimate_message_tokens;
+
+use super::summarizer::{MIN_COMPACTION_GAIN_TOKENS, extract_previous_summary, render_transcript};
 
 /// Find a safe compaction boundary in the message history.
 ///
@@ -72,11 +76,202 @@ pub fn record_compaction_boundary(
     super::plugin::CompactionAction::RecordBoundary(boundary)
 }
 
+/// Inputs needed to run a compaction off the main thread. Snapshotted at
+/// trigger time so the background task does not race with the live
+/// `messages` list (which keeps growing during summarization).
+#[derive(Debug, Clone)]
+pub struct CompactionPlan {
+    /// Pre-rendered transcript to feed the summarizer (Internal messages
+    /// already filtered).
+    pub transcript: String,
+    /// Previous cumulative summary, if any, for incremental updates.
+    pub previous_summary: Option<String>,
+    /// Stable id of the last message included in the summary. The swap
+    /// path locates the cut point against the current message list by
+    /// this id, so it survives any new messages appended in the window.
+    pub boundary_message_id: String,
+    /// Token estimate of the messages that the summary will replace.
+    /// Used for the `pre_tokens` field of the recorded boundary.
+    pub pre_tokens: usize,
+}
+
+/// Result of a successful in-place swap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AppliedCompaction {
+    /// Index in the original list where the cut happened.
+    pub boundary_index: usize,
+    /// Tokens that were dropped from the head of the message list.
+    pub pre_tokens: usize,
+    /// Tokens used by the inserted summary message.
+    pub post_tokens: usize,
+}
+
+/// Decide whether compaction should run right now and, if so, capture the
+/// inputs needed by the background summarization task. Returns `None` if
+/// compaction is not feasible (no safe boundary, savings below threshold,
+/// boundary message has no stable id, transcript is empty, etc.).
+pub fn plan_compaction(
+    messages: &[Arc<Message>],
+    policy: &ContextWindowPolicy,
+) -> Option<CompactionPlan> {
+    if messages.len() < 2 {
+        return None;
+    }
+    let keep_suffix = policy.compaction_raw_suffix_messages.min(messages.len());
+    let search_end = messages.len().saturating_sub(keep_suffix);
+    if search_end < 2 {
+        return None;
+    }
+    let boundary = find_compaction_boundary(messages, 0, search_end)?;
+    let boundary_message_id = messages[boundary].id.clone()?;
+    let pre_tokens: usize = messages[..=boundary]
+        .iter()
+        .map(|m| estimate_message_tokens(m))
+        .sum();
+    if pre_tokens < MIN_COMPACTION_GAIN_TOKENS {
+        return None;
+    }
+    let transcript = render_transcript(&messages[..=boundary]);
+    if transcript.is_empty() {
+        return None;
+    }
+    let previous_summary = extract_previous_summary(messages);
+    Some(CompactionPlan {
+        transcript,
+        previous_summary,
+        boundary_message_id,
+        pre_tokens,
+    })
+}
+
+/// Apply a freshly produced summary to the live message list. Locates the
+/// boundary message by id (not by index) so it is safe against any
+/// messages appended between trigger and completion. Returns `None` when
+/// the boundary message is no longer present (already trimmed by an
+/// earlier compaction or rewritten by another path); callers should treat
+/// that as a benign skip.
+pub fn apply_summary(
+    messages: &mut Vec<Arc<Message>>,
+    boundary_message_id: &str,
+    summary_text: &str,
+) -> Option<AppliedCompaction> {
+    let idx = messages
+        .iter()
+        .position(|m| m.id.as_deref() == Some(boundary_message_id))?;
+    let pre_tokens: usize = messages[..=idx]
+        .iter()
+        .map(|m| estimate_message_tokens(m))
+        .sum();
+    messages.drain(..=idx);
+    let summary_message = Arc::new(Message::internal_system(format!(
+        "<conversation-summary>\n{summary_text}\n</conversation-summary>"
+    )));
+    let post_tokens = estimate_message_tokens(&summary_message);
+    messages.insert(0, summary_message);
+    Some(AppliedCompaction {
+        boundary_index: idx,
+        pre_tokens,
+        post_tokens,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use awaken_contract::contract::message::ToolCall;
     use serde_json::json;
+
+    fn long_user(text: &str, copies: usize) -> Arc<Message> {
+        Arc::new(Message::user(text.repeat(copies)))
+    }
+
+    #[test]
+    fn plan_compaction_returns_none_when_savings_below_threshold() {
+        let messages: Vec<Arc<Message>> = vec![
+            Arc::new(Message::user("hi")),
+            Arc::new(Message::assistant("hello")),
+            Arc::new(Message::user("how are you?")),
+            Arc::new(Message::assistant("fine")),
+        ];
+        let policy = ContextWindowPolicy {
+            compaction_raw_suffix_messages: 1,
+            ..Default::default()
+        };
+        assert!(plan_compaction(&messages, &policy).is_none());
+    }
+
+    #[test]
+    fn plan_compaction_captures_boundary_message_id() {
+        // Pad the head with enough tokens to clear MIN_COMPACTION_GAIN_TOKENS.
+        let mut messages: Vec<Arc<Message>> = (0..6)
+            .map(|i| {
+                if i % 2 == 0 {
+                    long_user("filler ", 600)
+                } else {
+                    Arc::new(Message::assistant("ack"))
+                }
+            })
+            .collect();
+        messages.push(Arc::new(Message::user("recent")));
+        let policy = ContextWindowPolicy {
+            compaction_raw_suffix_messages: 1,
+            ..Default::default()
+        };
+        let plan = plan_compaction(&messages, &policy).expect("plan");
+        // Boundary id must reference an actual message in the snapshot.
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.id.as_deref() == Some(plan.boundary_message_id.as_str()))
+        );
+        assert!(plan.pre_tokens >= MIN_COMPACTION_GAIN_TOKENS);
+        assert!(!plan.transcript.is_empty());
+    }
+
+    #[test]
+    fn apply_summary_swaps_when_boundary_present() {
+        let mut messages: Vec<Arc<Message>> = vec![
+            Arc::new(Message::user("old1")),
+            Arc::new(Message::assistant("old2")),
+            Arc::new(Message::user("BOUNDARY")),
+            Arc::new(Message::assistant("after-boundary")),
+            Arc::new(Message::user("appended-during-window")),
+        ];
+        let boundary_id = messages[2].id.clone().unwrap();
+
+        let applied = apply_summary(&mut messages, &boundary_id, "synthetic summary").unwrap();
+        assert_eq!(applied.boundary_index, 2);
+        assert!(applied.pre_tokens > 0);
+        assert!(applied.post_tokens > 0);
+
+        // First message must now be the summary; messages after the boundary
+        // (including ones appended during the compaction window) are kept.
+        assert!(
+            messages[0]
+                .text()
+                .contains("<conversation-summary>\nsynthetic summary"),
+            "summary missing or malformed: {}",
+            messages[0].text()
+        );
+        assert_eq!(messages[1].text(), "after-boundary");
+        assert_eq!(messages[2].text(), "appended-during-window");
+        assert_eq!(messages.len(), 3);
+    }
+
+    #[test]
+    fn apply_summary_returns_none_when_boundary_already_gone() {
+        let mut messages: Vec<Arc<Message>> = vec![
+            Arc::new(Message::user("a")),
+            Arc::new(Message::assistant("b")),
+        ];
+        let original = messages.clone();
+        assert!(apply_summary(&mut messages, "non-existent-id", "any").is_none());
+        // Skip must be benign: the live list is unchanged.
+        assert_eq!(messages.len(), original.len());
+        for (a, b) in messages.iter().zip(original.iter()) {
+            assert_eq!(a.text(), b.text());
+        }
+    }
 
     #[test]
     fn find_compaction_boundary_respects_tool_pairs() {

--- a/crates/awaken-runtime/src/context/mod.rs
+++ b/crates/awaken-runtime/src/context/mod.rs
@@ -7,7 +7,8 @@ pub mod transform;
 pub mod truncation;
 
 pub use compaction::{
-    find_compaction_boundary, record_compaction_boundary, trim_to_compaction_boundary,
+    AppliedCompaction, CompactionPlan, apply_summary, find_compaction_boundary, plan_compaction,
+    record_compaction_boundary, trim_to_compaction_boundary,
 };
 pub use plugin::{
     CONTEXT_COMPACTION_PLUGIN_ID, CONTEXT_TRANSFORM_PLUGIN_ID, CompactionAction,

--- a/crates/awaken-runtime/src/context/mod.rs
+++ b/crates/awaken-runtime/src/context/mod.rs
@@ -7,13 +7,15 @@ pub mod transform;
 pub mod truncation;
 
 pub use compaction::{
-    AppliedCompaction, CompactionPlan, apply_summary, find_compaction_boundary, plan_compaction,
-    record_compaction_boundary, trim_to_compaction_boundary,
+    AppliedCompaction, COMPACTION_COMPLETED_EVENT, COMPACTION_FAILED_EVENT, CompactionPlan,
+    apply_summary, clear_compaction_in_flight, find_compaction_boundary, plan_compaction,
+    record_compaction_boundary, record_compaction_in_flight, trim_to_compaction_boundary,
+    try_consume_compaction_event,
 };
 pub use plugin::{
     CONTEXT_COMPACTION_PLUGIN_ID, CONTEXT_TRANSFORM_PLUGIN_ID, CompactionAction,
-    CompactionBoundary, CompactionConfig, CompactionConfigKey, CompactionPlugin, CompactionState,
-    CompactionStateKey, ContextTransformPlugin,
+    CompactionBoundary, CompactionConfig, CompactionConfigKey, CompactionInFlight,
+    CompactionPlugin, CompactionState, CompactionStateKey, ContextTransformPlugin,
 };
 pub use summarizer::{
     ContextSummarizer, DefaultSummarizer, MIN_COMPACTION_GAIN_TOKENS, SummarizationError,

--- a/crates/awaken-runtime/src/context/plugin.rs
+++ b/crates/awaken-runtime/src/context/plugin.rs
@@ -69,16 +69,35 @@ pub struct CompactionBoundary {
     pub timestamp_ms: u64,
 }
 
+/// Pointer to a single in-flight background compaction pass. Used as a
+/// single-flight guard so the runtime never spawns a second compaction
+/// while one is still summarizing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompactionInFlight {
+    /// Background task id of the running compaction.
+    pub task_id: String,
+    /// Stable message id of the boundary message at trigger time. Used
+    /// to locate the cut point against the current message list when the
+    /// summary lands — robust to messages appended during the window.
+    pub boundary_message_id: String,
+    /// Wall-clock millis when the task was spawned.
+    pub started_at_ms: u64,
+}
+
 /// Durable state for context compaction tracking.
 ///
 /// Stores a history of compaction boundaries so that load-time trimming
-/// and plugin queries can identify already-summarized ranges.
+/// and plugin queries can identify already-summarized ranges, plus a
+/// single-flight guard for background compaction passes.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CompactionState {
     /// Ordered list of compaction boundaries (most recent last).
     pub boundaries: Vec<CompactionBoundary>,
     /// Total number of compaction passes performed.
     pub total_compactions: u64,
+    /// Currently running background compaction, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_flight: Option<CompactionInFlight>,
 }
 
 /// Reducer actions for [`CompactionState`].
@@ -87,6 +106,10 @@ pub struct CompactionState {
 pub enum CompactionAction {
     /// Record a new compaction boundary.
     RecordBoundary(CompactionBoundary),
+    /// Mark a background compaction as in flight.
+    SetInFlight(CompactionInFlight),
+    /// Clear the in-flight marker (called on success and failure).
+    ClearInFlight,
     /// Clear all tracked boundaries (e.g. on thread reset).
     Clear,
 }
@@ -98,9 +121,16 @@ impl CompactionState {
                 self.boundaries.push(boundary);
                 self.total_compactions += 1;
             }
+            CompactionAction::SetInFlight(in_flight) => {
+                self.in_flight = Some(in_flight);
+            }
+            CompactionAction::ClearInFlight => {
+                self.in_flight = None;
+            }
             CompactionAction::Clear => {
                 self.boundaries.clear();
                 self.total_compactions = 0;
+                self.in_flight = None;
             }
         }
     }
@@ -108,6 +138,11 @@ impl CompactionState {
     /// Latest compaction boundary, if any.
     pub fn latest_boundary(&self) -> Option<&CompactionBoundary> {
         self.boundaries.last()
+    }
+
+    /// True when a background compaction pass is already running.
+    pub fn is_compacting(&self) -> bool {
+        self.in_flight.is_some()
     }
 }
 
@@ -261,6 +296,7 @@ mod tests {
                 timestamp_ms: 1,
             }],
             total_compactions: 1,
+            in_flight: None,
         };
 
         state.reduce(CompactionAction::Clear);
@@ -292,6 +328,7 @@ mod tests {
                 },
             ],
             total_compactions: 2,
+            in_flight: None,
         };
 
         let json = serde_json::to_string(&state).unwrap();
@@ -746,6 +783,59 @@ mod tests {
             long_total > policy_with_threshold.autocompact_threshold.unwrap(),
             "100-message conversation should exceed threshold of 500, got {long_total}"
         );
+    }
+
+    #[test]
+    fn in_flight_set_and_clear_round_trip() {
+        let mut state = CompactionState::default();
+        assert!(!state.is_compacting());
+
+        state.reduce(CompactionAction::SetInFlight(CompactionInFlight {
+            task_id: "bg_42".into(),
+            boundary_message_id: "01HZ-msg-01".into(),
+            started_at_ms: 100,
+        }));
+        let live = state.in_flight.as_ref().expect("in-flight set");
+        assert_eq!(live.task_id, "bg_42");
+        assert_eq!(live.boundary_message_id, "01HZ-msg-01");
+        assert!(state.is_compacting());
+
+        state.reduce(CompactionAction::ClearInFlight);
+        assert!(state.in_flight.is_none());
+        assert!(!state.is_compacting());
+    }
+
+    #[test]
+    fn clear_action_resets_in_flight_too() {
+        let mut state = CompactionState::default();
+        state.reduce(CompactionAction::SetInFlight(CompactionInFlight {
+            task_id: "bg_1".into(),
+            boundary_message_id: "msg-id".into(),
+            started_at_ms: 1,
+        }));
+        state.reduce(CompactionAction::Clear);
+        assert!(state.in_flight.is_none());
+        assert!(state.boundaries.is_empty());
+    }
+
+    #[test]
+    fn record_boundary_does_not_touch_in_flight() {
+        let mut state = CompactionState::default();
+        state.reduce(CompactionAction::SetInFlight(CompactionInFlight {
+            task_id: "bg_99".into(),
+            boundary_message_id: "msg".into(),
+            started_at_ms: 1,
+        }));
+        state.reduce(CompactionAction::RecordBoundary(CompactionBoundary {
+            summary: "s".into(),
+            pre_tokens: 10,
+            post_tokens: 1,
+            timestamp_ms: 2,
+        }));
+        // RecordBoundary alone does not clear the marker — the inbox
+        // event router is responsible for the explicit ClearInFlight.
+        assert!(state.is_compacting());
+        assert_eq!(state.boundaries.len(), 1);
     }
 
     #[test]

--- a/crates/awaken-runtime/src/loop_runner/compaction.rs
+++ b/crates/awaken-runtime/src/loop_runner/compaction.rs
@@ -191,6 +191,48 @@ mod tests {
         }
     }
 
+    /// Summarizer that always fails. Used to drive the failure round-trip.
+    struct FailingSummarizer {
+        gate: Arc<Notify>,
+        message: String,
+    }
+
+    #[async_trait]
+    impl ContextSummarizer for FailingSummarizer {
+        async fn summarize(
+            &self,
+            _transcript: &str,
+            _previous_summary: Option<&str>,
+            _executor: &dyn LlmExecutor,
+        ) -> Result<String, SummarizationError> {
+            self.gate.notified().await;
+            Err(SummarizationError::Inference(self.message.clone()))
+        }
+    }
+
+    /// Summarizer that records the transcript / previous_summary it received
+    /// so tests can assert what the spawn helper actually plumbed through.
+    struct CapturingSummarizer {
+        gate: Arc<Notify>,
+        captured_transcript: Arc<std::sync::Mutex<Option<String>>>,
+        captured_previous: Arc<std::sync::Mutex<Option<Option<String>>>>,
+    }
+
+    #[async_trait]
+    impl ContextSummarizer for CapturingSummarizer {
+        async fn summarize(
+            &self,
+            transcript: &str,
+            previous_summary: Option<&str>,
+            _executor: &dyn LlmExecutor,
+        ) -> Result<String, SummarizationError> {
+            *self.captured_transcript.lock().unwrap() = Some(transcript.to_string());
+            *self.captured_previous.lock().unwrap() = Some(previous_summary.map(|s| s.to_string()));
+            self.gate.notified().await;
+            Ok("captured".into())
+        }
+    }
+
     struct NoopExecutor;
 
     #[async_trait]
@@ -224,6 +266,13 @@ mod tests {
             .collect();
         messages.push(Arc::new(Message::user("recent")));
         messages
+    }
+
+    fn default_policy() -> awaken_contract::contract::inference::ContextWindowPolicy {
+        awaken_contract::contract::inference::ContextWindowPolicy {
+            compaction_raw_suffix_messages: 1,
+            ..Default::default()
+        }
     }
 
     fn make_resolved_agent(
@@ -338,5 +387,546 @@ mod tests {
             1,
             "summarizer entered exactly once"
         );
+    }
+
+    /// Without a manager, spawn must be a no-op even if a summarizer is set.
+    /// This is the documented gating contract.
+    #[tokio::test]
+    async fn maybe_spawn_compaction_no_op_without_background_manager() {
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+        let (inbox_tx, _inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        // Build an agent with a summarizer but DROP the background manager.
+        let summarizer: Arc<dyn ContextSummarizer> = Arc::new(GatedSummarizer {
+            gate: Arc::new(Notify::new()),
+            summary: "unused".into(),
+            observed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        });
+        let mut agent = ResolvedAgent::new(
+            "test-agent",
+            "test-model",
+            "system prompt",
+            Arc::new(NoopExecutor),
+        )
+        .with_context_summarizer(summarizer);
+        agent.env = env;
+        let mut messages = make_long_messages();
+        let identity = run_identity("thread-no-mgr");
+        let cancel = CancellationToken::new();
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        let mut ctx = StepContext {
+            agent: &mut agent,
+            messages: &mut messages,
+            runtime: &runtime,
+            sink,
+            checkpoint_store: None,
+            run_identity: &identity,
+            input_message_count: 0,
+            cancellation_token: Some(&cancel),
+            run_overrides: &None,
+            total_input_tokens: &mut total_in,
+            total_output_tokens: &mut total_out,
+            truncation_state: &mut truncation,
+            run_created_at: 0,
+            thread_ctx: None,
+        };
+
+        assert!(!maybe_spawn_compaction(&mut ctx, &default_policy()).await);
+        assert!(
+            !store
+                .read::<CompactionStateKey>()
+                .is_some_and(|s| s.is_compacting()),
+            "no in-flight should be recorded"
+        );
+    }
+
+    /// Without a summarizer, spawn must be a no-op — the manager alone is not
+    /// enough to enable compaction.
+    #[tokio::test]
+    async fn maybe_spawn_compaction_no_op_without_summarizer() {
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+        let (inbox_tx, _inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        let mut agent = ResolvedAgent::new(
+            "test-agent",
+            "test-model",
+            "system prompt",
+            Arc::new(NoopExecutor),
+        )
+        .with_background_manager(manager.clone());
+        agent.env = env;
+        let mut messages = make_long_messages();
+        let identity = run_identity("thread-no-sum");
+        let cancel = CancellationToken::new();
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        let mut ctx = StepContext {
+            agent: &mut agent,
+            messages: &mut messages,
+            runtime: &runtime,
+            sink,
+            checkpoint_store: None,
+            run_identity: &identity,
+            input_message_count: 0,
+            cancellation_token: Some(&cancel),
+            run_overrides: &None,
+            total_input_tokens: &mut total_in,
+            total_output_tokens: &mut total_out,
+            truncation_state: &mut truncation,
+            run_created_at: 0,
+            thread_ctx: None,
+        };
+
+        assert!(!maybe_spawn_compaction(&mut ctx, &default_policy()).await);
+        assert!(
+            !store
+                .read::<CompactionStateKey>()
+                .is_some_and(|s| s.is_compacting()),
+            "no in-flight should be recorded"
+        );
+    }
+
+    /// When the message list is short, plan_compaction returns None and spawn
+    /// must NOT touch the in-flight marker. Avoids triggering background work
+    /// for a useless summary that would not save tokens.
+    #[tokio::test]
+    async fn maybe_spawn_compaction_no_op_when_no_useful_boundary() {
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+        let (inbox_tx, _inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        let summarizer: Arc<dyn ContextSummarizer> = Arc::new(GatedSummarizer {
+            gate: Arc::new(Notify::new()),
+            summary: "unused".into(),
+            observed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        });
+        let mut agent = make_resolved_agent(manager.clone(), summarizer);
+        agent.env = env;
+        // Three short messages: nowhere near MIN_COMPACTION_GAIN_TOKENS.
+        let mut messages: Vec<Arc<Message>> = vec![
+            Arc::new(Message::user("hello")),
+            Arc::new(Message::assistant("hi")),
+            Arc::new(Message::user("again")),
+        ];
+        let identity = run_identity("thread-tiny");
+        let cancel = CancellationToken::new();
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        let mut ctx = StepContext {
+            agent: &mut agent,
+            messages: &mut messages,
+            runtime: &runtime,
+            sink,
+            checkpoint_store: None,
+            run_identity: &identity,
+            input_message_count: 0,
+            cancellation_token: Some(&cancel),
+            run_overrides: &None,
+            total_input_tokens: &mut total_in,
+            total_output_tokens: &mut total_out,
+            truncation_state: &mut truncation,
+            run_created_at: 0,
+            thread_ctx: None,
+        };
+
+        assert!(!maybe_spawn_compaction(&mut ctx, &default_policy()).await);
+        assert!(
+            !store
+                .read::<CompactionStateKey>()
+                .is_some_and(|s| s.is_compacting()),
+            "in-flight must remain unset"
+        );
+    }
+
+    /// End-to-end success: spawn → release → drain inbox → consume event →
+    /// messages compacted in place AND in-flight cleared AND a boundary
+    /// recorded. This is the full happy-path closing the loop the
+    /// orchestrator runs in production.
+    #[tokio::test]
+    async fn round_trip_swap_completes_after_event_drained() {
+        use crate::context::try_consume_compaction_event;
+
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+        let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        let gate = Arc::new(Notify::new());
+        let summarizer: Arc<dyn ContextSummarizer> = Arc::new(GatedSummarizer {
+            gate: gate.clone(),
+            summary: "round trip summary".into(),
+            observed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        });
+        let mut agent = make_resolved_agent(manager.clone(), summarizer);
+        agent.env = env;
+        let mut messages = make_long_messages();
+        let original_len = messages.len();
+        let identity = run_identity("thread-round-trip");
+        let cancel = CancellationToken::new();
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        {
+            let mut ctx = StepContext {
+                agent: &mut agent,
+                messages: &mut messages,
+                runtime: &runtime,
+                sink: sink.clone(),
+                checkpoint_store: None,
+                run_identity: &identity,
+                input_message_count: 0,
+                cancellation_token: Some(&cancel),
+                run_overrides: &None,
+                total_input_tokens: &mut total_in,
+                total_output_tokens: &mut total_out,
+                truncation_state: &mut truncation,
+                run_created_at: 0,
+                thread_ctx: None,
+            };
+            assert!(maybe_spawn_compaction(&mut ctx, &default_policy()).await);
+        }
+
+        gate.notify_one();
+        let payload = tokio::time::timeout(Duration::from_secs(2), inbox_rx.recv_or_cancel(None))
+            .await
+            .expect("event arrives in time")
+            .expect("event present");
+
+        let consumed = try_consume_compaction_event(&mut messages, &payload, runtime.store());
+        assert!(consumed, "router must claim compaction event");
+        assert!(
+            messages[0]
+                .text()
+                .contains("<conversation-summary>\nround trip summary"),
+            "summary not at front: {}",
+            messages[0].text()
+        );
+        assert!(
+            messages.len() < original_len,
+            "compaction must shrink the message list (was {original_len}, now {})",
+            messages.len()
+        );
+
+        let final_state = store.read::<CompactionStateKey>().unwrap();
+        assert!(!final_state.is_compacting(), "in-flight must be cleared");
+        assert_eq!(
+            final_state.boundaries.len(),
+            1,
+            "one boundary must be recorded"
+        );
+        assert_eq!(final_state.boundaries[0].summary, "round trip summary");
+    }
+
+    /// End-to-end failure: spawn → summarizer errs → failure event flows
+    /// back → consume → in-flight cleared, no boundary recorded.
+    #[tokio::test]
+    async fn round_trip_failure_clears_in_flight() {
+        use crate::context::try_consume_compaction_event;
+
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+        let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        let gate = Arc::new(Notify::new());
+        let summarizer: Arc<dyn ContextSummarizer> = Arc::new(FailingSummarizer {
+            gate: gate.clone(),
+            message: "upstream timeout".into(),
+        });
+        let mut agent = make_resolved_agent(manager.clone(), summarizer);
+        agent.env = env;
+        let mut messages = make_long_messages();
+        let identity = run_identity("thread-failure");
+        let cancel = CancellationToken::new();
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        {
+            let mut ctx = StepContext {
+                agent: &mut agent,
+                messages: &mut messages,
+                runtime: &runtime,
+                sink: sink.clone(),
+                checkpoint_store: None,
+                run_identity: &identity,
+                input_message_count: 0,
+                cancellation_token: Some(&cancel),
+                run_overrides: &None,
+                total_input_tokens: &mut total_in,
+                total_output_tokens: &mut total_out,
+                truncation_state: &mut truncation,
+                run_created_at: 0,
+                thread_ctx: None,
+            };
+            assert!(maybe_spawn_compaction(&mut ctx, &default_policy()).await);
+        }
+        let mid = store.read::<CompactionStateKey>().unwrap();
+        assert!(mid.is_compacting());
+
+        gate.notify_one();
+        let payload = tokio::time::timeout(Duration::from_secs(2), inbox_rx.recv_or_cancel(None))
+            .await
+            .expect("event arrives in time")
+            .expect("event present");
+        assert_eq!(payload["event_type"], "context.compaction_failed");
+        let err_text = payload["payload"]["error"].as_str().expect("error string");
+        assert!(
+            err_text.contains("upstream timeout"),
+            "error payload should surface underlying message: {err_text}"
+        );
+
+        let consumed = try_consume_compaction_event(&mut messages, &payload, runtime.store());
+        assert!(consumed);
+        let after = store.read::<CompactionStateKey>().unwrap();
+        assert!(!after.is_compacting(), "in-flight cleared after failure");
+        assert!(
+            after.boundaries.is_empty(),
+            "failure must not record a boundary"
+        );
+    }
+
+    /// Snapshot isolation: messages appended to the live list AFTER spawn
+    /// must not appear in the transcript handed to the summarizer. The plan
+    /// captures the transcript at trigger time and the background closure
+    /// owns it for the duration of the LLM call.
+    #[tokio::test]
+    async fn background_summarizer_uses_snapshot_not_live_messages() {
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+        let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        let gate = Arc::new(Notify::new());
+        let captured_transcript = Arc::new(std::sync::Mutex::new(None));
+        let captured_previous = Arc::new(std::sync::Mutex::new(None));
+        let summarizer: Arc<dyn ContextSummarizer> = Arc::new(CapturingSummarizer {
+            gate: gate.clone(),
+            captured_transcript: captured_transcript.clone(),
+            captured_previous: captured_previous.clone(),
+        });
+        let mut agent = make_resolved_agent(manager.clone(), summarizer);
+        agent.env = env;
+        let mut messages = make_long_messages();
+        let identity = run_identity("thread-snapshot");
+        let cancel = CancellationToken::new();
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        {
+            let mut ctx = StepContext {
+                agent: &mut agent,
+                messages: &mut messages,
+                runtime: &runtime,
+                sink: sink.clone(),
+                checkpoint_store: None,
+                run_identity: &identity,
+                input_message_count: 0,
+                cancellation_token: Some(&cancel),
+                run_overrides: &None,
+                total_input_tokens: &mut total_in,
+                total_output_tokens: &mut total_out,
+                truncation_state: &mut truncation,
+                run_created_at: 0,
+                thread_ctx: None,
+            };
+            assert!(maybe_spawn_compaction(&mut ctx, &default_policy()).await);
+        }
+
+        // Mutate the live list AFTER spawn — this must NOT reach the summarizer.
+        messages.push(Arc::new(Message::user(
+            "POSTSPAWN-MARKER-do-not-include-me",
+        )));
+
+        gate.notify_one();
+        let _ = tokio::time::timeout(Duration::from_secs(2), inbox_rx.recv_or_cancel(None))
+            .await
+            .expect("event arrives in time");
+
+        let transcript = captured_transcript.lock().unwrap().clone().unwrap();
+        assert!(
+            !transcript.contains("POSTSPAWN-MARKER"),
+            "snapshot leaked live messages: {transcript}"
+        );
+        assert!(
+            transcript.contains("filler"),
+            "snapshot must contain pre-spawn content"
+        );
+
+        // Sanity: in-flight cleared after we drain the event in real flow,
+        // but here we only consumed via inbox_rx so the marker may still be set.
+        let _ = store; // suppress unused warning
+    }
+
+    /// Cumulative summarization: when an internal_system <conversation-summary>
+    /// already exists in the message list, plan_compaction extracts it and
+    /// the spawn helper hands it to the summarizer as previous_summary so the
+    /// next pass produces an incremental update rather than re-summarizing
+    /// already-summarized content.
+    #[tokio::test]
+    async fn previous_summary_is_passed_to_summarizer_on_subsequent_pass() {
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+        let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        let gate = Arc::new(Notify::new());
+        let captured_transcript = Arc::new(std::sync::Mutex::new(None));
+        let captured_previous = Arc::new(std::sync::Mutex::new(None));
+        let summarizer: Arc<dyn ContextSummarizer> = Arc::new(CapturingSummarizer {
+            gate: gate.clone(),
+            captured_transcript: captured_transcript.clone(),
+            captured_previous: captured_previous.clone(),
+        });
+        let mut agent = make_resolved_agent(manager.clone(), summarizer);
+        agent.env = env;
+
+        // Pre-existing summary at the head, then plenty of content after.
+        let mut messages: Vec<Arc<Message>> = Vec::new();
+        messages.push(Arc::new(Message::internal_system(
+            "<conversation-summary>\nFirst pass summary text\n</conversation-summary>",
+        )));
+        for i in 0..6 {
+            if i % 2 == 0 {
+                messages.push(Arc::new(Message::user("filler ".repeat(600))));
+            } else {
+                messages.push(Arc::new(Message::assistant("ack")));
+            }
+        }
+        messages.push(Arc::new(Message::user("recent")));
+
+        let identity = run_identity("thread-cumulative");
+        let cancel = CancellationToken::new();
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        {
+            let mut ctx = StepContext {
+                agent: &mut agent,
+                messages: &mut messages,
+                runtime: &runtime,
+                sink: sink.clone(),
+                checkpoint_store: None,
+                run_identity: &identity,
+                input_message_count: 0,
+                cancellation_token: Some(&cancel),
+                run_overrides: &None,
+                total_input_tokens: &mut total_in,
+                total_output_tokens: &mut total_out,
+                truncation_state: &mut truncation,
+                run_created_at: 0,
+                thread_ctx: None,
+            };
+            assert!(maybe_spawn_compaction(&mut ctx, &default_policy()).await);
+        }
+
+        gate.notify_one();
+        let _ = tokio::time::timeout(Duration::from_secs(2), inbox_rx.recv_or_cancel(None))
+            .await
+            .expect("event arrives in time");
+
+        let prev = captured_previous.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            prev.as_deref(),
+            Some("First pass summary text"),
+            "summarizer must receive the existing summary for cumulative update"
+        );
+        let _ = store;
+    }
+
+    /// Robustness: completion event with a missing/empty summary or boundary
+    /// id must not panic and must still clear the in-flight marker. Defends
+    /// against a faulty background task that emits a malformed payload.
+    #[test]
+    fn try_consume_compaction_event_handles_malformed_payload() {
+        use crate::context::{
+            CompactionInFlight, CompactionStateKey, record_compaction_in_flight,
+            try_consume_compaction_event,
+        };
+        use crate::state::MutationBatch;
+        use serde_json::json;
+
+        let store = StateStore::new();
+        store.install_plugin(CompactionPlugin::default()).unwrap();
+
+        let mut messages: Vec<Arc<Message>> = vec![Arc::new(Message::user("only one"))];
+        let mut batch = MutationBatch::new();
+        batch.update::<CompactionStateKey>(record_compaction_in_flight(CompactionInFlight {
+            task_id: "bg_77".into(),
+            boundary_message_id: "any".into(),
+            started_at_ms: 1,
+        }));
+        store.commit(batch).unwrap();
+        assert!(store.read::<CompactionStateKey>().unwrap().is_compacting());
+
+        // Missing payload entirely.
+        let bad = json!({
+            "kind": "custom",
+            "task_id": "bg_77",
+            "event_type": "context.compacted",
+        });
+        let consumed = try_consume_compaction_event(&mut messages, &bad, &store);
+        assert!(consumed, "malformed compaction event still consumed");
+        let state = store.read::<CompactionStateKey>().unwrap();
+        assert!(
+            !state.is_compacting(),
+            "in-flight cleared even with malformed payload"
+        );
+        assert!(
+            state.boundaries.is_empty(),
+            "no boundary recorded for malformed payload"
+        );
+        assert_eq!(
+            messages.len(),
+            1,
+            "live messages untouched on malformed payload"
+        );
+    }
+
+    /// Persisted-state durability: CompactionInFlight must round-trip through
+    /// JSON so a process restart preserves the marker. The orchestrator
+    /// relies on the marker reaching the next process to suppress a
+    /// duplicate compaction during recovery.
+    #[test]
+    fn compaction_in_flight_serde_roundtrips() {
+        use crate::context::{CompactionInFlight, CompactionState};
+
+        let state = CompactionState {
+            in_flight: Some(CompactionInFlight {
+                task_id: "bg_persisted".into(),
+                boundary_message_id: "msg-id-stable".into(),
+                started_at_ms: 4242,
+            }),
+            ..CompactionState::default()
+        };
+
+        let json = serde_json::to_string(&state).expect("serialize");
+        let parsed: CompactionState = serde_json::from_str(&json).expect("deserialize");
+        let live = parsed.in_flight.expect("in-flight survives roundtrip");
+        assert_eq!(live.task_id, "bg_persisted");
+        assert_eq!(live.boundary_message_id, "msg-id-stable");
+        assert_eq!(live.started_at_ms, 4242);
     }
 }

--- a/crates/awaken-runtime/src/loop_runner/compaction.rs
+++ b/crates/awaken-runtime/src/loop_runner/compaction.rs
@@ -141,3 +141,202 @@ fn now_ms() -> u64 {
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use awaken_contract::contract::executor::{
+        InferenceExecutionError, InferenceRequest, LlmExecutor,
+    };
+    use awaken_contract::contract::identity::RunIdentity;
+    use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+    use awaken_contract::contract::message::{Message, gen_message_id};
+    use tokio::sync::Notify;
+
+    use awaken_contract::contract::event_sink::{EventSink, NullEventSink};
+    use awaken_contract::contract::identity::RunOrigin;
+
+    use crate::cancellation::CancellationToken;
+    use crate::context::{
+        CompactionPlugin, CompactionStateKey, ContextSummarizer, SummarizationError,
+        TruncationState,
+    };
+    use crate::extensions::background::{BackgroundTaskManager, BackgroundTaskPlugin};
+    use crate::phase::{ExecutionEnv, PhaseRuntime};
+    use crate::plugins::Plugin;
+    use crate::registry::ResolvedAgent;
+    use crate::state::StateStore;
+
+    struct GatedSummarizer {
+        gate: Arc<Notify>,
+        summary: String,
+        observed: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ContextSummarizer for GatedSummarizer {
+        async fn summarize(
+            &self,
+            _transcript: &str,
+            _previous_summary: Option<&str>,
+            _executor: &dyn LlmExecutor,
+        ) -> Result<String, SummarizationError> {
+            self.observed
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.gate.notified().await;
+            Ok(self.summary.clone())
+        }
+    }
+
+    struct NoopExecutor;
+
+    #[async_trait]
+    impl LlmExecutor for NoopExecutor {
+        async fn execute(
+            &self,
+            _request: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            Ok(StreamResult {
+                content: vec![],
+                tool_calls: vec![],
+                usage: Some(TokenUsage::default()),
+                stop_reason: Some(StopReason::EndTurn),
+                has_incomplete_tool_calls: false,
+            })
+        }
+        fn name(&self) -> &str {
+            "noop"
+        }
+    }
+
+    fn make_long_messages() -> Vec<Arc<Message>> {
+        let mut messages: Vec<Arc<Message>> = (0..6)
+            .map(|i| {
+                if i % 2 == 0 {
+                    Arc::new(Message::user("filler ".repeat(600)))
+                } else {
+                    Arc::new(Message::assistant("ack"))
+                }
+            })
+            .collect();
+        messages.push(Arc::new(Message::user("recent")));
+        messages
+    }
+
+    fn make_resolved_agent(
+        manager: Arc<BackgroundTaskManager>,
+        summarizer: Arc<dyn ContextSummarizer>,
+    ) -> ResolvedAgent {
+        ResolvedAgent::new(
+            "test-agent",
+            "test-model",
+            "system prompt",
+            Arc::new(NoopExecutor),
+        )
+        .with_context_summarizer(summarizer)
+        .with_background_manager(manager)
+    }
+
+    fn make_phase_runtime(
+        manager: &Arc<BackgroundTaskManager>,
+    ) -> (PhaseRuntime, StateStore, ExecutionEnv) {
+        let store = StateStore::new();
+        let runtime = PhaseRuntime::new(store.clone()).expect("runtime");
+        manager.set_store(store.clone());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager.clone()));
+        let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
+        store.register_keys(&env.key_registrations).unwrap();
+        store.install_plugin(CompactionPlugin::default()).unwrap();
+        (runtime, store, env)
+    }
+
+    fn run_identity(thread_id: &str) -> RunIdentity {
+        RunIdentity::new(
+            thread_id.to_string(),
+            None,
+            gen_message_id(),
+            None,
+            "agent".to_string(),
+            RunOrigin::User,
+        )
+    }
+
+    #[tokio::test]
+    async fn maybe_spawn_compaction_emits_event_after_summary_completes() {
+        use awaken_contract::contract::inference::ContextWindowPolicy;
+
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let (runtime, store, env) = make_phase_runtime(&manager);
+
+        let (inbox_tx, mut inbox_rx) = crate::inbox::inbox_channel();
+        manager.set_owner_inbox(inbox_tx);
+
+        let gate = Arc::new(Notify::new());
+        let observed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let summarizer = Arc::new(GatedSummarizer {
+            gate: gate.clone(),
+            summary: "synthetic summary text".into(),
+            observed: observed.clone(),
+        });
+
+        let mut agent = make_resolved_agent(manager.clone(), summarizer);
+        agent.env = env;
+        let mut messages = make_long_messages();
+        let identity = run_identity("thread-bg-compact");
+        let cancel = CancellationToken::new();
+        let policy = ContextWindowPolicy {
+            compaction_raw_suffix_messages: 1,
+            ..Default::default()
+        };
+        let mut total_in = 0u64;
+        let mut total_out = 0u64;
+        let mut truncation = TruncationState::default();
+        let sink: Arc<dyn EventSink> = Arc::new(NullEventSink);
+
+        let mut ctx = StepContext {
+            agent: &mut agent,
+            messages: &mut messages,
+            runtime: &runtime,
+            sink,
+            checkpoint_store: None,
+            run_identity: &identity,
+            input_message_count: 0,
+            cancellation_token: Some(&cancel),
+            run_overrides: &None,
+            total_input_tokens: &mut total_in,
+            total_output_tokens: &mut total_out,
+            truncation_state: &mut truncation,
+            run_created_at: 0,
+            thread_ctx: None,
+        };
+
+        // Summarizer is gated → spawn returns immediately, in_flight set,
+        // background task is parked at the gate.
+        let spawned = maybe_spawn_compaction(&mut ctx, &policy).await;
+        assert!(spawned, "compaction should have been spawned");
+        let mid_state = store.read::<CompactionStateKey>().unwrap();
+        assert!(mid_state.is_compacting(), "in-flight must be set");
+
+        // A second call must be a no-op while the first is still running.
+        let again = maybe_spawn_compaction(&mut ctx, &policy).await;
+        assert!(!again, "single-flight guard must reject second spawn");
+
+        // Release the gate; wait for the inbox event to arrive.
+        gate.notify_one();
+        let payload = tokio::time::timeout(Duration::from_secs(2), inbox_rx.recv_or_cancel(None))
+            .await
+            .expect("event arrives in time")
+            .expect("event present");
+        assert_eq!(payload["kind"], "custom");
+        assert_eq!(payload["event_type"], "context.compacted");
+        assert_eq!(payload["payload"]["summary"], "synthetic summary text");
+        assert_eq!(
+            observed.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "summarizer entered exactly once"
+        );
+    }
+}

--- a/crates/awaken-runtime/src/loop_runner/compaction.rs
+++ b/crates/awaken-runtime/src/loop_runner/compaction.rs
@@ -1,0 +1,143 @@
+//! Spawn-side wiring for non-blocking context compaction.
+//!
+//! `maybe_spawn_compaction` is called from the inference phase. When the
+//! agent is configured with both a context summarizer and a background
+//! task manager, and an in-flight compaction is not already running, it
+//! plans the compaction and offloads the LLM summarization to a
+//! background task. The completion event flows back via the inbox where
+//! [`crate::context::try_consume_compaction_event`] performs the swap.
+
+use std::sync::Arc;
+
+use awaken_contract::contract::inference::ContextWindowPolicy;
+use serde_json::json;
+
+use super::step::StepContext;
+use crate::context::{
+    COMPACTION_COMPLETED_EVENT, COMPACTION_FAILED_EVENT, CompactionInFlight, CompactionStateKey,
+    plan_compaction, record_compaction_in_flight,
+};
+use crate::extensions::background::{TaskParentContext, TaskResult};
+use crate::state::MutationBatch;
+
+/// Background task type used for the spawned compaction.
+pub const COMPACTION_TASK_TYPE: &str = "context_compaction";
+
+/// Background task description used for telemetry.
+const COMPACTION_TASK_DESCRIPTION: &str = "background context compaction";
+
+/// Spawn a background compaction pass when the conditions are met.
+///
+/// Returns `true` when a new background task was queued, `false` when the
+/// call was a no-op (no manager, no summarizer, no thread id, already
+/// compacting, or no useful boundary). Never blocks on the LLM call —
+/// the summarization runs in `tokio::spawn` and signals back through the
+/// owner inbox.
+pub(super) async fn maybe_spawn_compaction(
+    ctx: &mut StepContext<'_>,
+    policy: &ContextWindowPolicy,
+) -> bool {
+    let Some(manager) = ctx.agent.background_manager.clone() else {
+        return false;
+    };
+    let Some(summarizer) = ctx.agent.context_summarizer.clone() else {
+        return false;
+    };
+    let Some(thread_id) = ctx.run_identity.thread_id_opt() else {
+        return false;
+    };
+    let owner_thread_id = thread_id.to_string();
+
+    let store = ctx.runtime.store();
+    if store
+        .read::<CompactionStateKey>()
+        .is_some_and(|s| s.is_compacting())
+    {
+        return false;
+    }
+
+    let Some(plan) = plan_compaction(ctx.messages, policy) else {
+        return false;
+    };
+
+    let executor = Arc::clone(&ctx.agent.llm_executor);
+    let plan_for_task = plan.clone();
+    let boundary_id_for_state = plan.boundary_message_id.clone();
+    let pre_tokens = plan.pre_tokens;
+
+    let task_id = match manager
+        .spawn(
+            &owner_thread_id,
+            COMPACTION_TASK_TYPE,
+            None,
+            COMPACTION_TASK_DESCRIPTION,
+            TaskParentContext::default(),
+            move |task_ctx| async move {
+                let res = summarizer
+                    .summarize(
+                        &plan_for_task.transcript,
+                        plan_for_task.previous_summary.as_deref(),
+                        executor.as_ref(),
+                    )
+                    .await;
+                match res {
+                    Ok(summary) => {
+                        task_ctx.emit(
+                            COMPACTION_COMPLETED_EVENT,
+                            json!({
+                                "boundary_message_id": plan_for_task.boundary_message_id,
+                                "summary": summary,
+                                "pre_tokens": pre_tokens,
+                            }),
+                        );
+                        TaskResult::Success(serde_json::Value::Null)
+                    }
+                    Err(error) => {
+                        let error_text = error.to_string();
+                        task_ctx.emit(
+                            COMPACTION_FAILED_EVENT,
+                            json!({
+                                "boundary_message_id": plan_for_task.boundary_message_id,
+                                "error": error_text,
+                            }),
+                        );
+                        TaskResult::Failed(error.to_string())
+                    }
+                }
+            },
+        )
+        .await
+    {
+        Ok(id) => id,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "failed to spawn background compaction task; skipping this round"
+            );
+            return false;
+        }
+    };
+
+    let mut batch = MutationBatch::new();
+    batch.update::<CompactionStateKey>(record_compaction_in_flight(CompactionInFlight {
+        task_id: task_id.clone(),
+        boundary_message_id: boundary_id_for_state,
+        started_at_ms: now_ms(),
+    }));
+    if let Err(error) = store.commit(batch) {
+        tracing::warn!(
+            error = %error,
+            task_id = %task_id,
+            "failed to record CompactionInFlight; another spawn may race"
+        );
+    }
+    true
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -1,6 +1,5 @@
-//! LLM inference execution and context compaction.
+//! LLM inference execution.
 
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::cancellation::CancellationToken;
@@ -692,94 +691,11 @@ fn stream_retry_backoff(cause: &InterruptCause, attempt: u32, policy: &LlmRetryP
     }
 }
 
-/// Compact messages using the configured ContextSummarizer.
-///
-/// Finds a safe compaction boundary, renders messages as transcript (filtering
-/// Internal messages), extracts any previous summary for cumulative updates,
-/// calls the summarizer, and replaces old messages with the summary.
-///
-/// Skips compaction if the estimated token savings are below `MIN_COMPACTION_GAIN_TOKENS`.
-pub(super) async fn compact_with_llm(
-    agent: &ResolvedAgent,
-    messages: &mut Vec<Arc<Message>>,
-    policy: &awaken_contract::contract::inference::ContextWindowPolicy,
-) -> Result<(), AgentLoopError> {
-    use crate::context::{
-        MIN_COMPACTION_GAIN_TOKENS, extract_previous_summary, find_compaction_boundary,
-        render_transcript,
-    };
-
-    let summarizer = match agent.context_summarizer {
-        Some(ref s) => s,
-        None => return Ok(()),
-    };
-
-    if messages.len() < 2 {
-        return Ok(());
-    }
-
-    let keep_suffix = policy.compaction_raw_suffix_messages.min(messages.len());
-    let search_end = messages.len().saturating_sub(keep_suffix);
-    if search_end < 2 {
-        return Ok(());
-    }
-
-    let boundary = match find_compaction_boundary(messages, 0, search_end) {
-        Some(b) => b,
-        None => return Ok(()),
-    };
-
-    // Check minimum gain threshold
-    let compactable_tokens: usize = messages[..=boundary]
-        .iter()
-        .map(|message| awaken_contract::contract::transform::estimate_message_tokens(message))
-        .sum();
-    if compactable_tokens < MIN_COMPACTION_GAIN_TOKENS {
-        return Ok(());
-    }
-
-    // Render transcript (excludes Internal messages)
-    let transcript = render_transcript(&messages[..=boundary]);
-    if transcript.is_empty() {
-        return Ok(());
-    }
-
-    // Extract previous summary for cumulative update
-    let previous_summary = extract_previous_summary(messages);
-
-    let summary_text = summarizer
-        .summarize(
-            &transcript,
-            previous_summary.as_deref(),
-            agent.llm_executor.as_ref(),
-        )
-        .await
-        .map_err(|e| AgentLoopError::InferenceFailed(format!("compaction failed: {e}")))?;
-
-    // Replace messages up to boundary with the summary
-    let post_tokens =
-        awaken_contract::contract::transform::estimate_tokens(&messages[boundary + 1..]);
-    messages.drain(..=boundary);
-    messages.insert(
-        0,
-        Arc::new(Message::internal_system(format!(
-            "<conversation-summary>\n{summary_text}\n</conversation-summary>"
-        ))),
-    );
-
-    tracing::info!(
-        pre_tokens = compactable_tokens,
-        post_tokens,
-        boundary,
-        "compaction_complete"
-    );
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
     use crate::cancellation::CancellationToken;
     use crate::registry::ResolvedAgent;
     use async_trait::async_trait;

--- a/crates/awaken-runtime/src/loop_runner/mod.rs
+++ b/crates/awaken-runtime/src/loop_runner/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod actions;
 mod checkpoint;
+mod compaction;
 mod inference;
 mod orchestrator;
 #[cfg(feature = "parallel-tools")]

--- a/crates/awaken-runtime/src/loop_runner/orchestrator.rs
+++ b/crates/awaken-runtime/src/loop_runner/orchestrator.rs
@@ -1,6 +1,6 @@
 //! Main agent loop orchestration.
 
-use crate::context::TruncationState;
+use crate::context::{TruncationState, try_consume_compaction_event};
 use crate::inbox::inbox_payload_messages;
 use crate::state::StateStore;
 use awaken_contract::contract::event::AgentEvent;
@@ -39,6 +39,22 @@ fn push_inbox_payload(messages: &mut Vec<std::sync::Arc<Message>>, payload: &ser
     for message in inbox_payload_messages(payload) {
         messages.push(std::sync::Arc::new(message));
     }
+}
+
+/// Drain a single inbox payload. Returns `true` when the payload caused
+/// new conversational input to be appended (caller should keep the loop
+/// running). Compaction events return `false` because they perform an
+/// in-place context swap rather than introducing new turns for the LLM.
+fn apply_inbox_payload(
+    messages: &mut Vec<std::sync::Arc<Message>>,
+    payload: &serde_json::Value,
+    store: &StateStore,
+) -> bool {
+    if try_consume_compaction_event(messages, payload, store) {
+        return false;
+    }
+    push_inbox_payload(messages, payload);
+    true
 }
 
 #[tracing::instrument(skip_all, fields(agent_id = %params.agent_id, run_id = %params.run_identity.run_id))]
@@ -267,8 +283,9 @@ pub(super) async fn run_agent_loop_impl(
                 let mut has_new_messages = false;
                 if let Some(ref mut inbox) = inbox {
                     for msg in inbox.drain() {
-                        push_inbox_payload(&mut messages, &msg);
-                        has_new_messages = true;
+                        if apply_inbox_payload(&mut messages, &msg, store) {
+                            has_new_messages = true;
+                        }
                     }
                 }
 
@@ -288,9 +305,9 @@ pub(super) async fn run_agent_loop_impl(
                         if let Some(ref mut inbox) = inbox {
                             match inbox.recv_or_cancel(cancellation_token.as_ref()).await {
                                 Some(msg) => {
-                                    push_inbox_payload(&mut messages, &msg);
+                                    apply_inbox_payload(&mut messages, &msg, store);
                                     for extra in inbox.drain() {
-                                        push_inbox_payload(&mut messages, &extra);
+                                        apply_inbox_payload(&mut messages, &extra, store);
                                     }
                                     continue; // back to loop — LLM processes events
                                 }

--- a/crates/awaken-runtime/src/loop_runner/step.rs
+++ b/crates/awaken-runtime/src/loop_runner/step.rs
@@ -28,7 +28,8 @@ use super::actions::{
     resolve_intercept_payloads, take_context_messages,
 };
 use super::checkpoint::{StepCompletion, check_termination, complete_step};
-use super::inference::{CheckpointHandle, compact_with_llm, execute_streaming};
+use super::compaction::maybe_spawn_compaction;
+use super::inference::{CheckpointHandle, execute_streaming};
 use super::{AgentLoopError, commit_update, now_ms, tool_result_to_content};
 use crate::agent::state::{
     InferenceOverrideState, InferenceOverrideStateAction, RunLifecycle, RunLifecycleUpdate,
@@ -449,13 +450,16 @@ async fn run_inference_phase(
 ) -> Result<InferencePhaseOutput, AgentLoopError> {
     let store = ctx.runtime.store();
 
-    // LLM compaction
-    if let Some(policy) = ctx.agent.context_policy()
+    // Auto-compaction: if the token estimate has crossed the configured
+    // threshold and no background pass is already running, queue one. The
+    // current inference proceeds against the un-compacted message list;
+    // the swap lands via the inbox before the next inference round.
+    if let Some(policy) = ctx.agent.context_policy().cloned()
         && let Some(threshold) = policy.autocompact_threshold
     {
         let token_est = awaken_contract::contract::transform::estimate_tokens(ctx.messages);
         if token_est >= threshold {
-            compact_with_llm(ctx.agent, ctx.messages, policy).await?;
+            maybe_spawn_compaction(ctx, &policy).await;
         }
     }
 

--- a/crates/awaken-runtime/src/registry/resolve/pipeline.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline.rs
@@ -80,6 +80,7 @@ pub(crate) fn resolve_registry_set(
         llm_executor: executor,
         tool_executor: Arc::new(SequentialToolExecutor),
         context_summarizer: None,
+        background_manager: None,
         stream_checkpoint_store: None,
         env,
     })
@@ -150,6 +151,7 @@ fn resolve_local_spec(
         llm_executor: executor,
         tool_executor: Arc::new(SequentialToolExecutor),
         context_summarizer: None,
+        background_manager: None,
         stream_checkpoint_store: None,
         env,
     })

--- a/crates/awaken-runtime/src/registry/resolver.rs
+++ b/crates/awaken-runtime/src/registry/resolver.rs
@@ -29,6 +29,10 @@ pub struct ResolvedAgent {
     /// Context summarizer for LLM-based compaction. `None` disables LLM compaction
     /// (hard truncation still works if `context_policy` is set).
     pub context_summarizer: Option<Arc<dyn crate::context::ContextSummarizer>>,
+    /// Background task manager used to run context compaction off the
+    /// main agent loop. `None` falls back to no compaction (compaction is
+    /// only triggered when both this and `context_summarizer` are set).
+    pub background_manager: Option<Arc<crate::extensions::background::BackgroundTaskManager>>,
     /// Optional store for cross-process stream resume. When `Some`, the
     /// loop runner flushes mid-stream accumulator snapshots to this
     /// store and restores from it on the next `execute_streaming` call
@@ -72,6 +76,7 @@ impl ResolvedAgent {
             llm_executor,
             tool_executor: Arc::new(SequentialToolExecutor),
             context_summarizer: None,
+            background_manager: None,
             stream_checkpoint_store: None,
             env: ExecutionEnv::empty(),
         }
@@ -158,6 +163,18 @@ impl ResolvedAgent {
         summarizer: Arc<dyn crate::context::ContextSummarizer>,
     ) -> Self {
         self.context_summarizer = Some(summarizer);
+        self
+    }
+
+    /// Attach a background task manager so context compaction can run
+    /// off the main agent loop. Without this, compaction is disabled
+    /// even if a summarizer is configured.
+    #[must_use]
+    pub fn with_background_manager(
+        mut self,
+        manager: Arc<crate::extensions::background::BackgroundTaskManager>,
+    ) -> Self {
+        self.background_manager = Some(manager);
         self
     }
 
@@ -422,7 +439,19 @@ mod tests {
         assert!(agent.tools.is_empty());
         assert!(agent.context_policy().is_none());
         assert!(agent.context_summarizer.is_none());
+        assert!(agent.background_manager.is_none());
         assert_eq!(agent.max_continuation_retries(), 2);
+    }
+
+    #[test]
+    fn with_background_manager_attaches_handle() {
+        let manager = Arc::new(crate::extensions::background::BackgroundTaskManager::new());
+        let agent = ResolvedAgent::new("a", "m", "s", mock_executor())
+            .with_background_manager(manager.clone());
+        assert!(Arc::ptr_eq(
+            agent.background_manager.as_ref().unwrap(),
+            &manager
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the blocking, in-line `compact_with_llm` call inside the inference phase with a **non-blocking background pass**. The agent loop continues to handle user input and tool calls while the LLM summarization runs in `tokio::spawn`. When the summary lands, the existing message list is rewritten in place by stable message id so any user messages that arrived during the compaction window are preserved.

### Why
- The previous flow blocked the entire agent loop on a 5–30 s LLM summarization call. New user input could not be enqueued; tool calls in flight could not be drained.
- The inbox + background task infrastructure (`BackgroundTaskManager`, owner-thread `InboxSender`) already ran async work concurrently with input. Compaction was the last large blocking call on this path.

### Behavior
- Threshold check moves from "block until done" to "spawn if not already running". The current inference proceeds against the un-compacted message list; the summary swap lands before the next inference round.
- Single-flight guard: `CompactionState.in_flight` is recorded at spawn and cleared at completion (success **and** failure). A second call while a pass is running is a no-op.
- Boundary identification by stable `Message.id` (UUID v7), not by index. Robust against any messages appended between trigger and completion — the swap looks up the boundary in the live list, drains up to and including it, and inserts the summary at position 0. New tail messages are kept untouched.
- Missing-boundary case (boundary message no longer present at swap time) is a benign skip with a warn log; in-flight is still cleared so future compactions can run.
- Failure path emits `context.compaction_failed` event; the inbox-event handler clears in-flight and logs.
- Compaction events do NOT count as new conversational input — they perform an in-place context swap and the loop should not re-enter inference just because a swap completed.

### API surface
- New: `ResolvedAgent::with_background_manager(Arc<BackgroundTaskManager>)`. To enable background compaction, downstream code must wire **both** a summarizer and a manager onto the resolved agent (mirrors the existing `with_context_summarizer` pattern; production wiring stays caller-owned).
- New `CompactionState` fields/actions: `in_flight: Option<CompactionInFlight>`, `CompactionAction::SetInFlight` / `ClearInFlight`. `CompactionAction::Clear` now clears in-flight too. `serde(default)` on the new field — old persisted `CompactionState` deserializes without breakage.
- New helpers in `context::compaction`: `plan_compaction`, `apply_summary`, `try_consume_compaction_event`, `record_compaction_in_flight`, `clear_compaction_in_flight`.
- New event constants: `COMPACTION_COMPLETED_EVENT = "context.compacted"`, `COMPACTION_FAILED_EVENT = "context.compaction_failed"`.
- Removed: `loop_runner::inference::compact_with_llm` (the synchronous path is gone).

### Tests
- `try_consume_compaction_event_swaps_messages_and_records_boundary`: swap by id with a message appended during the compaction window — the new tail message survives.
- `try_consume_compaction_event_skips_swap_when_boundary_no_longer_present`: graceful skip when the boundary message has been removed; in-flight still cleared.
- `try_consume_compaction_event_clears_in_flight_on_failure`: failure event clears in-flight without recording a boundary.
- `try_consume_compaction_event_passes_through_unrelated_payloads`: other Custom events and the legacy non-Custom payloads bypass the router.
- `plan_compaction_returns_none_when_savings_below_threshold` / `plan_compaction_captures_boundary_message_id` / `apply_summary_*`: pure-helper unit tests.
- `maybe_spawn_compaction_emits_event_after_summary_completes`: gated background summarizer; asserts in-flight set, single-flight guard rejects second spawn, summarization runs exactly once, completion event arrives via the owner inbox.
- `in_flight_set_and_clear_round_trip` / `clear_action_resets_in_flight_too` / `record_boundary_does_not_touch_in_flight`: state reducer.
- All pre-existing compaction + loop runner tests continue to pass.

### Compatibility
- **Persisted state**: `CompactionState` gains `in_flight: Option<_>` with `serde(default, skip_serializing_if = Option::is_none)`. Old serialized state loads cleanly; new state with `None` serializes to the same shape.
- **Wire format**: completion/failure events are `TaskEvent::Custom { kind = "custom", event_type, payload }` — same shape as any other custom inbox event. Consumers that don't recognize the event type get no-op handling (it does not become a user message because the router consumes it).
- **API**: `ResolvedAgent` gained one optional field with a defaulted constructor. Existing call sites continue to compile.
- No changes to any thread-store schema or NATS layout.

## Testing
- `cargo test -p awaken-runtime --lib`
- `cargo test --workspace --exclude awaken-stores`
- `cargo build --workspace --exclude awaken-stores --exclude awaken-doctest`
