### PR TITLE
ADR-0028 version switching: POST /v1/config/:ns/:id/restore endpoint

### DIFF
--- a/crates/awaken-contract/src/contract/audit_log.rs
+++ b/crates/awaken-contract/src/contract/audit_log.rs
@@ -10,6 +10,7 @@ pub enum AuditAction {
     Delete,
     Restart,
     Publish,
+    Restore,
 }
 
 /// A self-contained audit record for a single admin action.
@@ -37,6 +38,9 @@ pub struct AuditEvent {
     /// Value of the `X-Request-Id` header if present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
+    /// For `action = restore`: the ULID of the audit event that was restored from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restored_from: Option<String>,
 }
 
 #[cfg(test)]
@@ -56,6 +60,7 @@ mod tests {
             after: Some(json!({"id": "my-agent"})),
             ip: Some("127.0.0.1".to_string()),
             request_id: None,
+            restored_from: None,
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -75,6 +80,7 @@ mod tests {
             after: None,
             ip: None,
             request_id: None,
+            restored_from: None,
         };
 
         let value = serde_json::to_value(&event).unwrap();
@@ -109,6 +115,10 @@ mod tests {
             serde_json::to_value(AuditAction::Publish).unwrap(),
             json!("publish")
         );
+        assert_eq!(
+            serde_json::to_value(AuditAction::Restore).unwrap(),
+            json!("restore")
+        );
     }
 
     #[test]
@@ -119,9 +129,70 @@ mod tests {
             ("delete", AuditAction::Delete),
             ("restart", AuditAction::Restart),
             ("publish", AuditAction::Publish),
+            ("restore", AuditAction::Restore),
         ] {
             let parsed: AuditAction = serde_json::from_str(&format!("\"{s}\"")).unwrap();
             assert_eq!(parsed, expected);
         }
+    }
+
+    #[test]
+    fn restore_event_with_restored_from_round_trip() {
+        let event = AuditEvent {
+            id: "01NEWULID00".to_string(),
+            ts: "2026-05-01T12:00:00Z".to_string(),
+            actor: "deadbeef01234567".to_string(),
+            action: AuditAction::Restore,
+            resource: "agents/my-agent".to_string(),
+            before: Some(json!({"id": "my-agent", "system_prompt": "old"})),
+            after: Some(json!({"id": "my-agent", "system_prompt": "restored"})),
+            ip: None,
+            request_id: None,
+            restored_from: Some("01OLDULID00".to_string()),
+        };
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert_eq!(serialized["action"], "restore");
+        assert_eq!(serialized["restored_from"], "01OLDULID00");
+
+        let parsed: AuditEvent = serde_json::from_value(serialized).unwrap();
+        assert_eq!(parsed, event);
+        assert_eq!(parsed.restored_from.as_deref(), Some("01OLDULID00"));
+    }
+
+    #[test]
+    fn restored_from_omitted_when_none() {
+        let event = AuditEvent {
+            id: "01ABCDEFGH".to_string(),
+            ts: "2026-05-01T00:00:00Z".to_string(),
+            actor: "anonymous".to_string(),
+            action: AuditAction::Create,
+            resource: "agents/new-agent".to_string(),
+            before: None,
+            after: Some(json!({"id": "new-agent"})),
+            ip: None,
+            request_id: None,
+            restored_from: None,
+        };
+
+        let value = serde_json::to_value(&event).unwrap();
+        assert!(
+            value.get("restored_from").is_none(),
+            "restored_from must be omitted when None"
+        );
+    }
+
+    #[test]
+    fn old_event_without_restored_from_deserializes_cleanly() {
+        // Simulate an event serialized before the restored_from field existed.
+        let json = r#"{
+            "id": "01LEGACY000",
+            "ts": "2026-05-01T00:00:00Z",
+            "actor": "anonymous",
+            "action": "create",
+            "resource": "agents/legacy"
+        }"#;
+        let event: AuditEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.restored_from, None);
     }
 }

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -16,7 +16,7 @@ use crate::app::AppState;
 use crate::routes::ApiError;
 use crate::services::audit_log::{AuditQuery, AuditQueryError};
 use crate::services::config_service::{
-    ConfigNamespace, ConfigService, ConfigServiceError, ProviderTestResult,
+    ConfigNamespace, ConfigService, ConfigServiceError, ProviderTestResult, RestoreError,
 };
 
 #[derive(Deserialize)]
@@ -42,6 +42,7 @@ pub fn config_routes() -> Router<AppState> {
             "/v1/config/:namespace/:id",
             get(get_config).put(put_config).delete(delete_config),
         )
