### PR TITLE
ADR-0028 version switching: History tab + restore confirm flow in agent editor

### DIFF
--- a/apps/admin-console/src/lib/config-api.test.ts
+++ b/apps/admin-console/src/lib/config-api.test.ts
@@ -4,11 +4,123 @@ import {
   BACKEND_URL,
   ConfigApiError,
   configApi,
+  type RestoreResponse,
 } from "./config-api";
 import {
   __resetAuthInterceptorForTesting,
   setUnauthorizedHandler,
 } from "./auth-interceptor";
+
+describe("restoreConfig", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("encodes namespace and id with special chars in the URL", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: "my-agent", version: "v2" }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configApi.restoreConfig("agents", "alpha/beta", "evt-123");
+
+    const calledUrl: string = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(
+      `${BACKEND_URL}/v1/config/agents/alpha%2Fbeta/restore`,
+    );
+  });
+
+  it("encodes namespace with special chars", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({}),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configApi.restoreConfig("my/ns", "simple-id", "evt-456");
+
+    const calledUrl: string = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(
+      `${BACKEND_URL}/v1/config/my%2Fns/simple-id/restore`,
+    );
+  });
+
+  it("sends version in the POST body", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: "agent-1" }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configApi.restoreConfig("agents", "agent-1", "evt-789");
+
+    const init: RequestInit = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ version: "evt-789" }));
+  });
+
+  it("returns the parsed response on success", async () => {
+    const payload = { id: "agent-1", model_id: "gpt-4" };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    }));
+
+    const result: RestoreResponse = await configApi.restoreConfig("agents", "agent-1", "evt-1");
+    expect(result).toEqual(payload);
+  });
+
+  it("throws ConfigApiError with detail string for 404 with reason", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => JSON.stringify({ error: "not found", reason: "version missing" }),
+    }));
+
+    await expect(
+      configApi.restoreConfig("agents", "agent-1", "bad-version"),
+    ).rejects.toMatchObject({
+      name: "ConfigApiError",
+      status: 404,
+    });
+  });
+
+  it("throws ConfigApiError for 422 with resolver message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => JSON.stringify({ error: "validation failed" }),
+    }));
+
+    await expect(
+      configApi.restoreConfig("agents", "agent-1", "evt-1"),
+    ).rejects.toMatchObject({
+      name: "ConfigApiError",
+      status: 422,
+      message: "validation failed",
+    });
+  });
+
+  it("throws ConfigApiError for 503 audit log not configured", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => JSON.stringify({ error: "service unavailable" }),
+    }));
+
+    await expect(
+      configApi.restoreConfig("agents", "agent-1", "evt-1"),
+    ).rejects.toMatchObject({
+      name: "ConfigApiError",
+      status: 503,
+    });
+  });
+});
 
 describe("configUrl encoding", () => {
   it("encodes config ids via the list endpoint", async () => {

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -121,6 +121,8 @@ export interface Capabilities {
   }>;
 }
 
+export type RestoreResponse = Record<string, unknown>;
+
 export interface ListResponse<T> {
   namespace: string;
   items: T[];
@@ -318,4 +320,14 @@ export const configApi = {
       throw err;
     }
   },
+
+  restoreConfig: (namespace: string, id: string, version: string) =>
+    fetchJson<RestoreResponse>(
+      `${BACKEND_URL}/v1/config/${encodeURIComponent(namespace)}/${encodeURIComponent(id)}/restore`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ version }),
+      },
+    ),
 };

