### PR TITLE
Audit log polish: restore filter + History auto-refresh + Change column for restore

### DIFF
--- a/apps/admin-console/src/lib/audit-log.test.ts
+++ b/apps/admin-console/src/lib/audit-log.test.ts
@@ -148,6 +148,26 @@ describe("summarizeChange", () => {
     );
     expect(result).toContain("old_field");
   });
+
+  it("returns restored from <prefix> for restore event", () => {
+    const event: AuditEvent = {
+      ...makeEvent("restore"),
+      restored_from: "01JXYZ12345678abcdef",
+    };
+    expect(summarizeChange(event)).toBe("restored from 01JXYZ12");
+  });
+
+  it("returns restored from unknown for restore event with null restored_from", () => {
+    const event: AuditEvent = {
+      ...makeEvent("restore"),
+      restored_from: null,
+    };
+    expect(summarizeChange(event)).toBe("restored from unknown");
+  });
+
+  it("returns restored from unknown for restore event with no restored_from", () => {
+    expect(summarizeChange(makeEvent("restore"))).toBe("restored from unknown");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/admin-console/src/lib/audit-log.ts
+++ b/apps/admin-console/src/lib/audit-log.ts
@@ -1,4 +1,4 @@
-export type AuditAction = "create" | "update" | "delete" | "restart" | "publish";
+export type AuditAction = "create" | "update" | "delete" | "restart" | "publish" | "restore";
 
 export interface AuditEvent {
   id: string;
@@ -10,6 +10,7 @@ export interface AuditEvent {
   after?: Record<string, unknown> | null;
   ip?: string | null;
   request_id?: string | null;
+  restored_from?: string | null;
 }
 
 export interface AuditQuery {
@@ -55,6 +56,11 @@ export function formatActor(actor: string): { hash: string; label: string | null
 
 /** Short human-readable summary for the change column of an audit table row. */
 export function summarizeChange(event: AuditEvent): string {
+  if (event.action === "restore") {
+    const sourcePrefix = event.restored_from?.slice(0, 8) ?? "unknown";
+    return `restored from ${sourcePrefix}`;
+  }
+
   const hasBefore = event.before != null;
   const hasAfter = event.after != null;
 
@@ -85,5 +91,8 @@ export function summarizeChange(event: AuditEvent): string {
       return "Restarted";
     case "publish":
       return "Published";
+    case "restore":
+      // handled by the early-return guard above; unreachable but keeps switch exhaustive
+      return `restored from ${event.restored_from?.slice(0, 8) ?? "unknown"}`;
   }
 }

--- a/apps/admin-console/src/lib/audit-log.ts
+++ b/apps/admin-console/src/lib/audit-log.ts
@@ -91,8 +91,5 @@ export function summarizeChange(event: AuditEvent): string {
       return "Restarted";
     case "publish":
       return "Published";
-    case "restore":
-      // handled by the early-return guard above; unreachable but keeps switch exhaustive
-      return `restored from ${event.restored_from?.slice(0, 8) ?? "unknown"}`;
   }
 }

--- a/apps/admin-console/src/lib/list-url-state.test.ts
+++ b/apps/admin-console/src/lib/list-url-state.test.ts
@@ -6,6 +6,8 @@ import {
   writeSkillsFilter,
   readFixtureFilter,
   writeFixtureFilter,
+  readAuditFilter,
+  writeAuditFilter,
   type ListState,
 } from "./list-url-state";
 import { DEFAULT_PAGE_SIZE } from "./list-view";
@@ -307,5 +309,34 @@ describe("writeFixtureFilter", () => {
     const written = writeFixtureFilter(p(""), original);
     const recovered = readFixtureFilter(written);
     expect(recovered).toEqual(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readAuditFilter / writeAuditFilter — restore action round-trip
+// ---------------------------------------------------------------------------
+
+describe("readAuditFilter", () => {
+  it("deserialises ?action=restore correctly", () => {
+    const state = readAuditFilter(p("action=restore"));
+    expect(state.action).toBe("restore");
+  });
+
+  it("rejects unknown action and falls back to empty string", () => {
+    const state = readAuditFilter(p("action=bogus"));
+    expect(state.action).toBe("");
+  });
+
+  it("round-trips restore action through write/read", () => {
+    const written = writeAuditFilter(p(""), {
+      since: "",
+      until: "",
+      action: "restore",
+      resource: "",
+      actor: "",
+    });
+    expect(written.get("action")).toBe("restore");
+    const recovered = readAuditFilter(written);
+    expect(recovered.action).toBe("restore");
   });
 });

--- a/apps/admin-console/src/lib/list-url-state.ts
+++ b/apps/admin-console/src/lib/list-url-state.ts
@@ -356,6 +356,7 @@ const VALID_AUDIT_ACTIONS: readonly AuditAction[] = [
   "delete",
   "restart",
   "publish",
+  "restore",
 ];
 
 export function readAuditFilter(params: URLSearchParams): AuditFilterState {

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -271,3 +271,103 @@ describe("agent editor History tab", () => {
     await screen.findByText("hash1");
   });
 });
+
+describe("agent editor History tab auto-refresh after Save", () => {
+  it("re-fetches history after a successful save", async () => {
+    let auditCallCount = 0;
+    const newEvent = {
+      id: "evt-new001",
+      ts: "2026-01-02T00:00:00Z",
+      actor: "hash2/dev",
+      action: "update",
+      resource: "agents/refresh-agent",
+      before: { id: "refresh-agent", model_id: "m1", system_prompt: "old", max_rounds: 8 },
+      after: { id: "refresh-agent", model_id: "m1", system_prompt: "new", max_rounds: 8 },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const u = String(url);
+        if (u.includes("/v1/capabilities")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                agents: [],
+                tools: [],
+                plugins: [],
+                skills: [],
+                models: [],
+                providers: [],
+                namespaces: [],
+              }),
+          };
+        }
+        if (u.includes("/v1/config/agents/refresh-agent") && !u.includes("audit") && init?.method === "PUT") {
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                id: "refresh-agent",
+                model_id: "m1",
+                system_prompt: "new",
+                max_rounds: 8,
+              }),
+          };
+        }
+        if (u.includes("/v1/config/agents/refresh-agent") && !u.includes("audit")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                id: "refresh-agent",
+                model_id: "m1",
+                system_prompt: "old",
+                max_rounds: 8,
+              }),
+          };
+        }
+        if (u.includes("/v1/audit-log")) {
+          auditCallCount += 1;
+          const items = auditCallCount >= 2 ? [newEvent] : [];
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ items }),
+          };
+        }
+        return { ok: false, status: 404, text: async () => "" };
+      }),
+    );
+
+    renderEditorRoute("/agents/refresh-agent");
+    await screen.findByText(/Edit refresh-agent/i);
+
+    // Switch to History — first audit fetch (returns 0 events)
+    const historyTab = screen.getByRole("tab", { name: "History" });
+    fireEvent.click(historyTab);
+    await screen.findByText(/No history yet/i);
+
+    // Switch to Basics, make the form dirty, then save
+    const basicsTab = screen.getByRole("tab", { name: "Basics" });
+    fireEvent.click(basicsTab);
+    await screen.findByLabelText("Agent ID");
+
+    // Modify system prompt to mark the form as dirty
+    const promptTextarea = screen.getByRole("textbox", { name: /system prompt/i });
+    fireEvent.change(promptTextarea, { target: { value: "new" } });
+
+    const saveButton = screen.getByRole("button", { name: /^save$/i });
+    fireEvent.click(saveButton);
+
+    // Switch back to History — should trigger second audit fetch (returns 1 event)
+    fireEvent.click(historyTab);
+    await screen.findByText("hash2");
+
+    expect(auditCallCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -852,6 +852,7 @@ const ACTION_BADGE: Record<string, string> = {
   delete: "bg-rose-100 text-rose-800",
   restart: "bg-amber-100 text-amber-800",
   publish: "bg-violet-100 text-violet-800",
+  restore: "bg-purple-100 text-purple-800",
 };
 
 function HistoryPanel({

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -56,6 +56,7 @@ export function AgentEditorPage() {
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
   const [activePluginConfig, setActivePluginConfig] = useState<string | null>(null);
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
   const toast = useToast();
 
   const isDirty = useMemo(() => {
@@ -157,6 +158,7 @@ export function AgentEditorPage() {
         setSpec(updated);
         setSavedSpec(updated);
         toast.success(`Agent "${updated.id}" saved`);
+        setHistoryRefreshKey((k) => k + 1);
       }
     } catch (saveError) {
       toast.error(
@@ -349,9 +351,11 @@ export function AgentEditorPage() {
                 <HistoryPanel
                   spec={spec}
                   isNew={isNew}
+                  refreshKey={historyRefreshKey}
                   onSpecRestored={(updated) => {
                     setSpec(updated);
                     setSavedSpec(updated);
+                    setHistoryRefreshKey((k) => k + 1);
                   }}
                 />
               )}
@@ -858,10 +862,12 @@ const ACTION_BADGE: Record<string, string> = {
 function HistoryPanel({
   spec,
   isNew,
+  refreshKey,
   onSpecRestored,
 }: {
   spec: AgentSpec;
   isNew: boolean;
+  refreshKey: number;
   onSpecRestored: (updated: AgentSpec) => void;
 }) {
   const toast = useToast();
@@ -888,7 +894,10 @@ function HistoryPanel({
 
   useEffect(() => {
     void load();
-  }, [load]);
+    // refreshKey is intentionally included: bumping it triggers a re-fetch
+    // after a successful save or restore without causing a re-render loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [load, refreshKey]);
 
   async function handleRestore(event: AuditEvent) {
     const targetSpec = event.action === "delete" ? event.before : event.after;

--- a/apps/admin-console/src/pages/audit-log-page.tsx
+++ b/apps/admin-console/src/pages/audit-log-page.tsx
@@ -16,6 +16,7 @@ const ACTION_OPTIONS: Array<{ value: AuditAction | ""; label: string }> = [
   { value: "delete", label: "Delete" },
   { value: "restart", label: "Restart" },
   { value: "publish", label: "Publish" },
+  { value: "restore", label: "Restore" },
 ];
 
 const ACTION_BADGE: Record<AuditAction, string> = {
@@ -24,6 +25,7 @@ const ACTION_BADGE: Record<AuditAction, string> = {
   delete: "bg-rose-100 text-rose-800",
   restart: "bg-amber-100 text-amber-800",
   publish: "bg-violet-100 text-violet-800",
+  restore: "bg-purple-100 text-purple-800",
 };
 
 export function AuditLogPage() {


### PR DESCRIPTION
## Summary

3 small followups on the audit-log + restore work that just landed (#158-#161). All FE-only, +7 tests.

## What landed

### Commit 1 — Add `restore` to FE `AuditAction`
The BE emits `AuditAction::Restore` (added in #160) but the FE was written before that variant existed. Three places brought into sync:
- `apps/admin-console/src/lib/audit-log.ts`: `AuditAction` union, `AuditEvent.restored_from?: string | null`, `summarizeChange()` early-return for restore
- `apps/admin-console/src/pages/audit-log-page.tsx`: `ACTION_OPTIONS` adds Restore; `ACTION_BADGE` colour for it (purple — distinct from publish's violet)
- `apps/admin-console/src/lib/list-url-state.ts`: `VALID_AUDIT_ACTIONS` accepts `?action=restore`

Without this fix the audit log table renders restore events with no badge styling and the action filter dropdown silently rejects the new variant.

### Commit 2 — History panel auto-refreshes after Save / Restore
A7 (the ARIA tablist refactor) made all editor tab panels persistently mounted with `hidden` instead of conditional unmount. Side effect: after a Save the History tab still showed stale data until the user manually clicked Refresh.

Fix: `historyRefreshKey: number` state on `AgentEditorPage`, bumped after `handleSave` succeeds and after `onSpecRestored` fires. `HistoryPanel` adds `refreshKey` to its `useEffect` deps and re-fetches when it changes. The panel itself stays mounted (preserves scroll position).

### Commit 3 — `summarizeChange` returns helpful text for restore events
When restore writes the same payload as the source version, the diff helper produced an empty string and the audit log "Change" column was blank. Now restore events show `restored from <8-char ULID>` (or `restored from unknown` if `restored_from` is somehow missing). Cross-events with `restored_from` short-circuit before the generic diff path.

## Test plan

- [x] `npm test` — **408 / 408** pass (was 401 → +7 new)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Spec review ✅: all 9 verification points checked

## Out of scope

- Real JSON diff library (still side-by-side `<pre>` blocks)
- Inline History tab in models/providers/mcp-servers drawers (CRUD pages)
- Audit log opt-in default in the starter agent
- Friendlier restore-failure messages when references break