### PR TITLE
ADR-0026 audit log: admin console page + history cross-links

### DIFF
--- a/apps/admin-console/src/app.tsx
+++ b/apps/admin-console/src/app.tsx
@@ -62,6 +62,11 @@ const AgentDashboardPage = lazy(async () => {
   return { default: module.AgentDashboardPage };
 });
 
+const AuditLogPage = lazy(async () => {
+  const module = await import("./pages/audit-log-page");
+  return { default: module.AuditLogPage };
+});
+
 /// Routes are declared once and reused via the data router so that v7
 /// hooks like `useBlocker` work. `<Routes>` (kept exported for tests
 /// that prefer the legacy router) renders the same structure.
@@ -153,6 +158,14 @@ export function appRoutes() {
           element={
             <RouteLoader>
               <EvalReportsPage />
+            </RouteLoader>
+          }
+        />
+        <Route
+          path="audit-log"
+          element={
+            <RouteLoader>
+              <AuditLogPage />
             </RouteLoader>
           }
         />

--- a/apps/admin-console/src/components/admin-layout.tsx
+++ b/apps/admin-console/src/components/admin-layout.tsx
@@ -13,6 +13,7 @@ const navItems = [
   { path: adminRoutes.mcpServers, label: "MCP Servers" },
   { path: adminRoutes.assistant, label: "AI Assistant" },
   { path: adminRoutes.evalReports, label: "Eval Reports" },
+  { path: adminRoutes.auditLog, label: "Audit Log" },
 ];
 
 const STATUS_TONE_CLASS = {

--- a/apps/admin-console/src/lib/audit-log.test.ts
+++ b/apps/admin-console/src/lib/audit-log.test.ts
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildAuditQueryString,
+  formatActor,
+  summarizeChange,
+  type AuditEvent,
+} from "./audit-log";
+import { BACKEND_URL, ConfigApiError, configApi } from "./config-api";
+
+// ---------------------------------------------------------------------------
+// buildAuditQueryString
+// ---------------------------------------------------------------------------
+
+describe("buildAuditQueryString", () => {
+  it("returns empty params when query is empty", () => {
+    const params = buildAuditQueryString({});
+    expect(params.toString()).toBe("");
+  });
+
+  it("includes since and until when provided", () => {
+    const params = buildAuditQueryString({
+      since: "2026-01-01T00:00:00Z",
+      until: "2026-02-01T00:00:00Z",
+    });
+    expect(params.get("since")).toBe("2026-01-01T00:00:00Z");
+    expect(params.get("until")).toBe("2026-02-01T00:00:00Z");
+  });
+
+  it("includes action filter", () => {
+    const params = buildAuditQueryString({ action: "delete" });
+    expect(params.get("action")).toBe("delete");
+  });
+
+  it("includes resource filter", () => {
+    const params = buildAuditQueryString({ resource: "agents/my-agent" });
+    expect(params.get("resource")).toBe("agents/my-agent");
+  });
+
+  it("includes actor filter", () => {
+    const params = buildAuditQueryString({ actor: "abc123" });
+    expect(params.get("actor")).toBe("abc123");
+  });
+
+  it("includes limit and cursor", () => {
+    const params = buildAuditQueryString({ limit: 50, cursor: "abc" });
+    expect(params.get("limit")).toBe("50");
+    expect(params.get("cursor")).toBe("abc");
+  });
+
+  it("omits undefined fields", () => {
+    const params = buildAuditQueryString({ action: "create" });
+    expect(params.has("since")).toBe(false);
+    expect(params.has("until")).toBe(false);
+    expect(params.has("resource")).toBe(false);
+    expect(params.has("cursor")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatActor
+// ---------------------------------------------------------------------------
+
+describe("formatActor", () => {
+  it("returns label null for bare hash", () => {
+    const result = formatActor("abc123def456789a");
+    expect(result.hash).toBe("abc123def456789a");
+    expect(result.label).toBeNull();
+  });
+
+  it("splits hash/label on first slash", () => {
+    const result = formatActor("abc123/ci/deploy-prod");
+    expect(result.hash).toBe("abc123");
+    expect(result.label).toBe("ci/deploy-prod");
+  });
+
+  it("handles anonymous actor", () => {
+    const result = formatActor("anonymous");
+    expect(result.hash).toBe("anonymous");
+    expect(result.label).toBeNull();
+  });
+
+  it("handles hash/label where label has no slashes", () => {
+    const result = formatActor("deadbeef12345678/admin");
+    expect(result.hash).toBe("deadbeef12345678");
+    expect(result.label).toBe("admin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeChange
+// ---------------------------------------------------------------------------
+
+function makeEvent(
+  action: AuditEvent["action"],
+  before?: Record<string, unknown> | null,
+  after?: Record<string, unknown> | null,
+): AuditEvent {
+  return {
+    id: "01J",
+    ts: "2026-01-01T00:00:00Z",
+    actor: "anonymous",
+    action,
+    resource: "agents/x",
+    before,
+    after,
+  };
+}
+
+describe("summarizeChange", () => {
+  it("returns Created for create action", () => {
+    expect(summarizeChange(makeEvent("create", null, { id: "x" }))).toBe("Created");
+  });
+
+  it("returns Deleted for delete action", () => {
+    expect(summarizeChange(makeEvent("delete", { id: "x" }, null))).toBe("Deleted");
+  });
+
+  it("returns Restarted for restart action", () => {
+    expect(summarizeChange(makeEvent("restart"))).toBe("Restarted");
+  });
+
+  it("returns Published for publish action", () => {
+    expect(summarizeChange(makeEvent("publish"))).toBe("Published");
+  });
+
+  it("returns Updated for update with no before/after", () => {
+    expect(summarizeChange(makeEvent("update"))).toBe("Updated");
+  });
+
+  it("lists changed fields for update with before/after", () => {
+    const result = summarizeChange(
+      makeEvent("update", { model_id: "gpt-4", name: "x" }, { model_id: "gpt-4o", name: "x" }),
+    );
+    expect(result).toContain("model_id");
+  });
+
+  it("lists added fields for update", () => {
+    const result = summarizeChange(
+      makeEvent("update", { model_id: "gpt-4" }, { model_id: "gpt-4", new_field: "v" }),
+    );
+    expect(result).toContain("new_field");
+  });
+
+  it("lists removed fields for update", () => {
+    const result = summarizeChange(
+      makeEvent("update", { model_id: "gpt-4", old_field: "v" }, { model_id: "gpt-4" }),
+    );
+    expect(result).toContain("old_field");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuditPage shape parsing
+// ---------------------------------------------------------------------------
+
+describe("AuditPage shape", () => {
+  it("deserializes correctly from JSON", () => {
+    const raw = {
+      items: [
+        {
+          id: "01JXYZ",
+          ts: "2026-01-01T00:00:00Z",
+          actor: "abc123",
+          action: "create",
+          resource: "agents/foo",
+          before: null,
+          after: { id: "foo" },
+          ip: "1.2.3.4",
+          request_id: "req-1",
+        },
+      ],
+      next_cursor: "abc",
+    };
+    // Shape check — ensure fields are accessible as typed
+    const page = raw as import("./audit-log").AuditPage;
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0].action).toBe("create");
+    expect(page.items[0].resource).toBe("agents/foo");
+    expect(page.next_cursor).toBe("abc");
+  });
+
+  it("handles page with no next_cursor", () => {
+    const raw = { items: [] };
+    const page = raw as import("./audit-log").AuditPage;
+    expect(page.next_cursor).toBeUndefined();
+    expect(page.items).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// configApi.auditLog
+// ---------------------------------------------------------------------------
+
+describe("configApi.auditLog", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls GET /v1/audit-log with no params when query empty", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ items: [], next_cursor: undefined }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configApi.auditLog({});
+
+    const calledUrl: string = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(`${BACKEND_URL}/v1/audit-log`);
+  });
+
+  it("serializes resource filter into query string", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ items: [] }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configApi.auditLog({ resource: "agents/my-agent" });
+
+    const calledUrl: string = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("resource=agents%2Fmy-agent");
+  });
+
+  it("throws ConfigApiError with status 400 on bad request", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => JSON.stringify({ error: "invalid cursor" }),
+      }),
+    );
+
+    await expect(configApi.auditLog({ cursor: "bad" })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("throws ConfigApiError with detail 'audit log not configured' on 503", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: async () => "Service Unavailable",
+      }),
+    );
+
+    const err = await configApi.auditLog({}).catch((e) => e);
+    expect(err).toBeInstanceOf(ConfigApiError);
+    expect((err as ConfigApiError).status).toBe(503);
+    expect((err as ConfigApiError).message).toContain("audit log not configured");
+  });
+});

--- a/apps/admin-console/src/lib/audit-log.ts
+++ b/apps/admin-console/src/lib/audit-log.ts
@@ -1,0 +1,89 @@
+export type AuditAction = "create" | "update" | "delete" | "restart" | "publish";
+
+export interface AuditEvent {
+  id: string;
+  ts: string; // RFC 3339
+  actor: string;
+  action: AuditAction;
+  resource: string; // "<namespace>/<id>"
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  ip?: string | null;
+  request_id?: string | null;
+}
+
+export interface AuditQuery {
+  since?: string;
+  until?: string;
+  action?: AuditAction;
+  resource?: string;
+  actor?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface AuditPage {
+  items: AuditEvent[];
+  next_cursor?: string;
+}
+
+/** Build a URLSearchParams from an AuditQuery, omitting undefined/empty fields. */
+export function buildAuditQueryString(query: AuditQuery): URLSearchParams {
+  const params = new URLSearchParams();
+  if (query.since) params.set("since", query.since);
+  if (query.until) params.set("until", query.until);
+  if (query.action) params.set("action", query.action);
+  if (query.resource) params.set("resource", query.resource);
+  if (query.actor) params.set("actor", query.actor);
+  if (query.limit !== undefined) params.set("limit", String(query.limit));
+  if (query.cursor) params.set("cursor", query.cursor);
+  return params;
+}
+
+/**
+ * Pretty-print an actor string.
+ * "abc123/label" → { hash: "abc123", label: "label" }
+ * "anonymous"    → { hash: "anonymous", label: null }
+ */
+export function formatActor(actor: string): { hash: string; label: string | null } {
+  const slash = actor.indexOf("/");
+  if (slash === -1) {
+    return { hash: actor, label: null };
+  }
+  return { hash: actor.slice(0, slash), label: actor.slice(slash + 1) };
+}
+
+/** Short human-readable summary for the change column of an audit table row. */
+export function summarizeChange(event: AuditEvent): string {
+  const hasBefore = event.before != null;
+  const hasAfter = event.after != null;
+
+  switch (event.action) {
+    case "create":
+      return hasAfter ? "Created" : "Created";
+    case "delete":
+      return hasBefore ? "Deleted" : "Deleted";
+    case "update":
+      if (hasBefore && hasAfter) {
+        const beforeKeys = Object.keys(event.before as Record<string, unknown>);
+        const afterKeys = Object.keys(event.after as Record<string, unknown>);
+        const changed = afterKeys.filter(
+          (k) =>
+            JSON.stringify((event.after as Record<string, unknown>)[k]) !==
+            JSON.stringify((event.before as Record<string, unknown>)[k]),
+        );
+        const added = afterKeys.filter((k) => !beforeKeys.includes(k));
+        const removed = beforeKeys.filter((k) => !afterKeys.includes(k));
+        const parts: string[] = [];
+        if (changed.length > 0) parts.push(`updated ${changed.join(", ")}`);
+        if (added.length > 0) parts.push(`added ${added.join(", ")}`);
+        if (removed.length > 0) parts.push(`removed ${removed.join(", ")}`);
+        return parts.length > 0 ? parts.join("; ") : "Updated";
+      }
+      return "Updated";
+    case "restart":
+      return "Restarted";
+    case "publish":
+      return "Published";
+  }
+}

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -2,6 +2,7 @@ import {
   hasUnauthorizedHandler,
   requestUnauthorizedRetry,
 } from "./auth-interceptor";
+import { type AuditPage, type AuditQuery, buildAuditQueryString } from "./audit-log";
 
 export const BACKEND_URL =
   import.meta.env.VITE_BACKEND_URL ?? "http://127.0.0.1:38080";
@@ -304,4 +305,17 @@ export const configApi = {
     fetchJson<void>(`${BACKEND_URL}/v1/mcp-servers/${encodeURIComponent(id)}/restart`, {
       method: "POST",
     }),
+
+  auditLog: async (query: AuditQuery): Promise<AuditPage> => {
+    const qs = buildAuditQueryString(query).toString();
+    const url = `${BACKEND_URL}/v1/audit-log${qs ? `?${qs}` : ""}`;
+    try {
+      return await fetchJson<AuditPage>(url);
+    } catch (err) {
+      if (err instanceof ConfigApiError && err.status === 503) {
+        throw new ConfigApiError(503, "audit log not configured");
+      }
+      throw err;
+    }
+  },
 };

--- a/apps/admin-console/src/lib/list-url-state.ts
+++ b/apps/admin-console/src/lib/list-url-state.ts
@@ -17,6 +17,7 @@ import {
   type FixtureFilterState,
   type FixtureStatusFilter,
 } from "./eval-reports-filter";
+import { type AuditAction } from "./audit-log";
 
 // ---------------------------------------------------------------------------
 // Generic list state (search + sort + pagination)
@@ -322,6 +323,107 @@ export function useFixtureFilterUrlState(): FixtureFilterUrlState {
     setSearchParams(
       (prev) =>
         writeFixtureFilter(prev, { ...readFixtureFilter(prev), ...patch }),
+      { replace: true },
+    );
+  }
+
+  return { ...filter, apply };
+}
+
+// ---------------------------------------------------------------------------
+// Audit log filter URL helpers
+// ---------------------------------------------------------------------------
+
+export interface AuditFilterState {
+  since: string;
+  until: string;
+  action: AuditAction | "";
+  resource: string;
+  actor: string;
+}
+
+export const DEFAULT_AUDIT_FILTER: AuditFilterState = {
+  since: "",
+  until: "",
+  action: "",
+  resource: "",
+  actor: "",
+};
+
+const VALID_AUDIT_ACTIONS: readonly AuditAction[] = [
+  "create",
+  "update",
+  "delete",
+  "restart",
+  "publish",
+];
+
+export function readAuditFilter(params: URLSearchParams): AuditFilterState {
+  const since = params.get("since") ?? DEFAULT_AUDIT_FILTER.since;
+  const until = params.get("until") ?? DEFAULT_AUDIT_FILTER.until;
+  const resource = params.get("resource") ?? DEFAULT_AUDIT_FILTER.resource;
+  const actor = params.get("actor") ?? DEFAULT_AUDIT_FILTER.actor;
+
+  const actionRaw = params.get("action");
+  const action: AuditAction | "" =
+    actionRaw !== null && VALID_AUDIT_ACTIONS.includes(actionRaw as AuditAction)
+      ? (actionRaw as AuditAction)
+      : DEFAULT_AUDIT_FILTER.action;
+
+  return { since, until, action, resource, actor };
+}
+
+export function writeAuditFilter(
+  params: URLSearchParams,
+  state: AuditFilterState,
+): URLSearchParams {
+  const next = new URLSearchParams(params.toString());
+
+  if (state.since) {
+    next.set("since", state.since);
+  } else {
+    next.delete("since");
+  }
+
+  if (state.until) {
+    next.set("until", state.until);
+  } else {
+    next.delete("until");
+  }
+
+  if (state.action) {
+    next.set("action", state.action);
+  } else {
+    next.delete("action");
+  }
+
+  if (state.resource) {
+    next.set("resource", state.resource);
+  } else {
+    next.delete("resource");
+  }
+
+  if (state.actor) {
+    next.set("actor", state.actor);
+  } else {
+    next.delete("actor");
+  }
+
+  return next;
+}
+
+export interface AuditFilterUrlState extends AuditFilterState {
+  apply: (patch: Partial<AuditFilterState>) => void;
+}
+
+export function useAuditFilterUrlState(): AuditFilterUrlState {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filter = useMemo(() => readAuditFilter(searchParams), [searchParams]);
+
+  function apply(patch: Partial<AuditFilterState>) {
+    setSearchParams(
+      (prev) => writeAuditFilter(prev, { ...readAuditFilter(prev), ...patch }),
       { replace: true },
     );
   }

--- a/apps/admin-console/src/lib/routes.ts
+++ b/apps/admin-console/src/lib/routes.ts
@@ -11,4 +11,7 @@ export const adminRoutes = {
   mcpServers: "/mcp-servers",
   assistant: "/assistant",
   evalReports: "/eval-reports",
+  auditLog: "/audit-log",
+  auditLogForResource: (resource: string) =>
+    `/audit-log?resource=${encodeURIComponent(resource)}`,
 } as const;

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -398,12 +398,22 @@ function StickyEditorHeader({
     <div className="sticky top-0 z-30 border-b border-slate-200 bg-white/95 px-6 pt-6 backdrop-blur md:px-8">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="min-w-0">
-          <Link
-            to={adminRoutes.agents}
-            className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
-          >
-            Back to agents
-          </Link>
+          <div className="flex items-center gap-4">
+            <Link
+              to={adminRoutes.agents}
+              className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
+            >
+              Back to agents
+            </Link>
+            {!isNew && agentId && (
+              <Link
+                to={adminRoutes.auditLogForResource(`agents/${agentId}`)}
+                className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
+              >
+                History
+              </Link>
+            )}
+          </div>
           <h2 className="mt-2 flex flex-wrap items-center gap-3 text-3xl font-semibold text-slate-950">
             <span>{isNew ? "New Agent" : `Edit ${agentId}`}</span>
             {isDirty ? (

--- a/apps/admin-console/src/pages/audit-log-page.tsx
+++ b/apps/admin-console/src/pages/audit-log-page.tsx
@@ -1,0 +1,419 @@
+import { useState } from "react";
+import { ConfigApiError, configApi } from "@/lib/config-api";
+import {
+  formatActor,
+  summarizeChange,
+  type AuditAction,
+  type AuditEvent,
+  type AuditPage,
+} from "@/lib/audit-log";
+import { useAuditFilterUrlState } from "@/lib/list-url-state";
+
+const ACTION_OPTIONS: Array<{ value: AuditAction | ""; label: string }> = [
+  { value: "", label: "All actions" },
+  { value: "create", label: "Create" },
+  { value: "update", label: "Update" },
+  { value: "delete", label: "Delete" },
+  { value: "restart", label: "Restart" },
+  { value: "publish", label: "Publish" },
+];
+
+const ACTION_BADGE: Record<AuditAction, string> = {
+  create: "bg-emerald-100 text-emerald-800",
+  update: "bg-blue-100 text-blue-800",
+  delete: "bg-rose-100 text-rose-800",
+  restart: "bg-amber-100 text-amber-800",
+  publish: "bg-violet-100 text-violet-800",
+};
+
+export function AuditLogPage() {
+  const { apply, ...filter } = useAuditFilterUrlState();
+
+  const [page, setPage] = useState<AuditPage | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notConfigured, setNotConfigured] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+
+  async function load(cursor?: string) {
+    setLoading(true);
+    setError(null);
+    setNotConfigured(false);
+    try {
+      const result = await configApi.auditLog({
+        since: filter.since || undefined,
+        until: filter.until || undefined,
+        action: filter.action || undefined,
+        resource: filter.resource || undefined,
+        actor: filter.actor || undefined,
+        cursor,
+      });
+      if (cursor) {
+        setPage((prev) => ({
+          items: [...(prev?.items ?? []), ...result.items],
+          next_cursor: result.next_cursor,
+        }));
+      } else {
+        setPage(result);
+      }
+      setHasLoaded(true);
+    } catch (err) {
+      if (err instanceof ConfigApiError && err.status === 503) {
+        setNotConfigured(true);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const hasActiveFilters =
+    filter.since || filter.until || filter.action || filter.resource || filter.actor;
+
+  const emptyMessage =
+    hasActiveFilters
+      ? "No audit events match these filters."
+      : "Audit log is empty.";
+
+  return (
+    <div className="mx-auto max-w-6xl p-6 md:p-8">
+      <header className="mb-8">
+        <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">
+          Security & Compliance
+        </p>
+        <h2 className="mt-2 text-3xl font-semibold text-slate-950">Audit Log</h2>
+        <p className="mt-2 max-w-2xl text-sm text-slate-600">
+          Track create, update, delete, restart, and publish operations on all
+          resources.
+        </p>
+      </header>
+
+      {notConfigured && (
+        <div className="mb-6 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 shadow-sm">
+          Audit log is not enabled on this server.{" "}
+          <a
+            href="https://docs.awaken.dev/audit-log"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline hover:no-underline"
+          >
+            Learn how to enable it
+          </a>
+          .
+        </div>
+      )}
+
+      {/* Filter bar */}
+      <section className="mb-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-slate-500">Since</span>
+            <input
+              type="datetime-local"
+              value={filter.since}
+              onChange={(e) => apply({ since: e.target.value })}
+              className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-slate-500">Until</span>
+            <input
+              type="datetime-local"
+              value={filter.until}
+              onChange={(e) => apply({ until: e.target.value })}
+              className="rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-slate-500">Action</span>
+            <select
+              value={filter.action}
+              onChange={(e) => apply({ action: e.target.value as AuditAction | "" })}
+              className="rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+            >
+              {ACTION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-slate-500">Resource</span>
+            <input
+              type="text"
+              value={filter.resource}
+              placeholder="e.g. agents/my-agent"
+              onChange={(e) => apply({ resource: e.target.value })}
+              className="w-48 rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-slate-500">Actor</span>
+            <input
+              type="text"
+              value={filter.actor}
+              placeholder="hash prefix or label"
+              onChange={(e) => apply({ actor: e.target.value })}
+              className="w-44 rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-slate-500"
+            />
+          </label>
+
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="rounded-xl bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? "Loading…" : "Search"}
+          </button>
+
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={() => {
+                apply({ since: "", until: "", action: "", resource: "", actor: "" });
+                setPage(null);
+                setHasLoaded(false);
+              }}
+              className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </section>
+
+      {error && (
+        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700 shadow-sm">
+          {error}
+        </div>
+      )}
+
+      {hasLoaded && !notConfigured && (
+        <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <table className="min-w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Time</th>
+                <th className="px-4 py-3">Actor</th>
+                <th className="px-4 py-3">Action</th>
+                <th className="px-4 py-3">Resource</th>
+                <th className="px-4 py-3">Change</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {page?.items.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={6}
+                    className="px-4 py-8 text-center text-sm text-slate-500"
+                  >
+                    {emptyMessage}
+                  </td>
+                </tr>
+              ) : (
+                page?.items.map((event) => (
+                  <AuditRow
+                    key={event.id}
+                    event={event}
+                    onView={() => setSelectedEvent(event)}
+                  />
+                ))
+              )}
+            </tbody>
+          </table>
+
+          {page?.next_cursor && (
+            <div className="border-t border-slate-200 px-4 py-3">
+              <button
+                type="button"
+                onClick={() => void load(page.next_cursor)}
+                disabled={loading}
+                className="text-sm font-medium text-slate-700 transition hover:text-slate-950 disabled:opacity-60"
+              >
+                {loading ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          )}
+        </section>
+      )}
+
+      {!hasLoaded && !loading && !notConfigured && (
+        <div className="rounded-2xl border border-slate-200 bg-white p-8 text-center text-sm text-slate-500 shadow-sm">
+          Set filters and click <strong>Search</strong> to load audit events.
+        </div>
+      )}
+
+      {selectedEvent && (
+        <EventPanel event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      )}
+    </div>
+  );
+}
+
+function AuditRow({
+  event,
+  onView,
+}: {
+  event: AuditEvent;
+  onView: () => void;
+}) {
+  const actor = formatActor(event.actor);
+  const ts = new Date(event.ts);
+
+  return (
+    <tr className="hover:bg-slate-50">
+      <td className="px-4 py-3 font-mono text-xs text-slate-700">
+        {ts.toLocaleString()}
+      </td>
+      <td className="px-4 py-3 text-sm text-slate-700">
+        <span className="font-mono text-xs">{actor.hash}</span>
+        {actor.label && (
+          <span className="ml-1 text-slate-500">/{actor.label}</span>
+        )}
+      </td>
+      <td className="px-4 py-3">
+        <span
+          className={[
+            "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+            ACTION_BADGE[event.action] ?? "bg-slate-100 text-slate-700",
+          ].join(" ")}
+        >
+          {event.action}
+        </span>
+      </td>
+      <td className="max-w-xs truncate px-4 py-3 font-mono text-xs text-slate-900">
+        {event.resource}
+      </td>
+      <td className="max-w-xs truncate px-4 py-3 text-xs text-slate-600">
+        {summarizeChange(event)}
+      </td>
+      <td className="px-4 py-3">
+        <button
+          type="button"
+          onClick={onView}
+          className="text-xs font-medium text-slate-500 transition hover:text-slate-900"
+        >
+          View
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function EventPanel({
+  event,
+  onClose,
+}: {
+  event: AuditEvent;
+  onClose: () => void;
+}) {
+  const actor = formatActor(event.actor);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Audit event details"
+      className="fixed inset-0 z-50 flex items-start justify-end bg-black/30"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex h-full w-full max-w-2xl flex-col overflow-y-auto bg-white shadow-2xl md:max-w-xl">
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <h3 className="text-base font-semibold text-slate-900">Audit event</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm text-slate-500 hover:bg-slate-100"
+          >
+            Close
+          </button>
+        </div>
+
+        <dl className="grid gap-3 px-6 py-4 text-sm">
+          <Row label="ID">
+            <span className="font-mono text-xs">{event.id}</span>
+          </Row>
+          <Row label="Time">
+            <span className="font-mono text-xs">{event.ts}</span>
+          </Row>
+          <Row label="Actor">
+            <span className="font-mono text-xs">{actor.hash}</span>
+            {actor.label && <span className="ml-1 text-slate-500">/{actor.label}</span>}
+          </Row>
+          <Row label="Action">
+            <span
+              className={[
+                "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                ACTION_BADGE[event.action] ?? "bg-slate-100 text-slate-700",
+              ].join(" ")}
+            >
+              {event.action}
+            </span>
+          </Row>
+          <Row label="Resource">
+            <span className="font-mono text-xs">{event.resource}</span>
+          </Row>
+          {event.ip && (
+            <Row label="IP">
+              <span className="font-mono text-xs">{event.ip}</span>
+            </Row>
+          )}
+          {event.request_id && (
+            <Row label="Request ID">
+              <span className="font-mono text-xs">{event.request_id}</span>
+            </Row>
+          )}
+        </dl>
+
+        <div className="grid gap-4 px-6 pb-6 md:grid-cols-2">
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+              Before
+            </p>
+            <pre className="overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs leading-relaxed text-slate-800">
+              {event.before != null
+                ? JSON.stringify(event.before, null, 2)
+                : <span className="text-slate-400">—</span>}
+            </pre>
+          </div>
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+              After
+            </p>
+            <pre className="overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs leading-relaxed text-slate-800">
+              {event.after != null
+                ? JSON.stringify(event.after, null, 2)
+                : <span className="text-slate-400">—</span>}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <dt className="w-24 shrink-0 text-xs font-medium text-slate-500">{label}</dt>
+      <dd className="min-w-0 text-slate-900">{children}</dd>
+    </div>
+  );
+}

--- a/apps/admin-console/src/pages/mcp-servers-page.tsx
+++ b/apps/admin-console/src/pages/mcp-servers-page.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router";
 import {
   type McpRestartPolicy,
   type McpServerRecord,
@@ -27,6 +28,7 @@ import {
 } from "@/lib/list-view";
 import { useListUrlState } from "@/lib/list-url-state";
 import { formatRelativeTime } from "@/lib/format-time";
+import { adminRoutes } from "@/lib/routes";
 import {
   parseJsonObject,
   parseLineList,
@@ -276,9 +278,19 @@ export function McpServersPage() {
 
       {crud.draft ? (
         <section className="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-950">
-            {crud.isEditingExisting ? "Edit MCP server" : "Create MCP server"}
-          </h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-950">
+              {crud.isEditingExisting ? "Edit MCP server" : "Create MCP server"}
+            </h3>
+            {crud.isEditingExisting && crud.draft.id && (
+              <Link
+                to={adminRoutes.auditLogForResource(`mcp-servers/${crud.draft.id}`)}
+                className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
+              >
+                History
+              </Link>
+            )}
+          </div>
 
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             <Field label="Server ID">

--- a/apps/admin-console/src/pages/models-page.tsx
+++ b/apps/admin-console/src/pages/models-page.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo } from "react";
+import { Link } from "react-router";
 import {
   type ModelBindingSpec,
   type ProviderRecord,
   configApi,
 } from "@/lib/config-api";
+import { adminRoutes } from "@/lib/routes";
 import { useCrudPage } from "@/lib/use-crud-page";
 import { Field } from "@/components/form-components";
 import {
@@ -126,9 +128,19 @@ export function ModelsPage() {
 
       {crud.draft ? (
         <section className="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-950">
-            {crud.isEditingExisting ? "Edit model" : "Create model"}
-          </h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-950">
+              {crud.isEditingExisting ? "Edit model" : "Create model"}
+            </h3>
+            {crud.isEditingExisting && crud.draft.id && (
+              <Link
+                to={adminRoutes.auditLogForResource(`models/${crud.draft.id}`)}
+                className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
+              >
+                History
+              </Link>
+            )}
+          </div>
           <div className="mt-4 grid gap-4 md:grid-cols-3">
             <Field label="Model ID">
               <input

--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router";
 import {
   ConfigApiError,
   configApi,
@@ -8,6 +9,7 @@ import {
 import { useToast } from "@/components/toast-provider";
 import { useCrudPage } from "@/lib/use-crud-page";
 import { Field, ModeButton } from "@/components/form-components";
+import { adminRoutes } from "@/lib/routes";
 import {
   ListSearchBar,
   PageSizeSelect,
@@ -223,9 +225,19 @@ export function ProvidersPage() {
 
       {crud.draft ? (
         <section className="mb-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-lg font-semibold text-slate-950">
-            {crud.isEditingExisting ? "Edit provider" : "Create provider"}
-          </h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-950">
+              {crud.isEditingExisting ? "Edit provider" : "Create provider"}
+            </h3>
+            {crud.isEditingExisting && crud.draft.id && (
+              <Link
+                to={adminRoutes.auditLogForResource(`providers/${crud.draft.id}`)}
+                className="text-sm font-medium text-slate-500 transition hover:text-slate-700"
+              >
+                History
+              </Link>
+            )}
+          </div>
 
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             <Field label="Provider ID">


### PR DESCRIPTION
## Summary

Frontend half of ADR-0026 (admin audit log). Adds a queryable Audit Log page to the admin console and "View history" cross-links from each resource editor. Depends on PR #158 (BE foundation).

## What landed (3 commits)

### Commit 1 — API client + types (`src/lib/audit-log.ts`)
- `AuditEvent`, `AuditAction`, `AuditQuery`, `AuditPage` TypeScript types matching the BE shape
- `configApi.auditLog(query)` GET /v1/audit-log with serialized query string
- 400 → `ConfigApiError` propagation (matches BE invalid-cursor behaviour)
- 503 → `ConfigApiError` with detail "audit log not configured" (matches BE when feature is opt-out)
- Helpers: `formatActor` (splits "hash/label"), `summarizeChange` (one-line table cell)
- 25 unit tests cover query string serialization, page parsing, cursor edge cases

### Commit 2 — `/audit-log` page
- Filter bar: since/until (datetime-local), action dropdown, resource search, actor search
- URL state via new `useAuditFilterUrlState` (matches existing `useFixtureFilterUrlState` pattern)
- Newest-first table: Time / Actor / Action / Resource / Change summary / View
- "Load more" button uses `next_cursor` keyset pagination
- Side panel renders full event JSON with `before` ↔ `after` side-by-side (plain `<pre>` for now; a real diff library can land later)
- 503 handled gracefully with an explanatory banner
- Sidebar nav link in `admin-layout.tsx`
- Search button is explicit (no auto-fetch on mount) to avoid surprise full scans

### Commit 3 — Cross-page integration
- "View history" link in agent / model / provider / mcp-server editors
- Routes to `/audit-log?resource=<ns>/<id>` (URL-encoded)
- Reuses existing sticky-header / drawer-header layout

## Test plan

- [x] `npm test` — 392 / 392 (was 367 → +25)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Two-stage subagent review: spec compliance ✅ + code quality ✅

## Out of scope

- Real diff library — current impl is plain side-by-side JSON; can swap in `microdiff` / `fast-json-patch` later without changing the API
- Dashboard "recent activity" widget — separate PR if/when product wants it
- Restore button in the History link path — depends on PR3 (ADR-0028 restore endpoint)

## Depends on

- **PR #158** — BE audit log foundation must merge first; this PR's branch is built on top of `feat/audit-log-impl`