### PR TITLE
🚀 ci(release): publish awaken facade before awaken-agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           publish awaken-ext-reminder
           publish awaken-ext-skills
           publish awaken-server
+          publish awaken
           # Final crate — no sleep needed
           echo "=== Publishing awaken-agent ==="
           cargo publish --no-verify -p awaken-agent


### PR DESCRIPTION
## Summary

`release.yml` was written when `awaken-agent` was the canonical umbrella crate. After the 0.4 brayniac transfer, `awaken` is canonical and `awaken-agent` is a thin compat shim that depends on `awaken`. The current publish loop never pushes `awaken` to crates.io, so the final `cargo publish -p awaken-agent` step would fail to resolve `awaken@0.4.0` and the GitHub Release step would be skipped.

This PR adds a single `publish awaken` line between `awaken-server` and the final `awaken-agent` push so 0.4.0 (and every subsequent release) can publish cleanly.

## Test plan

- [ ] Merge → push tag `v0.4.0` → confirm both `awaken@0.4.0` and `awaken-agent@0.4.0` appear on crates.io and the GitHub Release is created