### PR TITLE
Admin console week-1 UX overhaul + data router fix

### DIFF
--- a/apps/admin-console/package-lock.json
+++ b/apps/admin-console/package-lock.json
@@ -18,11 +18,14 @@
         "react-router": "^7"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4",
         "autoprefixer": "^10.4",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5",
         "tailwindcss": "^3.4",
         "typescript": "^5",
@@ -106,6 +109,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -341,6 +395,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -387,6 +451,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -829,6 +1046,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1348,6 +1583,61 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1657,6 +1947,29 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1684,6 +1997,16 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1743,6 +2066,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -1914,6 +2247,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1934,6 +2281,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1951,6 +2312,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -1975,12 +2343,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
       "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
@@ -2220,6 +2608,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2282,6 +2683,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -2297,6 +2705,57 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2399,6 +2858,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2425,6 +2894,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2534,6 +3010,19 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
@@ -2752,6 +3241,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -2768,6 +3279,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -2982,6 +3503,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3083,6 +3617,13 @@
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -3232,6 +3773,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3243,6 +3804,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -3264,6 +3851,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3521,6 +4118,54 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3537,6 +4182,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/apps/admin-console/package.json
+++ b/apps/admin-console/package.json
@@ -10,21 +10,24 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.81",
     "@rjsf/core": "^6.4.2",
     "@rjsf/utils": "^6.4.2",
     "@rjsf/validator-ajv8": "^6.4.2",
-    "@ai-sdk/react": "^3.0.81",
     "ai": "^6.0.79",
     "react": "19",
     "react-dom": "19",
     "react-router": "^7"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
     "autoprefixer": "^10.4",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5",
     "tailwindcss": "^3.4",
     "typescript": "^5",

