### PR TITLE
feat(contract): redacted secrets and adapter_options in ProviderSpec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "schemars 1.2.1",
+ "secrecy",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3804,6 +3805,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ agent-client-protocol = "0.10.4"
 jsonschema = "0.45"
 parking_lot = "0.12"
 proptest = "1"
+secrecy = { version = "0.10", features = ["serde"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 
 [workspace.lints.rust]

--- a/crates/awaken-contract/Cargo.toml
+++ b/crates/awaken-contract/Cargo.toml
@@ -24,6 +24,7 @@ jsonschema = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
+secrecy = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/awaken-contract/src/lib.rs
+++ b/crates/awaken-contract/src/lib.rs
@@ -19,6 +19,7 @@ mod error;
 pub mod model;
 pub mod periodic_refresh;
 pub mod registry_spec;
+pub mod secret;
 pub mod state;
 pub mod thread;
 pub mod time;
@@ -40,6 +41,9 @@ pub use registry_spec::{
     AgentSpec, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelBindingSpec,
     PluginConfigKey, ProviderSpec,
 };
+
+// ── secret ──
+pub use secret::RedactedString;
 
 // ── state ──
 pub use state::{

--- a/crates/awaken-contract/src/registry_spec.rs
+++ b/crates/awaken-contract/src/registry_spec.rs
@@ -278,14 +278,49 @@ pub struct ProviderSpec {
     /// GenAI adapter kind (for example `"openai"`, `"anthropic"`, `"ollama"`).
     pub adapter: String,
     /// Explicit API key. If absent, the adapter's environment variable is used.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub api_key: Option<String>,
-    /// Base URL override for proxy or self-hosted deployments.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ///
+    /// Wrapped in [`crate::RedactedString`] so it does not leak through
+    /// `Debug` / `Display`. The wire format remains a plain JSON string;
+    /// empty-string input deserializes to `None`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_non_empty",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub api_key: Option<crate::RedactedString>,
+    /// Base URL override for proxy or self-hosted deployments. Empty-string
+    /// input deserializes to `None`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_non_empty",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub base_url: Option<String>,
     /// Request timeout in seconds.
     #[serde(default = "default_provider_timeout_secs")]
     pub timeout_secs: u64,
+    /// Adapter-specific non-secret options consumed by
+    /// `build_genai_provider_executor` (for example
+    /// `{"headers": {"OpenAI-Organization": "org-xxx"}}`).
+    ///
+    /// Secrets must use [`ProviderSpec::api_key`]; do not store credentials
+    /// here. Unrecognised keys are accepted by the schema but ignored at
+    /// build time.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub adapter_options: BTreeMap<String, Value>,
+}
+
+/// Treat an absent field, JSON `null`, or `""` as `None`. Used by spec types
+/// that accept optional textual configuration so callers do not have to
+/// strip/convert empty values themselves.
+fn deserialize_optional_non_empty<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: From<String>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?
+        .filter(|value| !value.is_empty())
+        .map(T::from))
 }
 
 fn default_provider_timeout_secs() -> u64 {
@@ -408,6 +443,7 @@ impl Default for ProviderSpec {
             api_key: None,
             base_url: None,
             timeout_secs: default_provider_timeout_secs(),
+            adapter_options: BTreeMap::new(),
         }
     }
 }
