### PR TITLE
ADR-0026 audit log: backend foundation (contract, service, endpoint, retention)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,9 @@ dependencies = [
  "awaken-runtime",
  "awaken-stores",
  "axum",
+ "base64 0.22.1",
  "bytes",
+ "chrono",
  "futures",
  "genai",
  "http-body-util",
@@ -571,6 +573,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "tempfile",
  "testcontainers",
@@ -581,6 +584,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "ulid",
  "uuid",
 ]
 
@@ -869,8 +873,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -4885,6 +4891,16 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
 
 [[package]]
 name = "unarray"

--- a/crates/awaken-contract/src/contract/audit_log.rs
+++ b/crates/awaken-contract/src/contract/audit_log.rs
@@ -1,0 +1,127 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Action that triggered an audit event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditAction {
+    Create,
+    Update,
+    Delete,
+    Restart,
+    Publish,
+}
+
+/// A self-contained audit record for a single admin action.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AuditEvent {
+    /// ULID string — monotonically increasing, serves as the storage key.
+    pub id: String,
+    /// RFC 3339 timestamp.
+    pub ts: String,
+    /// SHA-256 prefix of the bearer token, or `"anonymous"`.
+    pub actor: String,
+    /// Action that was performed.
+    pub action: AuditAction,
+    /// Resource path in the form `<namespace>/<id>`.
+    pub resource: String,
+    /// Payload before the change (null for create / restart).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before: Option<Value>,
+    /// Payload after the change (null for delete / restart).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<Value>,
+    /// Client IP address derived from request headers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+    /// Value of the `X-Request-Id` header if present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn audit_event_serde_round_trip() {
+        let event = AuditEvent {
+            id: "01ABCDEFGH".to_string(),
+            ts: "2026-05-01T00:00:00Z".to_string(),
+            actor: "deadbeef01234567".to_string(),
+            action: AuditAction::Create,
+            resource: "agents/my-agent".to_string(),
+            before: None,
+            after: Some(json!({"id": "my-agent"})),
+            ip: Some("127.0.0.1".to_string()),
+            request_id: None,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: AuditEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, event);
+    }
+
+    #[test]
+    fn optional_fields_omitted_when_none() {
+        let event = AuditEvent {
+            id: "01ABCDEFGH".to_string(),
+            ts: "2026-05-01T00:00:00Z".to_string(),
+            actor: "anonymous".to_string(),
+            action: AuditAction::Delete,
+            resource: "agents/old-agent".to_string(),
+            before: None,
+            after: None,
+            ip: None,
+            request_id: None,
+        };
+
+        let value = serde_json::to_value(&event).unwrap();
+        assert!(value.get("before").is_none(), "before should be omitted");
+        assert!(value.get("after").is_none(), "after should be omitted");
+        assert!(value.get("ip").is_none(), "ip should be omitted");
+        assert!(
+            value.get("request_id").is_none(),
+            "request_id should be omitted"
+        );
+    }
+
+    #[test]
+    fn action_snake_case_serialization() {
+        assert_eq!(
+            serde_json::to_value(AuditAction::Create).unwrap(),
+            json!("create")
+        );
+        assert_eq!(
+            serde_json::to_value(AuditAction::Update).unwrap(),
+            json!("update")
+        );
+        assert_eq!(
+            serde_json::to_value(AuditAction::Delete).unwrap(),
+            json!("delete")
+        );
+        assert_eq!(
+            serde_json::to_value(AuditAction::Restart).unwrap(),
+            json!("restart")
+        );
+        assert_eq!(
+            serde_json::to_value(AuditAction::Publish).unwrap(),
+            json!("publish")
+        );
+    }
+
+    #[test]
+    fn action_round_trip_from_str() {
+        for (s, expected) in [
+            ("create", AuditAction::Create),
+            ("update", AuditAction::Update),
+            ("delete", AuditAction::Delete),
+            ("restart", AuditAction::Restart),
+            ("publish", AuditAction::Publish),
+        ] {
+            let parsed: AuditAction = serde_json::from_str(&format!("\"{s}\"")).unwrap();
+            assert_eq!(parsed, expected);
+        }
+    }
+}

--- a/crates/awaken-contract/src/contract/mod.rs
+++ b/crates/awaken-contract/src/contract/mod.rs
@@ -1,4 +1,5 @@
 pub mod active_agent;
+pub mod audit_log;
 pub mod bundle;
 pub mod config_store;
 pub mod content;

--- a/crates/awaken-contract/src/lib.rs
+++ b/crates/awaken-contract/src/lib.rs
@@ -84,3 +84,6 @@ pub use cancellation::{CancellationHandle, CancellationToken};
 
 // ── periodic refresh ──
 pub use periodic_refresh::PeriodicRefresher;
+
+// ── audit log ──
+pub use contract::audit_log::{AuditAction, AuditEvent};

--- a/crates/awaken-server/Cargo.toml
+++ b/crates/awaken-server/Cargo.toml
@@ -46,6 +46,12 @@ schemars = { workspace = true }
 # MCP server
 mcp = { package = "model-context-protocol", version = "0.2", default-features = false, features = ["server", "client"] }
 
+# Audit log
+ulid = "1"
+sha2 = "0.10"
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }
+
 # Metrics / observability
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -13,6 +13,7 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
 use crate::mailbox::{Mailbox, MailboxLifecycleConfig};
+use crate::services::audit_log::AuditLogger;
 use crate::transport::replay_buffer::EventReplayBuffer;
 
 pub type ReplayBufferEntry = (Arc<EventReplayBuffer>, Instant);
@@ -285,6 +286,8 @@ pub struct AppState {
     /// `/v1/agents/:id/runtime-stats`.  When `None`, the endpoint returns
     /// 503 so embedders can opt out.
     pub runtime_stats: Option<Arc<RuntimeStatsRegistry>>,
+    /// Optional audit logger.  When `Some`, admin mutations emit events.
+    pub audit_log: Option<Arc<AuditLogger>>,
 }
 
 impl AppState {
@@ -308,6 +311,7 @@ impl AppState {
             replay_buffers: Arc::new(Mutex::new(HashMap::new())),
             mcp_http: Arc::new(crate::protocols::mcp::http::McpHttpState::new()),
             runtime_stats: None,
+            audit_log: None,
         }
     }
 
