### PR TITLE
🔧 chore(version): bump to 0.4.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "awaken-examples",
  "clap",
@@ -267,7 +267,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awaken"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -289,14 +289,14 @@ dependencies = [
 
 [[package]]
 name = "awaken-agent"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "awaken",
 ]
 
 [[package]]
 name = "awaken-contract"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-doctest"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-examples"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-deferred-tools"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-generative-ui"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-mcp"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-observability"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-permission"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-reminder"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-skills"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-protocol-a2a"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-stores"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-tool-pattern"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "glob-match",
  "regex",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.4.0"
+version = "0.4.1-dev"
 dependencies = [
  "awaken-examples",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
@@ -32,19 +32,19 @@ keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-awaken-contract = { version = "0.4.0", path = "crates/awaken-contract" }
-awaken-protocol-a2a = { version = "0.4.0", path = "crates/awaken-protocol-a2a" }
-awaken-stores = { version = "0.4.0", path = "crates/awaken-stores" }
-awaken-runtime = { version = "0.4.0", path = "crates/awaken-runtime" }
-awaken-ext-permission = { version = "0.4.0", path = "crates/awaken-ext-permission" }
-awaken-ext-observability = { version = "0.4.0", path = "crates/awaken-ext-observability" }
-awaken-ext-mcp = { version = "0.4.0", path = "crates/awaken-ext-mcp" }
-awaken-ext-skills = { version = "0.4.0", path = "crates/awaken-ext-skills" }
-awaken-ext-reminder = { version = "0.4.0", path = "crates/awaken-ext-reminder" }
-awaken-ext-generative-ui = { version = "0.4.0", path = "crates/awaken-ext-generative-ui" }
-awaken-ext-deferred-tools = { version = "0.4.0", path = "crates/awaken-ext-deferred-tools" }
-awaken-tool-pattern = { version = "0.4.0", path = "crates/awaken-tool-pattern" }
-awaken-server = { version = "0.4.0", path = "crates/awaken-server" }
+awaken-contract = { version = "0.4.1-dev", path = "crates/awaken-contract" }
+awaken-protocol-a2a = { version = "0.4.1-dev", path = "crates/awaken-protocol-a2a" }
+awaken-stores = { version = "0.4.1-dev", path = "crates/awaken-stores" }
+awaken-runtime = { version = "0.4.1-dev", path = "crates/awaken-runtime" }
+awaken-ext-permission = { version = "0.4.1-dev", path = "crates/awaken-ext-permission" }
+awaken-ext-observability = { version = "0.4.1-dev", path = "crates/awaken-ext-observability" }
+awaken-ext-mcp = { version = "0.4.1-dev", path = "crates/awaken-ext-mcp" }
+awaken-ext-skills = { version = "0.4.1-dev", path = "crates/awaken-ext-skills" }
+awaken-ext-reminder = { version = "0.4.1-dev", path = "crates/awaken-ext-reminder" }
+awaken-ext-generative-ui = { version = "0.4.1-dev", path = "crates/awaken-ext-generative-ui" }
+awaken-ext-deferred-tools = { version = "0.4.1-dev", path = "crates/awaken-ext-deferred-tools" }
+awaken-tool-pattern = { version = "0.4.1-dev", path = "crates/awaken-tool-pattern" }
+awaken-server = { version = "0.4.1-dev", path = "crates/awaken-server" }
 glob-match = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/awaken-agent/Cargo.toml
+++ b/crates/awaken-agent/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 doctest = false
 
 [dependencies]
-awaken = { version = "0.4.0", path = "../awaken", default-features = false }
+awaken = { version = "0.4.1-dev", path = "../awaken", default-features = false }
 
 [features]
 default = ["full"]

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-awaken = { package = "awaken", version = "0.4.0", path = "../awaken", features = ["full"] }
+awaken = { package = "awaken", version = "0.4.1-dev", path = "../awaken", features = ["full"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Step 6 of the release flow in `CONTRIBUTING.md`: after `v0.4.0` is tagged and pushed, bump the workspace and all internal path-dependency pins back to `0.4.1-dev` so subsequent commits on `main` cannot accidentally publish under the released version.

- `Cargo.toml`: `version = "0.4.0"` → `"0.4.1-dev"` and 13 internal `awaken-*` workspace pins
- `Cargo.lock`: regenerated by `cargo check --workspace`
- `crates/awaken-agent/Cargo.toml` and `crates/awaken-doctest/Cargo.toml`: their `awaken = "0.4.0"` path-dep pin → `"0.4.1-dev"`

## Test plan

- [x] `cargo check --workspace` — clean