### PR TITLE
feat(server): opt out of admin CRUD HTTP routes via AdminApiConfig

### DIFF
--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -105,6 +105,16 @@ pub struct AdminApiConfig {
     /// Origins allowed to call browser admin APIs.
     #[serde(default = "default_admin_cors_allowed_origins")]
     pub cors_allowed_origins: Vec<String>,
+    /// Whether the server mounts the `/v1/config/*` and `/v1/agents` admin
+    /// CRUD routes. Defaults to `true` for back-compat. Embedders that drive
+    /// configuration through their own RBAC / audit pipeline can set this to
+    /// `false` to keep the HTTP surface free of those endpoints entirely.
+    #[serde(default = "default_expose_config_routes")]
+    pub expose_config_routes: bool,
+}
+
+const fn default_expose_config_routes() -> bool {
+    true
 }
 
 impl Default for AdminApiConfig {
@@ -112,6 +122,7 @@ impl Default for AdminApiConfig {
         Self {
             bearer_token: None,
             cors_allowed_origins: default_admin_cors_allowed_origins(),
+            expose_config_routes: default_expose_config_routes(),
         }
     }
 }
@@ -483,7 +494,7 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
     tracing::info!("listening on {addr}");
 
     let admin_cors = admin_cors_layer(&state)?;
-    let app = crate::routes::build_router()
+    let app = crate::routes::build_router(&state)
         .layer(tower::limit::ConcurrencyLimitLayer::new(max_concurrent))
         .layer(admin_cors)
         .with_state(state);
@@ -498,7 +509,11 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
 }
 
 fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
