### PR TITLE
feat(runtime): wire per-run BackgroundTaskManager + summarizer for context auto-compaction

### DIFF
--- a/crates/awaken-runtime/src/extensions/background/mod.rs
+++ b/crates/awaken-runtime/src/extensions/background/mod.rs
@@ -23,8 +23,8 @@ pub use plugin::BackgroundTaskPlugin;
 pub use send_message_tool::SendMessageTool;
 pub use state::{BackgroundTaskViewKey, PersistedTaskMeta};
 pub use types::{
-    AgentTaskContext, TaskContext, TaskEvent, TaskId, TaskParentContext, TaskResult, TaskStatus,
-    TaskSummary,
+    AgentTaskContext, BACKGROUND_TASKS_PLUGIN_ID, TaskContext, TaskEvent, TaskId,
+    TaskParentContext, TaskResult, TaskStatus, TaskSummary,
 };
 
 #[cfg(test)]

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -41,6 +41,142 @@ struct PreparedLocalRootExecution {
     phase_runtime: crate::phase::PhaseRuntime,
     inbox: crate::inbox::InboxReceiver,
     inbox_sender: crate::inbox::InboxSender,
+    /// Per-run wiring for context auto-compaction. Some when the preflight
+    /// resolved agent declared `autocompact_threshold` and the runtime had
+    /// not already attached a manager + summarizer.
+    compaction: Option<CompactionRuntime>,
+}
+
+/// Per-run context auto-compaction wiring: shared manager + summarizer that
+/// the loop's resolver-wrapper grafts onto every `ResolvedAgent` it produces.
+#[derive(Clone)]
+struct CompactionRuntime {
+    manager: std::sync::Arc<crate::extensions::background::BackgroundTaskManager>,
+    summarizer: std::sync::Arc<dyn crate::context::ContextSummarizer>,
+}
+
+/// Build the per-run compaction wiring when the preflight agent declared
+/// `autocompact_threshold` and no upstream code (builder, custom resolver)
+/// already attached a manager + summarizer.
+///
+/// The manager has its store and owner inbox bound here so background
+/// compaction tasks can commit metadata and deliver completion events.
+/// `BackgroundTaskPlugin`'s state keys are registered on the store; if a
+/// matching plugin is already installed the dup error is treated as a
+/// no-op since the keys are already live.
+fn build_compaction_runtime(
+    preflight_resolved: &crate::registry::ResolvedAgent,
+    store: &crate::state::StateStore,
+    owner_inbox: &crate::inbox::InboxSender,
+) -> Result<Option<CompactionRuntime>, AgentLoopError> {
+    let opts_in = preflight_resolved
+        .context_policy()
+        .and_then(|policy| policy.autocompact_threshold)
+        .is_some();
+    if !opts_in {
+        return Ok(None);
+    }
+    if preflight_resolved.background_manager.is_some()
+        && preflight_resolved.context_summarizer.is_some()
+    {
+        return Ok(None);
+    }
+
+    let manager = std::sync::Arc::new(crate::extensions::background::BackgroundTaskManager::new());
+    manager.set_store(store.clone());
+    manager.set_owner_inbox(owner_inbox.clone());
+
+    match store.install_plugin(crate::extensions::background::BackgroundTaskPlugin::new(
+        manager.clone(),
+    )) {
+        Ok(()) => {}
+        Err(awaken_contract::StateError::PluginAlreadyInstalled { .. }) => {
+            // Keys already registered by an upstream wiring; reuse store as-is.
+        }
+        Err(awaken_contract::StateError::KeyAlreadyRegistered { .. }) => {
+            // A different plugin owns one of the background-task keys; reuse them.
+        }
+        Err(error) => return Err(AgentLoopError::PhaseError(error)),
+    }
+
+    let compaction_config = preflight_resolved
+        .spec
+        .config::<crate::context::CompactionConfigKey>()
+        .unwrap_or_default();
+    let summarizer: std::sync::Arc<dyn crate::context::ContextSummarizer> = std::sync::Arc::new(
+        crate::context::DefaultSummarizer::with_config(compaction_config),
+    );
+
+    Ok(Some(CompactionRuntime {
+        manager,
+        summarizer,
+    }))
+}
+
+/// Resolver wrapper that grafts a per-run `BackgroundTaskManager` and
+/// `ContextSummarizer` onto every `ResolvedAgent` whose context policy opts
+/// in via `autocompact_threshold`. The same `Arc`s are reused across resolve
+/// calls so the manager bound during `bind_local_execution_env` is the one
+/// used by every subsequent loop step.
+struct CompactionResolver<'a> {
+    inner: &'a dyn crate::registry::ExecutionResolver,
+    runtime: CompactionRuntime,
+}
+
+impl<'a> CompactionResolver<'a> {
+    fn new(inner: &'a dyn crate::registry::ExecutionResolver, runtime: CompactionRuntime) -> Self {
+        Self { inner, runtime }
+    }
+
+    fn graft(
+        &self,
+        mut resolved: crate::registry::ResolvedAgent,
+    ) -> crate::registry::ResolvedAgent {
+        let opts_in = resolved
+            .context_policy()
+            .and_then(|policy| policy.autocompact_threshold)
+            .is_some();
+        if !opts_in {
+            return resolved;
+        }
+        if resolved.background_manager.is_none() {
+            resolved.background_manager = Some(self.runtime.manager.clone());
+        }
+        if resolved.context_summarizer.is_none() {
+            resolved.context_summarizer = Some(self.runtime.summarizer.clone());
+        }
+        resolved
+    }
+}
+
+impl crate::registry::AgentResolver for CompactionResolver<'_> {
+    fn resolve(
+        &self,
+        agent_id: &str,
+    ) -> Result<crate::registry::ResolvedAgent, crate::RuntimeError> {
+        self.inner
+            .resolve(agent_id)
+            .map(|resolved| self.graft(resolved))
+    }
+
+    fn agent_ids(&self) -> Vec<String> {
+        self.inner.agent_ids()
+    }
+}
+
+impl crate::registry::ExecutionResolver for CompactionResolver<'_> {
+    fn resolve_execution(
+        &self,
+        agent_id: &str,
+    ) -> Result<crate::registry::ResolvedExecution, crate::RuntimeError> {
+        let execution = self.inner.resolve_execution(agent_id)?;
+        Ok(match execution {
+            crate::registry::ResolvedExecution::Local(resolved) => {
+                crate::registry::ResolvedExecution::Local(Box::new(self.graft(*resolved)))
+            }
+            other => other,
+        })
+    }
 }
 
 impl AgentRuntime {
@@ -177,6 +313,7 @@ impl AgentRuntime {
         }
 
         let mut run_inbox = run_inbox;
+        let mut compaction_runtime: Option<CompactionRuntime> = None;
         let (messages, phase_runtime, inbox, live_inbox_sender, previous_non_local_state) =
             match &resolved_execution {
                 ResolvedExecution::Local(preflight_resolved) => {
@@ -191,6 +328,7 @@ impl AgentRuntime {
                             &thread_ctx,
                         )
                         .await?;
+                    compaction_runtime = prepared.compaction;
                     (
                         prepared.messages,
                         Some(prepared.phase_runtime),
@@ -237,12 +375,24 @@ impl AgentRuntime {
             None
         };
 
+        // Wrap the resolver so every `ResolvedAgent` it produces during this
+        // run carries the per-run compaction manager + summarizer when the
+        // agent opted in via `autocompact_threshold`. Lifetime is tied to
+        // `backend_request`, which is consumed before this scope ends.
+        let compaction_resolver = compaction_runtime
+            .clone()
+            .map(|runtime| CompactionResolver::new(run_resolver.as_ref(), runtime));
+        let resolver_for_backend: &dyn ExecutionResolver = match compaction_resolver.as_ref() {
+            Some(wrapper) => wrapper,
+            None => run_resolver.as_ref(),
+        };
+
         let backend_request = BackendRootRunRequest {
             agent_id: &agent_id,
             messages,
             new_messages,
             sink: sink.clone(),
-            resolver: run_resolver.as_ref(),
+            resolver: resolver_for_backend,
             run_identity: run_identity.clone(),
             checkpoint_store: match &resolved_execution {
                 ResolvedExecution::Local(_) => phase_runtime.as_ref().and(self.storage.as_deref()),
@@ -339,6 +489,8 @@ impl AgentRuntime {
         )
         .map_err(AgentLoopError::PhaseError)?;
 
+        let compaction = build_compaction_runtime(preflight_resolved, &store, &owner_inbox)?;
+
         let mut messages = if let Some(ctx) = thread_ctx {
             if let Some(ref prev_run) = ctx.latest_run
                 && let Some(ref persisted) = prev_run.state
@@ -382,6 +534,7 @@ impl AgentRuntime {
             phase_runtime,
             inbox: run_inbox.receiver,
             inbox_sender: owner_inbox,
+            compaction,
         })
     }
 

--- a/e2e/tests/mailbox.spec.ts
+++ b/e2e/tests/mailbox.spec.ts
@@ -12,7 +12,8 @@ test.describe('mailbox operations', () => {
     });
     expect(pushRes.status()).toBe(201);
     const body = await pushRes.json();
-    expect(body.job_id).toBeTruthy();
+    expect(body.dispatch_id).toBeTruthy();
+    expect(body.run_id).toBeTruthy();
     expect(body.thread_id).toBe(thread.id);
   });
 
@@ -27,7 +28,8 @@ test.describe('mailbox operations', () => {
     });
     expect(pushRes.status()).toBe(201);
     const body = await pushRes.json();
-    expect(body.job_id).toBeTruthy();
+    expect(body.dispatch_id).toBeTruthy();
+    expect(body.run_id).toBeTruthy();
   });
 
   test('peek thread mailbox returns items array', async ({ request }) => {


### PR DESCRIPTION
## Summary

- Auto-compaction (`maybe_spawn_compaction`) was implemented in `awaken-runtime` and unit-tested, but the resolve pipeline never attached `background_manager` or `context_summarizer` to `ResolvedAgent` — the spawn helper short-circuited at the first `None` gate even when the agent declared `autocompact_threshold`.
- This PR builds a per-run `BackgroundTaskManager` (store + owner-inbox bound) plus `DefaultSummarizer` inside `prepare_local_root_execution` whenever the preflight resolved agent opts in via `context_policy.autocompact_threshold`, then wraps the run resolver in a thin `CompactionResolver` that grafts the same `Arc`s onto every `ResolvedAgent` produced for the run (initial resolve + handoff re-resolves).
- Side fix: `e2e/tests/mailbox.spec.ts` was asserting the legacy `body.job_id`; the server has emitted `dispatch_id` since the mailbox refactor (`crates/awaken-server/src/routes.rs:605`). Aligned the assertions to `dispatch_id` + `run_id`.

Public API surfaces (`AgentLoopParams`, `BackendRootRunRequest`) are unchanged. The wrapper resolver is a private struct in `runtime::agent_runtime::runner` so the diff stays narrow (~156 net additions across 3 files).

## Test plan

- [x] `cargo test -p awaken-runtime` — 1150 passed, 0 failed (lib + integration).
- [x] `cargo test -p awaken-server -p awaken-examples -p awaken-stores -p awaken-contract` — all green.
- [x] `e2e/tests/*.spec.ts` (Playwright, scripted backend) — 173 passed.
- [x] `examples/copilotkit-starter/tests/e2e/*.spec.ts` (Next.js + scripted agent) — 12 passed.
- [x] `examples/ai-sdk-starter` vitest — 9 files / 44 passed; Vite UI smoke-tested in real browser (chat, send, SSE response, token usage).
- [x] `examples/openui-chat` vitest — 11 passed; Vite UI smoke-tested in real browser (renders OpenUI Lang structured response).
- [x] Auto-compaction triggered end-to-end: `compact` agent, 5-turn long thread (>3072 tokens) → `background_compaction_swap_applied pre_tokens=2559 post_tokens=33 boundary_index=5` in agent log (was 0 before this PR).