### PR TITLE
📝 docs(release): prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 Development work lands here before the next versioned release.
 
+## [0.4.0] - 2026-04-27
+
+This release adopts the `awaken` crate name on crates.io. Versions 0.1–0.3 of
+`awaken` belonged to a separate, now-archived crate maintained by
+[@brayniac](https://github.com/brayniac), who generously transferred the name —
+thank you. The codebase continues the line that previously shipped as
+`awaken-agent`; the 0.4 jump exists only to skip past the prior versions
+already published under the `awaken` name. There is no 0.3 release of this
+codebase. Rust imports remain `awaken` either way.
+
+The headline work since `awaken-agent 0.2.1`: streaming LLM calls now survive
+mid-stream failures and can resume across processes; threads carry a durable
+parent-child lineage with explicit child-delete strategies; provider keys and
+admin tokens redact themselves through `RedactedString`.
+
+### Added
+
+- New `AgentEvent::ToolCallCancel` and `AgentEvent::StreamReset` variants so
+  consumers can drop partial deltas during stream recovery without ambiguity.
+- `StreamCheckpointStore` contract for cross-process stream resume (the
+  in-process retry loop already covered same-process recovery).
+- `ProviderSpec.adapter_options`: a non-secret `BTreeMap<String, Value>` that
+  adapters can read for things like custom headers on OpenAI-compatible
+  proxies; unknown keys are accepted by the schema but ignored at build time.
+- Filtered thread queries (`ThreadQuery`/`ThreadPage`) and message paging
+  (`MessageQuery`/`MessagePage`) on `ThreadStore`, consumed by the AG-UI and
+  AI SDK v6 protocol routes.
+- Thread parent-child lineage: `Thread.parent_thread_id`,
+  `RunRequestSnapshot.parent_thread_id`, and
+  `ThreadStore::delete_thread_with_strategy` (`reject`/`detach`/`cascade`),
+  with backend-native overrides on the file, PostgreSQL, and NATS-buffered
+  stores.
+- `AdminApiConfig.expose_config_routes` toggle and
+  `ConfigRuntimeManager::with_min_apply_interval` for hardening and
+  debouncing the admin/config plane. Provider executors are reused across
+  applies whose `ProviderSpec` is unchanged.
+- `awaken::RedactedString` re-export from the facade so secret-handling code
+  no longer needs a direct `awaken-contract` dependency.
+
+### Changed
+
+- `ProviderSpec.api_key`, `AdminApiConfig.bearer_token`, and
+  `ServerConfig.a2a_extended_card_bearer_token` are now
+  `Option<RedactedString>`. JSON wire format is unchanged. Code that reads
+  these fields must call `.expose_secret()`; logging that relied on
+  `Debug`/`Display` now prints `***`.
+- `InferenceExecutionError` is `#[non_exhaustive]` and splits into retryable
+  (`Provider`, `RateLimited`, `Overloaded`, `Timeout`, `StreamInterrupted`),
+  permanent (`ContextOverflow`, `InvalidRequest`, `Unauthorized`,
+  `ModelNotFound`, `ContentFiltered`), and fail-fast (`AllModelsUnavailable`,
+  `Cancelled`) classes. `RateLimited` and `Overloaded` carry an optional
+  `retry_after` parsed from `Retry-After`. Prefer `is_retryable()`,
+  `counts_toward_circuit_breaker()`, and `retry_after()` over matching
+  specific variants.
+- Context compaction runs on a background task with single-flight semantics
+  and swaps the summary back through the owner inbox; the synchronous
+  `compact_with_llm` path is removed.
+
+### Fixed
+
+- NATS buffered thread store now quarantines poison WAL messages with
+  bounded NAK and a stable hash, so an unrecoverable entry no longer stalls
+  the WAL.
+- Background-task spawn commit failures surface through `SpawnError` and a
+  metric, rather than silently dropping the spawn.
+- Self-cancel commands now cascade across runs in the same lineage.
+- Thread-query history ordering hardened across server CI surfaces.
+
+### Compatibility
+
+- Existing serialized config keeps loading; `RedactedString` serializes and
+  deserializes as a plain JSON string.
+- The 0.4 jump is solely a name-collision skip; the Rust API additions and
+  changes are limited to the items above.
+- 0.2.0 mailbox and server-facing types remain compatible. The NATS backend
+  is additive behind the `awaken-stores/nats` feature.
+
 ## [0.2.1] - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "awaken-examples",
  "clap",
@@ -267,7 +267,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awaken"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -289,14 +289,14 @@ dependencies = [
 
 [[package]]
 name = "awaken-agent"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "awaken",
 ]
 
 [[package]]
 name = "awaken-contract"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-doctest"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-examples"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-deferred-tools"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-generative-ui"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-mcp"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-observability"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-permission"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-reminder"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-skills"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-protocol-a2a"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-stores"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-tool-pattern"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "glob-match",
  "regex",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.4.0-dev"