-    if admin_api_config(state).bearer_token.is_some() {
+    let admin = admin_api_config(state);
+    if !admin.expose_config_routes {
+        return Ok(());
+    }
+    if admin.bearer_token.is_some() {
         return Ok(());
     }
     if state.config_store.is_none() && state.config_runtime_manager.is_none() {
@@ -551,6 +566,70 @@ fn admin_cors_layer(state: &AppState) -> std::io::Result<tower_http::cors::CorsL
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn admin_api_config_default_exposes_config_routes() {
+        let config = AdminApiConfig::default();
+        assert!(
+            config.expose_config_routes,
+            "default AdminApiConfig must expose config CRUD routes for back-compat"
+        );
+    }
+
+    #[test]
+    fn validate_admin_surface_short_circuits_when_routes_disabled() {
+        use crate::mailbox::{Mailbox, MailboxConfig};
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_runtime::AgentRuntime;
+        use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
+
+        struct StubResolver;
+        impl awaken_runtime::AgentResolver for StubResolver {
+            fn resolve(
+                &self,
+                agent_id: &str,
+            ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
+                Err(awaken_runtime::RuntimeError::AgentNotFound {
+                    agent_id: agent_id.to_string(),
+                })
+            }
+        }
+
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let store = Arc::new(InMemoryStore::new());
+        let mailbox_store = Arc::new(InMemoryMailboxStore::new());
+        let mailbox = Arc::new(Mailbox::new(
+            runtime.clone(),
+            mailbox_store,
+            store.clone(),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        // Non-loopback bind, no bearer token, *with* a config store —
+        // historically this would refuse to start. The toggle should
+        // short-circuit that check.
+        let config = ServerConfig {
+            address: "0.0.0.0:3000".to_string(),
+            ..ServerConfig::default()
+        };
+
+        let state = AppState::new(
+            runtime,
+            mailbox,
+            store.clone() as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
+            Arc::new(StubResolver),
+            config,
+        )
+        .with_config_store(store as Arc<dyn ConfigStore>)
+        .with_admin_api_config(AdminApiConfig {
+            expose_config_routes: false,
+            ..AdminApiConfig::default()
+        });
+
+        validate_admin_surface(&state)
+            .expect("disabling config routes must waive the bearer-token requirement");
+    }
 
     #[test]
     fn server_config_default_values() {

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -93,22 +93,27 @@ fn map_run_control_error(error: RunControlError) -> ApiError {
     }
 }
 
-/// Build the complete router with all routes and a concurrency limit layer.
+/// Build the complete router for the given state.
 ///
-/// `max_concurrent` controls the maximum number of in-flight requests.
-/// Pass `0` to disable the limit (useful in tests).
-pub fn build_router() -> Router<AppState> {
+/// Honors [`AdminApiConfig::expose_config_routes`] — when disabled, the
+/// `/v1/config/*` and `/v1/agents` admin CRUD endpoints are not mounted.
+pub fn build_router(state: &AppState) -> Router<AppState> {
     crate::metrics::install_recorder();
 
-    Router::new()
+    let mut router = Router::new()
         .merge(health_routes())
         .merge(thread_routes())
         .merge(run_routes())
-        .merge(config_routes())
         .merge(ai_sdk_routes())
         .merge(ag_ui_routes())
         .merge(a2a_routes())
-        .merge(mcp_routes())
+        .merge(mcp_routes());
+
+    if state.admin_api_config().expose_config_routes {
+        router = router.merge(config_routes());
+    }
+
+    router
         .route("/metrics", get(crate::metrics::metrics_handler))
         .layer(middleware::from_fn(crate::metrics::http_metrics_middleware))
 }
@@ -1464,9 +1469,52 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn config_routes_return_404_when_admin_surface_disabled() {
+            use crate::app::AdminApiConfig;
+            use axum::http::StatusCode;
+
+            let state = make_app_state().with_admin_api_config(AdminApiConfig {
+                expose_config_routes: false,
+                ..AdminApiConfig::default()
+            });
+            let app = build_router(&state).with_state(state);
+
+            let req = axum::http::Request::builder()
+                .uri("/v1/agents")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "disabled config routes must not be mounted"
+            );
+        }
+
+        #[tokio::test]
+        async fn config_routes_mounted_by_default() {
+            use axum::http::StatusCode;
+
+            let state = make_app_state();
+            let app = build_router(&state).with_state(state);
+
+            let req = axum::http::Request::builder()
+                .uri("/v1/agents")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_ne!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "default config routes must remain mounted; got {}",
+                resp.status()
+            );
+        }
+
+        #[tokio::test]
         async fn health_live_returns_200() {
             let state = make_app_state();
-            let app = build_router().with_state(state);
+            let app = build_router(&state).with_state(state);
 
             let req = axum::http::Request::builder()
                 .uri("/health/live")
@@ -1479,7 +1527,7 @@ mod tests {
         #[tokio::test]
         async fn health_ready_returns_healthy_with_working_store() {
             let state = make_app_state();
-            let app = build_router().with_state(state);
+            let app = build_router(&state).with_state(state);
 
             let req = axum::http::Request::builder()
                 .uri("/health")
@@ -1498,7 +1546,7 @@ mod tests {
         #[tokio::test]
         async fn metrics_endpoint_is_installed_and_records_http_requests() {
             let state = make_app_state();
-            let app = build_router().with_state(state);
+            let app = build_router(&state).with_state(state);
 
             let req = axum::http::Request::builder()
                 .uri("/health/live")
@@ -1625,7 +1673,7 @@ mod tests {
                 Arc::new(StubResolver),
                 ServerConfig::default(),
             );
-            let app = build_router().with_state(state);
+            let app = build_router(&state).with_state(state);
 
             let req = axum::http::Request::builder()
                 .uri("/health")

--- a/crates/awaken-server/tests/a2a_gateway.rs
+++ b/crates/awaken-server/tests/a2a_gateway.rs
@@ -410,7 +410,7 @@ fn make_gateway_app_with_options(
     );
 
     TestApp {
-        router: build_router().with_state(state),
+        router: build_router(&state).with_state(state),
         store,
         runtime,
     }
@@ -477,7 +477,7 @@ fn make_delegate_gateway_app(mock_base_url: &str) -> TestApp {
     );
 
     TestApp {
-        router: build_router().with_state(state),
+        router: build_router(&state).with_state(state),
         store,
         runtime,
     }

--- a/crates/awaken-server/tests/a2a_http.rs
+++ b/crates/awaken-server/tests/a2a_http.rs
@@ -210,7 +210,7 @@ where
         runtime.resolver_arc(),
         config,
     );
-    (build_router().with_state(state), store)
+    (build_router(&state).with_state(state), store)
 }
 
 fn build_test_app<E>(agent_ids: &[&str], executor: Arc<E>, config: ServerConfig) -> axum::Router
@@ -290,7 +290,7 @@ fn build_background_cancel_fixture()
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    (build_router().with_state(state), store, manager)
+    (build_router(&state).with_state(state), store, manager)
 }
 
 async fn request_json(

--- a/crates/awaken-server/tests/a2a_loopback.rs
+++ b/crates/awaken-server/tests/a2a_loopback.rs
@@ -350,7 +350,7 @@ async fn a2a_loopback_remote_self_cancel_cascades_background_children() {
         ServerConfig::default(),
     );
 
-    let router = build_router().with_state(state);
+    let router = build_router(&state).with_state(state);
     let server_handle = tokio::spawn(async move {
         axum::serve(listener, router).await.ok();
     });
@@ -525,7 +525,7 @@ async fn a2a_dual_server_remote_self_cancel_cascades_background_children() {
         worker_runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    let worker_router = build_router().with_state(worker_state);
+    let worker_router = build_router(&worker_state).with_state(worker_state);
     let worker_handle = tokio::spawn(async move {
         axum::serve(worker_listener, worker_router).await.ok();
     });
@@ -608,7 +608,7 @@ async fn a2a_dual_server_remote_self_cancel_cascades_background_children() {
         orchestrator_runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    let orchestrator_router = build_router().with_state(orchestrator_state);
+    let orchestrator_router = build_router(&orchestrator_state).with_state(orchestrator_state);
     let orchestrator_handle = tokio::spawn(async move {
         axum::serve(orchestrator_listener, orchestrator_router)
             .await
@@ -852,7 +852,7 @@ async fn a2a_loopback_orchestrator_delegates_to_worker() {
 
     // -- Start server ---------------------------------------------------------
 
-    let router = build_router().with_state(state);
+    let router = build_router(&state).with_state(state);
     let server_handle = tokio::spawn(async move {
         axum::serve(listener, router).await.ok();
     });

--- a/crates/awaken-server/tests/ai_sdk_multi_turn.rs
+++ b/crates/awaken-server/tests/ai_sdk_multi_turn.rs
@@ -85,7 +85,7 @@ fn make_app() -> axum::Router {
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router().with_state(state)
+    build_router(&state).with_state(state)
 }
 
 /// Turn 3 of a multi-turn conversation where turns 1-2 included tool calls.

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -625,7 +625,7 @@ async fn make_app_with_skill_catalog_config_and_admin(
     }
 
     TestApp {
-        router: build_router().with_state(state),
+        router: build_router(&state).with_state(state),
         runtime,
         store,
         manager,
@@ -966,7 +966,7 @@ async fn documented_config_driven_agent_tuning_publishes_sections_and_retry() {
     )
     .with_config_store(config_store)
     .with_config_runtime_manager(manager);
-    let router = build_router().with_state(state);
+    let router = build_router(&state).with_state(state);
 
     let (status, _) = request_json(
         &router,

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -160,7 +160,7 @@ where
     .with_config_runtime_manager(manager);
 
     TestApp {
-        router: build_router().with_state(state),
+        router: build_router(&state).with_state(state),
         runtime,
         store,
     }
@@ -206,7 +206,7 @@ where
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router().with_state(state)
+    build_router(&state).with_state(state)
 }
 
 #[cfg(feature = "nats")]

--- a/crates/awaken-server/tests/explicit_composition.rs
+++ b/crates/awaken-server/tests/explicit_composition.rs
@@ -1,6 +1,0 @@
-use awaken_server::routes::build_router;
-
-#[test]
-fn router_composes_all_modules() {
-    let _ = build_router();
-}

--- a/crates/awaken-server/tests/http_api.rs
+++ b/crates/awaken-server/tests/http_api.rs
@@ -4,7 +4,7 @@
 //! API error types, and message conversion logic.
 
 use awaken_server::app::ServerConfig;
-use awaken_server::routes::{ApiError, build_router};
+use awaken_server::routes::ApiError;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde_json::json;
@@ -87,15 +87,6 @@ fn api_error_internal_response() {
     let err = ApiError::Internal("db error".into());
     let resp = err.into_response();
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-}
-
-// ============================================================================
-// Route builder (smoke test — verifies router construction doesn't panic)
-// ============================================================================
-
-#[test]
-fn build_router_constructs_without_panic() {
-    let _router = build_router();
 }
 
 // ============================================================================
@@ -360,7 +351,7 @@ mod integration {
             ServerConfig::default(),
         );
         TestApp {
-            router: build_router().with_state(state),
+            router: build_router(&state).with_state(state),
             store,
             mailbox_store,
         }

--- a/crates/awaken-server/tests/protocol_ag_ui_e2e.rs
+++ b/crates/awaken-server/tests/protocol_ag_ui_e2e.rs
@@ -216,7 +216,7 @@ fn make_ag_ui_app(llm: Arc<dyn LlmExecutor>, tools: Vec<(String, Arc<dyn Tool>)>
         ServerConfig::default(),
     );
     TestApp {
-        router: build_router().with_state(state),
+        router: build_router(&state).with_state(state),
         store,
     }
 }
@@ -1015,7 +1015,7 @@ async fn multiple_sequential_runs_on_same_thread() {
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    let router = build_router().with_state(state);
+    let router = build_router(&state).with_state(state);
 
     // First run
     let (status1, body1) = post_ag_ui_run(

--- a/crates/awaken-server/tests/protocol_mcp.rs
+++ b/crates/awaken-server/tests/protocol_mcp.rs
@@ -95,7 +95,7 @@ fn make_mcp_app() -> axum::Router {
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router().with_state(state)
+    build_router(&state).with_state(state)
 }
 
 async fn mcp_post(

--- a/crates/awaken-server/tests/protocol_parity.rs
+++ b/crates/awaken-server/tests/protocol_parity.rs
@@ -86,7 +86,7 @@ fn make_app() -> axum::Router {
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router().with_state(state)
+    build_router(&state).with_state(state)
 }
 
 async fn post_sse(app: axum::Router, uri: &str, payload: Value) -> (StatusCode, String) {

--- a/crates/awaken-server/tests/run_api.rs
+++ b/crates/awaken-server/tests/run_api.rs
@@ -211,7 +211,7 @@ fn make_test_app_with_runtime(
         ServerConfig::default(),
     );
     TestApp {
-        router: build_router().with_state(state),
+        router: build_router(&state).with_state(state),
         store,
     }
 }

--- a/docs/adr/0023-admin-api-surface-and-exposure-policy.md
+++ b/docs/adr/0023-admin-api-surface-and-exposure-policy.md
@@ -1,0 +1,104 @@
+# ADR-0023: Admin API Surface and Exposure Policy
+
+- **Status**: Accepted
+- **Date**: 2026-04-26
+- **Depends on**: ADR-0010, ADR-0018
+
+## Context
+
+The server hosts an admin/configuration HTTP surface — `/v1/config/:namespace`,
+`/v1/config/:namespace/:id`, `/v1/config/:namespace/$schema`, `/v1/agents`,
+`/v1/agents/:id`, `/v1/capabilities`. These endpoints write to the
+`ConfigStore` (PUT, POST, DELETE) and read every namespace including raw
+provider documents.
+
+Until now the access policy lived implicitly across three places:
+
+1. `AdminApiConfig::bearer_token` — optional bearer required by every
+   handler via `ensure_admin_auth`.
+2. `validate_admin_surface` — refuses to start the server when binding a
+   non-loopback address without a bearer token, *if* a config store or
+   runtime manager is attached.
+3. `build_router` — unconditionally merges `config_routes()`.
+
+This ad-hoc structure has two problems:
+
+- **There is no way to opt out of the routes entirely.** Embedders that
+  drive configuration through their own RBAC + audit pipeline can either
+  set a bearer token (still serves the routes, just behind one shared
+  secret) or set a loopback bind (excludes legitimate non-loopback uses).
+  Neither matches "do not expose this surface at all."
+- **The policy is split across three files** with no single source of
+  truth, making it easy for new admin endpoints to drift from the
+  established convention.
+
+## Decisions
+
+### D1: AdminApiConfig is the single container for admin policy
+
+All admin/configuration access policy lives in `AdminApiConfig`:
+
+```rust
+pub struct AdminApiConfig {
+    pub bearer_token: Option<String>,
+    pub cors_allowed_origins: Vec<String>,
+    pub expose_config_routes: bool, // default: true
+}
+```
+
+Future admin policy fields (rate limits, audit hooks, additional
+authentication strategies) extend this struct rather than introducing
+parallel mechanisms.
+
+### D2: `expose_config_routes` opt-out
+
+When `expose_config_routes` is `false`, `build_router` does not merge
+`config_routes()` into the public router. The endpoints return `404 Not
+Found` regardless of the request method or bearer header — the routes are
+not registered at all, so there is no handler to gate.
+
+Default is `true` for back-compat. Embedders that own their own
+configuration plane set it to `false` via:
+
+- `AppState::with_admin_api_config(...)` builder, or
+- `AWAKEN_ADMIN_EXPOSE_CONFIG_ROUTES` environment variable (when wired
+  through the embedder; the environment override is not provided by the
+  framework today and may be added when there is a use case).
+
+### D3: `validate_admin_surface` reads `expose_config_routes` first
+
+`validate_admin_surface` short-circuits to `Ok` when
+`expose_config_routes` is `false`. The bearer-token-on-non-loopback
+requirement applies only when the routes are actually mounted. This
+preserves the security posture for the default case while letting
+embedders that own configuration through other channels run on any bind
+address without a server-side bearer token.
+
+### D4: New admin endpoints share the toggle
+
+Future admin endpoints (e.g., audit log, runtime control) mount alongside
+`config_routes()` and respect the same `expose_config_routes` toggle. If a
+future endpoint warrants independent exposure control, that is a
+deliberate ADR amendment, not an ad-hoc field addition.
+
+### D5: The toggle controls mounting, not authentication
+
+`expose_config_routes = true` does not imply "open access" — bearer
+authentication via `bearer_token` and the non-loopback validation in
+`validate_admin_surface` continue to apply. The toggle is an additional
+upstream gate, not a replacement.
+
+## Consequences
+
+- Embedders running their own RBAC / audit can run on any bind address
+  with `expose_config_routes = false` and no admin bearer token, without
+  the framework refusing to start.
+- The default surface is unchanged: defaults remain
+  `expose_config_routes = true` and `bearer_token = None`, with the
+  loopback / bearer requirement enforced at startup when a config store
+  or runtime manager is attached.
+- `build_router` now requires `&AppState` so it can read the effective
+  admin policy at compose time. Test code constructs an `AppState` and
+  passes it; the API change is mechanical.
+- `validate_admin_surface` is shorter and reads top-down by relevance:
+  not exposed → token configured → no admin attached → loopback → fail.

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -1141,7 +1141,7 @@ Always greet the user warmly and ask how you can help today.
             as Arc<dyn SkillCatalogProvider>,
     );
 
-    let mut app = build_router().with_state(state);
+    let mut app = build_router(&state).with_state(state);
 
     if config.enable_cors {
         let cors = CorsLayer::new()


### PR DESCRIPTION
## Summary

- New field **`AdminApiConfig::expose_config_routes: bool`** (default `true`). When `false`, `build_router` does not merge `config_routes()` — the `/v1/config/*`, `/v1/agents`, `/v1/capabilities` endpoints return `404` regardless of method or bearer header (no handlers are registered).
- **`build_router(state: &AppState)`** now reads the effective `AdminApiConfig` from state at compose time. The signature change is mechanical: every existing caller already had an `AppState` in scope.
- **`validate_admin_surface`** short-circuits to `Ok` first when `expose_config_routes == false`. Loopback / bearer-token-on-non-loopback enforcement applies only when the routes are actually mounted.
- **ADR-0023** captures the now-explicit policy: `AdminApiConfig` is the single container for admin policy; future admin endpoints respect the same toggle; mounting and authentication remain orthogonal.

## Why

Embedders that drive configuration through their own RBAC + audit pipeline (vault-backed credential rotation, signed change events, custom approval workflows) do not want the framework's HTTP CRUD surface mounted at all. The previous options were:

1. Set a bearer token — still serves the routes behind one shared secret, leaks them to every operator who has the token.
2. Bind to loopback — excludes legitimate non-loopback uses.

Neither matches "do not expose this surface." The toggle adds the missing third option without weakening the default.

## Design

- **Single source of truth.** All admin policy lives in `AdminApiConfig` (`bearer_token`, `cors_allowed_origins`, `expose_config_routes`). Future fields extend this struct rather than introducing parallel mechanisms.
- **Mounting is upstream of authentication.** The toggle controls whether handlers exist; bearer auth and the non-loopback validation continue to apply when they do.
- **No new builder methods.** `with_admin_api_config(...)` already accepts the full struct — `expose_config_routes` rides on the existing entry point.
- **Validation reads top-down by relevance.** `validate_admin_surface` now reads: not exposed → token configured → no admin attached → loopback → fail. Each guard is an inexpensive short-circuit.

## Test plan

- [x] `admin_api_config_default_exposes_config_routes` — defaults preserve back-compat.
- [x] `validate_admin_surface_short_circuits_when_routes_disabled` — non-loopback bind + no token + with config_store + `expose_config_routes=false` returns `Ok` (without the toggle, this would refuse to start).
- [x] `config_routes_return_404_when_admin_surface_disabled` — full router integration: GET `/v1/agents` returns `404`.
- [x] `config_routes_mounted_by_default` — default config still serves the route (asserts `!= 404`).
- [x] Full workspace `cargo test` and `cargo clippy --all-targets` pass; `awaken-server` clippy is clean.
- [x] Existing admin-auth tests in `config_routes::tests` (bearer token enforcement) continue to pass — orthogonal to the toggle.

## Migration

Callers of `build_router()` must pass `&AppState`:

```diff
- build_router().with_state(state)
+ build_router(&state).with_state(state)
```

The `explicit_composition.rs` and `http_api.rs:build_router_constructs_without_panic` smoke tests are removed — both were redundant with the integration tests that already exercise router construction with a real state.