### PR TITLE
chore(deps): patch rustls-webpki to 0.103.13 and openssl to 0.10.78

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,9 +2756,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -2788,9 +2788,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -3681,9 +3681,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Two in-range security patches to the workspace lockfile (no Cargo.toml changes, no code changes):

- **rustls-webpki**: 0.103.10 → 0.103.13 — clears 1 high (`GHSA-82j2-j2ch-gfr8`) and 2 low CVEs that PR #141's async-nats bump only partially addressed (it landed on 0.103.10 which is still flagged).
- **openssl**: 0.10.76 → 0.10.78 — clears 5 alerts (4 high, 1 low) reachable via `model-context-protocol → reqwest 0.11 → hyper-tls → native-tls → openssl`.
- **openssl-sys**: 0.9.112 → 0.9.114 — pulled along with openssl 0.10.78.

## Why this didn't ride PR #141

PR #141 bumped `async-nats` 0.38 → 0.47 to escape the `rustls-webpki ^0.102` pin. That moved us into the 0.103 line, which Dependabot accepted as the "lowest-non-vulnerable-version" at the time, but additional CVEs landed against 0.103.10 / 0.103.11 since. `cargo update -p rustls-webpki` resolves them within the existing `^0.103` constraint without changing any Cargo.toml.

## Test plan

- [x] `cargo update -p rustls-webpki -p openssl` — clean, only lockfile churn.
- [x] `cargo test --workspace --lib` — all green (1095 + 594 + 139 + 115 + 6).
- [x] `cargo tree -i rustls-webpki@0.103.10` — package no longer in tree.
- [x] `cargo tree -i openssl` — sole version is 0.10.78.

## Out of scope

- The npm-side Dependabot alerts (vite, hono, postcss, dompurify, prismjs) live under `examples/` and `apps/admin-console`. Each has an open Dependabot auto-PR; they need separate review. Not blocking framework releases.
- `model-context-protocol 0.2.2` itself is the indirect cause of the older reqwest 0.11 → openssl pull. A future bump of that crate would let us drop reqwest 0.11 entirely. Out of scope here — this PR is a minimal-change security patch.