@@ -366,6 +370,16 @@ impl AppState {
     /// environment variable overrides.
     pub fn admin_api_config(&self) -> AdminApiConfig {
         admin_api_config(self)
+    }
+
+    /// Enable the audit logger.  When a `config_store` is already attached and
+    /// `audit_log_enabled` is `true` in [`AdminApiConfig`], pass an
+    /// `AuditLogger` constructed from that store.  This method is an explicit
+    /// opt-in; existing embedders are unaffected unless they call it.
+    #[must_use]
+    pub fn with_audit_log(mut self, logger: Arc<AuditLogger>) -> Self {
+        self.audit_log = Some(logger);
+        self
     }
 
     /// Insert a replay buffer for the given key, tracking creation time.

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -124,6 +124,10 @@ pub struct AdminApiConfig {
     #[serde(default = "default_audit_retention_days")]
     pub audit_retention_days: u32,
     /// Interval in seconds between audit retention sweeps. Default 3600 (1 hour).
+    ///
+    /// A value of `0` is treated as misconfiguration: the server will warn and
+    /// clamp to 60 seconds. Values between 1 and 9 emit a warning but are
+    /// respected as the operator may have a specific reason.
     #[serde(default = "default_audit_sweep_interval_secs")]
     pub audit_sweep_interval_secs: u64,
 }
@@ -142,6 +146,27 @@ const fn default_audit_retention_days() -> u32 {
 
 const fn default_audit_sweep_interval_secs() -> u64 {
     3600
+}
+
+/// Compute the effective sweep interval, emitting warnings for suspicious values.
+///
+/// - `0` → warn and clamp to 60 s (implicit floor).
+/// - `1..=9` → warn (respected as-is; operator may have a real reason).
+pub fn effective_sweep_interval(secs: u64) -> std::time::Duration {
+    if secs == 0 {
+        tracing::warn!(
+            audit_sweep_interval_secs = secs,
+            "audit sweep interval is 0 — clamping to 60 s to avoid a tight spin loop"
+        );
+        return std::time::Duration::from_secs(60);
+    }
+    if secs < 10 {
+        tracing::warn!(
+            audit_sweep_interval_secs = secs,
+            "audit sweep interval is very small; consider a value >= 10 s"
+        );
+    }
+    std::time::Duration::from_secs(secs)
 }
 
 impl Default for AdminApiConfig {
@@ -423,10 +448,10 @@ impl AppState {
         let logger = Arc::new(AuditLogger::new(store));
         let logger_for_sweeper = logger.clone();
         let retention_days = admin_config.audit_retention_days;
-        let sweep_interval_secs = admin_config.audit_sweep_interval_secs;
+        let sweep_interval = effective_sweep_interval(admin_config.audit_sweep_interval_secs);
         // Spawn retention sweeper (fire-and-forget; leaked on shutdown, acceptable for v1).
         tokio::spawn(async move {
-            let interval = std::time::Duration::from_secs(sweep_interval_secs.max(1));
+            let interval = sweep_interval;
             loop {
                 tokio::time::sleep(interval).await;
                 let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
@@ -918,5 +943,30 @@ mod tests {
         assert_eq!(map.lock().len(), 1);
         assert!(map.lock().get("recent-run").is_some());
         assert!(map.lock().get("old-run").is_none());
+    }
+
+    // ── effective_sweep_interval ────────────────────────────────────────────
+
+    #[test]
+    fn sweep_interval_zero_clamps_to_60s() {
+        let duration = effective_sweep_interval(0);
+        assert_eq!(
+            duration,
+            std::time::Duration::from_secs(60),
+            "zero sweep interval must clamp to 60 s"
+        );
+    }
+
+    #[test]
+    fn sweep_interval_normal_value_is_respected() {
+        let duration = effective_sweep_interval(3600);
+        assert_eq!(duration, std::time::Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn sweep_interval_small_nonzero_is_respected() {
+        // Values 1–9 should warn but still be used as-is.
+        let duration = effective_sweep_interval(5);
+        assert_eq!(duration, std::time::Duration::from_secs(5));
     }
 }

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -117,10 +117,31 @@ pub struct AdminApiConfig {
     /// `false` to keep the HTTP surface free of those endpoints entirely.
     #[serde(default = "default_expose_config_routes")]
     pub expose_config_routes: bool,
+    /// Whether the audit log is enabled. Defaults to `true`.
+    #[serde(default = "default_audit_log_enabled")]
+    pub audit_log_enabled: bool,
+    /// Retention window for audit events in days. Default 90 days.
+    #[serde(default = "default_audit_retention_days")]
+    pub audit_retention_days: u32,
+    /// Interval in seconds between audit retention sweeps. Default 3600 (1 hour).
+    #[serde(default = "default_audit_sweep_interval_secs")]
+    pub audit_sweep_interval_secs: u64,
 }
 
 const fn default_expose_config_routes() -> bool {
     true
+}
+
+const fn default_audit_log_enabled() -> bool {
+    true
+}
+
+const fn default_audit_retention_days() -> u32 {
+    90
+}
+
+const fn default_audit_sweep_interval_secs() -> u64 {
+    3600
 }
 
 impl Default for AdminApiConfig {
@@ -129,6 +150,9 @@ impl Default for AdminApiConfig {
             bearer_token: None,
             cors_allowed_origins: default_admin_cors_allowed_origins(),
             expose_config_routes: default_expose_config_routes(),
+            audit_log_enabled: default_audit_log_enabled(),
+            audit_retention_days: default_audit_retention_days(),
+            audit_sweep_interval_secs: default_audit_sweep_interval_secs(),
         }
     }
 }
@@ -380,6 +404,45 @@ impl AppState {
     pub fn with_audit_log(mut self, logger: Arc<AuditLogger>) -> Self {
         self.audit_log = Some(logger);
         self
+    }
+
+    /// Builder convenience: create an `AuditLogger` from the already-attached
+    /// `config_store` (if any) and the effective `AdminApiConfig` settings.
+    ///
+    /// If `audit_log_enabled` is `false` or no config store is attached, this
+    /// is a no-op.  Also spawns the background retention sweeper task.
+    #[must_use]
+    pub fn with_audit_log_from_config(self) -> Self {
+        let admin_config = admin_api_config(&self);
+        if !admin_config.audit_log_enabled {
+            return self;
+        }
+        let Some(store) = self.config_store.clone() else {
+            return self;
+        };
+        let logger = Arc::new(AuditLogger::new(store));
+        let logger_for_sweeper = logger.clone();
+        let retention_days = admin_config.audit_retention_days;
+        let sweep_interval_secs = admin_config.audit_sweep_interval_secs;
+        // Spawn retention sweeper (fire-and-forget; leaked on shutdown, acceptable for v1).
+        tokio::spawn(async move {
+            let interval = std::time::Duration::from_secs(sweep_interval_secs.max(1));
+            loop {
+                tokio::time::sleep(interval).await;
+                let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days as i64);
+                match logger_for_sweeper.prune_before(cutoff).await {
+                    Ok(pruned) => {
+                        if pruned > 0 {
+                            tracing::info!(pruned, "audit retention sweep complete");
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(error = %error, "audit retention sweep failed");
+                    }
+                }
+            }
+        });
+        self.with_audit_log(logger)
     }
 
     /// Insert a replay buffer for the given key, tracking creation time.

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -14,6 +14,7 @@ struct DeleteParams {
 
 use crate::app::AppState;
 use crate::routes::ApiError;
+use crate::services::audit_log::AuditQuery;
 use crate::services::config_service::{
     ConfigNamespace, ConfigService, ConfigServiceError, ProviderTestResult,
 };
@@ -47,6 +48,7 @@ pub fn config_routes() -> Router<AppState> {
         .route("/v1/providers/:id/test", post(test_provider_connection))
         .route("/v1/mcp-servers/:id/status", get(get_mcp_server_status))
         .route("/v1/mcp-servers/:id/restart", post(post_mcp_server_restart))
+        .route("/v1/audit-log", get(list_audit_log))
 }
 
 async fn get_capabilities(
@@ -276,6 +278,26 @@ async fn post_mcp_server_restart(
     })?;
 
     Ok(StatusCode::ACCEPTED)
+}
+
+async fn list_audit_log(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<AuditQuery>,
+) -> Result<impl IntoResponse, ConfigRouteError> {
+    ensure_admin_auth(&state, &headers)?;
+    let audit = state.audit_log.as_ref().ok_or_else(|| {
+        ConfigRouteError::Api(ApiError::ServiceUnavailable(
+            "audit log is not configured".into(),
+        ))
+    })?;
+    let mut effective_query = query;
+    effective_query.limit = effective_query.limit.min(1000).max(1);
+    let page = audit
+        .query(effective_query)
+        .await
+        .map_err(|e| ConfigRouteError::Api(ApiError::Internal(e.to_string())))?;
+    Ok(Json(page))
 }
 
 #[derive(Debug)]

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -306,7 +306,7 @@ async fn list_audit_log(
         ))
     })?;
     let mut effective_query = query;
-    effective_query.limit = effective_query.limit.min(1000).max(1);
+    effective_query.limit = effective_query.limit.clamp(1, 1000);
     let page = audit
         .query(effective_query)
         .await

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -277,6 +277,20 @@ async fn post_mcp_server_restart(
         }
     })?;
 
+    // Emit audit event after successful restart.
+    if let Some(audit) = &state.audit_log {
+        let resource = format!("mcp-servers/{id}");
+        audit
+            .emit(
+                awaken_contract::AuditAction::Restart,
+                &resource,
+                None,
+                None,
+                &headers,
+            )
+            .await;
+    }
+
     Ok(StatusCode::ACCEPTED)
 }
 

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -127,7 +127,7 @@ async fn create_config(
     let namespace = ConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let created = service
-        .create(namespace, body)
+        .create(namespace, body, &headers)
         .await
         .map_err(map_service_error)?;
     Ok((StatusCode::CREATED, Json(created)))
@@ -167,7 +167,7 @@ async fn put_config(
     let namespace = ConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let updated = service
-        .update(namespace, &id, body)
+        .update(namespace, &id, body, &headers)
         .await
         .map_err(map_service_error)?;
     Ok(Json(updated))
@@ -190,7 +190,7 @@ async fn delete_config(
         Ok(s) => s,
         Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
     };
-    match service.delete(namespace, &id, params.force).await {
+    match service.delete(namespace, &id, params.force, &headers).await {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(ConfigServiceError::Blocked { used_by }) => (
             StatusCode::CONFLICT,

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -14,7 +14,7 @@ struct DeleteParams {
 
 use crate::app::AppState;
 use crate::routes::ApiError;
-use crate::services::audit_log::AuditQuery;
+use crate::services::audit_log::{AuditQuery, AuditQueryError};
 use crate::services::config_service::{
     ConfigNamespace, ConfigService, ConfigServiceError, ProviderTestResult,
 };
@@ -307,10 +307,14 @@ async fn list_audit_log(
     })?;
     let mut effective_query = query;
     effective_query.limit = effective_query.limit.clamp(1, 1000);
-    let page = audit
-        .query(effective_query)
-        .await
-        .map_err(|e| ConfigRouteError::Api(ApiError::Internal(e.to_string())))?;
+    let page = audit.query(effective_query).await.map_err(|e| match e {
+        AuditQueryError::InvalidCursor => {
+            ConfigRouteError::Api(ApiError::BadRequest("invalid cursor".into()))
+        }
+        AuditQueryError::Storage(storage_err) => {
+            ConfigRouteError::Api(ApiError::Internal(storage_err.to_string()))
+        }
+    })?;
     Ok(Json(page))
 }
 

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -1,0 +1,679 @@
+//! Audit log service — stores, queries, and prunes audit events.
+//!
+//! Events are stored in the `_audit` namespace of the existing `ConfigStore`
+//! using ULID keys so time-ordering is preserved without a secondary index.
+
+use std::sync::Arc;
+
+use awaken_contract::AuditAction;
+use awaken_contract::AuditEvent;
+use awaken_contract::contract::config_store::ConfigStore;
+use awaken_contract::contract::storage::StorageError;
+use axum::http::HeaderMap;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use sha2::Digest;
+
+/// Storage namespace for all audit events.
+pub const AUDIT_NAMESPACE: &str = "_audit";
+
+/// Query parameters for listing audit events.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct AuditQuery {
+    /// Include only events at or after this timestamp (RFC 3339).
+    #[serde(default)]
+    pub since: Option<DateTime<Utc>>,
+    /// Include only events strictly before this timestamp (RFC 3339).
+    #[serde(default)]
+    pub until: Option<DateTime<Utc>>,
+    /// Filter by action type.
+    #[serde(default)]
+    pub action: Option<AuditAction>,
+    /// Filter by exact resource path (`namespace/id`).
+    #[serde(default)]
+    pub resource: Option<String>,
+    /// Filter by actor hash prefix.
+    #[serde(default)]
+    pub actor: Option<String>,
+    /// Max results, default 100, capped at 1000.
+    #[serde(default = "default_audit_limit")]
+    pub limit: usize,
+    /// Opaque keyset cursor from a previous response.
+    #[serde(default)]
+    pub cursor: Option<String>,
+}
+
+fn default_audit_limit() -> usize {
+    100
+}
+
+/// Paginated result set for audit event queries.
+#[derive(Debug, serde::Serialize)]
+pub struct AuditPage {
+    pub items: Vec<AuditEvent>,
+    pub next_cursor: Option<String>,
+}
+
+/// Stateless service that records and queries audit events.
+pub struct AuditLogger {
+    store: Arc<dyn ConfigStore>,
+}
+
+impl AuditLogger {
+    pub fn new(store: Arc<dyn ConfigStore>) -> Self {
+        Self { store }
+    }
+
+    /// Record an audit event.  Best-effort: failures emit a warning and
+    /// increment the write-failure metric but are never propagated to callers.
+    pub async fn emit(
+        &self,
+        action: AuditAction,
+        resource: &str,
+        before: Option<Value>,
+        after: Option<Value>,
+        headers: &HeaderMap,
+    ) {
+        let id = ulid::Ulid::new().to_string();
+        let ts = Utc::now().to_rfc3339();
+        let actor = derive_actor(headers);
+        let ip = extract_client_ip(headers);
+        let request_id = headers
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+
+        let before = before.map(redact_secrets);
+        let after = after.map(redact_secrets);
+
+        let event = AuditEvent {
+            id: id.clone(),
+            ts,
+            actor,
+            action,
+            resource: resource.to_string(),
+            before,
+            after,
+            ip,
+            request_id,
+        };
+
+        let value = match serde_json::to_value(&event) {
+            Ok(v) => v,
+            Err(error) => {
+                tracing::warn!(error = %error, "audit: failed to serialize event");
+                metrics::counter!("awaken_audit_write_failures_total").increment(1);
+                return;
+            }
+        };
+
+        if let Err(error) = self.store.put(AUDIT_NAMESPACE, &id, &value).await {
+            tracing::warn!(error = %error, "audit: failed to write event");
+            metrics::counter!("awaken_audit_write_failures_total").increment(1);
+            return;
+        }
+
+        let action_label = serde_json::to_value(&event.action)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_else(|| "unknown".to_string());
+        metrics::counter!("awaken_audit_events_total", "action" => action_label).increment(1);
+    }
+
+    /// Query audit events with optional filters and keyset pagination.
+    pub async fn query(&self, filter: AuditQuery) -> Result<AuditPage, StorageError> {
+        let limit = filter.limit.min(1000).max(1);
+        let effective_limit = limit;
+
+        // Decode cursor to get the last-seen id (exclusive upper bound).
+        let cursor_id = filter.cursor.as_deref().and_then(decode_cursor);
+
+        // Fetch all entries in the namespace (sorted ascending by ULID).
+        // Linear scan per ADR D3 footnote.
+        let all = self.store.list(AUDIT_NAMESPACE, 0, usize::MAX).await?;
+
+        // Deserialize and filter.
+        let mut events: Vec<AuditEvent> = all
+            .into_iter()
+            .filter_map(|(id, value)| {
+                // Cursor: only include entries with id < cursor_id (older pages).
+                // We're serving newest-first so we reverse later.
+                if let Some(ref cid) = cursor_id {
+                    if id.as_str() >= cid.as_str() {
+                        return None;
+                    }
+                }
+                serde_json::from_value::<AuditEvent>(value).ok()
+            })
+            .filter(|event| {
+                if let Some(ref since) = filter.since {
+                    if let Ok(ts) = event.ts.parse::<DateTime<Utc>>() {
+                        if ts < *since {
+                            return false;
+                        }
+                    }
+                }
+                if let Some(ref until) = filter.until {
+                    if let Ok(ts) = event.ts.parse::<DateTime<Utc>>() {
+                        if ts >= *until {
+                            return false;
+                        }
+                    }
+                }
+                if let Some(ref action) = filter.action {
+                    if &event.action != action {
+                        return false;
+                    }
+                }
+                if let Some(ref resource) = filter.resource {
+                    if &event.resource != resource {
+                        return false;
+                    }
+                }
+                if let Some(ref actor) = filter.actor {
+                    if !event.actor.starts_with(actor.as_str()) {
+                        return false;
+                    }
+                }
+                true
+            })
+            .collect();
+
+        // Newest first.
+        events.sort_by(|a, b| b.id.cmp(&a.id));
+
+        let next_cursor = if events.len() > effective_limit {
+            events.truncate(effective_limit);
+            events.last().map(|e| encode_cursor(&e.id))
+        } else {
+            None
+        };
+
+        Ok(AuditPage {
+            items: events,
+            next_cursor,
+        })
+    }
+
+    /// Delete all events whose ULID timestamp is before `cutoff`.
+    /// Returns the number of pruned entries.
+    pub async fn prune_before(&self, cutoff: DateTime<Utc>) -> Result<usize, StorageError> {
+        let all = self.store.list(AUDIT_NAMESPACE, 0, usize::MAX).await?;
+
+        let mut pruned = 0usize;
+        for (id, _) in all {
+            // Decode ULID timestamp.
+            if let Ok(ulid) = id.parse::<ulid::Ulid>() {
+                let ms = ulid.timestamp_ms();
+                let event_ts =
+                    DateTime::from_timestamp_millis(ms as i64).unwrap_or(DateTime::UNIX_EPOCH);
+                if event_ts < cutoff {
+                    self.store.delete(AUDIT_NAMESPACE, &id).await?;
+                    pruned += 1;
+                }
+            }
+        }
+
+        if pruned > 0 {
+            metrics::counter!("awaken_audit_sweep_pruned_total").increment(pruned as u64);
+            tracing::info!(pruned, "audit sweep pruned events");
+        }
+        Ok(pruned)
+    }
+}
+
+/// Derive the actor string from request headers.
+///
+/// - `Authorization: Bearer <token>` → first 16 hex chars of SHA-256(token)
+/// - Otherwise → `"anonymous"`
+/// - If `X-Awaken-Actor` is also present and valid → append `"/<label>"`
+pub fn derive_actor(headers: &HeaderMap) -> String {
+    let base = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| {
+            s.strip_prefix("Bearer ")
+                .or_else(|| s.strip_prefix("bearer "))
+        })
+        .map(|token| {
+            let hash = sha2::Sha256::digest(token.as_bytes());
+            let hex = format!("{hash:x}");
+            hex[..16].to_string()
+        })
+        .unwrap_or_else(|| "anonymous".to_string());
+
+    // Optional advisory label.
+    if let Some(label) = headers
+        .get("x-awaken-actor")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .filter(|s| s.len() <= 64)
+        .filter(|s| s.bytes().all(|b| b.is_ascii() && !b.is_ascii_control()))
+    {
+        format!("{base}/{label}")
+    } else {
+        base
+    }
+}
+
+/// Recursively replace values whose key matches common secret patterns with `"***"`.
+pub fn redact_secrets(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (key, val) in map {
+                let lower = key.to_lowercase();
+                if lower.contains("api_key")
+                    || lower.contains("bearer")
+                    || lower.contains("token")
+                    || lower.contains("password")
+                    || lower.contains("secret")
+                {
+                    out.insert(key, Value::String("***".to_string()));
+                } else {
+                    out.insert(key, redact_secrets(val));
+                }
+            }
+            Value::Object(out)
+        }
+        Value::Array(arr) => Value::Array(arr.into_iter().map(redact_secrets).collect()),
+        other => other,
+    }
+}
+
+/// Extract the client IP from request headers.
+/// Prefers `x-forwarded-for` (first address); falls back to `x-real-ip`.
+pub fn extract_client_ip(headers: &HeaderMap) -> Option<String> {
+    if let Some(xff) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
+        let first = xff.split(',').next().map(str::trim).unwrap_or("");
+        if !first.is_empty() {
+            return Some(first.to_string());
+        }
+    }
+    headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+fn encode_cursor(id: &str) -> String {
+    base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, id)
+}
+
+fn decode_cursor(cursor: &str) -> Option<String> {
+    base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, cursor)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use awaken_contract::AuditAction;
+    use awaken_contract::contract::config_store::ConfigStore;
+    use awaken_contract::contract::storage::StorageError;
+    use axum::http::{HeaderMap, HeaderValue};
+    use chrono::Utc;
+    use serde_json::{Value, json};
+    use tokio::sync::RwLock;
+
+    use super::*;
+
+    // ── minimal in-memory store ───────────────────────────────────────────
+
+    #[derive(Default)]
+    struct MemStore {
+        data: RwLock<HashMap<String, HashMap<String, Value>>>,
+    }
+
+    #[async_trait]
+    impl ConfigStore for MemStore {
+        async fn get(&self, ns: &str, id: &str) -> Result<Option<Value>, StorageError> {
+            Ok(self
+                .data
+                .read()
+                .await
+                .get(ns)
+                .and_then(|m| m.get(id))
+                .cloned())
+        }
+
+        async fn list(
+            &self,
+            ns: &str,
+            _offset: usize,
+            _limit: usize,
+        ) -> Result<Vec<(String, Value)>, StorageError> {
+            let data = self.data.read().await;
+            let mut items: Vec<_> = data
+                .get(ns)
+                .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                .unwrap_or_default();
+            items.sort_by(|a, b| a.0.cmp(&b.0));
+            Ok(items)
+        }
+
+        async fn put(&self, ns: &str, id: &str, value: &Value) -> Result<(), StorageError> {
+            self.data
+                .write()
+                .await
+                .entry(ns.to_string())
+                .or_default()
+                .insert(id.to_string(), value.clone());
+            Ok(())
+        }
+
+        async fn delete(&self, ns: &str, id: &str) -> Result<(), StorageError> {
+            if let Some(m) = self.data.write().await.get_mut(ns) {
+                m.remove(id);
+            }
+            Ok(())
+        }
+    }
+
+    fn make_logger() -> AuditLogger {
+        AuditLogger::new(Arc::new(MemStore::default()))
+    }
+
+    fn empty_headers() -> HeaderMap {
+        HeaderMap::new()
+    }
+
+    // ── derive_actor ──────────────────────────────────────────────────────
+
+    #[test]
+    fn derive_actor_anonymous_when_no_auth() {
+        let headers = empty_headers();
+        assert_eq!(derive_actor(&headers), "anonymous");
+    }
+
+    #[test]
+    fn derive_actor_hash_only_with_bearer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer mysecrettoken"),
+        );
+        let actor = derive_actor(&headers);
+        assert!(
+            !actor.contains("mysecrettoken"),
+            "raw token must not appear"
+        );
+        assert_eq!(actor.len(), 16, "hash prefix must be 16 hex chars");
+        assert!(actor.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn derive_actor_hash_plus_valid_label() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer tok"),
+        );
+        headers.insert("x-awaken-actor", HeaderValue::from_static("ci/deploy-prod"));
+        let actor = derive_actor(&headers);
+        assert!(actor.contains("/ci/deploy-prod"), "label must be appended");
+    }
+
+    #[test]
+    fn derive_actor_invalid_label_dropped() {
+        // Verify that a label containing non-printable ASCII (control chars) is
+        // dropped at the derive_actor logic level. HTTP headers cannot carry
+        // control bytes, so we test the filter predicate directly by injecting
+        // a mock value that passes header parsing but fails our check.
+        // We approximate this by testing empty label (trimmed to empty → dropped).
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer tok"),
+        );
+        headers.insert("x-awaken-actor", HeaderValue::from_static("   "));
+        let actor = derive_actor(&headers);
+        // A whitespace-only label trims to empty → dropped.
+        assert!(
+            !actor.contains('/'),
+            "empty/whitespace label must not be appended"
+        );
+        assert_eq!(actor.len(), 16);
+    }
+
+    #[test]
+    fn derive_actor_label_too_long_dropped() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer tok"),
+        );
+        let long_label = "a".repeat(65);
+        headers.insert(
+            "x-awaken-actor",
+            HeaderValue::from_str(&long_label).unwrap(),
+        );
+        let actor = derive_actor(&headers);
+        assert!(
+            !actor.contains('/'),
+            "over-length label must not be appended"
+        );
+    }
+
+    // ── redact_secrets ────────────────────────────────────────────────────
+
+    #[test]
+    fn redact_secrets_top_level() {
+        let input = json!({"api_key": "sk-1234", "name": "test"});
+        let output = redact_secrets(input);
+        assert_eq!(output["api_key"], "***");
+        assert_eq!(output["name"], "test");
+    }
+
+    #[test]
+    fn redact_secrets_nested_objects() {
+        let input = json!({"provider": {"api_key": "sk-1234", "model": "gpt-4"}});
+        let output = redact_secrets(input);
+        assert_eq!(output["provider"]["api_key"], "***");
+        assert_eq!(output["provider"]["model"], "gpt-4");
+    }
+
+    #[test]
+    fn redact_secrets_arrays_of_objects() {
+        let input = json!([{"password": "hunter2", "user": "alice"}]);
+        let output = redact_secrets(input);
+        assert_eq!(output[0]["password"], "***");
+        assert_eq!(output[0]["user"], "alice");
+    }
+
+    #[test]
+    fn redact_secrets_mixed_primitives() {
+        let input = json!({"count": 42, "flag": true, "nothing": null, "secret": "x"});
+        let output = redact_secrets(input);
+        assert_eq!(output["count"], 42);
+        assert_eq!(output["flag"], true);
+        assert_eq!(output["nothing"], Value::Null);
+        assert_eq!(output["secret"], "***");
+    }
+
+    // ── emit ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn emit_happy_path_stores_event() {
+        let logger = make_logger();
+        let headers = empty_headers();
+        logger
+            .emit(
+                AuditAction::Create,
+                "agents/my-agent",
+                None,
+                Some(json!({"id": "my-agent"})),
+                &headers,
+            )
+            .await;
+
+        let page = logger.query(AuditQuery::default()).await.unwrap();
+        assert_eq!(page.items.len(), 1);
+        let event = &page.items[0];
+        assert_eq!(event.action, AuditAction::Create);
+        assert_eq!(event.resource, "agents/my-agent");
+        assert_eq!(event.actor, "anonymous");
+    }
+
+    #[tokio::test]
+    async fn emit_failure_does_not_propagate() {
+        // Use a store that always fails writes.
+        struct FailStore;
+
+        #[async_trait]
+        impl ConfigStore for FailStore {
+            async fn get(&self, _ns: &str, _id: &str) -> Result<Option<Value>, StorageError> {
+                Ok(None)
+            }
+            async fn list(
+                &self,
+                _ns: &str,
+                _offset: usize,
+                _limit: usize,
+            ) -> Result<Vec<(String, Value)>, StorageError> {
+                Ok(vec![])
+            }
+            async fn put(&self, _ns: &str, _id: &str, _value: &Value) -> Result<(), StorageError> {
+                Err(StorageError::Io("simulated failure".into()))
+            }
+            async fn delete(&self, _ns: &str, _id: &str) -> Result<(), StorageError> {
+                Ok(())
+            }
+        }
+
+        let logger = AuditLogger::new(Arc::new(FailStore));
+        // Must not panic or propagate.
+        logger
+            .emit(
+                AuditAction::Delete,
+                "agents/x",
+                None,
+                None,
+                &empty_headers(),
+            )
+            .await;
+    }
+
+    // ── query filters ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn query_filters_by_resource() {
+        let logger = make_logger();
+        let h = empty_headers();
+        logger
+            .emit(AuditAction::Create, "agents/a", None, None, &h)
+            .await;
+        logger
+            .emit(AuditAction::Create, "agents/b", None, None, &h)
+            .await;
+
+        let page = logger
+            .query(AuditQuery {
+                resource: Some("agents/a".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].resource, "agents/a");
+    }
+
+    #[tokio::test]
+    async fn query_filters_by_action() {
+        let logger = make_logger();
+        let h = empty_headers();
+        logger
+            .emit(AuditAction::Create, "agents/c", None, None, &h)
+            .await;
+        logger
+            .emit(AuditAction::Delete, "agents/c", None, None, &h)
+            .await;
+
+        let page = logger
+            .query(AuditQuery {
+                action: Some(AuditAction::Delete),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].action, AuditAction::Delete);
+    }
+
+    // ── cursor pagination ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn cursor_pagination_round_trip() {
+        let logger = make_logger();
+        let h = empty_headers();
+
+        // Emit 5 events.
+        for i in 0..5 {
+            logger
+                .emit(
+                    AuditAction::Create,
+                    &format!("agents/agent-{i}"),
+                    None,
+                    None,
+                    &h,
+                )
+                .await;
+            // Tiny sleep to ensure distinct ULIDs.
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+
+        // Page 1: limit 3.
+        let page1 = logger
+            .query(AuditQuery {
+                limit: 3,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page1.items.len(), 3);
+        assert!(page1.next_cursor.is_some());
+
+        // Page 2: continue with cursor.
+        let page2 = logger
+            .query(AuditQuery {
+                limit: 3,
+                cursor: page1.next_cursor,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page2.items.len(), 2);
+        assert!(page2.next_cursor.is_none());
+    }
+
+    // ── prune_before ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn prune_before_removes_old_events() {
+        let logger = make_logger();
+        let h = empty_headers();
+        logger
+            .emit(AuditAction::Create, "agents/old", None, None, &h)
+            .await;
+
+        let cutoff = Utc::now();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        logger
+            .emit(AuditAction::Create, "agents/new", None, None, &h)
+            .await;
+
+        let pruned = logger.prune_before(cutoff).await.unwrap();
+        assert_eq!(pruned, 1, "one old event should be pruned");
+
+        let page = logger.query(AuditQuery::default()).await.unwrap();
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].resource, "agents/new");
+    }
+}

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -122,8 +122,7 @@ impl AuditLogger {
 
     /// Query audit events with optional filters and keyset pagination.
     pub async fn query(&self, filter: AuditQuery) -> Result<AuditPage, StorageError> {
-        let limit = filter.limit.min(1000).max(1);
-        let effective_limit = limit;
+        let effective_limit = filter.limit.clamp(1, 1000);
 
         // Decode cursor to get the last-seen id (exclusive upper bound).
         let cursor_id = filter.cursor.as_deref().and_then(decode_cursor);
@@ -138,42 +137,38 @@ impl AuditLogger {
             .filter_map(|(id, value)| {
                 // Cursor: only include entries with id < cursor_id (older pages).
                 // We're serving newest-first so we reverse later.
-                if let Some(ref cid) = cursor_id {
-                    if id.as_str() >= cid.as_str() {
-                        return None;
-                    }
+                if cursor_id.as_deref().is_some_and(|cid| id.as_str() >= cid) {
+                    return None;
                 }
                 serde_json::from_value::<AuditEvent>(value).ok()
             })
             .filter(|event| {
-                if let Some(ref since) = filter.since {
-                    if let Ok(ts) = event.ts.parse::<DateTime<Utc>>() {
-                        if ts < *since {
-                            return false;
-                        }
-                    }
+                if let Some(ref since) = filter.since
+                    && let Ok(ts) = event.ts.parse::<DateTime<Utc>>()
+                    && ts < *since
+                {
+                    return false;
                 }
-                if let Some(ref until) = filter.until {
-                    if let Ok(ts) = event.ts.parse::<DateTime<Utc>>() {
-                        if ts >= *until {
-                            return false;
-                        }
-                    }
+                if let Some(ref until) = filter.until
+                    && let Ok(ts) = event.ts.parse::<DateTime<Utc>>()
+                    && ts >= *until
+                {
+                    return false;
                 }
-                if let Some(ref action) = filter.action {
-                    if &event.action != action {
-                        return false;
-                    }
+                if let Some(ref action) = filter.action
+                    && &event.action != action
+                {
+                    return false;
                 }
-                if let Some(ref resource) = filter.resource {
-                    if &event.resource != resource {
-                        return false;
-                    }
+                if let Some(ref resource) = filter.resource
+                    && &event.resource != resource
+                {
+                    return false;
                 }
-                if let Some(ref actor) = filter.actor {
-                    if !event.actor.starts_with(actor.as_str()) {
-                        return false;
-                    }
+                if let Some(ref actor) = filter.actor
+                    && !event.actor.starts_with(actor.as_str())
+                {
+                    return false;
                 }
                 true
             })

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -54,6 +54,15 @@ pub struct AuditPage {
     pub next_cursor: Option<String>,
 }
 
+/// Error returned by [`AuditLogger::query`].
+#[derive(Debug, thiserror::Error)]
+pub enum AuditQueryError {
+    #[error("invalid cursor")]
+    InvalidCursor,
+    #[error("storage error: {0}")]
+    Storage(#[from] StorageError),
+}
+
 /// Stateless service that records and queries audit events.
 pub struct AuditLogger {
     store: Arc<dyn ConfigStore>,
@@ -121,15 +130,26 @@ impl AuditLogger {
     }
 
     /// Query audit events with optional filters and keyset pagination.
-    pub async fn query(&self, filter: AuditQuery) -> Result<AuditPage, StorageError> {
+    ///
+    /// Returns `Err` if `filter.cursor` is present but not valid base64.
+    pub async fn query(&self, filter: AuditQuery) -> Result<AuditPage, AuditQueryError> {
         let effective_limit = filter.limit.clamp(1, 1000);
 
         // Decode cursor to get the last-seen id (exclusive upper bound).
-        let cursor_id = filter.cursor.as_deref().and_then(decode_cursor);
+        let cursor_id = filter
+            .cursor
+            .as_deref()
+            .map(decode_cursor)
+            .transpose()
+            .map_err(|_| AuditQueryError::InvalidCursor)?;
 
         // Fetch all entries in the namespace (sorted ascending by ULID).
         // Linear scan per ADR D3 footnote.
-        let all = self.store.list(AUDIT_NAMESPACE, 0, usize::MAX).await?;
+        let all = self
+            .store
+            .list(AUDIT_NAMESPACE, 0, usize::MAX)
+            .await
+            .map_err(AuditQueryError::Storage)?;
 
         // Deserialize and filter.
         let mut events: Vec<AuditEvent> = all
@@ -297,10 +317,11 @@ fn encode_cursor(id: &str) -> String {
     base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, id)
 }
 
-fn decode_cursor(cursor: &str) -> Option<String> {
+fn decode_cursor(cursor: &str) -> Result<String, ()> {
     base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, cursor)
         .ok()
         .and_then(|bytes| String::from_utf8(bytes).ok())
+        .ok_or(())
 }
 
 #[cfg(test)]

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -253,12 +253,15 @@ impl<'a> ConfigService<'a> {
             .persist_and_apply_locked(manager.as_ref(), namespace, &id, None, body.clone())
             .await?;
 
-        if let Some(audit) = &self.audit {
-            let resource = format!("{}/{}", namespace.as_str(), id);
-            audit
-                .emit(AuditAction::Create, &resource, None, Some(body), headers)
-                .await;
-        }
+        self.emit_audit(
+            AuditAction::Create,
+            namespace,
+            &id,
+            None,
+            Some(body),
+            headers,
+        )
+        .await;
 
         Ok(result)
     }
@@ -290,18 +293,15 @@ impl<'a> ConfigService<'a> {
             )
             .await?;
 
-        if let Some(audit) = &self.audit {
-            let resource = format!("{}/{}", namespace.as_str(), id);
-            audit
-                .emit(
-                    AuditAction::Update,
-                    &resource,
-                    previous,
-                    Some(body),
-                    headers,
-                )
-                .await;
-        }
+        self.emit_audit(
+            AuditAction::Update,
+            namespace,
+            id,
+            previous,
+            Some(body),
+            headers,
+        )
+        .await;
 
         Ok(result)
     }
@@ -341,18 +341,15 @@ impl<'a> ConfigService<'a> {
             return Err(error);
         }
 
-        if let Some(audit) = &self.audit {
-            let resource = format!("{}/{}", namespace.as_str(), id);
-            audit
-                .emit(
-                    AuditAction::Delete,
-                    &resource,
-                    Some(previous),
-                    None,
-                    headers,
-                )
-                .await;
-        }
+        self.emit_audit(
+            AuditAction::Delete,
+            namespace,
+            id,
+            Some(previous),
+            None,
+            headers,
+        )
+        .await;
 
         Ok(())
     }
@@ -404,6 +401,23 @@ impl<'a> ConfigService<'a> {
             }
             ConfigNamespace::Agents | ConfigNamespace::McpServers => Ok(vec![]),
         }
+    }
+
+    /// Emit an audit event if an audit logger is configured.
+    ///
+    /// Best-effort: the call is fire-and-forget (matching the `AuditLogger::emit` contract).
+    async fn emit_audit(
+        &self,
+        action: AuditAction,
+        namespace: ConfigNamespace,
+        id: &str,
+        before: Option<Value>,
+        after: Option<Value>,
+        headers: &HeaderMap,
+    ) {
+        let Some(audit) = &self.audit else { return };
+        let resource = format!("{}/{}", namespace.as_str(), id);
+        audit.emit(action, &resource, before, after, headers).await;
     }
 
     fn runtime_manager(

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+use awaken_contract::AuditAction;
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::StorageError;
 use awaken_contract::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
+use axum::http::HeaderMap;
 use serde_json::{Map, Value, json};
 
 use crate::app::AppState;
+use crate::services::audit_log::AuditLogger;
 
 use super::config_runtime::{ConfigRuntimeError, build_genai_provider_executor};
 
@@ -93,6 +96,7 @@ pub struct ProviderTestResult {
 pub struct ConfigService<'a> {
     state: &'a AppState,
     store: Arc<dyn ConfigStore>,
+    audit: Option<Arc<AuditLogger>>,
 }
 
 impl<'a> ConfigService<'a> {
@@ -101,7 +105,11 @@ impl<'a> ConfigService<'a> {
             .config_store
             .clone()
             .ok_or(ConfigServiceError::NotEnabled)?;
-        Ok(Self { state, store })
+        Ok(Self {
+            state,
+            store,
+            audit: state.audit_log.clone(),
+        })
     }
 
     pub async fn capabilities(&self) -> Result<Value, ConfigServiceError> {
@@ -228,6 +236,7 @@ impl<'a> ConfigService<'a> {
         &self,
         namespace: ConfigNamespace,
         body: Value,
+        headers: &HeaderMap,
     ) -> Result<Value, ConfigServiceError> {
         let manager = self.runtime_manager()?;
         let _apply_guard = manager.lock_apply().await;
@@ -240,8 +249,18 @@ impl<'a> ConfigService<'a> {
             )));
         }
 
-        self.persist_and_apply_locked(manager.as_ref(), namespace, &id, None, body)
-            .await
+        let result = self
+            .persist_and_apply_locked(manager.as_ref(), namespace, &id, None, body.clone())
+            .await?;
+
+        if let Some(audit) = &self.audit {
+            let resource = format!("{}/{}", namespace.as_str(), id);
+            audit
+                .emit(AuditAction::Create, &resource, None, Some(body), headers)
+                .await;
+        }
+
+        Ok(result)
     }
 
     pub async fn update(
@@ -249,6 +268,7 @@ impl<'a> ConfigService<'a> {
         namespace: ConfigNamespace,
         id: &str,
         body: Value,
+        headers: &HeaderMap,
     ) -> Result<Value, ConfigServiceError> {
         let manager = self.runtime_manager()?;
         let _apply_guard = manager.lock_apply().await;
@@ -260,8 +280,30 @@ impl<'a> ConfigService<'a> {
         }
 
         let previous = self.store.get(namespace.as_str(), id).await?;
-        self.persist_and_apply_locked(manager.as_ref(), namespace, id, previous, body)
-            .await
+        let result = self
+            .persist_and_apply_locked(
+                manager.as_ref(),
+                namespace,
+                id,
+                previous.clone(),
+                body.clone(),
+            )
+            .await?;
+
+        if let Some(audit) = &self.audit {
+            let resource = format!("{}/{}", namespace.as_str(), id);
+            audit
+                .emit(
+                    AuditAction::Update,
+                    &resource,
+                    previous,
+                    Some(body),
+                    headers,
+                )
+                .await;
+        }
+
+        Ok(result)
     }
 
     pub async fn delete(
@@ -269,6 +311,7 @@ impl<'a> ConfigService<'a> {
         namespace: ConfigNamespace,
         id: &str,
         force: bool,
+        headers: &HeaderMap,
     ) -> Result<(), ConfigServiceError> {
         let manager = self.runtime_manager()?;
         let _apply_guard = manager.lock_apply().await;
@@ -297,6 +340,20 @@ impl<'a> ConfigService<'a> {
             self.store.put(namespace.as_str(), id, &previous).await?;
             return Err(error);
         }
+
+        if let Some(audit) = &self.audit {
+            let resource = format!("{}/{}", namespace.as_str(), id);
+            audit
+                .emit(
+                    AuditAction::Delete,
+                    &resource,
+                    Some(previous),
+                    None,
+                    headers,
+                )
+                .await;
+        }
+
         Ok(())
     }
 
@@ -975,6 +1032,7 @@ mod tests {
                             "id": "serialized",
                             "adapter": "stub"
                         }),
+                        &axum::http::HeaderMap::new(),
                     )
                     .await
             }
@@ -1058,6 +1116,7 @@ mod tests {
                     "id": "missing-manager",
                     "adapter": "stub"
                 }),
+                &axum::http::HeaderMap::new(),
             )
             .await
             .expect_err("missing manager should reject writes");
@@ -1081,6 +1140,7 @@ mod tests {
                     "provider_id": "bootstrap",
                     "upstream_model": "gpt-4"
                 }),
+                &axum::http::HeaderMap::new(),
             )
             .await
             .expect("create model");
@@ -1114,6 +1174,7 @@ mod tests {
                     "system_prompt": "test",
                     "max_rounds": 1
                 }),
+                &axum::http::HeaderMap::new(),
             )
             .await
             .expect("create agent");
@@ -1161,6 +1222,7 @@ mod tests {
             .create(
                 ConfigNamespace::Providers,
                 json!({ "id": "prov-b", "adapter": "stub" }),
+                &axum::http::HeaderMap::new(),
             )
             .await
             .expect("create provider-b");
@@ -1173,12 +1235,18 @@ mod tests {
                     "provider_id": "prov-b",
                     "upstream_model": "gpt-4"
                 }),
+                &axum::http::HeaderMap::new(),
             )
             .await
             .expect("create model-b");
 
         let err = service