@@ -819,5 +855,78 @@ mod tests {
         assert_eq!(spec.id, "reviewer");
         assert_eq!(spec.model_id, "claude-opus");
         assert!(spec.active_hook_filter.contains("permission"));
+    }
+
+    // ── ProviderSpec ───────────────────────────────────────────────────
+
+    #[test]
+    fn provider_spec_debug_does_not_leak_api_key() {
+        let spec = ProviderSpec {
+            id: "openai".into(),
+            adapter: "openai".into(),
+            api_key: Some("sk-super-secret-12345".into()),
+            ..ProviderSpec::default()
+        };
+        let debug = format!("{spec:?}");
+        assert!(
+            !debug.contains("sk-super-secret-12345"),
+            "ProviderSpec Debug must not contain the api_key value, got: {debug}"
+        );
+    }
+
+    #[test]
+    fn provider_spec_empty_string_api_key_deserializes_as_none() {
+        let json_str = r#"{"id":"x","adapter":"openai","api_key":""}"#;
+        let spec: ProviderSpec = serde_json::from_str(json_str).unwrap();
+        assert!(
+            spec.api_key.is_none(),
+            "empty-string api_key should deserialize as None"
+        );
+    }
+
+    #[test]
+    fn provider_spec_empty_string_base_url_deserializes_as_none() {
+        let json_str = r#"{"id":"x","adapter":"openai","base_url":""}"#;
+        let spec: ProviderSpec = serde_json::from_str(json_str).unwrap();
+        assert!(
+            spec.base_url.is_none(),
+            "empty-string base_url should deserialize as None"
+        );
+    }
+
+    #[test]
+    fn provider_spec_adapter_options_round_trip() {
+        let mut opts = BTreeMap::new();
+        opts.insert("headers".into(), json!({"OpenAI-Organization": "org-xyz"}));
+        let spec = ProviderSpec {
+            id: "openai".into(),
+            adapter: "openai".into(),
+            adapter_options: opts,
+            ..ProviderSpec::default()
+        };
+        let encoded = serde_json::to_string(&spec).unwrap();
+        let parsed: ProviderSpec = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(
+            parsed
+                .adapter_options
+                .get("headers")
+                .and_then(|value| value.get("OpenAI-Organization"))
+                .and_then(Value::as_str),
+            Some("org-xyz")
+        );
+    }
+
+    #[test]
+    fn provider_spec_adapter_options_skipped_when_empty() {
+        let spec = ProviderSpec {
+            id: "openai".into(),
+            adapter: "openai".into(),
+            ..ProviderSpec::default()
+        };
+        let encoded = serde_json::to_string(&spec).unwrap();
+        assert!(
+            !encoded.contains("adapter_options"),
+            "expected adapter_options to be elided when empty, got: {encoded}"
+        );
     }
 }

