### PR TITLE
Admin console week-2 follow-ups: docs, polish, BE-supported features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 Development work lands here before the next versioned release.
 
+### Added
+
+- Admin Console toast notification queue (`ToastProvider`/`useToast`) and admin
+  bearer-token modal (`AdminTokenModal`) for setting and rotating the
+  `awaken.adminToken` stored in `localStorage`. The sidebar shows a live
+  connection / auth status indicator.
+- Admin Console confirm dialog (`ConfirmDialogProvider`/`useConfirmDialog`)
+  replaces `window.confirm` for delete actions, and a router-level unsaved-
+  changes guard (`useUnsavedChangesGuard`) blocks navigation and `beforeunload`
+  while the agent editor has unsaved edits.
+- Client-side search, header-click sort, and 10/20/50/100 pagination on every
+  Admin Console catalog page (Agents, Models, Providers, MCP Servers); shared
+  helpers in `lib/list-view.ts` and `components/list-controls.tsx`.
+- Tabbed agent editor (Basics / Tools / Plugins / Delegates / Advanced) with a
+  sticky header bar that surfaces the Save button and an "Unsaved changes" /
+  "Up to date" badge; the active tab is mirrored via `?tab=` so it survives
+  page reloads.
+- Grouped tool selector (`ToolSelector`) with explicit `All tools` / `Custom`
+  modes, in-group search, select-all / clear-group affordances, and source
+  grouping (built-in / `plugin:*` / `mcp:*`).
+- UI surface for the previously-hidden `excluded_tools` and `reasoning_effort`
+  fields on `AgentSpec`. `reasoning_effort` exposes the `low` / `medium` /
+  `high` presets plus a custom override.
+- Skills page filters by caller (`user_invocable` / `model_invocable` /
+  internal) and execution context (`inline` / `fork`); Eval Reports page adds
+  a status filter (`passed` / `failed` / `regressions` / `fixed`) and per-
+  fixture search.
+- AI Assistant chat now renders streamed `tool-*` and `dynamic-tool` parts as
+  collapsible cards with status, input, output, and error payloads instead of
+  silently dropping them.
+- 401 responses from the backend automatically prompt for a fresh admin token
+  and replay the original request once the user submits.
+
+### Changed
+
+- Admin Console bootstrap migrated from `<BrowserRouter>` to
+  `createBrowserRouter` + `<RouterProvider>`. `useBlocker` (used by the
+  unsaved-changes guard) requires the data router; the legacy router crashed
+  the agent editor with an invariant. `appRoutes()` is exported so tests can
+  mount the same route tree under `createMemoryRouter`.
+
 ## [0.4.0] - 2026-04-27
 
 This release adopts the `awaken` crate name on crates.io. Versions 0.1–0.3 of

--- a/apps/admin-console/src/app.smoke.test.tsx
+++ b/apps/admin-console/src/app.smoke.test.tsx
@@ -99,6 +99,46 @@ describe("router smoke", () => {
   });
 });
 
