### PR TITLE
chore(stores): bump async-nats to 0.47 to drop vulnerable rustls-webpki 0.102

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,25 +177,24 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.38.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76433c4de73442daedb3a59e991d94e85c14ebfc33db53dfcd347a21cd6ef4f8"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures",
+ "futures-util",
  "memchr",
  "nkeys",
  "nuid",
- "once_cell",
  "pin-project",
  "portable-atomic",
  "rand 0.8.5",
  "regex",
  "ring",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.2.0",
- "rustls-webpki 0.102.8",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -204,6 +203,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-util",
  "tokio-websockets",
  "tracing",
@@ -752,7 +752,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -1956,7 +1956,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2568,10 +2568,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2779,12 +2779,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -3613,22 +3607,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -3637,10 +3618,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -3683,10 +3664,10 @@ dependencies = [
  "log",
  "once_cell",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
- "security-framework 3.7.0",
+ "rustls-webpki",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3697,17 +3678,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -3814,19 +3784,6 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -4723,11 +4680,11 @@ dependencies = [
  "httparse",
  "rand 0.8.5",
  "ring",
- "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5249,6 +5206,24 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/awaken-stores/Cargo.toml
+++ b/crates/awaken-stores/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = { workspace = true }
 # Optional backends
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], default-features = false, optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
-async-nats = { version = "0.38", optional = true }
+async-nats = { version = "0.47", optional = true }
 metrics = { version = "0.24", optional = true }
 bytes = "1"
 

--- a/crates/awaken-stores/src/nats_mailbox/mod.rs
+++ b/crates/awaken-stores/src/nats_mailbox/mod.rs
@@ -653,9 +653,7 @@ async fn deliver_live_subject(
                 | async_nats::client::RequestErrorKind::TimedOut => {
                     Ok(LiveDeliveryOutcome::NoSubscriber)
                 }
-                async_nats::client::RequestErrorKind::Other => {
-                    Err(StorageError::Io(format!("nats request: {err}")))
-                }
+                _ => Err(StorageError::Io(format!("nats request: {err}"))),
             },
         },
     };


### PR DESCRIPTION
## Summary

- Bump `async-nats` from `0.38` to `0.47` (workspace-wide via `crates/awaken-stores/Cargo.toml`).
- Loosen one `match err.kind()` arm in `nats_mailbox::mod.rs::live_request_send` to a wildcard so future `RequestErrorKind` additions remain forward-compatible.
- Drops the transitively-pulled `rustls-webpki 0.102.8` (CVE-flagged by Dependabot) — the lockfile now resolves to `rustls-webpki 0.103.10`.

## Why

GitHub Dependabot's daily security run on `main` keeps failing with `security_update_not_possible` because `async-nats 0.38.0` pins `rustls-webpki ^0.102`. Dependabot can't bump a transitive dependency across a major-ish boundary on its own; the parent (`async-nats`) has to move first. After this PR the failure stops.

## Scope

- `async-nats 0.38 → 0.47` is 9 minor versions, but the only API surface awaken-stores touches that changed is the `RequestErrorKind` enum — a new `InvalidSubject` variant was added in a non-exhaustive way that the existing `match` did not handle.
- Resolution: switch the catch-all from `RequestErrorKind::Other =>` to `_ =>`. Same observed behavior (any non-recoverable kind maps to `StorageError::Io`) and forward-compatible.
- All NATS-feature tests in `awaken-stores` pass: 99 lib tests, plus the integration tests that exercise NATS mailbox / buffered thread / hierarchy paths.
- No CVE was directly exploitable in our usage (the `rustls-webpki` issue is in cert verification paths the NATS client doesn't always reach), but eliminating Dependabot's recurring red CI is worth the small dep churn.

## Test plan

- [x] `cargo build -p awaken-stores --features nats` — clean.
- [x] `cargo build -p awaken-stores --features nats --tests` — clean.
- [x] `cargo test -p awaken-stores --features nats` — 99 lib + all integration suites green.
- [x] `cargo test --workspace --tests` — full workspace green.
- [x] `cargo clippy -p awaken-stores --features nats --all-targets` — no new warnings.
- [x] `cargo tree -i rustls-webpki@0.102.8` — no longer present in the lockfile; sole version is `0.103.10`.