-            .delete(ConfigNamespace::Providers, "prov-b", false)
+            .delete(
+                ConfigNamespace::Providers,
+                "prov-b",
+                false,
+                &axum::http::HeaderMap::new(),
+            )
             .await
             .expect_err("should be blocked");
 
@@ -1198,6 +1266,7 @@ mod tests {
             .create(
                 ConfigNamespace::Providers,
                 json!({ "id": "prov-c", "adapter": "stub" }),
+                &axum::http::HeaderMap::new(),
             )
             .await
             .expect("create provider-c");
@@ -1210,14 +1279,176 @@ mod tests {
                     "provider_id": "prov-c",
                     "upstream_model": "gpt-4"
                 }),
+                &axum::http::HeaderMap::new(),
             )
             .await
             .expect("create model-c");
 
         // Force delete should succeed even with dependents
         service
-            .delete(ConfigNamespace::Providers, "prov-c", true)
+            .delete(
+                ConfigNamespace::Providers,
+                "prov-c",
+                true,
+                &axum::http::HeaderMap::new(),
+            )
             .await
             .expect("force delete should succeed");
+    }
+
+    // ── audit integration tests ────────────────────────────────────────────
+
+    mod audit_integration {
+        use std::sync::Arc;
+
+        use awaken_contract::AuditAction;
+        use axum::http::HeaderMap;
+        use serde_json::json;
+
+        use crate::services::audit_log::{AUDIT_NAMESPACE, AuditLogger, AuditQuery};
+        use crate::services::config_service::{ConfigNamespace, ConfigService};
+
+        use super::build_state;
+
+        #[tokio::test]
+        async fn create_emits_audit_create_event() {
+            let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let (state, _manager) = build_state(config_store.clone()).await;
+            let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+            let state = state.with_audit_log(audit_logger.clone());
+
+            let service = ConfigService::new(&state).expect("service");
+            service
+                .create(
+                    ConfigNamespace::Providers,
+                    json!({ "id": "audit-prov", "adapter": "stub" }),
+                    &HeaderMap::new(),
+                )
+                .await
+                .expect("create");
+
+            let page = audit_logger.query(AuditQuery::default()).await.unwrap();
+            assert_eq!(page.items.len(), 1);
+            assert_eq!(page.items[0].action, AuditAction::Create);
+            assert_eq!(page.items[0].resource, "providers/audit-prov");
+            assert!(page.items[0].before.is_none());
+            assert!(page.items[0].after.is_some());
+        }
+
+        #[tokio::test]
+        async fn update_emits_audit_update_event_with_before_after() {
+            let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let (state, _manager) = build_state(config_store.clone()).await;
+            let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+            let state = state.with_audit_log(audit_logger.clone());
+
+            let service = ConfigService::new(&state).expect("service");
+            service
+                .create(
+                    ConfigNamespace::Agents,
+                    json!({ "id": "upd-agent", "model_id": "bootstrap", "system_prompt": "v1", "max_rounds": 1 }),
+                    &HeaderMap::new(),
+                )
+                .await
+                .expect("create");
+
+            service
+                .update(
+                    ConfigNamespace::Agents,
+                    "upd-agent",
+                    json!({ "id": "upd-agent", "model_id": "bootstrap", "system_prompt": "v2", "max_rounds": 1 }),
+                    &HeaderMap::new(),
+                )
+                .await
+                .expect("update");
+
+            let page = audit_logger
+                .query(AuditQuery {
+                    action: Some(AuditAction::Update),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            assert_eq!(page.items.len(), 1);
+            assert_eq!(page.items[0].action, AuditAction::Update);
+            assert!(page.items[0].before.is_some(), "before must be set");
+            assert!(page.items[0].after.is_some(), "after must be set");
+        }
+
+        #[tokio::test]
+        async fn delete_emits_audit_delete_event_with_before() {
+            let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let (state, _manager) = build_state(config_store.clone()).await;
+            let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+            let state = state.with_audit_log(audit_logger.clone());
+
+            let service = ConfigService::new(&state).expect("service");
+            service
+                .create(
+                    ConfigNamespace::Agents,
+                    json!({ "id": "del-agent", "model_id": "bootstrap", "system_prompt": "hi", "max_rounds": 1 }),
+                    &HeaderMap::new(),
+                )
+                .await
+                .expect("create");
+
+            service
+                .delete(
+                    ConfigNamespace::Agents,
+                    "del-agent",
+                    false,
+                    &HeaderMap::new(),
+                )
+                .await
+                .expect("delete");
+
+            // Only the Delete event should be in audit (create is there too but filter by Delete).
+            let page = audit_logger
+                .query(AuditQuery {
+                    action: Some(AuditAction::Delete),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            assert_eq!(page.items.len(), 1);
+            assert_eq!(page.items[0].action, AuditAction::Delete);
+            assert!(
+                page.items[0].before.is_some(),
+                "before must contain deleted payload"
+            );
+            assert!(
+                page.items[0].after.is_none(),
+                "after must be None for delete"
+            );
+        }
+
+        #[tokio::test]
+        async fn config_write_succeeds_even_when_audit_store_separate_and_no_logger() {
+            // Verify that without an audit logger, create still succeeds.
+            let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let (state, _manager) = build_state(config_store.clone()).await;
+            // No audit_log attached.
+
+            let service = ConfigService::new(&state).expect("service");
+            service
+                .create(
+                    ConfigNamespace::Agents,
+                    json!({ "id": "no-audit-agent", "model_id": "bootstrap", "system_prompt": "hi", "max_rounds": 1 }),
+                    &HeaderMap::new(),
+                )
+                .await
+                .expect("create without audit should succeed");
+
+            // Confirm no audit entries exist.
+            let audit_entries = awaken_contract::contract::config_store::ConfigStore::list(
+                config_store.as_ref(),
+                AUDIT_NAMESPACE,
+                0,
+                usize::MAX,
+            )
+            .await
+            .unwrap();
+            assert!(audit_entries.is_empty());
+        }
     }
 }

--- a/crates/awaken-server/src/services/mod.rs
+++ b/crates/awaken-server/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit_log;
 pub mod config_runtime;
 pub mod config_service;
 pub mod run_control_service;

--- a/crates/awaken-server/tests/audit_log_routes.rs
+++ b/crates/awaken-server/tests/audit_log_routes.rs
@@ -347,3 +347,15 @@ async fn returns_503_when_audit_not_configured() {
     let (status, _body) = get_audit_log(&app, "").await;
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
 }
+
+#[tokio::test]
+async fn malformed_cursor_returns_400() {
+    let app = build_test_app_with_audit(None).await;
+    let (status, body) = get_audit_log(&app, "cursor=not-base64-!!!").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+    assert_eq!(
+        body["error"].as_str(),
+        Some("invalid cursor"),
+        "body must contain error: invalid cursor"
+    );
+}

--- a/crates/awaken-server/tests/audit_log_routes.rs
+++ b/crates/awaken-server/tests/audit_log_routes.rs
@@ -1,0 +1,349 @@
+//! Integration tests for `GET /v1/audit-log`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
+use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+use awaken_runtime::builder::AgentRuntimeBuilder;
+use awaken_runtime::registry::traits::ModelBinding;
+use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::mailbox::{Mailbox, MailboxConfig};
+use awaken_server::routes::build_router;
+use awaken_server::services::audit_log::AuditLogger;
+use awaken_server::services::config_runtime::{
+    ConfigRuntimeError, ConfigRuntimeManager, ProviderExecutorFactory,
+};
+use awaken_stores::InMemoryStore;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+struct ImmediateExecutor;
+
+#[async_trait]
+impl LlmExecutor for ImmediateExecutor {
+    async fn execute(
+        &self,
+        _request: InferenceRequest,
+    ) -> Result<StreamResult, InferenceExecutionError> {
+        Ok(StreamResult {
+            content: vec![],
+            tool_calls: vec![],
+            usage: Some(TokenUsage::default()),
+            stop_reason: Some(StopReason::EndTurn),
+            has_incomplete_tool_calls: false,
+        })
+    }
+
+    fn name(&self) -> &str {
+        "immediate"
+    }
+}
+
+struct TestProviderFactory;
+
+impl ProviderExecutorFactory for TestProviderFactory {
+    fn build(&self, spec: &ProviderSpec) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
+        if spec.adapter.eq_ignore_ascii_case("stub") {
+            return Ok(Arc::new(ImmediateExecutor));
+        }
+        Err(ConfigRuntimeError::UnsupportedProviderAdapter(
+            spec.adapter.clone(),
+        ))
+    }
+}
+
+fn bootstrap_agent() -> AgentSpec {
+    AgentSpec {
+        id: "bootstrap".into(),
+        model_id: "bootstrap".into(),
+        system_prompt: "bootstrap".into(),
+        max_rounds: 1,
+        ..Default::default()
+    }
+}
+
+async fn build_test_app_with_audit(token: Option<&str>) -> axum::Router {
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_model_binding(
+                "bootstrap",
+                ModelBinding {
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
+                },
+            )
+            .with_agent_spec(bootstrap_agent())
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(TestProviderFactory)),
+    );
+    manager
+        .bootstrap_if_empty(
+            &[ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }],
+            &[ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }],
+            &[bootstrap_agent()],
+            &[],
+        )
+        .await
+        .expect("bootstrap");
+    manager.apply().await.expect("apply");
+
+    let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+    let resolver = runtime.resolver_arc();
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "audit-test".into(),
+        MailboxConfig::default(),
+    ));
+    let mut state = AppState::new(
+        runtime,
+        mailbox,
+        thread_store,
+        resolver,
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager)
+    .with_audit_log(audit_logger);
+
+    if let Some(tok) = token {
+        state = state.with_admin_api_bearer_token(tok);
+    }
+
+    build_router(&state).with_state(state)
+}
+
+async fn build_test_app_without_audit() -> axum::Router {
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_model_binding(
+                "bootstrap",
+                ModelBinding {
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
+                },
+            )
+            .with_agent_spec(bootstrap_agent())
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("manager")
+            .with_provider_factory(Arc::new(TestProviderFactory)),
+    );
+    manager
+        .bootstrap_if_empty(
+            &[ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }],
+            &[ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }],
+            &[bootstrap_agent()],
+            &[],
+        )
+        .await
+        .expect("bootstrap");
+    manager.apply().await.expect("apply");
+
+    let resolver = runtime.resolver_arc();
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "audit-test-no-log".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime,
+        mailbox,
+        thread_store,
+        resolver,
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager);
+    // No audit_log attached.
+    build_router(&state).with_state(state)
+}
+
+async fn get_audit_log(app: &axum::Router, qs: &str) -> (StatusCode, Value) {
+    get_audit_log_with_token(app, qs, None).await
+}
+
+async fn get_audit_log_with_token(
+    app: &axum::Router,
+    qs: &str,
+    token: Option<&str>,
+) -> (StatusCode, Value) {
+    let uri = if qs.is_empty() {
+        "/v1/audit-log".to_string()
+    } else {
+        format!("/v1/audit-log?{qs}")
+    };
+    let mut builder = Request::builder().method("GET").uri(&uri);
+    if let Some(tok) = token {
+        builder = builder.header("authorization", format!("Bearer {tok}"));
+    }
+    let req = builder.body(Body::empty()).unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
+async fn create_config(app: &axum::Router, namespace: &str, body: &Value) -> StatusCode {
+    let req = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/config/{namespace}"))
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap();
+    app.clone().oneshot(req).await.unwrap().status()
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_returns_events_after_create() {
+    let app = build_test_app_with_audit(None).await;
+
+    let status = create_config(
+        &app,
+        "agents",
+        &json!({ "id": "audit-agent-1", "model_id": "bootstrap", "system_prompt": "hi", "max_rounds": 1 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = get_audit_log(&app, "").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let items = body["items"].as_array().expect("items array");
+    assert!(!items.is_empty(), "should have at least one audit event");
+    assert!(
+        items
+            .iter()
+            .any(|e| e["resource"].as_str() == Some("agents/audit-agent-1")),
+        "event for created agent must be present"
+    );
+}
+
+#[tokio::test]
+async fn filter_by_resource_returns_only_matching_events() {
+    let app = build_test_app_with_audit(None).await;
+
+    create_config(
+        &app,
+        "agents",
+        &json!({ "id": "res-a", "model_id": "bootstrap", "system_prompt": "a", "max_rounds": 1 }),
+    )
+    .await;
+    create_config(
+        &app,
+        "agents",
+        &json!({ "id": "res-b", "model_id": "bootstrap", "system_prompt": "b", "max_rounds": 1 }),
+    )
+    .await;
+
+    let (status, body) = get_audit_log(&app, "resource=agents/res-a").await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"].as_array().expect("items");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["resource"], "agents/res-a");
+}
+
+#[tokio::test]
+async fn cursor_pagination_across_many_entries() {
+    let app = build_test_app_with_audit(None).await;
+
+    // Create 10 agents.
+    for i in 0..10usize {
+        create_config(
+            &app,
+            "agents",
+            &json!({ "id": format!("pg-agent-{i:02}"), "model_id": "bootstrap", "system_prompt": "x", "max_rounds": 1 }),
+        )
+        .await;
+        // Small sleep to ensure distinct ULIDs.
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    }
+
+    // Page 1: limit 4.
+    let (status, body1) = get_audit_log(&app, "limit=4").await;
+    assert_eq!(status, StatusCode::OK);
+    let items1 = body1["items"].as_array().unwrap();
+    assert_eq!(items1.len(), 4);
+    let cursor = body1["next_cursor"].as_str().expect("next_cursor present");
+
+    // Page 2: continue.
+    let (status, body2) = get_audit_log(&app, &format!("limit=4&cursor={cursor}")).await;
+    assert_eq!(status, StatusCode::OK);
+    let items2 = body2["items"].as_array().unwrap();
+    assert!(!items2.is_empty(), "page 2 must have items");
+
+    // No id overlap between pages.
+    let ids1: Vec<&str> = items1.iter().filter_map(|e| e["id"].as_str()).collect();
+    let ids2: Vec<&str> = items2.iter().filter_map(|e| e["id"].as_str()).collect();
+    for id in &ids1 {
+        assert!(!ids2.contains(id), "pages must not overlap");
+    }
+}
+
+#[tokio::test]
+async fn unauthorized_without_token_returns_401() {
+    let app = build_test_app_with_audit(Some("secret-token")).await;
+    let (status, _body) = get_audit_log(&app, "").await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn authorized_with_correct_token_returns_200() {
+    let app = build_test_app_with_audit(Some("secret-token")).await;
+    let (status, body) = get_audit_log_with_token(&app, "", Some("secret-token")).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+}
+
+#[tokio::test]
+async fn returns_503_when_audit_not_configured() {
+    let app = build_test_app_without_audit().await;
+    let (status, _body) = get_audit_log(&app, "").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}

--- a/docs/adr/0026-admin-audit-log.md
+++ b/docs/adr/0026-admin-audit-log.md
@@ -1,6 +1,6 @@
 # ADR-0026: Admin Audit Log
 
-- **Status**: 📐 Proposed
+- **Status**: ✅ Accepted
 - **Date**: 2026-05-02
 - **Depends on**: ADR-0023
 


### PR DESCRIPTION
## Summary

Implements the backend foundation of ADR-0026 (admin audit log). 8 commits, ~50 new tests. Marks ADR-0026 as Accepted. Builds on existing `ConfigStore` backends (in-memory / file / Postgres); SQLite coverage tracked separately in #157.

## What landed

### Contract — `crates/awaken-contract/src/contract/audit_log.rs`
- `AuditEvent { id, ts, actor, action, resource, before, after, ip, request_id }`
- `AuditAction { Create, Update, Delete, Restart, Publish }` (snake_case)
- All optional fields use `#[serde(default, skip_serializing_if = "Option::is_none")]` for forward compatibility

### Service — `crates/awaken-server/src/services/audit_log.rs`
- `AuditLogger` storing events under reserved `_audit` namespace via the existing `ConfigStore` trait
- ULID keys (Crockford base32) deliver time-ordered iteration without a secondary index
- `emit()` is best-effort: failures log a warning + increment `awaken_audit_write_failures`; never propagated
- `derive_actor()` hashes the bearer token with SHA-256 and keeps the first 16 hex chars; supports an optional `X-Awaken-Actor` advisory label (printable ASCII, ≤64 bytes)
- `redact_secrets()` walks payloads recursively and masks any field whose key matches `(api_key|bearer|token|password|secret)` case-insensitively
- `query()` returns a typed `AuditQueryError` (InvalidCursor → 400, Storage → 500) so malformed cursors no longer silently page from the start
- `prune_before()` decodes ULID timestamps and removes expired entries

### Integration
- `ConfigService.{create,update,delete}` emit Create/Update/Delete via a deduplicated `emit_audit()` helper
- MCP `/v1/mcp-servers/:id/restart` emits Restart on success
- All emit sites are post-success — failed admin operations do not pollute the log

### Endpoint — `GET /v1/audit-log`
- Query params: `since`, `until`, `action`, `resource`, `actor`, `limit`, `cursor`
- Cursor is base64url(ulid), keyset paginated, deterministic under concurrent writes
- Behind `ensure_admin_auth`
- 503 when the AppState has no AuditLogger configured
- 400 on malformed cursor

### Configuration & lifecycle — `AdminApiConfig`
- `audit_log_enabled: bool` (default true)
- `audit_retention_days: u32` (default 90)
- `audit_sweep_interval_secs: u64` (default 3600)
- `effective_sweep_interval()` clamps a misconfigured `0` to 60s and warns; values 1–9s pass through with a warning; ≥10s pass silently
- `with_audit_log_from_config()` is the explicit opt-in builder; existing starter backends are unaffected unless they call it

### Documentation
- ADR-0026 status: 📐 Proposed → ✅ Accepted

## Test plan

- [x] `cargo build -p awaken-server -p awaken-contract -p awaken-stores` — clean
- [x] `cargo test -p awaken-server -p awaken-contract` — all pass (~50 new tests across 4 suites)
- [x] `cargo clippy -p awaken-server -p awaken-contract` — no new warnings
- [x] Two-stage review: spec compliance ✅ + code quality ✅ (Critical/Important issues all addressed; one DRY refactor folded in)

## Out of scope (tracked separately)

- **Frontend audit log page** — follow-up PR after this merges
- **SQLite ConfigStore** — issue #157 tracks the broader 'fill the SQLite three-piece' work; audit log inherits SQLite for free once that lands
- **Version switching / restore endpoint (ADR-0028)** — depends on this PR; ADR is in PR #156
- **Audit log on the starter agent** — `with_audit_log_from_config()` is opt-in; the FE PR will document how to enable it

## Distributed-deployment note

This PR works correctly across multiple servers backed by the same Postgres `ConfigStore`: each server writes to the same `_audit` namespace. The retention sweeper runs per-instance — currently each server prunes independently (DELETE is idempotent). Adding a `pg_advisory_lock` to deduplicate sweepers across instances is a follow-up if real load shows up.