--- a/apps/admin-console/src/app.smoke.test.tsx
+++ b/apps/admin-console/src/app.smoke.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import {
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from "react-router";
+import { appRoutes } from "./app";
+import { AuthProvider } from "./components/auth-provider";
+import { ConfirmDialogProvider } from "./components/confirm-dialog";
+import { ToastProvider } from "./components/toast-provider";
+import { ADMIN_TOKEN_STORAGE_KEY } from "./lib/config-api";
+import { __resetAuthInterceptorForTesting } from "./lib/auth-interceptor";
+
+// AuthProvider probes /v1/capabilities on mount. The smoke tests are
+// purely about rendering the route tree; stub fetch so the probe
+// resolves with an empty capability set instead of going to a real
+// network. Each test installs its own mock so we don't leak state.
+
+function stubCapabilitiesFetch() {
+  const fetchSpy = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    text: async () =>
+      JSON.stringify({
+        agents: [],
+        tools: [],
+        plugins: [],
+        skills: [],
+        models: [],
+        providers: [],
+        namespaces: [],
+      }),
+  }));
+  vi.stubGlobal("fetch", fetchSpy);
+  return fetchSpy;
+}
+
+function renderRoute(path: string) {
+  const memRouter = createMemoryRouter(
+    createRoutesFromElements(appRoutes()),
+    { initialEntries: [path] },
+  );
+  return render(
+    <ToastProvider>
+      <ConfirmDialogProvider>
+        <AuthProvider>
+          <RouterProvider router={memRouter} />
+        </AuthProvider>
+      </ConfirmDialogProvider>
+    </ToastProvider>,
+  );
+}
+
+beforeEach(() => {
+  // The token modal listens to localStorage; jsdom provides a sane impl
+  // but we wipe it between tests to keep them deterministic.
+  globalThis.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+  stubCapabilitiesFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  __resetAuthInterceptorForTesting();
+});
+
+describe("router smoke", () => {
+  it("renders the dashboard route without throwing", async () => {
+    renderRoute("/");
+    // The lazy AdminLayout always shows "Admin Console" once mounted.
+    // findBy* waits for the suspense fallback to resolve.
+    expect(await screen.findByText("Admin Console")).toBeDefined();
+  });
+
+  it("renders the agent editor for /agents/new (regression: useBlocker invariant)", async () => {
+    renderRoute("/agents/new");
+    // The Basics tab renders an "Agent ID" labelled input — the same
+    // selector that broke when the AgentEditorPage crashed because the
+    // legacy BrowserRouter could not satisfy useBlocker.
+    expect(await screen.findByLabelText("Agent ID")).toBeDefined();
+    expect(await screen.findByRole("heading", { name: /New Agent/ })).toBeDefined();
+  });
+
+  it.each([
+    { path: "/agents", header: "Agents" },
+    { path: "/skills", header: "Skill Registry" },
+    { path: "/models", header: "Models" },
+    { path: "/providers", header: "Providers" },
+    { path: "/mcp-servers", header: "MCP Servers" },
+    { path: "/eval-reports", header: "Eval Reports" },
+  ])("renders $path without crashing", async ({ path, header }) => {
+    renderRoute(path);
+    expect(
+      await screen.findByRole("heading", { level: 2, name: header }),
+    ).toBeDefined();
+  });
+});
+
+describe("provider wiring", () => {
+  it("AuthProvider exposes the connected backend URL via the layout", async () => {
+    renderRoute("/");
+    expect(await screen.findByText(/Connected Backend/)).toBeDefined();
+  });
+
+  it("Suspense fallback wraps lazy routes (no plain throw on first render)", () => {
+    // Wrapping the smoke render in our own Suspense lets us assert the
+    // fallback render path is intact (the app uses RouteLoader for this
+    // internally, but a paranoia-level assertion here documents intent).
+    const memRouter = createMemoryRouter(
+      createRoutesFromElements(appRoutes()),
+      { initialEntries: ["/"] },
+    );
+    expect(() =>
+      render(
+        <Suspense fallback={<div>loading-shell</div>}>
+          <ToastProvider>
+            <ConfirmDialogProvider>
+              <AuthProvider>
+                <RouterProvider router={memRouter} />
+              </AuthProvider>
+            </ConfirmDialogProvider>
+          </ToastProvider>
+        </Suspense>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/apps/admin-console/src/app.tsx
+++ b/apps/admin-console/src/app.tsx
@@ -65,7 +65,7 @@ const AgentDashboardPage = lazy(async () => {
 /// Routes are declared once and reused via the data router so that v7
 /// hooks like `useBlocker` work. `<Routes>` (kept exported for tests
 /// that prefer the legacy router) renders the same structure.
-function appRoutes() {
+export function appRoutes() {
   return (
     <>
       <Route

--- a/apps/admin-console/src/app.tsx
+++ b/apps/admin-console/src/app.tsx
@@ -1,5 +1,11 @@
 import { type ReactNode, Suspense, lazy } from "react";
-import { Navigate, Route, Routes } from "react-router";
+import {
+  Navigate,
+  Route,
+  Routes,
+  createBrowserRouter,
+  createRoutesFromElements,
+} from "react-router";
 
 const AdminLayout = lazy(async () => {
   const module = await import("./components/admin-layout");
@@ -56,9 +62,12 @@ const AgentDashboardPage = lazy(async () => {
   return { default: module.AgentDashboardPage };
 });
 
-export function App() {
+/// Routes are declared once and reused via the data router so that v7
+/// hooks like `useBlocker` work. `<Routes>` (kept exported for tests
+/// that prefer the legacy router) renders the same structure.
+function appRoutes() {
   return (
-    <Routes>
+    <>
       <Route
         path="/"
         element={
@@ -149,8 +158,14 @@ export function App() {
         />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    </>
   );
+}
+
+export const router = createBrowserRouter(createRoutesFromElements(appRoutes()));
+
+export function App() {
+  return <Routes>{appRoutes()}</Routes>;
 }
 
 function RouteLoader({ children }: { children: ReactNode }) {

--- a/apps/admin-console/src/components/admin-layout.tsx
+++ b/apps/admin-console/src/components/admin-layout.tsx
@@ -1,6 +1,8 @@
 import { NavLink, Outlet } from "react-router";
 import { BACKEND_URL } from "@/lib/config-api";
+import { maskAdminToken } from "@/lib/admin-token";
 import { adminRoutes } from "@/lib/routes";
+import { describeAuthStatus, useAuth } from "./auth-provider";
 
 const navItems = [
   { path: adminRoutes.dashboard, label: "Dashboard", end: true },
@@ -13,7 +15,18 @@ const navItems = [
   { path: adminRoutes.evalReports, label: "Eval Reports" },
 ];
 
+const STATUS_TONE_CLASS = {
+  ok: "bg-emerald-400",
+  warn: "bg-amber-400",
+  error: "bg-rose-500",
+  neutral: "bg-slate-400",
+} as const;
+
 export function AdminLayout() {
+  const { token, status, openTokenModal } = useAuth();
+  const description = describeAuthStatus(status);
+  const dotClass = STATUS_TONE_CLASS[description.tone];
+
   return (
     <div className="min-h-screen text-slate-900 md:flex">
       <aside className="border-b border-slate-200 bg-[#102236] text-slate-100 md:min-h-screen md:w-80 md:border-b-0 md:border-r md:border-slate-800">
@@ -31,14 +44,31 @@ export function AdminLayout() {
             </p>
           </div>
 
-          <div className="mt-5 rounded-2xl border border-white/10 bg-white/5 p-4">
-            <div className="text-[11px] uppercase tracking-[0.2em] text-slate-400">
-              Connected Backend
+          <button
+            type="button"
+            onClick={openTokenModal}
+            className="mt-5 block w-full rounded-2xl border border-white/10 bg-white/5 p-4 text-left transition hover:border-white/20 hover:bg-white/10"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-[11px] uppercase tracking-[0.2em] text-slate-400">
+                Connected Backend
+              </div>
+              <span className="flex items-center gap-1.5 text-[11px] text-slate-300">
+                <span
+                  aria-hidden
+                  className={`h-2 w-2 rounded-full ${dotClass}`}
+                />
+                {description.label}
+              </span>
             </div>
             <div className="mt-2 break-all font-mono text-xs text-slate-200">
               {BACKEND_URL}
             </div>
-          </div>
+            <div className="mt-2 text-[11px] text-slate-400">
+              Admin token: <span className="font-mono">{maskAdminToken(token)}</span>
+              <span className="ml-2 text-slate-500">— click to manage</span>
+            </div>
+          </button>
         </div>
 
         <nav className="grid grid-cols-2 gap-2 px-4 py-4 sm:grid-cols-3 md:flex md:flex-col md:space-y-1 md:px-4 md:py-5">

--- a/apps/admin-console/src/components/admin-token-modal.tsx
+++ b/apps/admin-console/src/components/admin-token-modal.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+
+export interface AdminTokenModalProps {
+  open: boolean;
+  initialToken: string;
+  reason: "manual" | "unauthorized";
+  onSubmit: (token: string) => void;
+  onClear: () => void;
+  onCancel: () => void;
+}
+
+export function AdminTokenModal({
+  open,
+  initialToken,
+  reason,
+  onSubmit,
+  onClear,
+  onCancel,
+}: AdminTokenModalProps) {
+  const [draft, setDraft] = useState(initialToken);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setDraft(initialToken);
+    }
+  }, [open, initialToken]);
+
+  useEffect(() => {
+    if (open && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onCancel();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    onSubmit(draft);
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="admin-token-modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onCancel();
+        }
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl"
+      >
+        <h2
+          id="admin-token-modal-title"
+          className="text-lg font-semibold text-slate-950"
+        >
+          {reason === "unauthorized" ? "Admin token required" : "Set admin token"}
+        </h2>
+        <p className="mt-2 text-sm text-slate-600">
+          {reason === "unauthorized"
+            ? "The backend rejected the last request. Paste the bearer token to retry."
+            : "Tokens are stored in this browser only and sent as Authorization: Bearer."}
+        </p>
+        <input
+          ref={inputRef}
+          type="password"
+          autoComplete="off"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Bearer token"
+          className="mt-4 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+        />
+        <div className="mt-5 flex flex-wrap items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-sm font-medium text-rose-600 transition hover:text-rose-700"
+          >
+            Clear stored token
+          </button>
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={draft.trim().length === 0}
+            className="rounded-xl bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/admin-console/src/components/auth-provider.tsx
+++ b/apps/admin-console/src/components/auth-provider.tsx
@@ -1,0 +1,171 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  clearAdminToken,
+  readAdminToken,
+  writeAdminToken,
+} from "@/lib/admin-token";
+import { setUnauthorizedHandler } from "@/lib/auth-interceptor";
+import { configApi, ConfigApiError } from "@/lib/config-api";
+import { AdminTokenModal } from "./admin-token-modal";
+import { useToast } from "./toast-provider";
+
+export type AuthStatus =
+  | "checking"
+  | "ok"
+  | "unauthorized"
+  | "missing"
+  | "disconnected";
+
+interface AuthContextValue {
+  token: string | null;
+  status: AuthStatus;
+  openTokenModal: () => void;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface PendingPrompt {
+  reason: "manual" | "unauthorized";
+  resolve: (token: string | null) => void;
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => readAdminToken());
+  const [status, setStatus] = useState<AuthStatus>("checking");
+  const [pending, setPending] = useState<PendingPrompt | null>(null);
+  const toast = useToast();
+  const refreshSeqRef = useRef(0);
+
+  const probe = useCallback(async () => {
+    const seq = ++refreshSeqRef.current;
+    setStatus("checking");
+    try {
+      await configApi.capabilities();
+      if (refreshSeqRef.current === seq) setStatus("ok");
+    } catch (probeError) {
+      if (refreshSeqRef.current !== seq) return;
+      if (probeError instanceof ConfigApiError) {
+        if (probeError.status === 401) {
+          setStatus(readAdminToken() ? "unauthorized" : "missing");
+        } else {
+          setStatus("disconnected");
+        }
+      } else {
+        setStatus("disconnected");
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void probe();
+  }, [probe]);
+
+  const promptForToken = useCallback(
+    (reason: "manual" | "unauthorized"): Promise<string | null> => {
+      return new Promise((resolve) => {
+        setPending({ reason, resolve });
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const dispose = setUnauthorizedHandler(async () => {
+      const result = await promptForToken("unauthorized");
+      return result;
+    });
+    return dispose;
+  }, [promptForToken]);
+
+  const handleSubmit = useCallback(
+    (next: string) => {
+      const trimmed = next.trim();
+      if (trimmed.length === 0) return;
+      writeAdminToken(trimmed);
+      setToken(trimmed);
+      const current = pending;
+      setPending(null);
+      current?.resolve(trimmed);
+      toast.success("Admin token saved");
+      void probe();
+    },
+    [pending, probe, toast],
+  );
+
+  const handleClear = useCallback(() => {
+    clearAdminToken();
+    setToken(null);
+    const current = pending;
+    setPending(null);
+    current?.resolve(null);
+    toast.info("Admin token cleared");
+    setStatus("missing");
+  }, [pending, toast]);
+
+  const handleCancel = useCallback(() => {
+    const current = pending;
+    setPending(null);
+    current?.resolve(null);
+  }, [pending]);
+
+  const openTokenModal = useCallback(() => {
+    setPending((current) =>
+      current ? current : { reason: "manual", resolve: () => {} },
+    );
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ token, status, openTokenModal, refresh: probe }),
+    [token, status, openTokenModal, probe],
+  );
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+      <AdminTokenModal
+        open={pending !== null}
+        initialToken={token ?? ""}
+        reason={pending?.reason ?? "manual"}
+        onSubmit={handleSubmit}
+        onClear={handleClear}
+        onCancel={handleCancel}
+      />
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used inside <AuthProvider>");
+  }
+  return ctx;
+}
+
+export function describeAuthStatus(status: AuthStatus): {
+  label: string;
+  tone: "ok" | "warn" | "error" | "neutral";
+} {
+  switch (status) {
+    case "ok":
+      return { label: "Connected", tone: "ok" };
+    case "checking":
+      return { label: "Checking…", tone: "neutral" };
+    case "missing":
+      return { label: "Token missing", tone: "warn" };
+    case "unauthorized":
+      return { label: "Token rejected", tone: "error" };
+    case "disconnected":
+      return { label: "Backend unreachable", tone: "error" };
+  }
+}

--- a/apps/admin-console/src/components/auth-status.test.ts
+++ b/apps/admin-console/src/components/auth-status.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { describeAuthStatus, type AuthStatus } from "./auth-provider";
+
+describe("describeAuthStatus", () => {
+  const cases: Array<{ status: AuthStatus; label: string; tone: string }> = [
+    { status: "ok", label: "Connected", tone: "ok" },
+    { status: "checking", label: "Checking…", tone: "neutral" },
+    { status: "missing", label: "Token missing", tone: "warn" },
+    { status: "unauthorized", label: "Token rejected", tone: "error" },
+    { status: "disconnected", label: "Backend unreachable", tone: "error" },
+  ];
+
+  for (const { status, label, tone } of cases) {
+    it(`maps ${status} to label="${label}" tone="${tone}"`, () => {
+      expect(describeAuthStatus(status)).toEqual({ label, tone });
+    });
+  }
+});

--- a/apps/admin-console/src/components/confirm-dialog.tsx
+++ b/apps/admin-console/src/components/confirm-dialog.tsx
@@ -1,0 +1,126 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type ConfirmTone = "neutral" | "destructive";
+
+export interface ConfirmRequest {
+  title: string;
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  tone?: ConfirmTone;
+}
+
+type ConfirmFn = (request: ConfirmRequest) => Promise<boolean>;
+
+const ConfirmDialogContext = createContext<ConfirmFn | null>(null);
+
+interface PendingState extends ConfirmRequest {
+  resolve: (value: boolean) => void;
+}
+
+export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<PendingState | null>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement>(null);
+
+  const confirm = useCallback<ConfirmFn>((request) => {
+    return new Promise<boolean>((resolve) => {
+      setPending({ ...request, resolve });
+    });
+  }, []);
+
+  const respond = useCallback(
+    (value: boolean) => {
+      const current = pending;
+      setPending(null);
+      current?.resolve(value);
+    },
+    [pending],
+  );
+
+  useEffect(() => {
+    if (!pending) return;
+    confirmButtonRef.current?.focus();
+
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        respond(false);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [pending, respond]);
+
+  return (
+    <ConfirmDialogContext.Provider value={confirm}>
+      {children}
+      {pending ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-dialog-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) {
+              respond(false);
+            }
+          }}
+        >
+          <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl">
+            <h2
+              id="confirm-dialog-title"
+              className="text-lg font-semibold text-slate-950"
+            >
+              {pending.title}
+            </h2>
+            {pending.description ? (
+              <div className="mt-2 text-sm leading-6 text-slate-600">
+                {pending.description}
+              </div>
+            ) : null}
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => respond(false)}
+                className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                {pending.cancelLabel ?? "Cancel"}
+              </button>
+              <button
+                ref={confirmButtonRef}
+                type="button"
+                onClick={() => respond(true)}
+                className={
+                  pending.tone === "destructive"
+                    ? "rounded-xl bg-rose-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-rose-700"
+                    : "rounded-xl bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
+                }
+              >
+                {pending.confirmLabel ?? "Confirm"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </ConfirmDialogContext.Provider>
+  );
+}
+
+export function useConfirmDialog(): ConfirmFn {
+  const ctx = useContext(ConfirmDialogContext);
+  if (!ctx) {
+    throw new Error(
+      "useConfirmDialog must be used inside <ConfirmDialogProvider>",
+    );
+  }
+  return ctx;
+}

--- a/apps/admin-console/src/components/list-controls.tsx
+++ b/apps/admin-console/src/components/list-controls.tsx
@@ -1,0 +1,188 @@
+import type { ReactNode } from "react";
+import {
+  PAGE_SIZE_OPTIONS,
+  type PageSize,
+  type SortDirection,
+  type SortState,
+} from "@/lib/list-view";
+
+export function ListSearchBar({
+  value,
+  onChange,
+  placeholder = "Search by id…",
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <label className="relative block w-full max-w-xs">
+      <span className="sr-only">Search</span>
+      <input
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+      />
+    </label>
+  );
+}
+
+export function PageSizeSelect({
+  value,
+  onChange,
+}: {
+  value: PageSize;
+  onChange: (next: PageSize) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2 text-xs text-slate-500">
+      <span>Rows per page</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(Number(event.target.value) as PageSize)}
+        className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 outline-none focus:border-slate-500"
+      >
+        {PAGE_SIZE_OPTIONS.map((size) => (
+          <option key={size} value={size}>
+            {size}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export function Pagination({
+  page,
+  pageCount,
+  startIndex,
+  endIndex,
+  totalItems,
+  onPageChange,
+}: {
+  page: number;
+  pageCount: number;
+  startIndex: number;
+  endIndex: number;
+  totalItems: number;
+  onPageChange: (next: number) => void;
+}) {
+  const disablePrev = page <= 1;
+  const disableNext = page >= pageCount;
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-slate-200 bg-slate-50 px-4 py-2 text-xs text-slate-500">
+      <span>
+        {totalItems === 0
+          ? "0 results"
+          : `${startIndex + 1}–${endIndex} of ${totalItems}`}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onPageChange(page - 1)}
+          disabled={disablePrev}
+          className="rounded-md border border-slate-300 bg-white px-2 py-1 font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          ‹ Prev
+        </button>
+        <span className="font-mono text-slate-600">
+          {page}/{pageCount}
+        </span>
+        <button
+          type="button"
+          onClick={() => onPageChange(page + 1)}
+          disabled={disableNext}
+          className="rounded-md border border-slate-300 bg-white px-2 py-1 font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Next ›
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export interface SortableColumn<TKey extends string> {
+  key: TKey | null;
+  label: ReactNode;
+  align?: "left" | "right";
+  className?: string;
+}
+
+export function SortableHeader<TKey extends string>({
+  columns,
+  sort,
+  onSort,
+}: {
+  columns: SortableColumn<TKey>[];
+  sort: SortState<TKey> | null;
+  onSort: (key: TKey) => void;
+}) {
+  return (
+    <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+      <tr>
+        {columns.map((column, idx) => {
+          const align = column.align === "right" ? "text-right" : "text-left";
+          const baseClass = `px-5 py-3 ${align} ${column.className ?? ""}`.trim();
+          if (!column.key) {
+            return (
+              <th key={`col-${idx}`} className={baseClass}>
+                {column.label}
+              </th>
+            );
+          }
+          const active = sort?.key === column.key;
+          return (
+            <th key={column.key} className={baseClass}>
+              <button
+                type="button"
+                onClick={() => onSort(column.key as TKey)}
+                className={[
+                  "inline-flex items-center gap-1 font-semibold uppercase tracking-wide transition",
+                  active ? "text-slate-900" : "text-slate-500 hover:text-slate-700",
+                ].join(" ")}
+                aria-sort={ariaSort(active, sort?.direction)}
+              >
+                <span>{column.label}</span>
+                <SortIndicator
+                  active={active}
+                  direction={sort?.direction ?? null}
+                />
+              </button>
+            </th>
+          );
+        })}
+      </tr>
+    </thead>
+  );
+}
+
+function ariaSort(
+  active: boolean,
+  direction: SortDirection | undefined,
+): "ascending" | "descending" | "none" {
+  if (!active || !direction) return "none";
+  return direction === "asc" ? "ascending" : "descending";
+}
+
+function SortIndicator({
+  active,
+  direction,
+}: {
+  active: boolean;
+  direction: SortDirection | null;
+}) {
+  if (!active) {
+    return (
+      <span aria-hidden className="text-slate-300">
+        ↕
+      </span>
+    );
+  }
+  return (
+    <span aria-hidden className="text-slate-700">
+      {direction === "asc" ? "▲" : "▼"}
+    </span>
+  );
+}

--- a/apps/admin-console/src/components/toast-provider.tsx
+++ b/apps/admin-console/src/components/toast-provider.tsx
@@ -1,0 +1,198 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  appendToast,
+  createToast,
+  dismissToast,
+  expireToasts,
+  nextExpiryDelay,
+  type Toast,
+  type ToastInput,
+  type ToastTone,
+} from "@/lib/toast-queue";
+
+interface ToastContextValue {
+  push: (input: ToastInput) => string;
+  dismiss: (id: string) => void;
+  success: (message: string, detail?: string) => string;
+  error: (message: string, detail?: string) => string;
+  info: (message: string, detail?: string) => string;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let counter = 0;
+function nextToastId(): string {
+  counter += 1;
+  return `toast-${counter}-${Date.now().toString(36)}`;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((current) => dismissToast(current, id));
+  }, []);
+
+  const push = useCallback((input: ToastInput): string => {
+    const id = nextToastId();
+    const toast = createToast(input, id, Date.now());
+    setToasts((current) => appendToast(current, toast));
+    return id;
+  }, []);
+
+  const success = useCallback(
+    (message: string, detail?: string) => push({ tone: "success", message, detail }),
+    [push],
+  );
+  const error = useCallback(
+    (message: string, detail?: string) =>
+      push({ tone: "error", message, detail, durationMs: 0 }),
+    [push],
+  );
+  const info = useCallback(
+    (message: string, detail?: string) => push({ tone: "info", message, detail }),
+    [push],
+  );
+
+  useEffect(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    const delay = nextExpiryDelay(toasts, Date.now());
+    if (delay === null) {
+      return;
+    }
+
+    timerRef.current = setTimeout(() => {
+      setToasts((current) => expireToasts(current, Date.now()));
+    }, Math.max(delay, 50));
+
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [toasts]);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({ push, dismiss, success, error, info }),
+    [push, dismiss, success, error, info],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used inside <ToastProvider>");
+  }
+  return ctx;
+}
+
+function ToastViewport({
+  toasts,
+  onDismiss,
+}: {
+  toasts: Toast[];
+  onDismiss: (id: string) => void;
+}) {
+  if (toasts.length === 0) return null;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="pointer-events-none fixed bottom-4 right-4 z-50 flex max-w-sm flex-col gap-2"
+    >
+      {toasts.map((toast) => (
+        <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}
+
+const TONE_STYLES: Record<
+  ToastTone,
+  { container: string; badge: string; label: string }
+> = {
+  success: {
+    container: "border-emerald-200 bg-emerald-50 text-emerald-900",
+    badge: "bg-emerald-200 text-emerald-900",
+    label: "Success",
+  },
+  error: {
+    container: "border-rose-200 bg-rose-50 text-rose-900",
+    badge: "bg-rose-200 text-rose-900",
+    label: "Error",
+  },
+  info: {
+    container: "border-slate-200 bg-white text-slate-900",
+    badge: "bg-slate-200 text-slate-900",
+    label: "Info",
+  },
+};
+
+function ToastCard({
+  toast,
+  onDismiss,
+}: {
+  toast: Toast;
+  onDismiss: (id: string) => void;
+}) {
+  const styles = TONE_STYLES[toast.tone];
+  return (
+    <div
+      role="alert"
+      data-testid={`toast-${toast.tone}`}
+      className={[
+        "pointer-events-auto rounded-2xl border p-4 shadow-lg",
+        styles.container,
+      ].join(" ")}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className={[
+            "rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.18em]",
+            styles.badge,
+          ].join(" ")}
+        >
+          {styles.label}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold leading-5">{toast.message}</div>
+          {toast.detail ? (
+            <div className="mt-1 break-words text-xs leading-5 text-slate-700">
+              {toast.detail}
+            </div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={() => onDismiss(toast.id)}
+          className="rounded-md px-1.5 text-sm text-slate-400 transition hover:text-slate-700"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-console/src/components/tool-selector.tsx
+++ b/apps/admin-console/src/components/tool-selector.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useState } from "react";
+import type { ToolInfo } from "@/lib/config-api";
+import {
+  applyToolSelectionMode,
+  groupSelectionState,
+  groupToolsBySource,
+  isToolAllowed,
+  nextAllowedTools,
+  setGroupSelection,
+  toolSelectionMode,
+  type ToolSelectionMode,
+} from "@/lib/agent-tool-selection";
+
+interface ToolSelectorProps {
+  /// Headline label rendered above the selector.
+  title: string;
+  /// Free-form caption explaining the semantics.
+  description: string;
+  /// `undefined` = mode "all"; explicit list = mode "custom".
+  value: string[] | undefined;
+  onChange: (next: string[] | undefined) => void;
+  tools: ToolInfo[];
+  /// Default mode. "include" matches `allowed_tools` semantics where
+  /// undefined means "every tool". "exclude" matches `excluded_tools`
+  /// semantics where undefined means "exclude none" — but the storage
+  /// shape is identical (string[] | undefined), so we can reuse the
+  /// component with a different label set.
+  variant?: "include" | "exclude";
+}
+
+export function ToolSelector({
+  title,
+  description,
+  value,
+  onChange,
+  tools,
+  variant = "include",
+}: ToolSelectorProps) {
+  const [search, setSearch] = useState("");
+  const allToolIds = useMemo(() => tools.map((tool) => tool.id), [tools]);
+  const groups = useMemo(() => groupToolsBySource(tools), [tools]);
+
+  const filteredGroups = useMemo(() => {
+    const trimmed = search.trim().toLowerCase();
+    if (trimmed.length === 0) return groups;
+    return groups
+      .map((group) => ({
+        ...group,
+        tools: group.tools.filter((tool) => {
+          const haystack = `${tool.id} ${tool.name ?? ""} ${tool.description ?? ""}`
+            .toLowerCase();
+          return haystack.includes(trimmed);
+        }),
+      }))
+      .filter((group) => group.tools.length > 0);
+  }, [groups, search]);
+
+  const mode = toolSelectionMode(value);
+  const labels = LABELS_BY_VARIANT[variant];
+
+  function setMode(next: ToolSelectionMode) {
+    onChange(applyToolSelectionMode(value, next, allToolIds));
+  }
+
+  function toggleTool(toolId: string, checked: boolean) {
+    onChange(nextAllowedTools(value, allToolIds, toolId, checked));
+  }
+
+  function toggleGroup(groupToolIds: string[], selected: boolean) {
+    onChange(setGroupSelection(value, allToolIds, groupToolIds, selected));
+  }
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-950">{title}</h3>
+          <p className="mt-2 max-w-xl text-sm text-slate-500">{description}</p>
+        </div>
+        <fieldset
+          aria-label={`${title} mode`}
+          className="flex shrink-0 gap-2"
+        >
+          <ModeRadio
+            checked={mode === "all"}
+            onChange={() => setMode("all")}
+            label={labels.allLabel}
+            hint={labels.allHint}
+          />
+          <ModeRadio
+            checked={mode === "custom"}
+            onChange={() => setMode("custom")}
+            label={labels.customLabel}
+            hint={labels.customHint}
+          />
+        </fieldset>
+      </div>
+
+      {mode === "custom" ? (
+        <>
+          <div className="mt-4">
+            <label className="block">
+              <span className="sr-only">Search tools</span>
+              <input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search tools by id, name, or description…"
+                className="w-full max-w-md rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+              />
+            </label>
+          </div>
+
+          {filteredGroups.length === 0 ? (
+            <div className="mt-4 rounded-2xl border border-dashed border-slate-200 px-4 py-3 text-sm text-slate-500">
+              No tools match the current search.
+            </div>
+          ) : (
+            <div className="mt-4 space-y-5">
+              {filteredGroups.map((group) => {
+                const groupIds = group.tools.map((tool) => tool.id);
+                const state = groupSelectionState(value, groupIds);
+                return (
+                  <div
+                    key={group.source.key}
+                    className="rounded-2xl border border-slate-200 bg-slate-50 p-4"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="flex items-center gap-3">
+                        <span className="text-sm font-semibold text-slate-900">
+                          {group.source.label}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          {summariseSelection(state, groupIds.length, value, groupIds)}
+                        </span>
+                      </div>
+                      <div className="flex gap-2 text-xs font-medium">
+                        <button
+                          type="button"
+                          onClick={() => toggleGroup(groupIds, true)}
+                          className="rounded-md border border-slate-300 bg-white px-2 py-1 text-slate-600 hover:bg-slate-100"
+                        >
+                          Select all
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => toggleGroup(groupIds, false)}
+                          className="rounded-md border border-slate-300 bg-white px-2 py-1 text-slate-600 hover:bg-slate-100"
+                        >
+                          Clear
+                        </button>
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                      {group.tools.map((tool) => {
+                        const checked = isToolAllowed(value, tool.id);
+                        return (
+                          <label
+                            key={tool.id}
+                            className="flex gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={(event) =>
+                                toggleTool(tool.id, event.target.checked)
+                              }
+                            />
+                            <div className="min-w-0">
+                              <div className="font-mono text-xs text-slate-900">
+                                {tool.id}
+                              </div>
+                              <div className="mt-0.5 text-xs text-slate-500">
+                                {tool.description || tool.name}
+                              </div>
+                            </div>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="mt-4 text-sm text-slate-500">{labels.allBody}</p>
+      )}
+    </section>
+  );
+}
+
+function ModeRadio({
+  checked,
+  onChange,
+  label,
+  hint,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  hint: string;
+}) {
+  return (
+    <label
+      className={[
+        "min-w-[10rem] cursor-pointer rounded-xl border px-3 py-2 text-sm transition",
+        checked
+          ? "border-slate-900 bg-slate-900 text-white shadow-sm"
+          : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50",
+      ].join(" ")}
+    >
+      <input
+        type="radio"
+        className="sr-only"
+        checked={checked}
+        onChange={onChange}
+      />
+      <div className="font-semibold">{label}</div>
+      <div
+        className={[
+          "mt-0.5 text-xs leading-5",
+          checked ? "text-slate-200" : "text-slate-500",
+        ].join(" ")}
+      >
+        {hint}
+      </div>
+    </label>
+  );
+}
+
+function summariseSelection(
+  state: "all" | "some" | "none",
+  total: number,
+  value: string[] | undefined,
+  groupToolIds: string[],
+): string {
+  if (total === 0) return "0 tools";
+  if (state === "all") return `${total} of ${total} selected`;
+  if (state === "none") return `0 of ${total} selected`;
+  let selected = 0;
+  for (const id of groupToolIds) {
+    if (isToolAllowed(value, id)) selected += 1;
+  }
+  return `${selected} of ${total} selected`;
+}
+
+const LABELS_BY_VARIANT: Record<
+  "include" | "exclude",
+  {
+    allLabel: string;
+    allHint: string;
+    allBody: string;
+    customLabel: string;
+    customHint: string;
+  }
+> = {
+  include: {
+    allLabel: "All tools",
+    allHint: "Default — every published tool is callable.",
+    allBody:
+      "Every tool published to the runtime stays available to this agent. Choose Custom to restrict to a specific subset.",
+    customLabel: "Custom selection",
+    customHint: "Only the picked tools are exposed.",
+  },
+  exclude: {
+    allLabel: "Block none",
+    allHint: "Default — nothing is removed from the allowed set.",
+    allBody:
+      "No tools are explicitly excluded. Switch to Custom to remove individual tools even when they appear in the allow-list.",
+    customLabel: "Custom exclusion",
+    customHint: "Selected tools are excluded.",
+  },
+};

--- a/apps/admin-console/src/components/unsaved-changes-guard.tsx
+++ b/apps/admin-console/src/components/unsaved-changes-guard.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import { useBlocker } from "react-router";
+import { useConfirmDialog } from "./confirm-dialog";
+
+interface UnsavedChangesGuardOptions {
+  enabled: boolean;
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+/// Block in-app navigation and the browser-level unload event while
+/// `enabled` is true. The in-app block surfaces a styled confirm dialog
+/// so the user can review their unsaved changes before navigating away.
+export function useUnsavedChangesGuard({
+  enabled,
+  title = "Discard unsaved changes?",
+  description = "Your edits will be lost if you leave this page.",
+  confirmLabel = "Discard changes",
+  cancelLabel = "Keep editing",
+}: UnsavedChangesGuardOptions): void {
+  const confirmDialog = useConfirmDialog();
+
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      enabled && currentLocation.pathname !== nextLocation.pathname,
+  );
+
+  const promptingRef = useRef(false);
+
+  useEffect(() => {
+    if (blocker.state !== "blocked") return;
+    if (promptingRef.current) return;
+    promptingRef.current = true;
+
+    void confirmDialog({
+      title,
+      description,
+      confirmLabel,
+      cancelLabel,
+      tone: "destructive",
+    })
+      .then((accepted) => {
+        if (accepted) {
+          blocker.proceed();
+        } else {
+          blocker.reset();
+        }
+      })
+      .finally(() => {
+        promptingRef.current = false;
+      });
+  }, [blocker, confirmDialog, title, description, confirmLabel, cancelLabel]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    function onBeforeUnload(event: BeforeUnloadEvent) {
+      event.preventDefault();
+      event.returnValue = "";
+    }
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [enabled]);
+}

--- a/apps/admin-console/src/lib/admin-token.test.ts
+++ b/apps/admin-console/src/lib/admin-token.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearAdminToken,
+  maskAdminToken,
+  readAdminToken,
+  writeAdminToken,
+  type TokenStorage,
+} from "./admin-token";
+import { ADMIN_TOKEN_STORAGE_KEY } from "./config-api";
+
+class MemoryStorage implements TokenStorage {
+  private store = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+}
+
+let storage: MemoryStorage;
+
+beforeEach(() => {
+  storage = new MemoryStorage();
+});
+
+describe("readAdminToken", () => {
+  it("returns null when nothing is stored", () => {
+    expect(readAdminToken(storage)).toBeNull();
+  });
+
+  it("trims whitespace and returns the token", () => {
+    storage.setItem(ADMIN_TOKEN_STORAGE_KEY, "  secret  ");
+    expect(readAdminToken(storage)).toBe("secret");
+  });
+
+  it("treats whitespace-only values as missing", () => {
+    storage.setItem(ADMIN_TOKEN_STORAGE_KEY, "   ");
+    expect(readAdminToken(storage)).toBeNull();
+  });
+
+  it("returns null when storage is unavailable", () => {
+    expect(readAdminToken(null)).toBeNull();
+  });
+});
+
+describe("writeAdminToken", () => {
+  it("writes the trimmed token to storage", () => {
+    writeAdminToken("  abc  ", storage);
+    expect(storage.getItem(ADMIN_TOKEN_STORAGE_KEY)).toBe("abc");
+  });
+
+  it("is a no-op when storage is unavailable", () => {
+    expect(() => writeAdminToken("abc", null)).not.toThrow();
+  });
+});
+
+describe("clearAdminToken", () => {
+  it("removes the stored token", () => {
+    storage.setItem(ADMIN_TOKEN_STORAGE_KEY, "abc");
+    clearAdminToken(storage);
+    expect(storage.getItem(ADMIN_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("maskAdminToken", () => {
+  it("returns a placeholder when the token is missing", () => {
+    expect(maskAdminToken(null)).toBe("—");
+    expect(maskAdminToken("")).toBe("—");
+  });
+
+  it("masks short tokens entirely", () => {
+    expect(maskAdminToken("short")).toBe("••••");
+    expect(maskAdminToken("12345678")).toBe("••••");
+  });
+
+  it("shows the first four and last two characters of long tokens", () => {
+    expect(maskAdminToken("abcdef0123456789")).toBe("abcd…89");
+  });
+});

--- a/apps/admin-console/src/lib/admin-token.ts
+++ b/apps/admin-console/src/lib/admin-token.ts
@@ -1,0 +1,45 @@
+import { ADMIN_TOKEN_STORAGE_KEY } from "./config-api";
+
+export interface TokenStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function defaultStorage(): TokenStorage | null {
+  if (typeof globalThis.localStorage === "undefined") {
+    return null;
+  }
+  return globalThis.localStorage;
+}
+
+export function readAdminToken(storage: TokenStorage | null = defaultStorage()): string | null {
+  if (!storage) return null;
+  const stored = storage.getItem(ADMIN_TOKEN_STORAGE_KEY);
+  if (!stored) return null;
+  const trimmed = stored.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function writeAdminToken(
+  token: string,
+  storage: TokenStorage | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  storage.setItem(ADMIN_TOKEN_STORAGE_KEY, token.trim());
+}
+
+export function clearAdminToken(storage: TokenStorage | null = defaultStorage()): void {
+  if (!storage) return;
+  storage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+}
+
+/// Mask a token for display: keep the first 4 and last 2 characters.
+export function maskAdminToken(token: string | null | undefined): string {
+  if (!token) return "—";
+  const trimmed = token.trim();
+  if (trimmed.length <= 8) {
+    return "••••";
+  }
+  return `${trimmed.slice(0, 4)}…${trimmed.slice(-2)}`;
+}

--- a/apps/admin-console/src/lib/agent-stats.test.ts
+++ b/apps/admin-console/src/lib/agent-stats.test.ts
@@ -10,6 +10,7 @@ import {
   toolFailureRate,
   type AgentRuntimeSnapshot,
   type HistogramBucket,
+  type ToolRuntimeStats,
 } from "./agent-stats";
 import { BACKEND_URL } from "./config-api";
 
@@ -38,6 +39,23 @@ function makeSnapshot(
     handoffs: 0,
     delegations: 0,
     tool_calls_by_tool: [],
+    ...overrides,
+  };
+}
+
+function makeToolStats(overrides: Partial<ToolRuntimeStats> = {}): ToolRuntimeStats {
+  return {
+    tool: "search",
+    call_count: 0,
+    failure_count: 0,
+    total_duration_ms: 0,
+    avg_duration_ms: 0,
+    min_duration_ms: 0,
+    max_duration_ms: 0,
+    p50_duration_ms: 0,
+    p95_duration_ms: 0,
+    p99_duration_ms: 0,
+    duration_histogram: [],
     ...overrides,
   };
 }
@@ -231,20 +249,16 @@ describe("toolFailureRate", () => {
   it("aggregates calls and failures across all tools", () => {
     const snap = makeSnapshot({
       tool_calls_by_tool: [
-        {
+        makeToolStats({
           tool: "search",
           call_count: 8,
           failure_count: 1,
-          total_duration_ms: 0,
-          avg_duration_ms: 0,
-        },
-        {
+        }),
+        makeToolStats({
           tool: "write",
           call_count: 2,
           failure_count: 1,
-          total_duration_ms: 0,
-          avg_duration_ms: 0,
-        },
+        }),
       ],
     });
     expect(toolFailureRate(snap)).toBeCloseTo(0.2);

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { isToolAllowed, nextAllowedTools } from "./agent-tool-selection";
+import {
+  applyToolSelectionMode,
+  groupSelectionState,
+  groupToolsBySource,
+  isToolAllowed,
+  nextAllowedTools,
+  setGroupSelection,
+  toolSelectionMode,
+  toolSourceFor,
+} from "./agent-tool-selection";
 
 describe("agent tool selection", () => {
   const allToolIds = ["search", "write", "read"];
@@ -28,5 +37,123 @@ describe("agent tool selection", () => {
     expect(nextAllowedTools(["search", "write"], ["search", "write"], "search", true)).toBe(
       undefined,
     );
+  });
+});
+
+describe("toolSelectionMode", () => {
+  it("classifies undefined as the default 'all' mode", () => {
+    expect(toolSelectionMode(undefined)).toBe("all");
+  });
+
+  it("treats an explicit list as 'custom', even if it lists every tool", () => {
+    expect(toolSelectionMode([])).toBe("custom");
+    expect(toolSelectionMode(["search"])).toBe("custom");
+  });
+});
+
+describe("applyToolSelectionMode", () => {
+  it("clears the explicit list when switching back to 'all'", () => {
+    expect(applyToolSelectionMode(["search"], "all", ["search", "write"])).toBeUndefined();
+  });
+
+  it("preserves the existing custom list when re-entering custom mode", () => {
+    expect(applyToolSelectionMode(["search"], "custom", ["search", "write"])).toEqual([
+      "search",
+    ]);
+  });
+
+  it("seeds custom mode with every known tool when there is no prior list", () => {
+    expect(applyToolSelectionMode(undefined, "custom", ["a", "b"])).toEqual(["a", "b"]);
+  });
+});
+
+describe("toolSourceFor", () => {
+  it("recognises mcp:* tools and extracts the server id", () => {
+    expect(toolSourceFor("mcp:weather/forecast")).toMatchObject({
+      kind: "mcp",
+      key: "mcp:weather",
+      label: "MCP · weather",
+    });
+  });
+
+  it("recognises mcp:* with no server suffix", () => {
+    expect(toolSourceFor("mcp:")).toMatchObject({ kind: "mcp", label: "MCP" });
+  });
+
+  it("recognises plugin:* tools and extracts the plugin id", () => {
+    expect(toolSourceFor("plugin:reminder/add")).toMatchObject({
+      kind: "plugin",
+      key: "plugin:reminder",
+      label: "Plugin · reminder",
+    });
+  });
+
+  it("treats other tool ids as built-ins", () => {
+    expect(toolSourceFor("Bash")).toMatchObject({
+      kind: "builtin",
+      key: "builtin",
+    });
+  });
+});
+
+describe("groupToolsBySource", () => {
+  it("groups by source and orders builtin → plugin → mcp", () => {
+    const groups = groupToolsBySource([
+      { id: "mcp:weather/forecast" },
+      { id: "Read" },
+      { id: "plugin:reminder/add" },
+      { id: "Bash" },
+      { id: "mcp:weather/now" },
+      { id: "mcp:db/query" },
+    ]);
+    expect(groups.map((g) => g.source.key)).toEqual([
+      "builtin",
+      "plugin:reminder",
+      "mcp:db",
+      "mcp:weather",
+    ]);
+    const builtin = groups[0];
+    expect(builtin.tools.map((t) => t.id)).toEqual(["Bash", "Read"]);
+    const weather = groups[3];
+    expect(weather.tools.map((t) => t.id)).toEqual([
+      "mcp:weather/forecast",
+      "mcp:weather/now",
+    ]);
+  });
+});
+
+describe("groupSelectionState", () => {
+  const groupIds = ["a", "b"];
+
+  it("treats undefined allowed_tools as everything selected", () => {
+    expect(groupSelectionState(undefined, groupIds)).toBe("all");
+  });
+
+  it("returns 'none' when no group member is in the allowed list", () => {
+    expect(groupSelectionState(["x"], groupIds)).toBe("none");
+  });
+
+  it("returns 'some' when only part of the group is selected", () => {
+    expect(groupSelectionState(["a"], groupIds)).toBe("some");
+  });
+});
+
+describe("setGroupSelection", () => {
+  const allToolIds = ["a", "b", "c"];
+
+  it("adds every group tool when selecting", () => {
+    expect(setGroupSelection(["c"], allToolIds, ["a", "b"], true)).toBeUndefined();
+  });
+
+  it("removes every group tool when deselecting", () => {
+    expect(setGroupSelection(undefined, allToolIds, ["a", "b"], false)).toEqual(["c"]);
+  });
+
+  it("collapses to undefined when the result covers every known tool", () => {
+    expect(setGroupSelection([], allToolIds, ["a", "b", "c"], true)).toBeUndefined();
+  });
+
+  it("ignores group ids that are not part of the catalog", () => {
+    expect(setGroupSelection(["a"], allToolIds, ["a", "z"], false)).toEqual([]);
   });
 });

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -25,3 +25,140 @@ export function nextAllowedTools(
   const baseAllowed = allowedTools ?? allToolIds;
   return baseAllowed.filter((id) => id !== toolId);
 }
+
+/// Inclusion semantics — `undefined` (or missing) means "every tool"; an
+/// explicit array means "only these tools".
+export type ToolSelectionMode = "all" | "custom";
+
+export function toolSelectionMode(
+  allowedTools: string[] | undefined,
+): ToolSelectionMode {
+  return allowedTools === undefined ? "all" : "custom";
+}
+
+/// Switch between modes without losing user data. When toggling to "all",
+/// the explicit list is cleared (undefined). When toggling to "custom",
+/// the current list is preserved, falling back to *all* known tools so
+/// the resulting custom set has the same effective behaviour as "all".
+export function applyToolSelectionMode(
+  current: string[] | undefined,
+  mode: ToolSelectionMode,
+  allToolIds: string[],
+): string[] | undefined {
+  if (mode === "all") return undefined;
+  if (current !== undefined) return current;
+  return [...allToolIds];
+}
+
+/// Source bucket for grouping tools in the UI. We classify by id prefix:
+/// `mcp:server-id/...` → an MCP server; `plugin:...` → a plugin tool;
+/// otherwise it's a built-in.
+export type ToolSourceKind = "mcp" | "plugin" | "builtin";
+
+export interface ToolSource {
+  kind: ToolSourceKind;
+  /// Display label, e.g. "MCP · weather-service", "Plugin", "Built-in".
+  label: string;
+  /// Stable group key used for ordering and selection toggles.
+  key: string;
+}
+
+export function toolSourceFor(toolId: string): ToolSource {
+  if (toolId.startsWith("mcp:")) {
+    const remainder = toolId.slice(4);
+    const slash = remainder.indexOf("/");
+    const server = slash >= 0 ? remainder.slice(0, slash) : remainder;
+    const label = server.length > 0 ? `MCP · ${server}` : "MCP";
+    return { kind: "mcp", label, key: `mcp:${server}` };
+  }
+  if (toolId.startsWith("plugin:")) {
+    const remainder = toolId.slice(7);
+    const slash = remainder.indexOf("/");
+    const plugin = slash >= 0 ? remainder.slice(0, slash) : remainder;
+    const label = plugin.length > 0 ? `Plugin · ${plugin}` : "Plugin";
+    return { kind: "plugin", label, key: `plugin:${plugin}` };
+  }
+  return { kind: "builtin", label: "Built-in", key: "builtin" };
+}
+
+export interface ToolGroup<TTool> {
+  source: ToolSource;
+  tools: TTool[];
+}
+
+export function groupToolsBySource<TTool extends { id: string }>(
+  tools: TTool[],
+): ToolGroup<TTool>[] {
+  const buckets = new Map<string, ToolGroup<TTool>>();
+  for (const tool of tools) {
+    const source = toolSourceFor(tool.id);
+    let bucket = buckets.get(source.key);
+    if (!bucket) {
+      bucket = { source, tools: [] };
+      buckets.set(source.key, bucket);
+    }
+    bucket.tools.push(tool);
+  }
+
+  for (const bucket of buckets.values()) {
+    bucket.tools.sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  return Array.from(buckets.values()).sort((a, b) => {
+    if (a.source.kind !== b.source.kind) {
+      return SOURCE_ORDER[a.source.kind] - SOURCE_ORDER[b.source.kind];
+    }
+    return a.source.label.localeCompare(b.source.label);
+  });
+}
+
+const SOURCE_ORDER: Record<ToolSourceKind, number> = {
+  builtin: 0,
+  plugin: 1,
+  mcp: 2,
+};
+
+/// Apply a "select all in group" operation. Returns the new allowed_tools
+/// value, preserving the inclusion semantics: when every tool ends up
+/// selected we collapse to `undefined`.
+export function setGroupSelection(
+  allowedTools: string[] | undefined,
+  allToolIds: string[],
+  groupToolIds: string[],
+  selected: boolean,
+): string[] | undefined {
+  const baseline = allowedTools ?? allToolIds;
+  const baselineSet = new Set(baseline);
+
+  if (selected) {
+    for (const id of groupToolIds) {
+      baselineSet.add(id);
+    }
+  } else {
+    for (const id of groupToolIds) {
+      baselineSet.delete(id);
+    }
+  }
+
+  if (selected && allToolIds.every((id) => baselineSet.has(id))) {
+    return undefined;
+  }
+
+  return Array.from(baselineSet).filter((id) => allToolIds.includes(id));
+}
+
+/// Returns the selection state of a group: "all" if every tool in the
+/// group is selected, "none" if zero, or "some" otherwise.
+export function groupSelectionState(
+  allowedTools: string[] | undefined,
+  groupToolIds: string[],
+): "all" | "some" | "none" {
+  if (groupToolIds.length === 0) return "none";
+  let selected = 0;
+  for (const id of groupToolIds) {
+    if (isToolAllowed(allowedTools, id)) selected += 1;
+  }
+  if (selected === 0) return "none";
+  if (selected === groupToolIds.length) return "all";
+  return "some";
+}

--- a/apps/admin-console/src/lib/assistant-message.test.ts
+++ b/apps/admin-console/src/lib/assistant-message.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeToolCallState,
+  previewPayload,
+  viewMessage,
+} from "./assistant-message";
+
+describe("viewMessage", () => {
+  it("returns an empty block list for messages with no parts", () => {
+    expect(viewMessage({}).blocks).toEqual([]);
+    expect(viewMessage({ parts: [] }).blocks).toEqual([]);
+  });
+
+  it("preserves non-empty text parts and drops blank ones", () => {
+    const view = viewMessage({
+      parts: [
+        { type: "text", text: "Hello" },
+        { type: "text", text: "   " },
+        { type: "text", text: "world" },
+      ],
+    });
+    expect(view.blocks).toEqual([
+      { kind: "text", id: "0", text: "Hello" },
+      { kind: "text", id: "2", text: "world" },
+    ]);
+  });
+
+  it("captures reasoning parts and step markers", () => {
+    const view = viewMessage({
+      parts: [
+        { type: "reasoning", text: "thinking..." },
+        { type: "step-start" },
+      ],
+    });
+    expect(view.blocks).toEqual([
+      { kind: "reasoning", id: "0", text: "thinking..." },
+      { kind: "step-start", id: "1" },
+    ]);
+  });
+
+  it("normalises typed tool parts (tool-<name>)", () => {
+    const view = viewMessage({
+      parts: [
+        {
+          type: "tool-create_agent",
+          state: "output-available",
+          input: { id: "alpha" },
+          output: { id: "alpha", model_id: "gpt" },
+        },
+      ],
+    });
+    expect(view.blocks).toEqual([
+      {
+        kind: "tool-call",
+        id: "0",
+        toolName: "create_agent",
+        state: "output-available",
+        input: { id: "alpha" },
+        output: { id: "alpha", model_id: "gpt" },
+        errorText: undefined,
+      },
+    ]);
+  });
+
+  it("normalises dynamic-tool parts and uses the embedded toolName", () => {
+    const view = viewMessage({
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: "list_models",
+          state: "input-available",
+          input: {},
+        },
+      ],
+    });
+    expect(view.blocks[0]).toMatchObject({
+      kind: "tool-call",
+      toolName: "list_models",
+      state: "input-available",
+    });
+  });
+
+  it("captures tool errors", () => {
+    const view = viewMessage({
+      parts: [
+        {
+          type: "tool-foo",
+          state: "output-error",
+          errorText: "boom",
+        },
+      ],
+    });
+    expect(view.blocks[0]).toMatchObject({
+      kind: "tool-call",
+      state: "output-error",
+      errorText: "boom",
+    });
+  });
+
+  it("classifies unknown future states defensively", () => {
+    const view = viewMessage({
+      parts: [{ type: "tool-foo", state: "future-state" }],
+    });
+    expect(view.blocks[0]).toMatchObject({
+      kind: "tool-call",
+      state: "unknown",
+    });
+  });
+
+  it("captures unrecognised parts so the user sees them rather than nothing", () => {
+    const view = viewMessage({ parts: [{ type: "future-feature" }] });
+    expect(view.blocks).toEqual([
+      { kind: "unknown", id: "0", type: "future-feature" },
+    ]);
+  });
+
+  it("ignores garbage entries without crashing", () => {
+    const view = viewMessage({ parts: [null, undefined, 42, "string"] });
+    // None of these have a valid `type` string, so they all turn into
+    // unknown placeholders with empty type.
+    expect(view.blocks).toEqual([
+      { kind: "unknown", id: "0", type: "" },
+      { kind: "unknown", id: "1", type: "" },
+      { kind: "unknown", id: "2", type: "" },
+      { kind: "unknown", id: "3", type: "" },
+    ]);
+  });
+});
+
+describe("describeToolCallState", () => {
+  it("maps every known state to a label + tone", () => {
+    expect(describeToolCallState("output-available").tone).toBe("success");
+    expect(describeToolCallState("output-error").tone).toBe("error");
+    expect(describeToolCallState("approval-requested").tone).toBe("warn");
+    expect(describeToolCallState("input-available").label).toBe(
+      "Calling tool…",
+    );
+  });
+});
+
+describe("previewPayload", () => {
+  it("returns null for undefined and empty strings", () => {
+    expect(previewPayload(undefined)).toBeNull();
+    expect(previewPayload("")).toBeNull();
+  });
+
+  it("returns strings verbatim", () => {
+    expect(previewPayload("hello")).toBe("hello");
+  });
+
+  it("pretty-prints structured payloads", () => {
+    expect(previewPayload({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+
+  it("renders null literally", () => {
+    expect(previewPayload(null)).toBe("null");
+  });
+
+  it("falls back to String() when JSON serialisation fails", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(previewPayload(cyclic)).toBe("[object Object]");
+  });
+});

--- a/apps/admin-console/src/lib/assistant-message.ts
+++ b/apps/admin-console/src/lib/assistant-message.ts
@@ -1,0 +1,162 @@
+/// View-model layer over the @ai-sdk/react UIMessage parts.
+///
+/// We deliberately avoid importing the SDK's internal types — its part
+/// shapes evolve between minor versions, and we only care about a small
+/// projection (text + tool-call lifecycle) for rendering. Anything we
+/// don't recognise becomes an "unknown" block so the user can still see
+/// _that something happened_ without us crashing on a future version.
+
+export type AssistantBlockTone = "info" | "success" | "warn" | "error";
+
+export type AssistantBlock =
+  | { kind: "text"; id: string; text: string }
+  | { kind: "reasoning"; id: string; text: string }
+  | { kind: "step-start"; id: string }
+  | {
+      kind: "tool-call";
+      id: string;
+      toolName: string;
+      state: ToolCallState;
+      input?: unknown;
+      output?: unknown;
+      errorText?: string;
+    }
+  | { kind: "unknown"; id: string; type: string };
+
+export type ToolCallState =
+  | "input-streaming"
+  | "input-available"
+  | "approval-requested"
+  | "approval-responded"
+  | "output-available"
+  | "output-error"
+  | "output-denied"
+  | "unknown";
+
+export interface AssistantMessageView {
+  blocks: AssistantBlock[];
+}
+
+interface RawPart {
+  type?: unknown;
+  text?: unknown;
+  toolName?: unknown;
+  toolCallId?: unknown;
+  input?: unknown;
+  output?: unknown;
+  state?: unknown;
+  errorText?: unknown;
+}
+
+export function viewMessage(message: { parts?: unknown }): AssistantMessageView {
+  const parts = Array.isArray(message.parts) ? message.parts : [];
+  const blocks: AssistantBlock[] = [];
+
+  parts.forEach((rawPart, index) => {
+    const part = (rawPart ?? {}) as RawPart;
+    const type = typeof part.type === "string" ? part.type : "";
+    const id = `${index}`;
+
+    if (type === "text") {
+      const text = typeof part.text === "string" ? part.text : "";
+      if (text.trim().length > 0) {
+        blocks.push({ kind: "text", id, text });
+      }
+      return;
+    }
+
+    if (type === "reasoning") {
+      const text = typeof part.text === "string" ? part.text : "";
+      if (text.trim().length > 0) {
+        blocks.push({ kind: "reasoning", id, text });
+      }
+      return;
+    }
+
+    if (type === "step-start") {
+      blocks.push({ kind: "step-start", id });
+      return;
+    }
+
+    if (type === "dynamic-tool" || type.startsWith("tool-")) {
+      const toolName =
+        typeof part.toolName === "string"
+          ? part.toolName
+          : type.startsWith("tool-")
+            ? type.slice(5)
+            : "(unknown)";
+      blocks.push({
+        kind: "tool-call",
+        id,
+        toolName,
+        state: classifyToolState(part.state),
+        input: part.input,
+        output: part.output,
+        errorText:
+          typeof part.errorText === "string" ? part.errorText : undefined,
+      });
+      return;
+    }
+
+    blocks.push({ kind: "unknown", id, type });
+  });
+
+  return { blocks };
+}
+
+function classifyToolState(value: unknown): ToolCallState {
+  if (typeof value !== "string") return "unknown";
+  switch (value) {
+    case "input-streaming":
+    case "input-available":
+    case "approval-requested":
+    case "approval-responded":
+    case "output-available":
+    case "output-error":
+    case "output-denied":
+      return value;
+    default:
+      return "unknown";
+  }
+}
+
+export function describeToolCallState(state: ToolCallState): {
+  label: string;
+  tone: AssistantBlockTone;
+} {
+  switch (state) {
+    case "input-streaming":
+      return { label: "Preparing input…", tone: "info" };
+    case "input-available":
+      return { label: "Calling tool…", tone: "info" };
+    case "approval-requested":
+      return { label: "Waiting for approval", tone: "warn" };
+    case "approval-responded":
+      return { label: "Approval responded", tone: "info" };
+    case "output-available":
+      return { label: "Completed", tone: "success" };
+    case "output-error":
+      return { label: "Failed", tone: "error" };
+    case "output-denied":
+      return { label: "Denied", tone: "warn" };
+    case "unknown":
+      return { label: "Unknown state", tone: "info" };
+  }
+}
+
+/// Best-effort serialiser used to render tool input/output payloads.
+/// Strings stay verbatim; everything else is JSON-stringified with
+/// readable indentation. Returns null for `undefined` so callers can
+/// skip rendering empty payloads.
+export function previewPayload(value: unknown): string | null {
+  if (value === undefined) return null;
+  if (value === null) return "null";
+  if (typeof value === "string") {
+    return value.length > 0 ? value : null;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/apps/admin-console/src/lib/auth-interceptor.test.ts
+++ b/apps/admin-console/src/lib/auth-interceptor.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetAuthInterceptorForTesting,
+  hasUnauthorizedHandler,
+  requestUnauthorizedRetry,
+  setUnauthorizedHandler,
+} from "./auth-interceptor";
+
+afterEach(() => {
+  __resetAuthInterceptorForTesting();
+});
+
+describe("setUnauthorizedHandler", () => {
+  it("registers a handler and reports installation status", () => {
+    expect(hasUnauthorizedHandler()).toBe(false);
+    setUnauthorizedHandler(async () => "token");
+    expect(hasUnauthorizedHandler()).toBe(true);
+  });
+
+  it("disposer only removes the active handler", () => {
+    const handlerA = vi.fn(async () => "a");
+    const handlerB = vi.fn(async () => "b");
+    const disposeA = setUnauthorizedHandler(handlerA);
+    setUnauthorizedHandler(handlerB);
+    disposeA();
+    expect(hasUnauthorizedHandler()).toBe(true);
+  });
+});
+
+describe("requestUnauthorizedRetry", () => {
+  it("returns null when no handler is installed", async () => {
+    await expect(requestUnauthorizedRetry()).resolves.toBeNull();
+  });
+
+  it("invokes the handler exactly once per concurrent burst", async () => {
+    let resolveHandler: (value: string | null) => void = () => {};
+    const handler = vi.fn(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveHandler = resolve;
+        }),
+    );
+    setUnauthorizedHandler(handler);
+
+    const first = requestUnauthorizedRetry();
+    const second = requestUnauthorizedRetry();
+    const third = requestUnauthorizedRetry();
+
+    resolveHandler("token-1");
+    await expect(Promise.all([first, second, third])).resolves.toEqual([
+      "token-1",
+      "token-1",
+      "token-1",
+    ]);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-invokes the handler on a new burst after the previous resolves", async () => {
+    const handler = vi
+      .fn<UnauthorizedHandlerLike>()
+      .mockResolvedValueOnce("token-1")
+      .mockResolvedValueOnce(null);
+    setUnauthorizedHandler(handler);
+
+    await expect(requestUnauthorizedRetry()).resolves.toBe("token-1");
+    await expect(requestUnauthorizedRetry()).resolves.toBeNull();
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats handler rejection as a refusal", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("user closed modal");
+    });
+    setUnauthorizedHandler(handler);
+    await expect(requestUnauthorizedRetry()).resolves.toBeNull();
+  });
+});
+
+type UnauthorizedHandlerLike = () => Promise<string | null>;

--- a/apps/admin-console/src/lib/auth-interceptor.ts
+++ b/apps/admin-console/src/lib/auth-interceptor.ts
@@ -1,0 +1,44 @@
+/// Resolve to a fresh token to retry the request, or `null` to give up.
+export type UnauthorizedHandler = () => Promise<string | null>;
+
+let handler: UnauthorizedHandler | null = null;
+let inFlight: Promise<string | null> | null = null;
+
+/// Install or replace the global handler invoked when an admin request returns 401.
+/// Returns a disposer that uninstalls the handler if it is still the active one.
+export function setUnauthorizedHandler(next: UnauthorizedHandler | null): () => void {
+  handler = next;
+  return () => {
+    if (handler === next) {
+      handler = null;
+    }
+  };
+}
+
+/// Whether a handler is installed.
+export function hasUnauthorizedHandler(): boolean {
+  return handler !== null;
+}
+
+/// Invoke the registered handler, deduplicating concurrent calls so that a
+/// burst of 401s only opens a single token prompt.
+export async function requestUnauthorizedRetry(): Promise<string | null> {
+  if (!handler) {
+    return null;
+  }
+  if (!inFlight) {
+    const current = handler;
+    inFlight = current()
+      .catch(() => null)
+      .finally(() => {
+        inFlight = null;
+      });
+  }
+  return inFlight;
+}
+
+/// Test-only helper.
+export function __resetAuthInterceptorForTesting(): void {
+  handler = null;
+  inFlight = null;
+}

--- a/apps/admin-console/src/lib/config-api.test.ts
+++ b/apps/admin-console/src/lib/config-api.test.ts
@@ -5,6 +5,10 @@ import {
   ConfigApiError,
   configApi,
 } from "./config-api";
+import {
+  __resetAuthInterceptorForTesting,
+  setUnauthorizedHandler,
+} from "./auth-interceptor";
 
 describe("configUrl encoding", () => {
   it("encodes config ids via the list endpoint", async () => {
@@ -82,6 +86,69 @@ describe("configApi", () => {
     expect(new Headers(init.headers).get("authorization")).toBe(
       "Bearer stored-token",
     );
+  });
+
+  it("retries with a fresh token when the unauthorized handler returns one", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => "Unauthorized",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ namespace: "agents", items: [] }),
+      });
+    vi.stubGlobal("fetch", fetchSpy);
+    setUnauthorizedHandler(async () => "rotated-token");
+
+    await expect(configApi.list("agents")).resolves.toMatchObject({
+      items: [],
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const retryInit = fetchSpy.mock.calls[1][1] as RequestInit;
+    expect(new Headers(retryInit.headers).get("authorization")).toBe(
+      "Bearer rotated-token",
+    );
+
+    __resetAuthInterceptorForTesting();
+  });
+
+  it("propagates 401 when no handler is installed", async () => {
+    __resetAuthInterceptorForTesting();
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(configApi.list("agents")).rejects.toMatchObject({
+      name: "ConfigApiError",
+      status: 401,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates 401 when the handler refuses to provide a new token", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => "Unauthorized",
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    setUnauthorizedHandler(async () => null);
+
+    await expect(configApi.list("agents")).rejects.toMatchObject({
+      name: "ConfigApiError",
+      status: 401,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    __resetAuthInterceptorForTesting();
   });
 
   it("normalizes omitted skill arrays in capabilities", async () => {

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -1,3 +1,8 @@
+import {
+  hasUnauthorizedHandler,
+  requestUnauthorizedRetry,
+} from "./auth-interceptor";
+
 export const BACKEND_URL =
   import.meta.env.VITE_BACKEND_URL ?? "http://127.0.0.1:38080";
 
@@ -156,7 +161,14 @@ async function readResponseBody(response: Response): Promise<unknown> {
 }
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(url, withAdminAuth(init));
+  let response = await fetch(url, withAdminAuth(init));
+  if (response.status === 401 && hasUnauthorizedHandler()) {
+    const refreshed = await requestUnauthorizedRetry();
+    if (refreshed && refreshed.trim().length > 0) {
+      response = await fetch(url, withAdminAuth(init, refreshed.trim()));
+    }
+  }
+
   const detail = await readResponseBody(response);
 
   if (!response.ok) {
@@ -170,7 +182,11 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   return detail as T;
 }
 
-function adminBearerToken(): string | undefined {
+function adminBearerToken(override?: string): string | undefined {
+  if (typeof override === "string" && override.trim().length > 0) {
+    return override.trim();
+  }
+
   const envToken = import.meta.env.VITE_ADMIN_BEARER_TOKEN;
   if (typeof envToken === "string" && envToken.trim().length > 0) {
     return envToken.trim();
@@ -183,16 +199,14 @@ function adminBearerToken(): string | undefined {
   return stored?.trim() || undefined;
 }
 
-function withAdminAuth(init?: RequestInit): RequestInit | undefined {
-  const token = adminBearerToken();
+function withAdminAuth(init?: RequestInit, override?: string): RequestInit | undefined {
+  const token = adminBearerToken(override);
   if (!token) {
     return init;
   }
 
   const headers = new Headers(init?.headers);
-  if (!headers.has("authorization")) {
-    headers.set("authorization", `Bearer ${token}`);
-  }
+  headers.set("authorization", `Bearer ${token}`);
   return {
     ...init,
     headers,

--- a/apps/admin-console/src/lib/editor-tabs.test.ts
+++ b/apps/admin-console/src/lib/editor-tabs.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_EDITOR_TABS,
+  DEFAULT_AGENT_EDITOR_TAB,
+  isAgentEditorTab,
+  readTabFromSearch,
+  writeTabToSearch,
+} from "./editor-tabs";
+
+describe("AGENT_EDITOR_TABS", () => {
+  it("exposes a non-empty list and includes the default", () => {
+    expect(AGENT_EDITOR_TABS.length).toBeGreaterThan(0);
+    expect(AGENT_EDITOR_TABS.map((t) => t.id)).toContain(DEFAULT_AGENT_EDITOR_TAB);
+  });
+
+  it("uses unique tab ids", () => {
+    const ids = AGENT_EDITOR_TABS.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("isAgentEditorTab", () => {
+  it("accepts known tab ids", () => {
+    expect(isAgentEditorTab("basics")).toBe(true);
+    expect(isAgentEditorTab("advanced")).toBe(true);
+  });
+
+  it("rejects everything else", () => {
+    expect(isAgentEditorTab("foo")).toBe(false);
+    expect(isAgentEditorTab(undefined)).toBe(false);
+    expect(isAgentEditorTab(null)).toBe(false);
+    expect(isAgentEditorTab(42)).toBe(false);
+  });
+});
+
+describe("readTabFromSearch", () => {
+  it("returns the default when ?tab is absent", () => {
+    expect(readTabFromSearch("")).toBe(DEFAULT_AGENT_EDITOR_TAB);
+  });
+
+  it("returns the default when ?tab is unrecognised", () => {
+    expect(readTabFromSearch("?tab=bogus")).toBe(DEFAULT_AGENT_EDITOR_TAB);
+  });
+
+  it("returns the requested tab when present and valid", () => {
+    expect(readTabFromSearch("?tab=tools")).toBe("tools");
+  });
+
+  it("accepts URLSearchParams instances directly", () => {
+    expect(readTabFromSearch(new URLSearchParams({ tab: "delegates" }))).toBe(
+      "delegates",
+    );
+  });
+});
+
+describe("writeTabToSearch", () => {
+  it("removes the parameter when writing the default tab", () => {
+    expect(
+      writeTabToSearch("?tab=tools&other=keep", DEFAULT_AGENT_EDITOR_TAB).toString(),
+    ).toBe("other=keep");
+  });
+
+  it("sets the parameter when writing a non-default tab", () => {
+    expect(writeTabToSearch("", "advanced").toString()).toBe("tab=advanced");
+  });
+
+  it("preserves unrelated parameters", () => {
+    expect(
+      writeTabToSearch("?other=keep", "tools").toString(),
+    ).toBe("other=keep&tab=tools");
+  });
+});

--- a/apps/admin-console/src/lib/editor-tabs.ts
+++ b/apps/admin-console/src/lib/editor-tabs.ts
@@ -1,0 +1,58 @@
+export type AgentEditorTabId =
+  | "basics"
+  | "tools"
+  | "plugins"
+  | "delegates"
+  | "advanced";
+
+export interface AgentEditorTab {
+  id: AgentEditorTabId;
+  label: string;
+  description: string;
+}
+
+export const AGENT_EDITOR_TABS: readonly AgentEditorTab[] = [
+  { id: "basics", label: "Basics", description: "Identity, model, prompt, limits." },
+  { id: "tools", label: "Tools", description: "Allowed and excluded tools." },
+  { id: "plugins", label: "Plugins", description: "Enabled plugins and their config." },
+  { id: "delegates", label: "Delegates", description: "Agents this one can delegate to." },
+  { id: "advanced", label: "Advanced", description: "Raw JSON preview." },
+];
+
+export const DEFAULT_AGENT_EDITOR_TAB: AgentEditorTabId = "basics";
+
+export function isAgentEditorTab(value: unknown): value is AgentEditorTabId {
+  return (
+    typeof value === "string" &&
+    AGENT_EDITOR_TABS.some((tab) => tab.id === value)
+  );
+}
+
+/// Read the active tab from a query-string parameter (typically
+/// `?tab=tools`). Falls back to the default when missing or unrecognised.
+export function readTabFromSearch(
+  search: URLSearchParams | string,
+): AgentEditorTabId {
+  const params =
+    typeof search === "string" ? new URLSearchParams(search) : search;
+  const candidate = params.get("tab");
+  return isAgentEditorTab(candidate) ? candidate : DEFAULT_AGENT_EDITOR_TAB;
+}
+
+/// Produce the next URLSearchParams for a tab change. The default tab is
+/// represented by removing the `tab` parameter so the canonical URL stays
+/// clean.
+export function writeTabToSearch(
+  search: URLSearchParams | string,
+  tab: AgentEditorTabId,
+): URLSearchParams {
+  const params = new URLSearchParams(
+    typeof search === "string" ? search : search.toString(),
+  );
+  if (tab === DEFAULT_AGENT_EDITOR_TAB) {
+    params.delete("tab");
+  } else {
+    params.set("tab", tab);
+  }
+  return params;
+}

--- a/apps/admin-console/src/lib/eval-reports-filter.test.ts
+++ b/apps/admin-console/src/lib/eval-reports-filter.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FIXTURE_FILTER,
+  filterFixtures,
+  type FixtureFilterState,
+} from "./eval-reports-filter";
+import type { DiffEntry, ReplayReport } from "./eval-reports";
+
+function makeReport(overrides: Partial<ReplayReport> = {}): ReplayReport {
+  return {
+    fixture_id: "fixture-a",
+    passed: true,
+    failures: [],
+    final_text: "",
+    inference_count: 0,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    session_duration_ms: 0,
+    tool_calls: [],
+    tool_calls_by_agent: [],
+    ...overrides,
+  } as ReplayReport;
+}
+
+const REPORTS: ReplayReport[] = [
+  makeReport({ fixture_id: "checkout", passed: true }),
+  makeReport({ fixture_id: "search", passed: false }),
+  makeReport({ fixture_id: "auth-login", passed: true }),
+];
+
+const DIFFS: Map<string, DiffEntry> = new Map([
+  ["search", { kind: "regression", fixture_id: "search" } as DiffEntry],
+  ["auth-login", { kind: "fixed", fixture_id: "auth-login" } as DiffEntry],
+]);
+
+function withFilter(overrides: Partial<FixtureFilterState>): FixtureFilterState {
+  return { ...DEFAULT_FIXTURE_FILTER, ...overrides };
+}
+
+describe("filterFixtures", () => {
+  it("returns every report with the default filter", () => {
+    expect(filterFixtures(REPORTS, DEFAULT_FIXTURE_FILTER, DIFFS)).toEqual(REPORTS);
+  });
+
+  it("filters to passing fixtures", () => {
+    expect(
+      filterFixtures(REPORTS, withFilter({ status: "passed" })).map(
+        (r) => r.fixture_id,
+      ),
+    ).toEqual(["checkout", "auth-login"]);
+  });
+
+  it("filters to failing fixtures", () => {
+    expect(
+      filterFixtures(REPORTS, withFilter({ status: "failed" })).map(
+        (r) => r.fixture_id,
+      ),
+    ).toEqual(["search"]);
+  });
+
+  it("filters to regressions when a baseline diff is provided", () => {
+    expect(
+      filterFixtures(
+        REPORTS,
+        withFilter({ status: "regressions" }),
+        DIFFS,
+      ).map((r) => r.fixture_id),
+    ).toEqual(["search"]);
+  });
+
+  it("filters to newly fixed fixtures", () => {
+    expect(
+      filterFixtures(REPORTS, withFilter({ status: "fixed" }), DIFFS).map(
+        (r) => r.fixture_id,
+      ),
+    ).toEqual(["auth-login"]);
+  });
+
+  it("returns nothing when regressions are requested but no diff is loaded", () => {
+    expect(filterFixtures(REPORTS, withFilter({ status: "regressions" }))).toEqual([]);
+  });
+
+  it("matches search tokens case-insensitively against the fixture id", () => {
+    expect(
+      filterFixtures(REPORTS, withFilter({ search: "AUTH" })).map(
+        (r) => r.fixture_id,
+      ),
+    ).toEqual(["auth-login"]);
+  });
+
+  it("requires every search token to match", () => {
+    expect(
+      filterFixtures(REPORTS, withFilter({ search: "auth login" })).map(
+        (r) => r.fixture_id,
+      ),
+    ).toEqual(["auth-login"]);
+    expect(
+      filterFixtures(REPORTS, withFilter({ search: "auth zzz" })),
+    ).toEqual([]);
+  });
+});

--- a/apps/admin-console/src/lib/eval-reports-filter.ts
+++ b/apps/admin-console/src/lib/eval-reports-filter.ts
@@ -1,0 +1,64 @@
+import type { ReplayReport, DiffEntry } from "./eval-reports";
+import { isBlockingDiff } from "./eval-reports";
+
+export type FixtureStatusFilter =
+  | "all"
+  | "passed"
+  | "failed"
+  | "regressions"
+  | "fixed";
+
+export interface FixtureFilterState {
+  status: FixtureStatusFilter;
+  search: string;
+}
+
+export const DEFAULT_FIXTURE_FILTER: FixtureFilterState = {
+  status: "all",
+  search: "",
+};
+
+/// Filter the per-fixture rows for the report table. The diff lookup is
+/// optional — when no baseline is loaded, "regressions" / "fixed" still
+/// evaluate but match nothing.
+export function filterFixtures(
+  reports: ReplayReport[],
+  filter: FixtureFilterState,
+  diffs: Map<string, DiffEntry> = new Map(),
+): ReplayReport[] {
+  const tokens = filter.search
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+
+  return reports.filter((report) => {
+    if (!matchesStatus(report, filter.status, diffs)) return false;
+    if (tokens.length === 0) return true;
+    const haystack = report.fixture_id.toLowerCase();
+    return tokens.every((token) => haystack.includes(token));
+  });
+}
+
+function matchesStatus(
+  report: ReplayReport,
+  status: FixtureStatusFilter,
+  diffs: Map<string, DiffEntry>,
+): boolean {
+  switch (status) {
+    case "all":
+      return true;
+    case "passed":
+      return report.passed;
+    case "failed":
+      return !report.passed;
+    case "regressions": {
+      const diff = diffs.get(report.fixture_id);
+      return diff ? isBlockingDiff(diff) : false;
+    }
+    case "fixed": {
+      const diff = diffs.get(report.fixture_id);
+      return diff?.kind === "fixed";
+    }
+  }
+}

--- a/apps/admin-console/src/lib/list-view.test.ts
+++ b/apps/admin-console/src/lib/list-view.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareBoolean,
+  compareNumber,
+  compareString,
+  DEFAULT_PAGE_SIZE,
+  filterBySearch,
+  PAGE_SIZE_OPTIONS,
+  paginate,
+  sortItems,
+  toggleSort,
+  type SortConfig,
+  type SortState,
+} from "./list-view";
+
+interface Row {
+  id: string;
+  count: number;
+  active: boolean;
+}
+
+const ROWS: Row[] = [
+  { id: "alpha", count: 3, active: true },
+  { id: "Beta", count: 1, active: false },
+  { id: "gamma", count: 2, active: true },
+  { id: "alpha-prime", count: 0, active: false },
+];
+
+const SORT_CONFIG: SortConfig<Row, "id" | "count" | "active"> = {
+  id: (a, b) => compareString(a.id, b.id),
+  count: (a, b) => compareNumber(a.count, b.count),
+  active: (a, b) => compareBoolean(a.active, b.active),
+};
+
+describe("filterBySearch", () => {
+  it("returns items unchanged when the query is empty or whitespace", () => {
+    expect(filterBySearch(ROWS, "", (row) => [row.id])).toBe(ROWS);
+    expect(filterBySearch(ROWS, "   ", (row) => [row.id])).toBe(ROWS);
+  });
+
+  it("matches case-insensitively across all selector outputs", () => {
+    const matched = filterBySearch(ROWS, "BETA", (row) => [row.id]);
+    expect(matched.map((row) => row.id)).toEqual(["Beta"]);
+  });
+
+  it("requires every whitespace-delimited token to match somewhere", () => {
+    const matched = filterBySearch(ROWS, "alpha prime", (row) => [row.id]);
+    expect(matched.map((row) => row.id)).toEqual(["alpha-prime"]);
+  });
+
+  it("ignores nullish selector outputs", () => {
+    const items = [
+      { id: "x", description: undefined as string | undefined },
+      { id: "y", description: "hidden gem" },
+    ];
+    const matched = filterBySearch(items, "gem", (row) => [
+      row.id,
+      row.description,
+    ]);
+    expect(matched.map((r) => r.id)).toEqual(["y"]);
+  });
+});
+
+describe("sortItems", () => {
+  it("returns the original array when no sort is set", () => {
+    expect(sortItems(ROWS, null, SORT_CONFIG)).toBe(ROWS);
+  });
+
+  it("sorts ascending by string", () => {
+    const state: SortState<"id"> = { key: "id", direction: "asc" };
+    expect(sortItems(ROWS, state, SORT_CONFIG).map((r) => r.id)).toEqual([
+      "alpha",
+      "alpha-prime",
+      "Beta",
+      "gamma",
+    ]);
+  });
+
+  it("sorts descending by number", () => {
+    const state: SortState<"count"> = { key: "count", direction: "desc" };
+    expect(sortItems(ROWS, state, SORT_CONFIG).map((r) => r.count)).toEqual([
+      3, 2, 1, 0,
+    ]);
+  });
+
+  it("sorts booleans with false first when ascending", () => {
+    const state: SortState<"active"> = { key: "active", direction: "asc" };
+    const sorted = sortItems(ROWS, state, SORT_CONFIG);
+    expect(sorted.slice(0, 2).every((r) => !r.active)).toBe(true);
+    expect(sorted.slice(2).every((r) => r.active)).toBe(true);
+  });
+
+  it("ignores unknown sort keys", () => {
+    const state = { key: "missing" as never, direction: "asc" } as SortState<never>;
+    expect(sortItems(ROWS, state, SORT_CONFIG as never)).toBe(ROWS);
+  });
+});
+
+describe("toggleSort", () => {
+  it("starts a new sort ascending", () => {
+    expect(toggleSort(null, "id")).toEqual({ key: "id", direction: "asc" });
+  });
+
+  it("flips direction on the same key", () => {
+    expect(toggleSort({ key: "id", direction: "asc" }, "id")).toEqual({
+      key: "id",
+      direction: "desc",
+    });
+  });
+
+  it("clears the sort on the third toggle of the same key", () => {
+    expect(toggleSort({ key: "id", direction: "desc" }, "id")).toBeNull();
+  });
+
+  it("switches to a new key in ascending mode", () => {
+    expect(toggleSort({ key: "id", direction: "desc" }, "count")).toEqual({
+      key: "count",
+      direction: "asc",
+    });
+  });
+});
+
+describe("paginate", () => {
+  const items = Array.from({ length: 23 }, (_, idx) => ({ id: `i${idx}` }));
+
+  it("returns the requested page slice", () => {
+    const view = paginate(items, { page: 2, pageSize: 10, totalItems: items.length });
+    expect(view.items).toHaveLength(10);
+    expect(view.items[0].id).toBe("i10");
+    expect(view.startIndex).toBe(10);
+    expect(view.endIndex).toBe(20);
+    expect(view.pageCount).toBe(3);
+  });
+
+  it("clamps the page to the valid range", () => {
+    const view = paginate(items, { page: 99, pageSize: 10, totalItems: items.length });
+    expect(view.page).toBe(3);
+    expect(view.items[0].id).toBe("i20");
+    expect(view.endIndex).toBe(23);
+  });
+
+  it("treats an empty list as a single-page view", () => {
+    const view = paginate([], { page: 1, pageSize: 10, totalItems: 0 });
+    expect(view.pageCount).toBe(1);
+    expect(view.items).toEqual([]);
+  });
+
+  it("respects the chosen page size", () => {
+    const view = paginate(items, { page: 1, pageSize: 50, totalItems: items.length });
+    expect(view.items).toHaveLength(items.length);
+    expect(view.pageCount).toBe(1);
+  });
+});
+
+describe("constants", () => {
+  it("exposes sane defaults", () => {
+    expect(PAGE_SIZE_OPTIONS).toContain(DEFAULT_PAGE_SIZE);
+  });
+});

--- a/apps/admin-console/src/lib/list-view.ts
+++ b/apps/admin-console/src/lib/list-view.ts
@@ -1,0 +1,126 @@
+export type SortDirection = "asc" | "desc";
+
+export interface SortState<TKey extends string> {
+  key: TKey;
+  direction: SortDirection;
+}
+
+export type Comparator<T> = (a: T, b: T) => number;
+
+export type SortConfig<T, TKey extends string> = Record<TKey, Comparator<T>>;
+
+export type SearchSelector<T> = (item: T) => Iterable<string | null | undefined>;
+
+export const PAGE_SIZE_OPTIONS = [10, 20, 50, 100] as const;
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
+
+export const DEFAULT_PAGE_SIZE: PageSize = 20;
+
+/// Case-insensitive substring filter. Empty queries pass through unchanged.
+/// Whitespace is collapsed and split into AND-tokens, so "foo bar" matches
+/// items whose searchable strings contain both "foo" and "bar".
+export function filterBySearch<T>(
+  items: T[],
+  query: string,
+  selector: SearchSelector<T>,
+): T[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return items;
+  const tokens = trimmed
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+  if (tokens.length === 0) return items;
+
+  return items.filter((item) => {
+    const haystack = Array.from(selector(item))
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.toLowerCase())
+      .join("  ");
+    return tokens.every((token) => haystack.includes(token));
+  });
+}
+
+export function sortItems<T, TKey extends string>(
+  items: T[],
+  state: SortState<TKey> | null,
+  config: SortConfig<T, TKey>,
+): T[] {
+  if (!state) return items;
+  const comparator = config[state.key];
+  if (!comparator) return items;
+  const direction = state.direction === "asc" ? 1 : -1;
+  const copy = items.slice();
+  copy.sort((a, b) => comparator(a, b) * direction);
+  return copy;
+}
+
+export function toggleSort<TKey extends string>(
+  current: SortState<TKey> | null,
+  key: TKey,
+): SortState<TKey> | null {
+  if (!current || current.key !== key) {
+    return { key, direction: "asc" };
+  }
+  if (current.direction === "asc") {
+    return { key, direction: "desc" };
+  }
+  return null;
+}
+
+export interface PaginationState {
+  page: number;
+  pageSize: PageSize;
+  totalItems: number;
+}
+
+export interface PageView<T> {
+  items: T[];
+  page: number;
+  pageCount: number;
+  pageSize: PageSize;
+  totalItems: number;
+  startIndex: number;
+  endIndex: number;
+}
+
+export function paginate<T>(items: T[], state: PaginationState): PageView<T> {
+  const totalItems = items.length;
+  const pageCount = Math.max(1, Math.ceil(totalItems / state.pageSize));
+  const safePage = clamp(state.page, 1, pageCount);
+  const startIndex = (safePage - 1) * state.pageSize;
+  const endIndex = Math.min(totalItems, startIndex + state.pageSize);
+  return {
+    items: items.slice(startIndex, endIndex),
+    page: safePage,
+    pageCount,
+    pageSize: state.pageSize,
+    totalItems,
+    startIndex,
+    endIndex,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+export function compareString(a: string | undefined, b: string | undefined): number {
+  return (a ?? "").localeCompare(b ?? "");
+}
+
+export function compareNumber(a: number | undefined, b: number | undefined): number {
+  const left = typeof a === "number" ? a : 0;
+  const right = typeof b === "number" ? b : 0;
+  return left - right;
+}
+
+export function compareBoolean(
+  a: boolean | undefined,
+  b: boolean | undefined,
+): number {
+  return Number(Boolean(a)) - Number(Boolean(b));
+}

--- a/apps/admin-console/src/lib/reasoning-effort.test.ts
+++ b/apps/admin-console/src/lib/reasoning-effort.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  reasoningEffortMode,
+  reasoningEffortValue,
+} from "./reasoning-effort";
+
+describe("reasoningEffortMode", () => {
+  it("treats undefined / null / empty string as the runtime default", () => {
+    expect(reasoningEffortMode(undefined)).toEqual({ kind: "default" });
+    expect(reasoningEffortMode(null)).toEqual({ kind: "default" });
+    expect(reasoningEffortMode("")).toEqual({ kind: "default" });
+  });
+
+  it("recognises the three named presets", () => {
+    expect(reasoningEffortMode("low")).toEqual({
+      kind: "preset",
+      value: "low",
+    });
+    expect(reasoningEffortMode("medium")).toEqual({
+      kind: "preset",
+      value: "medium",
+    });
+    expect(reasoningEffortMode("high")).toEqual({
+      kind: "preset",
+      value: "high",
+    });
+  });
+
+  it("returns numeric levels as custom strings so they round-trip in the input", () => {
+    expect(reasoningEffortMode(42)).toEqual({ kind: "custom", value: "42" });
+  });
+
+  it("falls back to custom for unrecognised strings", () => {
+    expect(reasoningEffortMode("ultra")).toEqual({
+      kind: "custom",
+      value: "ultra",
+    });
+  });
+});
+
+describe("reasoningEffortValue", () => {
+  it("erases the field when the mode is default", () => {
+    expect(reasoningEffortValue({ kind: "default" })).toBeUndefined();
+  });
+
+  it("returns the preset string verbatim", () => {
+    expect(reasoningEffortValue({ kind: "preset", value: "high" })).toBe("high");
+  });
+
+  it("parses purely numeric custom values back into numbers", () => {
+    expect(reasoningEffortValue({ kind: "custom", value: " 17 " })).toBe(17);
+    expect(reasoningEffortValue({ kind: "custom", value: "1.5" })).toBe(1.5);
+  });
+
+  it("preserves non-numeric custom values as strings", () => {
+    expect(reasoningEffortValue({ kind: "custom", value: "ultra" })).toBe(
+      "ultra",
+    );
+  });
+
+  it("treats a blank custom value as the default", () => {
+    expect(reasoningEffortValue({ kind: "custom", value: "  " })).toBeUndefined();
+  });
+});

--- a/apps/admin-console/src/lib/reasoning-effort.ts
+++ b/apps/admin-console/src/lib/reasoning-effort.ts
@@ -1,0 +1,42 @@
+/// Reasoning effort presets understood by all major providers, plus a
+/// "Custom" option that surfaces a free-form input for numeric levels.
+export const REASONING_EFFORT_PRESETS = ["low", "medium", "high"] as const;
+export type ReasoningEffortPreset = (typeof REASONING_EFFORT_PRESETS)[number];
+
+export type ReasoningEffortMode =
+  | { kind: "default" }
+  | { kind: "preset"; value: ReasoningEffortPreset }
+  | { kind: "custom"; value: string };
+
+/// Inspect a stored reasoning_effort value (string | number | null) and
+/// classify it into a UI mode. Numbers become a custom string so they
+/// round-trip through the editor; unknown strings are treated as custom.
+export function reasoningEffortMode(
+  value: string | number | null | undefined,
+): ReasoningEffortMode {
+  if (value === undefined || value === null || value === "") {
+    return { kind: "default" };
+  }
+  if (typeof value === "number") {
+    return { kind: "custom", value: String(value) };
+  }
+  if ((REASONING_EFFORT_PRESETS as readonly string[]).includes(value)) {
+    return { kind: "preset", value: value as ReasoningEffortPreset };
+  }
+  return { kind: "custom", value };
+}
+
+/// Convert a UI mode back to the wire-shape stored on AgentSpec.
+export function reasoningEffortValue(
+  mode: ReasoningEffortMode,
+): string | number | null | undefined {
+  if (mode.kind === "default") return undefined;
+  if (mode.kind === "preset") return mode.value;
+  const trimmed = mode.value.trim();
+  if (trimmed.length === 0) return undefined;
+  const asNumber = Number(trimmed);
+  if (!Number.isNaN(asNumber) && /^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return asNumber;
+  }
+  return trimmed;
+}

--- a/apps/admin-console/src/lib/skills-filter.test.ts
+++ b/apps/admin-console/src/lib/skills-filter.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SKILLS_FILTER,
+  filterSkills,
+  type SkillsFilterState,
+} from "./skills-filter";
+import type { SkillInfo } from "./config-api";
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: "greeting",
+    name: "Greeting",
+    description: "Friendly opener",
+    allowed_tools: [],
+    when_to_use: null,
+    arguments: [],
+    argument_hint: null,
+    user_invocable: true,
+    model_invocable: false,
+    model_override: null,
+    context: "inline",
+    paths: [],
+    ...overrides,
+  };
+}
+
+const SKILLS: SkillInfo[] = [
+  makeSkill({
+    id: "greeting",
+    name: "Greeting",
+    description: "Friendly opener",
+    user_invocable: true,
+    model_invocable: false,
+    context: "inline",
+    allowed_tools: ["Read"],
+  }),
+  makeSkill({
+    id: "researcher",
+    name: "Researcher",
+    description: "Investigates topics",
+    user_invocable: false,
+    model_invocable: true,
+    context: "fork",
+    paths: ["docs/", "src/"],
+  }),
+  makeSkill({
+    id: "internal-helper",
+    name: "Internal Helper",
+    description: "Background utility",
+    user_invocable: false,
+    model_invocable: false,
+    context: "inline",
+  }),
+];
+
+function withFilter(overrides: Partial<SkillsFilterState>): SkillsFilterState {
+  return { ...DEFAULT_SKILLS_FILTER, ...overrides };
+}
+
+describe("filterSkills", () => {
+  it("returns every skill with the default filter", () => {
+    expect(filterSkills(SKILLS, DEFAULT_SKILLS_FILTER)).toEqual(SKILLS);
+  });
+
+  it("filters down to user-invocable skills", () => {
+    expect(
+      filterSkills(SKILLS, withFilter({ invocable: "user" })).map((s) => s.id),
+    ).toEqual(["greeting"]);
+  });
+
+  it("filters down to model-invocable skills", () => {
+    expect(
+      filterSkills(SKILLS, withFilter({ invocable: "model" })).map((s) => s.id),
+    ).toEqual(["researcher"]);
+  });
+
+  it("filters down to internal-only skills", () => {
+    expect(
+      filterSkills(SKILLS, withFilter({ invocable: "internal" })).map(
+        (s) => s.id,
+      ),
+    ).toEqual(["internal-helper"]);
+  });
+
+  it("filters by execution context", () => {
+    expect(
+      filterSkills(SKILLS, withFilter({ context: "fork" })).map((s) => s.id),
+    ).toEqual(["researcher"]);
+  });
+
+  it("matches search across id, name, description, when_to_use, tools, paths", () => {
+    expect(
+      filterSkills(SKILLS, withFilter({ search: "investigates" })).map(
+        (s) => s.id,
+      ),
+    ).toEqual(["researcher"]);
+    expect(
+      filterSkills(SKILLS, withFilter({ search: "Read" })).map((s) => s.id),
+    ).toEqual(["greeting"]);
+    expect(
+      filterSkills(SKILLS, withFilter({ search: "docs" })).map((s) => s.id),
+    ).toEqual(["researcher"]);
+  });
+
+  it("requires every search token to match", () => {
+    expect(
+      filterSkills(SKILLS, withFilter({ search: "researcher topics" })).map(
+        (s) => s.id,
+      ),
+    ).toEqual(["researcher"]);
+    expect(
+      filterSkills(SKILLS, withFilter({ search: "researcher zzz" })),
+    ).toEqual([]);
+  });
+
+  it("composes multiple filters", () => {
+    expect(
+      filterSkills(
+        SKILLS,
+        withFilter({ invocable: "model", context: "fork" }),
+      ).map((s) => s.id),
+    ).toEqual(["researcher"]);
+    expect(
+      filterSkills(
+        SKILLS,
+        withFilter({ invocable: "user", context: "fork" }),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/admin-console/src/lib/skills-filter.ts
+++ b/apps/admin-console/src/lib/skills-filter.ts
@@ -1,0 +1,65 @@
+import type { SkillInfo } from "./config-api";
+
+export type InvocableFilter = "any" | "user" | "model" | "internal";
+export type ContextFilter = "any" | "inline" | "fork";
+
+export interface SkillsFilterState {
+  search: string;
+  invocable: InvocableFilter;
+  context: ContextFilter;
+}
+
+export const DEFAULT_SKILLS_FILTER: SkillsFilterState = {
+  search: "",
+  invocable: "any",
+  context: "any",
+};
+
+/// Apply the user-controllable filters to the skills list.
+export function filterSkills(
+  skills: SkillInfo[],
+  filter: SkillsFilterState,
+): SkillInfo[] {
+  return skills.filter((skill) => {
+    if (!matchesInvocable(skill, filter.invocable)) return false;
+    if (!matchesContext(skill, filter.context)) return false;
+    if (!matchesSearch(skill, filter.search)) return false;
+    return true;
+  });
+}
+
+function matchesInvocable(skill: SkillInfo, filter: InvocableFilter): boolean {
+  switch (filter) {
+    case "any":
+      return true;
+    case "user":
+      return skill.user_invocable;
+    case "model":
+      return skill.model_invocable;
+    case "internal":
+      return !skill.user_invocable && !skill.model_invocable;
+  }
+}
+
+function matchesContext(skill: SkillInfo, filter: ContextFilter): boolean {
+  if (filter === "any") return true;
+  return skill.context === filter;
+}
+
+function matchesSearch(skill: SkillInfo, query: string): boolean {
+  const trimmed = query.trim().toLowerCase();
+  if (trimmed.length === 0) return true;
+  const tokens = trimmed.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length === 0) return true;
+  const haystack = [
+    skill.id,
+    skill.name,
+    skill.description,
+    skill.when_to_use ?? "",
+    ...skill.allowed_tools,
+    ...skill.paths,
+  ]
+    .join("  ")
+    .toLowerCase();
+  return tokens.every((token) => haystack.includes(token));
+}

--- a/apps/admin-console/src/lib/toast-queue.test.ts
+++ b/apps/admin-console/src/lib/toast-queue.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendToast,
+  createToast,
+  DEFAULT_DURATIONS_MS,
+  dismissToast,
+  expireToasts,
+  MAX_VISIBLE_TOASTS,
+  nextExpiryDelay,
+  type Toast,
+} from "./toast-queue";
+
+function makeToast(overrides: Partial<Toast> = {}): Toast {
+  return {
+    id: "t1",
+    tone: "info",
+    message: "Hello",
+    durationMs: 1000,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+describe("createToast", () => {
+  it("uses the per-tone default duration when none is provided", () => {
+    const toast = createToast({ tone: "success", message: "ok" }, "id-1", 100);
+    expect(toast.durationMs).toBe(DEFAULT_DURATIONS_MS.success);
+    expect(toast.id).toBe("id-1");
+    expect(toast.createdAt).toBe(100);
+  });
+
+  it("respects an explicit zero duration (sticky toast)", () => {
+    const toast = createToast(
+      { tone: "error", message: "Boom", durationMs: 0 },
+      "id-2",
+      100,
+    );
+    expect(toast.durationMs).toBe(0);
+  });
+
+  it("respects an explicit duration override", () => {
+    const toast = createToast(
+      { tone: "info", message: "x", durationMs: 250 },
+      "id-3",
+      0,
+    );
+    expect(toast.durationMs).toBe(250);
+  });
+
+  it("rejects negative durations and falls back to the default", () => {
+    const toast = createToast(
+      { tone: "info", message: "x", durationMs: -5 },
+      "id-4",
+      0,
+    );
+    expect(toast.durationMs).toBe(DEFAULT_DURATIONS_MS.info);
+  });
+});
+
+describe("appendToast", () => {
+  it("appends to the tail when below the cap", () => {
+    const a = makeToast({ id: "a" });
+    const b = makeToast({ id: "b" });
+    expect(appendToast([a], b)).toEqual([a, b]);
+  });
+
+  it("evicts the oldest toast when the cap is exceeded", () => {
+    const queue = Array.from({ length: MAX_VISIBLE_TOASTS }, (_, idx) =>
+      makeToast({ id: `t${idx}` }),
+    );
+    const incoming = makeToast({ id: "new" });
+    const next = appendToast(queue, incoming);
+    expect(next).toHaveLength(MAX_VISIBLE_TOASTS);
+    expect(next[0].id).toBe("t1");
+    expect(next[next.length - 1].id).toBe("new");
+  });
+});
+
+describe("dismissToast", () => {
+  it("removes the matching id and is a no-op when missing", () => {
+    const queue = [makeToast({ id: "a" }), makeToast({ id: "b" })];
+    expect(dismissToast(queue, "a")).toEqual([makeToast({ id: "b" })]);
+    expect(dismissToast(queue, "missing")).toEqual(queue);
+  });
+});
+
+describe("expireToasts", () => {
+  it("keeps toasts whose lifetime has not yet elapsed", () => {
+    const queue = [
+      makeToast({ id: "a", createdAt: 0, durationMs: 1000 }),
+      makeToast({ id: "b", createdAt: 0, durationMs: 500 }),
+    ];
+    expect(expireToasts(queue, 600).map((t) => t.id)).toEqual(["a"]);
+  });
+
+  it("preserves sticky toasts (durationMs === 0) regardless of time", () => {
+    const queue = [makeToast({ id: "sticky", durationMs: 0 })];
+    expect(expireToasts(queue, 1_000_000)).toEqual(queue);
+  });
+});
+
+describe("nextExpiryDelay", () => {
+  it("returns null for an empty queue", () => {
+    expect(nextExpiryDelay([], 0)).toBeNull();
+  });
+
+  it("returns null when every toast is sticky", () => {
+    expect(
+      nextExpiryDelay([makeToast({ durationMs: 0 })], 0),
+    ).toBeNull();
+  });
+
+  it("returns the soonest remaining lifetime", () => {
+    const queue = [
+      makeToast({ id: "a", createdAt: 0, durationMs: 1000 }),
+      makeToast({ id: "b", createdAt: 0, durationMs: 500 }),
+    ];
+    expect(nextExpiryDelay(queue, 200)).toBe(300);
+  });
+
+  it("clamps to zero when a toast is already overdue", () => {
+    const queue = [makeToast({ createdAt: 0, durationMs: 100 })];
+    expect(nextExpiryDelay(queue, 999)).toBe(0);
+  });
+});

--- a/apps/admin-console/src/lib/toast-queue.ts
+++ b/apps/admin-console/src/lib/toast-queue.ts
@@ -1,0 +1,73 @@
+export type ToastTone = "success" | "error" | "info";
+
+export interface Toast {
+  id: string;
+  tone: ToastTone;
+  message: string;
+  detail?: string;
+  durationMs: number;
+  createdAt: number;
+}
+
+export interface ToastInput {
+  tone: ToastTone;
+  message: string;
+  detail?: string;
+  durationMs?: number;
+}
+
+export const DEFAULT_DURATIONS_MS: Record<ToastTone, number> = {
+  success: 3500,
+  info: 4500,
+  error: 7000,
+};
+
+export const MAX_VISIBLE_TOASTS = 5;
+
+export function createToast(input: ToastInput, id: string, now: number): Toast {
+  const durationMs =
+    typeof input.durationMs === "number" && input.durationMs >= 0
+      ? input.durationMs
+      : DEFAULT_DURATIONS_MS[input.tone];
+  return {
+    id,
+    tone: input.tone,
+    message: input.message,
+    detail: input.detail,
+    durationMs,
+    createdAt: now,
+  };
+}
+
+export function appendToast(queue: Toast[], toast: Toast): Toast[] {
+  const next = [...queue, toast];
+  return next.length > MAX_VISIBLE_TOASTS
+    ? next.slice(next.length - MAX_VISIBLE_TOASTS)
+    : next;
+}
+
+export function dismissToast(queue: Toast[], id: string): Toast[] {
+  return queue.filter((toast) => toast.id !== id);
+}
+
+export function expireToasts(queue: Toast[], now: number): Toast[] {
+  return queue.filter((toast) => {
+    if (toast.durationMs === 0) {
+      return true;
+    }
+    return now - toast.createdAt < toast.durationMs;
+  });
+}
+
+export function nextExpiryDelay(queue: Toast[], now: number): number | null {
+  let soonest: number | null = null;
+  for (const toast of queue) {
+    if (toast.durationMs === 0) continue;
+    const remaining = toast.createdAt + toast.durationMs - now;
+    const safe = remaining < 0 ? 0 : remaining;
+    if (soonest === null || safe < soonest) {
+      soonest = safe;
+    }
+  }
+  return soonest;
+}

--- a/apps/admin-console/src/lib/use-crud-page.tsx
+++ b/apps/admin-console/src/lib/use-crud-page.tsx
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { configApi } from "@/lib/config-api";
+import { useToast } from "@/components/toast-provider";
+import { useConfirmDialog } from "@/components/confirm-dialog";
 
 export interface CrudPageOptions<TRecord extends { id: string }, TSpec = TRecord> {
   /** API namespace used for list/create/update/delete calls. */
@@ -37,6 +39,11 @@ export interface CrudPageState<TRecord extends { id: string }> {
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function capitalize(value: string): string {
+  if (value.length === 0) return value;
+  return value[0].toUpperCase() + value.slice(1);
 }
 
 export interface CrudPageLoadResult<TRecord extends { id: string }> {
@@ -87,6 +94,8 @@ export function useCrudPage<TRecord extends { id: string }, TSpec = TRecord>(
   options: CrudPageOptions<TRecord, TSpec>,
 ): CrudPageState<TRecord> {
   const { namespace, entityLabel, prepareSave, auxiliaryLoaders } = options;
+  const toast = useToast();
+  const confirmDialog = useConfirmDialog();
 
   const [items, setItems] = useState<TRecord[]>([]);
   const [draft, setDraft] = useState<TRecord | null>(null);
@@ -98,6 +107,14 @@ export function useCrudPage<TRecord extends { id: string }, TSpec = TRecord>(
 
   const isEditingExisting = editingId !== null;
 
+  const reportError = useCallback(
+    (message: string) => {
+      setError(message);
+      toast.error(message);
+    },
+    [toast],
+  );
+
   useEffect(() => {
     let cancelled = false;
 
@@ -108,11 +125,15 @@ export function useCrudPage<TRecord extends { id: string }, TSpec = TRecord>(
         if (!cancelled) {
           setItems(result.items);
           setAuxiliaryData(result.auxiliaryData);
-          setError(result.auxiliaryError);
+          if (result.auxiliaryError) {
+            reportError(result.auxiliaryError);
+          } else {
+            setError(null);
+          }
         }
       } catch (loadError) {
         if (!cancelled) {
-          setError(toErrorMessage(loadError));
+          reportError(toErrorMessage(loadError));
           setItems([]);
         }
       } finally {
@@ -167,6 +188,7 @@ export function useCrudPage<TRecord extends { id: string }, TSpec = TRecord>(
         setItems((current) =>
           current.map((item) => (item.id === editingId ? updated : item)),
         );
+        toast.success(`${capitalize(entityLabel)} "${editingId}" saved`);
       } else {
         const created = await configApi.create<TSpec, TRecord>(namespace, payload);
         setItems((current) =>
@@ -174,21 +196,33 @@ export function useCrudPage<TRecord extends { id: string }, TSpec = TRecord>(
             (left, right) => left.id.localeCompare(right.id),
           ),
         );
+        toast.success(`${capitalize(entityLabel)} "${created.id}" created`);
       }
       setDraft(null);
       setEditingId(null);
       setError(null);
     } catch (saveError) {
-      setError(toErrorMessage(saveError));
+      reportError(toErrorMessage(saveError));
     } finally {
       setSaving(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draft, editingId, namespace, prepareSave]);
+  }, [draft, editingId, namespace, prepareSave, entityLabel, toast, reportError]);
 
   const handleDelete = useCallback(
     async (id: string) => {
-      if (!confirm(`Delete ${entityLabel} "${id}"?`)) {
+      const confirmed = await confirmDialog({
+        title: `Delete ${entityLabel}?`,
+        description: (
+          <>
+            This permanently removes <span className="font-mono">{id}</span> from
+            the runtime catalog.
+          </>
+        ),
+        confirmLabel: "Delete",
+        tone: "destructive",
+      });
+      if (!confirmed) {
         return;
       }
 
@@ -196,11 +230,12 @@ export function useCrudPage<TRecord extends { id: string }, TSpec = TRecord>(
         await configApi.delete(namespace, id);
         setItems((current) => current.filter((item) => item.id !== id));
         setError(null);
+        toast.success(`${capitalize(entityLabel)} "${id}" deleted`);
       } catch (deleteError) {
-        setError(toErrorMessage(deleteError));
+        reportError(toErrorMessage(deleteError));
       }
     },
-    [namespace, entityLabel],
+    [namespace, entityLabel, confirmDialog, toast, reportError],
   );
 
   return {

--- a/apps/admin-console/src/main.tsx
+++ b/apps/admin-console/src/main.tsx
@@ -3,15 +3,18 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
 import { router } from "./app";
 import { AuthProvider } from "./components/auth-provider";
+import { ConfirmDialogProvider } from "./components/confirm-dialog";
 import { ToastProvider } from "./components/toast-provider";
 import "./globals.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ToastProvider>
-      <AuthProvider>
-        <RouterProvider router={router} />
-      </AuthProvider>
+      <ConfirmDialogProvider>
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
+      </ConfirmDialogProvider>
     </ToastProvider>
   </StrictMode>,
 );

--- a/apps/admin-console/src/main.tsx
+++ b/apps/admin-console/src/main.tsx
@@ -2,10 +2,16 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
 import { router } from "./app";
+import { AuthProvider } from "./components/auth-provider";
+import { ToastProvider } from "./components/toast-provider";
 import "./globals.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <ToastProvider>
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </ToastProvider>
   </StrictMode>,
 );

--- a/apps/admin-console/src/main.tsx
+++ b/apps/admin-console/src/main.tsx
@@ -1,13 +1,11 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router";
-import { App } from "./app";
+import { RouterProvider } from "react-router";
+import { router } from "./app";
 import "./globals.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <RouterProvider router={router} />
   </StrictMode>,
 );

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router";
 import { type AgentSpec, type Capabilities, configApi } from "@/lib/config-api";
 import { Field } from "@/components/form-components";
 import { AgentPreviewPanel } from "@/components/agent-preview-panel";
 import { PluginConfigWorkspace } from "@/components/plugin-config-workspace";
+import { useToast } from "@/components/toast-provider";
+import { useUnsavedChangesGuard } from "@/components/unsaved-changes-guard";
 import { isToolAllowed, nextAllowedTools } from "@/lib/agent-tool-selection";
 import { pluginConfigEntryKey, pluginDisplayName } from "@/lib/plugin-config";
 import { adminRoutes } from "@/lib/routes";
@@ -25,12 +27,28 @@ export function AgentEditorPage() {
   const isNew = id === "new";
 
   const [spec, setSpec] = useState<AgentSpec>({ ...EMPTY_AGENT });
+  const [savedSpec, setSavedSpec] = useState<AgentSpec | null>(null);
   const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
   const [activePluginConfig, setActivePluginConfig] = useState<string | null>(null);
+  const toast = useToast();
+
+  const isDirty = useMemo(() => {
+    if (saving) return false;
+    if (isNew) {
+      return (
+        spec.id.trim().length > 0 ||
+        spec.system_prompt.length > 0 ||
+        spec.model_id.length > 0 ||
+        (spec.plugin_ids?.length ?? 0) > 0
+      );
+    }
+    if (!savedSpec) return false;
+    return JSON.stringify(spec) !== JSON.stringify(savedSpec);
+  }, [spec, savedSpec, isNew, saving]);
+
+  useUnsavedChangesGuard({ enabled: isDirty });
 
   useEffect(() => {
     let cancelled = false;
@@ -43,7 +61,7 @@ export function AgentEditorPage() {
         }
       } catch (loadError) {
         if (!cancelled) {
-          setError(
+          toast.error(
             loadError instanceof Error ? loadError.message : String(loadError),
           );
         }
@@ -60,17 +78,20 @@ export function AgentEditorPage() {
       try {
         const nextSpec = await configApi.get<AgentSpec>("agents", id);
         if (!cancelled) {
-          setSpec({
+          const hydrated = {
             sections: {},
             plugin_ids: [],
             delegates: [],
             ...nextSpec,
-          });
-          setError(null);
+          };
+          setSpec(hydrated);
+          setSavedSpec(hydrated);
         }
       } catch (loadError) {
         if (!cancelled) {
-          setError(loadError instanceof Error ? loadError.message : String(loadError));
+          toast.error(
+            loadError instanceof Error ? loadError.message : String(loadError),
+          );
         }
       } finally {
         if (!cancelled) {
@@ -88,7 +109,6 @@ export function AgentEditorPage() {
 
   async function handleSave() {
     setSaving(true);
-    setSuccess(null);
     try {
       const payload = {
         ...spec,
@@ -101,7 +121,8 @@ export function AgentEditorPage() {
           "agents",
           payload,
         );
-        setSuccess("Agent created.");
+        setSavedSpec(created);
+        toast.success(`Agent "${created.id}" created`);
         navigate(adminRoutes.agent(created.id), { replace: true });
       } else {
         const updated = await configApi.update<typeof payload, AgentSpec>(
@@ -110,11 +131,13 @@ export function AgentEditorPage() {
           payload,
         );
         setSpec(updated);
-        setSuccess("Agent saved.");
+        setSavedSpec(updated);
+        toast.success(`Agent "${updated.id}" saved`);
       }
-      setError(null);
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : String(saveError));
+      toast.error(
+        saveError instanceof Error ? saveError.message : String(saveError),
+      );
     } finally {
       setSaving(false);
     }
@@ -268,18 +291,6 @@ export function AgentEditorPage() {
           {saving ? "Saving..." : "Save"}
         </button>
       </div>
-
-      {error ? (
-        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {error}
-        </div>
-      ) : null}
-
-      {success ? (
-        <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-          {success}
-        </div>
-      ) : null}
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr),24rem]">
         <div>

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -9,6 +9,7 @@ import { type AgentSpec, type Capabilities, configApi } from "@/lib/config-api";
 import { Field } from "@/components/form-components";
 import { AgentPreviewPanel } from "@/components/agent-preview-panel";
 import { PluginConfigWorkspace } from "@/components/plugin-config-workspace";
+import { ToolSelector } from "@/components/tool-selector";
 import { useToast } from "@/components/toast-provider";
 import { useUnsavedChangesGuard } from "@/components/unsaved-changes-guard";
 import {
@@ -17,8 +18,12 @@ import {
   readTabFromSearch,
   writeTabToSearch,
 } from "@/lib/editor-tabs";
-import { isToolAllowed, nextAllowedTools } from "@/lib/agent-tool-selection";
 import { pluginConfigEntryKey, pluginDisplayName } from "@/lib/plugin-config";
+import {
+  REASONING_EFFORT_PRESETS,
+  reasoningEffortMode,
+  reasoningEffortValue,
+} from "@/lib/reasoning-effort";
 import { adminRoutes } from "@/lib/routes";
 
 const EMPTY_AGENT: AgentSpec = {
@@ -212,13 +217,7 @@ export function AgentEditorPage() {
     });
   }
 
-  function toggleAllowedTool(toolId: string, checked: boolean) {
-    const allToolIds = (capabilities?.tools ?? []).map((tool) => tool.id);
-    updateField(
-      "allowed_tools",
-      nextAllowedTools(spec.allowed_tools, allToolIds, toolId, checked),
-    );
-  }
+  const reasoningMode = reasoningEffortMode(spec.reasoning_effort);
 
   const configurablePlugins = (capabilities?.plugins ?? []).filter(
     (plugin) => plugin.config_schemas.length > 0,
@@ -305,6 +304,7 @@ export function AgentEditorPage() {
               capabilities={capabilities}
               isNew={isNew}
               updateField={updateField}
+              reasoningMode={reasoningMode}
             />
           )}
 
@@ -312,7 +312,7 @@ export function AgentEditorPage() {
             <ToolsPanel
               spec={spec}
               capabilities={capabilities}
-              toggleAllowedTool={toggleAllowedTool}
+              updateField={updateField}
             />
           )}
 
@@ -429,11 +429,13 @@ function BasicsPanel({
   capabilities,
   isNew,
   updateField,
+  reasoningMode,
 }: {
   spec: AgentSpec;
   capabilities: Capabilities | null;
   isNew: boolean;
   updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
+  reasoningMode: ReturnType<typeof reasoningEffortMode>;
 }) {
   return (
     <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
@@ -487,6 +489,79 @@ function BasicsPanel({
             className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
           />
         </Field>
+        <Field label="Reasoning effort">
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={
+                reasoningMode.kind === "default"
+                  ? "__default__"
+                  : reasoningMode.kind === "preset"
+                    ? reasoningMode.value
+                    : "__custom__"
+              }
+              onChange={(event) => {
+                const choice = event.target.value;
+                if (choice === "__default__") {
+                  updateField(
+                    "reasoning_effort",
+                    reasoningEffortValue({ kind: "default" }) as
+                      | string
+                      | number
+                      | null
+                      | undefined,
+                  );
+                  return;
+                }
+                if (choice === "__custom__") {
+                  updateField(
+                    "reasoning_effort",
+                    reasoningEffortValue({
+                      kind: "custom",
+                      value:
+                        reasoningMode.kind === "custom"
+                          ? reasoningMode.value
+                          : "",
+                    }) as string | number | null | undefined,
+                  );
+                  return;
+                }
+                updateField(
+                  "reasoning_effort",
+                  reasoningEffortValue({
+                    kind: "preset",
+                    value: choice as (typeof REASONING_EFFORT_PRESETS)[number],
+                  }) as string | number | null | undefined,
+                );
+              }}
+              className="rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+            >
+              <option value="__default__">Provider default</option>
+              {REASONING_EFFORT_PRESETS.map((preset) => (
+                <option key={preset} value={preset}>
+                  {preset}
+                </option>
+              ))}
+              <option value="__custom__">Custom…</option>
+            </select>
+            {reasoningMode.kind === "custom" ? (
+              <input
+                type="text"
+                value={reasoningMode.value}
+                onChange={(event) =>
+                  updateField(
+                    "reasoning_effort",
+                    reasoningEffortValue({
+                      kind: "custom",
+                      value: event.target.value,
+                    }) as string | number | null | undefined,
+                  )
+                }
+                placeholder="e.g. 1, 2, ultra"
+                className="w-32 rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+              />
+            ) : null}
+          </div>
+        </Field>
       </div>
 
       <div className="mt-4">
@@ -509,11 +584,11 @@ function BasicsPanel({
 function ToolsPanel({
   spec,
   capabilities,
-  toggleAllowedTool,
+  updateField,
 }: {
   spec: AgentSpec;
   capabilities: Capabilities | null;
-  toggleAllowedTool: (toolId: string, checked: boolean) => void;
+  updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
 }) {
   if (!capabilities || capabilities.tools.length === 0) {
     return (
@@ -524,39 +599,24 @@ function ToolsPanel({
     );
   }
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-      <h3 className="text-lg font-semibold text-slate-950">Allowed Tools</h3>
-      <p className="mt-2 text-sm text-slate-500">
-        Leaving every tool selected keeps the default runtime behavior.
-      </p>
-      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-        {capabilities.tools.map((tool) => {
-          const checked = isToolAllowed(spec.allowed_tools, tool.id);
-          return (
-            <label
-              key={tool.id}
-              className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
-            >
-              <div className="flex items-start gap-3">
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={(event) =>
-                    toggleAllowedTool(tool.id, event.target.checked)
-                  }
-                />
-                <div>
-                  <div className="font-mono text-slate-900">{tool.id}</div>
-                  <div className="mt-1 text-slate-500">
-                    {tool.description || tool.name}
-                  </div>
-                </div>
-              </div>
-            </label>
-          );
-        })}
-      </div>
-    </section>
+    <>
+      <ToolSelector
+        title="Allowed Tools"
+        description='"All tools" is the default — every published tool is exposed. Switch to Custom to restrict the agent to a specific subset.'
+        tools={capabilities.tools}
+        value={spec.allowed_tools}
+        onChange={(next) => updateField("allowed_tools", next)}
+        variant="include"
+      />
+      <ToolSelector
+        title="Excluded Tools"
+        description="Excluded tools are removed from the effective allow-list, even if they appear in 'All tools'. Useful for keeping a tool published to other agents but blocking it here."
+        tools={capabilities.tools}
+        value={spec.excluded_tools}
+        onChange={(next) => updateField("excluded_tools", next)}
+        variant="exclude"
+      />
+    </>
   );
 }
 

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -1,11 +1,22 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router";
 import { type AgentSpec, type Capabilities, configApi } from "@/lib/config-api";
 import { Field } from "@/components/form-components";
 import { AgentPreviewPanel } from "@/components/agent-preview-panel";
 import { PluginConfigWorkspace } from "@/components/plugin-config-workspace";
 import { useToast } from "@/components/toast-provider";
 import { useUnsavedChangesGuard } from "@/components/unsaved-changes-guard";
+import {
+  AGENT_EDITOR_TABS,
+  type AgentEditorTabId,
+  readTabFromSearch,
+  writeTabToSearch,
+} from "@/lib/editor-tabs";
 import { isToolAllowed, nextAllowedTools } from "@/lib/agent-tool-selection";
 import { pluginConfigEntryKey, pluginDisplayName } from "@/lib/plugin-config";
 import { adminRoutes } from "@/lib/routes";
@@ -25,6 +36,12 @@ export function AgentEditorPage() {
   const navigate = useNavigate();
   const { id } = useParams();
   const isNew = id === "new";
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = readTabFromSearch(searchParams);
+  const setActiveTab = (next: AgentEditorTabId) => {
+    setSearchParams(writeTabToSearch(searchParams, next), { replace: true });
+  };
 
   const [spec, setSpec] = useState<AgentSpec>({ ...EMPTY_AGENT });
   const [savedSpec, setSavedSpec] = useState<AgentSpec | null>(null);
@@ -269,244 +286,439 @@ export function AgentEditorPage() {
   }
 
   return (
-    <div className="mx-auto max-w-[96rem] p-6 md:p-8">
-      <div className="mb-6 flex items-center justify-between gap-4">
-        <div>
+    <div className="mx-auto max-w-[96rem]">
+      <StickyEditorHeader
+        isNew={isNew}
+        agentId={spec.id}
+        isDirty={isDirty}
+        saving={saving}
+        onSave={() => void handleSave()}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
+
+      <div className="grid gap-6 px-6 py-6 md:px-8 xl:grid-cols-[minmax(0,1fr),24rem]">
+        <div className="space-y-6">
+          {activeTab === "basics" && (
+            <BasicsPanel
+              spec={spec}
+              capabilities={capabilities}
+              isNew={isNew}
+              updateField={updateField}
+            />
+          )}
+
+          {activeTab === "tools" && (
+            <ToolsPanel
+              spec={spec}
+              capabilities={capabilities}
+              toggleAllowedTool={toggleAllowedTool}
+            />
+          )}
+
+          {activeTab === "plugins" && (
+            <PluginsPanel
+              spec={spec}
+              capabilities={capabilities}
+              configurablePlugins={configurablePlugins}
+              visiblePluginSchemas={visiblePluginSchemas}
+              activePluginConfig={activePluginConfig}
+              setActivePluginConfig={setActivePluginConfig}
+              togglePlugin={togglePlugin}
+              updateSection={updateSection}
+            />
+          )}
+
+          {activeTab === "delegates" && (
+            <DelegatesPanel
+              spec={spec}
+              capabilities={capabilities}
+              toggleDelegate={toggleDelegate}
+            />
+          )}
+
+          {activeTab === "advanced" && <AdvancedPanel spec={spec} />}
+        </div>
+
+        <AgentPreviewPanel draft={spec} />
+      </div>
+    </div>
+  );
+}
+
+function StickyEditorHeader({
+  isNew,
+  agentId,
+  isDirty,
+  saving,
+  onSave,
+  activeTab,
+  onTabChange,
+}: {
+  isNew: boolean;
+  agentId: string;
+  isDirty: boolean;
+  saving: boolean;
+  onSave: () => void;
+  activeTab: AgentEditorTabId;
+  onTabChange: (next: AgentEditorTabId) => void;
+}) {
+  return (
+    <div className="sticky top-0 z-30 border-b border-slate-200 bg-white/95 px-6 pt-6 backdrop-blur md:px-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="min-w-0">
           <Link
             to={adminRoutes.agents}
             className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
           >
             Back to agents
           </Link>
-          <h2 className="mt-2 text-3xl font-semibold text-slate-950">
-            {isNew ? "New Agent" : `Edit ${spec.id}`}
+          <h2 className="mt-2 flex flex-wrap items-center gap-3 text-3xl font-semibold text-slate-950">
+            <span>{isNew ? "New Agent" : `Edit ${agentId}`}</span>
+            {isDirty ? (
+              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-800">
+                Unsaved changes
+              </span>
+            ) : !isNew ? (
+              <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-emerald-800">
+                Up to date
+              </span>
+            ) : null}
           </h2>
         </div>
         <button
           type="button"
-          onClick={() => void handleSave()}
-          disabled={saving}
+          onClick={onSave}
+          disabled={saving || (!isDirty && !isNew)}
           className="rounded-xl bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {saving ? "Saving..." : "Save"}
         </button>
       </div>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr),24rem]">
-        <div>
-      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h3 className="text-lg font-semibold text-slate-950">Basics</h3>
-        <div className="mt-4 grid gap-4 md:grid-cols-2">
-          <Field label="Agent ID">
-            <input
-              type="text"
-              value={spec.id}
-              disabled={!isNew}
-              onChange={(event) => updateField("id", event.target.value)}
-              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500 disabled:bg-slate-100 disabled:text-slate-500"
-            />
-          </Field>
-          <Field label="Model">
-            <select
-              value={String(spec.model_id ?? "")}
-              onChange={(event) => updateField("model_id", event.target.value)}
-              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+      <nav
+        aria-label="Editor sections"
+        className="mt-4 flex gap-1 overflow-x-auto"
+      >
+        {AGENT_EDITOR_TABS.map((tab) => {
+          const active = tab.id === activeTab;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onTabChange(tab.id)}
+              aria-current={active ? "page" : undefined}
+              className={[
+                "shrink-0 rounded-t-lg border-b-2 px-4 py-3 text-sm font-medium transition",
+                active
+                  ? "border-slate-900 text-slate-950"
+                  : "border-transparent text-slate-500 hover:text-slate-700",
+              ].join(" ")}
             >
-              <option value="">Select a model</option>
-              {(capabilities?.models ?? []).map((model) => (
-                <option key={model.id} value={model.id}>
-                  {model.id} ({model.upstream_model})
-                </option>
-              ))}
-            </select>
-          </Field>
-          <Field label="Max rounds">
-            <input
-              type="number"
-              min={1}
-              value={Number(spec.max_rounds ?? 16)}
-              onChange={(event) =>
-                updateField("max_rounds", Number(event.target.value) || 16)
-              }
-              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
-            />
-          </Field>
-          <Field label="Max continuation retries">
-            <input
-              type="number"
-              min={0}
-              value={Number(spec.max_continuation_retries ?? 2)}
-              onChange={(event) =>
-                updateField(
-                  "max_continuation_retries",
-                  Number(event.target.value) || 0,
-                )
-              }
-              className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
-            />
-          </Field>
-        </div>
+              {tab.label}
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}
 
-        <div className="mt-4">
-          <Field label="System prompt">
-            <textarea
-              value={String(spec.system_prompt ?? "")}
-              onChange={(event) =>
-                updateField("system_prompt", event.target.value)
-              }
-              rows={8}
-              className="w-full rounded-xl border border-slate-300 px-3 py-2 font-mono text-sm text-slate-900 outline-none transition focus:border-slate-500"
-            />
-          </Field>
-        </div>
-      </section>
+function BasicsPanel({
+  spec,
+  capabilities,
+  isNew,
+  updateField,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  isNew: boolean;
+  updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
+}) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-slate-950">Basics</h3>
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <Field label="Agent ID">
+          <input
+            type="text"
+            value={spec.id}
+            disabled={!isNew}
+            onChange={(event) => updateField("id", event.target.value)}
+            className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500 disabled:bg-slate-100 disabled:text-slate-500"
+          />
+        </Field>
+        <Field label="Model">
+          <select
+            value={String(spec.model_id ?? "")}
+            onChange={(event) => updateField("model_id", event.target.value)}
+            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+          >
+            <option value="">Select a model</option>
+            {(capabilities?.models ?? []).map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.id} ({model.upstream_model})
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Max rounds">
+          <input
+            type="number"
+            min={1}
+            value={Number(spec.max_rounds ?? 16)}
+            onChange={(event) =>
+              updateField("max_rounds", Number(event.target.value) || 16)
+            }
+            className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+          />
+        </Field>
+        <Field label="Max continuation retries">
+          <input
+            type="number"
+            min={0}
+            value={Number(spec.max_continuation_retries ?? 2)}
+            onChange={(event) =>
+              updateField(
+                "max_continuation_retries",
+                Number(event.target.value) || 0,
+              )
+            }
+            className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+          />
+        </Field>
+      </div>
 
-      {capabilities && capabilities.tools.length > 0 ? (
-        <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-950">Allowed Tools</h3>
-          <p className="mt-2 text-sm text-slate-500">
-            Leaving every tool selected keeps the default runtime behavior.
-          </p>
-          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {capabilities.tools.map((tool) => {
-              const checked = isToolAllowed(spec.allowed_tools, tool.id);
-              return (
-                <label
-                  key={tool.id}
-                  className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
-                >
-                  <div className="flex items-start gap-3">
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(event) =>
-                        toggleAllowedTool(tool.id, event.target.checked)
-                      }
-                    />
-                    <div>
-                      <div className="font-mono text-slate-900">{tool.id}</div>
-                      <div className="mt-1 text-slate-500">
-                        {tool.description || tool.name}
-                      </div>
-                    </div>
-                  </div>
-                </label>
-              );
-            })}
-          </div>
-        </section>
-      ) : null}
+      <div className="mt-4">
+        <Field label="System prompt">
+          <textarea
+            value={String(spec.system_prompt ?? "")}
+            onChange={(event) => updateField("system_prompt", event.target.value)}
+            rows={8}
+            className="w-full rounded-xl border border-slate-300 px-3 py-2 font-mono text-sm text-slate-900 outline-none transition focus:border-slate-500"
+          />
+        </Field>
+        <p className="mt-1 text-xs text-slate-500">
+          {String(spec.system_prompt ?? "").length} characters
+        </p>
+      </div>
+    </section>
+  );
+}
 
-      {capabilities && capabilities.plugins.length > 0 ? (
-        <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-950">Plugins</h3>
-          <p className="mt-2 text-sm text-slate-500">
-            Enable agent plugins here. Plugins with agent-level settings expose
-            their configuration forms below.
-          </p>
-          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {capabilities.plugins.map((plugin) => (
-              <label
-                key={plugin.id}
-                className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
-              >
-                <div className="flex items-start gap-3">
-                  <input
-                    type="checkbox"
-                    checked={(spec.plugin_ids ?? []).includes(plugin.id)}
-                    onChange={() => togglePlugin(plugin.id)}
-                  />
-                  <div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <div className="font-mono text-slate-900">
-                        {pluginDisplayName(plugin.id)}
-                      </div>
-                      <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-medium text-slate-600">
-                        {plugin.id}
-                      </span>
-                      {plugin.config_schemas.length > 0 ? (
-                        <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
-                          Configurable
-                        </span>
-                      ) : null}
-                    </div>
-                    <div className="mt-1 text-slate-500">
-                      {plugin.config_schemas.length === 0
-                        ? "No agent-level config sections"
-                        : `Config sections: ${plugin.config_schemas
-                            .map((schema) => schema.key)
-                            .join(", ")}`}
-                    </div>
+function ToolsPanel({
+  spec,
+  capabilities,
+  toggleAllowedTool,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  toggleAllowedTool: (toolId: string, checked: boolean) => void;
+}) {
+  if (!capabilities || capabilities.tools.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-6 text-sm text-slate-500">
+        No tools are currently published. Once plugins or MCP servers register
+        tools, they will appear here.
+      </div>
+    );
+  }
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-slate-950">Allowed Tools</h3>
+      <p className="mt-2 text-sm text-slate-500">
+        Leaving every tool selected keeps the default runtime behavior.
+      </p>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {capabilities.tools.map((tool) => {
+          const checked = isToolAllowed(spec.allowed_tools, tool.id);
+          return (
+            <label
+              key={tool.id}
+              className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
+            >
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={(event) =>
+                    toggleAllowedTool(tool.id, event.target.checked)
+                  }
+                />
+                <div>
+                  <div className="font-mono text-slate-900">{tool.id}</div>
+                  <div className="mt-1 text-slate-500">
+                    {tool.description || tool.name}
                   </div>
                 </div>
-              </label>
-            ))}
-          </div>
-
-          <div className="mt-6 border-t border-slate-200 pt-5">
-            <h4 className="text-base font-semibold text-slate-900">
-              Plugin Configuration
-            </h4>
-            <p className="mt-2 text-sm text-slate-500">
-              Existing saved sections stay visible even if a plugin is currently
-              disabled, so you can inspect and edit them before re-enabling the
-              plugin.
-            </p>
-          </div>
-
-          {configurablePlugins.length === 0 ? (
-            <div className="mt-4 rounded-2xl border border-dashed border-slate-200 px-4 py-3 text-sm text-slate-500">
-              No registered plugins expose agent-level configuration.
-            </div>
-          ) : (
-            <PluginConfigWorkspace
-              entries={visiblePluginSchemas}
-              sections={spec.sections ?? {}}
-              activeEntryKey={activePluginConfig}
-              onSelectEntry={setActivePluginConfig}
-              onUpdateSection={updateSection}
-            />
-          )}
-        </section>
-      ) : null}
-
-      {capabilities && capabilities.agents.length > 0 ? (
-        <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-950">Delegates</h3>
-          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {capabilities.agents
-              .filter((agentId) => agentId !== spec.id)
-              .map((agentId) => (
-                <label
-                  key={agentId}
-                  className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
-                >
-                  <div className="flex items-center gap-3">
-                    <input
-                      type="checkbox"
-                      checked={(spec.delegates ?? []).includes(agentId)}
-                      onChange={(event) =>
-                        toggleDelegate(agentId, event.target.checked)
-                      }
-                    />
-                    <span className="font-mono text-slate-900">{agentId}</span>
-                  </div>
-                </label>
-              ))}
-          </div>
-        </section>
-      ) : null}
-
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h3 className="text-lg font-semibold text-slate-950">JSON Preview</h3>
-        <pre className="mt-4 max-h-[28rem] overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-100">
-          {JSON.stringify(spec, null, 2)}
-        </pre>
-      </section>
-        </div>
-
-        <AgentPreviewPanel draft={spec} />
+              </div>
+            </label>
+          );
+        })}
       </div>
-    </div>
+    </section>
+  );
+}
+
+function PluginsPanel({
+  spec,
+  capabilities,
+  configurablePlugins,
+  visiblePluginSchemas,
+  activePluginConfig,
+  setActivePluginConfig,
+  togglePlugin,
+  updateSection,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  configurablePlugins: NonNullable<Capabilities["plugins"]>;
+  visiblePluginSchemas: Parameters<typeof PluginConfigWorkspace>[0]["entries"];
+  activePluginConfig: string | null;
+  setActivePluginConfig: (next: string | null) => void;
+  togglePlugin: (pluginId: string) => void;
+  updateSection: (key: string, value: unknown) => void;
+}) {
+  if (!capabilities || capabilities.plugins.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-6 text-sm text-slate-500">
+        No plugins are currently registered.
+      </div>
+    );
+  }
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-slate-950">Plugins</h3>
+      <p className="mt-2 text-sm text-slate-500">
+        Enable agent plugins here. Plugins with agent-level settings expose
+        their configuration forms below.
+      </p>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {capabilities.plugins.map((plugin) => (
+          <label
+            key={plugin.id}
+            className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
+          >
+            <div className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                checked={(spec.plugin_ids ?? []).includes(plugin.id)}
+                onChange={() => togglePlugin(plugin.id)}
+              />
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="font-mono text-slate-900">
+                    {pluginDisplayName(plugin.id)}
+                  </div>
+                  <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-medium text-slate-600">
+                    {plugin.id}
+                  </span>
+                  {plugin.config_schemas.length > 0 ? (
+                    <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+                      Configurable
+                    </span>
+                  ) : null}
+                </div>
+                <div className="mt-1 text-slate-500">
+                  {plugin.config_schemas.length === 0
+                    ? "No agent-level config sections"
+                    : `Config sections: ${plugin.config_schemas
+                        .map((schema) => schema.key)
+                        .join(", ")}`}
+                </div>
+              </div>
+            </div>
+          </label>
+        ))}
+      </div>
+
+      <div className="mt-6 border-t border-slate-200 pt-5">
+        <h4 className="text-base font-semibold text-slate-900">
+          Plugin Configuration
+        </h4>
+        <p className="mt-2 text-sm text-slate-500">
+          Existing saved sections stay visible even if a plugin is currently
+          disabled, so you can inspect and edit them before re-enabling the
+          plugin.
+        </p>
+      </div>
+
+      {configurablePlugins.length === 0 ? (
+        <div className="mt-4 rounded-2xl border border-dashed border-slate-200 px-4 py-3 text-sm text-slate-500">
+          No registered plugins expose agent-level configuration.
+        </div>
+      ) : (
+        <PluginConfigWorkspace
+          entries={visiblePluginSchemas}
+          sections={spec.sections ?? {}}
+          activeEntryKey={activePluginConfig}
+          onSelectEntry={setActivePluginConfig}
+          onUpdateSection={updateSection}
+        />
+      )}
+    </section>
+  );
+}
+
+function DelegatesPanel({
+  spec,
+  capabilities,
+  toggleDelegate,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  toggleDelegate: (delegateId: string, checked: boolean) => void;
+}) {
+  if (!capabilities || capabilities.agents.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-200 bg-white p-6 text-sm text-slate-500">
+        No other agents are registered yet, so this agent cannot delegate.
+      </div>
+    );
+  }
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-slate-950">Delegates</h3>
+      <p className="mt-2 text-sm text-slate-500">
+        Pick agents this one can hand work off to. The agent itself is omitted
+        from the list to prevent obvious self-loops.
+      </p>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {capabilities.agents
+          .filter((agentId) => agentId !== spec.id)
+          .map((agentId) => (
+            <label
+              key={agentId}
+              className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700"
+            >
+              <div className="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  checked={(spec.delegates ?? []).includes(agentId)}
+                  onChange={(event) =>
+                    toggleDelegate(agentId, event.target.checked)
+                  }
+                />
+                <span className="font-mono text-slate-900">{agentId}</span>
+              </div>
+            </label>
+          ))}
+      </div>
+    </section>
+  );
+}
+
+function AdvancedPanel({ spec }: { spec: AgentSpec }) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-slate-950">JSON Preview</h3>
+      <p className="mt-2 text-sm text-slate-500">
+        The exact payload that will be PUT to the config API. Useful for sanity
+        checking before publish.
+      </p>
+      <pre className="mt-4 max-h-[36rem] overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-100">
+        {JSON.stringify(spec, null, 2)}
+      </pre>
+    </section>
   );
 }

--- a/apps/admin-console/src/pages/agents-page.tsx
+++ b/apps/admin-console/src/pages/agents-page.tsx
@@ -1,9 +1,44 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { type AgentSpec, configApi } from "@/lib/config-api";
 import { useConfirmDialog } from "@/components/confirm-dialog";
 import { useToast } from "@/components/toast-provider";
+import {
+  ListSearchBar,
+  PageSizeSelect,
+  Pagination,
+  SortableHeader,
+  type SortableColumn,
+} from "@/components/list-controls";
+import {
+  compareNumber,
+  compareString,
+  DEFAULT_PAGE_SIZE,
+  filterBySearch,
+  paginate,
+  sortItems,
+  toggleSort,
+  type PageSize,
+  type SortConfig,
+  type SortState,
+} from "@/lib/list-view";
 import { adminRoutes } from "@/lib/routes";
+
+type AgentSortKey = "id" | "model_id" | "plugin_count";
+
+const SORT_CONFIG: SortConfig<AgentSpec, AgentSortKey> = {
+  id: (a, b) => compareString(a.id, b.id),
+  model_id: (a, b) => compareString(a.model_id, b.model_id),
+  plugin_count: (a, b) =>
+    compareNumber(a.plugin_ids?.length ?? 0, b.plugin_ids?.length ?? 0),
+};
+
+const COLUMNS: SortableColumn<AgentSortKey>[] = [
+  { key: "id", label: "ID" },
+  { key: "model_id", label: "Model" },
+  { key: "plugin_count", label: "Plugins" },
+  { key: null, label: "Actions" },
+];
 
 export function AgentsPage() {
   const navigate = useNavigate();
@@ -11,6 +46,13 @@ export function AgentsPage() {
   const confirmDialog = useConfirmDialog();
   const [agents, setAgents] = useState<AgentSpec[]>([]);
   const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortState<AgentSortKey> | null>({
+    key: "id",
+    direction: "asc",
+  });
+  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     let cancelled = false;
@@ -42,6 +84,37 @@ export function AgentsPage() {
       cancelled = true;
     };
   }, [toast]);
+
+  const filtered = useMemo(
+    () =>
+      filterBySearch(agents, search, (agent) => [
+        agent.id,
+        agent.model_id,
+        ...(agent.plugin_ids ?? []),
+      ]),
+    [agents, search],
+  );
+
+  const sorted = useMemo(
+    () => sortItems(filtered, sort, SORT_CONFIG),
+    [filtered, sort],
+  );
+
+  const view = useMemo(
+    () =>
+      paginate(sorted, {
+        page,
+        pageSize,
+        totalItems: sorted.length,
+      }),
+    [sorted, page, pageSize],
+  );
+
+  useEffect(() => {
+    if (view.page !== page) {
+      setPage(view.page);
+    }
+  }, [view.page, page]);
 
   async function handleDelete(id: string) {
     const accepted = await confirmDialog({
@@ -87,6 +160,24 @@ export function AgentsPage() {
         </Link>
       </div>
 
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <ListSearchBar
+          value={search}
+          onChange={(next) => {
+            setSearch(next);
+            setPage(1);
+          }}
+          placeholder="Search by id, model, or plugin…"
+        />
+        <PageSizeSelect
+          value={pageSize}
+          onChange={(next) => {
+            setPageSize(next);
+            setPage(1);
+          }}
+        />
+      </div>
+
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         {loading ? (
           <div className="px-5 py-6 text-sm text-slate-500">Loading agents...</div>
@@ -94,44 +185,57 @@ export function AgentsPage() {
           <div className="px-5 py-6 text-sm text-slate-500">
             No managed agents yet.
           </div>
+        ) : view.items.length === 0 ? (
+          <div className="px-5 py-6 text-sm text-slate-500">
+            No agents match the current filter.
+          </div>
         ) : (
-          <table className="min-w-full">
-            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
-              <tr>
-                <th className="px-5 py-3">ID</th>
-                <th className="px-5 py-3">Model</th>
-                <th className="px-5 py-3">Plugins</th>
-                <th className="px-5 py-3">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {agents.map((agent) => (
-                <tr
-                  key={agent.id}
-                  className="cursor-pointer border-t border-slate-200 text-sm text-slate-700 transition hover:bg-slate-50"
-                  onClick={() => navigate(adminRoutes.agent(agent.id))}
-                >
-                  <td className="px-5 py-4 font-mono text-slate-950">{agent.id}</td>
-                  <td className="px-5 py-4">{agent.model_id}</td>
-                  <td className="px-5 py-4 text-slate-500">
-                    {(agent.plugin_ids ?? []).join(", ") || "None"}
-                  </td>
-                  <td className="px-5 py-4">
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        void handleDelete(agent.id);
-                      }}
-                      className="text-sm font-medium text-rose-600 transition hover:text-rose-700"
-                    >
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <>
+            <table className="min-w-full">
+              <SortableHeader
+                columns={COLUMNS}
+                sort={sort}
+                onSort={(key) => setSort((current) => toggleSort(current, key))}
+              />
+              <tbody>
+                {view.items.map((agent) => (
+                  <tr
+                    key={agent.id}
+                    className="cursor-pointer border-t border-slate-200 text-sm text-slate-700 transition hover:bg-slate-50"
+                    onClick={() => navigate(adminRoutes.agent(agent.id))}
+                  >
+                    <td className="px-5 py-4 font-mono text-slate-950">{agent.id}</td>
+                    <td className="px-5 py-4">{agent.model_id}</td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {(agent.plugin_ids ?? []).join(", ") || "None"}
+                    </td>
+                    <td className="px-5 py-4">
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          void handleDelete(agent.id);
+                        }}
+                        className="text-sm font-medium text-rose-600 transition hover:text-rose-700"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {view.pageCount > 1 || view.totalItems > pageSize ? (
+              <Pagination
+                page={view.page}
+                pageCount={view.pageCount}
+                startIndex={view.startIndex}
+                endIndex={view.endIndex}
+                totalItems={view.totalItems}
+                onPageChange={setPage}
+              />
+            ) : null}
+          </>
         )}
       </div>
     </div>

--- a/apps/admin-console/src/pages/agents-page.tsx
+++ b/apps/admin-console/src/pages/agents-page.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { type AgentSpec, configApi } from "@/lib/config-api";
+import { useConfirmDialog } from "@/components/confirm-dialog";
+import { useToast } from "@/components/toast-provider";
 import { adminRoutes } from "@/lib/routes";
 
 export function AgentsPage() {
   const navigate = useNavigate();
+  const toast = useToast();
+  const confirmDialog = useConfirmDialog();
   const [agents, setAgents] = useState<AgentSpec[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -18,11 +21,10 @@ export function AgentsPage() {
         const response = await configApi.list<AgentSpec>("agents");
         if (!cancelled) {
           setAgents(response.items);
-          setError(null);
         }
       } catch (loadError) {
         if (!cancelled) {
-          setError(
+          toast.error(
             loadError instanceof Error ? loadError.message : String(loadError),
           );
           setAgents([]);
@@ -39,19 +41,30 @@ export function AgentsPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [toast]);
 
   async function handleDelete(id: string) {
-    if (!confirm(`Delete agent "${id}"?`)) {
+    const accepted = await confirmDialog({
+      title: "Delete agent?",
+      description: (
+        <>
+          This permanently removes <span className="font-mono">{id}</span> from
+          the runtime catalog.
+        </>
+      ),
+      confirmLabel: "Delete",
+      tone: "destructive",
+    });
+    if (!accepted) {
       return;
     }
 
     try {
       await configApi.delete("agents", id);
       setAgents((current) => current.filter((agent) => agent.id !== id));
-      setError(null);
+      toast.success(`Agent "${id}" deleted`);
     } catch (deleteError) {
-      setError(
+      toast.error(
         deleteError instanceof Error ? deleteError.message : String(deleteError),
       );
     }
@@ -73,12 +86,6 @@ export function AgentsPage() {
           New Agent
         </Link>
       </div>
-
-      {error ? (
-        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {error}
-        </div>
-      ) : null}
 
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         {loading ? (

--- a/apps/admin-console/src/pages/assistant-page.tsx
+++ b/apps/admin-console/src/pages/assistant-page.tsx
@@ -2,6 +2,13 @@ import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useRef, useEffect, useState, type FormEvent } from "react";
 import { BACKEND_URL } from "@/lib/config-api";
+import {
+  describeToolCallState,
+  previewPayload,
+  viewMessage,
+  type AssistantBlock,
+  type AssistantBlockTone,
+} from "@/lib/assistant-message";
 
 const suggestions = [
   "Create a coding agent with Bash and file tools",
@@ -37,17 +44,6 @@ export function AssistantPage() {
     setInput("");
   };
 
-  const getMessageText = (msg: (typeof messages)[number]): string => {
-    if (!msg.parts) return "";
-    return msg.parts
-      .filter(
-        (p): p is { type: "text"; text: string } =>
-          (p as { type: string }).type === "text",
-      )
-      .map((p) => p.text)
-      .join("");
-  };
-
   return (
     <div className="flex h-full flex-col">
       <header className="border-b border-slate-200 bg-white px-6 py-4">
@@ -81,22 +77,25 @@ export function AssistantPage() {
           </div>
         )}
 
-        {messages.map((m) => {
-          const text = getMessageText(m);
-          if (!text) return null;
+        {messages.map((message) => {
+          const view = viewMessage(message);
+          if (view.blocks.length === 0) return null;
+          const isUser = message.role === "user";
           return (
             <div
-              key={m.id}
-              className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
+              key={message.id}
+              className={`flex ${isUser ? "justify-end" : "justify-start"}`}
             >
               <div
-                className={`max-w-[80%] whitespace-pre-wrap rounded-lg px-4 py-2 text-sm ${
-                  m.role === "user"
+                className={`max-w-[80%] space-y-2 rounded-lg px-4 py-2 text-sm ${
+                  isUser
                     ? "bg-cyan-700 text-white"
                     : "bg-white text-slate-800 shadow"
                 }`}
               >
-                {text}
+                {view.blocks.map((block) => (
+                  <BlockView key={block.id} block={block} isUser={isUser} />
+                ))}
               </div>
             </div>
           );
@@ -129,6 +128,119 @@ export function AssistantPage() {
           Send
         </button>
       </form>
+    </div>
+  );
+}
+
+function BlockView({ block, isUser }: { block: AssistantBlock; isUser: boolean }) {
+  switch (block.kind) {
+    case "text":
+      return <div className="whitespace-pre-wrap break-words">{block.text}</div>;
+    case "reasoning":
+      return (
+        <div
+          className={[
+            "rounded-md px-3 py-2 text-xs italic leading-5",
+            isUser ? "bg-cyan-800 text-cyan-50" : "bg-slate-50 text-slate-600",
+          ].join(" ")}
+        >
+          <div className="text-[10px] font-semibold uppercase tracking-wide opacity-70">
+            Reasoning
+          </div>
+          <div className="mt-1 whitespace-pre-wrap break-words">{block.text}</div>
+        </div>
+      );
+    case "step-start":
+      return (
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+          ── new step ──
+        </div>
+      );
+    case "tool-call":
+      return <ToolCallView block={block} />;
+    case "unknown":
+      return (
+        <div
+          className={[
+            "rounded-md px-2 py-1 text-[11px] font-mono",
+            isUser ? "bg-cyan-800 text-cyan-100" : "bg-slate-100 text-slate-500",
+          ].join(" ")}
+        >
+          [unrendered: {block.type || "unknown"}]
+        </div>
+      );
+  }
+}
+
+const TONE_CLASS: Record<AssistantBlockTone, string> = {
+  info: "bg-slate-100 text-slate-700",
+  success: "bg-emerald-100 text-emerald-800",
+  warn: "bg-amber-100 text-amber-800",
+  error: "bg-rose-100 text-rose-800",
+};
+
+function ToolCallView({
+  block,
+}: {
+  block: Extract<AssistantBlock, { kind: "tool-call" }>;
+}) {
+  const description = describeToolCallState(block.state);
+  const inputPreview = previewPayload(block.input);
+  const outputPreview = previewPayload(block.output);
+  return (
+    <details className="group rounded-md border border-slate-200 bg-slate-50 text-slate-800 open:bg-white">
+      <summary className="flex cursor-pointer flex-wrap items-center gap-2 px-3 py-2 text-xs">
+        <span className="font-semibold">🛠</span>
+        <span className="font-mono">{block.toolName}</span>
+        <span
+          className={[
+            "rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            TONE_CLASS[description.tone],
+          ].join(" ")}
+        >
+          {description.label}
+        </span>
+        <span className="ml-auto text-[10px] text-slate-400 group-open:hidden">
+          click to expand
+        </span>
+      </summary>
+      <div className="space-y-2 border-t border-slate-200 px-3 py-2">
+        {inputPreview ? (
+          <PayloadPanel label="Input" payload={inputPreview} />
+        ) : null}
+        {outputPreview ? (
+          <PayloadPanel label="Output" payload={outputPreview} />
+        ) : null}
+        {block.errorText ? (
+          <PayloadPanel label="Error" payload={block.errorText} tone="error" />
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+function PayloadPanel({
+  label,
+  payload,
+  tone = "info",
+}: {
+  label: string;
+  payload: string;
+  tone?: AssistantBlockTone;
+}) {
+  return (
+    <div>
+      <div
+        className={[
+          "inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+          TONE_CLASS[tone],
+        ].join(" ")}
+      >
+        {label}
+      </div>
+      <pre className="mt-1 max-h-72 overflow-auto rounded-md bg-slate-950 px-3 py-2 text-[11px] leading-5 text-slate-100">
+        {payload}
+      </pre>
     </div>
   );
 }

--- a/apps/admin-console/src/pages/eval-reports-page.tsx
+++ b/apps/admin-console/src/pages/eval-reports-page.tsx
@@ -13,6 +13,20 @@ import {
   type ParseIssue,
   type ReplayReport,
 } from "@/lib/eval-reports";
+import {
+  DEFAULT_FIXTURE_FILTER,
+  filterFixtures,
+  type FixtureFilterState,
+  type FixtureStatusFilter,
+} from "@/lib/eval-reports-filter";
+
+const STATUS_OPTIONS: Array<{ value: FixtureStatusFilter; label: string }> = [
+  { value: "all", label: "All fixtures" },
+  { value: "passed", label: "Passing" },
+  { value: "failed", label: "Failing" },
+  { value: "regressions", label: "Regressions" },
+  { value: "fixed", label: "Newly fixed" },
+];
 
 type FileSlot = {
   name: string;
@@ -24,6 +38,9 @@ export function EvalReportsPage() {
   const [report, setReport] = useState<FileSlot | null>(null);
   const [baseline, setBaseline] = useState<FileSlot | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [fixtureFilter, setFixtureFilter] = useState<FixtureFilterState>(
+    DEFAULT_FIXTURE_FILTER,
+  );
 
   async function readFile(
     event: ChangeEvent<HTMLInputElement>,
@@ -55,6 +72,11 @@ export function EvalReportsPage() {
     if (!diff) return new Map<string, DiffEntry>();
     return new Map(diff.entries.map((e) => [e.fixture_id, e]));
   }, [diff]);
+
+  const visibleFixtures = useMemo(() => {
+    if (!report) return [] as ReplayReport[];
+    return filterFixtures(report.reports, fixtureFilter, diffByFixture);
+  }, [report, fixtureFilter, diffByFixture]);
 
   const perAgentRows = useMemo(
     () => (report ? aggregateToolCallsByAgent(report.reports) : []),
@@ -179,7 +201,54 @@ export function EvalReportsPage() {
             <ParseIssuesPanel issues={baseline.issues} forBaseline />
           )}
 
-          <section className="mt-6 rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <section className="mt-6 flex flex-wrap items-center gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <label className="text-xs text-slate-500">
+              <span className="mr-2">Show</span>
+              <select
+                value={fixtureFilter.status}
+                onChange={(event) =>
+                  setFixtureFilter((current) => ({
+                    ...current,
+                    status: event.target.value as FixtureStatusFilter,
+                  }))
+                }
+                className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 outline-none focus:border-slate-500"
+              >
+                {STATUS_OPTIONS.map((option) => (
+                  <option
+                    key={option.value}
+                    value={option.value}
+                    disabled={
+                      (option.value === "regressions" || option.value === "fixed") &&
+                      !diff
+                    }
+                  >
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block w-full max-w-sm">
+              <span className="sr-only">Search fixtures</span>
+              <input
+                type="search"
+                value={fixtureFilter.search}
+                onChange={(event) =>
+                  setFixtureFilter((current) => ({
+                    ...current,
+                    search: event.target.value,
+                  }))
+                }
+                placeholder="Search by fixture id…"
+                className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+              />
+            </label>
+            <span className="ml-auto text-xs text-slate-500">
+              {visibleFixtures.length} of {report.reports.length} shown
+            </span>
+          </section>
+
+          <section className="mt-3 rounded-2xl border border-slate-200 bg-white shadow-sm">
             <table className="min-w-full text-sm">
               <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
                 <tr>
@@ -201,8 +270,17 @@ export function EvalReportsPage() {
                       The report contained no fixtures.
                     </td>
                   </tr>
+                ) : visibleFixtures.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={diff ? 6 : 5}
+                      className="px-4 py-6 text-center text-sm text-slate-500"
+                    >
+                      No fixtures match the current filter.
+                    </td>
+                  </tr>
                 ) : (
-                  report.reports.map((r) => (
+                  visibleFixtures.map((r) => (
                     <FixtureRow
                       key={r.fixture_id}
                       report={r}

--- a/apps/admin-console/src/pages/mcp-servers-page.tsx
+++ b/apps/admin-console/src/pages/mcp-servers-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   type McpRestartPolicy,
   type McpServerRecord,
@@ -7,12 +7,53 @@ import {
 import { useCrudPage } from "@/lib/use-crud-page";
 import { Field, ModeButton } from "@/components/form-components";
 import {
+  ListSearchBar,
+  PageSizeSelect,
+  Pagination,
+  SortableHeader,
+  type SortableColumn,
+} from "@/components/list-controls";
+import {
+  compareString,
+  DEFAULT_PAGE_SIZE,
+  filterBySearch,
+  paginate,
+  sortItems,
+  toggleSort,
+  type PageSize,
+  type SortConfig,
+  type SortState,
+} from "@/lib/list-view";
+import {
   parseJsonObject,
   parseLineList,
   parseStringRecord,
   stringifyJsonObject,
   stringifyLineList,
 } from "@/lib/config-form-helpers";
+
+type McpSortKey = "id" | "transport" | "endpoint";
+
+function endpointFor(server: McpServerRecord): string {
+  if (server.transport === "stdio") {
+    return [server.command, ...(server.args ?? [])].filter(Boolean).join(" ");
+  }
+  return server.url ?? "";
+}
+
+const SORT_CONFIG: SortConfig<McpServerRecord, McpSortKey> = {
+  id: (a, b) => compareString(a.id, b.id),
+  transport: (a, b) => compareString(a.transport, b.transport),
+  endpoint: (a, b) => compareString(endpointFor(a), endpointFor(b)),
+};
+
+const COLUMNS: SortableColumn<McpSortKey>[] = [
+  { key: "id", label: "ID" },
+  { key: "transport", label: "Transport" },
+  { key: "endpoint", label: "Endpoint" },
+  { key: null, label: "Environment" },
+  { key: null, label: "Actions" },
+];
 
 type EnvMode = "preserve" | "replace" | "clear";
 
@@ -71,6 +112,37 @@ export function McpServersPage() {
     prepareSave,
   });
 
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortState<McpSortKey> | null>({
+    key: "id",
+    direction: "asc",
+  });
+  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = useState(1);
+
+  const filtered = useMemo(
+    () =>
+      filterBySearch(crud.items, search, (server) => [
+        server.id,
+        server.transport,
+        endpointFor(server),
+        ...(server.env_keys ?? []),
+      ]),
+    [crud.items, search],
+  );
+  const sorted = useMemo(
+    () => sortItems(filtered, sort, SORT_CONFIG),
+    [filtered, sort],
+  );
+  const view = useMemo(
+    () => paginate(sorted, { page, pageSize, totalItems: sorted.length }),
+    [sorted, page, pageSize],
+  );
+
+  useEffect(() => {
+    if (view.page !== page) setPage(view.page);
+  }, [view.page, page]);
+
   function startCreate() {
     crud.startNew({
       ...EMPTY_SERVER,
@@ -119,12 +191,6 @@ export function McpServersPage() {
           New MCP Server
         </button>
       </div>
-
-      {crud.error ? (
-        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {crud.error}
-        </div>
-      ) : null}
 
       {crud.draft ? (
         <section className="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
@@ -432,6 +498,24 @@ export function McpServersPage() {
         </section>
       ) : null}
 
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <ListSearchBar
+          value={search}
+          onChange={(next) => {
+            setSearch(next);
+            setPage(1);
+          }}
+          placeholder="Search by id, transport, endpoint, env key…"
+        />
+        <PageSizeSelect
+          value={pageSize}
+          onChange={(next) => {
+            setPageSize(next);
+            setPage(1);
+          }}
+        />
+      </div>
+
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         {crud.loading ? (
           <div className="px-5 py-6 text-sm text-slate-500">
@@ -441,57 +525,67 @@ export function McpServersPage() {
           <div className="px-5 py-6 text-sm text-slate-500">
             No managed MCP servers yet.
           </div>
+        ) : view.items.length === 0 ? (
+          <div className="px-5 py-6 text-sm text-slate-500">
+            No MCP servers match the current filter.
+          </div>
         ) : (
-          <table className="min-w-full">
-            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
-              <tr>
-                <th className="px-5 py-3">ID</th>
-                <th className="px-5 py-3">Transport</th>
-                <th className="px-5 py-3">Endpoint</th>
-                <th className="px-5 py-3">Environment</th>
-                <th className="px-5 py-3">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {crud.items.map((server) => (
-                <tr
-                  key={server.id}
-                  className="border-t border-slate-200 text-sm text-slate-700"
-                >
-                  <td className="px-5 py-4 font-mono text-slate-950">{server.id}</td>
-                  <td className="px-5 py-4">{server.transport}</td>
-                  <td className="px-5 py-4 text-slate-500">
-                    {server.transport === "stdio"
-                      ? [server.command, ...(server.args ?? [])].filter(Boolean).join(" ")
-                      : server.url ?? "Unconfigured"}
-                  </td>
-                  <td className="px-5 py-4 text-slate-500">
-                    {server.has_env
-                      ? (server.env_keys ?? []).join(", ") || "Stored"
-                      : "None"}
-                  </td>
-                  <td className="px-5 py-4">
-                    <div className="flex gap-4">
-                      <button
-                        type="button"
-                        onClick={() => startEdit(server)}
-                        className="font-medium text-slate-700 transition hover:text-slate-950"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void crud.handleDelete(server.id)}
-                        className="font-medium text-rose-600 transition hover:text-rose-700"
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <>
+            <table className="min-w-full">
+              <SortableHeader
+                columns={COLUMNS}
+                sort={sort}
+                onSort={(key) => setSort((current) => toggleSort(current, key))}
+              />
+              <tbody>
+                {view.items.map((server) => (
+                  <tr
+                    key={server.id}
+                    className="border-t border-slate-200 text-sm text-slate-700"
+                  >
+                    <td className="px-5 py-4 font-mono text-slate-950">{server.id}</td>
+                    <td className="px-5 py-4">{server.transport}</td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {endpointFor(server) || "Unconfigured"}
+                    </td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {server.has_env
+                        ? (server.env_keys ?? []).join(", ") || "Stored"
+                        : "None"}
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex gap-4">
+                        <button
+                          type="button"
+                          onClick={() => startEdit(server)}
+                          className="font-medium text-slate-700 transition hover:text-slate-950"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void crud.handleDelete(server.id)}
+                          className="font-medium text-rose-600 transition hover:text-rose-700"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {view.pageCount > 1 || view.totalItems > pageSize ? (
+              <Pagination
+                page={view.page}
+                pageCount={view.pageCount}
+                startIndex={view.startIndex}
+                endIndex={view.endIndex}
+                totalItems={view.totalItems}
+                onPageChange={setPage}
+              />
+            ) : null}
+          </>
         )}
       </div>
     </div>

--- a/apps/admin-console/src/pages/models-page.tsx
+++ b/apps/admin-console/src/pages/models-page.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   type ModelBindingSpec,
   type ProviderRecord,
@@ -6,6 +6,24 @@ import {
 } from "@/lib/config-api";
 import { useCrudPage } from "@/lib/use-crud-page";
 import { Field } from "@/components/form-components";
+import {
+  ListSearchBar,
+  PageSizeSelect,
+  Pagination,
+  SortableHeader,
+  type SortableColumn,
+} from "@/components/list-controls";
+import {
+  compareString,
+  DEFAULT_PAGE_SIZE,
+  filterBySearch,
+  paginate,
+  sortItems,
+  toggleSort,
+  type PageSize,
+  type SortConfig,
+  type SortState,
+} from "@/lib/list-view";
 
 const EMPTY_MODEL: ModelBindingSpec = {
   id: "",
@@ -18,12 +36,35 @@ const auxiliaryLoaders = () =>
     .list<ProviderRecord>("providers")
     .then((response) => response.items.map((provider) => provider.id));
 
+type ModelSortKey = "id" | "provider_id" | "upstream_model";
+
+const SORT_CONFIG: SortConfig<ModelBindingSpec, ModelSortKey> = {
+  id: (a, b) => compareString(a.id, b.id),
+  provider_id: (a, b) => compareString(a.provider_id, b.provider_id),
+  upstream_model: (a, b) => compareString(a.upstream_model, b.upstream_model),
+};
+
+const COLUMNS: SortableColumn<ModelSortKey>[] = [
+  { key: "id", label: "ID" },
+  { key: "provider_id", label: "Provider" },
+  { key: "upstream_model", label: "Upstream Model" },
+  { key: null, label: "Actions" },
+];
+
 export function ModelsPage() {
   const crud = useCrudPage<ModelBindingSpec>({
     namespace: "models",
     entityLabel: "model",
     auxiliaryLoaders,
   });
+
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortState<ModelSortKey> | null>({
+    key: "id",
+    direction: "asc",
+  });
+  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = useState(1);
 
   const providerIds = crud.auxiliaryData as string[];
   const providerOptions = useMemo(() => {
@@ -33,6 +74,35 @@ export function ModelsPage() {
     }
     return Array.from(options).sort((left, right) => left.localeCompare(right));
   }, [crud.draft?.provider_id, providerIds]);
+
+  const filtered = useMemo(
+    () =>
+      filterBySearch(crud.items, search, (model) => [
+        model.id,
+        model.provider_id,
+        model.upstream_model,
+      ]),
+    [crud.items, search],
+  );
+
+  const sorted = useMemo(
+    () => sortItems(filtered, sort, SORT_CONFIG),
+    [filtered, sort],
+  );
+
+  const view = useMemo(
+    () =>
+      paginate(sorted, {
+        page,
+        pageSize,
+        totalItems: sorted.length,
+      }),
+    [sorted, page, pageSize],
+  );
+
+  useEffect(() => {
+    if (view.page !== page) setPage(view.page);
+  }, [view.page, page]);
 
   return (
     <div className="mx-auto max-w-5xl p-6 md:p-8">
@@ -51,12 +121,6 @@ export function ModelsPage() {
           New Model
         </button>
       </div>
-
-      {crud.error ? (
-        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {crud.error}
-        </div>
-      ) : null}
 
       {crud.draft ? (
         <section className="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
@@ -131,6 +195,24 @@ export function ModelsPage() {
         </section>
       ) : null}
 
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <ListSearchBar
+          value={search}
+          onChange={(next) => {
+            setSearch(next);
+            setPage(1);
+          }}
+          placeholder="Search by id, provider, upstream…"
+        />
+        <PageSizeSelect
+          value={pageSize}
+          onChange={(next) => {
+            setPageSize(next);
+            setPage(1);
+          }}
+        />
+      </div>
+
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         {crud.loading ? (
           <div className="px-5 py-6 text-sm text-slate-500">Loading models...</div>
@@ -138,49 +220,62 @@ export function ModelsPage() {
           <div className="px-5 py-6 text-sm text-slate-500">
             No managed models yet.
           </div>
+        ) : view.items.length === 0 ? (
+          <div className="px-5 py-6 text-sm text-slate-500">
+            No models match the current filter.
+          </div>
         ) : (
-          <table className="min-w-full">
-            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
-              <tr>
-                <th className="px-5 py-3">ID</th>
-                <th className="px-5 py-3">Provider</th>
-                <th className="px-5 py-3">Upstream Model</th>
-                <th className="px-5 py-3">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {crud.items.map((model) => (
-                <tr
-                  key={model.id}
-                  className="border-t border-slate-200 text-sm text-slate-700"
-                >
-                  <td className="px-5 py-4 font-mono text-slate-950">{model.id}</td>
-                  <td className="px-5 py-4">{model.provider_id}</td>
-                  <td className="px-5 py-4 text-slate-500">
-                    {model.upstream_model}
-                  </td>
-                  <td className="px-5 py-4">
-                    <div className="flex gap-4">
-                      <button
-                        type="button"
-                        onClick={() => crud.startEdit(model)}
-                        className="font-medium text-slate-700 transition hover:text-slate-950"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void crud.handleDelete(model.id)}
-                        className="font-medium text-rose-600 transition hover:text-rose-700"
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <>
+            <table className="min-w-full">
+              <SortableHeader
+                columns={COLUMNS}
+                sort={sort}
+                onSort={(key) => setSort((current) => toggleSort(current, key))}
+              />
+              <tbody>
+                {view.items.map((model) => (
+                  <tr
+                    key={model.id}
+                    className="border-t border-slate-200 text-sm text-slate-700"
+                  >
+                    <td className="px-5 py-4 font-mono text-slate-950">{model.id}</td>
+                    <td className="px-5 py-4">{model.provider_id}</td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {model.upstream_model}
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex gap-4">
+                        <button
+                          type="button"
+                          onClick={() => crud.startEdit(model)}
+                          className="font-medium text-slate-700 transition hover:text-slate-950"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void crud.handleDelete(model.id)}
+                          className="font-medium text-rose-600 transition hover:text-rose-700"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {view.pageCount > 1 || view.totalItems > pageSize ? (
+              <Pagination
+                page={view.page}
+                pageCount={view.pageCount}
+                startIndex={view.startIndex}
+                endIndex={view.endIndex}
+                totalItems={view.totalItems}
+                onPageChange={setPage}
+              />
+            ) : null}
+          </>
         )}
       </div>
     </div>

--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   configApi,
   type ProviderRecord,
@@ -6,6 +6,42 @@ import {
 } from "@/lib/config-api";
 import { useCrudPage } from "@/lib/use-crud-page";
 import { Field, ModeButton } from "@/components/form-components";
+import {
+  ListSearchBar,
+  PageSizeSelect,
+  Pagination,
+  SortableHeader,
+  type SortableColumn,
+} from "@/components/list-controls";
+import {
+  compareBoolean,
+  compareString,
+  DEFAULT_PAGE_SIZE,
+  filterBySearch,
+  paginate,
+  sortItems,
+  toggleSort,
+  type PageSize,
+  type SortConfig,
+  type SortState,
+} from "@/lib/list-view";
+
+type ProviderSortKey = "id" | "adapter" | "base_url" | "has_api_key";
+
+const SORT_CONFIG: SortConfig<ProviderRecord, ProviderSortKey> = {
+  id: (a, b) => compareString(a.id, b.id),
+  adapter: (a, b) => compareString(a.adapter, b.adapter),
+  base_url: (a, b) => compareString(a.base_url, b.base_url),
+  has_api_key: (a, b) => compareBoolean(a.has_api_key, b.has_api_key),
+};
+
+const COLUMNS: SortableColumn<ProviderSortKey>[] = [
+  { key: "id", label: "ID" },
+  { key: "adapter", label: "Adapter" },
+  { key: "base_url", label: "Base URL" },
+  { key: "has_api_key", label: "API Key" },
+  { key: null, label: "Actions" },
+];
 
 const FALLBACK_ADAPTERS = [
   "anthropic",
@@ -78,6 +114,36 @@ export function ProvidersPage() {
     return Array.from(options).sort((left, right) => left.localeCompare(right));
   }, [crud.draft?.adapter, serverAdapters]);
 
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortState<ProviderSortKey> | null>({
+    key: "id",
+    direction: "asc",
+  });
+  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = useState(1);
+
+  const filtered = useMemo(
+    () =>
+      filterBySearch(crud.items, search, (provider) => [
+        provider.id,
+        provider.adapter,
+        provider.base_url,
+      ]),
+    [crud.items, search],
+  );
+  const sorted = useMemo(
+    () => sortItems(filtered, sort, SORT_CONFIG),
+    [filtered, sort],
+  );
+  const view = useMemo(
+    () => paginate(sorted, { page, pageSize, totalItems: sorted.length }),
+    [sorted, page, pageSize],
+  );
+
+  useEffect(() => {
+    if (view.page !== page) setPage(view.page);
+  }, [view.page, page]);
+
   function startCreate() {
     crud.startNew({ ...EMPTY_PROVIDER });
     setApiKeyMode("replace");
@@ -112,12 +178,6 @@ export function ProvidersPage() {
           New Provider
         </button>
       </div>
-
-      {crud.error ? (
-        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {crud.error}
-        </div>
-      ) : null}
 
       {crud.draft ? (
         <section className="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
@@ -265,6 +325,24 @@ export function ProvidersPage() {
         </section>
       ) : null}
 
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <ListSearchBar
+          value={search}
+          onChange={(next) => {
+            setSearch(next);
+            setPage(1);
+          }}
+          placeholder="Search by id, adapter, base url…"
+        />
+        <PageSizeSelect
+          value={pageSize}
+          onChange={(next) => {
+            setPageSize(next);
+            setPage(1);
+          }}
+        />
+      </div>
+
       <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         {crud.loading ? (
           <div className="px-5 py-6 text-sm text-slate-500">
@@ -274,53 +352,65 @@ export function ProvidersPage() {
           <div className="px-5 py-6 text-sm text-slate-500">
             No managed providers yet.
           </div>
+        ) : view.items.length === 0 ? (
+          <div className="px-5 py-6 text-sm text-slate-500">
+            No providers match the current filter.
+          </div>
         ) : (
-          <table className="min-w-full">
-            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
-              <tr>
-                <th className="px-5 py-3">ID</th>
-                <th className="px-5 py-3">Adapter</th>
-                <th className="px-5 py-3">Base URL</th>
-                <th className="px-5 py-3">API Key</th>
-                <th className="px-5 py-3">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {crud.items.map((provider) => (
-                <tr
-                  key={provider.id}
-                  className="border-t border-slate-200 text-sm text-slate-700"
-                >
-                  <td className="px-5 py-4 font-mono text-slate-950">{provider.id}</td>
-                  <td className="px-5 py-4">{provider.adapter}</td>
-                  <td className="px-5 py-4 text-slate-500">
-                    {provider.base_url ?? "Default"}
-                  </td>
-                  <td className="px-5 py-4 text-slate-500">
-                    {provider.has_api_key ? "Stored" : "Environment / none"}
-                  </td>
-                  <td className="px-5 py-4">
-                    <div className="flex gap-4">
-                      <button
-                        type="button"
-                        onClick={() => startEdit(provider)}
-                        className="font-medium text-slate-700 transition hover:text-slate-950"
-                      >
-                        Edit
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void crud.handleDelete(provider.id)}
-                        className="font-medium text-rose-600 transition hover:text-rose-700"
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <>
+            <table className="min-w-full">
+              <SortableHeader
+                columns={COLUMNS}
+                sort={sort}
+                onSort={(key) => setSort((current) => toggleSort(current, key))}
+              />
+              <tbody>
+                {view.items.map((provider) => (
+                  <tr
+                    key={provider.id}
+                    className="border-t border-slate-200 text-sm text-slate-700"
+                  >
+                    <td className="px-5 py-4 font-mono text-slate-950">{provider.id}</td>
+                    <td className="px-5 py-4">{provider.adapter}</td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {provider.base_url ?? "Default"}
+                    </td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {provider.has_api_key ? "Stored" : "Environment / none"}
+                    </td>
+                    <td className="px-5 py-4">
+                      <div className="flex gap-4">
+                        <button
+                          type="button"
+                          onClick={() => startEdit(provider)}
+                          className="font-medium text-slate-700 transition hover:text-slate-950"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void crud.handleDelete(provider.id)}
+                          className="font-medium text-rose-600 transition hover:text-rose-700"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {view.pageCount > 1 || view.totalItems > pageSize ? (
+              <Pagination
+                page={view.page}
+                pageCount={view.pageCount}
+                startIndex={view.startIndex}
+                endIndex={view.endIndex}
+                totalItems={view.totalItems}
+                onPageChange={setPage}
+              />
+            ) : null}
+          </>
         )}
       </div>
     </div>

--- a/apps/admin-console/src/pages/skills-page.tsx
+++ b/apps/admin-console/src/pages/skills-page.tsx
@@ -1,10 +1,32 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { type SkillInfo, configApi } from "@/lib/config-api";
+import { useToast } from "@/components/toast-provider";
+import {
+  DEFAULT_SKILLS_FILTER,
+  filterSkills,
+  type ContextFilter,
+  type InvocableFilter,
+  type SkillsFilterState,
+} from "@/lib/skills-filter";
+
+const INVOCABLE_OPTIONS: Array<{ value: InvocableFilter; label: string }> = [
+  { value: "any", label: "Any caller" },
+  { value: "user", label: "User callable" },
+  { value: "model", label: "Model callable" },
+  { value: "internal", label: "Internal only" },
+];
+
+const CONTEXT_OPTIONS: Array<{ value: ContextFilter; label: string }> = [
+  { value: "any", label: "Any context" },
+  { value: "inline", label: "Inline" },
+  { value: "fork", label: "Fork" },
+];
 
 export function SkillsPage() {
+  const toast = useToast();
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<SkillsFilterState>(DEFAULT_SKILLS_FILTER);
 
   useEffect(() => {
     let cancelled = false;
@@ -15,11 +37,10 @@ export function SkillsPage() {
         const capabilities = await configApi.capabilities();
         if (!cancelled) {
           setSkills(capabilities.skills);
-          setError(null);
         }
       } catch (loadError) {
         if (!cancelled) {
-          setError(
+          toast.error(
             loadError instanceof Error ? loadError.message : String(loadError),
           );
           setSkills([]);
@@ -36,7 +57,12 @@ export function SkillsPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [toast]);
+
+  const visibleSkills = useMemo(
+    () => filterSkills(skills, filter),
+    [skills, filter],
+  );
 
   return (
     <div className="mx-auto max-w-6xl p-6 md:p-8">
@@ -54,11 +80,61 @@ export function SkillsPage() {
         </p>
       </header>
 
-      {error ? (
-        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-          {error}
-        </div>
-      ) : null}
+      <section className="mb-4 flex flex-wrap items-end gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <label className="block w-full max-w-sm">
+          <span className="sr-only">Search skills</span>
+          <input
+            type="search"
+            value={filter.search}
+            onChange={(event) =>
+              setFilter((current) => ({ ...current, search: event.target.value }))
+            }
+            placeholder="Search by id, name, description, tool, path…"
+            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+          />
+        </label>
+        <label className="text-xs text-slate-500">
+          <span className="mr-2">Caller</span>
+          <select
+            value={filter.invocable}
+            onChange={(event) =>
+              setFilter((current) => ({
+                ...current,
+                invocable: event.target.value as InvocableFilter,
+              }))
+            }
+            className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 outline-none focus:border-slate-500"
+          >
+            {INVOCABLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-xs text-slate-500">
+          <span className="mr-2">Context</span>
+          <select
+            value={filter.context}
+            onChange={(event) =>
+              setFilter((current) => ({
+                ...current,
+                context: event.target.value as ContextFilter,
+              }))
+            }
+            className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 outline-none focus:border-slate-500"
+          >
+            {CONTEXT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <span className="ml-auto text-xs text-slate-500">
+          {visibleSkills.length} of {skills.length} shown
+        </span>
+      </section>
 
       {loading ? (
         <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">
@@ -68,9 +144,13 @@ export function SkillsPage() {
         <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">
           No skills are currently registered.
         </div>
+      ) : visibleSkills.length === 0 ? (
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-500 shadow-sm">
+          No skills match the current filter.
+        </div>
       ) : (
         <div className="grid gap-4 lg:grid-cols-2">
-          {skills.map((skill) => (
+          {visibleSkills.map((skill) => (
             <article
               key={skill.id}
               className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"

--- a/e2e/tests/admin-config-ui.spec.ts
+++ b/e2e/tests/admin-config-ui.spec.ts
@@ -292,4 +292,41 @@ test.describe('admin config UI', () => {
     ).not.toBe('error');
     expect(textDeltas(events).toLowerCase()).toContain('bigmodel-ui-ok');
   });
+
+  test('unsaved-changes guard intercepts in-app navigation', async ({ page }) => {
+    const agentId = `ui-guard-${suffix()}`;
+
+    await page.goto('/agents/new');
+    await page.getByLabel('Agent ID').fill(agentId);
+    await page.getByLabel(/System prompt/).fill('halfway through editing');
+
+    // Sticky header surfaces the dirty state; assert the badge appears
+    // so we know the editor agrees there are unsaved changes.
+    await expect(
+      page.getByText('Unsaved changes', { exact: true }),
+    ).toBeVisible();
+
+    // First attempt: click "Back to agents" then keep editing — the
+    // dialog should appear and the URL must stay on /agents/new.
+    await page.getByRole('link', { name: 'Back to agents' }).click();
+    const dialog = page.getByRole('dialog', {
+      name: /Discard unsaved changes/,
+    });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: 'Keep editing' }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/\/agents\/new$/);
+    await expect(page.getByLabel('Agent ID')).toHaveValue(agentId);
+
+    // Second attempt: click again, this time discard.
+    await page.getByRole('link', { name: 'Back to agents' }).click();
+    const discardDialog = page.getByRole('dialog', {
+      name: /Discard unsaved changes/,
+    });
+    await expect(discardDialog).toBeVisible();
+    await discardDialog
+      .getByRole('button', { name: 'Discard changes' })
+      .click();
+    await expect(page).toHaveURL(/\/agents$/);
+  });
 });

--- a/e2e/tests/admin-config-ui.spec.ts
+++ b/e2e/tests/admin-config-ui.spec.ts
@@ -30,7 +30,18 @@ function textDeltas(events: any[]): string {
     .join('');
 }
 
+async function gotoEditorTab(
+  page: import('@playwright/test').Page,
+  name: 'Basics' | 'Tools' | 'Plugins' | 'Delegates' | 'Advanced',
+) {
+  await page
+    .getByRole('navigation', { name: 'Editor sections' })
+    .getByRole('button', { name })
+    .click();
+}
+
 async function selectPlugin(page: import('@playwright/test').Page, pluginId: string) {
+  await gotoEditorTab(page, 'Plugins');
   const pluginsSection = page
     .locator('section')
     .filter({ has: page.getByRole('heading', { name: 'Plugins' }) })
@@ -42,6 +53,18 @@ async function selectPlugin(page: import('@playwright/test').Page, pluginId: str
     .getByRole('checkbox')
     .first()
     .check();
+}
+
+/// Match the toast emitted by the editor on a successful create. The
+/// admin console replaced the earlier inline "Agent created." banner
+/// with a per-record toast like `Agent "ui-permission-…" created`.
+function expectAgentCreatedToast(
+  page: import('@playwright/test').Page,
+  agentId: string,
+) {
+  return page.getByRole('alert').filter({
+    hasText: new RegExp(`Agent\\s+"${agentId.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}"\\s+created`),
+  });
 }
 
 async function createProviderViaUi(
@@ -119,7 +142,6 @@ test.describe('admin config UI', () => {
       .getByLabel('System prompt')
       .fill('Use the scripted tool directives when the user provides one.');
     await selectPlugin(page, 'permission');
-    await expect(page.locator('pre')).not.toContainText('deferred_tools');
 
     await page.getByRole('button', { name: /Permissions/ }).click();
     const pluginsSection = page
@@ -130,10 +152,13 @@ test.describe('admin config UI', () => {
       .getByRole('button', { name: /^Deny/ })
       .first()
       .evaluate((element) => (element as HTMLButtonElement).click());
+
+    await gotoEditorTab(page, 'Advanced');
     await expect(page.locator('pre')).toContainText('"default_behavior": "deny"');
+    await expect(page.locator('pre')).not.toContainText('deferred_tools');
 
     await page.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByText('Agent created.')).toBeVisible();
+    await expect(expectAgentCreatedToast(page, agentId)).toBeVisible();
 
     const response = await request.post(`${BACKEND_URL}/v1/runs`, {
       data: {
@@ -163,17 +188,19 @@ test.describe('admin config UI', () => {
     await selectPlugin(page, 'ext-deferred-tools');
 
     await page.getByRole('button', { name: /Deferred Tools/ }).first().click();
-    await expect(page.locator('pre')).toContainText('"deferred_tools"');
 
     const pluginsSection = page
       .locator('section')
       .filter({ has: page.getByRole('heading', { name: 'Plugins' }) })
       .first();
     await pluginsSection.getByLabel('beta_overhead').fill('0');
+
+    await gotoEditorTab(page, 'Advanced');
+    await expect(page.locator('pre')).toContainText('"deferred_tools"');
     await expect(page.locator('pre')).toContainText('"beta_overhead": 0');
 
     await page.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByText('Agent created.')).toBeVisible();
+    await expect(expectAgentCreatedToast(page, agentId)).toBeVisible();
 
     const agentResponse = await request.get(
       `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(agentId)}`,
@@ -243,7 +270,7 @@ test.describe('admin config UI', () => {
       .getByLabel('System prompt')
       .fill('Reply with exactly "bigmodel-ui-ok" and no other text.');
     await page.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByText('Agent created.')).toBeVisible();
+    await expect(expectAgentCreatedToast(page, agentId)).toBeVisible();
 
     const runResponse = await request.post(`${BACKEND_URL}/v1/runs`, {
       data: {


### PR DESCRIPTION
## Summary

Eight UX improvements to `apps/admin-console`, plus the prerequisite data-router migration that the new unsaved-changes guard surfaced. Tests cover both the new pure logic and the routing wiring that broke the editor before the fix.

### Bugfix

- **🐛 data router migration** — react-router 7's `useBlocker` requires `createBrowserRouter`. The legacy `<BrowserRouter>` crashes the AgentEditorPage with an invariant. Switched bootstrap to `RouterProvider` and exposed `appRoutes()` so tests can build memory routers.

### Features (Week-1 UX overhaul, all frontend-only)

1. **Toast queue + admin token modal + 401 retry** — `useToast()`, `useAuth()`, automatic prompt-and-retry on 401, sidebar shows live connection status & masked token.
2. **Confirm dialog + unsaved-changes guard** — replaces `window.confirm`, blocks both in-app navigation and `beforeunload`.
3. **List search / sort / pagination** — agents, models, providers, MCP servers all get a search bar, sortable headers, and 10/20/50/100 page-size selector.
4. **Tabbed agent editor + sticky save bar** — Basics / Tools / Plugins / Delegates / Advanced; URL-synced via `?tab=`; save button shows dirty / up-to-date badges.
5. **Grouped tool selector** — explicit "All tools / Custom" radio fixes the empty-array semantic confusion; tools group by source (built-in / plugin:* / mcp:*) with select-all & search.
6. **Surface previously-hidden fields** — `excluded_tools`, `reasoning_effort` (preset + custom).
7. **Skills / eval-report filters** — invocability + context for skills; status (passing / failing / regression / fixed) + fixture search for eval reports.
8. **Assistant renders tool-call parts** — folds out `tool-*` and `dynamic-tool` parts into status pills with input/output payloads.

## Test plan

Local results on branch HEAD:

- [x] `npm --prefix apps/admin-console test` — **238 / 238** unit tests pass (was 105 on `main`)
  - Includes 10 new jsdom router smoke tests that mount every route through providers (`app.smoke.test.tsx`); these would have caught the `useBlocker` regression
- [x] `apps/admin-console && tsc --noEmit` — clean
- [x] `apps/admin-console && npm run build` — clean
- [x] `cd e2e && npm run test:admin` — **4 / 4** runnable Playwright tests pass; 1 skipped (BigModel needs API key)
  - Includes new test: unsaved-changes guard keep / discard flows

## Known gaps (intentionally deferred)

- Search / sort / paginate state not persisted to URL on list pages (planned)
- No focus trap in dialogs (planned)
- No CHANGELOG / ADR yet (will follow when the broader plan lands)
- BigModel live e2e remains skipped without the API key