+        .route("/v1/config/:namespace/:id/restore", post(restore_config))
         .route("/v1/config/:namespace/$schema", get(get_schema))
         .route("/v1/agents", get(list_agents))
         .route("/v1/agents/:id", get(get_agent))
@@ -203,6 +204,68 @@ async fn delete_config(
         )
             .into_response(),
         Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
+}
+
+/// Body accepted by `POST /v1/config/:namespace/:id/restore`.
+#[derive(Deserialize)]
+struct RestoreBody {
+    version: String,
+}
+
+async fn restore_config(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((namespace, id)): Path<(String, String)>,
+    Json(body): Json<RestoreBody>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let namespace = match ConfigNamespace::parse(&namespace) {
+        Ok(ns) => ns,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service
+        .restore(namespace, &id, &body.version, &headers)
+        .await
+    {
+        Ok(result) => Json(result).into_response(),
+        Err(RestoreError::VersionNotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "version not found", "reason": "unknown"})),
+        )
+            .into_response(),
+        Err(RestoreError::AuditNotConfigured) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "audit log is not configured"})),
+        )
+            .into_response(),
+        Err(RestoreError::ResourceMismatch { .. }) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": "cross-resource restore not allowed"})),
+        )
+            .into_response(),
+        Err(RestoreError::NotRestorable) | Err(RestoreError::NoPayload(_)) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": "this event type is not restorable"})),
+        )
+            .into_response(),
+        Err(RestoreError::Service(ConfigServiceError::InvalidPayload(msg))) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({"error": msg})),
+        )
+            .into_response(),
+        Err(RestoreError::Service(e)) => {
+            ConfigRouteError::Api(map_service_error(e)).into_response()
+        }
+        Err(RestoreError::Storage(e)) => {
+            ConfigRouteError::Api(ApiError::Internal(e.to_string())).into_response()
+        }
     }
 }
 

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -105,6 +105,7 @@ impl AuditLogger {
             after,
             ip,
             request_id,
+            restored_from: None,
         };
 
         let value = match serde_json::to_value(&event) {
@@ -127,6 +128,68 @@ impl AuditLogger {
             .and_then(|v| v.as_str().map(str::to_string))
             .unwrap_or_else(|| "unknown".to_string());
         metrics::counter!("awaken_audit_events_total", "action" => action_label).increment(1);
+    }
+
+    /// Look up a single audit event by its ULID id.
+    ///
+    /// Returns `Ok(None)` when the event is not found (either never existed or was pruned).
+    pub async fn get_event(&self, id: &str) -> Result<Option<AuditEvent>, StorageError> {
+        let value = self.store.get(AUDIT_NAMESPACE, id).await?;
+        Ok(value.and_then(|v| serde_json::from_value::<AuditEvent>(v).ok()))
+    }
+
+    /// Emit a restore audit event with the `restored_from` field set.
+    ///
+    /// Best-effort — same semantics as [`AuditLogger::emit`].
+    pub async fn emit_restore(
+        &self,
+        resource: &str,
+        before: Option<Value>,
+        after: Option<Value>,
+        restored_from: String,
+        headers: &HeaderMap,
+    ) {
+        let id = ulid::Ulid::new().to_string();
+        let ts = Utc::now().to_rfc3339();
+        let actor = derive_actor(headers);
+        let ip = extract_client_ip(headers);
+        let request_id = headers
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+
+        let before = before.map(redact_secrets);
+        let after = after.map(redact_secrets);
+
+        let event = AuditEvent {
+            id: id.clone(),
+            ts,
+            actor,
+            action: AuditAction::Restore,
+            resource: resource.to_string(),
+            before,
+            after,
+            ip,
+            request_id,
+            restored_from: Some(restored_from),
+        };
+
+        let value = match serde_json::to_value(&event) {
+            Ok(v) => v,
+            Err(error) => {
+                tracing::warn!(error = %error, "audit: failed to serialize restore event");
+                metrics::counter!("awaken_audit_write_failures_total").increment(1);
+                return;
+            }
+        };
+
+        if let Err(error) = self.store.put(AUDIT_NAMESPACE, &id, &value).await {
+            tracing::warn!(error = %error, "audit: failed to write restore event");
+            metrics::counter!("awaken_audit_write_failures_total").increment(1);
+            return;
+        }
+
+        metrics::counter!("awaken_audit_events_total", "action" => "restore").increment(1);
     }
 
     /// Query audit events with optional filters and keyset pagination.

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -84,6 +84,30 @@ pub enum ConfigServiceError {
     Storage(#[from] StorageError),
 }
 
+/// Error type for the config restore operation.
+#[derive(Debug, thiserror::Error)]
+pub enum RestoreError {
+    #[error("audit log is not configured")]
+    AuditNotConfigured,
+    #[error("version not found")]
+    VersionNotFound,
+    #[error(
+        "cross-resource restore not allowed: event is for '{event_resource}', expected '{expected}'"
+    )]
+    ResourceMismatch {
+        event_resource: String,
+        expected: String,
+    },
+    #[error("action '{0:?}' does not carry a restorable spec")]
+    NoPayload(AuditAction),
+    #[error("restart events are not restorable")]
+    NotRestorable,
+    #[error("config service error: {0}")]
+    Service(#[from] ConfigServiceError),
+    #[error("storage error: {0}")]
+    Storage(#[from] StorageError),
+}
+
 /// Result returned by the provider test endpoint.
 #[derive(Debug, serde::Serialize)]
 pub struct ProviderTestResult {
@@ -352,6 +376,147 @@ impl<'a> ConfigService<'a> {
         .await;
 
         Ok(())
+    }
+
+    /// Restore a resource to a previous version identified by the audit event ULID `version`.
+    ///
+    /// Per ADR-0028 D2-D4:
+    /// - Looks up the audit event; returns `RestoreError::VersionNotFound` if missing.
+    /// - Validates that the event resource matches `<namespace>/<id>` (cross-resource rejected).
+    /// - Selects the spec payload: `after` for Create/Update/Publish/Restore; `before` for Delete.
+    /// - Returns `RestoreError::NotRestorable` for Restart events (no spec payload).
+    /// - Calls `persist_and_apply_locked` directly (both create and update paths) to avoid
+    ///   emitting a spurious Update audit event; only a single Restore event is written.
+    /// - Emits a Restore audit event with `restored_from` set to the source ULID.
+    pub async fn restore(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+        version: &str,
+        headers: &HeaderMap,
+    ) -> Result<Value, RestoreError> {
+        use awaken_contract::AuditAction as A;
+
+        let audit = self
+            .audit
+            .as_ref()
+            .ok_or(RestoreError::AuditNotConfigured)?;
+
+        // Look up the source audit event.
+        let event = audit
+            .get_event(version)
+            .await
+            .map_err(RestoreError::Storage)?
+            .ok_or(RestoreError::VersionNotFound)?;
+
+        // Verify cross-resource guard.
+        let expected_resource = format!("{}/{}", namespace.as_str(), id);
+        if event.resource != expected_resource {
+            return Err(RestoreError::ResourceMismatch {
+                event_resource: event.resource.clone(),
+                expected: expected_resource,
+            });
+        }
+
+        // Select payload per D3 mapping table.
+        let payload = match &event.action {
+            A::Create | A::Update | A::Publish | A::Restore => event
+                .after
+                .clone()
+                .ok_or(RestoreError::NoPayload(event.action.clone()))?,
+            A::Delete => event
+                .before
+                .clone()
+                .ok_or(RestoreError::NoPayload(event.action.clone()))?,
+            A::Restart => return Err(RestoreError::NotRestorable),
+        };
+
+        // Single store read: determines both existence and the pre-restore snapshot.
+        let before = self
+            .store
+            .get(namespace.as_str(), id)
+            .await
+            .map_err(RestoreError::Storage)?;
+
+        let manager = self.runtime_manager().map_err(RestoreError::Service)?;
+        let _apply_guard = manager.lock_apply().await;
+
+        let result = if before.is_some() {
+            // Resource exists — inline the update logic so we emit only a Restore
+            // audit event (calling update() would also fire an Update event).
+            let (body_id, prepared) = self
+                .prepare_body(namespace, Some(id), payload.clone())
+                .await
+                .map_err(RestoreError::Service)?;
+            if body_id != id {
+                return Err(RestoreError::Service(ConfigServiceError::InvalidPayload(
+                    format!("restored payload id '{body_id}' does not match URL id '{id}'"),
+                )));
+            }
+            self.persist_and_apply_locked(manager.as_ref(), namespace, id, before.clone(), prepared)
+                .await
+                .map_err(RestoreError::Service)?
+        } else {
+            // Resource does not exist — restore from a deleted state.
+            // We need to preserve created_at from the restored payload.
+            let (body_id, mut prepared) = self
+                .prepare_body(namespace, None, payload.clone())
+                .await
+                .map_err(RestoreError::Service)?;
+            if body_id != id {
+                return Err(RestoreError::Service(ConfigServiceError::InvalidPayload(
+                    format!("restored payload id '{body_id}' does not match URL id '{id}'"),
+                )));
+            }
+
+            // Restore created_at from the original payload if present.
+            if let (Some(original_created_at), Some(obj)) = (
+                payload
+                    .as_object()
+                    .and_then(|o| o.get("created_at"))
+                    .cloned(),
+                prepared.as_object_mut(),
+            ) {
+                obj.insert("created_at".to_string(), original_created_at);
+            }
+
+            if self
+                .store
+                .exists(namespace.as_str(), &body_id)
+                .await
+                .map_err(RestoreError::Storage)?
+            {
+                return Err(RestoreError::Service(ConfigServiceError::Conflict(
+                    format!("{}/{} already exists", namespace.as_str(), body_id),
+                )));
+            }
+
+            self.persist_and_apply_locked(
+                manager.as_ref(),
+                namespace,
+                &body_id,
+                None,
+                prepared.clone(),
+            )
+            .await
+            .map_err(RestoreError::Service)?
+        };
+
+        // Emit restore audit event.
+        if let Some(audit) = &self.audit {
+            let resource = format!("{}/{}", namespace.as_str(), id);
+            audit
+                .emit_restore(
+                    &resource,
+                    before,
+                    Some(payload),
+                    version.to_string(),
+                    headers,
+                )
+                .await;
+        }
+
+        Ok(result)
     }
 
     /// Return all records in other namespaces that reference `id` in `namespace`.

--- a/crates/awaken-server/tests/restore_routes.rs
+++ b/crates/awaken-server/tests/restore_routes.rs
@@ -1,0 +1,675 @@
+//! Integration tests for `POST /v1/config/:namespace/:id/restore`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
+use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+use awaken_runtime::builder::AgentRuntimeBuilder;
+use awaken_runtime::registry::traits::ModelBinding;
+use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::mailbox::{Mailbox, MailboxConfig};
+use awaken_server::routes::build_router;
+use awaken_server::services::audit_log::AuditLogger;
+use awaken_server::services::config_runtime::{
+    ConfigRuntimeError, ConfigRuntimeManager, ProviderExecutorFactory,
+};
+use awaken_stores::InMemoryStore;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+struct ImmediateExecutor;
+
+#[async_trait]
+impl LlmExecutor for ImmediateExecutor {
+    async fn execute(
+        &self,
+        _request: InferenceRequest,
+    ) -> Result<StreamResult, InferenceExecutionError> {
+        Ok(StreamResult {
+            content: vec![],
+            tool_calls: vec![],
+            usage: Some(TokenUsage::default()),
+            stop_reason: Some(StopReason::EndTurn),
+            has_incomplete_tool_calls: false,
+        })
+    }
+
+    fn name(&self) -> &str {
+        "immediate"
+    }
+}
+
+struct TestProviderFactory;
+
+impl ProviderExecutorFactory for TestProviderFactory {
+    fn build(&self, spec: &ProviderSpec) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
+        if spec.adapter.eq_ignore_ascii_case("stub") {
+            return Ok(Arc::new(ImmediateExecutor));
+        }
+        Err(ConfigRuntimeError::UnsupportedProviderAdapter(
+            spec.adapter.clone(),
+        ))
+    }
+}
+
+fn bootstrap_agent() -> AgentSpec {
+    AgentSpec {
+        id: "bootstrap".into(),
+        model_id: "bootstrap".into(),
+        system_prompt: "bootstrap".into(),
+        max_rounds: 1,
+        ..Default::default()
+    }
+}
+
+async fn build_test_app() -> axum::Router {
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_model_binding(
+                "bootstrap",
+                ModelBinding {
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
+                },
+            )
+            .with_agent_spec(bootstrap_agent())
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(TestProviderFactory)),
+    );
+    manager
+        .bootstrap_if_empty(
+            &[ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }],
+            &[ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }],
+            &[bootstrap_agent()],
+            &[],
+        )
+        .await
+        .expect("bootstrap");
+    manager.apply().await.expect("apply");
+
+    let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+    let resolver = runtime.resolver_arc();
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "restore-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime,
+        mailbox,
+        thread_store,
+        resolver,
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager)
+    .with_audit_log(audit_logger);
+
+    build_router(&state).with_state(state)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+async fn post_json(app: &axum::Router, uri: &str, body: &Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
+async fn put_json(app: &axum::Router, uri: &str, body: &Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
+async fn delete_resource(app: &axum::Router, uri: &str) -> StatusCode {
+    let req = Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    app.clone().oneshot(req).await.unwrap().status()
+}
+
+async fn get_audit_log(app: &axum::Router, qs: &str) -> Value {
+    let uri = if qs.is_empty() {
+        "/v1/audit-log".to_string()
+    } else {
+        format!("/v1/audit-log?{qs}")
+    };
+    let req = Request::builder()
+        .method("GET")
+        .uri(&uri)
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────
+
+/// Restore an updated agent to its prior version.
+#[tokio::test]
+async fn restore_agent_to_prior_version() {
+    let app = build_test_app().await;
+
+    // Create agent v1.
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/agents",
+        &json!({
+            "id": "restore-agent",
+            "model_id": "bootstrap",
+            "system_prompt": "v1 prompt",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Fetch the create event ULID.
+    let audit = get_audit_log(&app, "resource=agents/restore-agent").await;
+    let items = audit["items"].as_array().expect("items");
+    let create_event_id = items
+        .iter()
+        .find(|e| e["action"] == "create")
+        .and_then(|e| e["id"].as_str())
+        .expect("create event")
+        .to_string();
+
+    // Update agent to v2.
+    let (status, _) = put_json(
+        &app,
+        "/v1/config/agents/restore-agent",
+        &json!({
+            "id": "restore-agent",
+            "model_id": "bootstrap",
+            "system_prompt": "v2 prompt",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Count audit events before restore (create + update = 2).
+    let audit_before = get_audit_log(&app, "resource=agents/restore-agent").await;
+    let count_before = audit_before["items"].as_array().expect("items").len();
+
+    // Restore to v1.
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/restore-agent/restore",
+        &json!({ "version": create_event_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["system_prompt"], "v1 prompt");
+
+    // Audit log must contain exactly one new event (the Restore), not two.
+    let audit = get_audit_log(&app, "resource=agents/restore-agent").await;
+    let items = audit["items"].as_array().expect("items");
+    assert_eq!(
+        items.len(),
+        count_before + 1,
+        "restore must emit exactly one audit event; got {} (was {})",
+        items.len(),
+        count_before
+    );
+    let restore_event = items
+        .iter()
+        .find(|e| e["action"] == "restore")
+        .expect("restore event must be present");
+    assert_eq!(
+        restore_event["restored_from"].as_str(),
+        Some(create_event_id.as_str()),
+        "restored_from must reference the source event ULID"
+    );
+    assert!(
+        restore_event["before"].is_object(),
+        "before must contain the pre-restore spec"
+    );
+    assert!(
+        restore_event["after"].is_object(),
+        "after must contain the restored spec"
+    );
+}
+
+/// Restore a deleted resource uses the `before` payload via `create`.
+#[tokio::test]
+async fn restore_deleted_resource_uses_before() {
+    let app = build_test_app().await;
+
+    // Create and immediately delete an agent.
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/agents",
+        &json!({
+            "id": "deleted-agent",
+            "model_id": "bootstrap",
+            "system_prompt": "original",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let del_status = delete_resource(&app, "/v1/config/agents/deleted-agent").await;
+    assert_eq!(del_status, StatusCode::NO_CONTENT);
+
+    // Get the delete event ULID.
+    let audit = get_audit_log(&app, "resource=agents/deleted-agent").await;
+    let items = audit["items"].as_array().expect("items");
+    let delete_event_id = items
+        .iter()
+        .find(|e| e["action"] == "delete")
+        .and_then(|e| e["id"].as_str())
+        .expect("delete event")
+        .to_string();
+
+    // Restore from the delete event (should recreate using `before`).
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/deleted-agent/restore",
+        &json!({ "version": delete_event_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["system_prompt"], "original");
+    assert_eq!(body["id"], "deleted-agent");
+}
+
+/// Attempting to restore a Restart event returns 422.
+#[tokio::test]
+async fn restore_restart_event_returns_422() {
+    let _app = build_test_app().await;
+
+    use awaken_contract::AuditAction;
+    use awaken_contract::AuditEvent;
+    use awaken_contract::contract::config_store::ConfigStore;
+    use awaken_server::services::audit_log::AUDIT_NAMESPACE;
+
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_model_binding(
+                "bootstrap",
+                ModelBinding {
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
+                },
+            )
+            .with_agent_spec(bootstrap_agent())
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("manager")
+            .with_provider_factory(Arc::new(TestProviderFactory)),
+    );
+    manager
+        .bootstrap_if_empty(
+            &[ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }],
+            &[ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }],
+            &[bootstrap_agent()],
+            &[],
+        )
+        .await
+        .expect("bootstrap");
+    manager.apply().await.expect("apply");
+
+    // Write a Restart event directly into the audit store.
+    let restart_id = ulid::Ulid::new().to_string();
+    let restart_event = AuditEvent {
+        id: restart_id.clone(),
+        ts: chrono::Utc::now().to_rfc3339(),
+        actor: "anonymous".to_string(),
+        action: AuditAction::Restart,
+        resource: "agents/restart-target".to_string(),
+        before: None,
+        after: None,
+        ip: None,
+        request_id: None,
+        restored_from: None,
+    };
+    config_store
+        .put(
+            AUDIT_NAMESPACE,
+            &restart_id,
+            &serde_json::to_value(&restart_event).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+    let resolver = runtime.resolver_arc();
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "restart-restore-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime,
+        mailbox,
+        thread_store,
+        resolver,
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager)
+    .with_audit_log(audit_logger);
+    let app = build_router(&state).with_state(state);
+
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/restart-target/restore",
+        &json!({ "version": restart_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("not restorable")),
+        "body must mention 'not restorable': {body}"
+    );
+}
+
+/// Cross-resource restore returns 422.
+#[tokio::test]
+async fn cross_resource_restore_returns_422() {
+    let app = build_test_app().await;
+
+    // Create agent A.
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/agents",
+        &json!({
+            "id": "agent-a",
+            "model_id": "bootstrap",
+            "system_prompt": "for agent a",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Get its create event ULID.
+    let audit = get_audit_log(&app, "resource=agents/agent-a").await;
+    let items = audit["items"].as_array().expect("items");
+    let agent_a_event_id = items[0]["id"].as_str().expect("event id").to_string();
+
+    // Attempt to restore agent-a's event to agent-b.
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/agent-b/restore",
+        &json!({ "version": agent_a_event_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("cross-resource")),
+        "body must mention cross-resource: {body}"
+    );
+}
+
+/// Unknown version ULID returns 404 with reason "unknown".
+#[tokio::test]
+async fn unknown_version_returns_404_unknown() {
+    let app = build_test_app().await;
+
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/some-agent/restore",
+        &json!({ "version": "01DOESNOTEXIST0000000000000" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
+    assert_eq!(body["error"], "version not found");
+    assert_eq!(body["reason"], "unknown");
+}
+
+/// Restore failure when the referenced model no longer exists returns 422.
+#[tokio::test]
+async fn restore_fails_when_referenced_model_is_gone() {
+    let app = build_test_app().await;
+
+    // Create provider + model + agent referencing the model.
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/providers",
+        &json!({"id": "prov-restore-test", "adapter": "stub"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/models",
+        &json!({
+            "id": "model-restore-test",
+            "provider_id": "prov-restore-test",
+            "upstream_model": "gpt-4"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/agents",
+        &json!({
+            "id": "agent-orphan",
+            "model_id": "model-restore-test",
+            "system_prompt": "original",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // Update agent to use bootstrap model.
+    let (status, _) = put_json(
+        &app,
+        "/v1/config/agents/agent-orphan",
+        &json!({
+            "id": "agent-orphan",
+            "model_id": "bootstrap",
+            "system_prompt": "updated",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Force-delete model that the original version referenced.
+    let del_status = delete_resource(&app, "/v1/config/models/model-restore-test?force=true").await;
+    assert_eq!(del_status, StatusCode::NO_CONTENT);
+    let del_status =
+        delete_resource(&app, "/v1/config/providers/prov-restore-test?force=true").await;
+    assert_eq!(del_status, StatusCode::NO_CONTENT);
+
+    // Get create event (references deleted model).
+    let audit = get_audit_log(&app, "resource=agents/agent-orphan").await;
+    let items = audit["items"].as_array().expect("items");
+    let create_event_id = items
+        .iter()
+        .find(|e| e["action"] == "create")
+        .and_then(|e| e["id"].as_str())
+        .expect("create event")
+        .to_string();
+
+    // Restore to original version — should fail because model is gone.
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/agent-orphan/restore",
+        &json!({ "version": create_event_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
+    assert!(
+        body["error"].is_string(),
+        "body must contain error message: {body}"
+    );
+}
+
+/// The restore audit event has `restored_from` populated.
+#[tokio::test]
+async fn restore_audit_event_has_restored_from() {
+    let app = build_test_app().await;
+
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/agents",
+        &json!({
+            "id": "audit-check-agent",
+            "model_id": "bootstrap",
+            "system_prompt": "initial",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let audit = get_audit_log(&app, "resource=agents/audit-check-agent").await;
+    let items = audit["items"].as_array().expect("items");
+    let create_id = items[0]["id"].as_str().expect("event id").to_string();
+
+    // Update so current != initial.
+    let (status, _) = put_json(
+        &app,
+        "/v1/config/agents/audit-check-agent",
+        &json!({
+            "id": "audit-check-agent",
+            "model_id": "bootstrap",
+            "system_prompt": "changed",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Restore.
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/agents/audit-check-agent/restore",
+        &json!({ "version": create_id }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Inspect the restore event in the audit log.
+    let audit = get_audit_log(&app, "resource=agents/audit-check-agent").await;
+    let items = audit["items"].as_array().expect("items");
+    let restore_ev = items
+        .iter()
+        .find(|e| e["action"] == "restore")
+        .expect("restore event");
+
+    assert_eq!(
+        restore_ev["restored_from"].as_str(),
+        Some(create_id.as_str())
+    );
+    assert_eq!(restore_ev["action"], "restore");
+    assert!(restore_ev["after"]["system_prompt"] == "initial");
+}
+
+/// Restore from a Publish audit event restores `event.after` as the resource state.
+///
+/// # Why ignored
+///
+/// The publish flow described in ADR-0025 is not yet implemented. There is no API
+/// endpoint or service method that emits a `Publish` audit event, so it is not
+/// possible to construct one through the normal execution path. Synthesising a fake
+/// Publish event directly in the store would test the plumbing without validating
+/// that real publish events have the correct shape; that would give false confidence.
+///
+/// Enable this test once the publish endpoint from ADR-0025 is implemented and
+/// `AuditAction::Publish` events are produced by the real code path.
+#[tokio::test]
+#[ignore = "publish flow (ADR-0025) not yet implemented; enable once publish endpoint exists"]
+async fn restore_from_publish_event_uses_after() {
+    let app = build_test_app().await;
+
+    // Create an agent so there is at least one version on record.
+    let (status, _) = post_json(
+        &app,
+        "/v1/config/agents",
+        &json!({
+            "id": "publish-restore-agent",
+            "model_id": "bootstrap",
+            "system_prompt": "published version",
+            "max_rounds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // TODO: call the publish endpoint once it exists to emit a real Publish event,
+    // then retrieve its ULID from the audit log, call restore with it, and assert:
+    //   - response body matches event.after
+    //   - audit log has exactly one new entry of action=restore
+    //   - restored_from references the publish event ULID
+    todo!("wire up publish endpoint from ADR-0025")
+}

--- a/docs/adr/0028-config-version-switching.md
+++ b/docs/adr/0028-config-version-switching.md
@@ -1,0 +1,91 @@
+# ADR-0028: Config Version Switching
+
+- **Status**: ✅ Accepted
+- **Date**: 2026-05-01
+- **Depends on**: ADR-0026
+
+## Context
+
+ADR-0026 introduced a structured audit log that records every admin config
+change as an immutable event with `before` and `after` payloads. Operators
+asked for a one-click rollback: given a version ULID from the audit log,
+restore the resource to that exact state.
+
+The existing `/v1/config/:namespace/:id` CRUD surface already covers
+create/update/delete with full validate-and-apply semantics. A restore is
+simply a re-application of a historical spec through the same pipeline — no
+special bypass is needed.
+
+## Decisions
+
+### D1: API surface
+
+`POST /v1/config/:namespace/:id/restore` with body `{"version":"<ulid>"}`.
+The ULID is the `id` of an existing audit event.
+
+### D2: Auth
+
+The endpoint is behind `ensure_admin_auth`, same as all other config routes.
+
+### D3: Payload selection
+
+| Source event action | Payload used |
+|---------------------|-------------|
+| Create              | `event.after` |
+| Update              | `event.after` |
+| Publish             | `event.after` |
+| Restore             | `event.after` |
+| Delete              | `event.before` (re-creates the resource) |
+| Restart             | 422 — no spec payload exists |
+
+### D4: Timestamp handling
+
+`updated_at` is always set to the restore time (via the normal `prepare_body`
+path). For resources being re-created from a Delete event, `created_at` from
+the restored payload is preserved rather than being overwritten with the
+current time.
+
+### D5: Cross-resource guard
+
+If `event.resource` does not equal `<namespace>/<id>` from the URL, the
+request is rejected with 422. Cross-resource restores are not permitted.
+
+### D6: Normal validate+apply chain
+
+Restore goes through `ConfigService::create` or `ConfigService::update`
+(depending on whether the resource currently exists). There is no bypass of
+validation or the runtime apply step. A restore that references a deleted
+dependency returns 422 with the resolver error.
+
+### D7: Version-not-found response
+
+A missing audit event (either never existed or pruned by retention) returns:
+
+```json
+{"error": "version not found", "reason": "unknown"}
+```
+
+The `reason` is always `"unknown"` because the server cannot distinguish a
+pruned event from one that never existed. The ADR originally proposed
+`"expired"` for the pruned case but defensive uniformity is preferred.
+
+### D8: Audit event for the restore
+
+After a successful restore, a new audit event is emitted:
+
+```json
+{
+  "action":        "restore",
+  "resource":      "<namespace>/<id>",
+  "before":        <spec before restore or null>,
+  "after":         <restored spec>,
+  "restored_from": "<source event ULID>"
+}
+```
+
+### D9: AuditAction enum extension
+
+`AuditAction::Restore` is added to `awaken-contract`. The new
+`restored_from: Option<String>` field on `AuditEvent` uses
+`#[serde(default, skip_serializing_if)]` so all existing events
+deserialise cleanly without schema migration.


### PR DESCRIPTION
## Summary

Implements ADR-0028 (configuration version switching). 4 commits + audit log foundation. Adds a `POST /v1/config/:namespace/:id/restore` endpoint that takes a version ULID from the audit log and replays the corresponding payload through the normal validate + apply chain. Marks ADR-0028 as Accepted.

## Depends on

- **PR #158** — branch is built on top of `feat/audit-log-impl`. The audit log MUST merge first.

## What landed

### Contract (commit 1)
- `AuditAction::Restore` variant
- `restored_from: Option<String>` field on `AuditEvent` (default-None for backward compatibility)
- Unit tests for serde round-trip with the new field present and absent

### Service + endpoint (commit 2 + commit 4)
- `ConfigService::restore(namespace, id, version, headers)` selects payload per ADR D3:
  - `Create / Update / Publish / Restore → event.after`
  - `Delete → event.before` (route to create — resource doesn't currently exist)
  - `Restart → 422` (no spec to restore)
- Goes through normal validate + apply chain (no back door)
- D4 — `created_at` preserved from the restored payload (delete-restore path); `updated_at` re-stamped
- D7 — 404 with structured `{ "error": "version not found", "reason": "unknown" }` (we do not distinguish expired vs unknown — server cannot tell)
- D8 — emits exactly **one** new `Restore` audit event with `restored_from = <source-version-ulid>`. Cross-resource restore is rejected with 422.
- Single `store.get` (no race) and `persist_and_apply_locked` directly to avoid the spurious `Update` audit event that an earlier draft produced

### Documentation (commit 3)
- ADR-0028 status: 📐 Proposed → ✅ Accepted

## Test plan

- [x] `cargo test -p awaken-server -p awaken-contract` — 36 suites pass; 7 new integration tests in `tests/restore_routes.rs` (1 `#[ignore]` for the Publish path until ADR-0025 lands)
- [x] `cargo build -p awaken-server -p awaken-contract -p awaken-stores` clean
- [x] `cargo clippy --workspace --lib --bins --examples --locked -- -D clippy::correctness` clean
- [x] Two-stage subagent review: spec ✅ + code quality ✅ (Critical 0, Important 0 after fix-up commit)

## Test cases covered

- `restore_agent_to_prior_version` — restores an Update; asserts only one new audit event
- `restore_resurrects_deleted_resource` — uses `event.before`; verifies the resource exists post-restore
- `restore_restart_event_returns_422` — Restart action is unrestorable
- `restore_cross_resource_returns_422` — URL `/agents/foo/restore` with version of `agents/bar`
- `restore_unknown_version_returns_404` — never-existed ULID
- `restore_with_broken_resolver_returns_422` — restoring a spec whose model has been deleted; surfaces the resolver error
- `restore_from_publish_event_uses_after` (`#[ignore]`) — placeholder for when ADR-0025 publish flow lands

## Out of scope

- Frontend History tab + diff viewer (PR4 — depends on this)
- Cascade restore across multiple resources (operators sequence the calls)
- Schema-evolution migration framework (assumes additive serde changes; non-additive renames will fail explicitly)