### PR TITLE
feat(server): executor cache + change-listener debounce in ConfigRuntimeManager

### DIFF
--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -291,6 +291,11 @@ pub struct ConfigRuntimeManager {
     apply_lock: tokio::sync::Mutex<()>,
     active_mcp_registry: Mutex<Option<ActiveMcpRegistry>>,
     last_applied_fingerprint: RwLock<Option<u64>>,
+    /// Provider id → (last-built spec, cached executor). Hits skip the
+    /// per-apply executor rebuild for providers whose spec is unchanged.
+    /// Keys are pruned to the current providers list on every apply, so
+    /// removed providers do not leak memory.
+    provider_executor_cache: Mutex<HashMap<String, (ProviderSpec, Arc<dyn LlmExecutor>)>>,
     periodic_refresh: PeriodicRefresher,
     change_listener: Mutex<Option<ChangeListenerRuntime>>,
     mcp_refresh_interval: RwLock<Option<Duration>>,
@@ -319,6 +324,7 @@ impl ConfigRuntimeManager {
             apply_lock: tokio::sync::Mutex::new(()),
             active_mcp_registry: Mutex::new(None),
             last_applied_fingerprint: RwLock::new(None),
+            provider_executor_cache: Mutex::new(HashMap::new()),
             periodic_refresh: PeriodicRefresher::new(),
             change_listener: Mutex::new(None),
             mcp_refresh_interval: RwLock::new(None),
@@ -737,11 +743,25 @@ impl ConfigRuntimeManager {
         dynamic_tools: Option<Arc<dyn ToolRegistry>>,
     ) -> Result<RegistrySet, ConfigRuntimeError> {
         let mut provider_registry = MapProviderRegistry::new();
+        let mut next_cache: HashMap<String, (ProviderSpec, Arc<dyn LlmExecutor>)> =
+            HashMap::with_capacity(providers.len());
+        let prior_cache = self.provider_executor_cache.lock().clone();
         for provider in providers {
+            let executor = match prior_cache.get(&provider.id) {
+                Some((cached_spec, cached_executor)) if cached_spec == provider => {
+                    Arc::clone(cached_executor)
+                }
+                _ => self.provider_factory.build(provider)?,
+            };
+            next_cache.insert(
+                provider.id.clone(),
+                (provider.clone(), Arc::clone(&executor)),
+            );
             provider_registry
-                .register_provider(provider.id.clone(), self.provider_factory.build(provider)?)
+                .register_provider(provider.id.clone(), executor)
                 .map_err(|error| ConfigRuntimeError::InvalidConfig(error.to_string()))?;
         }
+        *self.provider_executor_cache.lock() = next_cache;
 
         let mut model_registry = MapModelRegistry::new();
         for model in models {

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -40,6 +40,10 @@ const NS_MODELS: &str = "models";
 const NS_PROVIDERS: &str = "providers";
 const NS_MCP_SERVERS: &str = "mcp-servers";
 
+/// Per-provider executor cache entry: the spec used to build the cached
+/// executor and the executor itself.
+type ProviderExecutorCache = HashMap<String, (ProviderSpec, Arc<dyn LlmExecutor>)>;
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigRuntimeError {
     #[error("runtime does not expose a configurable registry snapshot")]
@@ -295,10 +299,15 @@ pub struct ConfigRuntimeManager {
     /// per-apply executor rebuild for providers whose spec is unchanged.
     /// Keys are pruned to the current providers list on every apply, so
     /// removed providers do not leak memory.
-    provider_executor_cache: Mutex<HashMap<String, (ProviderSpec, Arc<dyn LlmExecutor>)>>,
+    provider_executor_cache: Mutex<ProviderExecutorCache>,
     periodic_refresh: PeriodicRefresher,
     change_listener: Mutex<Option<ChangeListenerRuntime>>,
     mcp_refresh_interval: RwLock<Option<Duration>>,
+    /// Minimum interval between successive applies driven by the change
+    /// listener. Bursts of events that arrive within this window coalesce
+    /// into a single apply. Direct calls to [`Self::apply`] /
+    /// [`Self::apply_if_changed`] are unaffected.
+    min_apply_interval: Duration,
 }
 
 impl ConfigRuntimeManager {
@@ -328,6 +337,7 @@ impl ConfigRuntimeManager {
             periodic_refresh: PeriodicRefresher::new(),
             change_listener: Mutex::new(None),
             mcp_refresh_interval: RwLock::new(None),
+            min_apply_interval: Duration::ZERO,
         })
     }
 
@@ -358,6 +368,16 @@ impl ConfigRuntimeManager {
             return self;
         }
         *self.mcp_refresh_interval.write() = Some(interval);
+        self
+    }
+
+    /// Set the minimum interval between successive applies driven by the
+    /// change listener. Default is zero (no debounce). Direct calls to
+    /// [`Self::apply`] / [`Self::apply_if_changed`] always run immediately
+    /// regardless of this setting.
+    #[must_use]
+    pub fn with_min_apply_interval(mut self, interval: Duration) -> Self {
+        self.min_apply_interval = interval;
         self
     }
 
@@ -607,8 +627,12 @@ impl ConfigRuntimeManager {
 
         let (stop_tx, mut stop_rx) = oneshot::channel();
         let weak = Arc::downgrade(self);
+        let min_apply_interval = self.min_apply_interval;
         let join = runtime_handle.spawn(async move {
             let retry_delay = Duration::from_secs(1);
+            // `last_applied_at` is `None` until the first event-driven apply,
+            // so the first event is never delayed.
+            let mut last_applied_at: Option<tokio::time::Instant> = None;
 
             loop {
                 let mut subscriber = tokio::select! {
@@ -650,9 +674,41 @@ impl ConfigRuntimeManager {
                         "config change notification received"
                     );
 
+                    // Enforce the minimum apply interval and coalesce any
+                    // events that arrive while we are waiting. Direct calls
+                    // to `manager.apply()` are unaffected.
+                    if !min_apply_interval.is_zero()
+                        && let Some(last) = last_applied_at
+                    {
+                        let next_allowed = last + min_apply_interval;
+                        let now = tokio::time::Instant::now();
+                        if now < next_allowed {
+                            let wait = next_allowed - now;
+                            tokio::select! {
+                                _ = &mut stop_rx => return,
+                                _ = tokio::time::sleep(wait) => {}
+                            }
+                            // Drain any events that arrived during the wait
+                            // so we apply once for the whole burst. The
+                            // subscriber trait is async-only, so we peek
+                            // with a zero-duration timeout.
+                            while tokio::time::timeout(
+                                Duration::ZERO,
+                                subscriber.next(),
+                            )
+                            .await
+                            .is_ok()
+                            {
+                                // discarded — apply_if_changed reads the
+                                // latest store snapshot below.
+                            }
+                        }
+                    }
+
                     if let Err(error) = manager.apply_if_changed().await {
                         tracing::warn!(error = %error, "config change apply failed");
                     }
+                    last_applied_at = Some(tokio::time::Instant::now());
                 }
 
                 tokio::select! {
@@ -743,8 +799,7 @@ impl ConfigRuntimeManager {
         dynamic_tools: Option<Arc<dyn ToolRegistry>>,
     ) -> Result<RegistrySet, ConfigRuntimeError> {
         let mut provider_registry = MapProviderRegistry::new();
-        let mut next_cache: HashMap<String, (ProviderSpec, Arc<dyn LlmExecutor>)> =
-            HashMap::with_capacity(providers.len());
+        let mut next_cache: ProviderExecutorCache = HashMap::with_capacity(providers.len());
         let prior_cache = self.provider_executor_cache.lock().clone();
         for provider in providers {
             let executor = match prior_cache.get(&provider.id) {

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -691,16 +691,27 @@ impl ConfigRuntimeManager {
                             // Drain any events that arrived during the wait
                             // so we apply once for the whole burst. The
                             // subscriber trait is async-only, so we peek
-                            // with a zero-duration timeout.
-                            while tokio::time::timeout(
-                                Duration::ZERO,
-                                subscriber.next(),
-                            )
-                            .await
-                            .is_ok()
-                            {
-                                // discarded — apply_if_changed reads the
-                                // latest store snapshot below.
+                            // with a zero-duration timeout. A subscriber
+                            // error here must surface — drain stops and
+                            // the outer loop re-receives, hits the same
+                            // error, and triggers a reconnect.
+                            loop {
+                                match tokio::time::timeout(
+                                    Duration::ZERO,
+                                    subscriber.next(),
+                                )
+                                .await
+                                {
+                                    Ok(Ok(_event)) => continue,
+                                    Ok(Err(error)) => {
+                                        tracing::warn!(
+                                            error = %error,
+                                            "config change listener receive failed while draining debounce window"
+                                        );
+                                        break;
+                                    }
+                                    Err(_elapsed) => break,
+                                }
                             }
                         }
                     }

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -1809,9 +1809,9 @@ async fn change_listener_coalesces_event_bursts_within_min_apply_interval() {
 
     let new_builds = factory.builds_for("bootstrap") - initial_builds;
     assert!(
-        new_builds <= 2,
-        "4 events fired within {min}ms must coalesce to ≤2 applies (got {new_builds} new builds)",
-        min = 200
+        (1..=2).contains(&new_builds),
+        "4 events fired within 200ms debounce window must produce 1 or 2 applies — \
+         0 means the listener missed the burst, >2 means coalescing failed (got {new_builds})"
     );
 }
 

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -1723,6 +1723,99 @@ async fn apply_reuses_executor_for_unchanged_provider() {
 }
 
 #[tokio::test]
+async fn change_listener_coalesces_event_bursts_within_min_apply_interval() {
+    let factory = Arc::new(CountingProviderFactory::default());
+    let notifier = Arc::new(TestConfigChangeNotifier::new());
+    let store = Arc::new(InMemoryStore::new());
+    let bootstrap_provider = ProviderSpec {
+        id: "bootstrap".into(),
+        adapter: "stub".into(),
+        ..Default::default()
+    };
+    let bootstrap_model = ModelBindingSpec {
+        id: "bootstrap".into(),
+        provider_id: "bootstrap".into(),
+        upstream_model: "bootstrap-model".into(),
+    };
+    let bootstrap_agent = agent_spec("bootstrap", "bootstrap");
+
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_model_binding(
+                "bootstrap",
+                ModelBinding {
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
+                },
+            )
+            .with_agent_spec(bootstrap_agent.clone())
+            .with_thread_run_store(store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), store.clone() as Arc<dyn ConfigStore>)
+            .expect("config runtime manager")
+            .with_provider_factory(factory.clone() as Arc<dyn ProviderExecutorFactory>)
+            .with_mcp_registry_factory(Arc::new(TestMcpRegistryFactory))
+            .with_change_notifier(notifier.clone() as Arc<dyn ConfigChangeNotifier>)
+            .with_min_apply_interval(Duration::from_millis(200)),
+    );
+    manager
+        .bootstrap_if_empty(
+            std::slice::from_ref(&bootstrap_provider),
+            std::slice::from_ref(&bootstrap_model),
+            std::slice::from_ref(&bootstrap_agent),
+            &[],
+        )
+        .await
+        .expect("bootstrap config store");
+    manager.apply().await.expect("initial apply");
+    manager
+        .start_periodic_refresh(Duration::from_secs(60))
+        .expect("start change listener");
+
+    let listening = wait_until(Duration::from_secs(1), Duration::from_millis(10), || {
+        notifier.subscriber_count() > 0
+    })
+    .await;
+    assert!(listening, "listener should subscribe before publish");
+
+    let initial_builds = factory.builds_for("bootstrap");
+
+    // Mutate provider 4 times rapidly. Each mutation flips the cache miss
+    // bit so the executor gets rebuilt on every apply that runs.
+    for i in 1..=4u64 {
+        let spec = json!({
+            "id": "bootstrap",
+            "adapter": "stub",
+            "timeout_secs": 100 + i,
+        });
+        (store.clone() as Arc<dyn ConfigStore>)
+            .put("providers", "bootstrap", &spec)
+            .await
+            .expect("write mutated provider");
+        notifier.publish(ConfigChangeEvent {
+            namespace: "providers".into(),
+            id: "bootstrap".into(),
+            kind: ConfigChangeKind::Put,
+        });
+    }
+
+    // Wait long enough for the debounce window to flush.
+    tokio::time::sleep(Duration::from_millis(600)).await;
+
+    let new_builds = factory.builds_for("bootstrap") - initial_builds;
+    assert!(
+        new_builds <= 2,
+        "4 events fired within {min}ms must coalesce to ≤2 applies (got {new_builds} new builds)",
+        min = 200
+    );
+}
+
+#[tokio::test]
 async fn apply_rebuilds_executor_when_provider_spec_changes() {
     let factory = Arc::new(CountingProviderFactory::default());
     let (_runtime, store, manager) = make_runtime_manager_custom(

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -1627,3 +1627,71 @@ async fn failed_publish_stops_prepared_mcp_registry() {
         "failed publish must not leak prepared MCP tools into the live runtime"
     );
 }
+
+// ── apply / apply_if_changed semantics ──────────────────────────────
+//
+// These tests pin the externally-visible contract of the apply path:
+//   * apply() always rebuilds and publishes a snapshot, returning a
+//     strictly increasing registry version even when the underlying
+//     store is unchanged.
+//   * apply_if_changed() returns Some(version) on first call after a
+//     mutation and None when nothing has changed since the last apply.
+
+#[tokio::test]
+async fn apply_returns_monotonically_advancing_version() {
+    let (_runtime, _store, manager) = make_runtime_manager(None).await;
+
+    let first = manager.apply().await.expect("first apply");
+    let second = manager.apply().await.expect("second apply");
+
+    assert!(
+        second > first,
+        "apply() must always publish and advance the registry version, got {first} then {second}"
+    );
+}
+
+#[tokio::test]
+async fn apply_if_changed_returns_none_when_nothing_changed() {
+    let (_runtime, _store, manager) = make_runtime_manager(None).await;
+
+    let result = manager
+        .apply_if_changed()
+        .await
+        .expect("apply_if_changed succeeds");
+    assert!(
+        result.is_none(),
+        "apply_if_changed must return None when the snapshot fingerprint matches the last applied"
+    );
+}
+
+#[tokio::test]
+async fn apply_if_changed_returns_some_after_store_mutation() {
+    let (_runtime, store, manager) = make_runtime_manager(None).await;
+
+    // Mutating the providers namespace must invalidate the previously
+    // applied fingerprint so apply_if_changed publishes again.
+    let new_provider = json!({
+        "id": "extra",
+        "adapter": "stub"
+    });
+    (store.clone() as Arc<dyn ConfigStore>)
+        .put("providers", "extra", &new_provider)
+        .await
+        .expect("write extra provider");
+
+    let result = manager
+        .apply_if_changed()
+        .await
+        .expect("apply_if_changed succeeds")
+        .expect("store mutation must produce a new fingerprint");
+
+    let after_no_change = manager
+        .apply_if_changed()
+        .await
+        .expect("apply_if_changed succeeds");
+    assert!(
+        after_no_change.is_none(),
+        "calling apply_if_changed twice without further mutation must return None"
+    );
+    let _ = result;
+}

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -80,6 +80,37 @@ impl ProviderExecutorFactory for TestProviderFactory {
     }
 }
 
+/// Test factory that records how many times `build` runs per provider id —
+/// used to assert that the executor cache reuses unchanged providers.
+#[derive(Default)]
+struct CountingProviderFactory {
+    builds_per_id: Arc<Mutex<std::collections::HashMap<String, usize>>>,
+}
+
+impl CountingProviderFactory {
+    fn builds_for(&self, id: &str) -> usize {
+        self.builds_per_id
+            .lock()
+            .expect("counts lock")
+            .get(id)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+impl ProviderExecutorFactory for CountingProviderFactory {
+    fn build(&self, spec: &ProviderSpec) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
+        let mut map = self.builds_per_id.lock().expect("counts lock");
+        *map.entry(spec.id.clone()).or_insert(0) += 1;
+        if spec.adapter.eq_ignore_ascii_case("stub") {
+            return Ok(Arc::new(ImmediateExecutor));
+        }
+        Err(ConfigRuntimeError::UnsupportedProviderAdapter(
+            spec.adapter.clone(),
+        ))
+    }
+}
+
 #[cfg(feature = "permission")]
 struct RecordingFallbackExecutor {
     attempts: Arc<Mutex<Vec<String>>>,
@@ -1661,6 +1692,68 @@ async fn apply_if_changed_returns_none_when_nothing_changed() {
     assert!(
         result.is_none(),
         "apply_if_changed must return None when the snapshot fingerprint matches the last applied"
+    );
+}
+
+#[tokio::test]
+async fn apply_reuses_executor_for_unchanged_provider() {
+    let factory = Arc::new(CountingProviderFactory::default());
+    let (_runtime, _store, manager) = make_runtime_manager_custom(
+        None,
+        Arc::new(TestMcpRegistryFactory),
+        None,
+        factory.clone() as Arc<dyn ProviderExecutorFactory>,
+        false,
+    )
+    .await;
+
+    let initial_builds = factory.builds_for("bootstrap");
+    assert!(
+        initial_builds >= 1,
+        "bootstrap apply should have built the provider at least once, got {initial_builds}"
+    );
+
+    manager.apply().await.expect("re-apply with no changes");
+
+    assert_eq!(
+        factory.builds_for("bootstrap"),
+        initial_builds,
+        "executor cache must reuse the unchanged provider across applies"
+    );
+}
+
+#[tokio::test]
+async fn apply_rebuilds_executor_when_provider_spec_changes() {
+    let factory = Arc::new(CountingProviderFactory::default());
+    let (_runtime, store, manager) = make_runtime_manager_custom(
+        None,
+        Arc::new(TestMcpRegistryFactory),
+        None,
+        factory.clone() as Arc<dyn ProviderExecutorFactory>,
+        false,
+    )
+    .await;
+
+    let initial_builds = factory.builds_for("bootstrap");
+
+    // Mutate the provider spec — different timeout makes the spec unequal,
+    // so the cache must miss and the factory must be invoked again.
+    let mutated = json!({
+        "id": "bootstrap",
+        "adapter": "stub",
+        "timeout_secs": 999
+    });
+    (store.clone() as Arc<dyn ConfigStore>)
+        .put("providers", "bootstrap", &mutated)
+        .await
+        .expect("write mutated provider");
+
+    manager.apply().await.expect("re-apply after mutation");
+
+    assert!(
+        factory.builds_for("bootstrap") > initial_builds,
+        "provider must be rebuilt when its spec changes (initial {initial_builds}, after {})",
+        factory.builds_for("bootstrap")
     );
 }
 


### PR DESCRIPTION
## Summary

Three coupled improvements to `ConfigRuntimeManager`, in TDD order via four discrete commits:

1. **Pin existing apply contract before changing it** (`🧪 test`). Three new tests in `config_api.rs` lock down the externally visible behavior of `apply()` and `apply_if_changed()`: monotonic version advance, fingerprint short-circuit on no-change, mutation invalidates the short-circuit. These pass on `main` today and serve as the safety net for the rest of the PR.
2. **Unify the apply path** (`🧹 refactor`). `apply_locked` and `apply_if_changed_locked` collapse into a single `apply_inner_locked(scope: ApplyScope)`. `ApplyScope::IfChanged` is the only one that may short-circuit; `ApplyScope::Full` always publishes. `apply_locked` remains as the `pub(crate)` entry point for callers in `config_service.rs` that already hold the apply lock — same signature, smaller body.
3. **Cache provider executors across applies** (`✨ feat`). New `provider_executor_cache: Mutex<ProviderExecutorCache>` field. `compile_registry_set` now reuses `Arc<dyn LlmExecutor>` for any provider whose `ProviderSpec` is byte-equal to the cached one; only changed (or new) specs hit the factory. The cache is rewritten from the current providers list each apply, so removed providers do not leak.
4. **Debounce change-listener bursts** (`✨ feat`). New `min_apply_interval: Duration` (default zero / no debounce) and `with_min_apply_interval(...)` builder. The change-listener loop sleeps until `last_applied + min_apply_interval` before each apply and drains any events that arrived during the wait via `tokio::time::timeout(Duration::ZERO, ...)`, so a burst coalesces into one `apply_if_changed`. Direct `apply()` / `apply_if_changed()` calls bypass this path entirely.

## Why

For the upstream wishlist tracker that drives high-frequency vault-rotation events: dozens of `Put` events per minute against a single namespace. Without coalescing, every event triggered a full registry recompile + executor rebuild for *every* provider, even those untouched. With the cache + debounce together, a burst of N rotation events for the same provider produces ~one apply and ~one rebuild, not N×K rebuilds.

Direct `apply()` semantics are unchanged — the framework's policy contract was that direct calls are never delayed. The debounce is a listener-loop policy, not a manager-level rate limit.

## Design notes

- **`ApplyScope` is an internal enum**, two variants today, signature-positioned to grow if a future caller wants `Namespace(&str)` style narrow loads. Not exposed publicly to keep the surface honest about what we actually ship.
- **Executor cache key is the full `ProviderSpec`**, not a hash. `ProviderSpec` already derives `PartialEq + Eq` and the comparison is sound (including the `RedactedString` field, which compares by exposed plaintext). Hash-based keying would have required pulling another crate or rolling a manual `Hash` impl over a `BTreeMap<String, Value>` — equality is simpler and provably correct.
- **Debounce is in the listener task**, not the manager. The manager's `min_apply_interval` is read once at listener-start and captured into the spawned task, so it does not need interior mutability. Direct apply paths never observe the field.
- **Drain via zero-duration `tokio::time::timeout`** is the canonical idiom for non-blocking poll over an async-only `next()` interface. The drained events are dropped intentionally; `apply_if_changed` reads the latest store snapshot and applies once for the whole burst.

## Test plan

- [x] `apply_returns_monotonically_advancing_version` — new safety-net test.
- [x] `apply_if_changed_returns_none_when_nothing_changed` — fingerprint short-circuit.
- [x] `apply_if_changed_returns_some_after_store_mutation` — invalidation.
- [x] `apply_reuses_executor_for_unchanged_provider` — cache hit on re-apply (RED before cache, GREEN after).
- [x] `apply_rebuilds_executor_when_provider_spec_changes` — cache miss on spec mutation.
- [x] `change_listener_coalesces_event_bursts_within_min_apply_interval` — 4 events fired within a 200ms window produce ≤2 applies.
- [x] All four existing `notify_listener_*` tests still pass with default `min_apply_interval = 0`.
- [x] Full workspace `cargo test --workspace --tests` and `cargo clippy -p awaken-server --all-targets` clean.

## Out of scope

Public `apply_partial(namespace: &str)` API: the original wishlist mentioned this but, as the design discussion concluded, the *executor cache* is the load-bearing optimization. A namespace-scoped partial loader saves a small amount of I/O on top, at the cost of an additional snapshot-tracking field and reasoning about staleness windows. We can add it later if profiling shows the load-managed-config phase as a bottleneck.