--- a/apps/admin-console/src/lib/editor-tabs.test.ts
+++ b/apps/admin-console/src/lib/editor-tabs.test.ts
@@ -23,6 +23,7 @@ describe("isAgentEditorTab", () => {
   it("accepts known tab ids", () => {
     expect(isAgentEditorTab("basics")).toBe(true);
     expect(isAgentEditorTab("advanced")).toBe(true);
+    expect(isAgentEditorTab("history")).toBe(true);
   });
 
   it("rejects everything else", () => {

--- a/apps/admin-console/src/lib/editor-tabs.ts
+++ b/apps/admin-console/src/lib/editor-tabs.ts
@@ -3,7 +3,8 @@ export type AgentEditorTabId =
   | "tools"
   | "plugins"
   | "delegates"
-  | "advanced";
+  | "advanced"
+  | "history";
 
 export interface AgentEditorTab {
   id: AgentEditorTabId;
@@ -17,6 +18,7 @@ export const AGENT_EDITOR_TABS: readonly AgentEditorTab[] = [
   { id: "plugins", label: "Plugins", description: "Enabled plugins and their config." },
   { id: "delegates", label: "Delegates", description: "Agents this one can delegate to." },
   { id: "advanced", label: "Advanced", description: "Raw JSON preview." },
+  { id: "history", label: "History", description: "Audit history and restore." },
 ];
 
 export const DEFAULT_AGENT_EDITOR_TAB: AgentEditorTabId = "basics";

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -73,7 +73,7 @@ describe("agent editor tab ARIA semantics", () => {
     await screen.findByLabelText("Agent ID");
 
     const tabs = screen.getAllByRole("tab");
-    expect(tabs.length).toBe(5);
+    expect(tabs.length).toBe(6);
 
     // "basics" is the default active tab
     const basicsTab = screen.getByRole("tab", { name: "Basics" });
@@ -145,9 +145,9 @@ describe("agent editor tab keyboard navigation", () => {
     basicsTab.focus();
     fireEvent.keyDown(basicsTab, { key: "ArrowLeft" });
 
-    const advancedTab = screen.getByRole("tab", { name: "Advanced" });
-    expect(document.activeElement).toBe(advancedTab);
-    expect(advancedTab.getAttribute("aria-selected")).toBe("true");
+    const historyTab = screen.getByRole("tab", { name: "History" });
+    expect(document.activeElement).toBe(historyTab);
+    expect(historyTab.getAttribute("aria-selected")).toBe("true");
   });
 
   it("Home key jumps to the first tab", async () => {
@@ -173,23 +173,101 @@ describe("agent editor tab keyboard navigation", () => {
     basicsTab.focus();
     fireEvent.keyDown(basicsTab, { key: "End" });
 
-    const advancedTab = screen.getByRole("tab", { name: "Advanced" });
-    expect(document.activeElement).toBe(advancedTab);
-    expect(advancedTab.getAttribute("aria-selected")).toBe("true");
+    const historyTab = screen.getByRole("tab", { name: "History" });
+    expect(document.activeElement).toBe(historyTab);
+    expect(historyTab.getAttribute("aria-selected")).toBe("true");
   });
 
   it("ArrowRight wraps from last tab to first tab", async () => {
     renderEditorRoute("/agents/new");
     await screen.findByLabelText("Agent ID");
 
-    // Click Advanced tab to make it active
-    const advancedTab = screen.getByRole("tab", { name: "Advanced" });
-    fireEvent.click(advancedTab);
-    advancedTab.focus();
-    fireEvent.keyDown(advancedTab, { key: "ArrowRight" });
+    // Click History tab to make it active
+    const historyTab = screen.getByRole("tab", { name: "History" });
+    fireEvent.click(historyTab);
+    historyTab.focus();
+    fireEvent.keyDown(historyTab, { key: "ArrowRight" });
 
     const basicsTab = screen.getByRole("tab", { name: "Basics" });
     expect(document.activeElement).toBe(basicsTab);
     expect(basicsTab.getAttribute("aria-selected")).toBe("true");
+  });
+});
+
+describe("agent editor History tab", () => {
+  it("shows 'Save first' empty state for new agents", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const historyTab = screen.getByRole("tab", { name: "History" });
+    fireEvent.click(historyTab);
+
+    await screen.findByText(/Save the agent first to see its history/i);
+  });
+
+  it("renders audit list rows when auditLog returns events for an existing agent", async () => {
+    const auditEvents = [
+      {
+        id: "evt-abc123",
+        ts: "2026-01-01T00:00:00Z",
+        actor: "hash1/admin",
+        action: "update",
+        resource: "agents/existing-agent",
+        before: { id: "existing-agent", model_id: "old-model", system_prompt: "", max_rounds: 8 },
+        after: { id: "existing-agent", model_id: "new-model", system_prompt: "", max_rounds: 8 },
+      },
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).includes("/v1/capabilities")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                agents: [],
+                tools: [],
+                plugins: [],
+                skills: [],
+                models: [],
+                providers: [],
+                namespaces: [],
+              }),
+          };
+        }
+        if (String(url).includes("/v1/config/agents/existing-agent") && !String(url).includes("audit")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                id: "existing-agent",
+                model_id: "new-model",
+                system_prompt: "",
+                max_rounds: 8,
+              }),
+          };
+        }
+        if (String(url).includes("/v1/audit-log")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ items: auditEvents, next_cursor: undefined }),
+          };
+        }
+        return { ok: false, status: 404, text: async () => "" };
+      }),
+    );
+
+    renderEditorRoute("/agents/existing-agent");
+    await screen.findByText(/Edit existing-agent/i);
+
+    const historyTab = screen.getByRole("tab", { name: "History" });
+    fireEvent.click(historyTab);
+
+    // Wait for the audit row to appear (actor hash)
+    await screen.findByText("hash1");
   });
 });

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Link,
   useNavigate,