+describe("agents-page URL state", () => {
+  it("reads search, sort direction, and page size from the URL on initial render", async () => {
+    // Override the fetch stub to return proper list responses for config endpoints,
+    // so agents-page's configApi.list() gets { items: [] } rather than crashing.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => ({
+        ok: true,
+        status: 200,
+        text: async () => {
+          if (String(url).includes("/v1/config/")) {
+            return JSON.stringify({ items: [], total: 0 });
+          }
+          return JSON.stringify({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          });
+        },
+      })),
+    );
+
+    renderRoute("/agents?q=foo&sort=model_id&dir=desc&size=50&page=2");
+    // Wait for the page to mount.
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Agents" }),
+    ).toBeDefined();
+    // The search bar input should reflect the URL param (aria-label from sr-only span).
+    const searchInput = screen.getByRole("searchbox");
+    expect((searchInput as HTMLInputElement).value).toBe("foo");
+    // The page-size selector should show 50.
+    const sizeSelect = await screen.findByDisplayValue("50");
+    expect(sizeSelect).toBeDefined();
+  });
+});
+
 describe("provider wiring", () => {
   it("AuthProvider exposes the connected backend URL via the layout", async () => {
     renderRoute("/");

--- a/apps/admin-console/src/components/admin-token-modal.test.tsx
+++ b/apps/admin-console/src/components/admin-token-modal.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, act, fireEvent } from "@testing-library/react";
+import { AdminTokenModal } from "./admin-token-modal";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderModal(overrides: Partial<Parameters<typeof AdminTokenModal>[0]> = {}) {
+  const props = {
+    open: true,
+    initialToken: "",
+    reason: "manual" as const,
+    onSubmit: vi.fn(),
+    onClear: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<AdminTokenModal {...props} />), props };
+}
+
+describe("AdminTokenModal", () => {
+  it("focuses the token input on open", async () => {
+    renderModal();
+    const input = await screen.findByPlaceholderText("Bearer token");
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("Tab cycling stays inside the modal — Tab from last reaches first focusable", () => {
+    renderModal({ initialToken: "abc" });
+
+    // Find all buttons and input (focusable elements inside the modal)
+    const buttons = screen.getAllByRole("button");
+    const lastButton = buttons[buttons.length - 1];
+
+    act(() => lastButton.focus());
+    expect(document.activeElement).toBe(lastButton);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    // Focus should wrap to the first focusable element inside the modal
+    const input = screen.getByPlaceholderText("Bearer token");
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("Tab cycling stays inside — Shift+Tab from input reaches last button", () => {
+    renderModal({ initialToken: "abc" });
+
+    const input = screen.getByPlaceholderText("Bearer token");
+    act(() => input.focus());
+    expect(document.activeElement).toBe(input);
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    const buttons = screen.getAllByRole("button");
+    const lastButton = buttons[buttons.length - 1];
+    expect(document.activeElement).toBe(lastButton);
+  });
+
+  it("restores focus to the trigger button when the modal closes", () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Open modal";
+    document.body.appendChild(trigger);
+    act(() => trigger.focus());
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <AdminTokenModal
+        open={true}
+        initialToken=""
+        reason="manual"
+        onSubmit={vi.fn()}
+        onClear={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Close the modal
+    rerender(
+      <AdminTokenModal
+        open={false}
+        initialToken=""
+        reason="manual"
+        onSubmit={vi.fn()}
+        onClear={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+
+  it("does not call onCancel when mousedown starts on backdrop but mouseup is inside modal", () => {
+    const { props } = renderModal();
+
+    const backdrop = screen.getByRole("dialog");
+
+    // Mousedown on backdrop sets the ref flag
+    fireEvent.mouseDown(backdrop);
+
+    // Mouseup on a child element (form button) — target is NOT the backdrop
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+    fireEvent.mouseUp(cancelBtn);
+
+    expect(props.onCancel).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel when both mousedown and mouseup land on the backdrop", () => {
+    const { props } = renderModal();
+
+    const backdrop = screen.getByRole("dialog");
+
+    fireEvent.mouseDown(backdrop);
+    fireEvent.mouseUp(backdrop);
+
+    expect(props.onCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/admin-console/src/components/admin-token-modal.tsx
+++ b/apps/admin-console/src/components/admin-token-modal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useFocusTrap } from "./focus-trap";
 
 export interface AdminTokenModalProps {
   open: boolean;
@@ -19,19 +20,19 @@ export function AdminTokenModal({
 }: AdminTokenModalProps) {
   const [draft, setDraft] = useState(initialToken);
   const inputRef = useRef<HTMLInputElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const mouseDownOnBackdropRef = useRef(false);
+
+  useFocusTrap(open, backdropRef, { initialFocus: inputRef });
 
   useEffect(() => {
     if (open) {
       setDraft(initialToken);
+      // Select existing text so the user can immediately type a replacement.
+      // Focus is moved by useFocusTrap; select() runs after it settles.
+      inputRef.current?.select();
     }
   }, [open, initialToken]);
-
-  useEffect(() => {
-    if (open && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
-    }
-  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -53,14 +54,22 @@ export function AdminTokenModal({
 
   return (
     <div
+      ref={backdropRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="admin-token-modal-title"
       className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4"
       onMouseDown={(event) => {
-        if (event.target === event.currentTarget) {
+        mouseDownOnBackdropRef.current = event.target === event.currentTarget;
+      }}
+      onMouseUp={(event) => {
+        if (
+          mouseDownOnBackdropRef.current &&
+          event.target === event.currentTarget
+        ) {
           onCancel();
         }
+        mouseDownOnBackdropRef.current = false;
       }}
     >
       <form

--- a/apps/admin-console/src/components/auth-provider.test.tsx
+++ b/apps/admin-console/src/components/auth-provider.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StrictMode } from "react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { AuthProvider, useAuth } from "./auth-provider";
+import { ToastProvider } from "./toast-provider";
+import { configApi } from "@/lib/config-api";
+import { __resetAuthInterceptorForTesting } from "@/lib/auth-interceptor";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  __resetAuthInterceptorForTesting();
+});
+
+function emptyCapabilities(): Awaited<ReturnType<typeof configApi.capabilities>> {
+  return {
+    agents: [],
+    tools: [],
+    plugins: [],
+    skills: [],
+    models: [],
+    providers: [],
+    namespaces: [],
+  } as Awaited<ReturnType<typeof configApi.capabilities>>;
+}
+
+function Consumer() {
+  return <div data-testid="child">child</div>;
+}
+
+function renderInStrictMode() {
+  return render(
+    <StrictMode>
+      <ToastProvider>
+        <AuthProvider>
+          <Consumer />
+        </AuthProvider>
+      </ToastProvider>
+    </StrictMode>,
+  );
+}
+
+describe("AuthProvider — StrictMode double-mount guard", () => {
+  it("calls configApi.capabilities exactly once even under StrictMode", async () => {
+    const spy = vi
+      .spyOn(configApi, "capabilities")
+      .mockResolvedValue(emptyCapabilities());
+
+    renderInStrictMode();
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("manual refresh() still triggers a fresh probe (guard is mount-only)", async () => {
+    const spy = vi
+      .spyOn(configApi, "capabilities")
+      .mockResolvedValue(emptyCapabilities());
+
+    let captured: ReturnType<typeof useAuth> | null = null;
+    function Capture() {
+      captured = useAuth();
+      return null;
+    }
+
+    render(
+      <StrictMode>
+        <ToastProvider>
+          <AuthProvider>
+            <Capture />
+          </AuthProvider>
+        </ToastProvider>
+      </StrictMode>,
+    );
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await captured!.refresh();
+    });
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/admin-console/src/components/auth-provider.test.tsx
+++ b/apps/admin-console/src/components/auth-provider.test.tsx
@@ -4,13 +4,17 @@ import { StrictMode } from "react";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { AuthProvider, useAuth } from "./auth-provider";
 import { ToastProvider } from "./toast-provider";
-import { configApi } from "@/lib/config-api";
-import { __resetAuthInterceptorForTesting } from "@/lib/auth-interceptor";
+import { configApi, ConfigApiError, ADMIN_TOKEN_STORAGE_KEY } from "@/lib/config-api";
+import {
+  __resetAuthInterceptorForTesting,
+  hasUnauthorizedHandler,
+} from "@/lib/auth-interceptor";
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   __resetAuthInterceptorForTesting();
+  localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
 });
 
 function emptyCapabilities(): Awaited<ReturnType<typeof configApi.capabilities>> {
@@ -39,6 +43,23 @@ function renderInStrictMode() {
       </ToastProvider>
     </StrictMode>,
   );
+}
+
+/** Mounts AuthProvider and exposes the auth context via a ref. */
+function renderWithCapture() {
+  let captured: ReturnType<typeof useAuth> | null = null;
+  function Capture() {
+    captured = useAuth();
+    return null;
+  }
+  const result = render(
+    <ToastProvider>
+      <AuthProvider>
+        <Capture />
+      </AuthProvider>
+    </ToastProvider>,
+  );
+  return { result, getCapture: () => captured! };
 }
 
 describe("AuthProvider — StrictMode double-mount guard", () => {
@@ -84,5 +105,120 @@ describe("AuthProvider — StrictMode double-mount guard", () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("AuthProvider — probe state machine", () => {
+  it('probe → "ok" when capabilities resolves successfully', async () => {
+    vi.spyOn(configApi, "capabilities").mockResolvedValue(emptyCapabilities());
+
+    const { getCapture } = renderWithCapture();
+
+    await waitFor(() => {
+      expect(getCapture().status).toBe("ok");
+    });
+  });
+
+  it('probe → "unauthorized" on 401 when a token is stored', async () => {
+    localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, "my-token");
+    vi.spyOn(configApi, "capabilities").mockRejectedValue(
+      new ConfigApiError(401, "Unauthorized"),
+    );
+
+    const { getCapture } = renderWithCapture();
+
+    await waitFor(() => {
+      expect(getCapture().status).toBe("unauthorized");
+    });
+  });
+
+  it('probe → "missing" on 401 when no token is stored', async () => {
+    localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+    vi.spyOn(configApi, "capabilities").mockRejectedValue(
+      new ConfigApiError(401, "Unauthorized"),
+    );
+
+    const { getCapture } = renderWithCapture();
+
+    await waitFor(() => {
+      expect(getCapture().status).toBe("missing");
+    });
+  });
+
+  it('probe → "disconnected" on a generic (non-ConfigApiError) network error', async () => {
+    vi.spyOn(configApi, "capabilities").mockRejectedValue(
+      new Error("fetch failed"),
+    );
+
+    const { getCapture } = renderWithCapture();
+
+    await waitFor(() => {
+      expect(getCapture().status).toBe("disconnected");
+    });
+  });
+
+  it("in-flight probe is superseded: second call's outcome wins", async () => {
+    // resolve1 controls the first probe, resolve2 controls the second.
+    let resolve1!: (v: Awaited<ReturnType<typeof configApi.capabilities>>) => void;
+    let resolve2!: (v: Awaited<ReturnType<typeof configApi.capabilities>>) => void;
+
+    const p1 = new Promise<Awaited<ReturnType<typeof configApi.capabilities>>>(
+      (res) => { resolve1 = res; },
+    );
+    // Second probe rejects so the final status is "disconnected" (distinct from "ok").
+    let reject2!: (e: unknown) => void;
+    const p2 = new Promise<Awaited<ReturnType<typeof configApi.capabilities>>>(
+      (_, rej) => { reject2 = rej; },
+    );
+
+    const spy = vi
+      .spyOn(configApi, "capabilities")
+      .mockReturnValueOnce(p1)
+      .mockReturnValueOnce(p2);
+
+    const { getCapture } = renderWithCapture();
+
+    // Wait until the initial probe is in-flight (spy called once).
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+
+    // Kick off a second probe (rapid refresh) before resolving the first.
+    void act(() => { void getCapture().refresh(); });
+
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(2));
+
+    // Resolve the first probe with "ok" — should be ignored because seq is stale.
+    await act(async () => {
+      resolve1(emptyCapabilities());
+      await p1;
+    });
+
+    // The status should NOT be "ok" yet; the second probe is still pending.
+    expect(getCapture().status).not.toBe("ok");
+
+    // Resolve the second probe with a network error → "disconnected".
+    await act(async () => {
+      reject2(new Error("network error"));
+      await p2.catch(() => {});
+    });
+
+    await waitFor(() => {
+      expect(getCapture().status).toBe("disconnected");
+    });
+  });
+
+  it("unauthorized handler is registered on mount and removed on unmount", async () => {
+    vi.spyOn(configApi, "capabilities").mockResolvedValue(emptyCapabilities());
+
+    const { result } = renderWithCapture();
+
+    await waitFor(() => {
+      expect(hasUnauthorizedHandler()).toBe(true);
+    });
+
+    act(() => {
+      result.unmount();
+    });
+
+    expect(hasUnauthorizedHandler()).toBe(false);
   });
 });

--- a/apps/admin-console/src/components/auth-provider.tsx
+++ b/apps/admin-console/src/components/auth-provider.tsx
@@ -66,7 +66,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const didMountRef = useRef(false);
   useEffect(() => {
+    if (didMountRef.current) return;
+    didMountRef.current = true;
     void probe();
   }, [probe]);
 

--- a/apps/admin-console/src/components/confirm-dialog.test.tsx
+++ b/apps/admin-console/src/components/confirm-dialog.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, act, fireEvent } from "@testing-library/react";
+import { ConfirmDialogProvider, useConfirmDialog } from "./confirm-dialog";
+import { useEffect } from "react";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// Helper component that triggers a confirm dialog on mount
+function Trigger({
+  onResult,
+}: {
+  onResult?: (value: boolean) => void;
+}) {
+  const confirm = useConfirmDialog();
+
+  useEffect(() => {
+    confirm({ title: "Delete item?", confirmLabel: "Delete", tone: "destructive" }).then(
+      onResult ?? (() => {}),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <button id="trigger">Trigger</button>;
+}
+
+function renderDialog(onResult?: (value: boolean) => void) {
+  return render(
+    <ConfirmDialogProvider>
+      <Trigger onResult={onResult} />
+    </ConfirmDialogProvider>,
+  );
+}
+
+describe("ConfirmDialog", () => {
+  it("focuses the confirm button when the dialog opens", async () => {
+    renderDialog();
+    const confirmBtn = await screen.findByRole("button", { name: "Delete" });
+    expect(document.activeElement).toBe(confirmBtn);
+  });
+
+  it("Tab cycling stays inside — Tab from confirm button reaches cancel button", async () => {
+    renderDialog();
+    const confirmBtn = await screen.findByRole("button", { name: "Delete" });
+    act(() => confirmBtn.focus());
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+    expect(document.activeElement).toBe(cancelBtn);
+  });
+
+  it("Shift+Tab from cancel button wraps to confirm button", async () => {
+    renderDialog();
+    const cancelBtn = await screen.findByRole("button", { name: "Cancel" });
+    act(() => cancelBtn.focus());
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    const confirmBtn = screen.getByRole("button", { name: "Delete" });
+    expect(document.activeElement).toBe(confirmBtn);
+  });
+
+  it("restores focus to the trigger button after the dialog closes", async () => {
+    const trigger = document.createElement("button");
+    trigger.id = "outside-trigger";
+    document.body.appendChild(trigger);
+    act(() => trigger.focus());
+
+    const onResult = vi.fn();
+    renderDialog(onResult);
+
+    const confirmBtn = await screen.findByRole("button", { name: "Delete" });
+    act(() => confirmBtn.click());
+
+    // Wait for the promise to resolve and state to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+
+  it("does not call respond when mousedown starts on backdrop but releases inside modal", async () => {
+    const onResult = vi.fn();
+    renderDialog(onResult);
+
+    const dialog = await screen.findByRole("dialog");
+    const inner = dialog.querySelector("div")!;
+
+    // Mousedown on backdrop, mouseup inside inner panel
+    fireEvent.mouseDown(dialog, { target: dialog });
+    fireEvent.mouseUp(inner, { target: inner });
+
+    // Dialog should still be visible
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+  });
+
+  it("closes the dialog when both mousedown and mouseup land on the backdrop", async () => {
+    renderDialog();
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.mouseDown(dialog, { target: dialog });
+    fireEvent.mouseUp(dialog, { target: dialog });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/apps/admin-console/src/components/confirm-dialog.tsx
+++ b/apps/admin-console/src/components/confirm-dialog.tsx
@@ -3,11 +3,11 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type ReactNode,
 } from "react";
+import { useFocusTrap } from "./focus-trap";
 
 export type ConfirmTone = "neutral" | "destructive";
 
@@ -30,6 +30,10 @@ interface PendingState extends ConfirmRequest {
 export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
   const [pending, setPending] = useState<PendingState | null>(null);
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const mouseDownOnBackdropRef = useRef(false);
+
+  useFocusTrap(pending !== null, dialogRef, { initialFocus: confirmButtonRef });
 
   const confirm = useCallback<ConfirmFn>((request) => {
     return new Promise<boolean>((resolve) => {
@@ -48,7 +52,6 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!pending) return;
-    confirmButtonRef.current?.focus();
 
     function onKey(event: KeyboardEvent) {
       if (event.key === "Escape") {
@@ -65,14 +68,22 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
       {children}
       {pending ? (
         <div
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="confirm-dialog-title"
           className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4"
           onMouseDown={(event) => {
-            if (event.target === event.currentTarget) {
+            mouseDownOnBackdropRef.current = event.target === event.currentTarget;
+          }}
+          onMouseUp={(event) => {
+            if (
+              mouseDownOnBackdropRef.current &&
+              event.target === event.currentTarget
+            ) {
               respond(false);
             }
+            mouseDownOnBackdropRef.current = false;
           }}
         >
           <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl">

--- a/apps/admin-console/src/components/focus-trap.test.tsx
+++ b/apps/admin-console/src/components/focus-trap.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, act, screen } from "@testing-library/react";
+import { useRef, type ReactNode } from "react";
+import { useFocusTrap } from "./focus-trap";
+
+afterEach(() => {
+  cleanup();
+});
+
+// Basic fixture — no initialFocus option
+function TrapFixture({
+  active,
+  children,
+}: {
+  active: boolean;
+  children?: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(active, ref);
+  return <div ref={ref}>{children}</div>;
+}
+
+// Fixture wiring initialFocus to the button with data-testid="initial"
+function TrapWithInitialFocus({
+  active,
+  children,
+}: {
+  active: boolean;
+  children?: ReactNode;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const initialRef = useRef<HTMLButtonElement>(null);
+  useFocusTrap(active, containerRef, { initialFocus: initialRef });
+  return (
+    <div ref={containerRef}>
+      {children}
+      {/* The element that should receive initial focus */}
+      <button ref={initialRef} data-testid="initial">
+        Initial
+      </button>
+      <button data-testid="other">Other</button>
+    </div>
+  );
+}
+
+// Fixture with no focusable children and no initialFocus option
+function EmptyTrapFixture({ active }: { active: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(active, ref);
+  return (
+    <div ref={ref} data-testid="container">
+      <p>No interactive elements</p>
+    </div>
+  );
+}
+
+function pressTab(shiftKey = false) {
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        shiftKey,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  });
+}
+
+describe("useFocusTrap", () => {
+  it("Tab on last focusable element wraps focus to the first", () => {
+    const { container } = render(
+      <TrapFixture active>
+        <button id="btn-a">A</button>
+        <button id="btn-b">B</button>
+        <button id="btn-c">C</button>
+      </TrapFixture>,
+    );
+
+    const buttons = container.querySelectorAll<HTMLButtonElement>("button");
+    // Focus the last button
+    act(() => buttons[2].focus());
+    expect(document.activeElement).toBe(buttons[2]);
+
+    pressTab(false);
+
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("Shift+Tab on first focusable element wraps focus to the last", () => {
+    const { container } = render(
+      <TrapFixture active>
+        <button id="btn-a">A</button>
+        <button id="btn-b">B</button>
+        <button id="btn-c">C</button>
+      </TrapFixture>,
+    );
+
+    const buttons = container.querySelectorAll<HTMLButtonElement>("button");
+    act(() => buttons[0].focus());
+    expect(document.activeElement).toBe(buttons[0]);
+
+    pressTab(true);
+
+    expect(document.activeElement).toBe(buttons[2]);
+  });
+
+  it("restores focus to the previously-focused element when active flips to false", () => {
+    // Render a trigger button outside the trap
+    const { getByText, rerender } = render(
+      <>
+        <button id="trigger">Open</button>
+        <TrapFixture active={false}>
+          <button>Inside</button>
+        </TrapFixture>
+      </>,
+    );
+
+    const trigger = getByText("Open") as HTMLButtonElement;
+    act(() => trigger.focus());
+    expect(document.activeElement).toBe(trigger);
+
+    // Activate trap — focus moves inside (simulated by component open logic)
+    rerender(
+      <>
+        <button id="trigger">Open</button>
+        <TrapFixture active={true}>
+          <button>Inside</button>
+        </TrapFixture>
+      </>,
+    );
+
+    // Deactivate — focus should return to trigger
+    rerender(
+      <>
+        <button id="trigger">Open</button>
+        <TrapFixture active={false}>
+          <button>Inside</button>
+        </TrapFixture>
+      </>,
+    );
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("does not throw when the container has no focusable elements", () => {
+    render(
+      <TrapFixture active>
+        <p>No interactive elements here</p>
+      </TrapFixture>,
+    );
+
+    // Pressing Tab should silently do nothing
+    expect(() => pressTab(false)).not.toThrow();
+    expect(() => pressTab(true)).not.toThrow();
+  });
+
+  // --- initial focus tests ---
+
+  it("without initialFocus option: focuses the first focusable element on activation", () => {
+    const { container } = render(
+      <TrapFixture active>
+        <button data-testid="first">First</button>
+        <button data-testid="second">Second</button>
+      </TrapFixture>,
+    );
+
+    const first = container.querySelector<HTMLButtonElement>("[data-testid='first']")!;
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("with initialFocus option: focuses the specified element on activation", () => {
+    render(<TrapWithInitialFocus active />);
+
+    const initial = screen.getByTestId("initial");
+    expect(document.activeElement).toBe(initial);
+  });
+
+  it("container with no focusable elements and no initialFocus: container itself receives focus", () => {
+    render(<EmptyTrapFixture active />);
+
+    const container = screen.getByTestId("container");
+    expect(document.activeElement).toBe(container);
+  });
+});

--- a/apps/admin-console/src/components/focus-trap.ts
+++ b/apps/admin-console/src/components/focus-trap.ts
@@ -1,0 +1,92 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+const FOCUSABLE_SELECTORS = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS));
+}
+
+/**
+ * Captures focus inside the given container while `active` is true and
+ * restores focus to the previously-focused element on deactivation.
+ *
+ * When `active` becomes true the hook moves focus to `options.initialFocus`
+ * if provided, otherwise to the first focusable element inside the container,
+ * otherwise to the container itself (tabIndex=-1 is applied if needed).
+ */
+export function useFocusTrap(
+  active: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+  options?: { initialFocus?: RefObject<HTMLElement | null> },
+): void {
+  const previousFocusRef = useRef<Element | null>(null);
+  // Stable ref identity avoids re-running the effect when the caller passes
+  // an inline options object on every render.
+  const initialFocusRef = options?.initialFocus ?? null;
+
+  useEffect(() => {
+    if (!active) return;
+
+    previousFocusRef.current = document.activeElement;
+
+    const container = containerRef.current;
+
+    // Move initial focus into the trap
+    if (initialFocusRef?.current) {
+      initialFocusRef.current.focus();
+    } else if (container) {
+      const focusable = getFocusableElements(container);
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        if (!container.hasAttribute("tabindex")) {
+          container.setAttribute("tabindex", "-1");
+        }
+        container.focus();
+      }
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Tab") return;
+      const trap = containerRef.current;
+      if (!trap) return;
+
+      const focusable = getFocusableElements(trap);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const focused = document.activeElement;
+
+      if (event.shiftKey) {
+        if (focused === first || !trap.contains(focused)) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (focused === last || !trap.contains(focused)) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      const prev = previousFocusRef.current;
+      if (prev && typeof (prev as HTMLElement).focus === "function") {
+        (prev as HTMLElement).focus();
+      }
+      previousFocusRef.current = null;
+    };
+  }, [active, containerRef, initialFocusRef]);
+}

--- a/apps/admin-console/src/components/toast-provider.test.tsx
+++ b/apps/admin-console/src/components/toast-provider.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, act, fireEvent } from "@testing-library/react";
+import { ToastProvider, useToast } from "./toast-provider";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function PushApp({ onParentKeyDown }: { onParentKeyDown?: React.KeyboardEventHandler }) {
+  const { push } = useToast();
+  return (
+    <div onKeyDown={onParentKeyDown}>
+      <button
+        type="button"
+        data-testid="push-btn"
+        onClick={() => push({ tone: "info", message: "Hello toast", durationMs: 0 })}
+      >
+        Push
+      </button>
+    </div>
+  );
+}
+
+function renderWithProvider(onParentKeyDown?: React.KeyboardEventHandler) {
+  return render(
+    <ToastProvider>
+      <PushApp onParentKeyDown={onParentKeyDown} />
+    </ToastProvider>,
+  );
+}
+
+describe("ToastProvider — Escape key on dismiss button", () => {
+  it("dismisses the toast when Escape is pressed on the dismiss button", () => {
+    renderWithProvider();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("push-btn"));
+    });
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
+    act(() => dismissBtn.focus());
+    act(() => {
+      fireEvent.keyDown(dismissBtn, { key: "Escape", bubbles: true, cancelable: true });
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not bubble Escape out of the toast viewport to a parent handler", () => {
+    const parentHandler = vi.fn();
+    renderWithProvider(parentHandler);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("push-btn"));
+    });
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
+    act(() => dismissBtn.focus());
+    act(() => {
+      fireEvent.keyDown(dismissBtn, { key: "Escape", bubbles: true, cancelable: true });
+    });
+
+    expect(parentHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("ToastProvider — displaced count semantics", () => {
+  function DisplacedApp() {
+    const { push } = useToast();
+    let i = 0;
+    return (
+      <button
+        type="button"
+        data-testid="push-btn"
+        onClick={() => {
+          i += 1;
+          push({ tone: "info", message: `Toast ${i}`, durationMs: 0 });
+        }}
+      >
+        Push
+      </button>
+    );
+  }
+
+  it("preserves displaced count when a visible toast is dismissed", () => {
+    render(
+      <ToastProvider>
+        <DisplacedApp />
+      </ToastProvider>,
+    );
+
+    // Push 6 toasts — MAX_VISIBLE_TOASTS is 5, so 1 displaced
+    act(() => {
+      for (let i = 0; i < 6; i++) {
+        fireEvent.click(screen.getByTestId("push-btn"));
+      }
+    });
+
+    expect(screen.getByText(/\+ 1 earlier/)).toBeTruthy();
+
+    // Dismiss one visible toast — displaced chip should still show
+    const dismissBtns = screen.getAllByRole("button", { name: "Dismiss" });
+    act(() => {
+      fireEvent.click(dismissBtns[0]);
+    });
+
+    expect(screen.getByText(/\+ 1 earlier/)).toBeTruthy();
+  });
+
+  it("clears displaced only when the chip dismiss button is clicked", () => {
+    render(
+      <ToastProvider>
+        <DisplacedApp />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      for (let i = 0; i < 6; i++) {
+        fireEvent.click(screen.getByTestId("push-btn"));
+      }
+    });
+
+    expect(screen.getByText(/\+ 1 earlier/)).toBeTruthy();
+
+    const chipDismiss = screen.getByRole("button", { name: "Dismiss earlier notifications" });
+    act(() => {
+      fireEvent.click(chipDismiss);
+    });
+
+    expect(screen.queryByText(/earlier/)).toBeNull();
+  });
+});

--- a/apps/admin-console/src/components/toast-provider.test.tsx
+++ b/apps/admin-console/src/components/toast-provider.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, act, fireEvent } from "@testing-library/react";
+import { StrictMode } from "react";
 import { ToastProvider, useToast } from "./toast-provider";
+import { DEFAULT_DURATIONS_MS, MAX_VISIBLE_TOASTS } from "@/lib/toast-queue";
 
 afterEach(() => {
   cleanup();
@@ -134,5 +136,180 @@ describe("ToastProvider — displaced count semantics", () => {
     });
 
     expect(screen.queryByText(/earlier/)).toBeNull();
+  });
+});
+
+describe("ToastProvider — timer-based auto-dismiss", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function SuccessApp() {
+    const { push } = useToast();
+    return (
+      <button
+        type="button"
+        data-testid="push-btn"
+        onClick={() => push({ tone: "success", message: "Auto-dismiss me" })}
+      >
+        Push
+      </button>
+    );
+  }
+
+  it("auto-dismisses a success toast after DEFAULT_DURATIONS_MS.success", () => {
+    render(
+      <ToastProvider>
+        <SuccessApp />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("push-btn"));
+    });
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_DURATIONS_MS.success + 100);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("error toast (durationMs:0) persists after 60 seconds", () => {
+    function ErrorApp() {
+      const { push } = useToast();
+      return (
+        <button
+          type="button"
+          data-testid="push-btn"
+          onClick={() => push({ tone: "error", message: "Sticky error", durationMs: 0 })}
+        >
+          Push
+        </button>
+      );
+    }
+
+    render(
+      <ToastProvider>
+        <ErrorApp />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("push-btn"));
+    });
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+});
+
+describe("ToastProvider — MAX_VISIBLE_TOASTS cap", () => {
+  function MultiPushApp() {
+    const { push } = useToast();
+    return (
+      <button
+        type="button"
+        data-testid="push-btn"
+        onClick={() => {
+          for (let i = 1; i <= MAX_VISIBLE_TOASTS + 1; i++) {
+            push({ tone: "info", message: `Toast ${i}`, durationMs: 0 });
+          }
+        }}
+      >
+        Push all
+      </button>
+    );
+  }
+
+  it("shows only MAX_VISIBLE_TOASTS cards and displaced chip for the excess", () => {
+    render(
+      <ToastProvider>
+        <MultiPushApp />
+      </ToastProvider>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("push-btn"));
+    });
+
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts).toHaveLength(MAX_VISIBLE_TOASTS);
+    expect(screen.getByText(`+ 1 earlier`)).toBeTruthy();
+  });
+});
+
+describe("ToastProvider — StrictMode double-mount timer safety", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not leave stale timers after unmount under StrictMode", () => {
+    function SuccessApp() {
+      const { push } = useToast();
+      return (
+        <button
+          type="button"
+          data-testid="push-btn"
+          onClick={() => push({ tone: "success", message: "StrictMode toast" })}
+        >
+          Push
+        </button>
+      );
+    }
+
+    const { unmount } = render(
+      <StrictMode>
+        <ToastProvider>
+          <SuccessApp />
+        </ToastProvider>
+      </StrictMode>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("push-btn"));
+    });
+
+    unmount();
+
+    // After unmount the cleanup should have cancelled all timers
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Advancing time should not fire any callbacks (no stale timers)
+    act(() => {
+      vi.advanceTimersByTime(DEFAULT_DURATIONS_MS.success * 2);
+    });
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("ToastProvider — useToast outside provider", () => {
+  it("throws when useToast is called outside <ToastProvider>", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    function Naked() {
+      useToast();
+      return null;
+    }
+
+    expect(() => render(<Naked />)).toThrow(/useToast must be used inside/i);
+
+    consoleSpy.mockRestore();
   });
 });

--- a/apps/admin-console/src/components/toast-provider.tsx
+++ b/apps/admin-console/src/components/toast-provider.tsx
@@ -4,8 +4,9 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
-  useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import {
@@ -35,18 +36,58 @@ function nextToastId(): string {
   return `toast-${counter}-${Date.now().toString(36)}`;
 }
 
+// ---------------------------------------------------------------------------
+// Reducer — pure state machine; StrictMode-safe (no side-effects in updater)
+// ---------------------------------------------------------------------------
+
+interface ToastState {
+  toasts: Toast[];
+  displaced: number;
+}
+
+type ToastAction =
+  | { kind: "push"; toast: Toast }
+  | { kind: "dismiss"; id: string }
+  | { kind: "clearDisplaced" }
+  | { kind: "expire"; now: number };
+
+function toastReducer(state: ToastState, action: ToastAction): ToastState {
+  switch (action.kind) {
+    case "push": {
+      const result = appendToast(state.toasts, action.toast, state.displaced);
+      return { toasts: result.queue, displaced: result.displaced };
+    }
+    case "dismiss": {
+      // Leave displaced unchanged — those earlier toasts are not retrievable.
+      return { ...state, toasts: dismissToast(state.toasts, action.id) };
+    }
+    case "clearDisplaced": {
+      return { ...state, displaced: 0 };
+    }
+    case "expire": {
+      return { ...state, toasts: expireToasts(state.toasts, action.now) };
+    }
+  }
+}
+
+const INITIAL_STATE: ToastState = { toasts: [], displaced: 0 };
+
 export function ToastProvider({ children }: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<Toast[]>([]);
+  const [{ toasts, displaced }, dispatch] = useReducer(toastReducer, INITIAL_STATE);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const dismiss = useCallback((id: string) => {
-    setToasts((current) => dismissToast(current, id));
+    dispatch({ kind: "dismiss", id });
+  }, []);
+
+  const clearDisplaced = useCallback(() => {
+    dispatch({ kind: "clearDisplaced" });
   }, []);
 
   const push = useCallback((input: ToastInput): string => {
     const id = nextToastId();
     const toast = createToast(input, id, Date.now());
-    setToasts((current) => appendToast(current, toast));
+    dispatch({ kind: "push", toast });
     return id;
   }, []);
 
@@ -76,7 +117,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     }
 
     timerRef.current = setTimeout(() => {
-      setToasts((current) => expireToasts(current, Date.now()));
+      dispatch({ kind: "expire", now: Date.now() });
     }, Math.max(delay, 50));
 
     return () => {
@@ -95,7 +136,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={value}>
       {children}
-      <ToastViewport toasts={toasts} onDismiss={dismiss} />
+      <ToastViewport toasts={toasts} displaced={displaced} onDismiss={dismiss} onClearDisplaced={clearDisplaced} />
     </ToastContext.Provider>
   );
 }
@@ -110,18 +151,35 @@ export function useToast(): ToastContextValue {
 
 function ToastViewport({
   toasts,
+  displaced,
   onDismiss,
+  onClearDisplaced,
 }: {
   toasts: Toast[];
+  displaced: number;
   onDismiss: (id: string) => void;
+  onClearDisplaced: () => void;
 }) {
-  if (toasts.length === 0) return null;
+  if (toasts.length === 0 && displaced === 0) return null;
   return (
     <div
       role="status"
       aria-live="polite"
       className="pointer-events-none fixed bottom-4 right-4 z-50 flex max-w-sm flex-col gap-2"
     >
+      {displaced > 0 && (
+        <div className="pointer-events-auto flex items-center justify-between rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-500 shadow">
+          <span>+ {displaced} earlier</span>
+          <button
+            type="button"
+            aria-label="Dismiss earlier notifications"
+            onClick={onClearDisplaced}
+            className="ml-3 rounded px-1 text-slate-400 transition hover:text-slate-700"
+          >
+            ×
+          </button>
+        </div>
+      )}
       {toasts.map((toast) => (
         <ToastCard key={toast.id} toast={toast} onDismiss={onDismiss} />
       ))}
@@ -188,6 +246,13 @@ function ToastCard({
           type="button"
           aria-label="Dismiss"
           onClick={() => onDismiss(toast.id)}
+          onKeyDown={(e: KeyboardEvent<HTMLButtonElement>) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              e.stopPropagation();
+              onDismiss(toast.id);
+            }
+          }}
           className="rounded-md px-1.5 text-sm text-slate-400 transition hover:text-slate-700"
         >
           ×

--- a/apps/admin-console/src/components/tool-selector.test.tsx
+++ b/apps/admin-console/src/components/tool-selector.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { cleanup, render, screen, act, fireEvent } from "@testing-library/react";
+import { ToolSelector } from "./tool-selector";
+import type { ToolInfo } from "@/lib/config-api";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const TOOLS: ToolInfo[] = [
+  { id: "Bash", name: "Bash", description: "Run shell commands" },
+  { id: "Read", name: "Read", description: "Read files" },
+  { id: "plugin:reminder/add", name: "Add Reminder", description: "Add reminder" },
+  { id: "plugin:reminder/list", name: "List Reminders", description: "List reminders" },
+  { id: "mcp:weather/forecast", name: "Forecast", description: "Weather forecast" },
+  { id: "mcp:db/query", name: "Query", description: "DB query" },
+];
+
+interface SelectorProps {
+  title?: string;
+  description?: string;
+  value?: string[] | undefined;
+  onChange?: Mock;
+  tools?: ToolInfo[];
+  variant?: "include" | "exclude";
+}
+
+function renderSelector(overrides: SelectorProps = {}) {
+  const onChange = overrides.onChange ?? vi.fn();
+  const props = {
+    title: "Allowed Tools",
+    description: "Configure which tools this agent can use.",
+    value: undefined as string[] | undefined,
+    onChange,
+    tools: TOOLS,
+    ...overrides,
+  };
+  return { ...render(<ToolSelector {...props} />), props };
+}
+
+describe("ToolSelector — default All-tools mode", () => {
+  it("hides group list and shows all-mode body when value is undefined", () => {
+    renderSelector({ value: undefined });
+
+    // "All tools" radio label should be present and checked
+    const allLabel = screen.getByText("All tools");
+    expect(allLabel).toBeTruthy();
+
+    const radio = allLabel
+      .closest("label")!
+      .querySelector("input[type='radio']") as HTMLInputElement;
+    expect(radio.checked).toBe(true);
+
+    // allBody description should be visible
+    expect(
+      screen.getByText(/Every tool published to the runtime/),
+    ).toBeTruthy();
+
+    // Group headers should NOT appear
+    expect(screen.queryByText("Built-in")).toBeNull();
+    expect(screen.queryByText(/Plugin/)).toBeNull();
+    expect(screen.queryByText(/MCP/)).toBeNull();
+  });
+});
+
+describe("ToolSelector — switching to Custom mode", () => {
+  it("reveals groups in correct order: Built-in → Plugin · reminder → MCP · db → MCP · weather", () => {
+    renderSelector({ value: undefined });
+
+    const customLabel = screen.getByText("Custom selection");
+    const customRadio = customLabel
+      .closest("label")!
+      .querySelector("input[type='radio']") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.click(customRadio);
+    });
+
+    // After clicking Custom the onChange will be called but value doesn't change
+    // since value is controlled — we need to re-render with the new value
+    // In test, we check that onChange was called with a list and re-render
+    // But since value is controlled, let's render with an explicit array to see groups.
+    cleanup();
+
+    renderSelector({ value: ["Bash", "Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"] });
+
+    const groupHeaders = screen.getAllByText(/Built-in|Plugin · reminder|MCP · db|MCP · weather/);
+    const texts = groupHeaders.map((el) => el.textContent);
+    expect(texts).toContain("Built-in");
+    expect(texts).toContain("Plugin · reminder");
+    expect(texts).toContain("MCP · db");
+    expect(texts).toContain("MCP · weather");
+
+    // Verify ordering by DOM position
+    const allGroupSpans = screen
+      .getAllByText(/^(Built-in|Plugin · reminder|MCP · db|MCP · weather)$/)
+      .map((el) => el.textContent!);
+    expect(allGroupSpans[0]).toBe("Built-in");
+    expect(allGroupSpans[1]).toBe("Plugin · reminder");
+    // MCP groups sorted alphabetically: db before weather
+    expect(allGroupSpans[2]).toBe("MCP · db");
+    expect(allGroupSpans[3]).toBe("MCP · weather");
+  });
+});
+
+describe("ToolSelector — search filtering", () => {
+  it("filters tools to only matching group when searching 'forecast'", () => {
+    renderSelector({ value: ["Bash", "Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"] });
+
+    const searchInput = screen.getByRole("searchbox");
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "forecast" } });
+    });
+
+    // Only MCP · weather group should be visible
+    expect(screen.getByText("MCP · weather")).toBeTruthy();
+    expect(screen.queryByText("Built-in")).toBeNull();
+    expect(screen.queryByText("Plugin · reminder")).toBeNull();
+    expect(screen.queryByText("MCP · db")).toBeNull();
+
+    // Only the forecast tool id should appear
+    expect(screen.getByText("mcp:weather/forecast")).toBeTruthy();
+    expect(screen.queryByText("mcp:db/query")).toBeNull();
+    expect(screen.queryByText("Bash")).toBeNull();
+  });
+});
+
+describe("ToolSelector — group Select all / Clear buttons", () => {
+  it("calls onChange with full set when 'Select all' is clicked on the built-in group", () => {
+    // value = all except Bash — so built-in group is partially selected
+    const value = ["Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"];
+    const { props } = renderSelector({ value });
+
+    // Find "Select all" buttons — the built-in group is first
+    const selectAllBtns = screen.getAllByRole("button", { name: "Select all" });
+    act(() => {
+      fireEvent.click(selectAllBtns[0]); // first group = Built-in
+    });
+
+    expect(props.onChange).toHaveBeenCalledOnce();
+    // setGroupSelection with all builtin tools selected plus existing — all 6 tools = collapse to undefined
+    const result = props.onChange.mock.calls[0][0];
+    // When every tool ends up selected, setGroupSelection returns undefined
+    expect(result).toBeUndefined();
+  });
+
+  it("calls onChange excluding group tools when 'Clear' is clicked on the built-in group", () => {
+    const value = ["Bash", "Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"];
+    const { props } = renderSelector({ value });
+
+    const clearBtns = screen.getAllByRole("button", { name: "Clear" });
+    act(() => {
+      fireEvent.click(clearBtns[0]); // first group = Built-in
+    });
+
+    expect(props.onChange).toHaveBeenCalledOnce();
+    const result = props.onChange.mock.calls[0][0] as string[];
+    expect(result).not.toContain("Bash");
+    expect(result).not.toContain("Read");
+    expect(result).toContain("plugin:reminder/add");
+    expect(result).toContain("mcp:weather/forecast");
+  });
+});
+
+describe("ToolSelector — group selection state badge", () => {
+  it("shows '1 of 1 selected' for MCP · weather when forecast is the only tool in that group", () => {
+    // MCP · weather group contains only mcp:weather/forecast (one tool)
+    // mcp:db/query is in a separate MCP · db group
+    renderSelector({ value: ["mcp:weather/forecast"] });
+
+    // groupSelectionState returns "all" for 1/1, so summariseSelection shows "N of N selected"
+    expect(screen.getByText("1 of 1 selected")).toBeTruthy();
+  });
+
+  it("shows '0 of 2 selected' for the plugin group when none are selected", () => {
+    // Only select non-plugin tools
+    renderSelector({ value: ["Bash", "Read", "mcp:weather/forecast", "mcp:db/query"] });
+
+    // Plugin group has 2 tools, none selected
+    expect(screen.getByText("0 of 2 selected")).toBeTruthy();
+  });
+
+  it("shows '1 of 2 selected' for the plugin group when one is selected", () => {
+    renderSelector({ value: ["Bash", "Read", "plugin:reminder/add", "mcp:weather/forecast", "mcp:db/query"] });
+
+    // Plugin group: 2 tools, 1 selected
+    expect(screen.getByText("1 of 2 selected")).toBeTruthy();
+  });
+});
+
+describe("ToolSelector — variant='exclude' labels", () => {
+  it("shows 'Block none' instead of 'All tools' for the all-mode radio", () => {
+    renderSelector({ value: undefined, variant: "exclude" });
+
+    expect(screen.getByText("Block none")).toBeTruthy();
+    expect(screen.queryByText("All tools")).toBeNull();
+  });
+
+  it("shows exclude-mode body text when value is undefined", () => {
+    renderSelector({ value: undefined, variant: "exclude" });
+
+    expect(screen.getByText(/No tools are explicitly excluded/)).toBeTruthy();
+  });
+});
+
+describe("ToolSelector — toggling individual tool", () => {
+  it("calls onChange with tool removed when unchecking a checked tool", () => {
+    const value = ["Bash", "Read"];
+    const { props } = renderSelector({ value });
+
+    // Find the checkbox for Bash by looking at the label containing "Bash" id text
+    const bashIdEl = screen.getByText("Bash");
+    const bashLabel = bashIdEl.closest("label")!;
+    const bashCheckbox = bashLabel.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(bashCheckbox.checked).toBe(true);
+
+    act(() => {
+      fireEvent.click(bashCheckbox);
+    });
+
+    expect(props.onChange).toHaveBeenCalledOnce();
+    const result = props.onChange.mock.calls[0][0] as string[];
+    expect(result).not.toContain("Bash");
+    expect(result).toContain("Read");
+  });
+
+  it("calls onChange with tool added when checking an unchecked tool", () => {
+    const value = ["Read"];
+    const { props } = renderSelector({ value });
+
+    const bashIdEl = screen.getByText("Bash");
+    const bashLabel = bashIdEl.closest("label")!;
+    const bashCheckbox = bashLabel.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(bashCheckbox.checked).toBe(false);
+
+    act(() => {
+      fireEvent.click(bashCheckbox);
+    });
+
+    expect(props.onChange).toHaveBeenCalledOnce();
+    const result = props.onChange.mock.calls[0][0];
+    // Adding Bash to Read still not all tools, so should be explicit array
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as string[]).sort()).toEqual(["Bash", "Read"].sort());
+  });
+});

--- a/apps/admin-console/src/components/used-by-list.tsx
+++ b/apps/admin-console/src/components/used-by-list.tsx
@@ -1,0 +1,26 @@
+interface UsedByItem {
+  namespace: string;
+  id: string;
+}
+
+interface UsedByListProps {
+  items: UsedByItem[];
+}
+
+export function UsedByList({ items }: UsedByListProps) {
+  return (
+    <div>
+      <p className="mb-2">
+        The following records reference this resource and would be affected:
+      </p>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li key={`${item.namespace}/${item.id}`} className="font-mono text-xs">
+            {item.namespace}/{item.id}
+          </li>
+        ))}
+      </ul>
+      <p className="mt-3">Force delete will remove this resource anyway.</p>
+    </div>
+  );
+}

--- a/apps/admin-console/src/lib/agent-stats.test.ts
+++ b/apps/admin-console/src/lib/agent-stats.test.ts
@@ -119,6 +119,30 @@ describe("fetchAgentRuntimeStats", () => {
     );
   });
 
+  it("appends ?window= when options.window is provided", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(makeSnapshot()));
+    await fetchAgentRuntimeStats("alpha", { window: "1h" }, fetchSpy);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND_URL}/v1/agents/alpha/runtime-stats?window=1h`,
+    );
+  });
+
+  it("omits ?window= when options.window is absent", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(makeSnapshot()));
+    await fetchAgentRuntimeStats("alpha", {}, fetchSpy);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND_URL}/v1/agents/alpha/runtime-stats`,
+    );
+  });
+
+  it("remains backward-compatible when second arg is a fetch function", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(makeSnapshot()));
+    await fetchAgentRuntimeStats("alpha", fetchSpy);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND_URL}/v1/agents/alpha/runtime-stats`,
+    );
+  });
+
   it("returns ok when server responds with 200", async () => {
     const snap = makeSnapshot({ agent_id: "x", inference_count: 7 });
     const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(snap));

--- a/apps/admin-console/src/lib/agent-stats.ts
+++ b/apps/admin-console/src/lib/agent-stats.ts
@@ -60,12 +60,28 @@ export type AgentRuntimeStatsResult =
 
 const REGISTRY_DISABLED_HINT = "runtime_stats registry not configured";
 
+export type FetchAgentRuntimeStatsOptions = {
+  /** Optional window string forwarded as `?window=`, e.g. `"1h"`, `"7d"`. */
+  window?: string;
+};
+
 /// Fetch the rolling-window snapshot for a single agent.
 export async function fetchAgentRuntimeStats(
   agentId: string,
+  options?: FetchAgentRuntimeStatsOptions | typeof fetch,
   fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<AgentRuntimeStatsResult> {
-  const url = `${BACKEND_URL}/v1/agents/${encodeURIComponent(agentId)}/runtime-stats`;
+  // Back-compat: second param used to be `fetchImpl` directly.
+  let opts: FetchAgentRuntimeStatsOptions = {};
+  if (typeof options === "function") {
+    fetchImpl = options;
+  } else if (options != null) {
+    opts = options;
+  }
+  let url = `${BACKEND_URL}/v1/agents/${encodeURIComponent(agentId)}/runtime-stats`;
+  if (opts.window) {
+    url += `?window=${encodeURIComponent(opts.window)}`;
+  }
   const resp = await fetchImpl(url);
   if (resp.status === 503) {
     return { kind: "registry_disabled" };

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -9,6 +9,7 @@ import {
   setGroupSelection,
   toolSelectionMode,
   toolSourceFor,
+  type ApiToolSource,
 } from "./agent-tool-selection";
 
 describe("agent tool selection", () => {
@@ -94,6 +95,42 @@ describe("toolSourceFor", () => {
       key: "builtin",
     });
   });
+
+  it("uses explicit mcp source from backend over id inference", () => {
+    const apiSource: ApiToolSource = { kind: "mcp", id: "weather" };
+    expect(toolSourceFor("mcp__weather__forecast", apiSource)).toMatchObject({
+      kind: "mcp",
+      key: "mcp:weather",
+      label: "MCP · weather",
+    });
+  });
+
+  it("uses explicit plugin source from backend over id inference", () => {
+    const apiSource: ApiToolSource = { kind: "plugin", id: "reminder" };
+    expect(toolSourceFor("some-tool-id", apiSource)).toMatchObject({
+      kind: "plugin",
+      key: "plugin:reminder",
+      label: "Plugin · reminder",
+    });
+  });
+
+  it("uses explicit builtin source from backend", () => {
+    const apiSource: ApiToolSource = { kind: "builtin" };
+    expect(toolSourceFor("Bash", apiSource)).toMatchObject({
+      kind: "builtin",
+      key: "builtin",
+      label: "Built-in",
+    });
+  });
+
+  it("handles mcp source with no id gracefully", () => {
+    const apiSource: ApiToolSource = { kind: "mcp" };
+    expect(toolSourceFor("mcp__x__y", apiSource)).toMatchObject({
+      kind: "mcp",
+      label: "MCP",
+      key: "mcp:",
+    });
+  });
 });
 
 describe("groupToolsBySource", () => {
@@ -119,6 +156,22 @@ describe("groupToolsBySource", () => {
       "mcp:weather/forecast",
       "mcp:weather/now",
     ]);
+  });
+
+  it("uses explicit source field when present, ignoring id prefix", () => {
+    const groups = groupToolsBySource([
+      { id: "mcp__weather__forecast", source: { kind: "mcp" as const, id: "weather" } },
+      { id: "some-tool", source: { kind: "plugin" as const, id: "reminder" } },
+      { id: "Bash", source: { kind: "builtin" as const } },
+    ]);
+    expect(groups.map((g) => g.source.key)).toEqual([
+      "builtin",
+      "plugin:reminder",
+      "mcp:weather",
+    ]);
+    expect(groups[0].tools.map((t) => t.id)).toEqual(["Bash"]);
+    expect(groups[1].tools.map((t) => t.id)).toEqual(["some-tool"]);
+    expect(groups[2].tools.map((t) => t.id)).toEqual(["mcp__weather__forecast"]);
   });
 });
 

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -63,7 +63,32 @@ export interface ToolSource {
   key: string;
 }
 
-export function toolSourceFor(toolId: string): ToolSource {
+/// Backend-supplied source descriptor (from `/v1/capabilities`).
+export interface ApiToolSource {
+  kind: "builtin" | "plugin" | "mcp";
+  id?: string;
+}
+
+/// Derive a ToolSource from a backend-supplied source descriptor when present,
+/// falling back to id-prefix inference for tools without an explicit source.
+export function toolSourceFor(
+  toolId: string,
+  apiSource?: ApiToolSource,
+): ToolSource {
+  if (apiSource) {
+    if (apiSource.kind === "mcp") {
+      const server = apiSource.id ?? "";
+      const label = server.length > 0 ? `MCP · ${server}` : "MCP";
+      return { kind: "mcp", label, key: `mcp:${server}` };
+    }
+    if (apiSource.kind === "plugin") {
+      const plugin = apiSource.id ?? "";
+      const label = plugin.length > 0 ? `Plugin · ${plugin}` : "Plugin";
+      return { kind: "plugin", label, key: `plugin:${plugin}` };
+    }
+    return { kind: "builtin", label: "Built-in", key: "builtin" };
+  }
+  // Fallback: infer from id prefix (legacy / tools without explicit source).
   if (toolId.startsWith("mcp:")) {
     const remainder = toolId.slice(4);
     const slash = remainder.indexOf("/");
@@ -86,12 +111,12 @@ export interface ToolGroup<TTool> {
   tools: TTool[];
 }
 
-export function groupToolsBySource<TTool extends { id: string }>(
+export function groupToolsBySource<TTool extends { id: string; source?: ApiToolSource }>(
   tools: TTool[],
 ): ToolGroup<TTool>[] {
   const buckets = new Map<string, ToolGroup<TTool>>();
   for (const tool of tools) {
-    const source = toolSourceFor(tool.id);
+    const source = toolSourceFor(tool.id, tool.source);
     let bucket = buckets.get(source.key);
     if (!bucket) {
       bucket = { source, tools: [] };

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -103,6 +103,7 @@ export interface ToolInfo {
   id: string;
   name: string;
   description: string;
+  source?: { kind: "builtin" | "plugin" | "mcp"; id?: string };
 }
 
 export interface Capabilities {

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -275,8 +275,12 @@ export const configApi = {
       body: JSON.stringify(body),
     }),
 
-  delete: (namespace: string, id: string) =>
-    fetchJson<void>(configUrl(namespace, id), { method: "DELETE" }),
+  delete: (namespace: string, id: string, options?: { force?: boolean }) => {
+    const url = options?.force
+      ? `${configUrl(namespace, id)}?force=true`
+      : configUrl(namespace, id);
+    return fetchJson<void>(url, { method: "DELETE" });
+  },
 
   capabilities: async () =>
     normalizeCapabilities(

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -292,4 +292,16 @@ export const configApi = {
       `${BACKEND_URL}/v1/providers/${encodeURIComponent(id)}/test`,
       { method: "POST" },
     ),
+
+  mcpStatus: (id: string) =>
+    fetchJson<{
+      connected: boolean;
+      last_error?: string | null;
+      tools: Array<{ name: string; description?: string | null }>;
+    }>(`${BACKEND_URL}/v1/mcp-servers/${encodeURIComponent(id)}/status`),
+
+  mcpRestart: (id: string) =>
+    fetchJson<void>(`${BACKEND_URL}/v1/mcp-servers/${encodeURIComponent(id)}/restart`, {
+      method: "POST",
+    }),
 };

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -20,12 +20,16 @@ export interface AgentSpec {
   excluded_tools?: string[];
   delegates?: string[];
   reasoning_effort?: string | number | null;
+  created_at?: number;
+  updated_at?: number;
 }
 
 export interface ModelBindingSpec {
   id: string;
   provider_id: string;
   upstream_model: string;
+  created_at?: number;
+  updated_at?: number;
 }
 
 export interface ProviderSpec {
@@ -34,6 +38,8 @@ export interface ProviderSpec {
   api_key?: string;
   base_url?: string;
   timeout_secs?: number;
+  created_at?: number;
+  updated_at?: number;
 }
 
 export interface ProviderRecord extends Omit<ProviderSpec, "api_key"> {
@@ -58,6 +64,8 @@ export interface McpServerSpec {
   timeout_secs?: number;
   env?: Record<string, string>;
   restart_policy?: McpRestartPolicy;
+  created_at?: number;
+  updated_at?: number;
 }
 
 export interface McpServerRecord extends Omit<McpServerSpec, "env"> {

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -286,4 +286,10 @@ export const configApi = {
     normalizeCapabilities(
       await fetchJson<Capabilities>(`${BACKEND_URL}/v1/capabilities`),
     ),
+
+  testProvider: (id: string) =>
+    fetchJson<{ ok: boolean; latency_ms: number; error?: string }>(
+      `${BACKEND_URL}/v1/providers/${encodeURIComponent(id)}/test`,
+      { method: "POST" },
+    ),
 };

--- a/apps/admin-console/src/lib/format-time.test.ts
+++ b/apps/admin-console/src/lib/format-time.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { formatRelativeTime } from "./format-time";
+
+const NOW = new Date("2026-05-01T12:00:00.000Z").getTime();
+
+describe("formatRelativeTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function at(ms: number) {
+    vi.setSystemTime(NOW);
+    return formatRelativeTime(NOW - ms);
+  }
+
+  it('returns "—" for undefined', () => {
+    expect(formatRelativeTime(undefined)).toBe("—");
+  });
+
+  it('returns "—" for null', () => {
+    expect(formatRelativeTime(null)).toBe("—");
+  });
+
+  it('returns "just now" for 0 seconds ago', () => {
+    vi.setSystemTime(NOW);
+    expect(formatRelativeTime(NOW)).toBe("just now");
+  });
+
+  it('returns "just now" for 30 seconds ago', () => {
+    expect(at(30_000)).toBe("just now");
+  });
+
+  it('returns "just now" for 59 seconds ago', () => {
+    expect(at(59_000)).toBe("just now");
+  });
+
+  it('returns "Xm ago" for 1 minute ago', () => {
+    expect(at(60_000)).toBe("1m ago");
+  });
+
+  it('returns "Xm ago" for 45 minutes ago', () => {
+    expect(at(45 * 60_000)).toBe("45m ago");
+  });
+
+  it('returns "Xm ago" for 59 minutes ago', () => {
+    expect(at(59 * 60_000)).toBe("59m ago");
+  });
+
+  it('returns "Xh ago" for 1 hour ago', () => {
+    expect(at(60 * 60_000)).toBe("1h ago");
+  });
+
+  it('returns "Xh ago" for 2 hours ago', () => {
+    expect(at(2 * 60 * 60_000)).toBe("2h ago");
+  });
+
+  it('returns "Xh ago" for 23 hours ago', () => {
+    expect(at(23 * 60 * 60_000)).toBe("23h ago");
+  });
+
+  it('returns "Xd ago" for 1 day ago', () => {
+    expect(at(24 * 60 * 60_000)).toBe("1d ago");
+  });
+
+  it('returns "Xd ago" for 5 days ago', () => {
+    expect(at(5 * 24 * 60 * 60_000)).toBe("5d ago");
+  });
+
+  it('returns "Xd ago" for 6 days ago', () => {
+    expect(at(6 * 24 * 60 * 60_000)).toBe("6d ago");
+  });
+
+  it("returns absolute date for 7 days ago", () => {
+    const result = at(7 * 24 * 60 * 60_000);
+    expect(result).toMatch(/\w+ \d+, \d{4}/);
+  });
+
+  it("returns absolute date for much older timestamps", () => {
+    vi.setSystemTime(NOW);
+    // Apr 20 is 11 days before May 1, so it falls into the absolute-date branch.
+    const result = formatRelativeTime(new Date("2026-04-20T00:00:00.000Z").getTime());
+    expect(result).toBe("Apr 20, 2026");
+  });
+});

--- a/apps/admin-console/src/lib/format-time.ts
+++ b/apps/admin-console/src/lib/format-time.ts
@@ -1,0 +1,45 @@
+/**
+ * Format an epoch-millisecond timestamp as a human-readable relative string.
+ *
+ * - Within the last 60 seconds: "just now"
+ * - Within the last 60 minutes: "Xm ago"
+ * - Within the last 24 hours: "Xh ago"
+ * - Within the last 7 days: "Xd ago"
+ * - Older: locale date string e.g. "Apr 27, 2026"
+ *
+ * Returns "—" when the timestamp is undefined or null.
+ */
+export function formatRelativeTime(ms: number | undefined | null): string {
+  if (ms === undefined || ms === null) {
+    return "—";
+  }
+
+  const now = Date.now();
+  const diffMs = now - ms;
+  const diffSecs = Math.floor(diffMs / 1000);
+
+  if (diffSecs < 60) {
+    return "just now";
+  }
+
+  const diffMins = Math.floor(diffSecs / 60);
+  if (diffMins < 60) {
+    return `${diffMins}m ago`;
+  }
+
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) {
+    return `${diffHours}h ago`;
+  }
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) {
+    return `${diffDays}d ago`;
+  }
+
+  return new Date(ms).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/admin-console/src/lib/list-url-state.test.ts
+++ b/apps/admin-console/src/lib/list-url-state.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vitest";
+import {
+  readListState,
+  writeListState,
+  readSkillsFilter,
+  writeSkillsFilter,
+  readFixtureFilter,
+  writeFixtureFilter,
+  type ListState,
+} from "./list-url-state";
+import { DEFAULT_PAGE_SIZE } from "./list-view";
+import { DEFAULT_SKILLS_FILTER } from "./skills-filter";
+import { DEFAULT_FIXTURE_FILTER } from "./eval-reports-filter";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+type AgentKey = "id" | "model_id" | "plugin_count";
+
+const AGENT_OPTIONS = {
+  validSortKeys: ["id", "model_id", "plugin_count"] as const,
+  defaultSort: { key: "id" as AgentKey, direction: "asc" as const },
+  defaultPageSize: DEFAULT_PAGE_SIZE,
+} satisfies Parameters<typeof readListState<AgentKey>>[1];
+
+function p(search: string) {
+  return new URLSearchParams(search);
+}
+
+// ---------------------------------------------------------------------------
+// readListState
+// ---------------------------------------------------------------------------
+
+describe("readListState", () => {
+  it("returns defaults when URL is empty", () => {
+    const state = readListState(p(""), AGENT_OPTIONS);
+    expect(state.search).toBe("");
+    expect(state.sort).toEqual({ key: "id", direction: "asc" });
+    expect(state.pageSize).toBe(DEFAULT_PAGE_SIZE);
+    expect(state.page).toBe(1);
+  });
+
+  it("parses valid params correctly", () => {
+    const state = readListState(
+      p("q=hello&sort=model_id&dir=desc&size=50&page=3"),
+      AGENT_OPTIONS,
+    );
+    expect(state.search).toBe("hello");
+    expect(state.sort).toEqual({ key: "model_id", direction: "desc" });
+    expect(state.pageSize).toBe(50);
+    expect(state.page).toBe(3);
+  });
+
+  it("ignores unknown sort key and uses default sort", () => {
+    const state = readListState(p("sort=nonexistent&dir=asc"), AGENT_OPTIONS);
+    expect(state.sort).toEqual({ key: "id", direction: "asc" });
+  });
+
+  it("clamps invalid page size to default", () => {
+    const state = readListState(p("size=999"), AGENT_OPTIONS);
+    expect(state.pageSize).toBe(DEFAULT_PAGE_SIZE);
+  });
+
+  it("clamps page to 1 when value is 0", () => {
+    const state = readListState(p("page=0"), AGENT_OPTIONS);
+    expect(state.page).toBe(1);
+  });
+
+  it("clamps page to 1 when value is negative", () => {
+    const state = readListState(p("page=-5"), AGENT_OPTIONS);
+    expect(state.page).toBe(1);
+  });
+
+  it("clamps page to 1 when value is non-numeric", () => {
+    const state = readListState(p("page=abc"), AGENT_OPTIONS);
+    expect(state.page).toBe(1);
+  });
+
+  it("defaults dir to asc when dir is absent but sort key is present", () => {
+    const state = readListState(p("sort=plugin_count"), AGENT_OPTIONS);
+    expect(state.sort).toEqual({ key: "plugin_count", direction: "asc" });
+  });
+
+  it("defaults dir to asc when dir is invalid", () => {
+    const state = readListState(p("sort=model_id&dir=sideways"), AGENT_OPTIONS);
+    expect(state.sort).toEqual({ key: "model_id", direction: "asc" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeListState
+// ---------------------------------------------------------------------------
+
+describe("writeListState", () => {
+  it("omits all params when state equals defaults", () => {
+    const state: ListState<AgentKey> = {
+      search: "",
+      sort: { key: "id", direction: "asc" },
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 1,
+    };
+    const result = writeListState(p(""), state, AGENT_OPTIONS);
+    expect(result.toString()).toBe("");
+  });
+
+  it("includes q when search is non-empty", () => {
+    const state: ListState<AgentKey> = {
+      search: "foo",
+      sort: { key: "id", direction: "asc" },
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 1,
+    };
+    const result = writeListState(p(""), state, AGENT_OPTIONS);
+    expect(result.get("q")).toBe("foo");
+  });
+
+  it("includes sort+dir=desc when sort differs from default with desc direction", () => {
+    const state: ListState<AgentKey> = {
+      search: "",
+      sort: { key: "model_id", direction: "desc" },
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 1,
+    };
+    const result = writeListState(p(""), state, AGENT_OPTIONS);
+    expect(result.get("sort")).toBe("model_id");
+    expect(result.get("dir")).toBe("desc");
+  });
+
+  it("omits dir when sort differs from default but direction is asc", () => {
+    const state: ListState<AgentKey> = {
+      search: "",
+      sort: { key: "model_id", direction: "asc" },
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 1,
+    };
+    const result = writeListState(p(""), state, AGENT_OPTIONS);
+    expect(result.get("sort")).toBe("model_id");
+    expect(result.get("dir")).toBeNull();
+  });
+
+  it("includes size when pageSize differs from default", () => {
+    const state: ListState<AgentKey> = {
+      search: "",
+      sort: { key: "id", direction: "asc" },
+      pageSize: 50,
+      page: 1,
+    };
+    const result = writeListState(p(""), state, AGENT_OPTIONS);
+    expect(result.get("size")).toBe("50");
+  });
+
+  it("includes page when page > 1", () => {
+    const state: ListState<AgentKey> = {
+      search: "",
+      sort: { key: "id", direction: "asc" },
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 5,
+    };
+    const result = writeListState(p(""), state, AGENT_OPTIONS);
+    expect(result.get("page")).toBe("5");
+  });
+
+  it("omits sort+dir when sort is null and default is null", () => {
+    const optionsNoDefault = {
+      validSortKeys: ["id", "model_id"] as const,
+      defaultSort: null,
+    };
+    const state: ListState<"id" | "model_id"> = {
+      search: "",
+      sort: null,
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 1,
+    };
+    const result = writeListState(p(""), state, optionsNoDefault);
+    expect(result.get("sort")).toBeNull();
+    expect(result.get("dir")).toBeNull();
+  });
+
+  it("preserves unrelated params already in the search string", () => {
+    const state: ListState<AgentKey> = {
+      search: "bar",
+      sort: { key: "id", direction: "asc" },
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 1,
+    };
+    const result = writeListState(p("tab=tools"), state, AGENT_OPTIONS);
+    expect(result.get("tab")).toBe("tools");
+    expect(result.get("q")).toBe("bar");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip
+// ---------------------------------------------------------------------------
+
+describe("round-trip readListState / writeListState", () => {
+  it("round-trips a fully non-default state", () => {
+    const original: ListState<AgentKey> = {
+      search: "alpha",
+      sort: { key: "plugin_count", direction: "desc" },
+      pageSize: 100,
+      page: 7,
+    };
+    const written = writeListState(p(""), original, AGENT_OPTIONS);
+    const recovered = readListState(written, AGENT_OPTIONS);
+    expect(recovered).toEqual(original);
+  });
+
+  it("round-trips the default state without adding params", () => {
+    const original: ListState<AgentKey> = {
+      search: "",
+      sort: { key: "id", direction: "asc" },
+      pageSize: DEFAULT_PAGE_SIZE,
+      page: 1,
+    };
+    const written = writeListState(p(""), original, AGENT_OPTIONS);
+    expect(written.toString()).toBe("");
+    const recovered = readListState(written, AGENT_OPTIONS);
+    expect(recovered).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readSkillsFilter / writeSkillsFilter
+// ---------------------------------------------------------------------------
+
+describe("readSkillsFilter", () => {
+  it("returns defaults when URL is empty", () => {
+    expect(readSkillsFilter(p(""))).toEqual(DEFAULT_SKILLS_FILTER);
+  });
+
+  it("parses valid caller and ctx params", () => {
+    const state = readSkillsFilter(p("q=tool&caller=user&ctx=fork"));
+    expect(state).toEqual({ search: "tool", invocable: "user", context: "fork" });
+  });
+
+  it("ignores invalid caller and falls back to default", () => {
+    const state = readSkillsFilter(p("caller=bogus"));
+    expect(state.invocable).toBe(DEFAULT_SKILLS_FILTER.invocable);
+  });
+
+  it("ignores invalid ctx and falls back to default", () => {
+    const state = readSkillsFilter(p("ctx=bogus"));
+    expect(state.context).toBe(DEFAULT_SKILLS_FILTER.context);
+  });
+});
+
+describe("writeSkillsFilter", () => {
+  it("omits all params when state equals defaults", () => {
+    const result = writeSkillsFilter(p(""), DEFAULT_SKILLS_FILTER);
+    expect(result.toString()).toBe("");
+  });
+
+  it("includes non-default caller and ctx", () => {
+    const result = writeSkillsFilter(p(""), {
+      search: "",
+      invocable: "model",
+      context: "inline",
+    });
+    expect(result.get("caller")).toBe("model");
+    expect(result.get("ctx")).toBe("inline");
+    expect(result.get("q")).toBeNull();
+  });
+
+  it("round-trips non-default skills filter", () => {
+    const original = { search: "playwright", invocable: "user" as const, context: "fork" as const };
+    const written = writeSkillsFilter(p(""), original);
+    const recovered = readSkillsFilter(written);
+    expect(recovered).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readFixtureFilter / writeFixtureFilter
+// ---------------------------------------------------------------------------
+
+describe("readFixtureFilter", () => {
+  it("returns defaults when URL is empty", () => {
+    expect(readFixtureFilter(p(""))).toEqual(DEFAULT_FIXTURE_FILTER);
+  });
+
+  it("parses valid status and search params", () => {
+    const state = readFixtureFilter(p("q=fixture1&status=failed"));
+    expect(state).toEqual({ search: "fixture1", status: "failed" });
+  });
+
+  it("ignores invalid status and falls back to default", () => {
+    const state = readFixtureFilter(p("status=unknown"));
+    expect(state.status).toBe(DEFAULT_FIXTURE_FILTER.status);
+  });
+});
+
+describe("writeFixtureFilter", () => {
+  it("omits all params when state equals defaults", () => {
+    const result = writeFixtureFilter(p(""), DEFAULT_FIXTURE_FILTER);
+    expect(result.toString()).toBe("");
+  });
+
+  it("includes non-default status", () => {
+    const result = writeFixtureFilter(p(""), { search: "", status: "regressions" });
+    expect(result.get("status")).toBe("regressions");
+  });
+
+  it("round-trips non-default fixture filter", () => {
+    const original = { search: "perf-test", status: "passed" as const };
+    const written = writeFixtureFilter(p(""), original);
+    const recovered = readFixtureFilter(written);
+    expect(recovered).toEqual(original);
+  });
+});

--- a/apps/admin-console/src/lib/list-url-state.ts
+++ b/apps/admin-console/src/lib/list-url-state.ts
@@ -1,0 +1,330 @@
+import { useMemo } from "react";
+import { useSearchParams } from "react-router";
+import {
+  DEFAULT_PAGE_SIZE,
+  PAGE_SIZE_OPTIONS,
+  type PageSize,
+  type SortState,
+} from "./list-view";
+import {
+  DEFAULT_SKILLS_FILTER,
+  type ContextFilter,
+  type InvocableFilter,
+  type SkillsFilterState,
+} from "./skills-filter";
+import {
+  DEFAULT_FIXTURE_FILTER,
+  type FixtureFilterState,
+  type FixtureStatusFilter,
+} from "./eval-reports-filter";
+
+// ---------------------------------------------------------------------------
+// Generic list state (search + sort + pagination)
+// ---------------------------------------------------------------------------
+
+export interface ListState<TKey extends string> {
+  search: string;
+  sort: SortState<TKey> | null;
+  pageSize: PageSize;
+  page: number;
+}
+
+export interface ReadListStateOptions<TKey extends string> {
+  /// Allowed sort keys (rejected if URL has unknown key)
+  validSortKeys: readonly TKey[];
+  /// Default sort (used when URL omits or value is invalid)
+  defaultSort?: SortState<TKey> | null;
+  /// Default page size
+  defaultPageSize?: PageSize;
+}
+
+export function readListState<TKey extends string>(
+  params: URLSearchParams,
+  options: ReadListStateOptions<TKey>,
+): ListState<TKey> {
+  const defaultSort = options.defaultSort ?? null;
+  const defaultPageSize = options.defaultPageSize ?? DEFAULT_PAGE_SIZE;
+
+  // search
+  const search = params.get("q") ?? "";
+
+  // sort
+  const sortKeyRaw = params.get("sort");
+  const dirRaw = params.get("dir");
+  let sort: SortState<TKey> | null = defaultSort;
+  if (sortKeyRaw !== null) {
+    const key = sortKeyRaw as TKey;
+    if (options.validSortKeys.includes(key)) {
+      const direction = dirRaw === "desc" ? "desc" : "asc";
+      sort = { key, direction };
+    }
+    // unknown key → fall back to default (no-op, already set above)
+  }
+
+  // pageSize
+  const sizeRaw = params.get("size");
+  let pageSize: PageSize = defaultPageSize;
+  if (sizeRaw !== null) {
+    const parsed = Number(sizeRaw);
+    const matched = PAGE_SIZE_OPTIONS.find((s) => s === parsed);
+    if (matched !== undefined) {
+      pageSize = matched;
+    }
+    // invalid → keep default
+  }
+
+  // page (1-based)
+  const pageRaw = params.get("page");
+  let page = 1;
+  if (pageRaw !== null) {
+    const parsed = Number(pageRaw);
+    if (Number.isInteger(parsed) && parsed >= 1) {
+      page = parsed;
+    }
+    // invalid → clamp to 1
+  }
+
+  return { search, sort, pageSize, page };
+}
+
+export function writeListState<TKey extends string>(
+  params: URLSearchParams,
+  state: ListState<TKey>,
+  options: ReadListStateOptions<TKey>,
+): URLSearchParams {
+  const defaultSort = options.defaultSort ?? null;
+  const defaultPageSize = options.defaultPageSize ?? DEFAULT_PAGE_SIZE;
+  const next = new URLSearchParams(params.toString());
+
+  // search: omit when empty
+  if (state.search.length > 0) {
+    next.set("q", state.search);
+  } else {
+    next.delete("q");
+  }
+
+  // sort: omit when matches default
+  const sortMatchesDefault =
+    defaultSort === null
+      ? state.sort === null
+      : state.sort !== null &&
+        state.sort.key === defaultSort.key &&
+        state.sort.direction === defaultSort.direction;
+
+  if (state.sort !== null && !sortMatchesDefault) {
+    next.set("sort", state.sort.key);
+    if (state.sort.direction === "desc") {
+      next.set("dir", "desc");
+    } else {
+      next.delete("dir");
+    }
+  } else if (state.sort === null) {
+    next.delete("sort");
+    next.delete("dir");
+  } else {
+    // sort matches default — omit
+    next.delete("sort");
+    next.delete("dir");
+  }
+
+  // pageSize: omit when default
+  if (state.pageSize !== defaultPageSize) {
+    next.set("size", String(state.pageSize));
+  } else {
+    next.delete("size");
+  }
+
+  // page: omit when 1
+  if (state.page > 1) {
+    next.set("page", String(state.page));
+  } else {
+    next.delete("page");
+  }
+
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Skills filter URL helpers
+// ---------------------------------------------------------------------------
+
+const VALID_INVOCABLE: readonly InvocableFilter[] = [
+  "any",
+  "user",
+  "model",
+  "internal",
+];
+const VALID_CONTEXT: readonly ContextFilter[] = ["any", "inline", "fork"];
+
+export function readSkillsFilter(params: URLSearchParams): SkillsFilterState {
+  const search = params.get("q") ?? DEFAULT_SKILLS_FILTER.search;
+
+  const invocableRaw = params.get("caller");
+  const invocable: InvocableFilter =
+    invocableRaw !== null &&
+    VALID_INVOCABLE.includes(invocableRaw as InvocableFilter)
+      ? (invocableRaw as InvocableFilter)
+      : DEFAULT_SKILLS_FILTER.invocable;
+
+  const contextRaw = params.get("ctx");
+  const context: ContextFilter =
+    contextRaw !== null && VALID_CONTEXT.includes(contextRaw as ContextFilter)
+      ? (contextRaw as ContextFilter)
+      : DEFAULT_SKILLS_FILTER.context;
+
+  return { search, invocable, context };
+}
+
+export function writeSkillsFilter(
+  params: URLSearchParams,
+  state: SkillsFilterState,
+): URLSearchParams {
+  const next = new URLSearchParams(params.toString());
+
+  if (state.search.length > 0) {
+    next.set("q", state.search);
+  } else {
+    next.delete("q");
+  }
+
+  if (state.invocable !== DEFAULT_SKILLS_FILTER.invocable) {
+    next.set("caller", state.invocable);
+  } else {
+    next.delete("caller");
+  }
+
+  if (state.context !== DEFAULT_SKILLS_FILTER.context) {
+    next.set("ctx", state.context);
+  } else {
+    next.delete("ctx");
+  }
+
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture (eval reports) filter URL helpers
+// ---------------------------------------------------------------------------
+
+const VALID_STATUS: readonly FixtureStatusFilter[] = [
+  "all",
+  "passed",
+  "failed",
+  "regressions",
+  "fixed",
+];
+
+export function readFixtureFilter(
+  params: URLSearchParams,
+): FixtureFilterState {
+  const search = params.get("q") ?? DEFAULT_FIXTURE_FILTER.search;
+
+  const statusRaw = params.get("status");
+  const status: FixtureStatusFilter =
+    statusRaw !== null &&
+    VALID_STATUS.includes(statusRaw as FixtureStatusFilter)
+      ? (statusRaw as FixtureStatusFilter)
+      : DEFAULT_FIXTURE_FILTER.status;
+
+  return { search, status };
+}
+
+export function writeFixtureFilter(
+  params: URLSearchParams,
+  state: FixtureFilterState,
+): URLSearchParams {
+  const next = new URLSearchParams(params.toString());
+
+  if (state.search.length > 0) {
+    next.set("q", state.search);
+  } else {
+    next.delete("q");
+  }
+
+  if (state.status !== DEFAULT_FIXTURE_FILTER.status) {
+    next.set("status", state.status);
+  } else {
+    next.delete("status");
+  }
+
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// React hooks — URL glue
+// ---------------------------------------------------------------------------
+
+export interface ListUrlState<TKey extends string> extends ListState<TKey> {
+  apply: (patch: Partial<ListState<TKey>>) => void;
+}
+
+export function useListUrlState<TKey extends string>(
+  options: ReadListStateOptions<TKey>,
+): ListUrlState<TKey> {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const { search, sort, pageSize, page } = useMemo(
+    () => readListState(searchParams, options),
+    // options is a module-level constant on every call site; including it
+    // would break memoisation if callers passed an inline object.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [searchParams],
+  );
+
+  function apply(patch: Partial<ListState<TKey>>) {
+    setSearchParams(
+      (prev) => {
+        const current = readListState(prev, options);
+        return writeListState(prev, { ...current, ...patch }, options);
+      },
+      { replace: true },
+    );
+  }
+
+  return { search, sort, pageSize, page, apply };
+}
+
+export interface SkillsFilterUrlState extends SkillsFilterState {
+  apply: (patch: Partial<SkillsFilterState>) => void;
+}
+
+export function useSkillsFilterUrlState(): SkillsFilterUrlState {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filter = useMemo(
+    () => readSkillsFilter(searchParams),
+    [searchParams],
+  );
+
+  function apply(patch: Partial<SkillsFilterState>) {
+    setSearchParams(
+      (prev) => writeSkillsFilter(prev, { ...readSkillsFilter(prev), ...patch }),
+      { replace: true },
+    );
+  }
+
+  return { ...filter, apply };
+}
+
+export interface FixtureFilterUrlState extends FixtureFilterState {
+  apply: (patch: Partial<FixtureFilterState>) => void;
+}
+
+export function useFixtureFilterUrlState(): FixtureFilterUrlState {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filter = useMemo(
+    () => readFixtureFilter(searchParams),
+    [searchParams],
+  );
+
+  function apply(patch: Partial<FixtureFilterState>) {
+    setSearchParams(
+      (prev) =>
+        writeFixtureFilter(prev, { ...readFixtureFilter(prev), ...patch }),
+      { replace: true },
+    );
+  }
+
+  return { ...filter, apply };
+}

--- a/apps/admin-console/src/lib/toast-queue.test.ts
+++ b/apps/admin-console/src/lib/toast-queue.test.ts
@@ -7,6 +7,7 @@ import {
   expireToasts,
   MAX_VISIBLE_TOASTS,
   nextExpiryDelay,
+  type AppendResult,
   type Toast,
 } from "./toast-queue";
 
@@ -61,7 +62,9 @@ describe("appendToast", () => {
   it("appends to the tail when below the cap", () => {
     const a = makeToast({ id: "a" });
     const b = makeToast({ id: "b" });
-    expect(appendToast([a], b)).toEqual([a, b]);
+    const result = appendToast([a], b);
+    expect(result.queue).toEqual([a, b]);
+    expect(result.displaced).toBe(0);
   });
 
   it("evicts the oldest toast when the cap is exceeded", () => {
@@ -69,10 +72,33 @@ describe("appendToast", () => {
       makeToast({ id: `t${idx}` }),
     );
     const incoming = makeToast({ id: "new" });
-    const next = appendToast(queue, incoming);
+    const { queue: next, displaced } = appendToast(queue, incoming);
     expect(next).toHaveLength(MAX_VISIBLE_TOASTS);
     expect(next[0].id).toBe("t1");
     expect(next[next.length - 1].id).toBe("new");
+    expect(displaced).toBe(1);
+  });
+
+  it("displaced is 0 when no eviction occurs", () => {
+    const result = appendToast([], makeToast({ id: "a" }));
+    expect(result.displaced).toBe(0);
+  });
+
+  it("accumulates displaced across multiple evictions", () => {
+    const queue = Array.from({ length: MAX_VISIBLE_TOASTS }, (_, idx) =>
+      makeToast({ id: `t${idx}` }),
+    );
+    // First eviction: displaced goes from 0 to 1
+    const r1 = appendToast(queue, makeToast({ id: "new1" }));
+    expect(r1.displaced).toBe(1);
+    // Second eviction: pass displaced=1 forward
+    const r2 = appendToast(r1.queue, makeToast({ id: "new2" }), r1.displaced);
+    expect(r2.displaced).toBe(2);
+  });
+
+  it("carries over a non-zero currentDisplaced when no eviction occurs", () => {
+    const result: AppendResult = appendToast([], makeToast({ id: "x" }), 3);
+    expect(result.displaced).toBe(3);
   });
 });
 

--- a/apps/admin-console/src/lib/toast-queue.ts
+++ b/apps/admin-console/src/lib/toast-queue.ts
@@ -39,11 +39,25 @@ export function createToast(input: ToastInput, id: string, now: number): Toast {
   };
 }
 
-export function appendToast(queue: Toast[], toast: Toast): Toast[] {
+export interface AppendResult {
+  queue: Toast[];
+  displaced: number;
+}
+
+export function appendToast(
+  queue: Toast[],
+  toast: Toast,
+  currentDisplaced = 0,
+): AppendResult {
   const next = [...queue, toast];
-  return next.length > MAX_VISIBLE_TOASTS
-    ? next.slice(next.length - MAX_VISIBLE_TOASTS)
-    : next;
+  if (next.length > MAX_VISIBLE_TOASTS) {
+    const evicted = next.length - MAX_VISIBLE_TOASTS;
+    return {
+      queue: next.slice(evicted),
+      displaced: currentDisplaced + evicted,
+    };
+  }
+  return { queue: next, displaced: currentDisplaced };
 }
 
 export function dismissToast(queue: Toast[], id: string): Toast[] {

--- a/apps/admin-console/src/lib/use-crud-page-delete.test.tsx
+++ b/apps/admin-console/src/lib/use-crud-page-delete.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, act, screen, fireEvent } from "@testing-library/react";
+import React, { useEffect } from "react";
+
+import { ConfigApiError, configApi } from "./config-api";
+import { useCrudPage } from "./use-crud-page";
+import { ConfirmDialogProvider } from "@/components/confirm-dialog";
+import { ToastProvider } from "@/components/toast-provider";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+interface SimpleRecord {
+  id: string;
+}
+
+// Wrapper component that exposes handleDelete via a button click
+function TestPage({
+  targetId,
+  onDone,
+}: {
+  targetId: string;
+  onDone?: () => void;
+}) {
+  const { handleDelete, items } = useCrudPage<SimpleRecord>({
+    namespace: "providers",
+    entityLabel: "provider",
+  });
+
+  return (
+    <div>
+      <div data-testid="items">{items.map((i) => i.id).join(",")}</div>
+      <button
+        data-testid="delete-btn"
+        onClick={() => {
+          void handleDelete(targetId).then(onDone);
+        }}
+      >
+        Delete
+      </button>
+    </div>
+  );
+}
+
+function renderTest(targetId: string, onDone?: () => void) {
+  return render(
+    <ToastProvider>
+      <ConfirmDialogProvider>
+        <TestPage targetId={targetId} onDone={onDone} />
+      </ConfirmDialogProvider>
+    </ToastProvider>,
+  );
+}
+
+describe("useCrudPage handleDelete 409 → force flow", () => {
+  it("re-prompts with used_by list when delete returns 409 and force-deletes on confirm", async () => {
+    // First delete call: 409 with used_by
+    const deleteStub = vi
+      .spyOn(configApi, "delete")
+      .mockRejectedValueOnce(
+        new ConfigApiError(409, {
+          error: "blocked",
+          used_by: [{ namespace: "models", id: "model-a" }],
+        }),
+      )
+      // Force delete call: success
+      .mockResolvedValueOnce(undefined);
+
+    vi.spyOn(configApi, "list").mockResolvedValue({
+      namespace: "providers",
+      items: [{ id: "prov-a" }],
+      offset: 0,
+      limit: 100,
+    });
+
+    renderTest("prov-a");
+
+    // Click delete button
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-btn"));
+    });
+
+    // First dialog: "Delete provider?" should appear
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText(/Delete provider\?/)).toBeTruthy();
+
+        // Confirm initial delete — click the confirm button inside the dialog
+    await act(async () => {
+      const dialog = screen.getByRole("dialog");
+      const confirmBtn = dialog.querySelector<HTMLButtonElement>("button:last-child");
+      fireEvent.click(confirmBtn!);
+    });
+
+    // Second dialog: "Still delete?" with used_by list
+    expect(screen.getByText(/Still delete\?/)).toBeTruthy();
+    expect(screen.getByText(/models\/model-a/)).toBeTruthy();
+
+    // Confirm force delete
+    await act(async () => {
+      fireEvent.click(screen.getByText("Force delete"));
+    });
+
+    // delete called twice: first without force, then with force
+    expect(deleteStub).toHaveBeenCalledTimes(2);
+    expect(deleteStub.mock.calls[0]).toEqual(["providers", "prov-a"]);
+    expect(deleteStub.mock.calls[1]).toEqual([
+      "providers",
+      "prov-a",
+      { force: true },
+    ]);
+  });
+
+  it("cancels without force-delete when user dismisses the second dialog", async () => {
+    const deleteStub = vi
+      .spyOn(configApi, "delete")
+      .mockRejectedValueOnce(
+        new ConfigApiError(409, {
+          error: "blocked",
+          used_by: [{ namespace: "models", id: "model-b" }],
+        }),
+      );
+
+    vi.spyOn(configApi, "list").mockResolvedValue({
+      namespace: "providers",
+      items: [{ id: "prov-b" }],
+      offset: 0,
+      limit: 100,
+    });
+
+    renderTest("prov-b");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-btn"));
+    });
+
+    // Confirm initial delete — click the confirm button inside the dialog
+    await act(async () => {
+      const dialog = screen.getByRole("dialog");
+      const confirmBtn = dialog.querySelector<HTMLButtonElement>("button:last-child");
+      fireEvent.click(confirmBtn!);
+    });
+
+    // Second dialog appears
+    expect(screen.getByText(/Still delete\?/)).toBeTruthy();
+
+    // Cancel — first button in the second dialog
+    await act(async () => {
+      fireEvent.click(screen.getByText("Cancel"));
+    });
+
+    // Force delete should NOT have been called
+    expect(deleteStub).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports error for non-409 errors without re-prompting", async () => {
+    vi.spyOn(configApi, "delete").mockRejectedValueOnce(
+      new ConfigApiError(500, { error: "internal error" }),
+    );
+
+    vi.spyOn(configApi, "list").mockResolvedValue({
+      namespace: "providers",
+      items: [{ id: "prov-c" }],
+      offset: 0,
+      limit: 100,
+    });
+
+    renderTest("prov-c");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("delete-btn"));
+    });
+
+    // Confirm initial delete — click the confirm button inside the dialog
+    await act(async () => {
+      const dialog = screen.getByRole("dialog");
+      const confirmBtn = dialog.querySelector<HTMLButtonElement>("button:last-child");
+      fireEvent.click(confirmBtn!);
+    });
+
+    // "Still delete?" should NOT appear
+    expect(screen.queryByText(/Still delete\?/)).toBeNull();
+  });
+});

--- a/apps/admin-console/src/lib/use-crud-page.tsx
+++ b/apps/admin-console/src/lib/use-crud-page.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
-import { configApi } from "@/lib/config-api";
+import { ConfigApiError, configApi } from "@/lib/config-api";
 import { useToast } from "@/components/toast-provider";
 import { useConfirmDialog } from "@/components/confirm-dialog";
+import { UsedByList } from "@/components/used-by-list";
 
 export interface CrudPageOptions<TRecord extends { id: string }, TSpec = TRecord> {
   /** API namespace used for list/create/update/delete calls. */
@@ -232,7 +233,35 @@ export function useCrudPage<TRecord extends { id: string }, TSpec = TRecord>(
         setError(null);
         toast.success(`${capitalize(entityLabel)} "${id}" deleted`);
       } catch (deleteError) {
-        reportError(toErrorMessage(deleteError));
+        if (
+          deleteError instanceof ConfigApiError &&
+          deleteError.status === 409 &&
+          deleteError.detail !== null &&
+          typeof deleteError.detail === "object" &&
+          "used_by" in deleteError.detail &&
+          Array.isArray((deleteError.detail as Record<string, unknown>).used_by)
+        ) {
+          const usedBy = (
+            deleteError.detail as { used_by: Array<{ namespace: string; id: string }> }
+          ).used_by;
+          const force = await confirmDialog({
+            title: "Still delete?",
+            description: <UsedByList items={usedBy} />,
+            confirmLabel: "Force delete",
+            tone: "destructive",
+          });
+          if (!force) return;
+          try {
+            await configApi.delete(namespace, id, { force: true });
+            setItems((current) => current.filter((item) => item.id !== id));
+            setError(null);
+            toast.success(`${capitalize(entityLabel)} "${id}" deleted`);
+          } catch (forceError) {
+            reportError(toErrorMessage(forceError));
+          }
+        } else {
+          reportError(toErrorMessage(deleteError));
+        }
       }
     },
     [namespace, entityLabel, confirmDialog, toast, reportError],

--- a/apps/admin-console/src/pages/agent-dashboard-page.tsx
+++ b/apps/admin-console/src/pages/agent-dashboard-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router";
+import { Link, useParams, useSearchParams } from "react-router";
 import {
   errorRate,
   fetchAgentRuntimeStats,
@@ -13,8 +13,18 @@ import {
 } from "@/lib/agent-stats";
 import { adminRoutes } from "@/lib/routes";
 
+const WINDOW_OPTIONS = [
+  { label: "Default", value: "" },
+  { label: "1h", value: "1h" },
+  { label: "6h", value: "6h" },
+  { label: "24h", value: "24h" },
+  { label: "7d", value: "7d" },
+] as const;
+
 export function AgentDashboardPage() {
   const { id } = useParams<{ id: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const windowParam = searchParams.get("window") ?? "";
   const [result, setResult] = useState<AgentRuntimeStatsResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
@@ -24,7 +34,8 @@ export function AgentDashboardPage() {
     let cancelled = false;
     setResult(null);
     setError(null);
-    void fetchAgentRuntimeStats(id)
+    const opts = windowParam ? { window: windowParam } : undefined;
+    void fetchAgentRuntimeStats(id, opts)
       .then((r) => {
         if (!cancelled) setResult(r);
       })
@@ -36,7 +47,7 @@ export function AgentDashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [id, reloadKey]);
+  }, [id, windowParam, reloadKey]);
 
   if (!id) {
     return <Shell title="Agent Dashboard">Missing agent id.</Shell>;
@@ -91,22 +102,58 @@ export function AgentDashboardPage() {
 
   return (
     <Shell title={`Dashboard · ${snapshot.agent_id}`}>
-      <p className="-mt-4 mb-6 text-sm text-slate-500">
-        Rolling-window snapshot for the last{" "}
-        <span className="font-mono">{formatWindow(snapshot.window_seconds)}</span>{" "}
-        ({snapshot.bucket_count} buckets ×{" "}
-        <span className="font-mono">
-          {formatWindow(snapshot.bucket_window_seconds)}
-        </span>
-        ).{" "}
+      <div className="-mt-4 mb-6 flex flex-wrap items-center gap-3">
+        <p className="text-sm text-slate-500">
+          Rolling-window snapshot for the last{" "}
+          <span className="font-mono">{formatWindow(snapshot.window_seconds)}</span>{" "}
+          ({snapshot.bucket_count} buckets ×{" "}
+          <span className="font-mono">
+            {formatWindow(snapshot.bucket_window_seconds)}
+          </span>
+          ).
+        </p>
+        <div className="flex items-center gap-2">
+          <label
+            htmlFor="window-picker"
+            className="text-xs text-slate-500"
+          >
+            Window:
+          </label>
+          <select
+            id="window-picker"
+            value={windowParam}
+            onChange={(e) => {
+              const val = e.target.value;
+              setSearchParams(
+                (prev) => {
+                  const next = new URLSearchParams(prev);
+                  if (val) {
+                    next.set("window", val);
+                  } else {
+                    next.delete("window");
+                  }
+                  return next;
+                },
+                { replace: true },
+              );
+            }}
+            className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 shadow-sm"
+          >
+            {WINDOW_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
         <button
           type="button"
           onClick={() => setReloadKey((k) => k + 1)}
-          className="ml-2 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-600 hover:bg-slate-50"
+          className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs text-slate-600 hover:bg-slate-50"
         >
           Refresh
         </button>
-      </p>
+      </div>
 
       <Section title="Runtime health">
         <StatGrid>

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from "react-router";
+import { appRoutes } from "../app";
+import { AuthProvider } from "../components/auth-provider";
+import { ConfirmDialogProvider } from "../components/confirm-dialog";
+import { ToastProvider } from "../components/toast-provider";
+import { ADMIN_TOKEN_STORAGE_KEY } from "../lib/config-api";
+import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
+
+function stubCapabilitiesFetch() {
+  const fetchSpy = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    text: async () =>
+      JSON.stringify({
+        agents: [],
+        tools: [],
+        plugins: [],
+        skills: [],
+        models: [],
+        providers: [],
+        namespaces: [],
+      }),
+  }));
+  vi.stubGlobal("fetch", fetchSpy);
+  return fetchSpy;
+}
+
+function renderEditorRoute(path = "/agents/new") {
+  const memRouter = createMemoryRouter(
+    createRoutesFromElements(appRoutes()),
+    { initialEntries: [path] },
+  );
+  return render(
+    <ToastProvider>
+      <ConfirmDialogProvider>
+        <AuthProvider>
+          <RouterProvider router={memRouter} />
+        </AuthProvider>
+      </ConfirmDialogProvider>
+    </ToastProvider>,
+  );
+}
+
+beforeEach(() => {
+  globalThis.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+  stubCapabilitiesFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  __resetAuthInterceptorForTesting();
+});
+
+describe("agent editor tab ARIA semantics", () => {
+  it("renders a tablist with correct role", async () => {
+    renderEditorRoute("/agents/new");
+    // Wait for the page to render (Agent ID field indicates Basics panel is shown)
+    await screen.findByLabelText("Agent ID");
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toBeDefined();
+  });
+
+  it("each tab has role=tab and aria-selected reflects active state", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.length).toBe(5);
+
+    // "basics" is the default active tab
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    expect(basicsTab.getAttribute("aria-selected")).toBe("true");
+
+    // All other tabs are not selected
+    for (const tab of tabs) {
+      if (tab !== basicsTab) {
+        expect(tab.getAttribute("aria-selected")).toBe("false");
+      }
+    }
+  });
+
+  it("active tab has tabIndex=0 and inactive tabs have tabIndex=-1", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    expect(basicsTab.getAttribute("tabindex")).toBe("0");
+
+    const toolsTab = screen.getByRole("tab", { name: "Tools" });
+    expect(toolsTab.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("tab has aria-controls pointing to the corresponding panel id", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    expect(basicsTab.getAttribute("aria-controls")).toBe("panel-basics");
+    expect(basicsTab.getAttribute("id")).toBe("tab-basics");
+  });
+
+  it("active panel has role=tabpanel and aria-labelledby matching the active tab id", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    // By default the basics panel is visible (not hidden)
+    const panels = screen.getAllByRole("tabpanel");
+    // Only one panel should be "visible" (not hidden) at a time
+    // getAllByRole returns only visible roles by default
+    expect(panels.length).toBe(1);
+    const panel = panels[0];
+    expect(panel.getAttribute("aria-labelledby")).toBe("tab-basics");
+    expect(panel.getAttribute("id")).toBe("panel-basics");
+  });
+});
+
+describe("agent editor tab keyboard navigation", () => {
+  it("ArrowRight moves focus and activates next tab", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    basicsTab.focus();
+    fireEvent.keyDown(basicsTab, { key: "ArrowRight" });
+
+    const toolsTab = screen.getByRole("tab", { name: "Tools" });
+    expect(document.activeElement).toBe(toolsTab);
+    expect(toolsTab.getAttribute("aria-selected")).toBe("true");
+    expect(basicsTab.getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("ArrowLeft from first tab wraps to last tab", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    basicsTab.focus();
+    fireEvent.keyDown(basicsTab, { key: "ArrowLeft" });
+
+    const advancedTab = screen.getByRole("tab", { name: "Advanced" });
+    expect(document.activeElement).toBe(advancedTab);
+    expect(advancedTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("Home key jumps to the first tab", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    // Click Tools tab first to make it active, then press Home
+    const toolsTab = screen.getByRole("tab", { name: "Tools" });
+    fireEvent.click(toolsTab);
+    toolsTab.focus();
+    fireEvent.keyDown(toolsTab, { key: "Home" });
+
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    expect(document.activeElement).toBe(basicsTab);
+    expect(basicsTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("End key jumps to the last tab", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    basicsTab.focus();
+    fireEvent.keyDown(basicsTab, { key: "End" });
+
+    const advancedTab = screen.getByRole("tab", { name: "Advanced" });
+    expect(document.activeElement).toBe(advancedTab);
+    expect(advancedTab.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("ArrowRight wraps from last tab to first tab", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    // Click Advanced tab to make it active
+    const advancedTab = screen.getByRole("tab", { name: "Advanced" });
+    fireEvent.click(advancedTab);
+    advancedTab.focus();
+    fireEvent.keyDown(advancedTab, { key: "ArrowRight" });
+
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    expect(document.activeElement).toBe(basicsTab);
+    expect(basicsTab.getAttribute("aria-selected")).toBe("true");
+  });
+});

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Link,
   useNavigate,
@@ -298,46 +298,53 @@ export function AgentEditorPage() {
 
       <div className="grid gap-6 px-6 py-6 md:px-8 xl:grid-cols-[minmax(0,1fr),24rem]">
         <div className="space-y-6">
-          {activeTab === "basics" && (
-            <BasicsPanel
-              spec={spec}
-              capabilities={capabilities}
-              isNew={isNew}
-              updateField={updateField}
-              reasoningMode={reasoningMode}
-            />
-          )}
-
-          {activeTab === "tools" && (
-            <ToolsPanel
-              spec={spec}
-              capabilities={capabilities}
-              updateField={updateField}
-            />
-          )}
-
-          {activeTab === "plugins" && (
-            <PluginsPanel
-              spec={spec}
-              capabilities={capabilities}
-              configurablePlugins={configurablePlugins}
-              visiblePluginSchemas={visiblePluginSchemas}
-              activePluginConfig={activePluginConfig}
-              setActivePluginConfig={setActivePluginConfig}
-              togglePlugin={togglePlugin}
-              updateSection={updateSection}
-            />
-          )}
-
-          {activeTab === "delegates" && (
-            <DelegatesPanel
-              spec={spec}
-              capabilities={capabilities}
-              toggleDelegate={toggleDelegate}
-            />
-          )}
-
-          {activeTab === "advanced" && <AdvancedPanel spec={spec} />}
+          {AGENT_EDITOR_TABS.map((tab) => (
+            <div
+              key={tab.id}
+              role="tabpanel"
+              id={`panel-${tab.id}`}
+              aria-labelledby={`tab-${tab.id}`}
+              tabIndex={0}
+              hidden={activeTab !== tab.id}
+            >
+              {tab.id === "basics" && (
+                <BasicsPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  isNew={isNew}
+                  updateField={updateField}
+                  reasoningMode={reasoningMode}
+                />
+              )}
+              {tab.id === "tools" && (
+                <ToolsPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  updateField={updateField}
+                />
+              )}
+              {tab.id === "plugins" && (
+                <PluginsPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  configurablePlugins={configurablePlugins}
+                  visiblePluginSchemas={visiblePluginSchemas}
+                  activePluginConfig={activePluginConfig}
+                  setActivePluginConfig={setActivePluginConfig}
+                  togglePlugin={togglePlugin}
+                  updateSection={updateSection}
+                />
+              )}
+              {tab.id === "delegates" && (
+                <DelegatesPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  toggleDelegate={toggleDelegate}
+                />
+              )}
+              {tab.id === "advanced" && <AdvancedPanel spec={spec} />}
+            </div>
+          ))}
         </div>
 
         <AgentPreviewPanel draft={spec} />
@@ -363,6 +370,30 @@ function StickyEditorHeader({
   activeTab: AgentEditorTabId;
   onTabChange: (next: AgentEditorTabId) => void;
 }) {
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function handleKeyDown(event: React.KeyboardEvent, index: number) {
+    const count = AGENT_EDITOR_TABS.length;
+    let nextIndex: number | null = null;
+
+    if (event.key === "ArrowRight") {
+      nextIndex = (index + 1) % count;
+    } else if (event.key === "ArrowLeft") {
+      nextIndex = (index - 1 + count) % count;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = count - 1;
+    }
+
+    if (nextIndex !== null) {
+      event.preventDefault();
+      const nextTab = AGENT_EDITOR_TABS[nextIndex];
+      onTabChange(nextTab.id);
+      tabRefs.current[nextIndex]?.focus();
+    }
+  }
+
   return (
     <div className="sticky top-0 z-30 border-b border-slate-200 bg-white/95 px-6 pt-6 backdrop-blur md:px-8">
       <div className="flex flex-wrap items-center justify-between gap-4">
@@ -396,18 +427,28 @@ function StickyEditorHeader({
         </button>
       </div>
 
-      <nav
+      <div
+        role="tablist"
         aria-label="Editor sections"
+        aria-orientation="horizontal"
         className="mt-4 flex gap-1 overflow-x-auto"
       >
-        {AGENT_EDITOR_TABS.map((tab) => {
+        {AGENT_EDITOR_TABS.map((tab, index) => {
           const active = tab.id === activeTab;
           return (
             <button
               key={tab.id}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
               type="button"
+              role="tab"
+              id={`tab-${tab.id}`}
+              aria-selected={active}
+              aria-controls={`panel-${tab.id}`}
+              tabIndex={active ? 0 : -1}
               onClick={() => onTabChange(tab.id)}
-              aria-current={active ? "page" : undefined}
+              onKeyDown={(event) => handleKeyDown(event, index)}
               className={[
                 "shrink-0 rounded-t-lg border-b-2 px-4 py-3 text-sm font-medium transition",
                 active
@@ -419,7 +460,7 @@ function StickyEditorHeader({
             </button>
           );
         })}
-      </nav>
+      </div>
     </div>
   );
 }

--- a/apps/admin-console/src/pages/agents-page.tsx
+++ b/apps/admin-console/src/pages/agents-page.tsx
@@ -13,15 +13,13 @@ import {
 import {
   compareNumber,
   compareString,
-  DEFAULT_PAGE_SIZE,
   filterBySearch,
   paginate,
   sortItems,
   toggleSort,
-  type PageSize,
   type SortConfig,
-  type SortState,
 } from "@/lib/list-view";
+import { useListUrlState } from "@/lib/list-url-state";
 import { adminRoutes } from "@/lib/routes";
 
 type AgentSortKey = "id" | "model_id" | "plugin_count";
@@ -40,19 +38,19 @@ const COLUMNS: SortableColumn<AgentSortKey>[] = [
   { key: null, label: "Actions" },
 ];
 
+const LIST_OPTIONS = {
+  validSortKeys: ["id", "model_id", "plugin_count"] as const,
+  defaultSort: { key: "id" as AgentSortKey, direction: "asc" as const },
+} as const;
+
 export function AgentsPage() {
   const navigate = useNavigate();
   const toast = useToast();
   const confirmDialog = useConfirmDialog();
   const [agents, setAgents] = useState<AgentSpec[]>([]);
   const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<SortState<AgentSortKey> | null>({
-    key: "id",
-    direction: "asc",
-  });
-  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
-  const [page, setPage] = useState(1);
+
+  const { search, sort, pageSize, page, apply: applyListState } = useListUrlState<AgentSortKey>(LIST_OPTIONS);
 
   useEffect(() => {
     let cancelled = false;
@@ -112,8 +110,9 @@ export function AgentsPage() {
 
   useEffect(() => {
     if (view.page !== page) {
-      setPage(view.page);
+      applyListState({ page: view.page });
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view.page, page]);
 
   async function handleDelete(id: string) {
@@ -163,18 +162,12 @@ export function AgentsPage() {
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <ListSearchBar
           value={search}
-          onChange={(next) => {
-            setSearch(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ search: next, page: 1 })}
           placeholder="Search by id, model, or plugin…"
         />
         <PageSizeSelect
           value={pageSize}
-          onChange={(next) => {
-            setPageSize(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ pageSize: next, page: 1 })}
         />
       </div>
 
@@ -195,7 +188,9 @@ export function AgentsPage() {
               <SortableHeader
                 columns={COLUMNS}
                 sort={sort}
-                onSort={(key) => setSort((current) => toggleSort(current, key))}
+                onSort={(key) =>
+                  applyListState({ sort: toggleSort(sort, key), page: 1 })
+                }
               />
               <tbody>
                 {view.items.map((agent) => (
@@ -232,7 +227,7 @@ export function AgentsPage() {
                 startIndex={view.startIndex}
                 endIndex={view.endIndex}
                 totalItems={view.totalItems}
-                onPageChange={setPage}
+                onPageChange={(p) => applyListState({ page: p })}
               />
             ) : null}
           </>

--- a/apps/admin-console/src/pages/agents-page.tsx
+++ b/apps/admin-console/src/pages/agents-page.tsx
@@ -21,25 +21,28 @@ import {
 } from "@/lib/list-view";
 import { useListUrlState } from "@/lib/list-url-state";
 import { adminRoutes } from "@/lib/routes";
+import { formatRelativeTime } from "@/lib/format-time";
 
-type AgentSortKey = "id" | "model_id" | "plugin_count";
+type AgentSortKey = "id" | "model_id" | "plugin_count" | "updated_at";
 
 const SORT_CONFIG: SortConfig<AgentSpec, AgentSortKey> = {
   id: (a, b) => compareString(a.id, b.id),
   model_id: (a, b) => compareString(a.model_id, b.model_id),
   plugin_count: (a, b) =>
     compareNumber(a.plugin_ids?.length ?? 0, b.plugin_ids?.length ?? 0),
+  updated_at: (a, b) => compareNumber(a.updated_at ?? 0, b.updated_at ?? 0),
 };
 
 const COLUMNS: SortableColumn<AgentSortKey>[] = [
   { key: "id", label: "ID" },
   { key: "model_id", label: "Model" },
   { key: "plugin_count", label: "Plugins" },
+  { key: "updated_at", label: "Last modified" },
   { key: null, label: "Actions" },
 ];
 
 const LIST_OPTIONS = {
-  validSortKeys: ["id", "model_id", "plugin_count"] as const,
+  validSortKeys: ["id", "model_id", "plugin_count", "updated_at"] as const,
   defaultSort: { key: "id" as AgentSortKey, direction: "asc" as const },
 } as const;
 
@@ -203,6 +206,9 @@ export function AgentsPage() {
                     <td className="px-5 py-4">{agent.model_id}</td>
                     <td className="px-5 py-4 text-slate-500">
                       {(agent.plugin_ids ?? []).join(", ") || "None"}
+                    </td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {formatRelativeTime(agent.updated_at)}
                     </td>
                     <td className="px-5 py-4">
                       <button

--- a/apps/admin-console/src/pages/eval-reports-page.tsx
+++ b/apps/admin-console/src/pages/eval-reports-page.tsx
@@ -14,11 +14,10 @@ import {
   type ReplayReport,
 } from "@/lib/eval-reports";
 import {
-  DEFAULT_FIXTURE_FILTER,
   filterFixtures,
-  type FixtureFilterState,
   type FixtureStatusFilter,
 } from "@/lib/eval-reports-filter";
+import { useFixtureFilterUrlState } from "@/lib/list-url-state";
 
 const STATUS_OPTIONS: Array<{ value: FixtureStatusFilter; label: string }> = [
   { value: "all", label: "All fixtures" },
@@ -38,9 +37,8 @@ export function EvalReportsPage() {
   const [report, setReport] = useState<FileSlot | null>(null);
   const [baseline, setBaseline] = useState<FileSlot | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [fixtureFilter, setFixtureFilter] = useState<FixtureFilterState>(
-    DEFAULT_FIXTURE_FILTER,
-  );
+
+  const { apply: applyFixtureFilter, ...fixtureFilter } = useFixtureFilterUrlState();
 
   async function readFile(
     event: ChangeEvent<HTMLInputElement>,
@@ -207,10 +205,9 @@ export function EvalReportsPage() {
               <select
                 value={fixtureFilter.status}
                 onChange={(event) =>
-                  setFixtureFilter((current) => ({
-                    ...current,
+                  applyFixtureFilter({
                     status: event.target.value as FixtureStatusFilter,
-                  }))
+                  })
                 }
                 className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 outline-none focus:border-slate-500"
               >
@@ -234,10 +231,7 @@ export function EvalReportsPage() {
                 type="search"
                 value={fixtureFilter.search}
                 onChange={(event) =>
-                  setFixtureFilter((current) => ({
-                    ...current,
-                    search: event.target.value,
-                  }))
+                  applyFixtureFilter({ search: event.target.value })
                 }
                 placeholder="Search by fixture id…"
                 className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"

--- a/apps/admin-console/src/pages/mcp-servers-page.test.tsx
+++ b/apps/admin-console/src/pages/mcp-servers-page.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from "react-router";
+import { appRoutes } from "../app";
+import { AuthProvider } from "../components/auth-provider";
+import { ConfirmDialogProvider } from "../components/confirm-dialog";
+import { ToastProvider } from "../components/toast-provider";
+import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
+
+// Minimal MCP server record returned by the list endpoint.
+function mcpServerItem(id: string) {
+  return {
+    id,
+    transport: "stdio",
+    command: "node",
+    args: ["server.js"],
+    timeout_secs: 30,
+    config: {},
+    restart_policy: { enabled: false },
+    updated_at: 1_700_000_000_000,
+  };
+}
+
+function mcpStatusResponse(connected: boolean, tools: Array<{ name: string; description?: string }> = []) {
+  return { connected, last_error: connected ? null : "connection refused", tools };
+}
+
+function buildFetchMock(overrides?: {
+  listItems?: unknown[];
+  statusConnected?: boolean;
+  statusTools?: Array<{ name: string; description?: string }>;
+}) {
+  const items = overrides?.listItems ?? [mcpServerItem("my-server")];
+  const connected = overrides?.statusConnected ?? true;
+  const tools = overrides?.statusTools ?? [{ name: "ping", description: "ping tool" }];
+
+  return vi.fn(async (url: string | URL | Request) => {
+    const href = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+
+    // capabilities
+    if (href.includes("/v1/capabilities")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({ agents: [], tools: [], plugins: [], skills: [], models: [], providers: [], namespaces: [] }),
+      };
+    }
+
+    // list mcp-servers
+    if (href.includes("/v1/config/mcp-servers") && !href.includes("/status") && !href.includes("/restart")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({ namespace: "mcp-servers", items, offset: 0, limit: 100 }),
+      };
+    }
+
+    // per-server status
+    if (href.includes("/v1/mcp-servers/") && href.includes("/status")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(mcpStatusResponse(connected, tools)),
+      };
+    }
+
+    // fallback: 404
+    return { ok: false, status: 404, text: async () => JSON.stringify({ error: "not found" }) };
+  });
+}
+
+function renderMcpPage() {
+  const memRouter = createMemoryRouter(
+    createRoutesFromElements(appRoutes()),
+    { initialEntries: ["/mcp-servers"] },
+  );
+  return render(
+    <ToastProvider>
+      <ConfirmDialogProvider>
+        <AuthProvider>
+          <RouterProvider router={memRouter} />
+        </AuthProvider>
+      </ConfirmDialogProvider>
+    </ToastProvider>,
+  );
+}
+
+beforeEach(() => {
+  if (typeof globalThis.localStorage !== "undefined") {
+    globalThis.localStorage.clear();
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  __resetAuthInterceptorForTesting();
+});
+
+describe("MCP servers page — status badge", () => {
+  it("renders a green status badge when the server is connected", async () => {
+    vi.stubGlobal("fetch", buildFetchMock({ statusConnected: true }));
+    renderMcpPage();
+
+    // Wait for the server row to appear.
+    await screen.findByText("my-server");
+
+    // Wait for status fetch to complete; the connected badge has title="Connected".
+    await waitFor(() => {
+      const badge = document.querySelector('[title="Connected"]');
+      expect(badge).not.toBeNull();
+    });
+  });
+
+  it("renders a red status badge when the server is disconnected", async () => {
+    vi.stubGlobal("fetch", buildFetchMock({ statusConnected: false, statusTools: [] }));
+    renderMcpPage();
+
+    await screen.findByText("my-server");
+
+    await waitFor(() => {
+      const badge = document.querySelector('[title^="Error:"]');
+      expect(badge).not.toBeNull();
+    });
+  });
+
+  it("shows a loading badge (grey) before status is fetched", async () => {
+    // Use a fetch that hangs for status to observe the loading state.
+    let resolveStatus!: () => void;
+    const statusPending = new Promise<void>((r) => { resolveStatus = r; });
+
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const href = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+
+      if (href.includes("/v1/capabilities")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({ agents: [], tools: [], plugins: [], skills: [], models: [], providers: [], namespaces: [] }),
+        };
+      }
+      if (href.includes("/v1/config/mcp-servers")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({ namespace: "mcp-servers", items: [mcpServerItem("my-server")], offset: 0, limit: 100 }),
+        };
+      }
+      if (href.includes("/v1/mcp-servers/") && href.includes("/status")) {
+        await statusPending;
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(mcpStatusResponse(true, [])),
+        };
+      }
+      return { ok: false, status: 404, text: async () => '{"error":"not found"}' };
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderMcpPage();
+
+    await screen.findByText("my-server");
+
+    // While status is pending, a grey/loading dot should be present.
+    const loadingBadge = document.querySelector('[title="Loading status..."]');
+    expect(loadingBadge).not.toBeNull();
+
+    resolveStatus();
+  });
+
+  it("renders discovered tools in the editor when status is loaded", async () => {
+    const tools = [
+      { name: "list_files", description: "List directory files" },
+      { name: "read_file", description: "Read a file" },
+    ];
+    vi.stubGlobal("fetch", buildFetchMock({ statusConnected: true, statusTools: tools }));
+    renderMcpPage();
+
+    await screen.findByText("my-server");
+
+    // Click Edit to open the editor.
+    const editButton = await screen.findByRole("button", { name: "Edit" });
+    editButton.click();
+
+    // Wait for the tools list to appear in the editor.
+    await waitFor(() => {
+      expect(screen.getByText("list_files")).toBeDefined();
+      expect(screen.getByText("read_file")).toBeDefined();
+    });
+  });
+});

--- a/apps/admin-console/src/pages/mcp-servers-page.tsx
+++ b/apps/admin-console/src/pages/mcp-servers-page.tsx
@@ -15,15 +15,13 @@ import {
 } from "@/components/list-controls";
 import {
   compareString,
-  DEFAULT_PAGE_SIZE,
   filterBySearch,
   paginate,
   sortItems,
   toggleSort,
-  type PageSize,
   type SortConfig,
-  type SortState,
 } from "@/lib/list-view";
+import { useListUrlState } from "@/lib/list-url-state";
 import {
   parseJsonObject,
   parseLineList,
@@ -54,6 +52,11 @@ const COLUMNS: SortableColumn<McpSortKey>[] = [
   { key: null, label: "Environment" },
   { key: null, label: "Actions" },
 ];
+
+const LIST_OPTIONS = {
+  validSortKeys: ["id", "transport", "endpoint"] as const,
+  defaultSort: { key: "id" as McpSortKey, direction: "asc" as const },
+} as const;
 
 type EnvMode = "preserve" | "replace" | "clear";
 
@@ -112,13 +115,7 @@ export function McpServersPage() {
     prepareSave,
   });
 
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<SortState<McpSortKey> | null>({
-    key: "id",
-    direction: "asc",
-  });
-  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
-  const [page, setPage] = useState(1);
+  const { search, sort, pageSize, page, apply: applyListState } = useListUrlState<McpSortKey>(LIST_OPTIONS);
 
   const filtered = useMemo(
     () =>
@@ -140,7 +137,8 @@ export function McpServersPage() {
   );
 
   useEffect(() => {
-    if (view.page !== page) setPage(view.page);
+    if (view.page !== page) applyListState({ page: view.page });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view.page, page]);
 
   function startCreate() {
@@ -501,18 +499,12 @@ export function McpServersPage() {
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <ListSearchBar
           value={search}
-          onChange={(next) => {
-            setSearch(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ search: next, page: 1 })}
           placeholder="Search by id, transport, endpoint, env key…"
         />
         <PageSizeSelect
           value={pageSize}
-          onChange={(next) => {
-            setPageSize(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ pageSize: next, page: 1 })}
         />
       </div>
 
@@ -535,7 +527,9 @@ export function McpServersPage() {
               <SortableHeader
                 columns={COLUMNS}
                 sort={sort}
-                onSort={(key) => setSort((current) => toggleSort(current, key))}
+                onSort={(key) =>
+                  applyListState({ sort: toggleSort(sort, key), page: 1 })
+                }
               />
               <tbody>
                 {view.items.map((server) => (
@@ -582,7 +576,7 @@ export function McpServersPage() {
                 startIndex={view.startIndex}
                 endIndex={view.endIndex}
                 totalItems={view.totalItems}
-                onPageChange={setPage}
+                onPageChange={(p) => applyListState({ page: p })}
               />
             ) : null}
           </>

--- a/apps/admin-console/src/pages/mcp-servers-page.tsx
+++ b/apps/admin-console/src/pages/mcp-servers-page.tsx
@@ -3,8 +3,11 @@ import {
   type McpRestartPolicy,
   type McpServerRecord,
   type McpServerSpec,
+  configApi,
 } from "@/lib/config-api";
 import { useCrudPage } from "@/lib/use-crud-page";
+import { useConfirmDialog } from "@/components/confirm-dialog";
+import { useToast } from "@/components/toast-provider";
 import { Field, ModeButton } from "@/components/form-components";
 import {
   ListSearchBar,
@@ -54,6 +57,7 @@ const COLUMNS: SortableColumn<McpSortKey>[] = [
   { key: "endpoint", label: "Endpoint" },
   { key: null, label: "Environment" },
   { key: "updated_at", label: "Last modified" },
+  { key: null, label: "Status" },
   { key: null, label: "Actions" },
 ];
 
@@ -81,11 +85,39 @@ const EMPTY_SERVER: McpServerRecord = {
   restart_policy: { ...DEFAULT_RESTART_POLICY },
 };
 
+type McpServerStatus = {
+  connected: boolean;
+  last_error?: string | null;
+  tools: Array<{ name: string; description?: string | null }>;
+};
+
+function StatusBadge({ status }: { status: McpServerStatus | null | undefined }) {
+  if (status === undefined) {
+    return <span className="inline-block h-2 w-2 rounded-full bg-slate-300" title="Loading status..." />;
+  }
+  if (status === null) {
+    return <span className="inline-block h-2 w-2 rounded-full bg-slate-300" title="Status unavailable" />;
+  }
+  if (status.connected) {
+    return <span className="inline-block h-2 w-2 rounded-full bg-green-500" title="Connected" />;
+  }
+  return (
+    <span
+      className="inline-block h-2 w-2 rounded-full bg-red-500"
+      title={status.last_error ? `Error: ${status.last_error}` : "Disconnected"}
+    />
+  );
+}
+
 export function McpServersPage() {
   const [argsDraft, setArgsDraft] = useState("");
   const [configDraft, setConfigDraft] = useState("{}");
   const [envDraft, setEnvDraft] = useState("{}");
   const [envMode, setEnvMode] = useState<EnvMode>("replace");
+  const [statuses, setStatuses] = useState<Record<string, McpServerStatus | null>>({});
+  const [restarting, setRestarting] = useState(false);
+  const confirm = useConfirmDialog();
+  const toast = useToast();
 
   const prepareSave = useCallback(
     (draft: McpServerRecord): McpServerSpec => {
@@ -120,6 +152,54 @@ export function McpServersPage() {
   });
 
   const { search, sort, pageSize, page, apply: applyListState } = useListUrlState<McpSortKey>(LIST_OPTIONS);
+
+  // Fetch live status for all loaded servers in parallel.
+  useEffect(() => {
+    if (crud.items.length === 0) return;
+    const ids = crud.items.map((s) => s.id);
+    // Initialise to undefined (loading) for unknown ids.
+    setStatuses((prev) => {
+      const next = { ...prev };
+      for (const id of ids) {
+        if (!(id in next)) next[id] = undefined as unknown as null;
+      }
+      return next;
+    });
+    void Promise.allSettled(
+      ids.map((id) =>
+        configApi.mcpStatus(id).then(
+          (s) => setStatuses((prev) => ({ ...prev, [id]: s })),
+          () => setStatuses((prev) => ({ ...prev, [id]: null })),
+        ),
+      ),
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [crud.items.length]);
+
+  async function handleRestart(id: string) {
+    const ok = await confirm({
+      title: "Restart MCP server?",
+      description: `This will immediately reconnect "${id}". In-flight tool calls may be interrupted.`,
+      confirmLabel: "Restart",
+    });
+    if (!ok) return;
+    setRestarting(true);
+    try {
+      await configApi.mcpRestart(id);
+      toast.push({ message: `MCP server "${id}" restart triggered.`, tone: "success" });
+      // Re-fetch status after restart.
+      try {
+        const s = await configApi.mcpStatus(id);
+        setStatuses((prev) => ({ ...prev, [id]: s }));
+      } catch {
+        setStatuses((prev) => ({ ...prev, [id]: null }));
+      }
+    } catch (err) {
+      toast.push({ message: `Restart failed: ${err instanceof Error ? err.message : String(err)}`, tone: "error" });
+    } finally {
+      setRestarting(false);
+    }
+  }
 
   const filtered = useMemo(
     () =>
@@ -480,6 +560,45 @@ export function McpServersPage() {
             </div>
           </section>
 
+          {crud.isEditingExisting && crud.draft ? (
+            <section className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-2">
+                  <StatusBadge status={statuses[crud.draft.id]} />
+                  <h4 className="text-sm font-semibold text-slate-900">Live Status</h4>
+                  {statuses[crud.draft.id]?.last_error ? (
+                    <span className="text-xs text-red-600">{statuses[crud.draft.id]?.last_error}</span>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  disabled={restarting}
+                  onClick={() => void handleRestart(crud.draft!.id)}
+                  className="rounded-xl border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {restarting ? "Restarting..." : "Restart"}
+                </button>
+              </div>
+              {statuses[crud.draft.id]?.tools && statuses[crud.draft.id]!.tools.length > 0 ? (
+                <div className="mt-3">
+                  <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-slate-500">
+                    Discovered tools ({statuses[crud.draft.id]!.tools.length})
+                  </p>
+                  <ul className="space-y-1">
+                    {statuses[crud.draft.id]!.tools.map((tool) => (
+                      <li key={tool.name} className="flex flex-col">
+                        <span className="font-mono text-xs text-slate-800">{tool.name}</span>
+                        {tool.description ? (
+                          <span className="text-xs text-slate-500">{tool.description}</span>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+
           <div className="mt-5 flex gap-3">
             <button
               type="button"
@@ -553,6 +672,9 @@ export function McpServersPage() {
                     </td>
                     <td className="px-5 py-4 text-slate-500">
                       {formatRelativeTime(server.updated_at)}
+                    </td>
+                    <td className="px-5 py-4">
+                      <StatusBadge status={statuses[server.id]} />
                     </td>
                     <td className="px-5 py-4">
                       <div className="flex gap-4">

--- a/apps/admin-console/src/pages/mcp-servers-page.tsx
+++ b/apps/admin-console/src/pages/mcp-servers-page.tsx
@@ -14,6 +14,7 @@ import {
   type SortableColumn,
 } from "@/components/list-controls";
 import {
+  compareNumber,
   compareString,
   filterBySearch,
   paginate,
@@ -22,6 +23,7 @@ import {
   type SortConfig,
 } from "@/lib/list-view";
 import { useListUrlState } from "@/lib/list-url-state";
+import { formatRelativeTime } from "@/lib/format-time";
 import {
   parseJsonObject,
   parseLineList,
@@ -30,7 +32,7 @@ import {
   stringifyLineList,
 } from "@/lib/config-form-helpers";
 
-type McpSortKey = "id" | "transport" | "endpoint";
+type McpSortKey = "id" | "transport" | "endpoint" | "updated_at";
 
 function endpointFor(server: McpServerRecord): string {
   if (server.transport === "stdio") {
@@ -43,6 +45,7 @@ const SORT_CONFIG: SortConfig<McpServerRecord, McpSortKey> = {
   id: (a, b) => compareString(a.id, b.id),
   transport: (a, b) => compareString(a.transport, b.transport),
   endpoint: (a, b) => compareString(endpointFor(a), endpointFor(b)),
+  updated_at: (a, b) => compareNumber(a.updated_at ?? 0, b.updated_at ?? 0),
 };
 
 const COLUMNS: SortableColumn<McpSortKey>[] = [
@@ -50,11 +53,12 @@ const COLUMNS: SortableColumn<McpSortKey>[] = [
   { key: "transport", label: "Transport" },
   { key: "endpoint", label: "Endpoint" },
   { key: null, label: "Environment" },
+  { key: "updated_at", label: "Last modified" },
   { key: null, label: "Actions" },
 ];
 
 const LIST_OPTIONS = {
-  validSortKeys: ["id", "transport", "endpoint"] as const,
+  validSortKeys: ["id", "transport", "endpoint", "updated_at"] as const,
   defaultSort: { key: "id" as McpSortKey, direction: "asc" as const },
 } as const;
 
@@ -546,6 +550,9 @@ export function McpServersPage() {
                       {server.has_env
                         ? (server.env_keys ?? []).join(", ") || "Stored"
                         : "None"}
+                    </td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {formatRelativeTime(server.updated_at)}
                     </td>
                     <td className="px-5 py-4">
                       <div className="flex gap-4">

--- a/apps/admin-console/src/pages/models-page.tsx
+++ b/apps/admin-console/src/pages/models-page.tsx
@@ -14,6 +14,7 @@ import {
   type SortableColumn,
 } from "@/components/list-controls";
 import {
+  compareNumber,
   compareString,
   filterBySearch,
   paginate,
@@ -22,6 +23,7 @@ import {
   type SortConfig,
 } from "@/lib/list-view";
 import { useListUrlState } from "@/lib/list-url-state";
+import { formatRelativeTime } from "@/lib/format-time";
 
 const EMPTY_MODEL: ModelBindingSpec = {
   id: "",
@@ -34,23 +36,25 @@ const auxiliaryLoaders = () =>
     .list<ProviderRecord>("providers")
     .then((response) => response.items.map((provider) => provider.id));
 
-type ModelSortKey = "id" | "provider_id" | "upstream_model";
+type ModelSortKey = "id" | "provider_id" | "upstream_model" | "updated_at";
 
 const SORT_CONFIG: SortConfig<ModelBindingSpec, ModelSortKey> = {
   id: (a, b) => compareString(a.id, b.id),
   provider_id: (a, b) => compareString(a.provider_id, b.provider_id),
   upstream_model: (a, b) => compareString(a.upstream_model, b.upstream_model),
+  updated_at: (a, b) => compareNumber(a.updated_at ?? 0, b.updated_at ?? 0),
 };
 
 const COLUMNS: SortableColumn<ModelSortKey>[] = [
   { key: "id", label: "ID" },
   { key: "provider_id", label: "Provider" },
   { key: "upstream_model", label: "Upstream Model" },
+  { key: "updated_at", label: "Last modified" },
   { key: null, label: "Actions" },
 ];
 
 const LIST_OPTIONS = {
-  validSortKeys: ["id", "provider_id", "upstream_model"] as const,
+  validSortKeys: ["id", "provider_id", "upstream_model", "updated_at"] as const,
   defaultSort: { key: "id" as ModelSortKey, direction: "asc" as const },
 } as const;
 
@@ -236,6 +240,9 @@ export function ModelsPage() {
                     <td className="px-5 py-4">{model.provider_id}</td>
                     <td className="px-5 py-4 text-slate-500">
                       {model.upstream_model}
+                    </td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {formatRelativeTime(model.updated_at)}
                     </td>
                     <td className="px-5 py-4">
                       <div className="flex gap-4">

--- a/apps/admin-console/src/pages/models-page.tsx
+++ b/apps/admin-console/src/pages/models-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import {
   type ModelBindingSpec,
   type ProviderRecord,
@@ -15,15 +15,13 @@ import {
 } from "@/components/list-controls";
 import {
   compareString,
-  DEFAULT_PAGE_SIZE,
   filterBySearch,
   paginate,
   sortItems,
   toggleSort,
-  type PageSize,
   type SortConfig,
-  type SortState,
 } from "@/lib/list-view";
+import { useListUrlState } from "@/lib/list-url-state";
 
 const EMPTY_MODEL: ModelBindingSpec = {
   id: "",
@@ -51,6 +49,11 @@ const COLUMNS: SortableColumn<ModelSortKey>[] = [
   { key: null, label: "Actions" },
 ];
 
+const LIST_OPTIONS = {
+  validSortKeys: ["id", "provider_id", "upstream_model"] as const,
+  defaultSort: { key: "id" as ModelSortKey, direction: "asc" as const },
+} as const;
+
 export function ModelsPage() {
   const crud = useCrudPage<ModelBindingSpec>({
     namespace: "models",
@@ -58,13 +61,7 @@ export function ModelsPage() {
     auxiliaryLoaders,
   });
 
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<SortState<ModelSortKey> | null>({
-    key: "id",
-    direction: "asc",
-  });
-  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
-  const [page, setPage] = useState(1);
+  const { search, sort, pageSize, page, apply: applyListState } = useListUrlState<ModelSortKey>(LIST_OPTIONS);
 
   const providerIds = crud.auxiliaryData as string[];
   const providerOptions = useMemo(() => {
@@ -101,7 +98,8 @@ export function ModelsPage() {
   );
 
   useEffect(() => {
-    if (view.page !== page) setPage(view.page);
+    if (view.page !== page) applyListState({ page: view.page });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view.page, page]);
 
   return (
@@ -198,18 +196,12 @@ export function ModelsPage() {
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <ListSearchBar
           value={search}
-          onChange={(next) => {
-            setSearch(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ search: next, page: 1 })}
           placeholder="Search by id, provider, upstream…"
         />
         <PageSizeSelect
           value={pageSize}
-          onChange={(next) => {
-            setPageSize(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ pageSize: next, page: 1 })}
         />
       </div>
 
@@ -230,7 +222,9 @@ export function ModelsPage() {
               <SortableHeader
                 columns={COLUMNS}
                 sort={sort}
-                onSort={(key) => setSort((current) => toggleSort(current, key))}
+                onSort={(key) =>
+                  applyListState({ sort: toggleSort(sort, key), page: 1 })
+                }
               />
               <tbody>
                 {view.items.map((model) => (
@@ -272,7 +266,7 @@ export function ModelsPage() {
                 startIndex={view.startIndex}
                 endIndex={view.endIndex}
                 totalItems={view.totalItems}
-                onPageChange={setPage}
+                onPageChange={(p) => applyListState({ page: p })}
               />
             ) : null}
           </>

--- a/apps/admin-console/src/pages/providers-page.test.tsx
+++ b/apps/admin-console/src/pages/providers-page.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, act } from "@testing-library/react";
+import {
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from "react-router";
+import { appRoutes } from "../app";
+import { AuthProvider } from "../components/auth-provider";
+import { ConfirmDialogProvider } from "../components/confirm-dialog";
+import { ToastProvider } from "../components/toast-provider";
+import { ADMIN_TOKEN_STORAGE_KEY } from "../lib/config-api";
+import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
+
+const PROVIDER_RECORD = {
+  id: "my-openai",
+  adapter: "openai",
+  has_api_key: true,
+  timeout_secs: 300,
+  created_at: 1000,
+  updated_at: 2000,
+};
+
+function stubFetch(overrides?: Record<string, unknown>) {
+  const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method?.toUpperCase() ?? "GET";
+    const urlStr = String(url);
+
+    // capabilities
+    if (urlStr.includes("/v1/capabilities")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            supported_adapters: ["openai", "anthropic"],
+            namespaces: [],
+          }),
+      };
+    }
+
+    // list providers
+    if (urlStr.includes("/v1/config/providers") && method === "GET") {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            namespace: "providers",
+            items: [PROVIDER_RECORD],
+            offset: 0,
+            limit: 100,
+          }),
+      };
+    }
+
+    // test provider
+    if (urlStr.includes("/v1/providers/") && urlStr.endsWith("/test") && method === "POST") {
+      const defaults = { ok: true, latency_ms: 42 };
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ ...defaults, ...overrides }),
+      };
+    }
+
+    // fallback
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({}),
+    };
+  });
+  vi.stubGlobal("fetch", fetchSpy);
+  return fetchSpy;
+}
+
+function renderProviders() {
+  const memRouter = createMemoryRouter(
+    createRoutesFromElements(appRoutes()),
+    { initialEntries: ["/providers"] },
+  );
+  return render(
+    <ToastProvider>
+      <ConfirmDialogProvider>
+        <AuthProvider>
+          <RouterProvider router={memRouter} />
+        </AuthProvider>
+      </ConfirmDialogProvider>
+    </ToastProvider>,
+  );
+}
+
+beforeEach(() => {
+  globalThis.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  __resetAuthInterceptorForTesting();
+});
+
+describe("ProvidersPage — Test connection button", () => {
+  it("does not show Test connection button when creating a new provider", async () => {
+    stubFetch();
+    renderProviders();
+
+    const newButton = await screen.findByRole("button", { name: /new provider/i });
+    fireEvent.click(newButton);
+
+    await screen.findByText(/create provider/i);
+    const buttons = screen.queryAllByRole("button", { name: /test connection/i });
+    expect(buttons).toHaveLength(0);
+  });
+
+  it("shows Test connection button when editing an existing provider", async () => {
+    stubFetch();
+    renderProviders();
+
+    const editButton = await screen.findByRole("button", { name: /edit/i });
+    fireEvent.click(editButton);
+
+    await screen.findByText(/edit provider/i);
+    expect(screen.getByRole("button", { name: /test connection/i })).toBeDefined();
+  });
+
+  it("calls testProvider and shows success status badge on OK result", async () => {
+    const fetchSpy = stubFetch({ ok: true, latency_ms: 55 });
+    renderProviders();
+
+    const editButton = await screen.findByRole("button", { name: /edit/i });
+    fireEvent.click(editButton);
+
+    await screen.findByText(/edit provider/i);
+
+    const testBtn = screen.getByRole("button", { name: /test connection/i });
+    await act(async () => {
+      fireEvent.click(testBtn);
+    });
+
+    // status badge should appear
+    await screen.findByText(/OK — 55ms/i);
+
+    // fetch was called with the test endpoint
+    const testCall = fetchSpy.mock.calls.find(([url]) =>
+      String(url).includes("/v1/providers/my-openai/test"),
+    );
+    expect(testCall).toBeDefined();
+  });
+
+  it("shows failure status badge when test returns ok=false", async () => {
+    stubFetch({ ok: false, latency_ms: 10, error: "unsupported adapter: stub" });
+    renderProviders();
+
+    const editButton = await screen.findByRole("button", { name: /edit/i });
+    fireEvent.click(editButton);
+
+    await screen.findByText(/edit provider/i);
+
+    const testBtn = screen.getByRole("button", { name: /test connection/i });
+    await act(async () => {
+      fireEvent.click(testBtn);
+    });
+
+    await screen.findByText(/Failed.*unsupported adapter: stub/i);
+  });
+});

--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/list-controls";
 import {
   compareBoolean,
+  compareNumber,
   compareString,
   filterBySearch,
   paginate,
@@ -23,14 +24,16 @@ import {
   type SortConfig,
 } from "@/lib/list-view";
 import { useListUrlState } from "@/lib/list-url-state";
+import { formatRelativeTime } from "@/lib/format-time";
 
-type ProviderSortKey = "id" | "adapter" | "base_url" | "has_api_key";
+type ProviderSortKey = "id" | "adapter" | "base_url" | "has_api_key" | "updated_at";
 
 const SORT_CONFIG: SortConfig<ProviderRecord, ProviderSortKey> = {
   id: (a, b) => compareString(a.id, b.id),
   adapter: (a, b) => compareString(a.adapter, b.adapter),
   base_url: (a, b) => compareString(a.base_url, b.base_url),
   has_api_key: (a, b) => compareBoolean(a.has_api_key, b.has_api_key),
+  updated_at: (a, b) => compareNumber(a.updated_at ?? 0, b.updated_at ?? 0),
 };
 
 const COLUMNS: SortableColumn<ProviderSortKey>[] = [
@@ -38,6 +41,7 @@ const COLUMNS: SortableColumn<ProviderSortKey>[] = [
   { key: "adapter", label: "Adapter" },
   { key: "base_url", label: "Base URL" },
   { key: "has_api_key", label: "API Key" },
+  { key: "updated_at", label: "Last modified" },
   { key: null, label: "Actions" },
 ];
 
@@ -69,7 +73,7 @@ const EMPTY_PROVIDER: ProviderRecord = {
 };
 
 const LIST_OPTIONS = {
-  validSortKeys: ["id", "adapter", "base_url", "has_api_key"] as const,
+  validSortKeys: ["id", "adapter", "base_url", "has_api_key", "updated_at"] as const,
   defaultSort: { key: "id" as ProviderSortKey, direction: "asc" as const },
 } as const;
 
@@ -371,6 +375,9 @@ export function ProvidersPage() {
                     </td>
                     <td className="px-5 py-4 text-slate-500">
                       {provider.has_api_key ? "Stored" : "Environment / none"}
+                    </td>
+                    <td className="px-5 py-4 text-slate-500">
+                      {formatRelativeTime(provider.updated_at)}
                     </td>
                     <td className="px-5 py-4">
                       <div className="flex gap-4">

--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ConfigApiError,
   configApi,
   type ProviderRecord,
   type ProviderSpec,
 } from "@/lib/config-api";
+import { useToast } from "@/components/toast-provider";
 import { useCrudPage } from "@/lib/use-crud-page";
 import { Field, ModeButton } from "@/components/form-components";
 import {
@@ -77,9 +79,20 @@ const LIST_OPTIONS = {
   defaultSort: { key: "id" as ProviderSortKey, direction: "asc" as const },
 } as const;
 
+interface TestStatus {
+  ok: boolean;
+  latency_ms: number;
+  error?: string;
+  testedAt: number;
+}
+
 export function ProvidersPage() {
   const [apiKeyMode, setApiKeyMode] = useState<ApiKeyMode>("replace");
   const [apiKeyDraft, setApiKeyDraft] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [testStatus, setTestStatus] = useState<TestStatus | null>(null);
+  const toast = useToast();
+  const testingIdRef = useRef<string | null>(null);
 
   const prepareSave = useCallback(
     (draft: ProviderRecord): ProviderSpec => {
@@ -150,12 +163,39 @@ export function ProvidersPage() {
     crud.startNew({ ...EMPTY_PROVIDER });
     setApiKeyMode("replace");
     setApiKeyDraft("");
+    setTestStatus(null);
   }
 
   function startEdit(provider: ProviderRecord) {
     crud.startEdit(provider);
     setApiKeyMode("preserve");
     setApiKeyDraft("");
+    setTestStatus(null);
+  }
+
+  async function handleTestConnection() {
+    if (!crud.draft || !crud.isEditingExisting) return;
+    const id = crud.draft.id;
+    testingIdRef.current = id;
+    setTesting(true);
+    try {
+      const result = await configApi.testProvider(id);
+      if (testingIdRef.current !== id) return;
+      setTestStatus({ ...result, testedAt: Date.now() });
+      if (result.ok) {
+        toast.success(`Provider OK (${result.latency_ms}ms)`);
+      } else {
+        toast.error(result.error ?? "Provider test failed");
+      }
+    } catch (err) {
+      if (testingIdRef.current !== id) return;
+      const message =
+        err instanceof ConfigApiError ? err.message : "Provider test failed";
+      setTestStatus({ ok: false, latency_ms: 0, error: message, testedAt: Date.now() });
+      toast.error(message);
+    } finally {
+      if (testingIdRef.current === id) setTesting(false);
+    }
   }
 
   async function handleSave() {
@@ -307,7 +347,7 @@ export function ProvidersPage() {
             )}
           </section>
 
-          <div className="mt-5 flex gap-3">
+          <div className="mt-5 flex flex-wrap items-center gap-3">
             <button
               type="button"
               onClick={() => void handleSave()}
@@ -323,7 +363,36 @@ export function ProvidersPage() {
             >
               Cancel
             </button>
+            {crud.isEditingExisting ? (
+              <button
+                type="button"
+                onClick={() => void handleTestConnection()}
+                disabled={testing}
+                className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {testing ? "Testing..." : "Test connection"}
+              </button>
+            ) : null}
           </div>
+
+          {testStatus !== null ? (
+            <div
+              className={`mt-3 flex items-center gap-2 rounded-xl border px-4 py-2 text-sm ${
+                testStatus.ok
+                  ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                  : "border-rose-200 bg-rose-50 text-rose-700"
+              }`}
+            >
+              <span className="font-medium">
+                {testStatus.ok
+                  ? `OK — ${testStatus.latency_ms}ms`
+                  : `Failed${testStatus.error ? `: ${testStatus.error}` : ""}`}
+              </span>
+              <span className="ml-auto text-xs opacity-60">
+                {new Date(testStatus.testedAt).toLocaleTimeString()}
+              </span>
+            </div>
+          ) : null}
         </section>
       ) : null}
 

--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -16,15 +16,13 @@ import {
 import {
   compareBoolean,
   compareString,
-  DEFAULT_PAGE_SIZE,
   filterBySearch,
   paginate,
   sortItems,
   toggleSort,
-  type PageSize,
   type SortConfig,
-  type SortState,
 } from "@/lib/list-view";
+import { useListUrlState } from "@/lib/list-url-state";
 
 type ProviderSortKey = "id" | "adapter" | "base_url" | "has_api_key";
 
@@ -70,6 +68,11 @@ const EMPTY_PROVIDER: ProviderRecord = {
   timeout_secs: 300,
 };
 
+const LIST_OPTIONS = {
+  validSortKeys: ["id", "adapter", "base_url", "has_api_key"] as const,
+  defaultSort: { key: "id" as ProviderSortKey, direction: "asc" as const },
+} as const;
+
 export function ProvidersPage() {
   const [apiKeyMode, setApiKeyMode] = useState<ApiKeyMode>("replace");
   const [apiKeyDraft, setApiKeyDraft] = useState("");
@@ -114,13 +117,7 @@ export function ProvidersPage() {
     return Array.from(options).sort((left, right) => left.localeCompare(right));
   }, [crud.draft?.adapter, serverAdapters]);
 
-  const [search, setSearch] = useState("");
-  const [sort, setSort] = useState<SortState<ProviderSortKey> | null>({
-    key: "id",
-    direction: "asc",
-  });
-  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
-  const [page, setPage] = useState(1);
+  const { search, sort, pageSize, page, apply: applyListState } = useListUrlState<ProviderSortKey>(LIST_OPTIONS);
 
   const filtered = useMemo(
     () =>
@@ -141,7 +138,8 @@ export function ProvidersPage() {
   );
 
   useEffect(() => {
-    if (view.page !== page) setPage(view.page);
+    if (view.page !== page) applyListState({ page: view.page });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [view.page, page]);
 
   function startCreate() {
@@ -328,18 +326,12 @@ export function ProvidersPage() {
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <ListSearchBar
           value={search}
-          onChange={(next) => {
-            setSearch(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ search: next, page: 1 })}
           placeholder="Search by id, adapter, base url…"
         />
         <PageSizeSelect
           value={pageSize}
-          onChange={(next) => {
-            setPageSize(next);
-            setPage(1);
-          }}
+          onChange={(next) => applyListState({ pageSize: next, page: 1 })}
         />
       </div>
 
@@ -362,7 +354,9 @@ export function ProvidersPage() {
               <SortableHeader
                 columns={COLUMNS}
                 sort={sort}
-                onSort={(key) => setSort((current) => toggleSort(current, key))}
+                onSort={(key) =>
+                  applyListState({ sort: toggleSort(sort, key), page: 1 })
+                }
               />
               <tbody>
                 {view.items.map((provider) => (
@@ -407,7 +401,7 @@ export function ProvidersPage() {
                 startIndex={view.startIndex}
                 endIndex={view.endIndex}
                 totalItems={view.totalItems}
-                onPageChange={setPage}
+                onPageChange={(p) => applyListState({ page: p })}
               />
             ) : null}
           </>

--- a/apps/admin-console/src/pages/skills-page.tsx
+++ b/apps/admin-console/src/pages/skills-page.tsx
@@ -2,12 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import { type SkillInfo, configApi } from "@/lib/config-api";
 import { useToast } from "@/components/toast-provider";
 import {
-  DEFAULT_SKILLS_FILTER,
   filterSkills,
   type ContextFilter,
   type InvocableFilter,
-  type SkillsFilterState,
 } from "@/lib/skills-filter";
+import { useSkillsFilterUrlState } from "@/lib/list-url-state";
 
 const INVOCABLE_OPTIONS: Array<{ value: InvocableFilter; label: string }> = [
   { value: "any", label: "Any caller" },
@@ -26,7 +25,8 @@ export function SkillsPage() {
   const toast = useToast();
   const [skills, setSkills] = useState<SkillInfo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filter, setFilter] = useState<SkillsFilterState>(DEFAULT_SKILLS_FILTER);
+
+  const { apply: applyFilter, ...filter } = useSkillsFilterUrlState();
 
   useEffect(() => {
     let cancelled = false;
@@ -87,7 +87,7 @@ export function SkillsPage() {
             type="search"
             value={filter.search}
             onChange={(event) =>
-              setFilter((current) => ({ ...current, search: event.target.value }))
+              applyFilter({ search: event.target.value })
             }
             placeholder="Search by id, name, description, tool, path…"
             className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
@@ -98,10 +98,7 @@ export function SkillsPage() {
           <select
             value={filter.invocable}
             onChange={(event) =>
-              setFilter((current) => ({
-                ...current,
-                invocable: event.target.value as InvocableFilter,
-              }))
+              applyFilter({ invocable: event.target.value as InvocableFilter })
             }
             className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 outline-none focus:border-slate-500"
           >
@@ -117,10 +114,7 @@ export function SkillsPage() {
           <select
             value={filter.context}
             onChange={(event) =>
-              setFilter((current) => ({
-                ...current,
-                context: event.target.value as ContextFilter,
-              }))
+              applyFilter({ context: event.target.value as ContextFilter })
             }
             className="rounded-md border border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 outline-none focus:border-slate-500"
           >

--- a/crates/awaken-contract/src/registry_spec.rs
+++ b/crates/awaken-contract/src/registry_spec.rs
@@ -111,6 +111,12 @@ pub struct AgentSpec {
     /// `None` for locally defined agents; `Some("cloud")` for agents from the "cloud" registry.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub registry: Option<String>,
+    /// Creation timestamp in epoch milliseconds. Set by the config API on first write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<u64>,
+    /// Last-modified timestamp in epoch milliseconds. Updated by the config API on every write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<u64>,
 }
 
 /// Remote backend authentication configuration.
@@ -264,6 +270,12 @@ pub struct ModelBindingSpec {
     pub provider_id: String,
     /// Actual model name sent to the upstream provider.
     pub upstream_model: String,
+    /// Creation timestamp in epoch milliseconds. Set by the config API on first write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<u64>,
+    /// Last-modified timestamp in epoch milliseconds. Updated by the config API on every write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -308,6 +320,12 @@ pub struct ProviderSpec {
     /// build time.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub adapter_options: BTreeMap<String, Value>,
+    /// Creation timestamp in epoch milliseconds. Set by the config API on first write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<u64>,
+    /// Last-modified timestamp in epoch milliseconds. Updated by the config API on every write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<u64>,
 }
 
 /// Treat an absent field, JSON `null`, or `""` as `None`. Used by spec types
@@ -413,6 +431,12 @@ pub struct McpServerSpec {
     /// Restart policy for reconnecting failed servers.
     #[serde(default)]
     pub restart_policy: McpRestartPolicy,
+    /// Creation timestamp in epoch milliseconds. Set by the config API on first write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<u64>,
+    /// Last-modified timestamp in epoch milliseconds. Updated by the config API on every write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<u64>,
 }
 
 fn default_mcp_timeout_secs() -> u64 {
@@ -431,6 +455,8 @@ impl Default for McpServerSpec {
             timeout_secs: default_mcp_timeout_secs(),
             env: BTreeMap::new(),
             restart_policy: McpRestartPolicy::default(),
+            created_at: None,
+            updated_at: None,
         }
     }
 }
@@ -444,6 +470,8 @@ impl Default for ProviderSpec {
             base_url: None,
             timeout_secs: default_provider_timeout_secs(),
             adapter_options: BTreeMap::new(),
+            created_at: None,
+            updated_at: None,
         }
     }
 }
@@ -466,6 +494,8 @@ impl Default for AgentSpec {
             delegates: Vec::new(),
             sections: HashMap::new(),
             registry: None,
+            created_at: None,
+            updated_at: None,
         }
     }
 }
@@ -651,6 +681,8 @@ mod tests {
             id: "default".into(),
             provider_id: "openai".into(),
             upstream_model: "gpt-4o-mini".into(),
+            created_at: None,
+            updated_at: None,
         };
 
         let encoded = serde_json::to_value(&canonical).unwrap();

--- a/crates/awaken-ext-mcp/src/lib.rs
+++ b/crates/awaken-ext-mcp/src/lib.rs
@@ -15,7 +15,8 @@ pub mod transport;
 pub use config::{McpServerConnectionConfig, TransportTypeId};
 pub use error::McpError;
 pub use manager::{
-    McpPromptEntry, McpRefreshHealth, McpResourceEntry, McpToolRegistry, McpToolRegistryManager,
+    McpPromptEntry, McpRefreshHealth, McpResourceEntry, McpServerStatusSnapshot,
+    McpServerToolEntry, McpToolRegistry, McpToolRegistryManager,
 };
 pub use plugin::McpPlugin;
 pub use progress::McpProgressUpdate;

--- a/crates/awaken-ext-mcp/src/manager.rs
+++ b/crates/awaken-ext-mcp/src/manager.rs
@@ -54,6 +54,27 @@ pub struct McpRefreshHealth {
     pub permanently_failed: bool,
 }
 
+/// Per-tool entry returned by [`McpToolRegistryManager::server_status_snapshot`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServerToolEntry {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+/// Snapshot of a single MCP server's runtime status.
+///
+/// Returned by [`McpToolRegistryManager::server_status_snapshot`] and exposed
+/// via the `GET /v1/mcp-servers/:id/status` admin endpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServerStatusSnapshot {
+    /// Whether the server's lifecycle is currently [`McpServerLifecycle::Connected`].
+    pub connected: bool,
+    /// Last error recorded by the health-tracking subsystem, if any.
+    pub last_error: Option<String>,
+    /// Tools discovered during the most recent successful catalog refresh.
+    pub tools: Vec<McpServerToolEntry>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct McpHealthBudget {
     last_attempt_at: Option<SystemTime>,
@@ -390,7 +411,7 @@ struct McpServerRuntime {
 
 #[derive(Clone, Default)]
 struct McpPublishedCatalog {
-    _tool_defs: Vec<McpToolDefinition>,
+    tool_defs: Vec<McpToolDefinition>,
     tools: PublishedTools,
 }
 
@@ -863,10 +884,7 @@ async fn discover_catalog_from_lease(
         &tool_defs,
         runtime.transport_type,
     )?;
-    Ok(McpPublishedCatalog {
-        _tool_defs: tool_defs,
-        tools,
-    })
+    Ok(McpPublishedCatalog { tool_defs, tools })
 }
 
 fn apply_catalog_if_current(
@@ -1521,6 +1539,40 @@ impl McpToolRegistryManager {
         let servers = read_lock(&self.state.servers);
         let index = find_server_index(&servers, server_name)?;
         Ok(servers[index].health.clone())
+    }
+
+    /// Return a status snapshot for the named server, including connection state and
+    /// the most recently discovered tool list.
+    ///
+    /// Returns [`McpError::UnknownServer`] when `server_name` is not registered.
+    pub fn server_status_snapshot(
+        &self,
+        server_name: &str,
+    ) -> Result<McpServerStatusSnapshot, McpError> {
+        let servers = read_lock(&self.state.servers);
+        let index = find_server_index(&servers, server_name)?;
+        let slot = &servers[index];
+        let connected = slot.lifecycle == McpServerLifecycle::Connected;
+        let last_error = slot.health.last_error.clone();
+        let tools = slot
+            .published_snapshot
+            .as_ref()
+            .map(|snap| {
+                snap.catalog
+                    .tool_defs
+                    .iter()
+                    .map(|def| McpServerToolEntry {
+                        name: def.name.clone(),
+                        description: def.description.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(McpServerStatusSnapshot {
+            connected,
+            last_error,
+            tools,
+        })
     }
 
     pub fn servers(&self) -> Vec<(String, TransportTypeId)> {
@@ -2419,7 +2471,7 @@ mod tests {
             published_snapshot: Some(McpPublishedSnapshot {
                 generation: 1,
                 catalog: McpPublishedCatalog {
-                    _tool_defs: vec![MockTransport::tool_def("echo")],
+                    tool_defs: vec![MockTransport::tool_def("echo")],
                     tools: HashMap::new(),
                 },
             }),

--- a/crates/awaken-ext-observability/src/lib.rs
+++ b/crates/awaken-ext-observability/src/lib.rs
@@ -9,7 +9,7 @@ mod metrics;
 mod persistent;
 mod plugin;
 mod prometheus;
-mod runtime_stats;
+pub mod runtime_stats;
 mod sink;
 mod stats;
 mod wiring;

--- a/crates/awaken-ext-observability/src/runtime_stats.rs
+++ b/crates/awaken-ext-observability/src/runtime_stats.rs
@@ -67,6 +67,7 @@ struct AgentBuckets {
     buckets: VecDeque<Bucket>,
 }
 
+#[derive(Clone)]
 struct Bucket {
     /// Monotonic instant the bucket opened.
     opened_at: Instant,
@@ -86,6 +87,7 @@ struct Bucket {
     tools: HashMap<String, ToolBucket>,
 }
 
+#[derive(Clone)]
 struct ToolBucket {
     call_count: u64,
     failure_count: u64,
@@ -158,9 +160,58 @@ impl RuntimeStatsRegistry {
     /// Aggregate every retained bucket for `agent_id` into a single
     /// snapshot.  Returns `None` when the agent is unknown.
     pub fn snapshot_for(&self, agent_id: &str) -> Option<AgentRuntimeSnapshot> {
+        self.snapshot_for_window(agent_id, None)
+    }
+
+    /// Aggregate the last `window` worth of buckets for `agent_id`.
+    ///
+    /// * `window = None` — aggregate all retained buckets (same as
+    ///   [`snapshot_for`]).
+    /// * `window = Some(d)` — consume only the trailing
+    ///   `n = ceil(d / bucket_window)` buckets, clamped to `[1,
+    ///   bucket_count]`.  The returned `window_seconds` reflects the
+    ///   actual span covered by those `n` buckets.
+    ///
+    /// Returns `None` when the agent is unknown.
+    pub fn snapshot_for_window(
+        &self,
+        agent_id: &str,
+        window: Option<Duration>,
+    ) -> Option<AgentRuntimeSnapshot> {
         let inner = self.inner.lock();
         let agent = inner.agents.get(agent_id)?;
-        Some(self.snapshot_from_buckets(agent_id, &agent.buckets))
+        let buckets = match window {
+            None => return Some(self.snapshot_from_buckets(agent_id, &agent.buckets)),
+            Some(d) => {
+                let n = ((d.as_nanos() + self.bucket_window.as_nanos() - 1)
+                    / self.bucket_window.as_nanos())
+                .max(1)
+                .min(self.bucket_count as u128) as usize;
+                let skip = agent.buckets.len().saturating_sub(n);
+                let slice: VecDeque<_> = agent.buckets.iter().skip(skip).cloned().collect();
+                slice
+            }
+        };
+        Some(self.snapshot_from_window_buckets(agent_id, &buckets, window))
+    }
+
+    /// Like `snapshot_from_buckets` but overrides `window_seconds` to
+    /// reflect the requested window rather than the registry maximum.
+    fn snapshot_from_window_buckets(
+        &self,
+        agent_id: &str,
+        buckets: &VecDeque<Bucket>,
+        window: Option<Duration>,
+    ) -> AgentRuntimeSnapshot {
+        let mut snap = self.snapshot_from_buckets(agent_id, buckets);
+        if let Some(d) = window {
+            let n = ((d.as_nanos() + self.bucket_window.as_nanos() - 1)
+                / self.bucket_window.as_nanos())
+            .max(1)
+            .min(self.bucket_count as u128) as usize;
+            snap.window_seconds = (self.bucket_window * n as u32).as_secs();
+        }
+        snap
     }
 
     fn snapshot_from_buckets(
@@ -504,6 +555,45 @@ pub struct ToolRuntimeStats {
     /// samples were recorded.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub duration_histogram: Vec<HistogramBucket>,
+}
+
+// ---------------------------------------------------------------------------
+// Window string parser  (`1h`, `24h`, `7d`, `3600`, `90s`, etc.)
+// ---------------------------------------------------------------------------
+
+/// Parse a `window` query-string value into a [`Duration`].
+///
+/// Accepted formats:
+/// - `<n>s` — seconds
+/// - `<n>m` — minutes
+/// - `<n>h` — hours
+/// - `<n>d` — days
+/// - `<n>`  — bare integer → seconds
+///
+/// Returns `Err(String)` with a human-readable explanation on invalid input.
+pub fn parse_window_str(s: &str) -> Result<Duration, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("window value is empty".into());
+    }
+    let (digits, multiplier) = if let Some(d) = s.strip_suffix('s') {
+        (d, 1u64)
+    } else if let Some(d) = s.strip_suffix('m') {
+        (d, 60)
+    } else if let Some(d) = s.strip_suffix('h') {
+        (d, 3600)
+    } else if let Some(d) = s.strip_suffix('d') {
+        (d, 86400)
+    } else {
+        (s, 1u64)
+    };
+    let n: u64 = digits
+        .parse()
+        .map_err(|_| format!("invalid window format {s:?}: expected <n>[s|m|h|d]"))?;
+    if n == 0 {
+        return Err(format!("window {s:?} must be greater than zero"));
+    }
+    Ok(Duration::from_secs(n * multiplier))
 }
 
 // ---------------------------------------------------------------------------
@@ -1058,6 +1148,129 @@ mod tests {
         r.record(&MetricsEvent::Tool(tool("a", "search", 1, false)));
         let snap = r.snapshot_for("a").unwrap();
         assert!(!snap.tool_calls_by_tool[0].duration_histogram.is_empty());
+    }
+
+    // ── parse_window_str ───────────────────────────────────────────
+
+    #[test]
+    fn parse_window_str_seconds_suffix() {
+        assert_eq!(parse_window_str("30s").unwrap(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn parse_window_str_minutes_suffix() {
+        assert_eq!(parse_window_str("5m").unwrap(), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn parse_window_str_hours_suffix() {
+        assert_eq!(parse_window_str("1h").unwrap(), Duration::from_secs(3600));
+        assert_eq!(
+            parse_window_str("24h").unwrap(),
+            Duration::from_secs(24 * 3600)
+        );
+    }
+
+    #[test]
+    fn parse_window_str_days_suffix() {
+        assert_eq!(
+            parse_window_str("7d").unwrap(),
+            Duration::from_secs(7 * 86400)
+        );
+    }
+
+    #[test]
+    fn parse_window_str_bare_integer_treated_as_seconds() {
+        assert_eq!(parse_window_str("3600").unwrap(), Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn parse_window_str_rejects_unknown_suffix() {
+        assert!(parse_window_str("5x").is_err());
+        assert!(parse_window_str("foo").is_err());
+    }
+
+    #[test]
+    fn parse_window_str_rejects_zero() {
+        assert!(parse_window_str("0h").is_err());
+        assert!(parse_window_str("0").is_err());
+    }
+
+    #[test]
+    fn parse_window_str_rejects_empty() {
+        assert!(parse_window_str("").is_err());
+    }
+
+    // ── snapshot_for_window ────────────────────────────────────────
+
+    /// Build a registry with `bucket_count` buckets of `bucket_window`
+    /// each, filling each bucket with one inference of the given
+    /// `token_input` so we can verify which buckets were selected by
+    /// counting `input_tokens` in the snapshot.
+    fn fixture_registry(bucket_window_ms: u64, bucket_count: usize) -> RuntimeStatsRegistry {
+        RuntimeStatsRegistry::with_window(Duration::from_millis(bucket_window_ms), bucket_count)
+    }
+
+    #[test]
+    fn snapshot_for_window_none_returns_all_buckets() {
+        let r = fixture_registry(1, 4);
+        // Push 4 inferences into the same (single) bucket (no sleep needed).
+        for i in 0..4u32 {
+            r.record(&MetricsEvent::Inference(inference(
+                "a", i as i32, 0, 1, false,
+            )));
+        }
+        let snap_all = r.snapshot_for("a").unwrap();
+        let snap_win = r.snapshot_for_window("a", None).unwrap();
+        assert_eq!(snap_all.inference_count, snap_win.inference_count);
+        assert_eq!(snap_all.window_seconds, snap_win.window_seconds);
+    }
+
+    #[test]
+    fn snapshot_for_window_small_window_selects_fewer_buckets() {
+        // 3 buckets × 10 ms each.  We inject one inference per bucket by
+        // sleeping between them so the registry rolls forward.
+        let r = RuntimeStatsRegistry::with_window(Duration::from_millis(20), 3);
+        // Bucket 1
+        r.record(&MetricsEvent::Inference(inference("a", 10, 0, 1, false)));
+        std::thread::sleep(Duration::from_millis(25));
+        // Bucket 2
+        r.record(&MetricsEvent::Inference(inference("a", 20, 0, 1, false)));
+        std::thread::sleep(Duration::from_millis(25));
+        // Bucket 3
+        r.record(&MetricsEvent::Inference(inference("a", 30, 0, 1, false)));
+
+        // Request only 1 bucket_window (20 ms) → should see only the last bucket.
+        let snap = r
+            .snapshot_for_window("a", Some(Duration::from_millis(20)))
+            .unwrap();
+        // Only last bucket: input_tokens == 30.
+        assert_eq!(snap.input_tokens, 30, "expected only the last bucket");
+        assert_eq!(snap.inference_count, 1);
+        // window_seconds should reflect 1 × bucket_window.
+        assert_eq!(snap.window_seconds, r.bucket_window().as_secs());
+    }
+
+    #[test]
+    fn snapshot_for_window_larger_than_total_returns_all() {
+        let r = RuntimeStatsRegistry::with_window(Duration::from_millis(20), 3);
+        r.record(&MetricsEvent::Inference(inference("a", 5, 0, 1, false)));
+        // Ask for 10 days — way beyond 3 × 20 ms.
+        let snap = r
+            .snapshot_for_window("a", Some(Duration::from_secs(864_000)))
+            .unwrap();
+        assert_eq!(snap.input_tokens, 5);
+        // window_seconds clamped to bucket_count × bucket_window.
+        assert_eq!(snap.window_seconds, r.window().as_secs());
+    }
+
+    #[test]
+    fn snapshot_for_window_unknown_agent_returns_none() {
+        let r = RuntimeStatsRegistry::new();
+        assert!(
+            r.snapshot_for_window("ghost", Some(Duration::from_secs(3600)))
+                .is_none()
+        );
     }
 
     // ── thread-safety smoke ────────────────────────────────────────

--- a/crates/awaken-runtime/src/registry/config.rs
+++ b/crates/awaken-runtime/src/registry/config.rs
@@ -222,6 +222,8 @@ mod tests {
                 id: "opus".to_string(),
                 provider_id: "anthropic".to_string(),
                 upstream_model: "claude-opus-4-0-20250514".to_string(),
+                created_at: None,
+                updated_at: None,
             }],
             agents: vec![AgentSpec {
                 id: "coder".into(),

--- a/crates/awaken-runtime/src/registry/resolver.rs
+++ b/crates/awaken-runtime/src/registry/resolver.rs
@@ -68,6 +68,8 @@ impl ResolvedAgent {
             delegates: Vec::new(),
             sections: Default::default(),
             registry: None,
+            created_at: None,
+            updated_at: None,
         });
         Self {
             spec,

--- a/crates/awaken-runtime/src/registry/traits.rs
+++ b/crates/awaken-runtime/src/registry/traits.rs
@@ -130,6 +130,8 @@ mod tests {
             id: "default".into(),
             provider_id: "openai".into(),
             upstream_model: "gpt-4o-mini".into(),
+            created_at: None,
+            updated_at: None,
         };
 
         let binding = ModelBinding::from(&spec);

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -45,6 +45,8 @@ pub fn config_routes() -> Router<AppState> {
         .route("/v1/agents", get(list_agents))
         .route("/v1/agents/:id", get(get_agent))
         .route("/v1/providers/:id/test", post(test_provider_connection))
+        .route("/v1/mcp-servers/:id/status", get(get_mcp_server_status))
+        .route("/v1/mcp-servers/:id/restart", post(post_mcp_server_restart))
 }
 
 async fn get_capabilities(
@@ -214,6 +216,66 @@ async fn test_provider_connection(
         .await
         .map_err(map_service_error)?;
     Ok(Json(result))
+}
+
+async fn get_mcp_server_status(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ConfigRouteError> {
+    ensure_admin_auth(&state, &headers)?;
+
+    // 503 when no MCP runtime is configured.
+    let manager = state.config_runtime_manager.as_ref().ok_or_else(|| {
+        ConfigRouteError::Api(ApiError::ServiceUnavailable(
+            "MCP runtime is not configured".into(),
+        ))
+    })?;
+
+    // 404 when the id is unknown to the active registry.
+    let status = manager
+        .mcp_server_status(&id)
+        .ok_or_else(|| ConfigRouteError::Api(ApiError::NotFound(format!("mcp-server/{id}"))))?;
+
+    Ok(Json(json!({
+        "connected": status.connected,
+        "last_error": status.last_error,
+        "tools": status.tools.iter().map(|t| json!({
+            "name": t.name,
+            "description": t.description,
+        })).collect::<Vec<_>>(),
+    })))
+}
+
+async fn post_mcp_server_restart(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ConfigRouteError> {
+    ensure_admin_auth(&state, &headers)?;
+
+    // 503 when no MCP runtime is configured.
+    let manager = state.config_runtime_manager.as_ref().ok_or_else(|| {
+        ConfigRouteError::Api(ApiError::ServiceUnavailable(
+            "MCP runtime is not configured".into(),
+        ))
+    })?;
+
+    manager.mcp_server_reconnect(&id).await.map_err(|e| {
+        // Map unknown-server errors (surfaced as InvalidConfig wrapping UnknownServer) to 404.
+        let msg = e.to_string();
+        if msg.contains("unknown server") || msg.contains("no MCP registry is active") {
+            if msg.contains("no MCP registry") {
+                ConfigRouteError::Api(ApiError::ServiceUnavailable(msg))
+            } else {
+                ConfigRouteError::Api(ApiError::NotFound(format!("mcp-server/{id}")))
+            }
+        } else {
+            ConfigRouteError::Api(ApiError::Internal(msg))
+        }
+    })?;
+
+    Ok(StatusCode::ACCEPTED)
 }
 
 #[derive(Debug)]

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -1,7 +1,7 @@
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -14,7 +14,9 @@ struct DeleteParams {
 
 use crate::app::AppState;
 use crate::routes::ApiError;
-use crate::services::config_service::{ConfigNamespace, ConfigService, ConfigServiceError};
+use crate::services::config_service::{
+    ConfigNamespace, ConfigService, ConfigServiceError, ProviderTestResult,
+};
 
 #[derive(Deserialize)]
 struct ListParams {
@@ -42,6 +44,7 @@ pub fn config_routes() -> Router<AppState> {
         .route("/v1/config/:namespace/$schema", get(get_schema))
         .route("/v1/agents", get(list_agents))
         .route("/v1/agents/:id", get(get_agent))
+        .route("/v1/providers/:id/test", post(test_provider_connection))
 }
 
 async fn get_capabilities(
@@ -197,6 +200,20 @@ async fn delete_config(
             .into_response(),
         Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
     }
+}
+
+async fn test_provider_connection(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ConfigRouteError> {
+    ensure_admin_auth(&state, &headers)?;
+    let service = ConfigService::new(&state).map_err(map_service_error)?;
+    let result: ProviderTestResult = service
+        .test_provider(&id)
+        .await
+        .map_err(map_service_error)?;
+    Ok(Json(result))
 }
 
 #[derive(Debug)]
@@ -563,6 +580,109 @@ mod tests {
 
             let (status, _) = delete_record(&app, "agents", "agent-leaf", false).await;
             assert_eq!(status, StatusCode::NO_CONTENT);
+        }
+
+        async fn test_provider(app: &axum::Router, id: &str) -> (StatusCode, Value) {
+            let req = Request::builder()
+                .method("POST")
+                .uri(format!("/v1/providers/{id}/test"))
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            let status = resp.status();
+            let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+            let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+            (status, body)
+        }
+
+        #[tokio::test]
+        async fn test_provider_existing_openai_spec_returns_200_with_result() {
+            // The bootstrap provider has adapter "stub" which is not a valid
+            // genai adapter, so build_genai_provider_executor returns an error
+            // and ok=false. The route still returns HTTP 200 — the ok field
+            // inside the body conveys the probe outcome.
+            let app = build_test_app().await;
+            let (status, body) = test_provider(&app, "bootstrap").await;
+            assert_eq!(status, StatusCode::OK, "body: {body}");
+            // The response must contain ok and latency_ms regardless of outcome.
+            assert!(body.get("ok").is_some(), "must have ok field");
+            assert!(
+                body["latency_ms"].is_number(),
+                "expected latency_ms to be a number"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_provider_with_valid_genai_adapter_returns_ok_true() {
+            // Create a provider with a genai-supported adapter via the route.
+            // TestProviderFactory accepts any adapter for apply so we override it
+            // in the test state. Instead, we can create the spec directly in the
+            // config store and bypass the apply path.
+            let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let runtime = Arc::new(
+                AgentRuntimeBuilder::new()
+                    .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+                    .with_model_binding(
+                        "bootstrap",
+                        ModelBinding {
+                            provider_id: "bootstrap".into(),
+                            upstream_model: "bootstrap-model".into(),
+                        },
+                    )
+                    .with_agent_spec(bootstrap_agent())
+                    .with_thread_run_store(thread_store.clone())
+                    .build()
+                    .expect("build runtime"),
+            );
+            // Use GenaiProviderExecutorFactory so we can create openai providers.
+            let manager = Arc::new(
+                crate::services::config_runtime::ConfigRuntimeManager::new(
+                    runtime.clone(),
+                    config_store.clone(),
+                )
+                .expect("manager"),
+            );
+            // Write an openai provider directly into the store (skip apply).
+            awaken_contract::contract::config_store::ConfigStore::put(
+                config_store.as_ref(),
+                "providers",
+                "prov-openai",
+                &serde_json::json!({ "id": "prov-openai", "adapter": "openai" }),
+            )
+            .await
+            .expect("put provider");
+
+            let resolver = runtime.resolver_arc();
+            let mailbox = Arc::new(Mailbox::new(
+                runtime.clone(),
+                Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+                thread_store.clone(),
+                "route-test-2".into(),
+                MailboxConfig::default(),
+            ));
+            let state = AppState::new(
+                runtime,
+                mailbox,
+                thread_store,
+                resolver,
+                ServerConfig::default(),
+            )
+            .with_config_store(config_store)
+            .with_config_runtime_manager(manager);
+            let app = build_router(&state).with_state(state);
+
+            let (status, body) = test_provider(&app, "prov-openai").await;
+            assert_eq!(status, StatusCode::OK, "body: {body}");
+            assert_eq!(body["ok"], true, "expected ok=true for openai adapter");
+            assert!(body.get("error").is_none(), "should have no error field");
+        }
+
+        #[tokio::test]
+        async fn test_provider_missing_id_returns_404() {
+            let app = build_test_app().await;
+            let (status, _body) = test_provider(&app, "no-such-provider").await;
+            assert_eq!(status, StatusCode::NOT_FOUND);
         }
     }
 }

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -6,6 +6,12 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+#[derive(Deserialize, Default)]
+struct DeleteParams {
+    #[serde(default)]
+    force: bool,
+}
+
 use crate::app::AppState;
 use crate::routes::ApiError;
 use crate::services::config_service::{ConfigNamespace, ConfigService, ConfigServiceError};
@@ -166,15 +172,31 @@ async fn delete_config(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
-    ensure_admin_auth(&state, &headers)?;
-    let namespace = ConfigNamespace::parse(&namespace).map_err(map_service_error)?;
-    let service = ConfigService::new(&state).map_err(map_service_error)?;
-    service
-        .delete(namespace, &id)
-        .await
-        .map_err(map_service_error)?;
-    Ok(StatusCode::NO_CONTENT)
+    Query(params): Query<DeleteParams>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let namespace = match ConfigNamespace::parse(&namespace) {
+        Ok(ns) => ns,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service.delete(namespace, &id, params.force).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(ConfigServiceError::Blocked { used_by }) => (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "error": "cannot delete: other records depend on this resource",
+                "used_by": used_by,
+            })),
+        )
+            .into_response(),
+        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
 }
 
 #[derive(Debug)]
@@ -251,6 +273,8 @@ fn map_service_error(error: ConfigServiceError) -> ApiError {
         ConfigServiceError::Serialization(_)
         | ConfigServiceError::Apply(_)
         | ConfigServiceError::Storage(_) => ApiError::Internal(error.to_string()),
+        // Blocked is matched inline in delete_config before reaching this function.
+        ConfigServiceError::Blocked { .. } => ApiError::Conflict(error.to_string()),
     }
 }
 
@@ -291,5 +315,254 @@ mod tests {
             HeaderValue::from_static("Bearer secret"),
         );
         assert!(ensure_admin_auth_for_token(Some(&expected), &headers).is_ok());
+    }
+
+    // ── delete 409 / force integration tests ──────────────────────────────
+
+    mod delete_integration {
+        use std::sync::Arc;
+
+        use async_trait::async_trait;
+        use awaken_contract::contract::executor::{
+            InferenceExecutionError, InferenceRequest, LlmExecutor,
+        };
+        use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+        use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+        use awaken_runtime::builder::AgentRuntimeBuilder;
+        use awaken_runtime::registry::traits::ModelBinding;
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use http_body_util::BodyExt;
+        use serde_json::Value;
+        use tower::ServiceExt;
+
+        use crate::app::{AppState, ServerConfig};
+        use crate::mailbox::{Mailbox, MailboxConfig};
+        use crate::routes::build_router;
+        use crate::services::config_runtime::{ConfigRuntimeManager, ProviderExecutorFactory};
+        use crate::services::config_service::ConfigNamespace;
+
+        struct ImmediateExecutor;
+
+        #[async_trait]
+        impl LlmExecutor for ImmediateExecutor {
+            async fn execute(
+                &self,
+                _request: InferenceRequest,
+            ) -> Result<StreamResult, InferenceExecutionError> {
+                Ok(StreamResult {
+                    content: vec![],
+                    tool_calls: vec![],
+                    usage: Some(TokenUsage::default()),
+                    stop_reason: Some(StopReason::EndTurn),
+                    has_incomplete_tool_calls: false,
+                })
+            }
+
+            fn name(&self) -> &str {
+                "immediate"
+            }
+        }
+
+        struct TestProviderFactory;
+
+        impl ProviderExecutorFactory for TestProviderFactory {
+            fn build(
+                &self,
+                spec: &ProviderSpec,
+            ) -> Result<Arc<dyn LlmExecutor>, crate::services::config_runtime::ConfigRuntimeError>
+            {
+                if spec.adapter.eq_ignore_ascii_case("stub") {
+                    return Ok(Arc::new(ImmediateExecutor));
+                }
+                Err(
+                    crate::services::config_runtime::ConfigRuntimeError::UnsupportedProviderAdapter(
+                        spec.adapter.clone(),
+                    ),
+                )
+            }
+        }
+
+        fn bootstrap_agent() -> AgentSpec {
+            AgentSpec {
+                id: "bootstrap".into(),
+                model_id: "bootstrap".into(),
+                system_prompt: "bootstrap".into(),
+                max_rounds: 1,
+                ..Default::default()
+            }
+        }
+
+        async fn build_test_app() -> axum::Router {
+            let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let runtime = Arc::new(
+                AgentRuntimeBuilder::new()
+                    .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+                    .with_model_binding(
+                        "bootstrap",
+                        ModelBinding {
+                            provider_id: "bootstrap".into(),
+                            upstream_model: "bootstrap-model".into(),
+                        },
+                    )
+                    .with_agent_spec(bootstrap_agent())
+                    .with_thread_run_store(thread_store.clone())
+                    .build()
+                    .expect("build runtime"),
+            );
+
+            let manager = Arc::new(
+                ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+                    .expect("config runtime manager")
+                    .with_provider_factory(Arc::new(TestProviderFactory)),
+            );
+            manager
+                .bootstrap_if_empty(
+                    &[ProviderSpec {
+                        id: "bootstrap".into(),
+                        adapter: "stub".into(),
+                        ..Default::default()
+                    }],
+                    &[ModelBindingSpec {
+                        id: "bootstrap".into(),
+                        provider_id: "bootstrap".into(),
+                        upstream_model: "bootstrap-model".into(),
+                        created_at: None,
+                        updated_at: None,
+                    }],
+                    &[bootstrap_agent()],
+                    &[],
+                )
+                .await
+                .expect("bootstrap config store");
+            manager.apply().await.expect("publish config");
+
+            let resolver = runtime.resolver_arc();
+            let mailbox = Arc::new(Mailbox::new(
+                runtime.clone(),
+                Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+                thread_store.clone(),
+                "route-test".into(),
+                MailboxConfig::default(),
+            ));
+            let state = AppState::new(
+                runtime,
+                mailbox,
+                thread_store,
+                resolver,
+                ServerConfig::default(),
+            )
+            .with_config_store(config_store)
+            .with_config_runtime_manager(manager);
+
+            build_router(&state).with_state(state)
+        }
+
+        async fn create_record(app: &axum::Router, namespace: &str, body: &str) -> StatusCode {
+            let req = Request::builder()
+                .method("POST")
+                .uri(format!("/v1/config/{namespace}"))
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap();
+            app.clone().oneshot(req).await.unwrap().status()
+        }
+
+        async fn delete_record(
+            app: &axum::Router,
+            namespace: &str,
+            id: &str,
+            force: bool,
+        ) -> (StatusCode, Value) {
+            let uri = if force {
+                format!("/v1/config/{namespace}/{id}?force=true")
+            } else {
+                format!("/v1/config/{namespace}/{id}")
+            };
+            let req = Request::builder()
+                .method("DELETE")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            let status = resp.status();
+            let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+            let body: Value = if bytes.is_empty() {
+                Value::Null
+            } else {
+                serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+            };
+            (status, body)
+        }
+
+        #[tokio::test]
+        async fn delete_provider_with_referencing_model_returns_409_with_used_by() {
+            let app = build_test_app().await;
+
+            // Create a new provider and a model referencing it
+            assert_eq!(
+                create_record(&app, "providers", r#"{"id":"prov-x","adapter":"stub"}"#).await,
+                StatusCode::CREATED
+            );
+            assert_eq!(
+                create_record(
+                    &app,
+                    "models",
+                    r#"{"id":"model-x","provider_id":"prov-x","upstream_model":"gpt-4"}"#
+                )
+                .await,
+                StatusCode::CREATED
+            );
+
+            let (status, body) = delete_record(&app, "providers", "prov-x", false).await;
+            assert_eq!(status, StatusCode::CONFLICT);
+            let used_by = body["used_by"].as_array().expect("used_by array");
+            assert!(!used_by.is_empty());
+            assert!(used_by.iter().any(|r| r["id"] == "model-x"));
+        }
+
+        #[tokio::test]
+        async fn delete_provider_with_force_true_succeeds_despite_dependents() {
+            let app = build_test_app().await;
+
+            assert_eq!(
+                create_record(&app, "providers", r#"{"id":"prov-y","adapter":"stub"}"#).await,
+                StatusCode::CREATED
+            );
+            assert_eq!(
+                create_record(
+                    &app,
+                    "models",
+                    r#"{"id":"model-y","provider_id":"prov-y","upstream_model":"gpt-4"}"#
+                )
+                .await,
+                StatusCode::CREATED
+            );
+
+            let (status, _) = delete_record(&app, "providers", "prov-y", true).await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+        }
+
+        #[tokio::test]
+        async fn delete_agent_is_always_unblocked() {
+            let app = build_test_app().await;
+
+            // Bootstrap agent is a leaf — should delete without blocker
+            // (bootstrap is a leaf, no dependents)
+            // Create a standalone agent
+            assert_eq!(
+                create_record(
+                    &app,
+                    "agents",
+                    r#"{"id":"agent-leaf","model_id":"bootstrap","system_prompt":"hi","max_rounds":1}"#
+                )
+                .await,
+                StatusCode::CREATED
+            );
+
+            let (status, _) = delete_record(&app, "agents", "agent-leaf", false).await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+        }
     }
 }

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -11,6 +11,7 @@ use serde_json::{Value, json};
 
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::storage::{ChildThreadDeleteStrategy, StorageError};
+use awaken_ext_observability::runtime_stats::parse_window_str;
 
 use crate::app::AppState;
 use crate::config_routes::config_routes;
@@ -162,13 +163,25 @@ fn run_routes() -> Router<AppState> {
 
 // ── Agent runtime-stats endpoints ───────────────────────────────────
 
+/// Query params for `GET /v1/agents/:id/runtime-stats`.
+#[derive(Debug, Deserialize, Default)]
+struct RuntimeStatsQuery {
+    /// Optional time window, e.g. `1h`, `24h`, `7d`, `3600s`, `90`.
+    window: Option<String>,
+}
+
 /// `GET /v1/agents/:id/runtime-stats` — return the agent's rolling-window
 /// snapshot, or 404 when the agent has not been seen by the registry, or
 /// 503 when the registry is not configured on this server.
+///
+/// Accepts an optional `?window=` query parameter (e.g. `1h`, `24h`, `7d`)
+/// to restrict the snapshot to a shorter sub-window of the registry's full
+/// history.  An invalid format returns 400.
 #[tracing::instrument(skip(state))]
 async fn get_agent_runtime_stats(
     State(state): State<AppState>,
     Path(id): Path<String>,
+    Query(params): Query<RuntimeStatsQuery>,
 ) -> Response {
     let Some(registry) = state.runtime_stats.as_ref() else {
         return (
@@ -177,7 +190,18 @@ async fn get_agent_runtime_stats(
         )
             .into_response();
     };
-    match registry.snapshot_for(&id) {
+
+    let window = match params.window.as_deref() {
+        None => None,
+        Some(s) => match parse_window_str(s) {
+            Ok(d) => Some(d),
+            Err(msg) => {
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
+            }
+        },
+    };
+
+    match registry.snapshot_for_window(&id, window) {
         Some(snapshot) => Json(snapshot).into_response(),
         None => (
             StatusCode::NOT_FOUND,

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -37,6 +37,7 @@ pub enum ApiError {
     ThreadNotFound(String),
     RunNotFound(String),
     Internal(String),
+    ServiceUnavailable(String),
 }
 
 impl IntoResponse for ApiError {
@@ -50,6 +51,7 @@ impl IntoResponse for ApiError {
             }
             ApiError::RunNotFound(id) => (StatusCode::NOT_FOUND, format!("run not found: {id}")),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
         };
         (status, Json(json!({"error": message}))).into_response()
     }

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -12,7 +12,9 @@ use awaken_contract::{
     AgentSpec, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelBindingSpec,
     PeriodicRefresher, ProviderSpec,
 };
-use awaken_ext_mcp::{McpServerConnectionConfig, McpToolRegistry, McpToolRegistryManager};
+use awaken_ext_mcp::{
+    McpServerConnectionConfig, McpServerStatusSnapshot, McpToolRegistry, McpToolRegistryManager,
+};
 use awaken_runtime::engine::GenaiExecutor;
 use awaken_runtime::registry::BackendRegistry;
 use awaken_runtime::registry::memory::{
@@ -181,6 +183,8 @@ pub trait ManagedMcpRegistry: Send + Sync {
     fn periodic_refresh_running(&self) -> bool;
     fn start_periodic_refresh(&self, interval: Duration) -> Result<(), ConfigRuntimeError>;
     async fn stop_periodic_refresh(&self) -> bool;
+    fn server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot>;
+    async fn reconnect(&self, server_name: &str) -> Result<(), ConfigRuntimeError>;
 }
 
 #[async_trait]
@@ -218,6 +222,17 @@ impl ManagedMcpRegistry for RealManagedMcpRegistry {
 
     async fn stop_periodic_refresh(&self) -> bool {
         self.manager.stop_periodic_refresh().await
+    }
+
+    fn server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot> {
+        self.manager.server_status_snapshot(server_name).ok()
+    }
+
+    async fn reconnect(&self, server_name: &str) -> Result<(), ConfigRuntimeError> {
+        self.manager
+            .reconnect(server_name)
+            .await
+            .map_err(|e| ConfigRuntimeError::InvalidConfig(e.to_string()))
     }
 }
 
@@ -504,6 +519,35 @@ impl ConfigRuntimeManager {
 
     pub fn periodic_refresh_running(&self) -> bool {
         self.periodic_refresh.is_running()
+    }
+
+    /// Return the live status snapshot for a managed MCP server.
+    ///
+    /// Returns `None` when no MCP registry is active (i.e. the runtime has no
+    /// MCP servers configured) or the server name is unknown to the registry.
+    pub fn mcp_server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot> {
+        self.active_mcp_registry
+            .lock()
+            .as_ref()
+            .and_then(|active| active.handle.server_status(server_name))
+    }
+
+    /// Trigger an immediate reconnect for the named MCP server.
+    ///
+    /// Returns an error when no MCP registry is active or the server name is
+    /// unknown.
+    pub async fn mcp_server_reconnect(&self, server_name: &str) -> Result<(), ConfigRuntimeError> {
+        let handle = self
+            .active_mcp_registry
+            .lock()
+            .as_ref()
+            .map(|active| Arc::clone(&active.handle));
+        match handle {
+            Some(h) => h.reconnect(server_name).await,
+            None => Err(ConfigRuntimeError::InvalidConfig(
+                "no MCP registry is active".to_string(),
+            )),
+        }
     }
 
     async fn publish(&self, managed: ManagedConfigSnapshot) -> Result<u64, ConfigRuntimeError> {

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -102,10 +102,16 @@ impl<'a> ConfigService<'a> {
             .filter_map(|id| {
                 registries.tools.get_tool(&id).map(|tool| {
                     let descriptor = tool.descriptor();
+                    // First-pass classifier: derive source from tool id prefix.
+                    // MCP tools follow "mcp__{server}__{tool}"; plugin tools use
+                    // arbitrary ids registered by plugins. If the registry gains
+                    // explicit source tracking, replace this with that.
+                    let source = classify_tool_source(&descriptor.id);
                     json!({
                         "id": descriptor.id,
                         "name": descriptor.name,
                         "description": descriptor.description,
+                        "source": source,
                     })
                 })
             })
@@ -537,6 +543,20 @@ impl<'a> ConfigService<'a> {
         }
         Ok(())
     }
+}
+
+/// Classify a tool's source from its id.
+///
+/// MCP tools registered by `awaken-ext-mcp` follow `mcp__{server}__{tool}`.
+/// The global registry currently holds only built-in tools, but the classifier
+/// is written defensively so it still works if MCP tools are ever surfaced here.
+fn classify_tool_source(id: &str) -> Value {
+    if let Some(rest) = id.strip_prefix("mcp__") {
+        // Extract server id: the segment between the two `__` delimiters.
+        let server = rest.split("__").next().unwrap_or(rest);
+        return json!({ "kind": "mcp", "id": server });
+    }
+    json!({ "kind": "builtin" })
 }
 
 fn map_runtime_error(error: ConfigRuntimeError) -> ConfigServiceError {

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -50,6 +50,13 @@ impl ConfigNamespace {
     }
 }
 
+/// A record that depends on the resource being deleted.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DependentRef {
+    pub namespace: &'static str,
+    pub id: String,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigServiceError {
     #[error("config management API not enabled")]
@@ -68,6 +75,8 @@ pub enum ConfigServiceError {
     Serialization(String),
     #[error("runtime apply failed: {0}")]
     Apply(String),
+    #[error("blocked: {used_by:?} record(s) depend on this resource")]
+    Blocked { used_by: Vec<DependentRef> },
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
 }
@@ -250,6 +259,7 @@ impl<'a> ConfigService<'a> {
         &self,
         namespace: ConfigNamespace,
         id: &str,
+        force: bool,
     ) -> Result<(), ConfigServiceError> {
         let manager = self.runtime_manager()?;
         let _apply_guard = manager.lock_apply().await;
@@ -260,6 +270,13 @@ impl<'a> ConfigService<'a> {
             .ok_or_else(|| {
                 ConfigServiceError::NotFound(format!("{}/{}", namespace.as_str(), id))
             })?;
+
+        if !force {
+            let blockers = self.find_dependents(namespace, id).await?;
+            if !blockers.is_empty() {
+                return Err(ConfigServiceError::Blocked { used_by: blockers });
+            }
+        }
 
         self.store.delete(namespace.as_str(), id).await?;
         let apply_result = manager
@@ -272,6 +289,55 @@ impl<'a> ConfigService<'a> {
             return Err(error);
         }
         Ok(())
+    }
+
+    /// Return all records in other namespaces that reference `id` in `namespace`.
+    ///
+    /// - Providers: scans models for `provider_id == id`
+    /// - Models: scans agents for `model_id == id`
+    /// - Agents / McpServers: leaf nodes, no dependents
+    async fn find_dependents(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+    ) -> Result<Vec<DependentRef>, ConfigServiceError> {
+        match namespace {
+            ConfigNamespace::Providers => {
+                let models = self.store.list("models", 0, usize::MAX).await?;
+                let refs = models
+                    .into_iter()
+                    .filter(|(_, value)| {
+                        value
+                            .get("provider_id")
+                            .and_then(Value::as_str)
+                            .is_some_and(|pid| pid == id)
+                    })
+                    .map(|(model_id, _)| DependentRef {
+                        namespace: "models",
+                        id: model_id,
+                    })
+                    .collect();
+                Ok(refs)
+            }
+            ConfigNamespace::Models => {
+                let agents = self.store.list("agents", 0, usize::MAX).await?;
+                let refs = agents
+                    .into_iter()
+                    .filter(|(_, value)| {
+                        value
+                            .get("model_id")
+                            .and_then(Value::as_str)
+                            .is_some_and(|mid| mid == id)
+                    })
+                    .map(|(agent_id, _)| DependentRef {
+                        namespace: "agents",
+                        id: agent_id,
+                    })
+                    .collect();
+                Ok(refs)
+            }
+            ConfigNamespace::Agents | ConfigNamespace::McpServers => Ok(vec![]),
+        }
     }
 
     fn runtime_manager(
@@ -948,5 +1014,162 @@ mod tests {
             .await
             .expect_err("missing manager should reject writes");
         assert!(matches!(error, ConfigServiceError::NotEnabled));
+    }
+
+    // ── find_dependents / blocked delete tests ──────────────────────────────
+
+    #[tokio::test]
+    async fn find_dependents_provider_returns_referencing_models() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("config service");
+
+        // Create a model that references provider "bootstrap"
+        service
+            .create(
+                ConfigNamespace::Models,
+                json!({
+                    "id": "model-ref-bootstrap",
+                    "provider_id": "bootstrap",
+                    "upstream_model": "gpt-4"
+                }),
+            )
+            .await
+            .expect("create model");
+
+        let dependents = service
+            .find_dependents(ConfigNamespace::Providers, "bootstrap")
+            .await
+            .expect("find_dependents");
+
+        assert_eq!(dependents.len(), 2, "bootstrap model + model-ref-bootstrap");
+        let ids: Vec<&str> = dependents.iter().map(|d| d.id.as_str()).collect();
+        assert!(ids.contains(&"model-ref-bootstrap"));
+        for d in &dependents {
+            assert_eq!(d.namespace, "models");
+        }
+    }
+
+    #[tokio::test]
+    async fn find_dependents_model_returns_referencing_agents() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("config service");
+
+        // Create an agent referencing the bootstrap model
+        service
+            .create(
+                ConfigNamespace::Agents,
+                json!({
+                    "id": "agent-ref-bootstrap",
+                    "model_id": "bootstrap",
+                    "system_prompt": "test",
+                    "max_rounds": 1
+                }),
+            )
+            .await
+            .expect("create agent");
+
+        let dependents = service
+            .find_dependents(ConfigNamespace::Models, "bootstrap")
+            .await
+            .expect("find_dependents");
+
+        assert!(!dependents.is_empty());
+        let ids: Vec<&str> = dependents.iter().map(|d| d.id.as_str()).collect();
+        assert!(ids.contains(&"agent-ref-bootstrap"));
+        for d in &dependents {
+            assert_eq!(d.namespace, "agents");
+        }
+    }
+
+    #[tokio::test]
+    async fn find_dependents_agents_and_mcp_servers_are_leaf_nodes() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("config service");
+
+        let agent_deps = service
+            .find_dependents(ConfigNamespace::Agents, "any-agent")
+            .await
+            .expect("find_dependents agents");
+        assert!(agent_deps.is_empty());
+
+        let mcp_deps = service
+            .find_dependents(ConfigNamespace::McpServers, "any-mcp")
+            .await
+            .expect("find_dependents mcp-servers");
+        assert!(mcp_deps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_without_force_returns_blocked_when_dependents_exist() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("config service");
+
+        // Create a second provider and a model referencing it
+        service
+            .create(
+                ConfigNamespace::Providers,
+                json!({ "id": "prov-b", "adapter": "stub" }),
+            )
+            .await
+            .expect("create provider-b");
+
+        service
+            .create(
+                ConfigNamespace::Models,
+                json!({
+                    "id": "model-b",
+                    "provider_id": "prov-b",
+                    "upstream_model": "gpt-4"
+                }),
+            )
+            .await
+            .expect("create model-b");
+
+        let err = service
+            .delete(ConfigNamespace::Providers, "prov-b", false)
+            .await
+            .expect_err("should be blocked");
+
+        assert!(
+            matches!(err, ConfigServiceError::Blocked { ref used_by } if !used_by.is_empty()),
+            "expected Blocked error"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_with_force_removes_despite_dependents() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("config service");
+
+        service
+            .create(
+                ConfigNamespace::Providers,
+                json!({ "id": "prov-c", "adapter": "stub" }),
+            )
+            .await
+            .expect("create provider-c");
+
+        service
+            .create(
+                ConfigNamespace::Models,
+                json!({
+                    "id": "model-c",
+                    "provider_id": "prov-c",
+                    "upstream_model": "gpt-4"
+                }),
+            )
+            .await
+            .expect("create model-c");
+
+        // Force delete should succeed even with dependents
+        service
+            .delete(ConfigNamespace::Providers, "prov-c", true)
+            .await
+            .expect("force delete should succeed");
     }
 }

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::StorageError;
@@ -340,6 +341,35 @@ impl<'a> ConfigService<'a> {
                     .await?;
             }
             ConfigNamespace::Agents | ConfigNamespace::Models => {}
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        if path_id.is_none() {
+            // Create: set both timestamps.
+            object.insert("created_at".into(), Value::Number(now.into()));
+            object.insert("updated_at".into(), Value::Number(now.into()));
+        } else {
+            // Update: preserve existing created_at if present; always refresh updated_at.
+            if !object.contains_key("created_at") {
+                if let Ok(Some(existing)) = self.store.get(namespace.as_str(), &id).await {
+                    if let Some(existing_created_at) = existing
+                        .as_object()
+                        .and_then(|obj| obj.get("created_at"))
+                        .cloned()
+                    {
+                        object.insert("created_at".into(), existing_created_at);
+                    } else {
+                        object.insert("created_at".into(), Value::Number(now.into()));
+                    }
+                } else {
+                    object.insert("created_at".into(), Value::Number(now.into()));
+                }
+            }
+            object.insert("updated_at".into(), Value::Number(now.into()));
         }
 
         Ok((id, Value::Object(object)))
@@ -728,6 +758,8 @@ mod tests {
                     id: "bootstrap".into(),
                     provider_id: "bootstrap".into(),
                     upstream_model: "bootstrap-model".into(),
+                    created_at: None,
+                    updated_at: None,
                 }],
                 &[bootstrap_agent()],
                 &[],

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::StorageError;
@@ -8,7 +8,7 @@ use serde_json::{Map, Value, json};
 
 use crate::app::AppState;
 
-use super::config_runtime::ConfigRuntimeError;
+use super::config_runtime::{ConfigRuntimeError, build_genai_provider_executor};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigNamespace {
@@ -79,6 +79,15 @@ pub enum ConfigServiceError {
     Blocked { used_by: Vec<DependentRef> },
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
+}
+
+/// Result returned by the provider test endpoint.
+#[derive(Debug, serde::Serialize)]
+pub struct ProviderTestResult {
+    pub ok: bool,
+    pub latency_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 pub struct ConfigService<'a> {
@@ -579,6 +588,45 @@ impl<'a> ConfigService<'a> {
                 Ok(Value::Object(object))
             }
             ConfigNamespace::Agents | ConfigNamespace::Models => Ok(value),
+        }
+    }
+
+    /// Test whether a stored provider config is usable.
+    ///
+    /// Strategy (construction-only probe): load the stored `ProviderSpec` and
+    /// attempt to build a genai client from it via
+    /// `build_genai_provider_executor`. A successful build proves that the
+    /// adapter name is recognised and the credentials are syntactically valid
+    /// (e.g. not an obviously empty key when one is expected). It does **not**
+    /// make a live network call, so it catches misconfiguration but not
+    /// unreachable hosts or revoked keys. A live-chat probe would require a
+    /// full runtime context and async stream handling that is disproportionate
+    /// for a health-check endpoint, so the construction-only approach is used.
+    pub async fn test_provider(&self, id: &str) -> Result<ProviderTestResult, ConfigServiceError> {
+        let raw = self
+            .store
+            .get(ConfigNamespace::Providers.as_str(), id)
+            .await?
+            .ok_or_else(|| ConfigServiceError::NotFound(format!("providers/{id}")))?;
+
+        let spec: ProviderSpec = serde_json::from_value(raw)
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        let start = Instant::now();
+        let result = build_genai_provider_executor(&spec);
+        let latency_ms = start.elapsed().as_millis() as u64;
+
+        match result {
+            Ok(_) => Ok(ProviderTestResult {
+                ok: true,
+                latency_ms,
+                error: None,
+            }),
+            Err(e) => Ok(ProviderTestResult {
+                ok: false,
+                latency_ms,
+                error: Some(e.to_string()),
+            }),
         }
     }
 

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -1541,13 +1541,34 @@ async fn put_rejects_path_and_body_id_mismatch() {
 }
 
 #[tokio::test]
-async fn delete_rolls_back_when_runtime_apply_would_break_graph() {
+async fn delete_provider_with_dependents_returns_409() {
     let app = make_app().await;
 
+    // bootstrap provider is referenced by bootstrap model — should be blocked
     let (status, body) = request_json(
         &app.router,
         Method::DELETE,
         "/v1/config/providers/bootstrap",
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CONFLICT);
+    let used_by = body["used_by"].as_array().expect("used_by array");
+    assert!(!used_by.is_empty(), "should report dependent models");
+}
+
+#[tokio::test]
+async fn delete_rolls_back_when_runtime_apply_would_break_graph() {
+    let app = make_app().await;
+
+    // With force=true, the dependency check is bypassed and the runtime apply
+    // is attempted.  Removing the bootstrap provider while the bootstrap model
+    // still references it breaks the runtime graph → 400 + rollback.
+    let (status, body) = request_json(
+        &app.router,
+        Method::DELETE,
+        "/v1/config/providers/bootstrap?force=true",
         None,
     )
     .await;

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -542,6 +542,8 @@ async fn make_runtime_manager_custom(
         id: "bootstrap".into(),
         provider_id: "bootstrap".into(),
         upstream_model: "bootstrap-model".into(),
+        created_at: None,
+        updated_at: None,
     };
     let bootstrap_agent = agent_spec("bootstrap", "bootstrap");
 
@@ -1736,6 +1738,8 @@ async fn change_listener_coalesces_event_bursts_within_min_apply_interval() {
         id: "bootstrap".into(),
         provider_id: "bootstrap".into(),
         upstream_model: "bootstrap-model".into(),
+        created_at: None,
+        updated_at: None,
     };
     let bootstrap_agent = agent_spec("bootstrap", "bootstrap");
 

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -212,6 +212,14 @@ impl ManagedMcpRegistry for TestManagedMcpRegistry {
     async fn stop_periodic_refresh(&self) -> bool {
         self.periodic_refresh_running.swap(false, Ordering::Relaxed)
     }
+
+    fn server_status(&self, _server_name: &str) -> Option<awaken_ext_mcp::McpServerStatusSnapshot> {
+        None
+    }
+
+    async fn reconnect(&self, _server_name: &str) -> Result<(), ConfigRuntimeError> {
+        Ok(())
+    }
 }
 
 struct TestMcpRegistryFactory;
@@ -281,6 +289,14 @@ impl ManagedMcpRegistry for TrackingManagedMcpRegistry {
         self.state
             .periodic_refresh_running
             .swap(false, Ordering::Relaxed)
+    }
+
+    fn server_status(&self, _server_name: &str) -> Option<awaken_ext_mcp::McpServerStatusSnapshot> {
+        None
+    }
+
+    async fn reconnect(&self, _server_name: &str) -> Result<(), ConfigRuntimeError> {
+        Ok(())
     }
 }
 
@@ -1905,4 +1921,130 @@ async fn apply_if_changed_returns_some_after_store_mutation() {
         "calling apply_if_changed twice without further mutation must return None"
     );
     let _ = result;
+}
+
+// ── MCP server status and restart endpoint smoke tests ──────────────────────
+
+#[tokio::test]
+async fn mcp_status_returns_503_when_no_runtime_configured() {
+    // Build a state without a config_runtime_manager so the MCP status endpoint
+    // returns 503 Service Unavailable.
+    let store = Arc::new(InMemoryStore::new());
+    let thread_store = store.clone();
+    use awaken_contract::AgentSpec;
+    use awaken_runtime::builder::AgentRuntimeBuilder;
+    use awaken_runtime::registry::traits::ModelBinding;
+
+    struct StubExecutor;
+    #[async_trait]
+    impl awaken_contract::contract::executor::LlmExecutor for StubExecutor {
+        async fn execute(
+            &self,
+            _request: awaken_contract::contract::executor::InferenceRequest,
+        ) -> Result<
+            awaken_contract::contract::inference::StreamResult,
+            awaken_contract::contract::executor::InferenceExecutionError,
+        > {
+            Ok(awaken_contract::contract::inference::StreamResult {
+                content: vec![],
+                tool_calls: vec![],
+                usage: Some(awaken_contract::contract::inference::TokenUsage::default()),
+                stop_reason: Some(awaken_contract::contract::inference::StopReason::EndTurn),
+                has_incomplete_tool_calls: false,
+            })
+        }
+        fn name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    let bootstrap_agent = AgentSpec {
+        id: "boot".into(),
+        model_id: "boot".into(),
+        system_prompt: "boot".into(),
+        max_rounds: 1,
+        ..Default::default()
+    };
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("boot", Arc::new(StubExecutor))
+            .with_model_binding(
+                "boot",
+                ModelBinding {
+                    provider_id: "boot".into(),
+                    upstream_model: "m".into(),
+                },
+            )
+            .with_agent_spec(bootstrap_agent)
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("runtime"),
+    );
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "mcp-status-test".into(),
+        MailboxConfig::default(),
+    ));
+    // No config_runtime_manager attached → MCP endpoints return 503.
+    let state = awaken_server::app::AppState::new(
+        runtime.clone(),
+        mailbox,
+        thread_store as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+    let router = build_router(&state).with_state(state);
+
+    let (status, _body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/mcp-servers/anything/status",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let (status, _body) = request_json(
+        &router,
+        Method::POST,
+        "/v1/mcp-servers/anything/restart",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn mcp_status_returns_404_for_unknown_server() {
+    // The default test app has no MCP servers registered; querying a name
+    // that the manager doesn't know about should return 404.
+    let app = make_app().await;
+
+    let (status, _body) = request_json(
+        &app.router,
+        Method::GET,
+        "/v1/mcp-servers/no-such-server/status",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn mcp_restart_returns_404_for_unknown_server() {
+    // As above: restart on an unknown id should 404 when no MCP registry is
+    // active (the default test app has no configured mcp-servers).
+    let app = make_app().await;
+
+    let (status, _body) = request_json(
+        &app.router,
+        Method::POST,
+        "/v1/mcp-servers/no-such-server/restart",
+        None,
+    )
+    .await;
+    // The manager returns "no MCP registry is active" → 503.
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -88,6 +88,8 @@ fn bootstrap_model() -> ModelBindingSpec {
         id: "bootstrap".into(),
         provider_id: "bootstrap".into(),
         upstream_model: "bootstrap-model".into(),
+        created_at: None,
+        updated_at: None,
     }
 }
 

--- a/crates/awaken-server/tests/e2e_tensorzero.rs
+++ b/crates/awaken-server/tests/e2e_tensorzero.rs
@@ -472,6 +472,8 @@ async fn tz_router_provider_compiles_smoke() {
         )),
         timeout_secs: 60,
         adapter_options: Default::default(),
+        created_at: None,
+        updated_at: None,
     };
     let executor =
         build_genai_provider_executor(&provider_spec).expect("genai executor builds for TZ");
@@ -752,6 +754,8 @@ mod helper_tests {
             base_url: Some("http://127.0.0.1:3000/openai/v1/".into()),
             timeout_secs: 30,
             adapter_options: Default::default(),
+            created_at: None,
+            updated_at: None,
         };
         let _executor = build_genai_provider_executor(&spec)
             .expect("genai executor builds for TensorZero base URL");
@@ -766,6 +770,8 @@ mod helper_tests {
             base_url: Some("http://127.0.0.1:3000/openai/v1".into()),
             timeout_secs: 30,
             adapter_options: Default::default(),
+            created_at: None,
+            updated_at: None,
         };
         let _executor = build_genai_provider_executor(&spec)
             .expect("base URL without trailing slash should build");
@@ -783,6 +789,8 @@ mod helper_tests {
             base_url: Some("http://127.0.0.1:3000/openai/v1/".into()),
             timeout_secs: 30,
             adapter_options: Default::default(),
+            created_at: None,
+            updated_at: None,
         };
         let executor = build_genai_provider_executor(&spec).expect("executor");
         let store = Arc::new(InMemoryStore::new());

--- a/crates/awaken-server/tests/public_api_compat_extended.rs
+++ b/crates/awaken-server/tests/public_api_compat_extended.rs
@@ -215,6 +215,7 @@ fn api_error_exhaustive_match_keeps_0_2_variants() {
             ApiError::ThreadNotFound(_) => "thread_not_found",
             ApiError::RunNotFound(_) => "run_not_found",
             ApiError::Internal(_) => "internal",
+            ApiError::ServiceUnavailable(_) => "service_unavailable",
         }
     }
     assert_eq!(label(ApiError::NotFound("x".into())), "not_found");

--- a/crates/awaken-stores/tests/config_store.rs
+++ b/crates/awaken-stores/tests/config_store.rs
@@ -20,6 +20,8 @@ async fn exercise_store(store: Arc<dyn ConfigStore>) {
         id: "gpt-4o-mini".into(),
         provider_id: "openai".into(),
         upstream_model: "gpt-4o-mini".into(),
+        created_at: None,
+        updated_at: None,
     };
     let agent = AgentSpec {
         id: "assistant".into(),

--- a/crates/awaken/tests/skill_permission_e2e.rs
+++ b/crates/awaken/tests/skill_permission_e2e.rs
@@ -304,6 +304,8 @@ fn make_agent_spec_deny_all_with_extra_allowed_tools(extra_allowed_tools: &[&str
             }),
         )]),
         registry: None,
+        created_at: None,
+        updated_at: None,
     }
 }
 

--- a/docs/adr/0024-admin-console-data-router.md
+++ b/docs/adr/0024-admin-console-data-router.md
@@ -1,0 +1,103 @@
+# ADR-0024: Admin Console Data Router Migration
+
+- **Status**: Accepted
+- **Date**: 2026-05-02
+- **Depends on**: ADR-0023
+
+## Context
+
+PR #154 introduced `apps/admin-console/src/components/unsaved-changes-guard.tsx`
+to intercept navigation away from the agent editor when the form has
+unsaved changes. The guard uses `useBlocker` (react-router v7), which only
+operates under a *data router* context; mounting the same application under
+the legacy `<BrowserRouter>` causes react-router to throw `useBlocker must
+be used within a data router` at runtime, taking the entire
+`AgentEditorPage` down with it.
+
+Until that PR the entrypoint in `apps/admin-console/src/main.tsx` rendered
+`<BrowserRouter><App /></BrowserRouter>`, a pattern that predates the v7
+data-router API. Unit tests, type checking, and `npm run build` all passed
+because the invariant is thrown at runtime, not at compile time. The
+regression was first observed when the new Playwright suite that exercises
+the unsaved-changes guard timed out waiting for `getByLabel('Agent ID')`;
+the editor never rendered because the hook crashed during component mount.
+
+## Decisions
+
+### D1: Bootstrap the runtime entrypoint with `createBrowserRouter` + `RouterProvider`
+
+`apps/admin-console/src/main.tsx` no longer uses `<BrowserRouter>`. Instead,
+it imports a `router` constant from `apps/admin-console/src/app.tsx` and
+renders `<RouterProvider router={router} />`. The `router` is constructed once
+at module load:
+
+```ts
+export const router = createBrowserRouter(createRoutesFromElements(appRoutes()));
+```
+
+The legacy `App` export in `apps/admin-console/src/app.tsx` is kept intact:
+it renders `<Routes>{appRoutes()}</Routes>` and is available to callers that
+control their own router context (e.g., embed the component inside a larger
+application that already provides a data router).
+
+### D2: Export `appRoutes()` so tests can build an equivalent memory router
+
+The route tree is extracted into a named export `appRoutes()` in
+`apps/admin-console/src/app.tsx`. The smoke-test suite builds a
+`createMemoryRouter` from the same elements:
+
+```ts
+createMemoryRouter(createRoutesFromElements(appRoutes()), { initialEntries: [path] })
+```
+
+This ensures tests exercise exactly the route tree that runs in production,
+including any loaders or actions attached to individual routes, without
+spawning a real browser.
+
+### D3: Provider order — `ToastProvider > ConfirmDialogProvider > AuthProvider > RouterProvider`
+
+Providers that supply UI context (`ToastProvider`, `ConfirmDialogProvider`)
+and the authentication context (`AuthProvider`) are placed *outside*
+`RouterProvider`. This means route components and any data-router loaders
+or actions can call hooks from those providers without additional wrapper
+layers. `RouterProvider` is the innermost shell so that all navigation state
+is contained within an already-initialised application context.
+
+### D4: Test policy — every new top-level route requires a smoke test
+
+The smoke-test suite at `apps/admin-console/src/app.smoke.test.tsx`
+(jsdom environment, Vitest) is the canonical CI guardrail against future
+v7-only-hook regressions. Every new top-level route added to `appRoutes()`
+must have at least one smoke-test case that mounts it under a
+`createMemoryRouter` and asserts the route renders without throwing. This
+prevents a silent rollback to `<BrowserRouter>`-only semantics — and any
+analogous "unit tests pass but runtime crashes" failure mode — from going
+undetected.
+
+## Alternatives Considered
+
+**Manual navigation blocking via `history.block` or a custom `usePrompt`.**
+This avoids the data-router requirement but re-implements browser navigation
+interception by hand, including the `beforeunload` edge case that
+`useBlocker` already handles. Rejected because it trades a one-line
+invariant error for an ongoing maintenance surface.
+
+**`unstable_usePrompt` from react-router.**
+Available under `<BrowserRouter>` in some react-router versions, but the API
+is explicitly marked unstable and is not guaranteed to survive minor version
+bumps. Rejected in favour of the stable `useBlocker` API introduced in
+react-router v6.8 and carried into v7.
+
+## Consequences
+
+- All stable react-router v7 data-router APIs (`useBlocker`, `useNavigation`,
+  route-level `loader`/`action`) are available to every route component
+  without additional wrapper changes.
+- The `<App>` export retains the legacy `<Routes>`-based rendering for
+  callers that embed the console inside a host application; this export
+  continues to work as long as the host provides any router context that
+  satisfies the `<Routes>` contract.
+- Developers accustomed to the `<BrowserRouter>` + `<Routes>` pattern will
+  encounter `createBrowserRouter` as the entry point;
+  `apps/admin-console/src/app.smoke.test.tsx` demonstrates the
+  `createMemoryRouter` equivalent and serves as a worked example.

--- a/docs/adr/0025-config-draft-state.md
+++ b/docs/adr/0025-config-draft-state.md
@@ -1,0 +1,158 @@
+# ADR-0025: Config Draft State (Save vs Publish)
+
+- **Status**: 📐 Proposed
+- **Date**: 2026-05-02
+- **Depends on**: ADR-0018, ADR-0023
+
+## Context
+
+Every `PUT /v1/config/:namespace/:id` request currently writes to `ConfigStore`
+and then triggers `ConfigRuntimeManager::apply`, which rebuilds the live runtime
+immediately. The apply path in
+`crates/awaken-server/src/services/config_runtime.rs` holds no concept of a
+pending or staged state: whatever is stored is also live.
+
+This creates three practical problems:
+
+1. **No review window.** A partial edit — changing a system prompt mid-sentence,
+   or referencing a provider that does not yet exist — goes live the moment the
+   PUT lands. There is no way to stage several related changes and commit them
+   atomically.
+2. **No rollback affordance for the UI.** The admin console's agent editor
+   (`apps/admin-console/src/pages/agent-editor-page.tsx`) tracks an unsaved
+   form state locally and guards navigation with `UnsavedChangesGuard`. Once
+   the user saves, the runtime is already updated. Undoing requires the user to
+   re-open the editor and type the old values back.
+3. **Production risk.** Teams sharing a single server instance across
+   engineering and production traffic have no safe way to prepare a config
+   change without immediately exposing it.
+
+## Options
+
+### Option A — `draft` flag on every spec; explicit publish endpoint
+
+Add a boolean `draft` field to every stored document. `PUT` writes the document
+with `draft: true` by default unless `?publish=true` is passed. A new endpoint
+`POST /v1/config/:namespace/:id/publish` flips the flag and triggers apply.
+
+**Storage shape**: same `ConfigStore` namespace, single document per resource,
+`draft` field participates in the stored JSON. `ConfigService::list` may filter
+by `draft` status via a query parameter.
+
+**API surface**: one new endpoint per namespace; existing `PUT` semantics change
+(callers that relied on immediate apply must add `?publish=true`).
+
+**Migration**: existing documents gain `draft: false` on first read via a
+serde default. No data migration required.
+
+**Observability**: `ConfigRuntimeManager::apply` can log and meter how many
+resources are still in draft state.
+
+**RBAC implication**: a future two-role model could restrict `publish` to
+operators while allowing `draft` writes from editors.
+
+### Option B — Separate `drafts/` namespace; promote with a copy
+
+Draft documents live under a parallel namespace key: `drafts/agents/my-agent`
+vs `agents/my-agent`. A `POST /v1/config/drafts/:namespace/:id/promote` copies
+the draft document over the live namespace key and triggers apply.
+
+**Storage shape**: doubles the key space. Both the live and draft copy exist
+independently. Diffs are possible by comparing the two keys.
+
+**API surface**: new namespace prefix and promote endpoint. Existing endpoints
+are unchanged.
+
+**Migration**: no migration; drafts namespace starts empty.
+
+**Observability**: easy to count draft documents by listing the drafts prefix.
+
+**RBAC implication**: same as Option A; promote action is the privilege
+boundary.
+
+### Option C — Per-resource `state` enum + atomic state machine
+
+Each stored document carries a `state: "draft" | "published"` field managed
+through explicit transitions. `PUT` creates or updates the document without
+changing its state. A `PATCH /v1/config/:namespace/:id/state` with body
+`{"state":"published"}` makes the transition atomic at the store level.
+
+**Storage shape**: same as Option A with richer semantics. Future states
+(`archived`, `deprecated`) fit naturally.
+
+**API surface**: one new PATCH endpoint; apply is only triggered on transitions
+into `published`.
+
+**Migration**: existing documents default to `state: "published"` via serde.
+
+**Observability**: state field is queryable; metrics can track documents per
+state.
+
+**RBAC implication**: state transitions are a natural permission boundary
+independent of CRUD.
+
+### Option D — Do nothing; rely on a staging environment
+
+Keep instant-apply semantics. Teams that need a review window operate a second
+server instance pointing at a separate config store, promote changes by
+exporting and importing configs, and use infrastructure-level controls
+(separate URLs, network policies) to separate staging from production.
+
+**Storage shape**: unchanged.
+
+**API surface**: unchanged.
+
+**Migration**: none.
+
+**Observability**: unchanged.
+
+**RBAC implication**: none at the config level; isolation is at the
+infrastructure level.
+
+## Trade-offs
+
+| | API compat | Storage delta | Atomic multi-resource | RBAC boundary | Complexity |
+|---|---|---|---|---|---|
+| A — draft flag | Breaking (PUT default changes) | Minimal | No | Publish endpoint | Low |
+| B — drafts namespace | Non-breaking | 2× key space | No | Promote endpoint | Medium |
+| C — state enum | Non-breaking | Minimal | Possible via batch | PATCH transition | Medium |
+| D — do nothing | None | None | N/A | External | None |
+
+## Recommendation
+
+**Option C** (per-resource `state` enum) is recommended.
+
+It is the only option that is non-breaking, keeps a single authoritative document
+per resource, and provides a natural extension point for additional states
+without a schema revision. The `PATCH /v1/config/:namespace/:id/state` verb
+is unambiguous — no overloading of the `PUT` semantics — and aligns with how
+`ConfigRuntimeManager::apply` works today: only the `published` state triggers
+an apply, leaving the existing fast-path intact for embedders that never touch
+the state field (they always see `state: "published"` via the serde default).
+
+Option A is attractive for its simplicity but the change to `PUT` default
+semantics would silently break any integration that calls `PUT` and expects the
+runtime to update. Option D is acceptable for small single-tenant deployments
+but leaves the problem unsolved for the growing multi-team use case.
+
+## Consequences
+
+**Implementers gain:**
+
+- A review window between writing a config change and deploying it to the live
+  runtime, controllable per-resource.
+- A foundation for future RBAC: the state transition endpoint can be gated by
+  a separate permission without touching the CRUD surface.
+- An audit hook insertion point: every `published` transition is a discrete,
+  loggable event (see ADR-0026).
+
+**Implementers pay:**
+
+- `ConfigService` must filter documents by state when calling
+  `apply_locked`: only `state: "published"` documents participate in the
+  runtime snapshot.
+- `GET /v1/config/:namespace` must expose state in the list response and accept
+  a `?state=` filter so the admin console can show drafts separately.
+- The admin console agent editor must learn the distinction between a local
+  unsaved form and a server-side draft, adding a second save action ("Save
+  draft" vs "Publish").

--- a/docs/adr/0026-admin-audit-log.md
+++ b/docs/adr/0026-admin-audit-log.md
@@ -1,0 +1,159 @@
+# ADR-0026: Admin Audit Log
+
+- **Status**: 📐 Proposed
+- **Date**: 2026-05-02
+- **Depends on**: ADR-0023
+
+## Context
+
+Admin actions — config writes (`PUT`, `POST`, `DELETE` on
+`/v1/config/:namespace/:id`), runtime control operations
+(`/v1/mcp-servers/:id/restart`), and future state transitions such as publish
+(see ADR-0025) — leave no structured record. The only signal available today is
+the OpenTelemetry span emitted by `awaken-ext-observability` and the axum
+request logs, neither of which captures the resource payload before and after
+the change.
+
+This gap matters in three scenarios:
+
+1. **Incident investigation.** When a live agent misbehaves, operators need to
+   know who changed the agent spec, when, and what the previous value was.
+2. **Compliance.** Regulated environments require a tamper-evident log of every
+   configuration change.
+3. **Admin console UX.** The console has no history page. Users rely on memory
+   or external version control to understand what changed.
+
+The existing observability stack in `crates/awaken-ext-observability` emits
+OTel metrics and traces but does not persist a queryable event log. Traces are
+ephemeral and are not designed for structured querying by resource or actor.
+
+## Decisions
+
+### D1: Event shape
+
+Each audit event is a self-contained JSON document:
+
+```
+{
+  "id":         "<ulid>",
+  "ts":         "<RFC 3339 timestamp>",
+  "actor":      "<SHA-256 prefix of the bearer token, or 'anonymous'>",
+  "action":     "<create | update | delete | publish | restart>",
+  "resource":   "<namespace>/<id>",
+  "before":     <JSON or null>,
+  "after":      <JSON or null>,
+  "ip":         "<client IP or null if behind a proxy without forwarding>",
+  "request_id": "<X-Request-Id header value or null>"
+}
+```
+
+`before` and `after` carry the full stored document at the point of change.
+For `delete`, `after` is null. For `create`, `before` is null. For
+`restart`, both are null (no document is modified).
+
+The actor field uses a truncated hash of the bearer token rather than the token
+itself, preserving the ability to correlate events from the same caller without
+storing credentials.
+
+### D2: Storage
+
+Audit events are stored in the existing `ConfigStore` under a dedicated
+namespace key `_audit`. The underscore prefix is reserved by `ConfigNamespace`
+validation and is never exposed as a user-facing namespace, so there is no
+collision risk.
+
+This reuses `ConfigStore` — including its file, in-memory, and Postgres backends
+in `crates/awaken-stores/` — without introducing a new trait or dependency.
+The tradeoff is that audit events share the same storage backend as config
+documents; teams that want an independent audit sink (e.g., write-once object
+storage) can introduce an `AuditLogStore` trait at that time as a deliberate
+extension point.
+
+Entries are appended using ULID-based keys so time-ordering is preserved
+without a secondary sort index.
+
+### D3: Query API
+
+```
+GET /v1/audit-log
+  ?since=<RFC 3339>          # lower bound on ts (inclusive)
+  &until=<RFC 3339>          # upper bound on ts (exclusive)
+  &action=<action>           # filter by action name
+  &resource=<namespace/id>   # filter by exact resource path
+  &actor=<hash prefix>       # filter by actor hash prefix
+  &limit=<n>                 # max results, default 100, cap 1000
+  &cursor=<opaque string>    # keyset cursor for pagination
+```
+
+Response:
+
+```json
+{
+  "items": [ ...events... ],
+  "next_cursor": "<string or null>"
+}
+```
+
+The endpoint mounts inside `config_routes()` and is gated by the same
+`ensure_admin_auth` check used by all other admin routes (ADR-0023, D4).
+
+### D4: Retention
+
+The server applies a rolling retention window. The default window is 90 days;
+entries older than the window are pruned during a background sweep that runs
+at server startup and on a configurable interval. The retention window is
+configurable via `AdminApiConfig` (extending the struct introduced in ADR-0023,
+D1). Deployments that require longer retention should configure an external
+backup of the `_audit` namespace before the window expires.
+
+### D5: Actor identification
+
+The actor field in each event is derived as follows:
+
+1. If the request carries a valid `Authorization: Bearer <token>` header, the
+   actor is the first 16 hex characters of the SHA-256 hash of the token bytes.
+2. If the server is configured without a bearer token (open admin), the actor
+   is `"anonymous"`.
+3. Clients may supply an `X-Awaken-Actor` header with a human-readable label
+   (e.g., a CI job name). When present, this label is appended to the actor
+   field: `"<hash>/<label>"`. The label is truncated to 64 bytes and must
+   contain only printable ASCII; non-conforming values are dropped silently.
+
+The `X-Awaken-Actor` header is advisory and unauthenticated; it assists
+readability but is not a security boundary.
+
+## Alternatives Considered
+
+**Stream to OTel only.** Low implementation cost, but OTel backends are not
+designed for structured querying by resource or actor, and the `before`/`after`
+payload would bloat span attributes beyond practical limits. Rejected as the
+sole mechanism; OTel spans may be emitted in addition to the structured log as
+a diagnostic aid.
+
+**Write to a local file.** Simple, but the file is not queryable via the admin
+API and is not replicated across server instances. Rejected as the primary
+store; a future sidecar or log-shipping agent may tail the file as a secondary
+export path.
+
+**Separate `AuditLogStore` trait with dedicated implementations.** Cleanest
+architecture, but premature until there is evidence that audit storage
+requirements diverge from `ConfigStore` semantics. The `_audit` namespace
+approach can be migrated to a dedicated trait later without changing the API
+surface.
+
+## Consequences
+
+- The admin console gains a foundation for an Audit Log page: fetch
+  `GET /v1/audit-log` and render a time-ordered table. No new API design is
+  required.
+- Storage cost is proportional to the volume of admin actions and the
+  configured retention window. Config namespaces are typically low-write; audit
+  events are small JSON documents. The overhead is expected to be negligible for
+  most deployments.
+- `ConfigService` methods (`create`, `update`, `delete`) must emit audit events
+  after a successful store write. This adds one async write per admin mutation
+  on the critical path.
+- Any SLO on admin endpoint latency must account for the additional store write.
+  The write is non-transactional with the config write; if the audit write
+  fails, the config change is already committed. Implementers should log the
+  failure and continue rather than rolling back the config change.

--- a/docs/adr/0027-server-side-eval-history.md
+++ b/docs/adr/0027-server-side-eval-history.md
@@ -1,0 +1,168 @@
+# ADR-0027: Server-Side Eval History
+
+- **Status**: 📐 Proposed
+- **Date**: 2026-05-02
+- **Depends on**: ADR-0018, ADR-0023
+
+## Context
+
+`awaken-eval replay` runs fixture-driven evaluation locally and writes one NDJSON
+line per fixture to a file on disk
+(`crates/awaken-eval/src/report.rs`, `write_ndjson_path`). The output is
+consumed by:
+
+- `awaken-eval check`, which diffs two NDJSON files and exits non-zero on
+  regression.
+- The Eval Reports page in the admin console
+  (`apps/admin-console/src/pages/eval-reports-page.tsx`), which today requires
+  the user to drag a local NDJSON file into the browser.
+
+Neither path persists reports on the server. Consequences:
+
+1. **No shared baseline.** Two engineers running `awaken-eval replay` against
+   the same agent spec produce independent local files that are never
+   consolidated. Comparing results across machines requires manual file sharing.
+2. **No history.** There is no record of how eval scores changed over time for
+   a given agent. Regressions are detectable only within a single `check` run
+   against a committed baseline.
+3. **CI friction.** CI pipelines write NDJSON to an artifact store, but the
+   admin console cannot fetch those artifacts; operators must download and
+   drag them in manually.
+4. **Eval-server coupling.** `awaken-eval` currently has no dependency on
+   `awaken-server`. Introducing a hard link risks coupling the CLI tool to
+   server internals; any solution must preserve the option of running eval
+   offline.
+
+## Options
+
+### Option A — `awaken-eval` pushes reports to a server endpoint
+
+`awaken-eval replay` gains an optional `--server` flag. When supplied, the
+command sends a `POST /v1/eval/reports` request with the NDJSON body after all
+fixtures complete (or line-by-line as they finish, for streaming). The server
+stores the report and returns a report ID.
+
+**Storage**: a new `eval-reports` namespace in `ConfigStore` (or a dedicated
+`EvalReportStore` trait — see below). Each report is stored as a single JSON
+document keyed by a ULID.
+
+**Retention policy**: reports older than a configurable window (default 30
+days) are pruned by the same background sweep used for audit entries (ADR-0026,
+D4). Operators may configure a longer window for compliance purposes.
+
+**Query API for the admin console**:
+
+```
+GET /v1/eval/reports
+  ?agent_id=<id>       # filter by agent under evaluation
+  &since=<RFC 3339>
+  &limit=<n>
+  &cursor=<opaque>
+
+GET /v1/eval/reports/:id          # full report NDJSON
+
+GET /v1/eval/reports/:id/summary  # aggregated pass/fail counts
+```
+
+**Authentication**: `POST /v1/eval/reports` accepts the same admin bearer token
+used by `config_routes()`. For CI environments that run eval without admin
+credentials, a dedicated eval-runner bearer token may be introduced as a
+narrower scope — this is left to a follow-on ADR that extends `AdminApiConfig`.
+
+**Offline operation**: eval continues to write local NDJSON files as it does
+today. The `--server` flag is additive; pipelines that do not supply it are
+unaffected.
+
+### Option B — Server polls a configured directory
+
+The server watches a directory path (configurable in `ServerConfig`) for new
+NDJSON files. When a file appears, it is ingested, stored, and the file is
+optionally deleted or moved to an archive subdirectory.
+
+**Storage**: same as Option A.
+
+**Authentication**: no HTTP auth required; access is controlled by filesystem
+permissions.
+
+**Offline operation**: fully preserved; eval writes files as today and the
+server picks them up.
+
+**Drawbacks**: the server must run on the same host as the eval CLI, or share a
+network filesystem. This breaks multi-machine CI setups. File polling is fragile
+(partial writes, concurrent runs) and requires careful ordering logic. The
+approach is not viable for containerised or distributed deployments.
+
+### Option C — Keep eval-server separation strict; out of scope
+
+Server never stores eval reports. The admin console's drag-and-drop model is
+the intended interaction. Teams that want history build their own tooling on top
+of CI artifact storage.
+
+**Tradeoff**: zero implementation cost; zero server complexity. The admin
+console Eval Reports page remains a local-file viewer. This option is viable as
+a long-term position only if eval is treated as a developer-local tool and not
+a shared operational dashboard.
+
+## Chosen Path: Option A
+
+Option A preserves the offline-first design of `awaken-eval` while enabling
+server-side history. The `--server` flag is purely additive: existing `Makefile`
+targets, CI steps, and developer workflows that call `awaken-eval replay` without
+`--server` are unaffected. Option B is rejected because it requires filesystem
+co-location. Option C is rejected because it forecloses shared baselines and
+history, which are the highest-value features of a server-side eval store.
+
+### Storage detail
+
+Reports are stored in the existing `ConfigStore` under the `eval-reports`
+namespace. This reuses the file, in-memory, and Postgres backends without a new
+storage trait. Each document is:
+
+```json
+{
+  "id":        "<ulid>",
+  "agent_id":  "<string or null>",
+  "created_at": "<RFC 3339>",
+  "fixture_count": <integer>,
+  "pass_count":    <integer>,
+  "fail_count":    <integer>,
+  "lines":     [ ...ReplayReport objects... ]
+}
+```
+
+If individual reports grow beyond a practical document size (many thousands of
+fixtures), an `EvalReportStore` trait may be introduced to store lines
+separately. This decision is deferred; the `ConfigStore` approach is sufficient
+for typical fixture counts and can be migrated transparently behind the
+`/v1/eval/reports` surface.
+
+### Retention policy
+
+Default: 30 days. Configurable via `AdminApiConfig`. The background sweep
+(shared with audit-log retention, ADR-0026, D4) deletes reports beyond the
+window. Operators who need longer retention should configure a `ConfigStore`
+backend with its own archival policy (e.g., Postgres with a cold-storage export
+job).
+
+### Authentication
+
+`POST /v1/eval/reports` is gated by `ensure_admin_auth` alongside the other
+config routes. CI pipelines that have the admin bearer token can push reports
+directly. A narrower eval-runner credential scope is deferred to a follow-on
+ADR that extends `AdminApiConfig` with a secondary bearer token.
+
+## Consequences
+
+- The admin console Eval Reports page can be extended with a "Load from server"
+  mode that fetches `GET /v1/eval/reports` without requiring file upload.
+  Drag-and-drop remains available for offline use.
+- `awaken-eval` gains a new optional dependency on an HTTP client (e.g.,
+  `reqwest`) gated behind a feature flag so that builds that do not need server
+  push remain lean.
+- The `ConfigStore` key space grows with one document per eval run. At typical
+  CI cadences (tens of runs per day), the storage overhead is small. The
+  retention sweep bounds the total size.
+- Teams running `awaken-eval` against a server that does not expose
+  `/v1/eval/reports` (e.g., `expose_config_routes = false`, ADR-0023, D2) will
+  receive a `404 Not Found` when passing `--server`. The CLI should surface a
+  clear error and fall back to writing the local file only.

--- a/e2e/playwright.admin.config.ts
+++ b/e2e/playwright.admin.config.ts
@@ -4,6 +4,8 @@ const adminStorageDir =
   process.env.AWAKEN_E2E_ADMIN_STORAGE_DIR ??
   `./target/e2e-admin-sessions/${Date.now()}-${process.pid}`;
 
+export const TEST_ADMIN_TOKEN = 'test-bearer-abc';
+
 export default defineConfig({
   testDir: './tests',
   testMatch: /admin-config-ui\.spec\.ts/,
@@ -15,7 +17,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `AWAKEN_STORAGE_DIR=${adminStorageDir} cargo run -p ai-sdk-starter-agent`,
+      command: `AWAKEN_STORAGE_DIR=${adminStorageDir} AWAKEN_ADMIN_BEARER_TOKEN=${TEST_ADMIN_TOKEN} cargo run -p ai-sdk-starter-agent`,
       cwd: '..',
       port: 38080,
       timeout: 120_000,

--- a/e2e/tests/admin-config-ui.spec.ts
+++ b/e2e/tests/admin-config-ui.spec.ts
@@ -35,8 +35,8 @@ async function gotoEditorTab(
   name: 'Basics' | 'Tools' | 'Plugins' | 'Delegates' | 'Advanced',
 ) {
   await page
-    .getByRole('navigation', { name: 'Editor sections' })
-    .getByRole('button', { name })
+    .getByRole('tablist', { name: 'Editor sections' })
+    .getByRole('tab', { name })
     .click();
 }
 

--- a/e2e/tests/admin-config-ui.spec.ts
+++ b/e2e/tests/admin-config-ui.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { TEST_ADMIN_TOKEN } from '../playwright.admin.config';
 
 const BACKEND_URL = process.env.AWAKEN_BACKEND_URL ?? 'http://127.0.0.1:38080';
 const BIGMODEL_BASE_URL =
@@ -110,8 +111,16 @@ async function createModelViaUi(
 }
 
 test.describe('admin config UI', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((token) => {
+      localStorage.setItem('awaken.adminToken', token);
+    }, TEST_ADMIN_TOKEN);
+  });
+
   test('exposes every registered configurable plugin in capabilities', async ({ request }) => {
-    const response = await request.get(`${BACKEND_URL}/v1/capabilities`);
+    const response = await request.get(`${BACKEND_URL}/v1/capabilities`, {
+      headers: { Authorization: `Bearer ${TEST_ADMIN_TOKEN}` },
+    });
     expect(response.ok()).toBeTruthy();
 
     const capabilities = await response.json();
@@ -204,6 +213,7 @@ test.describe('admin config UI', () => {
 
     const agentResponse = await request.get(
       `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(agentId)}`,
+      { headers: { Authorization: `Bearer ${TEST_ADMIN_TOKEN}` } },
     );
     expect(agentResponse.ok()).toBeTruthy();
     const agent = await agentResponse.json();
@@ -251,6 +261,7 @@ test.describe('admin config UI', () => {
 
     const providerResponse = await request.get(
       `${BACKEND_URL}/v1/config/providers/${encodeURIComponent(providerId)}`,
+      { headers: { Authorization: `Bearer ${TEST_ADMIN_TOKEN}` } },
     );
     expect(providerResponse.ok()).toBeTruthy();
     const provider = await providerResponse.json();
@@ -291,6 +302,36 @@ test.describe('admin config UI', () => {
       `BigModel provider returned an error termination: ${termination}`,
     ).not.toBe('error');
     expect(textDeltas(events).toLowerCase()).toContain('bigmodel-ui-ok');
+  });
+
+  test('401 prompts admin token modal and retries the original request', async ({ page }) => {
+    // Start with no token so the backend returns 401 and triggers the modal.
+    await page.addInitScript(() => {
+      localStorage.removeItem('awaken.adminToken');
+    });
+
+    const agentListResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/v1/config/agents') && response.status() !== 401,
+    );
+
+    await page.goto('/agents');
+
+    // The 401 should trigger the admin token modal.
+    const modal = page.getByRole('dialog', { name: /Admin token required/ });
+    await expect(modal).toBeVisible();
+
+    // Fill in the correct token and save.
+    await modal.locator('input[type="password"]').fill(TEST_ADMIN_TOKEN);
+    await modal.getByRole('button', { name: 'Save' }).click();
+
+    // Modal closes and the retry succeeds.
+    await expect(modal).toBeHidden();
+    const agentListResponse = await agentListResponsePromise;
+    expect(agentListResponse.ok()).toBeTruthy();
+
+    // Clean up so subsequent tests start without this token in localStorage.
+    await page.evaluate(() => localStorage.removeItem('awaken.adminToken'));
   });
 
   test('unsaved-changes guard intercepts in-app navigation', async ({ page }) => {

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -1141,6 +1141,16 @@ Always greet the user warmly and ask how you can help today.
             as Arc<dyn SkillCatalogProvider>,
     );
 
+    let state = if let Ok(token) = std::env::var("AWAKEN_ADMIN_BEARER_TOKEN") {
+        if !token.is_empty() {
+            state.with_admin_api_bearer_token(token)
+        } else {
+            state
+        }
+    } else {
+        state
+    };
+
     let mut app = build_router(&state).with_state(state);
 
     if config.enable_cors {

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -846,6 +846,8 @@ Deterministic compatibility directives:\n\
         id: DEFAULT_MODEL_ID.into(),
         provider_id: DEFAULT_PROVIDER_ID.into(),
         upstream_model: args.model.clone(),
+        created_at: None,
+        updated_at: None,
     };
     let executor = provider_factory
         .build(&default_provider)


### PR DESCRIPTION
## Summary

Follow-up to PR #154. 20 commits across documentation, A11Y, UX polish, three new BE-supported features, and three Proposed-status ADRs setting design direction for larger work.

### Documentation
- **CHANGELOG**: backfilled the week-1 admin-console UX entries.
- **ADR-0024 (Accepted)**: data-router migration that PR #154 introduced.
- **ADR-0025/0026/0027 (Proposed)**: draft/publish lifecycle, admin audit log, server-side eval history.

### Bugs / regressions fixed
- AdminTokenModal/ConfirmDialog backdrop-click misfired when the user dragged out of an input — now requires symmetric mousedown+mouseup on the backdrop.
- AuthProvider issued duplicate `/v1/capabilities` probes under React.StrictMode — guarded with a mount ref.
- e2e selector regressed to `getByRole('navigation', ...)` after A7 changed the wrapper to `role="tablist"` — selector updated.

### A11Y
- Focus traps in both modals (`useFocusTrap`); restores focus on close; supports `initialFocus` ref.
- Agent editor tabs now use `role="tablist" / role="tab" / role="tabpanel"` with arrow-key, Home, End navigation; tab panels render persistently with `hidden`, preserving form state across tab switches.
- Toast cap surfaces `+N earlier dismissed` instead of silently evicting; per-toast Escape dismisses without bubbling out of the viewport.

### UX
- All list / filter pages persist search / sort / page state in the URL via shared `useListUrlState`, `useSkillsFilterUrlState`, `useFixtureFilterUrlState` hooks.

### Backend-supported features (BE+FE pairs)
- **B1 — Last modified**: `created_at`/`updated_at` on the four config spec types; `prepare_body` injects timestamps; new sortable column on every list page; `formatRelativeTime` helper.
- **B2 — Tool source**: capabilities response carries `{ source: { kind, id? } }` per tool; `ToolSelector` consumes it (id-prefix inference kept as fallback).
- **B3 — Provider test**: `POST /v1/providers/:id/test` performs a construction-only probe (documented); editor surfaces a "Test connection" button + status badge.
- **B4 — MCP status / restart**: `GET /v1/mcp-servers/:id/status` returns live `{ connected, last_error?, tools[] }` from `McpToolRegistryManager`; `POST /v1/mcp-servers/:id/restart` triggers reconnect; list shows live badge, editor shows tool list + Restart with confirm dialog.
- **B5 — Runtime-stats time-range**: `GET /v1/agents/:id/runtime-stats?window=1h|6h|24h|7d`; agent dashboard adds a picker with `?window=` URL persistence.
- **B6 — Delete reference impact**: `DELETE` returns `409 + { used_by: [...] }` when the target is referenced (provider→models, model→agents); admin console catches 409 and re-prompts with the impact list before allowing `?force=true` retry.

### Tests added
- 5 jsdom React component test suites: `ToolSelector`, `ToastProvider` (auto-dismiss / cap / StrictMode / outside-provider), `AuthProvider` state machine, `AdminTokenModal`, `ConfirmDialog`, `useFocusTrap`, agent-editor tablist / arrow nav.
- new e2e: 401 → admin token modal → replay full flow (extends starter agent with optional `AWAKEN_ADMIN_BEARER_TOKEN`).
- BE: `find_dependents`, `parse_window_str`, `snapshot_for_window`, MCP status/restart routes, provider test endpoint.

## Test plan

- [x] `npm --prefix apps/admin-console test` — **367 / 367** pass (was 238 → 367, +129)
- [x] `apps/admin-console && tsc --noEmit` — clean
- [x] `apps/admin-console && npm run build` — clean
- [x] `cargo build -p awaken-server -p awaken-contract -p awaken-ext-mcp -p awaken-ext-observability` — clean
- [x] `cargo test --workspace --no-run` — clean (after `9ed299ed4` backfilled spec literals)
- [x] `cd e2e && npm run test:admin` — 5 / 5 pass; 1 skipped (BigModel needs API key)

## Known gaps (intentionally out of scope)

- ADR-0025/0026/0027 are **Proposed**; implementation deferred to follow-up PRs.
- B3 provider probe is construction-only (catches misconfiguration but not network/auth issues until a real chat path is wired).
- Restart on an MCP server is best-effort: in-flight tool calls may fail mid-flight (matches existing reconnect semantics).