+version = "0.4.0"
 dependencies = [
  "awaken-examples",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0-dev"
+version = "0.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
@@ -32,19 +32,19 @@ keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-awaken-contract = { version = "0.4.0-dev", path = "crates/awaken-contract" }
-awaken-protocol-a2a = { version = "0.4.0-dev", path = "crates/awaken-protocol-a2a" }
-awaken-stores = { version = "0.4.0-dev", path = "crates/awaken-stores" }
-awaken-runtime = { version = "0.4.0-dev", path = "crates/awaken-runtime" }
-awaken-ext-permission = { version = "0.4.0-dev", path = "crates/awaken-ext-permission" }
-awaken-ext-observability = { version = "0.4.0-dev", path = "crates/awaken-ext-observability" }
-awaken-ext-mcp = { version = "0.4.0-dev", path = "crates/awaken-ext-mcp" }
-awaken-ext-skills = { version = "0.4.0-dev", path = "crates/awaken-ext-skills" }
-awaken-ext-reminder = { version = "0.4.0-dev", path = "crates/awaken-ext-reminder" }
-awaken-ext-generative-ui = { version = "0.4.0-dev", path = "crates/awaken-ext-generative-ui" }
-awaken-ext-deferred-tools = { version = "0.4.0-dev", path = "crates/awaken-ext-deferred-tools" }
-awaken-tool-pattern = { version = "0.4.0-dev", path = "crates/awaken-tool-pattern" }
-awaken-server = { version = "0.4.0-dev", path = "crates/awaken-server" }
+awaken-contract = { version = "0.4.0", path = "crates/awaken-contract" }
+awaken-protocol-a2a = { version = "0.4.0", path = "crates/awaken-protocol-a2a" }
+awaken-stores = { version = "0.4.0", path = "crates/awaken-stores" }
+awaken-runtime = { version = "0.4.0", path = "crates/awaken-runtime" }
+awaken-ext-permission = { version = "0.4.0", path = "crates/awaken-ext-permission" }
+awaken-ext-observability = { version = "0.4.0", path = "crates/awaken-ext-observability" }
+awaken-ext-mcp = { version = "0.4.0", path = "crates/awaken-ext-mcp" }
+awaken-ext-skills = { version = "0.4.0", path = "crates/awaken-ext-skills" }
+awaken-ext-reminder = { version = "0.4.0", path = "crates/awaken-ext-reminder" }
+awaken-ext-generative-ui = { version = "0.4.0", path = "crates/awaken-ext-generative-ui" }
+awaken-ext-deferred-tools = { version = "0.4.0", path = "crates/awaken-ext-deferred-tools" }
+awaken-tool-pattern = { version = "0.4.0", path = "crates/awaken-tool-pattern" }
+awaken-server = { version = "0.4.0", path = "crates/awaken-server" }
 glob-match = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/README.md
+++ b/README.md
@@ -2,49 +2,46 @@
 
 [English](./README.md) | [中文](./README.zh-CN.md)
 
-[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io awaken](https://img.shields.io/crates/v/awaken.svg?label=awaken)](https://crates.io/crates/awaken) [![crates.io awaken-agent](https://img.shields.io/crates/v/awaken-agent.svg?label=awaken-agent)](https://crates.io/crates/awaken-agent) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.93-orange)
+[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io awaken](https://img.shields.io/crates/v/awaken.svg?label=awaken)](https://crates.io/crates/awaken) [![crates.io awaken-agent](https://img.shields.io/crates/v/awaken-agent.svg?label=awaken-agent)](https://crates.io/crates/awaken-agent) [![Changelog](https://img.shields.io/badge/changelog-0.4.0-informational)](./CHANGELOG.md) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.93-orange)
 
-Production AI agent runtime for Rust — type-safe state, multi-protocol serving, plugin extensibility.
+A Rust agent runtime that serves AI SDK, CopilotKit, A2A, and MCP from the same backend, recovers from mid-stream LLM failures, and treats configuration as the control plane.
 
-Published on crates.io as both `awaken` and `awaken-agent`. `awaken` is the
-primary umbrella package; `awaken-agent` is a compatibility package. Import in
-Rust as `awaken` either way.
-The workspace uses Rust 1.93.0 for development; the crate MSRV is 1.93.
+`awaken` is the canonical crate (transferred to this project from
+[@brayniac](https://github.com/brayniac); see the acknowledgement below).
+`awaken-agent` is a thin compatibility republish from when the project shipped
+under that name. Import path is `awaken` either way. MSRV: Rust 1.93.
 
-Docs: [GitHub Pages](https://awakenworks.github.io/awaken/) | [Chinese docs](https://awakenworks.github.io/awaken/zh-CN/)
+Docs: [GitHub Pages](https://awakenworks.github.io/awaken/) · [Chinese docs](https://awakenworks.github.io/awaken/zh-CN/) · [Changelog](./CHANGELOG.md)
 
 <p align="center">
   <img src="./docs/assets/demo.svg" alt="Awaken demo — tool call + LLM streaming" width="800">
 </p>
 
-## Highlights
+## What you get in 0.4
 
-- **Rust-first agent runtime**: typed tools, generated JSON Schema, typed state keys, scoped snapshots, and atomic state commits.
-- **One runtime, many clients**: HTTP/SSE run API, AI SDK v6, AG-UI/CopilotKit, A2A, and MCP JSON-RPC from the same backend.
-- **Configuration-first optimization**: choose models/providers, tune prompts, reminders, permissions, generative UI, and deferred tools through `/v1/config/*`, `/v1/capabilities`, and the admin console.
-- **Production control paths**: mailbox-backed background runs, HITL decisions, cancellation/interrupt, SSE replay, retries, fallback models, circuit breakers, metrics, and health probes.
-- **Plugin surface**: permission gates, reminders, OpenTelemetry, MCP tools, skills, generative UI, and deferred tool loading with an explicit probability model.
+- **Multi-protocol from one backend.** A single runtime serves AI SDK v6, AG-UI / CopilotKit, A2A, and MCP. The same `/v1/runs` powers all of them.
+- **Streaming LLM calls survive transient failures.** Mid-stream interruptions and idle stalls are detected and recovered through four explicit plans (continue text, replay completed tool calls, restart with a cancelled-tool hint, or whole restart). `Retry-After` is honored. A `StreamCheckpointStore` contract extends the same recovery across process restarts. ([details](./docs/book/src/how-to/recover-streaming-llms.md))
+- **Threads have a parent-child lineage.** Sub-agent runs create child threads; deletion is explicit (`reject` / `detach` / `cascade`). Filters and cursors on `/v1/threads` make hierarchical UIs straightforward.
+- **Secrets stay redacted.** `ProviderSpec.api_key`, admin and A2A bearer tokens are wrapped in `RedactedString` — `Debug`/`Display` print `***`, the buffer is zeroized on drop, and the JSON wire format is unchanged.
+- **Configuration is the control plane.** Models, providers, prompts, reminders, permissions, and tool-loading policy live behind `/v1/config/*` and `/v1/capabilities`. Apply bursts can be debounced and provider executors are reused across unchanged specs.
+- **Type-safe state and tools.** Typed `StateKey`s with merge strategies, generated JSON Schema for `TypedTool`, atomic batched commits after each phase. `unsafe_code = "forbid"` workspace-wide.
 
-## 30-second mental model
+## Mental model
 
-1. **Tools** — implement `Tool` directly or `TypedTool` with `schemars`-generated JSON Schema
-2. **Agents** — each agent has a system prompt, a model, and a set of allowed tools; the LLM drives orchestration through natural language — no predefined graphs
-3. **State** — typed run/thread state plus persistent profile/shared state for cross-thread or cross-agent coordination
-4. **Plugins** — lifecycle hooks for permissions, observability, context management, skills, MCP, and more
+1. **Tools** — implement `Tool` directly, or `TypedTool` with `schemars`-generated JSON Schema.
+2. **Agents** — system prompt, model binding, allowed tools. The LLM orchestrates through natural language; there is no DAG.
+3. **State** — typed run/thread state plus persistent profile and shared state for cross-thread or cross-agent coordination.
+4. **Plugins** — lifecycle hooks for permission, observability, context management, skills, MCP, generative UI.
 
-Your agent picks tools, calls them, reads and updates state, and repeats — all orchestrated by the runtime through 9 typed phases, including a pure `ToolGate` before tool execution. Every state change is committed atomically after the gather phase.
+The runtime drives 9 typed phases per round, including a pure `ToolGate` before tool execution. State mutations are batched and committed atomically.
 
-## Try it in 5 minutes
+## Quickstart
 
-Prerequisites: Rust 1.93+ for the published crate, or the pinned `rust-toolchain.toml`
-toolchain when working from this repository, plus an LLM provider API key.
-
-- Rust 1.93 or newer. This repository pins Rust 1.93.0 for local development.
-- An OpenAI-compatible API key.
+Prerequisites: Rust 1.93+ and an OpenAI-compatible API key.
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1.51.0", features = ["full"] }
 async-trait = "0.1.89"
 serde_json = "1.0.149"
@@ -169,36 +166,33 @@ serve(state).await?;
 | A2A | `POST /v1/a2a/message:send` | Other agents |
 | MCP | `POST /v1/mcp` | JSON-RPC 2.0 |
 
-The optional admin console uses `/v1/capabilities` and `/v1/config/*` to edit
-agents, models, providers, MCP servers, and plugin config sections in the
-browser. Plugins expose JSON Schema through the same typed `PluginConfigKey`
-path used by runtime hooks, so saving an agent section such as `permission`,
-`reminder`, `generative-ui`, or `deferred_tools` publishes a new registry
-snapshot and applies to subsequent `/v1/runs` requests. OpenAI-compatible
-providers, including BigModel, use the `openai` adapter with a provider-specific
-`base_url`.
+The optional admin console reads `/v1/capabilities` and writes through
+`/v1/config/*` to manage agents, models, providers, MCP servers, and plugin
+config sections. Plugins expose their schema via the same typed
+`PluginConfigKey` used at runtime, so saving an agent's `permission`,
+`reminder`, `generative-ui`, or `deferred_tools` section publishes a new
+registry snapshot that takes effect on the next `/v1/runs` request.
+OpenAI-compatible providers (including BigModel) use the `openai` adapter
+with their own `base_url`; non-secret extras go in `ProviderSpec.adapter_options`.
 
-The design intent is that agent optimization stays data-driven: model choice,
-provider endpoints, base prompts, system reminders, generated-UI instructions,
-permission policy, and tool-loading policy should be configured through the
-same schema-backed path rather than hard-coded into the agent loop.
-
-| Tuning surface | Configuration path |
+| Tuning surface | Where it lives |
 |---|---|
-| Base prompt | `AgentSpec.system_prompt` on the agent entry |
-| Model and provider routing | `AgentSpec.model_id`, `/v1/config/models`, `/v1/config/providers` |
-| System reminders and prompt context injection | `reminder` plugin section, using `system` or `suffix_system` targets |
-| Generative UI prompt guidance | `generative-ui` plugin section (`catalog_id`, `examples`, or full `instructions`) |
+| Base prompt | `AgentSpec.system_prompt` |
+| Model and provider routing | `AgentSpec.model_id` + `/v1/config/models` + `/v1/config/providers` |
+| System reminders and prompt injection | `reminder` plugin section |
+| Generative UI prompt guidance | `generative-ui` plugin section |
 | Tool policy and context cost | `permission` and `deferred_tools` plugin sections |
-| Prompt semantic hooks | Not a built-in plugin yet; add them as typed `PluginConfigKey` sections with schema-backed hooks |
 
 **React + AI SDK v6:**
 
 ```typescript
-import { useChat } from "ai/react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
 
-const { messages, input, handleSubmit } = useChat({
-  api: "http://localhost:3000/v1/ai-sdk/chat",
+const { messages, sendMessage } = useChat({
+  transport: new DefaultChatTransport({
+    api: "http://localhost:3000/v1/ai-sdk/chat",
+  }),
 });
 ```
 
@@ -218,54 +212,37 @@ Wire a `ConfigStore` into `AppState` to manage agents, models, providers, and MC
 
 ## Built-in plugins
 
-Facade features are enabled by default via the `full` feature. Use
-`default-features = false` to opt out. Workspace extension crates that are not
-re-exported by the facade, such as deferred tools, are added as direct
-dependencies.
+The facade `full` feature pulls in the plugins below. Use
+`default-features = false` to opt out. `awaken-ext-deferred-tools` is not
+re-exported by the facade and is added as a direct dependency.
 
 | Plugin | What it does | Feature flag |
 |---|---|---|
-| **Permission** | Firewall-style tool access control with Deny/Allow/Ask rules, glob/regex matching, and HITL suspension via mailbox. | `permission` |
-| **Reminder** | Injects system or conversation-level context messages when tool calls match configured patterns. | `reminder` |
-| **Observability** | OpenTelemetry telemetry aligned with GenAI Semantic Conventions; supports OTLP, file, and in-memory export. | `observability` |
+| **Permission** | Allow/Deny/Ask rules with glob and regex matching on tool name and arguments. Deny beats Allow beats Ask; Ask suspends the run via the mailbox for HITL. | `permission` |
+| **Reminder** | Injects system or conversation-level context messages when a tool call matches a configured pattern. | `reminder` |
+| **Observability** | OpenTelemetry traces and metrics aligned with the GenAI Semantic Conventions; OTLP, file, and in-memory exports. | `observability` |
 | **MCP** | Connects to external MCP servers and registers their tools as native Awaken tools. | `mcp` |
 | **Skills** | Discovers skill packages and injects a catalog before inference so the LLM can activate skills on demand. | `skills` |
 | **Generative UI** | Streams declarative UI components to frontends via A2UI, JSON Render, and OpenUI Lang integrations. | `generative-ui` |
-| **Deferred Tools** | Hides large tool schemas behind `ToolSearch`, then uses a discounted Beta probability model to re-defer idle promoted tools. | direct crate: `awaken-ext-deferred-tools` |
+| **Deferred Tools** | Hides large tool schemas behind a `ToolSearch` step, then re-defers tools that have been idle for a configurable number of turns using a discounted Beta usage model. | direct crate: `awaken-ext-deferred-tools` |
 
-Deferred tools are configured through the `deferred_tools` agent section when
-the `ext-deferred-tools` plugin is registered. See
-[Use Deferred Tools](./docs/book/src/how-to/use-deferred-tools.md) for setup,
-the activation heuristic, and the DiscBeta probability model.
+Custom tool interception goes through `ToolGateHook` via
+`PluginRegistrar::register_tool_gate_hook()`. `BeforeToolExecute` is reserved
+for execution-time hooks that only run when a tool is actually about to execute.
 
-Custom interception hooks should use `ToolGateHook` via `PluginRegistrar::register_tool_gate_hook()`. `BeforeToolExecute` is reserved for execution-time hooks that run only when a tool is actually about to execute.
+## When this fits
 
-## Why Awaken
+- You want a **Rust backend** for AI agents with compile-time guarantees.
+- You need to serve **AI SDK, CopilotKit, A2A, and/or MCP** from a single backend.
+- Tools need to **share state safely** during concurrent execution, and runs need **auditable history** with checkpoints and resume.
+- You're comfortable registering your own tools and providers instead of relying on batteries-included defaults.
 
-- One backend serves multiple protocols: AI SDK v6, AG-UI, A2A, MCP, plus native HTTP/SSE routes.
-- Configuration is the control plane: model/provider routing, prompts, reminders, permissions, and tool-loading policy use schema-backed config that can be validated and applied at runtime.
-- The LLM orchestrates: define the agent identity, model binding, and tool access; no hand-coded DAG is required.
-- Runtime-managed configuration updates agents, model bindings, providers, and MCP servers through the Config API or Admin Console.
-- Plugin extension points are typed: 9 lifecycle phases, `PhaseHook`, `ToolGateHook`, scheduled actions, effects, request transforms, and plugin-provided tools.
-- State is type-safe: `StateKey` binds each key to Rust value/update types, scopes it to run/thread/profile, and applies declared merge strategies before commit.
-- Operational surfaces are built in: LLM retry/backoff, per-model circuit breaker, request timeout, graceful shutdown, Prometheus metrics, health probes, and mailbox retry/backoff.
-- Zero `unsafe` — the entire workspace forbids `unsafe` and relies on the Rust compiler for memory safety.
+## When it doesn't
 
-## When to use Awaken
-
-- You want a **Rust backend** for AI agents with compile-time safety
-- You need to serve **multiple frontend or agent protocols** from one backend
-- Your tools need to **safely share state** during concurrent execution
-- You need **auditable thread history**, checkpoints, and resumable control paths
-- You are comfortable wiring your own tools, providers, and model registry instead of relying on batteries-included defaults
-
-## When NOT to use Awaken
-
-- You need **built-in file/shell/web tools** out of the box — consider OpenAI Agents SDK, Dify, or CrewAI
-- You want a **visual workflow builder** — consider Dify, LangGraph Studio
-- You want **Python** and rapid prototyping — consider LangGraph, AG2, PydanticAI
-- You need a **stable, slow-moving surface area** more than an evolving runtime platform
-- You need **LLM-managed memory** (agent decides what to remember) — consider Letta
+- You need **built-in file/shell/web tools** out of the box — consider OpenAI Agents SDK, Dify, or CrewAI.
+- You want a **visual workflow builder** — consider Dify or LangGraph Studio.
+- You want **Python** and rapid prototyping — consider LangGraph, AG2, or PydanticAI.
+- You need an **LLM-managed memory** subsystem where the agent decides what to remember — consider Letta.
 
 ## Architecture
 
@@ -333,9 +310,19 @@ Areas where contributions are especially welcome:
 
 Join the conversation on [GitHub Discussions](https://github.com/AwakenWorks/awaken/discussions).
 
----
+## Acknowledgement
 
-Awaken is a ground-up rewrite of [tirea](../../tree/tirea-0.5); it is not backwards-compatible. The tirea 0.5 codebase is archived on the [`tirea-0.5`](../../tree/tirea-0.5) branch.
+The `awaken` crate name on crates.io was generously transferred from
+[@brayniac](https://github.com/brayniac), who maintained an earlier crate
+under the same name and offered to hand it over so this project could publish
+canonically. Versions `0.1`–`0.3` of `awaken` on crates.io belong to that
+earlier project; this codebase resumes the line that previously shipped as
+`awaken-agent 0.2.x` and starts at `0.4.0` to skip past the prior versions.
+Thank you.
+
+Awaken is also a ground-up rewrite of [tirea](../../tree/tirea-0.5) and is not
+backwards-compatible with it. The tirea 0.5 codebase remains archived on the
+[`tirea-0.5`](../../tree/tirea-0.5) branch.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,47 +2,47 @@
 
 [English](./README.md) | [中文](./README.zh-CN.md)
 
-[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io awaken](https://img.shields.io/crates/v/awaken.svg?label=awaken)](https://crates.io/crates/awaken) [![crates.io awaken-agent](https://img.shields.io/crates/v/awaken-agent.svg?label=awaken-agent)](https://crates.io/crates/awaken-agent) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.93-orange)
+[![CI](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml/badge.svg)](https://github.com/AwakenWorks/awaken/actions/workflows/test.yml) [![crates.io awaken](https://img.shields.io/crates/v/awaken.svg?label=awaken)](https://crates.io/crates/awaken) [![crates.io awaken-agent](https://img.shields.io/crates/v/awaken-agent.svg?label=awaken-agent)](https://crates.io/crates/awaken-agent) [![Changelog](https://img.shields.io/badge/changelog-0.4.0-informational)](./CHANGELOG.md) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue) ![MSRV](https://img.shields.io/badge/MSRV-1.93-orange)
 
-生产级 Rust AI Agent 运行时 — 类型安全状态、多协议服务、插件化扩展。
+一个用 Rust 写的 Agent runtime：同一份 backend 同时给 AI SDK、CopilotKit、A2A、MCP 用，能在 LLM 流式过程中自愈，并把配置当作真正的控制面。
 
-在 crates.io 上同时发布 `awaken` 和 `awaken-agent`。其中 `awaken`
-是主 umbrella package，`awaken-agent` 是兼容包；两者在 Rust 代码中都保持导入为
-`awaken`。
-仓库开发工具链由 Rust 1.93.0 固定，crate 的 MSRV 为 1.93。
+`awaken` 是当前的规范 crate（由 [@brayniac](https://github.com/brayniac) 转
+让而来，详见下方鸣谢）。`awaken-agent` 是项目早期发布期的兼容包，导入名都是
+`awaken`。MSRV：Rust 1.93。
 
-在线文档：[GitHub Pages（英文）](https://awakenworks.github.io/awaken/) | [GitHub Pages（中文）](https://awakenworks.github.io/awaken/zh-CN/)
+在线文档：[GitHub Pages（英文）](https://awakenworks.github.io/awaken/) ·
+[GitHub Pages（中文）](https://awakenworks.github.io/awaken/zh-CN/) ·
+[Changelog](./CHANGELOG.md)
 
 <p align="center">
   <img src="./docs/assets/demo.svg" alt="Awaken 演示 — 工具调用 + LLM 流式输出" width="800">
 </p>
 
-## 亮点
+## 0.4 给你什么
 
-- **Rust-first Agent Runtime**：类型化工具、自动生成 JSON Schema、类型化 state key、作用域化 snapshot，以及原子状态提交。
-- **一个 runtime 服务多类客户端**：同一后端同时提供 HTTP/SSE run API、AI SDK v6、AG-UI/CopilotKit、A2A 与 MCP JSON-RPC。
-- **配置优先的优化控制面**：model/provider 选择、prompt、reminder、permission、generative UI 与 deferred tools 都通过 `/v1/config/*`、`/v1/capabilities` 和 admin console 管理。
-- **生产控制路径**：mailbox 后台 run、HITL 决策、取消/中断、SSE replay、重试、fallback model、熔断器、指标和健康检查。
-- **插件能力面**：权限网关、Reminder、OpenTelemetry、MCP tools、Skills、Generative UI，以及带明确概率模型的 deferred tool loading。
+- **一个 backend 同时多协议。** 同一个 runtime 同时提供 AI SDK v6、AG-UI / CopilotKit、A2A、MCP；它们都跑在同一个 `/v1/runs` 之上。
+- **流式 LLM 调用能从瞬时故障中恢复。** mid-stream 中断与 idle stall 会被识别，并按四种明确方案恢复：继续文本、回放已完成的 tool call、注入 cancelled tool 提示重启、整轮重启；`Retry-After` 被尊重；`StreamCheckpointStore` 契约让恢复可以跨进程。 ([详情](./docs/book/src/zh-CN/how-to/recover-streaming-llms.md))
+- **Thread 有父子层级。** sub-agent run 会创建子 thread，删除策略需显式指定（`reject` / `detach` / `cascade`）；`/v1/threads` 上的过滤与游标让带层级的 UI 直接好做。
+- **凭据自动遮蔽。** `ProviderSpec.api_key`、admin / A2A bearer token 都用 `RedactedString` 包裹：`Debug`/`Display` 输出 `***`，`Drop` 时清零，JSON 序列化保持不变。
+- **配置即控制面。** model、provider、prompt、reminder、permission、tool-loading 策略都在 `/v1/config/*` 与 `/v1/capabilities` 后面；apply 可以去抖，未变化的 provider executor 会被复用。
+- **类型安全的状态与工具。** 类型化 `StateKey` + 合并策略，`TypedTool` 自动生成 JSON Schema，每个 phase 后批量原子提交。整个 workspace `unsafe_code = "forbid"`。
 
-## 30 秒速览
+## 心智模型
 
-1. **Tools** — 可直接实现 `Tool`，也可用 `TypedTool` 通过 `schemars` 生成 JSON Schema
-2. **Agents** — 每个 Agent 拥有系统提示词、模型和允许的工具集；LLM 通过自然语言驱动编排 — 无需预定义流程图
-3. **State** — 既有 `run` / `thread` 作用域的类型化状态，也有用于跨线程/跨 Agent 协作的持久化 profile/shared state
-4. **Plugins** — 生命周期钩子覆盖权限、可观测性、上下文管理、Skills、MCP 等
+1. **Tools** — 直接实现 `Tool`，或用 `TypedTool` 通过 `schemars` 生成 JSON Schema。
+2. **Agents** — 系统提示词 + model binding + 允许的工具集；LLM 用自然语言编排，没有 DAG。
+3. **State** — `run`/`thread` 作用域的类型化状态，加上跨 thread/agent 协作用的持久 profile 与 shared state。
+4. **Plugins** — 覆盖 permission、可观测性、上下文管理、Skills、MCP、Generative UI 的生命周期钩子。
 
-Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运行时通过 9 个类型化阶段编排，其中在真正执行工具前增加了纯判定的 `ToolGate`。每次状态变更都在 gather 阶段后原子提交。
+runtime 每轮跑 9 个类型化 phase，其中包含一个纯判定的 `ToolGate`；状态变更在每轮结束时批量原子提交。
 
-## 5 分钟上手
+## 上手
 
-**前置条件：** 使用发布 crate 时需要 Rust `1.93+`；从本仓库运行示例时使用 `rust-toolchain.toml` 固定的 `1.93.0`；还需要一个 LLM 提供商 API Key。
-
-在 `Cargo.toml` 中添加：
+**前置条件：** Rust 1.93+ 和一个 OpenAI 兼容的 API Key。
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1.51.0", features = ["full"] }
 async-trait = "0.1.89"
 serde_json = "1.0.149"
@@ -176,33 +176,31 @@ serve(state).await?;
 | A2A | `POST /v1/a2a/message:send` | 其他 Agent |
 | MCP | `POST /v1/mcp` | JSON-RPC 2.0 |
 
-可选的 admin console 通过 `/v1/capabilities` 与 `/v1/config/*` 在页面中编辑
-agents、models、providers、MCP servers 以及插件配置 section。插件配置通过
-同一套类型化 `PluginConfigKey` 逻辑暴露 JSON Schema，运行时 hook 也从同一
-section 读取，因此保存 `permission`、`reminder`、`generative-ui` 或
-`deferred_tools` 后会发布新的 registry snapshot，并对后续 `/v1/runs` 生效。
-BigModel 等 OpenAI 兼容服务使用 `openai` adapter，并配置对应的 `base_url`。
+可选的 admin console 读取 `/v1/capabilities`、写入 `/v1/config/*`，在浏览器里
+管理 agents、models、providers、MCP servers 和插件配置 section。插件通过同一
+套 `PluginConfigKey` 暴露 schema，因此保存 `permission`、`reminder`、
+`generative-ui`、`deferred_tools` 等 section 后会发布新的 registry snapshot，
+对下一次 `/v1/runs` 立即生效。BigModel 等 OpenAI 兼容服务使用 `openai`
+adapter + 对应 `base_url`；非密的扩展项放到 `ProviderSpec.adapter_options`。
 
-设计意图是把 agent 优化能力保持为数据驱动：model 选择、provider 端点、基础
-prompt、system reminder、生成式 UI 指令、permission 策略和工具加载策略都应走
-同一套 schema-backed 配置链路，而不是硬编码进 agent loop。
-
-| 调优面 | 配置路径 |
+| 调优面 | 配置位置 |
 |---|---|
-| 基础 prompt | agent 条目中的 `AgentSpec.system_prompt` |
-| model/provider 路由 | `AgentSpec.model_id`、`/v1/config/models`、`/v1/config/providers` |
-| system reminder 与 prompt 上下文注入 | `reminder` 插件 section，使用 `system` 或 `suffix_system` target |
-| Generative UI prompt 指令 | `generative-ui` 插件 section（`catalog_id`、`examples` 或完整 `instructions`） |
+| 基础 prompt | `AgentSpec.system_prompt` |
+| model 与 provider 路由 | `AgentSpec.model_id` + `/v1/config/models` + `/v1/config/providers` |
+| system reminder 与 prompt 注入 | `reminder` 插件 section |
+| Generative UI prompt 指令 | `generative-ui` 插件 section |
 | 工具策略与上下文成本 | `permission` 与 `deferred_tools` 插件 section |
-| prompt 语义 hook | 当前还不是内置插件；后续应以类型化 `PluginConfigKey` section 和 schema-backed hook 接入 |
 
 **React + AI SDK v6：**
 
 ```typescript
-import { useChat } from "ai/react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
 
-const { messages, input, handleSubmit } = useChat({
-  api: "http://localhost:3000/v1/ai-sdk/chat",
+const { messages, sendMessage } = useChat({
+  transport: new DefaultChatTransport({
+    api: "http://localhost:3000/v1/ai-sdk/chat",
+  }),
 });
 ```
 
@@ -222,51 +220,35 @@ import { CopilotKit } from "@copilotkit/react-core";
 
 ## 内置插件
 
-| Plugin | 说明 | Feature Flag |
+门面 crate 的 `full` feature 默认启用以下插件。`default-features = false` 可
+按需关闭。`awaken-ext-deferred-tools` 不被门面 crate 重新导出，需要直接依赖。
+
+| 插件 | 作用 | Feature flag |
 |---|---|---|
-| **Permission** | 防火墙式工具访问控制，支持 Deny/Allow/Ask 规则、glob/正则匹配和 HITL 邮箱暂停。 | `permission` |
-| **Reminder** | 工具调用匹配模式时自动注入 system/conversation 级别的上下文消息。 | `reminder` |
-| **Observability** | 符合 GenAI 语义规范的 OpenTelemetry 遥测，支持 OTLP、文件和内存导出。 | `observability` |
-| **MCP** | 连接外部 MCP 服务器，自动发现并注册其工具为 Awaken 原生工具。 | `mcp` |
-| **Skills** | 发现技能包，推理前注入技能目录供 LLM 按需激活。 | `skills` |
-| **Generative UI** | 通过 A2UI、JSON Render 和 OpenUI Lang 集成向前端流式推送声明式 UI 组件。 | `generative-ui` |
-| **Deferred Tools** | 将大型工具 schema 隐藏在 `ToolSearch` 之后，并用折扣 Beta 概率模型把空闲的已提升工具重新延迟。 | 直接依赖：`awaken-ext-deferred-tools` |
+| **Permission** | Allow/Deny/Ask 规则匹配工具名和参数（支持 glob 与正则）。优先级 Deny > Allow > Ask；Ask 通过 mailbox 暂停 run，等待 HITL 决策。 | `permission` |
+| **Reminder** | 工具调用匹配某模式时，在 system 或会话级注入上下文消息。 | `reminder` |
+| **Observability** | 与 GenAI Semantic Conventions 对齐的 OpenTelemetry trace 与 metric；支持 OTLP、文件和内存导出。 | `observability` |
+| **MCP** | 连接外部 MCP server，把它们的工具注册成 Awaken 原生工具。 | `mcp` |
+| **Skills** | 发现 skill 包，推理前注入 catalog 让 LLM 按需激活。 | `skills` |
+| **Generative UI** | 通过 A2UI、JSON Render、OpenUI Lang 把声明式 UI 组件流式发到前端。 | `generative-ui` |
+| **Deferred Tools** | 把大体量工具 schema 藏在 `ToolSearch` 后，连续多轮没用就用折扣 Beta 用量模型把已提升的工具重新延迟。 | 直接依赖：`awaken-ext-deferred-tools` |
 
-`awaken-ext-deferred-tools` 未包含在 `awaken` 门面 crate 的 `full` feature 中。
-注册 `ext-deferred-tools` 插件后，通过 agent 的 `deferred_tools` section 配置。
-设置方式、自动启用启发式以及 DiscBeta 概率模型见
-[使用延迟加载工具](./docs/book/src/zh-CN/how-to/use-deferred-tools.md)。
+自定义工具拦截通过 `ToolGateHook` + `PluginRegistrar::register_tool_gate_hook()`
+完成；`BeforeToolExecute` 仅用于工具真正即将执行那一刻的钩子。
 
-如需自定义工具拦截，应实现 `ToolGateHook` 并通过 `PluginRegistrar::register_tool_gate_hook()` 注册；`BeforeToolExecute` 仅用于真正执行前的一次性钩子。
+## 适合的场景
 
-## 为什么选择 Awaken
+- 想用 **Rust 后端**写 AI Agent，要编译期保证。
+- 需要从一个 backend 同时服务 **AI SDK、CopilotKit、A2A 或 MCP**。
+- 工具需要在并发中**安全共享状态**，run 需要**可审计历史 + checkpoint + 可恢复控制路径**。
+- 可以接受自己注册工具与 provider，而不是依赖开箱即用的默认能力。
 
-- **一个后端服务多种协议** — 同一个二进制可提供 AI SDK v6、AG-UI、A2A、MCP，以及原生 HTTP/SSE 路由。
-- **配置就是控制面** — model/provider 路由、prompt、reminder、permission 与工具加载策略使用 schema-backed 配置，可校验并在运行时应用。
-- **LLM 编排，无需 DAG** — 定义 Agent 身份、模型绑定和工具访问权限；无需手写流程图。
-- **运行时托管配置** — 通过 Config API 或 Admin Console 更新 agents、model bindings、providers 与 MCP servers。
-- **类型化插件扩展点** — 9 个生命周期阶段、`PhaseHook`、`ToolGateHook`、scheduled actions、effects、request transforms 和插件注册工具都由代码契约约束。
-- **类型安全的状态与回放** — `StateKey` 把每个 key 绑定到 Rust value/update 类型，限定 run/thread/profile 作用域，并在提交前按声明的 merge strategy 合并。
-- **内置运维面** — LLM retry/backoff、按 model 维度的熔断器、请求超时、优雅关闭、Prometheus 指标、健康探针和 mailbox retry/backoff。
-- **零 `unsafe` 代码** — 整个工作空间禁止 `unsafe`，内存安全由 Rust 编译器保证。
+## 不适合的场景
 
-## 适用场景 / 不适用场景
-
-**适合 Awaken：**
-
-- 需要 **Rust 后端**构建 AI Agent，享受编译时安全
-- 需要从一个后端同时提供**多种前端或 Agent 协议**
-- 工具需要在并发执行中**安全共享状态**
-- 需要**可审计的线程历史**、checkpoint 与可恢复控制路径
-- 能接受自己注册工具、provider 与 model registry，而不是依赖开箱即用的默认能力
-
-**不适合 Awaken：**
-
-- 需要**开箱即用的文件/Shell/Web 工具** — 可考虑 OpenAI Agents SDK、Dify、CrewAI
-- 需要**可视化工作流编辑器** — 考虑 Dify、LangGraph Studio
-- 需要 **Python** 快速原型开发 — 考虑 LangGraph、AG2、PydanticAI
-- 需要一个**稳定且变化缓慢**的表面 API，而不是持续演进的运行时平台
-- 需要 **LLM 自主管理的记忆**（Agent 自行决定记住什么）— 考虑 Letta
+- 想要**开箱即用的文件 / Shell / Web 工具** — 看 OpenAI Agents SDK、Dify、CrewAI。
+- 想要**可视化工作流编辑器** — 看 Dify、LangGraph Studio。
+- 想要 **Python** 快速原型开发 — 看 LangGraph、AG2、PydanticAI。
+- 想要 **LLM 自主管理记忆**（让 Agent 自行决定记住什么）— 看 Letta。
 
 ## 架构
 
@@ -333,8 +315,17 @@ npm --prefix apps/admin-console run dev
 
 **贡献流程：** Fork → 新建分支 → 实现 + 测试 → `cargo clippy` 通过 → PR。
 
+## 鸣谢
+
+crates.io 上 `awaken` 这个名字是
+[@brayniac](https://github.com/brayniac) 转让过来的——他原先维护着同名的另
+一个 crate，并主动愿意把名字让出来，让本项目能用规范名发布。crates.io 上的
+`awaken` `0.1`–`0.3` 属于那个早期项目；本仓库的发版历史延续自之前的
+`awaken-agent 0.2.x`，并直接从 `0.4.0` 起步以跳过此前的版本号。再次感谢。
+
+Awaken 也是 [tirea](../../tree/tirea-0.5) 的全新重写版本，与 tirea **不兼容**。
+tirea 0.5 代码归档在 [`tirea-0.5`](../../tree/tirea-0.5) 分支。
+
 ## 许可证
 
 双重许可：[MIT](./LICENSE-MIT) 或 [Apache-2.0](./LICENSE-APACHE)。
-
-> Awaken 是 [tirea](../../tree/tirea-0.5) 的全新重写版本，专为简洁性和生产可靠性而设计。tirea 0.5 代码已归档在 [`tirea-0.5`](../../tree/tirea-0.5) 分支，Awaken 与 tirea **不兼容**。

--- a/crates/awaken-agent/Cargo.toml
+++ b/crates/awaken-agent/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 doctest = false
 
 [dependencies]
-awaken = { version = "0.4.0-dev", path = "../awaken", default-features = false }
+awaken = { version = "0.4.0", path = "../awaken", default-features = false }
 
 [features]
 default = ["full"]

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-awaken = { package = "awaken", version = "0.4.0-dev", path = "../awaken", features = ["full"] }
+awaken = { package = "awaken", version = "0.4.0", path = "../awaken", features = ["full"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/awaken-runtime/src/extensions/background/mod.rs
+++ b/crates/awaken-runtime/src/extensions/background/mod.rs
@@ -23,8 +23,8 @@ pub use plugin::BackgroundTaskPlugin;
 pub use send_message_tool::SendMessageTool;
 pub use state::{BackgroundTaskViewKey, PersistedTaskMeta};
 pub use types::{
-    AgentTaskContext, TaskContext, TaskEvent, TaskId, TaskParentContext, TaskResult, TaskStatus,
-    TaskSummary,
+    AgentTaskContext, BACKGROUND_TASKS_PLUGIN_ID, TaskContext, TaskEvent, TaskId,
+    TaskParentContext, TaskResult, TaskStatus, TaskSummary,
 };
 
 #[cfg(test)]

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -41,6 +41,142 @@ struct PreparedLocalRootExecution {
     phase_runtime: crate::phase::PhaseRuntime,
     inbox: crate::inbox::InboxReceiver,
     inbox_sender: crate::inbox::InboxSender,
+    /// Per-run wiring for context auto-compaction. Some when the preflight
+    /// resolved agent declared `autocompact_threshold` and the runtime had
+    /// not already attached a manager + summarizer.
+    compaction: Option<CompactionRuntime>,
+}
+
+/// Per-run context auto-compaction wiring: shared manager + summarizer that
+/// the loop's resolver-wrapper grafts onto every `ResolvedAgent` it produces.
+#[derive(Clone)]
+struct CompactionRuntime {
+    manager: std::sync::Arc<crate::extensions::background::BackgroundTaskManager>,
+    summarizer: std::sync::Arc<dyn crate::context::ContextSummarizer>,
+}
+
+/// Build the per-run compaction wiring when the preflight agent declared
+/// `autocompact_threshold` and no upstream code (builder, custom resolver)
+/// already attached a manager + summarizer.
+///
+/// The manager has its store and owner inbox bound here so background
+/// compaction tasks can commit metadata and deliver completion events.
+/// `BackgroundTaskPlugin`'s state keys are registered on the store; if a
+/// matching plugin is already installed the dup error is treated as a
+/// no-op since the keys are already live.
+fn build_compaction_runtime(
+    preflight_resolved: &crate::registry::ResolvedAgent,
+    store: &crate::state::StateStore,
+    owner_inbox: &crate::inbox::InboxSender,
+) -> Result<Option<CompactionRuntime>, AgentLoopError> {
+    let opts_in = preflight_resolved
+        .context_policy()
+        .and_then(|policy| policy.autocompact_threshold)
+        .is_some();
+    if !opts_in {
+        return Ok(None);
+    }
+    if preflight_resolved.background_manager.is_some()
+        && preflight_resolved.context_summarizer.is_some()
+    {
+        return Ok(None);
+    }
+
+    let manager = std::sync::Arc::new(crate::extensions::background::BackgroundTaskManager::new());
+    manager.set_store(store.clone());
+    manager.set_owner_inbox(owner_inbox.clone());
+
+    match store.install_plugin(crate::extensions::background::BackgroundTaskPlugin::new(
+        manager.clone(),
+    )) {
+        Ok(()) => {}
+        Err(awaken_contract::StateError::PluginAlreadyInstalled { .. }) => {
+            // Keys already registered by an upstream wiring; reuse store as-is.
+        }
+        Err(awaken_contract::StateError::KeyAlreadyRegistered { .. }) => {
+            // A different plugin owns one of the background-task keys; reuse them.
+        }
+        Err(error) => return Err(AgentLoopError::PhaseError(error)),
+    }
+
+    let compaction_config = preflight_resolved
+        .spec
+        .config::<crate::context::CompactionConfigKey>()
+        .unwrap_or_default();
+    let summarizer: std::sync::Arc<dyn crate::context::ContextSummarizer> = std::sync::Arc::new(
+        crate::context::DefaultSummarizer::with_config(compaction_config),
+    );
+
+    Ok(Some(CompactionRuntime {
+        manager,
+        summarizer,
+    }))
+}
+
+/// Resolver wrapper that grafts a per-run `BackgroundTaskManager` and
+/// `ContextSummarizer` onto every `ResolvedAgent` whose context policy opts
+/// in via `autocompact_threshold`. The same `Arc`s are reused across resolve
+/// calls so the manager bound during `bind_local_execution_env` is the one
+/// used by every subsequent loop step.
+struct CompactionResolver<'a> {
+    inner: &'a dyn crate::registry::ExecutionResolver,
+    runtime: CompactionRuntime,
+}
+
+impl<'a> CompactionResolver<'a> {
+    fn new(inner: &'a dyn crate::registry::ExecutionResolver, runtime: CompactionRuntime) -> Self {
+        Self { inner, runtime }
+    }
+
+    fn graft(
+        &self,
+        mut resolved: crate::registry::ResolvedAgent,
+    ) -> crate::registry::ResolvedAgent {
+        let opts_in = resolved
+            .context_policy()
+            .and_then(|policy| policy.autocompact_threshold)
+            .is_some();
+        if !opts_in {
+            return resolved;
+        }
+        if resolved.background_manager.is_none() {
+            resolved.background_manager = Some(self.runtime.manager.clone());
+        }
+        if resolved.context_summarizer.is_none() {
+            resolved.context_summarizer = Some(self.runtime.summarizer.clone());
+        }
+        resolved
+    }
+}
+
+impl crate::registry::AgentResolver for CompactionResolver<'_> {
+    fn resolve(
+        &self,
+        agent_id: &str,
+    ) -> Result<crate::registry::ResolvedAgent, crate::RuntimeError> {
+        self.inner
+            .resolve(agent_id)
+            .map(|resolved| self.graft(resolved))
+    }
+
+    fn agent_ids(&self) -> Vec<String> {
+        self.inner.agent_ids()
+    }
+}
+
+impl crate::registry::ExecutionResolver for CompactionResolver<'_> {
+    fn resolve_execution(
+        &self,
+        agent_id: &str,
+    ) -> Result<crate::registry::ResolvedExecution, crate::RuntimeError> {
+        let execution = self.inner.resolve_execution(agent_id)?;
+        Ok(match execution {
+            crate::registry::ResolvedExecution::Local(resolved) => {
+                crate::registry::ResolvedExecution::Local(Box::new(self.graft(*resolved)))
+            }
+            other => other,
+        })
+    }
 }
 
 impl AgentRuntime {
@@ -177,6 +313,7 @@ impl AgentRuntime {
         }
 
         let mut run_inbox = run_inbox;
+        let mut compaction_runtime: Option<CompactionRuntime> = None;
         let (messages, phase_runtime, inbox, live_inbox_sender, previous_non_local_state) =
             match &resolved_execution {
                 ResolvedExecution::Local(preflight_resolved) => {
@@ -191,6 +328,7 @@ impl AgentRuntime {
                             &thread_ctx,
                         )
                         .await?;
+                    compaction_runtime = prepared.compaction;
                     (
                         prepared.messages,
                         Some(prepared.phase_runtime),
@@ -237,12 +375,24 @@ impl AgentRuntime {
             None
         };
 
+        // Wrap the resolver so every `ResolvedAgent` it produces during this
+        // run carries the per-run compaction manager + summarizer when the
+        // agent opted in via `autocompact_threshold`. Lifetime is tied to
+        // `backend_request`, which is consumed before this scope ends.
+        let compaction_resolver = compaction_runtime
+            .clone()
+            .map(|runtime| CompactionResolver::new(run_resolver.as_ref(), runtime));
+        let resolver_for_backend: &dyn ExecutionResolver = match compaction_resolver.as_ref() {
+            Some(wrapper) => wrapper,
+            None => run_resolver.as_ref(),
+        };
+
         let backend_request = BackendRootRunRequest {
             agent_id: &agent_id,
             messages,
             new_messages,
             sink: sink.clone(),
-            resolver: run_resolver.as_ref(),
+            resolver: resolver_for_backend,
             run_identity: run_identity.clone(),
             checkpoint_store: match &resolved_execution {
                 ResolvedExecution::Local(_) => phase_runtime.as_ref().and(self.storage.as_deref()),
@@ -339,6 +489,8 @@ impl AgentRuntime {
         )
         .map_err(AgentLoopError::PhaseError)?;
 
+        let compaction = build_compaction_runtime(preflight_resolved, &store, &owner_inbox)?;
+
         let mut messages = if let Some(ctx) = thread_ctx {
             if let Some(ref prev_run) = ctx.latest_run
                 && let Some(ref persisted) = prev_run.state
@@ -382,6 +534,7 @@ impl AgentRuntime {
             phase_runtime,
             inbox: run_inbox.receiver,
             inbox_sender: owner_inbox,
+            compaction,
         })
     }
 

--- a/crates/awaken/src/lib.rs
+++ b/crates/awaken/src/lib.rs
@@ -139,9 +139,9 @@ pub mod state {
 // contract types
 pub use awaken_contract::{
     AgentSpec, EffectSpec, FailedScheduledActions, JsonValue, KeyScope, MergeStrategy,
-    PendingScheduledActions, PersistedState, Phase, PluginConfigKey, ScheduledActionSpec, Snapshot,
-    StateError, StateKey, StateKeyOptions, StateMap, TypedEffect, TypedTool, UnknownKeyPolicy,
-    generate_tool_schema, sanitize_for_llm, validate_against_schema,
+    PendingScheduledActions, PersistedState, Phase, PluginConfigKey, RedactedString,
+    ScheduledActionSpec, Snapshot, StateError, StateKey, StateKeyOptions, StateMap, TypedEffect,
+    TypedTool, UnknownKeyPolicy, generate_tool_schema, sanitize_for_llm, validate_against_schema,
 };
 
 // runtime types

--- a/docs/book/README.zh-CN.md
+++ b/docs/book/README.zh-CN.md
@@ -38,7 +38,7 @@ Agent 选择工具、调用工具、读写状态，如此循环 — 全部由运
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1.51.0", features = ["full"] }
 async-trait = "0.1.89"
 serde_json = "1.0.149"

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -48,6 +48,7 @@
 - [Report Tool Progress](./how-to/report-tool-progress.md)
 - [Testing Strategy](./how-to/testing-strategy.md)
 - [Use Shared State](./how-to/use-shared-state.md)
+- [Recover Streaming LLMs](./how-to/recover-streaming-llms.md)
 
 # Reference
 

--- a/docs/book/src/how-to/enable-observability.md
+++ b/docs/book/src/how-to/enable-observability.md
@@ -10,7 +10,7 @@ Use this when you need to trace LLM inference calls and tool executions with Ope
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["observability"] }
+awaken = { version = "0.4.0", features = ["observability"] }
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/book/src/how-to/enable-tool-permission-hitl.md
+++ b/docs/book/src/how-to/enable-tool-permission-hitl.md
@@ -9,7 +9,7 @@ Use this when you need to control which tools an agent can invoke, with human-in
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["permission"] }
+awaken = { version = "0.4.0", features = ["permission"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/how-to/expose-http-sse.md
+++ b/docs/book/src/how-to/expose-http-sse.md
@@ -14,7 +14,7 @@ Use this when you need to serve agents over HTTP with Server-Sent Events streami
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["server"] }
+awaken = { version = "0.4.0", features = ["server"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 ```
 

--- a/docs/book/src/how-to/integrate-ai-sdk-frontend.md
+++ b/docs/book/src/how-to/integrate-ai-sdk-frontend.md
@@ -10,7 +10,7 @@ Use this when you have a Vercel AI SDK (v6) React frontend and need to connect i
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["server"] }
+awaken = { version = "0.4.0", features = ["server"] }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde_json = "1"
@@ -104,32 +104,53 @@ The server automatically registers AI SDK v6 routes at:
 npm install ai @ai-sdk/react
 ```
 
-Use the `useChat` hook pointed at your awaken server:
+Use the `useChat` hook pointed at your awaken server. AI SDK v6 returns
+`{ messages, sendMessage, status, ... }` and reads requests from a transport,
+so the awaken endpoint goes inside `DefaultChatTransport`:
 
 ```tsx
+import { useState } from "react";
 import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
 
 export default function Chat() {
-  const { messages, input, handleInputChange, handleSubmit } = useChat({
-    api: "http://localhost:3000/v1/ai-sdk/chat",
+  const { messages, sendMessage } = useChat({
     id: "thread-1",
+    transport: new DefaultChatTransport({
+      api: "http://localhost:3000/v1/ai-sdk/chat",
+    }),
   });
+  const [input, setInput] = useState("");
 
   return (
     <div>
       {messages.map((m) => (
         <div key={m.id}>
-          <strong>{m.role}:</strong> {m.content}
+          <strong>{m.role}:</strong>
+          {m.parts.map((part, idx) =>
+            part.type === "text" ? <span key={idx}>{part.text}</span> : null,
+          )}
         </div>
       ))}
-      <form onSubmit={handleSubmit}>
-        <input value={input} onChange={handleInputChange} />
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input value={input} onChange={(event) => setInput(event.target.value)} />
         <button type="submit">Send</button>
       </form>
     </div>
   );
 }
 ```
+
+For the full pattern with custom transport headers, automatic resubmission, and
+typed tool parts, see the working example in
+[`examples/ai-sdk-starter/src/hooks/use-chat-session.ts`](../../../../examples/ai-sdk-starter/src/hooks/use-chat-session.ts).
 
 3. Run both sides.
 

--- a/docs/book/src/how-to/integrate-copilotkit-ag-ui.md
+++ b/docs/book/src/how-to/integrate-copilotkit-ag-ui.md
@@ -10,7 +10,7 @@ Use this when you have a CopilotKit React frontend and need to connect it to an 
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["server"] }
+awaken = { version = "0.4.0", features = ["server"] }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde_json = "1"
@@ -117,7 +117,7 @@ import "@copilotkit/react-ui/styles.css";
 
 export default function App() {
   return (
-    <CopilotKit runtimeUrl="http://localhost:3000/v1/ag-ui">
+    <CopilotKit runtimeUrl="http://localhost:3000/v1/ag-ui/run">
       <CopilotChat
         labels={{ title: "Agent", initial: "How can I help?" }}
       />
@@ -148,7 +148,7 @@ npm run dev
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | CORS error in browser | No CORS middleware | Add `tower-http` CORS layer to the axum router |
-| CopilotKit shows "connection failed" | Wrong `runtimeUrl` | Confirm it points to `http://localhost:3000/v1/ag-ui` |
+| CopilotKit shows "connection failed" | Wrong `runtimeUrl` | Confirm it points to `http://localhost:3000/v1/ag-ui/run` (the AG-UI run endpoint, not the namespace) |
 | Events arrive but UI does not update | AG-UI event format mismatch | Ensure CopilotKit version is compatible with AG-UI protocol |
 | 404 on `/v1/ag-ui/run` | Missing `server` feature | Enable `features = ["server"]` in `Cargo.toml` |
 

--- a/docs/book/src/how-to/optimize-context-window.md
+++ b/docs/book/src/how-to/optimize-context-window.md
@@ -118,6 +118,26 @@ The built-in `DefaultSummarizer` reads prompts from `CompactionConfig` and suppo
 
 The transcript renderer filters out `Visibility::Internal` messages before sending to the summarizer, since system-injected context is re-injected each turn and should not be included in summaries.
 
+### Background execution
+
+Compaction does **not** block the inference phase. When the conditions are
+met, `maybe_spawn_compaction` plans the boundary, writes a
+`CompactionInFlight` marker into `CompactionStateKey`, and offloads the
+summarization LLM call to a background task through the agent's
+`BackgroundTaskManager`. The completion event flows back through the owner
+inbox; `try_consume_compaction_event` picks it up and `apply_summary` swaps
+the summary into the message log if the boundary is still present.
+
+Two consequences worth knowing:
+
+- Compaction is single-flight per agent. While `CompactionState::is_compacting`
+  is true, subsequent inference rounds skip planning a new compaction and run
+  with the un-compacted history. Once the swap completes, the next round
+  continues with the summarized prefix.
+- A compaction pass needs both an LLM summarizer and a `BackgroundTaskManager`
+  on the resolved agent. Without either, `maybe_spawn_compaction` is a no-op
+  and the runtime falls back to truncation.
+
 ### Summary storage
 
 Compaction summaries are stored as `<conversation-summary>` tagged internal system messages. On load, `trim_to_compaction_boundary` drops all messages before the latest summary message, so already-summarized history is never re-loaded into the context window.

--- a/docs/book/src/how-to/recover-streaming-llms.md
+++ b/docs/book/src/how-to/recover-streaming-llms.md
@@ -1,0 +1,131 @@
+# Recover Streaming LLMs
+
+Use this when transient provider failures during a streaming inference call
+must not surface as run errors. The runtime retries whole requests that fail
+*before* streaming starts; this page is about the harder case — failures that
+arrive *after* the model already started producing tokens.
+
+## What the runtime handles for you
+
+The streaming inference path detects four mid-stream interruption causes
+through `InferenceExecutionError::StreamInterrupted` and the
+`InterruptCause` enum:
+
+- `ConnectionReset` (TCP/HTTP/2 connection dropped after headers)
+- `IdleStall` (no bytes received within the idle window)
+- `GoAway` (HTTP/2 GOAWAY frame mid-response)
+- `Provider5xxMidStream(u16)` (provider returned a 5xx after streaming began)
+
+When any of these fires, the loop runner consults
+`InterruptSnapshot::plan()` and picks one of four recovery plans. The naming
+in code is `R1..R4`:
+
+| Plan | When it fires | What the runtime does |
+|---|---|---|
+| **R1 — `ContinueText`** | Only text accumulated, no tool calls in flight | Retries with the accumulated text as an assistant prefix and a continuation prompt; the model picks up where it left off |
+| **R2 — `SynthesizeToolUse`** | At least one tool call had complete argument JSON | Synthesizes a `StopReason::ToolUse` terminal state so the loop runner executes the completed tools; any unfinished tool is captured as a hint and surfaced to the model on the next user message |
+| **R3 — `TruncateBeforeTool`** | Text plus a single unclosed tool call | Truncates to the text prefix, emits `AgentEvent::ToolCallCancel` so consumers drop the partial argument delta, then continues |
+| **R4 — `WholeRestart`** | Nothing salvageable (no text, no completed tools) | Restarts the assistant turn from scratch; emits `AgentEvent::StreamReset` so consumers discard already-emitted deltas |
+
+`Retry-After` is honored: when the provider returns `429` or `529` with a
+`Retry-After` header, `InferenceExecutionError::RateLimited` and
+`Overloaded` carry the parsed `Duration` and the retry subsystem waits at
+least that long before retrying.
+
+## What clients see
+
+SSE consumers receive normal `TextDelta` and `ToolCallDelta` events during the
+recovered turn. Two new events tell consumers what to drop:
+
+- `ToolCallCancel { id, name, reason }` — drop any buffered partial delta for
+  this tool call.
+- `StreamReset { reason }` — discard *all* deltas for the current assistant
+  turn; new deltas follow.
+
+Both events are advisory. They never appear in the durable thread log;
+clients that re-render from `MessagesSnapshot` do not need to special-case
+them.
+
+## Cross-process resume
+
+A single-process retry loop is enough when the same server stays up through
+the interruption. Cross-process resume — picking up from where a previous
+*process* left off — uses the `StreamCheckpointStore` contract.
+
+```rust,ignore
+use std::sync::Arc;
+use awaken::contract::stream_checkpoint::{
+    InMemoryStreamCheckpointStore, StreamCheckpoint, StreamCheckpointStore,
+};
+
+#[async_trait::async_trait]
+trait StreamCheckpointStore: Send + Sync {
+    async fn put(&self, checkpoint: StreamCheckpoint) -> Result<(), _>;
+    async fn get(&self, run_id: &str) -> Result<Option<StreamCheckpoint>, _>;
+    async fn delete(&self, run_id: &str) -> Result<(), _>;
+}
+```
+
+While a stream runs, the loop runner periodically writes the accumulated
+`partial_text`, `completed_tool_calls`, and the open `in_flight_tool` to the
+store under the run's `run_id`. When a fresh process picks up that run, the
+checkpoint is read at the start of `execute_streaming` and translated into the
+same R1 prefix-injection that the in-process retry loop uses.
+
+The checkpoint is **not** a full conversation log — committed messages are
+still owned by `ThreadRunStore`. The checkpoint only captures the in-flight
+delta accumulator, which is why the contract is small (`put`, `get`,
+`delete`).
+
+### Attaching a store to an agent
+
+The store lives on `ResolvedAgent::stream_checkpoint_store`, populated through
+the builder method:
+
+```rust,ignore
+use awaken::contract::stream_checkpoint::{
+    InMemoryStreamCheckpointStore, StreamCheckpointStore,
+};
+use std::sync::Arc;
+
+let store: Arc<dyn StreamCheckpointStore> =
+    Arc::new(InMemoryStreamCheckpointStore::new());
+
+let resolved = resolved.with_stream_checkpoint_store(store);
+```
+
+The default resolver pipeline leaves the field as `None`. To make every
+resolution carry the store, wrap your `AgentResolver` so it decorates the
+returned `ResolvedAgent` with `with_stream_checkpoint_store(store.clone())`
+before handing it to the runtime. `AgentRuntimeBuilder` does not yet expose a
+direct shortcut for this; track the open builder integration in
+[GitHub issues](https://github.com/AwakenWorks/awaken/issues) if you need it.
+
+The shipped `InMemoryStreamCheckpointStore` is fine for tests and for
+single-process operation. For true cross-process resume, implement the trait
+on a shared backend (NATS JetStream KV, Redis, a filesystem path, etc.). Each
+`put` should idempotently upsert the checkpoint for `run_id`; `delete` runs
+after the turn commits.
+
+## What this does not do
+
+- It does not retry permanent errors. `ContextOverflow`, `InvalidRequest`,
+  `Unauthorized`, `ModelNotFound`, and `ContentFiltered` short-circuit the
+  retry subsystem and propagate to the caller.
+- It does not repair malformed-but-not-truncated tool call JSON. That is a
+  separate concern; the recovery snapshot only classifies arguments as
+  "completed" when they parse as JSON.
+- It does not fold back into the durable message log on its own. The
+  re-emitted deltas in the recovered turn produce the same final assistant
+  message that a fresh run would have produced; checkpoint cleanup happens
+  after that message is committed.
+
+## Related
+
+- [Errors](../reference/errors.md) for the full `InferenceExecutionError`
+  taxonomy and accessors.
+- [Events](../reference/events.md) for `ToolCallCancel` / `StreamReset`
+  semantics.
+- [Optimize the Context Window](./optimize-context-window.md) for the
+  separate truncation-recovery path used when the model itself stops with
+  `MaxTokens`.

--- a/docs/book/src/how-to/use-deferred-tools.md
+++ b/docs/book/src/how-to/use-deferred-tools.md
@@ -9,8 +9,8 @@ Use this when your agent has many tools and you want to reduce context window us
 
 ```toml
 [dependencies]
-awaken-ext-deferred-tools = { version = "0.4.0-dev" }
-awaken = { version = "0.4.0-dev" }
+awaken-ext-deferred-tools = { version = "0.4.0" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/how-to/use-file-store.md
+++ b/docs/book/src/how-to/use-file-store.md
@@ -12,15 +12,15 @@ Use this when you need file-based persistence for threads, runs, and messages wi
 
 ```toml
 [dependencies]
-awaken-stores = { version = "0.4.0-dev", features = ["file"] }
+awaken-stores = { version = "0.4.0", features = ["file"] }
 ```
 
 Or, if using the `awaken` facade crate (which re-exports `awaken-stores`), add `awaken-stores` directly for the feature flag:
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
-awaken-stores = { version = "0.4.0-dev", features = ["file"] }
+awaken = { version = "0.4.0" }
+awaken-stores = { version = "0.4.0", features = ["file"] }
 ```
 
 2. Create a FileStore.

--- a/docs/book/src/how-to/use-generative-ui.md
+++ b/docs/book/src/how-to/use-generative-ui.md
@@ -15,7 +15,7 @@ Awaken currently supports two integration styles:
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/how-to/use-mcp-tools.md
+++ b/docs/book/src/how-to/use-mcp-tools.md
@@ -10,7 +10,7 @@ Use this when you want to connect to external Model Context Protocol (MCP) serve
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["mcp"] }
+awaken = { version = "0.4.0", features = ["mcp"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/how-to/use-nats-stores.md
+++ b/docs/book/src/how-to/use-nats-stores.md
@@ -22,7 +22,7 @@ Two backends live in the `nats` feature of `awaken-stores`:
 
 ```toml
 [dependencies]
-awaken-stores = { version = "0.4.0-dev", features = ["nats"] }
+awaken-stores = { version = "0.4.0", features = ["nats"] }
 ```
 
 ## NatsMailboxStore
@@ -222,6 +222,16 @@ store.force_flush("thread-123").await?;
 
 Blocks until the background flusher has drained every WAL entry for the given
 thread into the inner store. Use for admin operations or critical reads.
+
+### Poison-message quarantine
+
+A WAL entry that consistently fails to apply (for example, a deserialization
+error after an incompatible upgrade) is quarantined instead of being retried
+forever. The flusher computes a stable hash over the entry, NAKs with bounded
+backoff, and after the configured threshold parks the entry to a side channel
+so the WAL stream keeps moving. Operators see this as a metric tick rather
+than as silently stuck checkpoints. Inspect quarantined entries through the
+JetStream admin tooling and replay them after the underlying defect is fixed.
 
 ## When to choose which
 

--- a/docs/book/src/how-to/use-postgres-store.md
+++ b/docs/book/src/how-to/use-postgres-store.md
@@ -14,7 +14,7 @@ Use this when you need durable, multi-instance persistence backed by PostgreSQL.
 
 ```toml
 [dependencies]
-awaken-stores = { version = "0.4.0-dev", features = ["postgres"] }
+awaken-stores = { version = "0.4.0", features = ["postgres"] }
 ```
 
 2. Create a connection pool.

--- a/docs/book/src/how-to/use-reminder-plugin.md
+++ b/docs/book/src/how-to/use-reminder-plugin.md
@@ -9,7 +9,7 @@ Use this when you want the agent to receive automatic context messages after too
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["reminder"] }
+awaken = { version = "0.4.0", features = ["reminder"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/how-to/use-skills-subsystem.md
+++ b/docs/book/src/how-to/use-skills-subsystem.md
@@ -9,7 +9,7 @@ Use this when you want agents to discover and activate skill packages at runtime
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["skills"] }
+awaken = { version = "0.4.0", features = ["skills"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/operate.md
+++ b/docs/book/src/operate.md
@@ -8,9 +8,26 @@ This path is for hardening an agent service once the happy path already works.
 2. [Enable Tool Permission HITL](./how-to/enable-tool-permission-hitl.md) to add approval control over tool execution.
 3. [Configure Stop Policies](./how-to/configure-stop-policies.md) to keep agent loops bounded and predictable.
 4. [Report Tool Progress](./how-to/report-tool-progress.md) and [Testing Strategy](./how-to/testing-strategy.md) to improve operator visibility and confidence.
+5. [Recover Streaming LLMs](./how-to/recover-streaming-llms.md) when transient provider failures must not surface as run errors.
+
+## Harden the admin and config plane
+
+Two orthogonal levers, both detailed in the
+[config reference](./reference/config.md):
+
+- `AdminApiConfig.bearer_token` (or `AWAKEN_ADMIN_API_BEARER_TOKEN`) protects
+  `/v1/capabilities`, `/v1/config/*`, and `/v1/agents*`.
+- `AdminApiConfig.expose_config_routes = false` drops the admin CRUD routes
+  entirely when configuration is owned by an external pipeline.
+
+For storms of small config writes, set
+`ConfigRuntimeManager::with_min_apply_interval(Duration)` to coalesce
+listener-driven applies; cached `ProviderSpec` executors are reused across
+unchanged specs.
 
 ## Keep nearby
 
 - [Errors](./reference/errors.md)
 - [Cancellation](./reference/cancellation.md)
 - [HITL and Mailbox](./explanation/hitl-and-mailbox.md)
+- [Config](./reference/config.md)

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -228,17 +228,20 @@ present. New config should use `auth`, `target`, and `options`.
 HTTP server configuration. Used when the `server` feature is enabled.
 
 ```rust,ignore
+use awaken::RedactedString;
+
 pub struct ServerConfig {
-    pub address: String,                   // default: "0.0.0.0:3000"
-    pub sse_buffer_size: usize,            // default: 64
-    pub replay_buffer_capacity: usize,     // default: 1024
+    pub address: String,                              // default: "0.0.0.0:3000"
+    pub sse_buffer_size: usize,                       // default: 64
+    pub replay_buffer_capacity: usize,                // default: 1024
     pub shutdown: ShutdownConfig,
-    pub max_concurrent_requests: usize,    // default: 100
-    pub a2a_extended_card_bearer_token: Option<String>,
+    pub max_concurrent_requests: usize,               // default: 100
+    pub a2a_extended_card_bearer_token: Option<RedactedString>,
+    pub mailbox_lifecycle: MailboxLifecycleMode,      // default: Auto
 }
 
 pub struct ShutdownConfig {
-    pub timeout_secs: u64,                 // default: 30
+    pub timeout_secs: u64,                            // default: 30
 }
 ```
 
@@ -250,7 +253,8 @@ pub struct ShutdownConfig {
 | `sse_buffer_size` | `usize` | `64` | Maximum SSE channel buffer size per connection |
 | `replay_buffer_capacity` | `usize` | `1024` | Maximum SSE frames buffered per run for reconnection replay |
 | `max_concurrent_requests` | `usize` | `100` | Maximum in-flight requests; excess requests receive 503 |
-| `a2a_extended_card_bearer_token` | `Option<String>` | `None` | Enables authenticated `GET /v1/a2a/extendedAgentCard` when set |
+| `a2a_extended_card_bearer_token` | `Option<RedactedString>` | `None` | Enables authenticated `GET /v1/a2a/extendedAgentCard` when set. The token redacts itself in `Debug`/`Display`; call `expose_secret()` to read the value. JSON wire format remains a plain string |
+| `mailbox_lifecycle` | `MailboxLifecycleMode` | `Auto` | `Auto` lets the framework start and shut down the mailbox; `Manual` hands lifecycle to the embedder |
 | `shutdown.timeout_secs` | `u64` | `30` | Seconds to wait for in-flight requests to drain before force-exiting |
 
 ## AdminApiConfig
@@ -260,16 +264,20 @@ Admin/configuration API security settings. Attach this to `AppState` with
 `AppState::with_admin_api_bearer_token` when only bearer auth is needed.
 
 ```rust,ignore
+use awaken::RedactedString;
+
 pub struct AdminApiConfig {
-    pub bearer_token: Option<String>,
+    pub bearer_token: Option<RedactedString>,
     pub cors_allowed_origins: Vec<String>,
+    pub expose_config_routes: bool,                   // default: true
 }
 ```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `bearer_token` | `Option<String>` | `None` | Requires `Authorization: Bearer ...` for `/v1/capabilities`, `/v1/config/*`, and `/v1/agents*` when set |
+| `bearer_token` | `Option<RedactedString>` | `None` | Requires `Authorization: Bearer ...` for `/v1/capabilities`, `/v1/config/*`, and `/v1/agents*` when set. Redacts itself in `Debug`/`Display`; call `expose_secret()` to read the value. JSON wire format remains a plain string |
 | `cors_allowed_origins` | `Vec<String>` | `["http://127.0.0.1:3002", "http://localhost:3002"]` | Browser origins allowed by the admin CORS layer |
+| `expose_config_routes` | `bool` | `true` | Whether the server mounts the `/v1/config/*` and `/v1/agents` admin CRUD routes. Set to `false` to drop those routes entirely when configuration is driven through an external RBAC/audit pipeline. `/v1/capabilities` remains available so frontends can still discover registered components |
 
 Environment variables override the `AppState` admin settings:
 
@@ -277,6 +285,31 @@ Environment variables override the `AppState` admin settings:
 |---|---|
 | `AWAKEN_ADMIN_API_BEARER_TOKEN` | Bearer token required for admin/configuration APIs |
 | `AWAKEN_ADMIN_CORS_ALLOWED_ORIGINS` | Comma-separated CORS origins for browser admin APIs |
+
+### Secret handling
+
+`RedactedString` (re-exported from the facade as `awaken::RedactedString`,
+defined in `awaken_contract::secret`) is the single trust boundary for
+credentials in serialized config. The wire format is a plain JSON
+string, JSON Schema reports `string`, and the inner buffer is zeroized on drop.
+`Debug` formats as `RedactedString(***)` and `Display` formats as `***`. Call
+`expose_secret()` to obtain the plaintext when actually issuing a request, and
+do not propagate the returned `&str` into log lines. Code that previously held
+plain `String` tokens needs a one-line `.into()` at construction or a
+`.expose_secret()` at the read site.
+
+## ConfigRuntimeManager
+
+`ConfigRuntimeManager` compiles candidate registry snapshots when configuration
+changes and publishes them to the live runtime.
+
+| Builder method | Default | Description |
+|---|---|---|
+| `with_provider_factory(factory)` | `GenaiProviderExecutorFactory` | Override how `ProviderSpec` is materialized into an `LlmExecutor` |
+| `with_change_notifier(notifier)` | `None` | Subscribe to native change notifications instead of polling |
+| `with_mcp_registry_factory(factory)` | `DefaultMcpRegistryFactory` | Override how MCP server specs are turned into a registry |
+| `with_mcp_refresh_interval(interval)` | disabled | Periodically refresh MCP server connections |
+| `with_min_apply_interval(interval)` | `Duration::ZERO` | Minimum interval between successive applies driven by the change listener. Bursts that arrive within this window coalesce into a single apply. Direct calls to `apply` / `apply_if_changed` are unaffected. Provider executors are reused across applies for specs whose hash is unchanged |
 
 ## MailboxConfig
 

--- a/docs/book/src/reference/errors.md
+++ b/docs/book/src/reference/errors.md
@@ -99,15 +99,72 @@ pub enum RuntimeError {
 
 ## InferenceExecutionError
 
-Errors from the LLM execution layer.
+Errors from the LLM execution layer. Variants split into three recoverability
+classes:
+
+- **Transient** — retryable and counted toward the per-model circuit breaker.
+- **Permanent** — not retryable and not counted toward the circuit breaker;
+  these would have failed with the same error on any model.
+- **Fail-fast** — the retry subsystem cannot or should not try again.
+
+The enum is `#[non_exhaustive]`. Code outside the crate must handle a
+`_ => …` arm and should prefer the `is_retryable()`,
+`counts_toward_circuit_breaker()`, and `retry_after()` accessors over matching
+specific variants.
 
 ```rust,no_run
+use std::time::Duration;
+use awaken::contract::executor::{InterruptCause, InterruptSnapshot};
+
+#[non_exhaustive]
 pub enum InferenceExecutionError {
+    // Transient
     Provider(String),
-    RateLimited(String),
+    RateLimited { message: String, retry_after: Option<Duration> },
+    Overloaded  { message: String, retry_after: Option<Duration> },
     Timeout(String),
+    StreamInterrupted { cause: InterruptCause, snapshot: Box<InterruptSnapshot> },
+
+    // Permanent
+    ContextOverflow(String),
+    InvalidRequest(String),
+    Unauthorized(String),
+    ModelNotFound(String),
+    ContentFiltered(String),
+
+    // Fail-fast
+    AllModelsUnavailable,
     Cancelled,
 }
+```
+
+| Class | Variants |
+|---|---|
+| Transient (retryable) | `Provider`, `RateLimited`, `Overloaded`, `Timeout`, `StreamInterrupted` |
+| Permanent (not retryable) | `ContextOverflow`, `InvalidRequest`, `Unauthorized`, `ModelNotFound`, `ContentFiltered` |
+| Fail-fast | `AllModelsUnavailable`, `Cancelled` |
+
+`RateLimited` and `Overloaded` carry an optional `retry_after` parsed from the
+provider's `Retry-After` header. The retry subsystem honors that hint before
+falling back to exponential backoff.
+
+`StreamInterrupted` carries an `InterruptCause`
+(`ConnectionReset`, `IdleStall`, `GoAway`, or `Provider5xxMidStream(u16)`) and
+an `InterruptSnapshot` capturing the partial assistant text, completed tool
+calls, and the open tool whose arguments had not finished arriving. The loop
+runner consumes the snapshot to choose one of four recovery plans; see
+[Recover Streaming LLMs](../how-to/recover-streaming-llms.md).
+
+### Convenience accessors
+
+```rust,ignore
+fn is_retryable(&self) -> bool;
+fn counts_toward_circuit_breaker(&self) -> bool;
+fn retry_after(&self) -> Option<std::time::Duration>;
+
+// Short constructors for common cases:
+fn rate_limited(message: impl Into<String>) -> Self;
+fn overloaded(message: impl Into<String>) -> Self;
 ```
 
 **Crate path:** `awaken::contract::executor::InferenceExecutionError`

--- a/docs/book/src/reference/events.md
+++ b/docs/book/src/reference/events.md
@@ -14,11 +14,13 @@ pub enum AgentEvent {
         thread_id: String,
         run_id: String,
         parent_run_id: Option<String>,    // omitted when None
+        identity: Option<RunIdentity>,    // omitted when None
     },
 
     RunFinish {
         thread_id: String,
         run_id: String,
+        identity: Option<RunIdentity>,    // omitted when None
         result: Option<Value>,            // omitted when None
         termination: TerminationReason,
     },
@@ -53,6 +55,20 @@ pub enum AgentEvent {
     },
 
     ToolCallResumed { target_id: String, result: Value },
+
+    /// A tool call that started streaming was cancelled before its argument
+    /// JSON closed (mid-stream interruption recovery). Consumers should drop
+    /// any partial deltas they buffered for this `id`.
+    ToolCallCancel {
+        id: String,
+        name: String,
+        reason: String,                   // e.g. "connection reset", "idle stall"
+    },
+
+    /// The current assistant turn was restarted after a mid-stream
+    /// interruption that could not be recovered via continuation. Consumers
+    /// should discard all previously-emitted deltas in this turn.
+    StreamReset { reason: String },
 
     MessagesSnapshot { messages: Vec<Value> },
 
@@ -91,6 +107,15 @@ pub enum AgentEvent {
 ```
 
 **Crate path:** `awaken::contract::event::AgentEvent`
+
+### Stream-recovery semantics
+
+`ToolCallCancel` and `StreamReset` are advisory drop signals emitted during
+mid-stream recovery. Consumers discard partial deltas for the named tool call
+(or for the whole turn) and keep reading; the recovered deltas follow on the
+normal `TextDelta` / `ToolCallDelta` channels. See
+[Recover Streaming LLMs](../how-to/recover-streaming-llms.md) for the four
+recovery plans and `StreamCheckpointStore` wiring.
 
 ### Helper
 

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -18,21 +18,22 @@ and `crates/awaken-server/src/config_routes.rs`.
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/v1/threads` | List thread IDs |
-| `POST` | `/v1/threads` | Create a thread. Body: `{ "title": "..." }` |
-| `GET` | `/v1/threads/summaries` | List thread summaries |
+| `GET` | `/v1/threads` | List thread IDs with paging and lineage filters; returns `{ items, offset, limit, total, has_more, next_cursor }` |
+| `POST` | `/v1/threads` | Create a thread. Body: `{ "title"?: string, "resource_id"?: string, "parent_thread_id"?: string }` |
+| `GET` | `/v1/threads/summaries` | List thread summaries (id, `resource_id`, `parent_thread_id`, title, `updated_at`, `agent_id`) with the same paging and lineage filters as `/v1/threads` |
 | `GET` | `/v1/threads/:id` | Get a thread by ID |
 | `PATCH` | `/v1/threads/:id` | Update thread metadata |
-| `DELETE` | `/v1/threads/:id` | Delete a thread |
+| `DELETE` | `/v1/threads/:id` | Delete a thread; accepts `?child_strategy=detach\|reject\|cascade` (default `detach`) to control how direct and transitive child threads are handled |
 | `POST` | `/v1/threads/:id/cancel` | Cancel a specific queued or running dispatch addressed by this thread ID. Returns `cancel_requested`. |
 | `POST` | `/v1/threads/:id/decision` | Submit a HITL decision for a waiting run on this thread |
 | `POST` | `/v1/threads/:id/interrupt` | Interrupt the thread: bumps the thread dispatch epoch, supersedes all pending queued dispatches, and cancels the active run. Returns `interrupt_requested` with `superseded_dispatches` count. Unlike `/cancel`, this performs a clean-slate interrupt via `mailbox.interrupt()`. |
 | `PATCH` | `/v1/threads/:id/metadata` | Alias for thread metadata updates |
-| `GET` | `/v1/threads/:id/messages` | List thread messages |
+| `GET` | `/v1/threads/:id/messages` | List thread messages with cursor pagination, sequence range, ordering, and visibility/run filters |
 | `POST` | `/v1/threads/:id/messages` | Submit messages as a background run on this thread |
 | `POST` | `/v1/threads/:id/mailbox` | Push a message payload to the thread mailbox |
 | `GET` | `/v1/threads/:id/mailbox` | List mailbox dispatches for the thread |
 | `GET` | `/v1/threads/:id/runs` | List runs for the thread |
+| `GET` | `/v1/threads/:id/runs/active` | Get the active run for the thread, if any |
 | `GET` | `/v1/threads/:id/runs/latest` | Get the latest run for the thread |
 
 `POST /v1/threads/:id/messages` and `POST /v1/runs/:id/inputs` accept an
@@ -152,11 +153,35 @@ responses. All MCP HTTP routes validate `Origin` when present.
 
 ## Common query parameters
 
+Pagination:
+
 - `offset` — number of items to skip
-- `limit` — maximum items to return, clamped to `1..=200`
-- `cursor` — message-history pagination cursor; when provided it takes precedence over `offset`, and history responses return `next_cursor`
-- `status` — run filter: `running`, `waiting`, or `done`
-- `visibility` — message filter: omit for external-only, set to `all` to include internal messages
+- `limit` — maximum items to return, clamped to `1..=200` (default `50`)
+- `cursor` — opaque pagination cursor; when provided it takes precedence over
+  `offset`. Cursors are bound to the original query shape and rejected if
+  any filter changes between requests
+- `next_cursor` / `prev_cursor` — returned in the response body when more
+  pages exist
+
+Thread list filters (`/v1/threads`, `/v1/threads/summaries`):
+
+- `resource_id` (alias `resourceId`) — filter by external resource grouping
+- `parent_thread_id` (alias `parentThreadId`) — restrict to direct children of
+  this parent thread
+- `root` — when `true`, restrict to root threads with no parent. Cannot be
+  combined with `parent_thread_id`
+
+Message list filters (`/v1/threads/:id/messages` and the protocol-specific
+aliases):
+
+- `after`, `before` — sequence-number window
+- `order` — `asc` (default) or `desc`
+- `visibility` — `external` (default), `internal`, or `all`
+- `run_id` (alias `runId`) — restrict to messages produced by this run
+
+Run list filters:
+
+- `status` — `running`, `waiting`, or `done`
 
 ## Error format
 

--- a/docs/book/src/reference/provider-model-config.md
+++ b/docs/book/src/reference/provider-model-config.md
@@ -81,7 +81,8 @@ Example config documents:
   "adapter": "openai",
   "api_key": "sk-...",
   "base_url": null,
-  "timeout_secs": 300
+  "timeout_secs": 300,
+  "adapter_options": {}
 }
 ```
 
@@ -98,6 +99,33 @@ Example config documents:
   "id": "assistant",
   "model_id": "default",
   "system_prompt": "You are helpful."
+}
+```
+
+### ProviderSpec fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `id` | `String` | required | Provider identifier referenced by `ModelBindingSpec.provider_id` |
+| `adapter` | `String` | required | GenAI adapter kind (e.g. `"openai"`, `"anthropic"`, `"ollama"`) |
+| `api_key` | `Option<RedactedString>` | `None` | Wrapped in `RedactedString`; redacted in `Debug`/`Display`. Wire format is a plain JSON string. Empty-string input deserializes as `None` so a stored key is preserved when the field is omitted on update |
+| `base_url` | `Option<String>` | `None` | Override base URL for proxies or self-hosted deployments. Empty-string input deserializes as `None` |
+| `timeout_secs` | `u64` | `300` | Request timeout in seconds |
+| `adapter_options` | `BTreeMap<String, Value>` | `{}` | Adapter-specific non-secret options. Today the OpenAI-compatible adapter recognizes `headers` (an object of string→string pairs added as default request headers). Unknown keys are accepted by the schema and ignored at build time. Secrets must use `api_key`; do not store credentials here |
+
+Example with custom headers:
+
+```json
+{
+  "id": "bigmodel",
+  "adapter": "openai",
+  "api_key": "<redacted>",
+  "base_url": "https://open.bigmodel.cn/api/paas/v4",
+  "adapter_options": {
+    "headers": {
+      "X-Tenant-Id": "team-42"
+    }
+  }
 }
 ```
 
@@ -139,14 +167,16 @@ rg '"model"\s*:|"provider"\s*:|fallback_models' config/ docs/ tests/
 Each match should be checked. Protocol payloads may still use a field named
 `model` when they mirror an external protocol; managed Awaken config should not.
 
-## Provider secrets
+## Provider secrets via the config API
 
-Provider API keys are write-only through the config API:
+The config API treats `api_key` as write-only:
 
-- responses redact `api_key`;
-- responses expose `has_api_key: true` when a key is stored;
-- updating a provider without `api_key` preserves the existing key;
-- setting `api_key` to `null` or an empty string clears it.
+- list/get responses replace `api_key` with `has_api_key: true|false`;
+- `PUT` with `api_key` omitted keeps the stored key;
+- `PUT` with `api_key: null` or `api_key: ""` clears it.
+
+The in-memory representation is `RedactedString` (see
+[config reference — secret handling](./config.md#secret-handling)).
 
 ## Runtime snapshot behavior
 

--- a/docs/book/src/reference/thread-model.md
+++ b/docs/book/src/reference/thread-model.md
@@ -20,7 +20,11 @@ RunRecord produces MessageRecord through checkpointed assistant/tool output.
 pub struct Thread {
     /// Unique thread identifier (UUID v7).
     pub id: String,
-    /// Thread metadata.
+    /// External resource or tenant grouping for this thread.
+    pub resource_id: Option<String>,
+    /// Parent thread id when this thread was created by a sub-agent run.
+    pub parent_thread_id: Option<String>,
+    /// Thread metadata (timestamps, title, custom data).
     pub metadata: ThreadMetadata,
     /// Run currently executing on a worker for this thread.
     pub active_run_id: Option<String>,
@@ -32,6 +36,13 @@ pub struct Thread {
 ```
 
 **Crate path:** `awaken::contract::thread::Thread` (re-exported from `awaken-contract`)
+
+`parent_thread_id` is normalized on assignment: leading/trailing whitespace is
+trimmed and empty strings deserialize to `None`. The same trimming is applied
+to `resource_id`. Thread hierarchy participates in the run lifecycle: when a
+sub-agent run begins, `RunRequestSnapshot.parent_thread_id` carries the parent
+thread, and the checkpoint projection populates `Thread.parent_thread_id` on
+the child thread the first time it is materialized.
 
 ### Constructors
 
@@ -47,6 +58,8 @@ fn with_id(id: impl Into<String>) -> Self
 
 ```rust,ignore
 fn with_title(self, title: impl Into<String>) -> Self
+fn with_resource_id(self, resource_id: impl Into<String>) -> Self
+fn with_parent_thread_id(self, parent_thread_id: impl Into<String>) -> Self
 ```
 
 `Thread` implements `Default` (delegates to `Thread::new()`), `Clone`,
@@ -105,10 +118,32 @@ pub trait ThreadStore: Send + Sync {
 }
 ```
 
-The default helpers on `ThreadStore` now cover first-class lineage filtering,
+The default helpers on `ThreadStore` cover first-class lineage filtering,
 parent existence / cycle validation, and child-thread delete strategies
-(`reject`, `detach`, `cascade`) without requiring every backend to reimplement
-that logic.
+without requiring every backend to reimplement that logic.
+
+```rust,ignore
+pub enum ChildThreadDeleteStrategy {
+    /// Reject deletion when at least one direct child exists.
+    Reject,
+    /// Preserve child threads and clear their `parent_thread_id`. Default.
+    Detach,
+    /// Recursively delete all descendants before deleting the target thread.
+    Cascade,
+}
+```
+
+The default `delete_thread_with_strategy` implementation issues multiple
+low-level writes and is **not atomic** across child updates and the final
+delete. Production backends with concurrent writers should override the
+method with a transactional or otherwise fenced implementation. The file,
+PostgreSQL, and NATS-buffered backends ship with backend-native overrides.
+
+The default `list_threads_query` walks `list_threads` in fixed-size chunks
+and filters in memory; the file, PostgreSQL, and NATS-buffered backends each
+override it with a backend-native pushdown. Cursors returned by
+`ThreadQuery::encode_cursor` are validated against the original query shape
+on decode, so a paged sequence cannot drift onto a different filter.
 
 `Message` is the protocol payload sent to agents and protocol adapters.
 `MessageRecord` is the durable thread-log projection:

--- a/docs/book/src/state-and-storage.md
+++ b/docs/book/src/state-and-storage.md
@@ -8,6 +8,28 @@ This path is for teams moving beyond stateless demos.
 - where runtime config, mailbox jobs, and profile/shared state should live
 - how state is keyed and merged
 - how much context should reach the model each turn
+- how to model parent–child threads when sub-agents create their own threads
+
+## Thread hierarchy
+
+Threads carry an optional `parent_thread_id`. The runtime sets it on a child
+thread the first time a sub-agent run materializes the thread, taking the
+value from `RunRequestSnapshot.parent_thread_id`. `ThreadStore` exposes
+`list_child_threads`, `validate_thread_hierarchy`, and
+`delete_thread_with_strategy(reject | detach | cascade)` so callers can pick a
+child-handling policy explicitly. The default `Detach` strategy preserves
+children with `parent_thread_id` cleared. The default
+`delete_thread_with_strategy` implementation is not atomic across child writes
+and the final delete; production stores with concurrent writers should
+override it. The file, PostgreSQL, and NATS-buffered backends ship native
+overrides.
+
+Pagination: `list_threads_query(&ThreadQuery)` supports `parent_filter`
+(`Any`, `Root`, or `Parent(parent_id)`) and `resource_id` filters with cursor
+tokens that are validated against the original query shape on decode.
+`list_message_records(thread_id, &MessageQuery)` paginates messages with
+sequence-number windows, `asc`/`desc` ordering, visibility filters, and
+producing-run filters.
 
 ## Recommended order
 

--- a/docs/book/src/tutorials/first-agent.md
+++ b/docs/book/src/tutorials/first-agent.md
@@ -8,7 +8,7 @@ Run one agent end-to-end and inspect the final result.
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde_json = "1"

--- a/docs/book/src/tutorials/first-tool.md
+++ b/docs/book/src/tutorials/first-tool.md
@@ -13,7 +13,7 @@ Implement one tool that reads typed state from `ToolCallContext` during executio
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/docs/book/src/zh-CN/SUMMARY.md
+++ b/docs/book/src/zh-CN/SUMMARY.md
@@ -46,6 +46,7 @@
 - [启用可观测性](./how-to/enable-observability.md)
 - [上报 Tool 进度](./how-to/report-tool-progress.md)
 - [测试策略](./how-to/testing-strategy.md)
+- [流式 LLM 错误恢复](./how-to/recover-streaming-llms.md)
 
 # 参考
 

--- a/docs/book/src/zh-CN/how-to/enable-observability.md
+++ b/docs/book/src/zh-CN/how-to/enable-observability.md
@@ -10,7 +10,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["observability"] }
+awaken = { version = "0.4.0", features = ["observability"] }
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/book/src/zh-CN/how-to/enable-tool-permission-hitl.md
+++ b/docs/book/src/zh-CN/how-to/enable-tool-permission-hitl.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["permission"] }
+awaken = { version = "0.4.0", features = ["permission"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/zh-CN/how-to/expose-http-sse.md
+++ b/docs/book/src/zh-CN/how-to/expose-http-sse.md
@@ -14,7 +14,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["server"] }
+awaken = { version = "0.4.0", features = ["server"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
 ```
 

--- a/docs/book/src/zh-CN/how-to/integrate-ai-sdk-frontend.md
+++ b/docs/book/src/zh-CN/how-to/integrate-ai-sdk-frontend.md
@@ -10,7 +10,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["server"] }
+awaken = { version = "0.4.0", features = ["server"] }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde_json = "1"
@@ -99,32 +99,52 @@ AI SDK v6 相关路由：
 npm install ai @ai-sdk/react
 ```
 
-3. 在前端里使用 `useChat`：
+3. 在前端里使用 `useChat`。AI SDK v6 的 `useChat` 返回
+   `{ messages, sendMessage, status, ... }`，请求通过 transport 发出，因此
+   awaken 后端 URL 写在 `DefaultChatTransport` 里：
 
 ```tsx
+import { useState } from "react";
 import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
 
 export default function Chat() {
-  const { messages, input, handleInputChange, handleSubmit } = useChat({
-    api: "http://localhost:3000/v1/ai-sdk/chat",
+  const { messages, sendMessage } = useChat({
     id: "thread-1",
+    transport: new DefaultChatTransport({
+      api: "http://localhost:3000/v1/ai-sdk/chat",
+    }),
   });
+  const [input, setInput] = useState("");
 
   return (
     <div>
       {messages.map((m) => (
         <div key={m.id}>
-          <strong>{m.role}:</strong> {m.content}
+          <strong>{m.role}:</strong>
+          {m.parts.map((part, idx) =>
+            part.type === "text" ? <span key={idx}>{part.text}</span> : null,
+          )}
         </div>
       ))}
-      <form onSubmit={handleSubmit}>
-        <input value={input} onChange={handleInputChange} />
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!input.trim()) return;
+          sendMessage({ text: input });
+          setInput("");
+        }}
+      >
+        <input value={input} onChange={(event) => setInput(event.target.value)} />
         <button type="submit">Send</button>
       </form>
     </div>
   );
 }
 ```
+
+完整模式（自定义 transport header、自动续发、带类型的 tool parts）见
+[`examples/ai-sdk-starter/src/hooks/use-chat-session.ts`](../../../../examples/ai-sdk-starter/src/hooks/use-chat-session.ts)。
 
 4. 分别启动后端和前端。
 

--- a/docs/book/src/zh-CN/how-to/integrate-copilotkit-ag-ui.md
+++ b/docs/book/src/zh-CN/how-to/integrate-copilotkit-ag-ui.md
@@ -10,7 +10,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["server"] }
+awaken = { version = "0.4.0", features = ["server"] }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde_json = "1"
@@ -117,7 +117,7 @@ import "@copilotkit/react-ui/styles.css";
 
 export default function App() {
   return (
-    <CopilotKit runtimeUrl="http://localhost:3000/v1/ag-ui">
+    <CopilotKit runtimeUrl="http://localhost:3000/v1/ag-ui/run">
       <CopilotChat
         labels={{ title: "Agent", initial: "How can I help?" }}
       />
@@ -140,7 +140,7 @@ export default function App() {
 | 错误 | 原因 | 修复 |
 |---|---|---|
 | 浏览器 CORS 错误 | 未配置 CORS 中间件 | 给 axum router 加 CORS |
-| CopilotKit 提示 connection failed | `runtimeUrl` 错了 | 指向 `http://localhost:3000/v1/ag-ui` |
+| CopilotKit 提示 connection failed | `runtimeUrl` 错了 | 指向 `http://localhost:3000/v1/ag-ui/run`（AG-UI 的 run 端点，不是命名空间） |
 | 有事件但 UI 不更新 | AG-UI 事件格式不兼容 | 确认 CopilotKit 版本匹配 |
 | `/v1/ag-ui/run` 返回 404 | 没开 `server` feature | 在 `Cargo.toml` 里启用 |
 

--- a/docs/book/src/zh-CN/how-to/optimize-context-window.md
+++ b/docs/book/src/zh-CN/how-to/optimize-context-window.md
@@ -108,6 +108,22 @@ let config = CompactionConfig {
 
 内置 `DefaultSummarizer` 会读取 `CompactionConfig`，并支持“在已有摘要上继续增量总结”。
 
+### 后台执行
+
+压缩**不会**阻塞推理 phase。条件满足时，`maybe_spawn_compaction` 会先确定边
+界、把 `CompactionInFlight` 标记写进 `CompactionStateKey`，再通过 agent 的
+`BackgroundTaskManager` 把摘要 LLM 调用 spawn 到后台。完成事件经由 owner inbox
+返回，由 `try_consume_compaction_event` 消费；如果边界依然存在，
+`apply_summary` 会把摘要 swap 到消息日志里。
+
+实践上需要知道两件事：
+
+- 同一 agent 上的压缩是单飞（single-flight）的。`CompactionState::is_compacting`
+  为真时，下一轮推理不会再规划新的压缩，直接以未压缩的历史继续；swap 完成后
+  下一轮才会基于新的摘要前缀继续。
+- 一次压缩需要已解析 agent 上同时存在 LLM summarizer 和 `BackgroundTaskManager`。
+  缺少任意一个，`maybe_spawn_compaction` 直接 no-op，runtime 退回到 truncation。
+
 ### 摘要存储
 
 压缩结果会被保存成带 `<conversation-summary>` 标签的内部 system message。重新加载时，历史中较早的已摘要部分不会再被重新放回上下文窗口。

--- a/docs/book/src/zh-CN/how-to/recover-streaming-llms.md
+++ b/docs/book/src/zh-CN/how-to/recover-streaming-llms.md
@@ -1,0 +1,113 @@
+# 流式 LLM 错误恢复
+
+当流式推理过程中出现的瞬时 provider 故障不应该浮现为 run 错误时，看这里。
+runtime 会重试在流式开始**之前**就失败的整个请求；本页讨论更难的情况——模型已
+经开始产 token 之后才出现的失败。
+
+## runtime 替你处理的部分
+
+流式推理通过 `InferenceExecutionError::StreamInterrupted` 与 `InterruptCause`
+检测四种 mid-stream 中断原因：
+
+- `ConnectionReset`：响应头之后 TCP/HTTP/2 连接断开
+- `IdleStall`：空闲窗口内没有收到新字节
+- `GoAway`：响应中途收到 HTTP/2 GOAWAY
+- `Provider5xxMidStream(u16)`：流式开始后 provider 返回 5xx
+
+任意一种触发后，loop runner 会调用 `InterruptSnapshot::plan()` 选择四种恢复方
+案之一。代码里命名为 `R1..R4`：
+
+| 方案 | 触发条件 | runtime 行为 |
+|---|---|---|
+| **R1 — `ContinueText`** | 只有累积文本，没有 in-flight tool call | 把已累积文本作为 assistant 前缀 + 继续提示重试；模型从断点继续生成 |
+| **R2 — `SynthesizeToolUse`** | 至少一个 tool call 的参数 JSON 已完整到达 | 合成 `StopReason::ToolUse` 终态，让 loop runner 执行已完成的 tool；未完成的 tool 作为提示在下一轮 user message 里告诉模型 |
+| **R3 — `TruncateBeforeTool`** | 既有文本又有一个未闭合的 tool call | 截到文本前缀，发出 `AgentEvent::ToolCallCancel` 让消费者丢弃 partial 参数 delta，然后继续 |
+| **R4 — `WholeRestart`** | 啥都救不回来（既无文本也无完整 tool） | 重启整个 assistant 轮次；发出 `AgentEvent::StreamReset` 让消费者丢弃这一轮已发出的所有 delta |
+
+`Retry-After` 会被尊重：当 provider 在 `429` 或 `529` 返回 `Retry-After` 时，
+`InferenceExecutionError::RateLimited` 与 `Overloaded` 携带解析得到的
+`Duration`，retry 子系统至少等待该时长后再重试。
+
+## 客户端看到的事件
+
+恢复后的轮次中，SSE 消费者照常收到 `TextDelta` 与 `ToolCallDelta`。两个新事
+件告诉消费者要丢什么：
+
+- `ToolCallCancel { id, name, reason }`：丢掉这个 tool call 已缓冲的 partial
+  delta。
+- `StreamReset { reason }`：丢掉当前 assistant 轮次的**全部** delta，新的
+  delta 接着到来。
+
+这两种事件只是告知，不会进入持久化的 thread 日志；通过 `MessagesSnapshot` 重
+新渲染的客户端不需要特殊处理。
+
+## 跨进程续接
+
+单进程的重试循环已经足以应对同一台服务器活到中断之后的场景。要做跨进程恢复
+——也就是从**前一个进程**的断点继续——就需要 `StreamCheckpointStore` 契约。
+
+```rust,ignore
+use awaken::contract::stream_checkpoint::{
+    InMemoryStreamCheckpointStore, StreamCheckpoint, StreamCheckpointStore,
+};
+
+#[async_trait::async_trait]
+trait StreamCheckpointStore: Send + Sync {
+    async fn put(&self, checkpoint: StreamCheckpoint) -> Result<(), _>;
+    async fn get(&self, run_id: &str) -> Result<Option<StreamCheckpoint>, _>;
+    async fn delete(&self, run_id: &str) -> Result<(), _>;
+}
+```
+
+stream 运行过程中，loop runner 会按 `run_id` 周期性地把累积的 `partial_text`、
+`completed_tool_calls` 以及未闭合的 `in_flight_tool` 写入 store。当新的进程接
+管这个 run 时，`execute_streaming` 起始处会读到 checkpoint，并把它转换成与
+进程内重试路径相同的 R1 前缀注入。
+
+checkpoint **不是**完整的对话日志——已提交的消息仍由 `ThreadRunStore` 拥有。
+checkpoint 只保留 in-flight delta 累积态，因此契约只有三个方法（`put`、`get`、
+`delete`）。
+
+### 把 store 接到 Agent 上
+
+store 存在 `ResolvedAgent::stream_checkpoint_store`，通过 builder 方法填充：
+
+```rust,ignore
+use awaken::contract::stream_checkpoint::{
+    InMemoryStreamCheckpointStore, StreamCheckpointStore,
+};
+use std::sync::Arc;
+
+let store: Arc<dyn StreamCheckpointStore> =
+    Arc::new(InMemoryStreamCheckpointStore::new());
+
+let resolved = resolved.with_stream_checkpoint_store(store);
+```
+
+默认 resolver 管线把这个字段置为 `None`。要让每次解析都带上 store，可以包装
+你的 `AgentResolver`，在它返回的 `ResolvedAgent` 上调一次
+`with_stream_checkpoint_store(store.clone())` 再交给 runtime。
+`AgentRuntimeBuilder` 暂时还没有直接的快捷方法；如有需要可以在
+[GitHub issues](https://github.com/AwakenWorks/awaken/issues) 跟进。
+
+仓库里自带的 `InMemoryStreamCheckpointStore` 适合测试和单进程使用。要做跨进
+程恢复，请基于共享后端（NATS JetStream KV、Redis、文件系统路径等）实现该
+trait。每次 `put` 都应该按 `run_id` 幂等地 upsert checkpoint；`delete` 在轮次
+提交完成后调用。
+
+## 不在范围内
+
+- 不会重试永久性错误。`ContextOverflow`、`InvalidRequest`、`Unauthorized`、
+  `ModelNotFound`、`ContentFiltered` 会短路重试子系统直接抛回调用方。
+- 不会修复"格式错但没截断"的 tool call JSON。这是另一回事；恢复 snapshot 只
+  在参数能解析为 JSON 时才算它"完成"。
+- 不会自动把恢复内容回写到持久化消息日志。恢复后轮次重新发出的 delta 会产生
+  与一次新 run 相同的最终 assistant 消息，checkpoint 在该消息提交后才被清理。
+
+## 相关
+
+- [错误](../reference/errors.md)：完整的 `InferenceExecutionError` 分类与访问
+  器。
+- [事件](../reference/events.md)：`ToolCallCancel` / `StreamReset` 语义。
+- [优化上下文窗口](./optimize-context-window.md)：另一个独立的截断恢复路径，
+  适用于模型自己以 `MaxTokens` 停止的场景。

--- a/docs/book/src/zh-CN/how-to/use-deferred-tools.md
+++ b/docs/book/src/zh-CN/how-to/use-deferred-tools.md
@@ -9,8 +9,8 @@
 
 ```toml
 [dependencies]
-awaken-ext-deferred-tools = { version = "0.4.0-dev" }
-awaken = { version = "0.4.0-dev" }
+awaken-ext-deferred-tools = { version = "0.4.0" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/zh-CN/how-to/use-file-store.md
+++ b/docs/book/src/zh-CN/how-to/use-file-store.md
@@ -12,7 +12,7 @@
 
 ```toml
 [dependencies]
-awaken-stores = { version = "0.4.0-dev", features = ["file"] }
+awaken-stores = { version = "0.4.0", features = ["file"] }
 ```
 
 如果使用 `awaken` 门面 crate，也建议直接加 `awaken-stores` 来启用 `file` feature。

--- a/docs/book/src/zh-CN/how-to/use-generative-ui.md
+++ b/docs/book/src/zh-CN/how-to/use-generative-ui.md
@@ -15,7 +15,7 @@ Awaken 当前支持两种集成方式：
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/zh-CN/how-to/use-mcp-tools.md
+++ b/docs/book/src/zh-CN/how-to/use-mcp-tools.md
@@ -10,7 +10,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["mcp"] }
+awaken = { version = "0.4.0", features = ["mcp"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/zh-CN/how-to/use-postgres-store.md
+++ b/docs/book/src/zh-CN/how-to/use-postgres-store.md
@@ -14,7 +14,7 @@
 
 ```toml
 [dependencies]
-awaken-stores = { version = "0.4.0-dev", features = ["postgres"] }
+awaken-stores = { version = "0.4.0", features = ["postgres"] }
 ```
 
 2. 创建连接池：

--- a/docs/book/src/zh-CN/how-to/use-reminder-plugin.md
+++ b/docs/book/src/zh-CN/how-to/use-reminder-plugin.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["reminder"] }
+awaken = { version = "0.4.0", features = ["reminder"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/zh-CN/how-to/use-skills-subsystem.md
+++ b/docs/book/src/zh-CN/how-to/use-skills-subsystem.md
@@ -9,7 +9,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev", features = ["skills"] }
+awaken = { version = "0.4.0", features = ["skills"] }
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/book/src/zh-CN/operate.md
+++ b/docs/book/src/zh-CN/operate.md
@@ -8,9 +8,24 @@
 2. 再启用 [工具权限 HITL](./how-to/enable-tool-permission-hitl.md)，为工具执行增加审批控制。
 3. 通过 [配置停止策略](./how-to/configure-stop-policies.md) 把 agent loop 约束在可预测范围内。
 4. 用 [上报 Tool 进度](./how-to/report-tool-progress.md) 和 [测试策略](./how-to/testing-strategy.md) 提升可观测性和上线信心。
+5. 当瞬时 provider 故障不应该浮现为 run 错误时，参考 [流式 LLM 错误恢复](./how-to/recover-streaming-llms.md)。
+
+## 加固 admin 与配置面
+
+两个互不相关的开关，详见 [配置参考](./reference/config.md)：
+
+- `AdminApiConfig.bearer_token`（或 `AWAKEN_ADMIN_API_BEARER_TOKEN`）保护
+  `/v1/capabilities`、`/v1/config/*`、`/v1/agents*`。
+- `AdminApiConfig.expose_config_routes = false` 把 admin CRUD 路由整组卸下，
+  适合配置由外部流水线管理的部署。
+
+如果配置写入频繁碎小，给 `ConfigRuntimeManager::with_min_apply_interval(Duration)`
+设一个窗口可以把 listener 触发的 apply 合并；hash 未变的 `ProviderSpec` 会
+复用缓存的 executor。
 
 ## 建议搭配阅读
 
 - [错误](./reference/errors.md)
 - [取消](./reference/cancellation.md)
 - [HITL 与 Mailbox](./explanation/hitl-and-mailbox.md)
+- [配置](./reference/config.md)

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -195,17 +195,20 @@ pub struct RemoteAuth {
 HTTP server 配置。需启用 `server` feature。
 
 ```rust,ignore
+use awaken::RedactedString;
+
 pub struct ServerConfig {
-    pub address: String,                   // default: "0.0.0.0:3000"
-    pub sse_buffer_size: usize,            // default: 64
-    pub replay_buffer_capacity: usize,     // default: 1024
+    pub address: String,                              // default: "0.0.0.0:3000"
+    pub sse_buffer_size: usize,                       // default: 64
+    pub replay_buffer_capacity: usize,                // default: 1024
     pub shutdown: ShutdownConfig,
-    pub max_concurrent_requests: usize,    // default: 100
-    pub a2a_extended_card_bearer_token: Option<String>,
+    pub max_concurrent_requests: usize,               // default: 100
+    pub a2a_extended_card_bearer_token: Option<RedactedString>,
+    pub mailbox_lifecycle: MailboxLifecycleMode,      // default: Auto
 }
 
 pub struct ShutdownConfig {
-    pub timeout_secs: u64,                 // default: 30
+    pub timeout_secs: u64,                            // default: 30
 }
 ```
 
@@ -217,7 +220,8 @@ pub struct ShutdownConfig {
 | `sse_buffer_size` | `usize` | `64` | 单连接 SSE 通道最大缓冲帧数 |
 | `replay_buffer_capacity` | `usize` | `1024` | 每次 run 用于断线续接的最大 replay buffer 帧数 |
 | `max_concurrent_requests` | `usize` | `100` | 最大并发请求数；超出时返回 503 |
-| `a2a_extended_card_bearer_token` | `Option<String>` | `None` | 设置后启用带认证的 `GET /v1/a2a/extendedAgentCard` |
+| `a2a_extended_card_bearer_token` | `Option<RedactedString>` | `None` | 设置后启用带认证的 `GET /v1/a2a/extendedAgentCard`。`Debug`/`Display` 自动遮蔽，需要明文请调用 `expose_secret()`；JSON 序列化保持普通字符串 |
+| `mailbox_lifecycle` | `MailboxLifecycleMode` | `Auto` | `Auto` 由框架启停 mailbox；`Manual` 把生命周期交给嵌入应用 |
 | `shutdown.timeout_secs` | `u64` | `30` | 强制退出前等待飞行中请求排空的秒数 |
 
 ## AdminApiConfig
@@ -227,16 +231,20 @@ admin/configuration API 安全配置。通过
 认证时可使用 `AppState::with_admin_api_bearer_token`。
 
 ```rust,ignore
+use awaken::RedactedString;
+
 pub struct AdminApiConfig {
-    pub bearer_token: Option<String>,
+    pub bearer_token: Option<RedactedString>,
     pub cors_allowed_origins: Vec<String>,
+    pub expose_config_routes: bool,                   // default: true
 }
 ```
 
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
-| `bearer_token` | `Option<String>` | `None` | 设置后，`/v1/capabilities`、`/v1/config/*` 和 `/v1/agents*` 要求 `Authorization: Bearer ...` |
+| `bearer_token` | `Option<RedactedString>` | `None` | 设置后，`/v1/capabilities`、`/v1/config/*` 和 `/v1/agents*` 要求 `Authorization: Bearer ...`。`Debug`/`Display` 自动遮蔽，需要明文请调用 `expose_secret()`；JSON 序列化保持普通字符串 |
 | `cors_allowed_origins` | `Vec<String>` | `["http://127.0.0.1:3002", "http://localhost:3002"]` | admin CORS layer 允许的浏览器来源 |
+| `expose_config_routes` | `bool` | `true` | 是否挂载 `/v1/config/*` 与 `/v1/agents` 这套 admin CRUD 路由。当配置由外部 RBAC/审计流水线管理时设为 `false`，可以彻底隐藏这部分 HTTP 表面；`/v1/capabilities` 仍保持暴露以便前端发现已注册组件 |
 
 环境变量会覆盖 `AppState` 上的 admin 配置：
 
@@ -244,6 +252,27 @@ pub struct AdminApiConfig {
 |---|---|
 | `AWAKEN_ADMIN_API_BEARER_TOKEN` | admin/configuration API 要求的 bearer token |
 | `AWAKEN_ADMIN_CORS_ALLOWED_ORIGINS` | 浏览器 admin API 的 CORS 来源，逗号分隔 |
+
+### 凭据处理
+
+`RedactedString`（门面 crate 重新导出为 `awaken::RedactedString`，定义在
+`awaken_contract::secret`）是序列化配置中所有凭据的唯一信任边界。线缆格式仍是普通 JSON 字符串、JSON Schema 报告 `string`，内
+部 buffer 在 `Drop` 时被清零。`Debug` 输出 `RedactedString(***)`，`Display`
+输出 `***`；真正发起请求时调用 `expose_secret()` 获取明文，且不要把返回的
+`&str` 传到日志。原本持有 `String` token 的代码只需在构造处加一个 `.into()`
+或在读取处加一个 `.expose_secret()`。
+
+## ConfigRuntimeManager
+
+`ConfigRuntimeManager` 在配置变化时编译候选注册快照并发布到运行中的 runtime。
+
+| 构建器方法 | 默认值 | 说明 |
+|---|---|---|
+| `with_provider_factory(factory)` | `GenaiProviderExecutorFactory` | 覆盖 `ProviderSpec` 到 `LlmExecutor` 的物化方式 |
+| `with_change_notifier(notifier)` | `None` | 订阅原生变更通知，避免轮询 |
+| `with_mcp_registry_factory(factory)` | `DefaultMcpRegistryFactory` | 覆盖 MCP server spec 到注册表的转换 |
+| `with_mcp_refresh_interval(interval)` | 关闭 | 周期性刷新 MCP server 连接 |
+| `with_min_apply_interval(interval)` | `Duration::ZERO` | 由 change listener 驱动的相邻 apply 之间的最小间隔。窗口内到达的事件会合并为一次 apply；直接调用 `apply` / `apply_if_changed` 不受影响。spec hash 未变的 provider 在 apply 之间会复用缓存的 executor |
 
 ## MailboxConfig
 

--- a/docs/book/src/zh-CN/reference/errors.md
+++ b/docs/book/src/zh-CN/reference/errors.md
@@ -73,16 +73,70 @@ pub enum RuntimeError {
 
 ## InferenceExecutionError
 
-LLM 执行层错误。
+LLM 执行层错误。变体按可恢复性分为三类：
+
+- **Transient（可重试）**：会被重试子系统再次发起，且计入每模型的熔断器计数。
+- **Permanent（不可重试）**：换模型也会失败，不计入熔断器。
+- **Fail-fast**：重试子系统已经无法（或不应该）再尝试。
+
+枚举为 `#[non_exhaustive]`。crate 外部的代码必须包含 `_ => …` 分支，并优先使
+用 `is_retryable()`、`counts_toward_circuit_breaker()`、`retry_after()` 三个
+访问器，而不是直接对具体变体做模式匹配。
 
 ```rust,ignore
+use std::time::Duration;
+use awaken::contract::executor::{InterruptCause, InterruptSnapshot};
+
+#[non_exhaustive]
 pub enum InferenceExecutionError {
+    // Transient
     Provider(String),
-    RateLimited(String),
+    RateLimited { message: String, retry_after: Option<Duration> },
+    Overloaded  { message: String, retry_after: Option<Duration> },
     Timeout(String),
+    StreamInterrupted { cause: InterruptCause, snapshot: Box<InterruptSnapshot> },
+
+    // Permanent
+    ContextOverflow(String),
+    InvalidRequest(String),
+    Unauthorized(String),
+    ModelNotFound(String),
+    ContentFiltered(String),
+
+    // Fail-fast
+    AllModelsUnavailable,
     Cancelled,
 }
 ```
+
+| 类别 | 变体 |
+|---|---|
+| Transient（可重试） | `Provider`、`RateLimited`、`Overloaded`、`Timeout`、`StreamInterrupted` |
+| Permanent（不可重试） | `ContextOverflow`、`InvalidRequest`、`Unauthorized`、`ModelNotFound`、`ContentFiltered` |
+| Fail-fast | `AllModelsUnavailable`、`Cancelled` |
+
+`RateLimited` 与 `Overloaded` 携带从 provider `Retry-After` 头解析得到的可选
+`retry_after`；retry 子系统会优先尊重该提示，再回退到指数退避。
+
+`StreamInterrupted` 携带 `InterruptCause`（`ConnectionReset`、`IdleStall`、
+`GoAway`、`Provider5xxMidStream(u16)`）以及 `InterruptSnapshot`，里面记录了
+中断时的 partial 文本、已完成的 tool call，以及参数尚未完成的 in-flight tool。
+loop runner 据此选择四种恢复方案之一，详见
+[流式 LLM 错误恢复](../how-to/recover-streaming-llms.md)。
+
+### 便捷访问器
+
+```rust,ignore
+fn is_retryable(&self) -> bool;
+fn counts_toward_circuit_breaker(&self) -> bool;
+fn retry_after(&self) -> Option<std::time::Duration>;
+
+// 常用短构造：
+fn rate_limited(message: impl Into<String>) -> Self;
+fn overloaded(message: impl Into<String>) -> Self;
+```
+
+**Crate 路径：** `awaken::contract::executor::InferenceExecutionError`
 
 ## StorageError
 

--- a/docs/book/src/zh-CN/reference/events.md
+++ b/docs/book/src/zh-CN/reference/events.md
@@ -12,11 +12,13 @@ pub enum AgentEvent {
         thread_id: String,
         run_id: String,
         parent_run_id: Option<String>,    // 为 None 时省略
+        identity: Option<RunIdentity>,    // 为 None 时省略
     },
 
     RunFinish {
         thread_id: String,
         run_id: String,
+        identity: Option<RunIdentity>,    // 为 None 时省略
         result: Option<Value>,            // 为 None 时省略
         termination: TerminationReason,
     },
@@ -67,6 +69,18 @@ pub enum AgentEvent {
 
     ToolCallResumed { target_id: String, result: Value },
 
+    /// 已经开始流式产生的 tool call，在参数 JSON 闭合前被中途取消（mid-stream
+    /// 中断恢复路径触发）。消费者应该把对应 `id` 已缓冲的 partial delta 丢掉。
+    ToolCallCancel {
+        id: String,
+        name: String,
+        reason: String,                   // 例如 "connection reset"、"idle stall"
+    },
+
+    /// 当前 assistant 轮次因 mid-stream 中断而无法通过 continuation 恢复，
+    /// 整个轮次重启。消费者应该把这一轮已发出的所有 delta 丢掉。
+    StreamReset { reason: String },
+
     StepStart { message_id: String },
 
     StepEnd,
@@ -89,6 +103,14 @@ pub enum AgentEvent {
 ```
 
 **Crate 路径：** `awaken::contract::event::AgentEvent`
+
+### 流式恢复语义
+
+`ToolCallCancel` 和 `StreamReset` 是 mid-stream 恢复期间发出的"丢弃信号"。
+消费者把对应 tool call（或整轮）的 partial buffer 丢掉、继续读流即可，恢复后
+的 delta 会通过常规的 `TextDelta` / `ToolCallDelta` 通道到来。四种恢复方案与
+`StreamCheckpointStore` 接入见
+[流式 LLM 错误恢复](../how-to/recover-streaming-llms.md)。
 
 ### Helper
 

--- a/docs/book/src/zh-CN/reference/http-api.md
+++ b/docs/book/src/zh-CN/reference/http-api.md
@@ -16,21 +16,22 @@
 
 | 方法 | 路径 | 说明 |
 |---|---|---|
-| `GET` | `/v1/threads` | 列出 thread ID |
-| `POST` | `/v1/threads` | 创建 thread |
-| `GET` | `/v1/threads/summaries` | 列出 thread 摘要 |
+| `GET` | `/v1/threads` | 列出 thread ID，支持分页与父子过滤；返回 `{ items, offset, limit, total, has_more, next_cursor }` |
+| `POST` | `/v1/threads` | 创建 thread；body：`{ "title"?: string, "resource_id"?: string, "parent_thread_id"?: string }` |
+| `GET` | `/v1/threads/summaries` | 列出 thread 摘要（id、`resource_id`、`parent_thread_id`、title、`updated_at`、`agent_id`），分页与父子过滤参数与 `/v1/threads` 相同 |
 | `GET` | `/v1/threads/:id` | 获取 thread |
 | `PATCH` | `/v1/threads/:id` | 更新 thread 元信息 |
-| `DELETE` | `/v1/threads/:id` | 删除 thread |
+| `DELETE` | `/v1/threads/:id` | 删除 thread；可通过 `?child_strategy=detach\|reject\|cascade`（默认 `detach`）控制子 thread 的处理方式 |
 | `POST` | `/v1/threads/:id/cancel` | 取消该 thread 上排队或运行中的某个 dispatch；返回 `cancel_requested` |
 | `POST` | `/v1/threads/:id/decision` | 向该 thread 上等待中的 run 提交 HITL decision |
 | `POST` | `/v1/threads/:id/interrupt` | 中断该 thread：递增 thread dispatch epoch、取消所有待执行 dispatch、中止活动 run；返回 `interrupt_requested` 及 `superseded_dispatches` 计数。与 `/cancel` 不同，此接口通过 `mailbox.interrupt()` 执行完整的"清空并中断"操作 |
 | `PATCH` | `/v1/threads/:id/metadata` | 更新 metadata 的别名接口 |
-| `GET` | `/v1/threads/:id/messages` | 列出消息 |
+| `GET` | `/v1/threads/:id/messages` | 列出消息，支持游标分页、序号窗口、排序、可见性与产生 run 过滤 |
 | `POST` | `/v1/threads/:id/messages` | 作为后台 run 提交消息 |
 | `POST` | `/v1/threads/:id/mailbox` | 向 mailbox 推送消息载荷 |
 | `GET` | `/v1/threads/:id/mailbox` | 查看该 thread 的 mailbox dispatch |
 | `GET` | `/v1/threads/:id/runs` | 列出该 thread 的 runs |
+| `GET` | `/v1/threads/:id/runs/active` | 获取该 thread 当前活动 run（如有） |
 | `GET` | `/v1/threads/:id/runs/latest` | 获取最新 run |
 
 `POST /v1/threads/:id/messages` 与 `POST /v1/runs/:id/inputs` 支持可选的
@@ -147,11 +148,31 @@ section。
 
 ## 常见查询参数
 
+分页：
+
 - `offset`：跳过的条数
-- `limit`：返回上限，范围会被限制在 `1..=200`
-- `cursor`：消息历史分页游标；提供后会优先于 `offset`，历史消息接口响应会返回 `next_cursor`
-- `status`：按 run 状态过滤，支持 `running`、`waiting`、`done`
-- `visibility`：消息可见性过滤；省略时只看外部消息，`all` 表示包含内部消息
+- `limit`：返回上限，范围限制在 `1..=200`（默认 `50`）
+- `cursor`：不透明分页游标，提供后会优先于 `offset`。游标绑定到原始 query
+  形状，filter 一旦改变就会被拒绝
+- 响应中的 `next_cursor` / `prev_cursor` 在仍有更多页时返回
+
+Thread 列表过滤（`/v1/threads`、`/v1/threads/summaries`）：
+
+- `resource_id`（别名 `resourceId`）：按外部资源分组过滤
+- `parent_thread_id`（别名 `parentThreadId`）：仅返回该父 thread 的直接子线程
+- `root`：为 `true` 时仅返回没有父线程的根 thread；不能与 `parent_thread_id`
+  同时使用
+
+消息列表过滤（`/v1/threads/:id/messages` 及各协议别名）：
+
+- `after`、`before`：序号窗口
+- `order`：`asc`（默认）或 `desc`
+- `visibility`：`external`（默认）、`internal` 或 `all`
+- `run_id`（别名 `runId`）：仅保留由该 run 产生的消息
+
+Run 列表过滤：
+
+- `status`：`running`、`waiting` 或 `done`
 
 ## 错误格式
 

--- a/docs/book/src/zh-CN/reference/provider-model-config.md
+++ b/docs/book/src/zh-CN/reference/provider-model-config.md
@@ -76,7 +76,8 @@ let runtime = AgentRuntimeBuilder::new()
   "adapter": "openai",
   "api_key": "sk-...",
   "base_url": null,
-  "timeout_secs": 300
+  "timeout_secs": 300,
+  "adapter_options": {}
 }
 ```
 
@@ -93,6 +94,33 @@ let runtime = AgentRuntimeBuilder::new()
   "id": "assistant",
   "model_id": "default",
   "system_prompt": "You are helpful."
+}
+```
+
+### ProviderSpec 字段
+
+| 字段 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `id` | `String` | 必填 | provider 标识，被 `ModelBindingSpec.provider_id` 引用 |
+| `adapter` | `String` | 必填 | GenAI 适配器类型（如 `"openai"`、`"anthropic"`、`"ollama"`） |
+| `api_key` | `Option<RedactedString>` | `None` | 用 `RedactedString` 包裹，`Debug`/`Display` 自动遮蔽。线缆格式是普通 JSON 字符串。空字符串输入会反序列化为 `None`，便于在更新时省略字段以保留已有 key |
+| `base_url` | `Option<String>` | `None` | 代理或自托管部署的 base URL 覆盖。空字符串输入反序列化为 `None` |
+| `timeout_secs` | `u64` | `300` | 请求超时（秒） |
+| `adapter_options` | `BTreeMap<String, Value>` | `{}` | 适配器专属、非密的扩展选项。当前 OpenAI 兼容适配器识别 `headers`（一个 string→string 的对象，作为默认请求头加进去）。Schema 接受未知 key，但构建时会被忽略。秘密值必须用 `api_key`，不要塞到这里 |
+
+带自定义 header 的示例：
+
+```json
+{
+  "id": "bigmodel",
+  "adapter": "openai",
+  "api_key": "<redacted>",
+  "base_url": "https://open.bigmodel.cn/api/paas/v4",
+  "adapter_options": {
+    "headers": {
+      "X-Tenant-Id": "team-42"
+    }
+  }
 }
 ```
 
@@ -133,14 +161,16 @@ rg '"model"\s*:|"provider"\s*:|fallback_models' config/ docs/ tests/
 每个匹配项都需要人工确认。某些外部协议 payload 可能仍然有名为 `model` 的字段；
 Awaken 托管配置不应再使用这些旧字段。
 
-## Provider 密钥
+## Provider 密钥（配置 API 视角）
 
-Provider API key 通过配置 API 写入后不会明文返回：
+配置 API 把 `api_key` 当作只写字段：
 
-- 响应会移除 `api_key`；
-- 已保存 key 时响应包含 `has_api_key: true`；
-- 更新 provider 时省略 `api_key` 会保留已有 key；
-- 把 `api_key` 设为 `null` 或空字符串会清除 key。
+- list/get 响应中 `api_key` 被替换为 `has_api_key: true|false`；
+- `PUT` 时省略 `api_key` 会保留已有 key；
+- `PUT` `api_key: null` 或 `""` 会清空 key。
+
+进程内的存储类型是 `RedactedString`（详见
+[配置参考 — 凭据处理](./config.md#凭据处理)）。
 
 ## Runtime 快照行为
 

--- a/docs/book/src/zh-CN/reference/thread-model.md
+++ b/docs/book/src/zh-CN/reference/thread-model.md
@@ -19,6 +19,8 @@ RunRecord 通过 checkpoint 产出 assistant/tool 消息。
 ```rust,ignore
 pub struct Thread {
     pub id: String,
+    pub resource_id: Option<String>,
+    pub parent_thread_id: Option<String>,
     pub metadata: ThreadMetadata,
     pub active_run_id: Option<String>,
     pub open_run_id: Option<String>,
@@ -29,6 +31,11 @@ pub struct Thread {
 `active_run_id` 指向正在 worker 上执行的 run。`open_run_id` 指向当前未完成、
 可以继续恢复的用户意图。`latest_run_id` 指向最近一次 run。过期 dispatch
 的 supersede epoch 属于 `RunDispatch`/mailbox 平面，不属于 thread 真相。
+
+`parent_thread_id` 在赋值时会规范化：去除前后空白、空字符串反序列化为 `None`，
+`resource_id` 同样处理。Thread hierarchy 与 run 生命周期联动：当一个 sub-agent
+run 启动时，`RunRequestSnapshot.parent_thread_id` 携带父 thread；checkpoint
+投影会在子 thread 第一次被物化时填充 `Thread.parent_thread_id`。
 
 ### 构造函数
 
@@ -41,6 +48,8 @@ fn with_id(id: impl Into<String>) -> Self
 
 ```rust,ignore
 fn with_title(self, title: impl Into<String>) -> Self
+fn with_resource_id(self, resource_id: impl Into<String>) -> Self
+fn with_parent_thread_id(self, parent_thread_id: impl Into<String>) -> Self
 ```
 
 ## ThreadMetadata
@@ -86,8 +95,28 @@ pub trait ThreadStore: Send + Sync {
 }
 ```
 
-`ThreadStore` 的默认辅助方法现在直接覆盖了 lineage 过滤、父线程存在性/环检测，
-以及子线程删除策略（`reject` / `detach` / `cascade`），后端不需要重复实现这套逻辑。
+`ThreadStore` 的默认辅助方法直接覆盖了 lineage 过滤、父线程存在性/环检测，
+以及子线程删除策略，后端不需要重复实现这套逻辑。
+
+```rust,ignore
+pub enum ChildThreadDeleteStrategy {
+    /// 当存在直接子 thread 时，拒绝删除。
+    Reject,
+    /// 保留子 thread，并清空它们的 `parent_thread_id`。默认值。
+    Detach,
+    /// 递归删除所有后代 thread，再删除目标 thread。
+    Cascade,
+}
+```
+
+默认的 `delete_thread_with_strategy` 实现会发出多次低级写操作，**不是**原子操
+作。生产级的并发后端应该用事务或栅栏化的实现覆盖该方法；file、PostgreSQL 与
+NATS-buffered 后端已经提供了原生覆盖。
+
+默认的 `list_threads_query` 会按固定步长扫 `list_threads` 后在内存里做过滤；
+file、PostgreSQL 与 NATS-buffered 后端各自提供了原生下推。
+`ThreadQuery::encode_cursor` 返回的游标在 decode 时会校验原始 query 的形状，
+因此分页序列不会漂移到不同的过滤条件。
 
 `Message` 是协议载荷；`MessageRecord` 是 thread 消息日志的持久化投影：
 

--- a/docs/book/src/zh-CN/state-and-storage.md
+++ b/docs/book/src/zh-CN/state-and-storage.md
@@ -8,6 +8,23 @@
 - runtime config、mailbox job 与 profile/shared state 放在哪里
 - 状态键和合并策略怎么组织
 - 每一轮究竟把多少上下文送给模型
+- sub-agent 派生子 thread 时，父子层级如何建模
+
+## Thread 父子层级
+
+Thread 携带可选的 `parent_thread_id`。当 sub-agent run 第一次物化子 thread
+时，runtime 会用 `RunRequestSnapshot.parent_thread_id` 填充该字段。
+`ThreadStore` 暴露 `list_child_threads`、`validate_thread_hierarchy` 和
+`delete_thread_with_strategy(reject | detach | cascade)`，让调用方显式选择子
+线程的处理策略。默认 `Detach` 会保留子线程并清空它们的 `parent_thread_id`。
+默认的 `delete_thread_with_strategy` 在「子线程更新 + 最终删除」之间不是原子
+操作；并发写场景下应当用事务或栅栏化的实现覆盖；file、PostgreSQL 与
+NATS-buffered 后端已经有原生覆盖。
+
+分页：`list_threads_query(&ThreadQuery)` 支持 `parent_filter`（`Any`、`Root`
+或 `Parent(parent_id)`）与 `resource_id` 过滤，游标在 decode 时会校验原始
+query 形状。`list_message_records(thread_id, &MessageQuery)` 提供带序号窗口、
+`asc`/`desc` 排序、可见性过滤与产生 run 过滤的消息分页。
 
 ## 推荐顺序
 

--- a/docs/book/src/zh-CN/tutorials/first-agent.md
+++ b/docs/book/src/zh-CN/tutorials/first-agent.md
@@ -8,7 +8,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde_json = "1"

--- a/docs/book/src/zh-CN/tutorials/first-tool.md
+++ b/docs/book/src/zh-CN/tutorials/first-tool.md
@@ -13,7 +13,7 @@
 
 ```toml
 [dependencies]
-awaken = { version = "0.4.0-dev" }
+awaken = { version = "0.4.0" }
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/e2e/tests/mailbox.spec.ts
+++ b/e2e/tests/mailbox.spec.ts
@@ -12,7 +12,8 @@ test.describe('mailbox operations', () => {
     });
     expect(pushRes.status()).toBe(201);
     const body = await pushRes.json();
-    expect(body.job_id).toBeTruthy();
+    expect(body.dispatch_id).toBeTruthy();
+    expect(body.run_id).toBeTruthy();
     expect(body.thread_id).toBe(thread.id);
   });
 
@@ -27,7 +28,8 @@ test.describe('mailbox operations', () => {
     });
     expect(pushRes.status()).toBe(201);
     const body = await pushRes.json();
-    expect(body.job_id).toBeTruthy();
+    expect(body.dispatch_id).toBeTruthy();
+    expect(body.run_id).toBeTruthy();
   });
 
   test('peek thread mailbox returns items array', async ({ request }) => {


### PR DESCRIPTION
## Summary

- Bump workspace `0.4.0-dev → 0.4.0` and write the `[0.4.0]` CHANGELOG entry.
  The `awaken` name on crates.io was transferred from
  [@brayniac](https://github.com/brayniac); this codebase continues the
  `awaken-agent 0.2.x` line and skips past the prior `awaken 0.1`–`0.3`.
- Restructure README + zh-CN around what 0.4 actually delivers: cross-process
  stream recovery (`StreamCheckpointStore`, R1–R4 plans, new
  `AgentEvent::ToolCallCancel` / `StreamReset`), parent-child thread lineage
  with explicit child-delete strategies, `RedactedString` for provider keys
  and admin tokens, paged thread/message queries, `expose_config_routes` and
  `min_apply_interval` on the config plane.
- Add `how-to/recover-streaming-llms.md` (en + zh) and refresh the affected
  reference and how-to pages (`config`, `provider-model-config`, `errors`,
  `events`, `http-api`, `thread-model`, `state-and-storage`, `operate`,
  `optimize-context-window`, `use-nats-stores`, AI SDK / CopilotKit how-tos).
- Re-export `awaken::RedactedString` from the facade so the documented
  import path actually compiles.
- Carries the prior commits already on this branch:
  `feat(runtime): wire per-run BackgroundTaskManager + summarizer` and
  `test(e2e): align mailbox push assertions with dispatch_id`.

## Test plan

- [x] `mdbook build docs/book` — zero warnings
- [x] `cargo check -p awaken -p awaken-server -p awaken-contract`
- [x] `cargo test -p awaken --test readme_quickstart`
- [ ] Reviewer eyes on README/CHANGELOG tone and the brayniac acknowledgement