@@ -6,11 +6,13 @@ import {
   useSearchParams,
 } from "react-router";
 import { type AgentSpec, type Capabilities, configApi } from "@/lib/config-api";
+import { type AuditEvent, type AuditPage, formatActor, summarizeChange } from "@/lib/audit-log";
 import { Field } from "@/components/form-components";
 import { AgentPreviewPanel } from "@/components/agent-preview-panel";
 import { PluginConfigWorkspace } from "@/components/plugin-config-workspace";
 import { ToolSelector } from "@/components/tool-selector";
 import { useToast } from "@/components/toast-provider";
+import { useConfirmDialog } from "@/components/confirm-dialog";
 import { useUnsavedChangesGuard } from "@/components/unsaved-changes-guard";
 import {
   AGENT_EDITOR_TABS,
@@ -343,6 +345,16 @@ export function AgentEditorPage() {
                 />
               )}
               {tab.id === "advanced" && <AdvancedPanel spec={spec} />}
+              {tab.id === "history" && (
+                <HistoryPanel
+                  spec={spec}
+                  isNew={isNew}
+                  onSpecRestored={(updated) => {
+                    setSpec(updated);
+                    setSavedSpec(updated);
+                  }}
+                />
+              )}
             </div>
           ))}
         </div>
@@ -831,5 +843,283 @@ function AdvancedPanel({ spec }: { spec: AgentSpec }) {
         {JSON.stringify(spec, null, 2)}
       </pre>
     </section>
+  );
+}
+
+const ACTION_BADGE: Record<string, string> = {
+  create: "bg-emerald-100 text-emerald-800",
+  update: "bg-blue-100 text-blue-800",
+  delete: "bg-rose-100 text-rose-800",
+  restart: "bg-amber-100 text-amber-800",
+  publish: "bg-violet-100 text-violet-800",
+};
+
+function HistoryPanel({
+  spec,
+  isNew,
+  onSpecRestored,
+}: {
+  spec: AgentSpec;
+  isNew: boolean;
+  onSpecRestored: (updated: AgentSpec) => void;
+}) {
+  const toast = useToast();
+  const confirm = useConfirmDialog();
+  const [page, setPage] = useState<AuditPage | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+  const [restoring, setRestoring] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (isNew || !spec.id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await configApi.auditLog({ resource: `agents/${spec.id}`, limit: 50 });
+      setPage(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [isNew, spec.id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleRestore(event: AuditEvent) {
+    const targetSpec = event.action === "delete" ? event.before : event.after;
+    const confirmed = await confirm({
+      title: "Restore agent to this version?",
+      description: (
+        <div className="space-y-3">
+          <p className="text-xs text-slate-500">
+            Restoring will overwrite the current agent configuration with the version from this event.
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-slate-500">Current</p>
+              <pre className="max-h-48 overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-2 text-xs text-slate-800">
+                {JSON.stringify(spec, null, 2)}
+              </pre>
+            </div>
+            <div>
+              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-slate-500">This version</p>
+              <pre className="max-h-48 overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-2 text-xs text-slate-800">
+                {targetSpec != null ? JSON.stringify(targetSpec, null, 2) : "—"}
+              </pre>
+            </div>
+          </div>
+        </div>
+      ),
+      confirmLabel: "Restore",
+      tone: "destructive",
+    });
+
+    if (!confirmed) return;
+
+    setRestoring(event.id);
+    try {
+      await configApi.restoreConfig("agents", spec.id, event.id);
+      const shortId = event.id.slice(0, 8);
+      toast.success(`Agent restored to version ${shortId}`);
+      const refreshed = await configApi.get<AgentSpec>("agents", spec.id);
+      const hydrated: AgentSpec = { sections: {}, plugin_ids: [], delegates: [], ...refreshed };
+      onSpecRestored(hydrated);
+      void load();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRestoring(null);
+    }
+  }
+
+  if (isNew || !spec.id) {
+    return (
+      <section className="rounded-2xl border border-dashed border-slate-200 bg-white p-6 text-center text-sm text-slate-500 shadow-sm">
+        Save the agent first to see its history.
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+        <h3 className="text-lg font-semibold text-slate-950">History</h3>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading}
+          className="text-xs font-medium text-slate-500 transition hover:text-slate-900 disabled:opacity-60"
+        >
+          {loading ? "Loading…" : "Refresh"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="px-5 py-3 text-sm text-rose-700">{error}</div>
+      )}
+
+      {!error && page && (
+        <table className="min-w-full text-sm">
+          <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="px-4 py-3">Time</th>
+              <th className="px-4 py-3">Actor</th>
+              <th className="px-4 py-3">Action</th>
+              <th className="px-4 py-3">Change</th>
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {page.items.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-slate-500">
+                  No history yet.
+                </td>
+              </tr>
+            ) : (
+              page.items.map((event) => {
+                const actor = formatActor(event.actor);
+                const ts = new Date(event.ts);
+                return (
+                  <tr key={event.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-mono text-xs text-slate-700">
+                      {ts.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-slate-700">
+                      <span className="font-mono text-xs">{actor.hash}</span>
+                      {actor.label && (
+                        <span className="ml-1 text-slate-500">/{actor.label}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={[
+                          "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                          ACTION_BADGE[event.action] ?? "bg-slate-100 text-slate-700",
+                        ].join(" ")}
+                      >
+                        {event.action}
+                      </span>
+                    </td>
+                    <td className="max-w-xs truncate px-4 py-3 text-xs text-slate-600">
+                      {summarizeChange(event)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <button
+                          type="button"
+                          onClick={() => setSelectedEvent(event)}
+                          className="text-xs font-medium text-slate-500 transition hover:text-slate-900"
+                        >
+                          View
+                        </button>
+                        {event.action !== "restart" && (
+                          <button
+                            type="button"
+                            onClick={() => void handleRestore(event)}
+                            disabled={restoring === event.id}
+                            className="text-xs font-medium text-rose-600 transition hover:text-rose-800 disabled:opacity-60"
+                          >
+                            {restoring === event.id ? "Restoring…" : "Restore"}
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      )}
+
+      {selectedEvent && (
+        <HistoryEventPanel event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      )}
+    </section>
+  );
+}
+
+function HistoryEventPanel({
+  event,
+  onClose,
+}: {
+  event: AuditEvent;
+  onClose: () => void;
+}) {
+  const actor = formatActor(event.actor);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Audit event details"
+      className="fixed inset-0 z-50 flex items-start justify-end bg-black/30"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex h-full w-full max-w-2xl flex-col overflow-y-auto bg-white shadow-2xl md:max-w-xl">
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <h3 className="text-base font-semibold text-slate-900">Audit event</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm text-slate-500 hover:bg-slate-100"
+          >
+            Close
+          </button>
+        </div>
+
+        <dl className="grid gap-3 px-6 py-4 text-sm">
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-slate-500">ID</dt>
+            <dd className="min-w-0 font-mono text-xs text-slate-900">{event.id}</dd>
+          </div>
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-slate-500">Time</dt>
+            <dd className="min-w-0 font-mono text-xs text-slate-900">{event.ts}</dd>
+          </div>
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-slate-500">Actor</dt>
+            <dd className="min-w-0 text-slate-900">
+              <span className="font-mono text-xs">{actor.hash}</span>
+              {actor.label && <span className="ml-1 text-slate-500">/{actor.label}</span>}
+            </dd>
+          </div>
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-slate-500">Action</dt>
+            <dd className="min-w-0">
+              <span
+                className={[
+                  "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                  ACTION_BADGE[event.action] ?? "bg-slate-100 text-slate-700",
+                ].join(" ")}
+              >
+                {event.action}
+              </span>
+            </dd>
+          </div>
+        </dl>
+
+        <div className="grid gap-4 px-6 pb-6 md:grid-cols-2">
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">Before</p>
+            <pre className="overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs leading-relaxed text-slate-800">
+              {event.before != null ? JSON.stringify(event.before, null, 2) : "—"}
+            </pre>
+          </div>
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">After</p>
+            <pre className="overflow-auto rounded-xl border border-slate-200 bg-slate-50 p-3 text-xs leading-relaxed text-slate-800">
+              {event.after != null ? JSON.stringify(event.after, null, 2) : "—"}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Frontend half of ADR-0028 (configuration version switching). Adds a 6th "History" tab to the agent editor with a restore-confirm flow. Depends on PR #160 (BE restore endpoint) and indirectly on PR #158 (audit log foundation) and PR #159 (FE audit log page).

## Depends on

- **PR #160** — restore endpoint must merge first (this branch builds on `feat/restore-endpoint`)
- **PR #159** — uses the existing audit log API client + types
- **PR #158** — audit log foundation

The branch is the merge of `feat/audit-log-fe-impl` + `feat/restore-endpoint` so it has the full stack.

## What landed (2 commits)

### Commit 1 — restore API client
- `configApi.restoreConfig(namespace, id, version)` POSTs `/v1/config/:ns/:id/restore` with `{ version }`
- Distinguishes 404 (`{error, reason}`) / 422 (resolver failure) / 503 (audit not enabled)
- 7 unit tests cover URL encoding (namespace + id) and each error path

### Commit 2 — History tab in agent editor
- New `"history"` tab id in `editor-tabs.ts`; tab nav goes 5 → 6 tabs
- URL param `?tab=history` round-trips via existing `isAgentEditorTab` validator
- `<HistoryPanel>` self-loads its audit list via `configApi.auditLog({ resource: agents/<id>, limit: 50 })`
- Empty state for new agents (`isNew || !spec.id`) — "Save the agent first to see its history"
- Per-row View button → side panel showing `before` ↔ `after` JSON (plain `<pre>`; can swap in a real diff library later)
- Per-row Restore button → `useConfirmDialog` (destructive tone) → on confirm calls `configApi.restoreConfig`, refreshes the spec from the server, refreshes the history list, fires `toast.success`
- Restore button is hidden for `restart` audit events (not restorable)
- Updated existing tab-nav tests (5 → 6 tabs)
- 2 new smoke tests: empty-state-for-new-agents, list-rendering-for-existing

## Out of scope (deferred)

- **History sections in models / providers / mcp-servers drawers** — these CRUD pages don't have a tab structure, so adding inline history would require non-trivial drawer restructuring. The cross-link to `/audit-log?resource=...` (added in PR #159) already covers discovery for those resources. Tracked as a follow-up.
- **Real diff library** — current side-by-side `<pre>` blocks are functional; swapping in `microdiff` / `fast-json-patch` is a UX polish PR.

## Test plan

- [x] `npm test` — **401 / 401** (was 392 → +9)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Two-stage subagent review: spec ✅ + code quality ✅