### PR TITLE
fix(server): type-tighten admin and A2A bearer tokens to RedactedString

### DIFF
--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, Weak};
 use std::time::Instant;
 
+use awaken_contract::RedactedString;
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::ThreadRunStore;
 use awaken_runtime::{AgentResolver, AgentRuntime};
@@ -100,8 +101,11 @@ pub enum MailboxLifecycleMode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AdminApiConfig {
     /// Optional bearer token required for admin/configuration APIs.
+    ///
+    /// Wrapped in [`RedactedString`] so it does not leak through `Debug` /
+    /// `Display`. The wire format remains a plain JSON string.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub bearer_token: Option<String>,
+    pub bearer_token: Option<RedactedString>,
     /// Origins allowed to call browser admin APIs.
     #[serde(default = "default_admin_cors_allowed_origins")]
     pub cors_allowed_origins: Vec<String>,
@@ -146,8 +150,11 @@ pub struct ServerConfig {
     #[serde(default = "default_max_concurrent")]
     pub max_concurrent_requests: usize,
     /// Optional bearer token required for authenticated extended A2A agent cards.
+    ///
+    /// Wrapped in [`RedactedString`] so it does not leak through `Debug` /
+    /// `Display`. The wire format remains a plain JSON string.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub a2a_extended_card_bearer_token: Option<String>,
+    pub a2a_extended_card_bearer_token: Option<RedactedString>,
     /// Mailbox lifecycle ownership. Defaults to framework-managed auto mode.
     #[serde(default)]
     pub mailbox_lifecycle: MailboxLifecycleMode,
@@ -173,11 +180,12 @@ fn admin_api_config_registry() -> &'static Mutex<AdminApiConfigRegistry> {
     ADMIN_API_CONFIGS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn admin_api_bearer_token_from_env() -> Option<String> {
+fn admin_api_bearer_token_from_env() -> Option<RedactedString> {
     std::env::var(ADMIN_API_BEARER_TOKEN_ENV)
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+        .map(RedactedString::from)
 }
 
 fn admin_cors_allowed_origins_from_env() -> Option<Vec<String>> {
@@ -326,7 +334,7 @@ impl AppState {
     }
 
     /// Require a bearer token for admin/configuration APIs.
-    pub fn with_admin_api_bearer_token(self, token: impl Into<String>) -> Self {
+    pub fn with_admin_api_bearer_token(self, token: impl Into<RedactedString>) -> Self {
         let mut config = admin_api_config(&self);
         config.bearer_token = Some(token.into());
         self.with_admin_api_config(config)
@@ -573,6 +581,32 @@ mod tests {
         assert!(
             config.expose_config_routes,
             "default AdminApiConfig must expose config CRUD routes for back-compat"
+        );
+    }
+
+    #[test]
+    fn admin_api_config_debug_does_not_leak_bearer_token() {
+        let config = AdminApiConfig {
+            bearer_token: Some("admin-bearer-secret-12345".into()),
+            ..AdminApiConfig::default()
+        };
+        let debug = format!("{config:?}");
+        assert!(
+            !debug.contains("admin-bearer-secret-12345"),
+            "AdminApiConfig Debug must redact bearer_token, got: {debug}"
+        );
+    }
+
+    #[test]
+    fn server_config_debug_does_not_leak_a2a_extended_card_bearer_token() {
+        let config = ServerConfig {
+            a2a_extended_card_bearer_token: Some("a2a-secret-67890".into()),
+            ..ServerConfig::default()
+        };
+        let debug = format!("{config:?}");
+        assert!(
+            !debug.contains("a2a-secret-67890"),
+            "ServerConfig Debug must redact a2a_extended_card_bearer_token, got: {debug}"
         );
     }
 

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -202,11 +202,11 @@ impl IntoResponse for ConfigRouteError {
 
 fn ensure_admin_auth(state: &AppState, headers: &HeaderMap) -> Result<(), ConfigRouteError> {
     let config = crate::app::admin_api_config(state);
-    ensure_admin_auth_for_token(config.bearer_token.as_deref(), headers)
+    ensure_admin_auth_for_token(config.bearer_token.as_ref(), headers)
 }
 
 fn ensure_admin_auth_for_token(
-    expected: Option<&str>,
+    expected: Option<&awaken_contract::RedactedString>,
     headers: &HeaderMap,
 ) -> Result<(), ConfigRouteError> {
     let Some(expected) = expected else {
@@ -228,7 +228,7 @@ fn ensure_admin_auth_for_token(
             "Authorization header must use Bearer authentication".into(),
         ));
     };
-    if token != expected {
+    if token != expected.expose_secret() {
         return Err(ConfigRouteError::Unauthorized(
             "invalid admin bearer token".into(),
         ));
@@ -257,6 +257,7 @@ fn map_service_error(error: ConfigServiceError) -> ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use awaken_contract::RedactedString;
     use axum::http::{HeaderMap, HeaderValue, header};
 
     #[test]
@@ -267,8 +268,9 @@ mod tests {
 
     #[test]
     fn admin_auth_rejects_missing_or_wrong_token() {
+        let expected = RedactedString::from("secret");
         let headers = HeaderMap::new();
-        let missing = ensure_admin_auth_for_token(Some("secret"), &headers).unwrap_err();
+        let missing = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
         assert_eq!(missing.into_response().status(), StatusCode::UNAUTHORIZED);
 
         let mut headers = HeaderMap::new();
@@ -276,17 +278,18 @@ mod tests {
             header::AUTHORIZATION,
             HeaderValue::from_static("Bearer wrong"),
         );
-        let wrong = ensure_admin_auth_for_token(Some("secret"), &headers).unwrap_err();
+        let wrong = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
         assert_eq!(wrong.into_response().status(), StatusCode::UNAUTHORIZED);
     }
 
     #[test]
     fn admin_auth_accepts_bearer_token() {
+        let expected = RedactedString::from("secret");
         let mut headers = HeaderMap::new();
         headers.insert(
             header::AUTHORIZATION,
             HeaderValue::from_static("Bearer secret"),
         );
-        assert!(ensure_admin_auth_for_token(Some("secret"), &headers).is_ok());
+        assert!(ensure_admin_auth_for_token(Some(&expected), &headers).is_ok());
     }
 }

--- a/crates/awaken-server/src/protocols/a2a/http.rs
+++ b/crates/awaken-server/src/protocols/a2a/http.rs
@@ -1944,7 +1944,7 @@ fn supports_extended_agent_card(st: &AppState) -> bool {
 }
 
 fn ensure_extended_card_auth(st: &AppState, headers: &HeaderMap) -> Result<(), A2aError> {
-    let Some(expected) = st.config.a2a_extended_card_bearer_token.as_deref() else {
+    let Some(expected) = st.config.a2a_extended_card_bearer_token.as_ref() else {
         return Err(A2aError::unsupported_operation(
             "extendedAgentCard is not configured for this agent",
         ));
@@ -1962,7 +1962,7 @@ fn ensure_extended_card_auth(st: &AppState, headers: &HeaderMap) -> Result<(), A
             "Authorization header must use Bearer authentication",
         ));
     };
-    if token.trim() != expected {
+    if token.trim() != expected.expose_secret() {
         return Err(A2aError::unauthenticated(
             "invalid bearer token for extendedAgentCard",
         ));

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -608,7 +608,7 @@ async fn make_app_with_admin_token(token: &str) -> TestApp {
         None,
         ServerConfig::default(),
         Some(AdminApiConfig {
-            bearer_token: Some(token.to_string()),
+            bearer_token: Some(token.into()),
             ..Default::default()
         }),
     )


### PR DESCRIPTION
## Summary

Two `Option<String>` fields holding live bearer tokens were derived through `Debug` and serialized in plaintext via `Serialize`. Switch both to `Option<RedactedString>` so they redact in logs / panic / error contexts and round-trip wire-compatibly.

- `AdminApiConfig::bearer_token` — protects the `/v1/config/*` and `/v1/agents` admin CRUD surface.
- `ServerConfig::a2a_extended_card_bearer_token` — protects the authenticated extended A2A agent card.

## Why

PR #138 introduced `RedactedString` to fix exactly this class of leak in `ProviderSpec::api_key`, but missed two siblings in `awaken-server` itself. Both fields:

- Live on a `#[derive(Debug)]` struct → `format!("{config:?}")` reveals the token.
- Are accepted from JSON / env / builder → can flow into structured logs as part of an `AppState` dump.

This isn't a hypothetical — `validate_admin_surface` and several admin tests construct `AdminApiConfig` and we already ship a panic-on-startup path that includes the config in error context.

## Design

- **Single trust boundary stays single.** The only new `expose_secret()` calls are at the `==` comparison in `ensure_admin_auth_for_token` (config_routes.rs) and `ensure_extended_card_auth` (a2a/http.rs). Grep for `expose_secret` in `awaken-server` after this PR returns exactly 3 sites: provider auth, admin auth, A2A auth — every place a token leaves its wrapper.
- **Wire-compat preserved.** `RedactedString` deserializes from a plain JSON string and serializes back to a plain JSON string. Existing config files / env exports load unchanged.
- **Builder ergonomics preserved.** `with_admin_api_bearer_token(token: impl Into<RedactedString>)` accepts `&str`, `String`, and `RedactedString` — no caller change required for the common cases.
- **Env var helper changed at the source.** `admin_api_bearer_token_from_env() -> Option<RedactedString>` wraps at the env boundary, so the plaintext string never escapes that function. The caller doesn't need to know.

## Test plan

- [x] `admin_api_config_debug_does_not_leak_bearer_token` — RED before the type change (printed `Some("admin-bearer-secret-12345")`), GREEN after.
- [x] `server_config_debug_does_not_leak_a2a_extended_card_bearer_token` — same RED→GREEN cycle.
- [x] Existing `admin_auth_allows_unconfigured_routes`, `admin_auth_rejects_missing_or_wrong_token`, `admin_auth_accepts_bearer_token` — updated test fixtures construct `RedactedString::from("secret")`, otherwise unchanged. All pass.
- [x] Full `cargo test -p awaken-server` — 28 test summaries, 0 failures.
- [x] `cargo clippy -p awaken-server --all-targets` — clean (no new warnings on awaken-server; pre-existing warnings on awaken-contract / awaken-runtime are unrelated).

## Migration

Wire format: no migration needed.

Struct literal callers (test fixtures, config builders):

```diff
- bearer_token: Some("token".to_string()),
+ bearer_token: Some("token".into()),
```

`.into()` works because `RedactedString: From<String> + From<&str>`.

## Out of scope

- `RemoteAuth::params: BTreeMap<String, Value>` stores the bearer token in a generic JSON map when `auth_type == "bearer"`. Replacing this with a typed enum is the audit's #4 `AuthStrategy` work and needs concrete adapter requirements (Bedrock SigV4, Vertex GCP service-account JSON, mTLS) before a non-speculative design can land. Tracked separately.