--- a/crates/awaken-contract/src/secret.rs
+++ b/crates/awaken-contract/src/secret.rs
@@ -1,0 +1,197 @@
+//! Secret value newtype that redacts itself in `Debug`/`Display` while still
+//! round-tripping through `serde`.
+//!
+//! Use [`RedactedString`] for any field that holds a credential. The inner
+//! buffer is held inside [`secrecy::SecretBox`], so it is zeroized when the
+//! value is dropped. The plaintext is reachable only via
+//! [`RedactedString::expose_secret`] — this single accessor is the grep-able
+//! "trust boundary" for the codebase.
+//!
+//! Wire format is a plain JSON string. JSON Schema reports `string`. Storage
+//! backends that persist this value see the secret in cleartext, so storage
+//! choices remain a separate concern.
+
+use std::borrow::Cow;
+use std::fmt;
+
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+use secrecy::{ExposeSecret, SecretBox};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// String wrapper whose `Debug`/`Display` implementations never reveal the
+/// underlying value, and whose buffer is zeroized on drop.
+pub struct RedactedString(SecretBox<String>);
+
+impl RedactedString {
+    /// Construct from any `Into<String>`.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(SecretBox::new(Box::new(value.into())))
+    }
+
+    /// Reach through the redaction to obtain the plaintext value.
+    ///
+    /// Calls to this function are the trust boundary: every caller is
+    /// responsible for not propagating the returned `&str` into any path that
+    /// might log it.
+    pub fn expose_secret(&self) -> &str {
+        self.0.expose_secret().as_str()
+    }
+
+    /// Returns `true` if the inner string is empty.
+    pub fn is_empty(&self) -> bool {
+        self.expose_secret().is_empty()
+    }
+
+    /// Redacted preview suitable for operator-facing logs: first four and
+    /// last four characters with the middle masked, e.g. `"sk-a***wxyz"`.
+    ///
+    /// Values shorter than twelve characters render as `"***"` so that the
+    /// preview never reveals more than half of any single secret.
+    /// Char-aware so multi-byte UTF-8 cannot be split in the middle of a code
+    /// point. Not a cryptographic identifier — do not use for authentication
+    /// or de-duplication.
+    pub fn preview(&self) -> String {
+        let chars: Vec<char> = self.expose_secret().chars().collect();
+        if chars.len() < 12 {
+            return "***".into();
+        }
+        let head: String = chars.iter().take(4).collect();
+        let tail: String = chars.iter().skip(chars.len() - 4).collect();
+        format!("{head}***{tail}")
+    }
+}
+
+impl Clone for RedactedString {
+    fn clone(&self) -> Self {
+        Self::new(self.expose_secret().to_owned())
+    }
+}
+
+impl PartialEq for RedactedString {
+    fn eq(&self, other: &Self) -> bool {
+        self.expose_secret() == other.expose_secret()
+    }
+}
+
+impl Eq for RedactedString {}
+
+impl fmt::Debug for RedactedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RedactedString(***)")
+    }
+}
+
+impl fmt::Display for RedactedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("***")
+    }
+}
+
+impl From<String> for RedactedString {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&str> for RedactedString {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Serialize for RedactedString {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.expose_secret())
+    }
+}
+
+impl<'de> Deserialize<'de> for RedactedString {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::new(value))
+    }
+}
+
+impl JsonSchema for RedactedString {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("String")
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        String::json_schema(generator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts() {
+        let s = RedactedString::new("sk-secret");
+        assert_eq!(format!("{s:?}"), "RedactedString(***)");
+    }
+
+    #[test]
+    fn display_redacts() {
+        let s = RedactedString::new("sk-secret");
+        assert_eq!(format!("{s}"), "***");
+    }
+
+    #[test]
+    fn debug_in_option_redacts() {
+        let s = Some(RedactedString::new("sk-secret"));
+        let formatted = format!("{s:?}");
+        assert!(!formatted.contains("sk-secret"), "leaked: {formatted}");
+    }
+
+    #[test]
+    fn clone_preserves_value() {
+        let original = RedactedString::new("sk-secret");
+        let copied = original.clone();
+        assert_eq!(copied.expose_secret(), "sk-secret");
+        assert_eq!(original.expose_secret(), "sk-secret");
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_value() {
+        let s = RedactedString::new("sk-secret");
+        let encoded = serde_json::to_string(&s).unwrap();
+        assert_eq!(encoded, "\"sk-secret\"");
+        let decoded: RedactedString = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.expose_secret(), "sk-secret");
+    }
+
+    #[test]
+    fn json_schema_is_plain_string() {
+        let schema = schemars::schema_for!(RedactedString);
+        let value = serde_json::to_value(&schema).unwrap();
+        assert_eq!(value.get("type").and_then(|v| v.as_str()), Some("string"));
+    }
+
+    #[test]
+    fn preview_keeps_first_and_last_four_chars() {
+        let s = RedactedString::new("sk-abcd1234567890wxyz");
+        assert_eq!(s.preview(), "sk-a***wxyz");
+    }
+
+    #[test]
+    fn preview_masks_short_values_completely() {
+        for short in ["", "abc", "sk-12345", "12345678901"] {
+            let s = RedactedString::new(short);
+            assert_eq!(
+                s.preview(),
+                "***",
+                "values shorter than 12 chars must render as `***`, got input {short:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn preview_does_not_panic_on_multibyte_utf8() {
+        let s = RedactedString::new("αβγδ-中文-emoji-🔑🔑🔑🔑");
+        let preview = s.preview();
+        assert!(preview.contains("***"));
+        assert!(!preview.contains("中文"));
+    }
+}

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
@@ -23,11 +23,11 @@ use awaken_runtime::registry::{
     AgentSpecRegistry, ModelBinding, PluginSource, RegistrySet, ToolRegistry,
 };
 use awaken_runtime::{AgentResolver, AgentRuntime};
-use genai::Client;
 use genai::adapter::AdapterKind;
 use genai::resolver::{AuthData, Endpoint};
-use genai::{ModelIden, ServiceTarget};
+use genai::{Client, ModelIden, ServiceTarget, WebConfig};
 use parking_lot::{Mutex, RwLock};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::Value;
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -827,9 +827,10 @@ pub fn build_genai_provider_executor(
         Ok(ModelIden::new(adapter_kind, model.model_name.to_string()))
     });
 
-    if let Some(api_key) = spec.api_key.clone().filter(|value| !value.is_empty()) {
-        builder = builder
-            .with_auth_resolver_fn(move |_| Ok(Some(AuthData::from_single(api_key.clone()))));
+    if let Some(api_key) = spec.api_key.as_ref().filter(|value| !value.is_empty()) {
+        let key = api_key.expose_secret().to_owned();
+        builder =
+            builder.with_auth_resolver_fn(move |_| Ok(Some(AuthData::from_single(key.clone()))));
     }
 
     if let Some(base_url) = spec.base_url.clone().filter(|value| !value.is_empty()) {
@@ -844,10 +845,55 @@ pub fn build_genai_provider_executor(
         });
     }
 
+    if let Some(headers) = build_default_headers_from_options(&spec.adapter_options)? {
+        builder = builder.with_web_config(WebConfig::default().with_default_headers(headers));
+    }
+
     let client = builder.build();
     let executor = GenaiExecutor::with_client(client)
         .with_timeout(Duration::from_secs(spec.timeout_secs.max(1)));
     Ok(Arc::new(executor))
+}
+
+/// Parse `adapter_options.headers` into a [`HeaderMap`]. Returns `Ok(None)`
+/// when the key is absent. Returns [`ConfigRuntimeError::InvalidConfig`] when
+/// the value is not an object of `string -> string` pairs or when an entry
+/// fails to parse as a valid HTTP header.
+///
+/// All other keys in `adapter_options` are ignored here — unknown keys are a
+/// forward-compatibility surface, not an error.
+fn build_default_headers_from_options(
+    options: &BTreeMap<String, Value>,
+) -> Result<Option<HeaderMap>, ConfigRuntimeError> {
+    let Some(headers_value) = options.get("headers") else {
+        return Ok(None);
+    };
+    let entries = headers_value.as_object().ok_or_else(|| {
+        ConfigRuntimeError::InvalidConfig(
+            "adapter_options.headers must be an object of string -> string pairs".into(),
+        )
+    })?;
+
+    let mut map = HeaderMap::with_capacity(entries.len());
+    for (name, value) in entries {
+        let value_str = value.as_str().ok_or_else(|| {
+            ConfigRuntimeError::InvalidConfig(format!(
+                "adapter_options.headers[{name}] must be a string"
+            ))
+        })?;
+        let header_name = HeaderName::try_from(name).map_err(|err| {
+            ConfigRuntimeError::InvalidConfig(format!(
+                "adapter_options.headers[{name}] invalid header name: {err}"
+            ))
+        })?;
+        let header_value = HeaderValue::from_str(value_str).map_err(|err| {
+            ConfigRuntimeError::InvalidConfig(format!(
+                "adapter_options.headers[{name}] invalid header value: {err}"
+            ))
+        })?;
+        map.insert(header_name, header_value);
+    }
+    Ok(Some(map))
 }
 
 /// Canonical list of provider adapter identifiers supported by the runtime.
@@ -1005,5 +1051,108 @@ fn canonicalize_value(value: &Value) -> Value {
             Value::Object(normalized)
         }
         _ => value.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn provider_spec_with_options(adapter_options: BTreeMap<String, Value>) -> ProviderSpec {
+        ProviderSpec {
+            id: "test".into(),
+            adapter: "openai".into(),
+            adapter_options,
+            ..ProviderSpec::default()
+        }
+    }
+
+    #[test]
+    fn build_genai_with_valid_headers_succeeds() {
+        let mut options = BTreeMap::new();
+        options.insert("headers".into(), json!({"OpenAI-Organization": "org-xyz"}));
+        let spec = provider_spec_with_options(options);
+        build_genai_provider_executor(&spec).expect("valid headers must build");
+    }
+
+    #[test]
+    fn build_genai_rejects_non_object_headers() {
+        let mut options = BTreeMap::new();
+        options.insert("headers".into(), json!("not-an-object"));
+        let spec = provider_spec_with_options(options);
+        let err = match build_genai_provider_executor(&spec) {
+            Ok(_) => panic!("expected build to fail"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, ConfigRuntimeError::InvalidConfig(ref msg) if msg.contains("headers")),
+            "expected InvalidConfig mentioning headers, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_genai_rejects_non_string_header_value() {
+        let mut options = BTreeMap::new();
+        options.insert("headers".into(), json!({"X-Numeric-Value": 42}));
+        let spec = provider_spec_with_options(options);
+        let err = match build_genai_provider_executor(&spec) {
+            Ok(_) => panic!("expected build to fail"),
+            Err(e) => e,
+        };
+        assert!(
+            matches!(err, ConfigRuntimeError::InvalidConfig(ref msg) if msg.contains("X-Numeric-Value")),
+            "expected InvalidConfig naming the bad header, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn build_genai_ignores_unknown_adapter_options() {
+        let mut options = BTreeMap::new();
+        options.insert("future_extension_key".into(), json!({"anything": true}));
+        let spec = provider_spec_with_options(options);
+        build_genai_provider_executor(&spec)
+            .expect("unknown adapter_options keys must not break the build");
+    }
+
+    #[test]
+    fn build_default_headers_returns_none_when_absent() {
+        let result = build_default_headers_from_options(&BTreeMap::new()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn build_default_headers_parses_string_pairs() {
+        let mut options = BTreeMap::new();
+        options.insert(
+            "headers".into(),
+            json!({
+                "OpenAI-Organization": "org-xyz",
+                "X-Custom": "value",
+            }),
+        );
+        let map = build_default_headers_from_options(&options)
+            .unwrap()
+            .expect("headers should be present");
+        assert_eq!(
+            map.get("openai-organization").and_then(|v| v.to_str().ok()),
+            Some("org-xyz")
+        );
+        assert_eq!(
+            map.get("x-custom").and_then(|v| v.to_str().ok()),
+            Some("value")
+        );
+    }
+
+    #[test]
+    fn build_default_headers_rejects_invalid_header_name() {
+        let mut options = BTreeMap::new();
+        options.insert("headers".into(), json!({"Invalid Header Name": "value"}));
+        let err = build_default_headers_from_options(&options).unwrap_err();
+        assert!(
+            matches!(err, ConfigRuntimeError::InvalidConfig(ref msg) if msg.contains("Invalid Header Name")),
+            "expected InvalidConfig naming the bad header, got: {err:?}"
+        );
     }
 }

--- a/crates/awaken-stores/tests/config_store.rs
+++ b/crates/awaken-stores/tests/config_store.rs
@@ -14,6 +14,7 @@ async fn exercise_store(store: Arc<dyn ConfigStore>) {
         api_key: Some("sk-test".into()),
         base_url: Some("https://proxy.example.com/v1".into()),
         timeout_secs: 120,
+        ..ProviderSpec::default()
     };
     let model = ModelBindingSpec {
         id: "gpt-4o-mini".into(),

--- a/docs/adr/0010-registry-and-resolve.md
+++ b/docs/adr/0010-registry-and-resolve.md
@@ -65,9 +65,35 @@ pub struct ModelBinding {
     pub provider_id: String,        // ProviderRegistry ID
     pub upstream_model: String,     // Actual model name for API call
 }
+
+pub struct ProviderSpec {
+    pub id: String,
+    pub adapter: String,                       // genai adapter kind
+    pub api_key: Option<RedactedString>,       // redacted in Debug, zeroized on drop
+    pub base_url: Option<String>,
+    pub timeout_secs: u64,
+    pub adapter_options: BTreeMap<String, Value>,  // non-secret adapter knobs
+}
 ```
 
 Resolution: `model_id → ModelBinding → provider_id → Arc<dyn LlmExecutor>`.
+
+**Spec invariants** (enforced at the type level rather than by convention):
+
+- **Secrets are typed.** `api_key` is wrapped in `RedactedString` so `Debug` /
+  `Display` cannot leak the value. The plaintext is reachable only via
+  `expose_secret()`; `preview()` returns a head-4/tail-4 mask suitable for
+  operator-facing logs. The wire format remains a plain JSON string.
+- **`adapter_options` is non-secret.** Adapter-specific knobs (custom HTTP
+  headers, organization IDs, API versions) live here and may be inspected
+  freely. Credentials must use `api_key`. A future cross-adapter
+  authentication abstraction (`AuthStrategy`) is deferred to a 0.x version
+  bump; until then secrets that do not fit `api_key` are out of scope.
+- **Empty strings deserialize as `None`.** `api_key` and `base_url` accept
+  `""` from JSON and treat it as unset, removing the need for callers to
+  strip empty values.
+- **Forward-compatible options.** Unknown keys in `adapter_options` are
+  ignored at build time so older binaries do not reject newer specs.
 
 ### D4: resolve(agent_id) → ResolvedRun
 

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -243,7 +243,7 @@ fn build_default_provider_spec(model_name: &str) -> ProviderSpec {
         ProviderSpec {
             id: DEFAULT_PROVIDER_ID.into(),
             adapter: adapter_kind_name(adapter).into(),
-            api_key: std::env::var("OPENAI_API_KEY").ok(),
+            api_key: std::env::var("OPENAI_API_KEY").ok().map(Into::into),
             base_url: std::env::var("OPENAI_BASE_URL").ok(),
             ..Default::default()
         }


### PR DESCRIPTION
## Summary

- **`api_key` is now `Option<RedactedString>`** — wraps `secrecy::SecretBox<String>` so it never leaks through `Debug` / `Display` / panic / structured-log paths and is zeroized on drop. Wire format is unchanged (plain JSON string).
- **`adapter_options: BTreeMap<String, Value>`** — new optional field for non-secret adapter-specific knobs. PR1 ships a single concrete consumer: `adapter_options.headers` is parsed into a `reqwest::HeaderMap` and applied via `genai::WebConfig::with_default_headers`. Other keys are ignored at build time so older binaries do not reject newer specs.
- **Empty-string → `None`** for both `api_key` and `base_url` via a single `deserialize_optional_non_empty<T>` helper, so callers stop having to strip empty values.
- **`RedactedString::preview()`** returns a head-4/tail-4 mask (`sk-1***wxyz`) for operator-facing logs. `Debug` / `Display` always render `***`; preview is opt-in only.

## Why

`ProviderSpec.api_key: Option<String>` leaked through every `Debug`, every panic message, and every structured-log path that captured the spec. `secrecy::SecretBox<String>` is the canonical Rust hardening — wrapping it in our own newtype gives us the right intent in the type system (`expose_secret()` is the single grep-able trust boundary), keeps field declarations free of `with =` / `schemars(with =)` boilerplate, and doesn't preclude swapping the internal storage later. The `adapter_options` field unblocks Azure (`api_version`), self-hosted proxies (custom headers), and any other adapter-specific config without taking a 0.x bump.

## Design

- **Single accessor `expose_secret()` is the trust boundary**: one call site in `build_genai_provider_executor` (`config_runtime.rs:830`) — grep that name to audit every plaintext escape.
- **`adapter_options` is non-secret by contract** (documented on the field). Secrets must use `api_key` until a future cross-adapter `AuthStrategy` is introduced.
- **`build_default_headers_from_options` is the only `adapter_options` consumer in this PR.** Future per-adapter knobs land as small `match adapter_kind` arms, not as a strategy trait.
- **ADR-0010 D3 updated** with the new spec invariants: typed secrets, non-secret options, empty-string normalization, forward-compatible unknown keys.

## Test plan

- [x] Contract: 9 new tests in `awaken-contract` covering `Debug` / `Display` redaction, char-aware `preview()`, multibyte UTF-8 safety, serde round-trip, JSON Schema, `Clone` correctness.
- [x] Contract: 5 new tests in `registry_spec` covering empty-string normalization, `adapter_options` round-trip, and `skip_serializing_if` elision.
- [x] Server: 7 new tests in `config_runtime` covering valid headers happy path, invalid header name / value rejection, non-object `headers` rejection, unknown options ignored, helper `build_default_headers_from_options` directly inspecting `HeaderMap` contents.
- [x] Full workspace `cargo test` and `cargo clippy --all-targets` pass; no new warnings.
- [x] Existing `config_api` integration tests still pass — the server-side `redact_response` layer that strips `api_key` from list/get responses is unaffected.

## Out of scope (future)

- `AuthStrategy` enum for SigV4 / GCP service accounts (deferred to 0.x major)
- Additional `adapter_options` consumers per adapter (added as needed)