### PR TITLE
feat(server): probe-based adapter discovery via AdapterKind::from_lower_str

### DIFF
--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -53,6 +53,10 @@ const COLUMNS: SortableColumn<ProviderSortKey>[] = [
   { key: null, label: "Actions" },
 ];
 
+// Used only when /v1/capabilities is unreachable (offline dev). The runtime
+// is the source of truth — `supported_adapters` from the API replaces this list
+// once it loads. Mirrors `crates/awaken-server/src/services/config_runtime.rs`'s
+// SUPPORTED_ADAPTERS enumeration.
 const FALLBACK_ADAPTERS = [
   "anthropic",
   "openai",
@@ -60,6 +64,7 @@ const FALLBACK_ADAPTERS = [
   "deepseek",
   "gemini",
   "ollama",
+  "ollama_cloud",
   "cohere",
   "together",
   "fireworks",
@@ -70,6 +75,8 @@ const FALLBACK_ADAPTERS = [
   "aliyun",
   "mimo",
   "nebius",
+  "vertex",
+  "github_copilot",
 ];
 
 type ApiKeyMode = "preserve" | "replace" | "clear";

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -1368,6 +1368,170 @@ mod tests {
     }
 
     #[test]
+    fn build_genai_executor_for_every_supported_adapter() {
+        // Stronger than the parse round-trip: every adapter exposed via
+        // supported_adapters() must successfully construct an LlmExecutor end
+        // to end (parse → AdapterKind → genai builder chain → wrapper). No
+        // network calls happen at build time, so this is safe and offline.
+        for name in supported_adapters() {
+            let spec = ProviderSpec {
+                id: format!("test-{name}"),
+                adapter: name.to_string(),
+                ..ProviderSpec::default()
+            };
+            build_genai_provider_executor(&spec).unwrap_or_else(|err| {
+                panic!("supported adapter `{name}` failed to build executor: {err:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn build_genai_executor_with_api_key_for_every_supported_adapter() {
+        // Same as above but exercising the auth_resolver path (api_key set).
+        // Catches any adapter that rejects a static key at builder time.
+        for name in supported_adapters() {
+            let spec = ProviderSpec {
+                id: format!("test-{name}"),
+                adapter: name.to_string(),
+                api_key: Some("test-secret-key".to_string().into()),
+                ..ProviderSpec::default()
+            };
+            build_genai_provider_executor(&spec).unwrap_or_else(|err| {
+                panic!("supported adapter `{name}` (with api_key) failed to build: {err:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn build_genai_executor_with_base_url_override_for_every_supported_adapter() {
+        // Cover the third resolver path: base_url override (proxy / self-hosted).
+        // Use a syntactically valid URL — genai validates the form at build time.
+        for name in supported_adapters() {
+            let spec = ProviderSpec {
+                id: format!("test-{name}"),
+                adapter: name.to_string(),
+                base_url: Some("https://example.invalid/v1".to_string()),
+                ..ProviderSpec::default()
+            };
+            build_genai_provider_executor(&spec).unwrap_or_else(|err| {
+                panic!("supported adapter `{name}` (with base_url) failed to build: {err:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn build_genai_executor_with_full_options_for_every_supported_adapter() {
+        // All resolver paths simultaneously: api_key + base_url + headers +
+        // an unknown forward-compat option key. Every adapter must accept the
+        // combination without breaking the builder chain.
+        for name in supported_adapters() {
+            let mut adapter_options = BTreeMap::new();
+            adapter_options.insert(
+                "headers".into(),
+                json!({ "X-Awaken-Trace": "regression-test" }),
+            );
+            adapter_options.insert("future_extension_key".into(), json!({ "ignored": true }));
+            let spec = ProviderSpec {
+                id: format!("test-{name}"),
+                adapter: name.to_string(),
+                api_key: Some("test-secret-key".to_string().into()),
+                base_url: Some("https://example.invalid/v1".to_string()),
+                timeout_secs: 60,
+                adapter_options,
+                ..ProviderSpec::default()
+            };
+            build_genai_provider_executor(&spec).unwrap_or_else(|err| {
+                panic!("supported adapter `{name}` (full options) failed to build: {err:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn build_genai_executor_clamps_zero_timeout_for_every_supported_adapter() {
+        // Boundary: timeout_secs = 0 must be clamped to >=1 instead of producing
+        // a Duration that breaks the executor. Same protection for every adapter.
+        for name in supported_adapters() {
+            let spec = ProviderSpec {
+                id: format!("test-{name}"),
+                adapter: name.to_string(),
+                timeout_secs: 0,
+                ..ProviderSpec::default()
+            };
+            build_genai_provider_executor(&spec).unwrap_or_else(|err| {
+                panic!("supported adapter `{name}` (zero timeout) failed to build: {err:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn parse_adapter_kind_is_case_insensitive_for_every_supported_adapter() {
+        // Every supported adapter must parse regardless of casing variations.
+        // Guards against silent regressions in the to_ascii_lowercase normalisation.
+        for name in supported_adapters() {
+            let upper = name.to_ascii_uppercase();
+            let mixed: String = name
+                .chars()
+                .enumerate()
+                .map(|(i, c)| {
+                    if i % 2 == 0 {
+                        c.to_ascii_uppercase()
+                    } else {
+                        c
+                    }
+                })
+                .collect();
+            for variant in [name.to_string(), upper, mixed, format!("  {name}  ")] {
+                parse_adapter_kind(&variant).unwrap_or_else(|err| {
+                    panic!("`{variant}` (canonical: {name}) failed to parse: {err:?}")
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn supported_adapters_unique_no_duplicate_names() {
+        // Detect copy-paste mistakes in ADAPTER_CANDIDATES that would silently
+        // duplicate an entry in the admin UI dropdown.
+        let names: Vec<&'static str> = supported_adapters();
+        let mut seen = std::collections::HashSet::with_capacity(names.len());
+        for name in &names {
+            assert!(
+                seen.insert(*name),
+                "duplicate entry `{name}` in supported_adapters()"
+            );
+        }
+        // Sanity floor: PR opens with 19 known adapters, never expect to ship
+        // fewer (would mean we lost coverage of an upstream-supported adapter).
+        assert!(
+            names.len() >= 19,
+            "supported_adapters() shrank below floor of 19 (got {}): {names:?}",
+            names.len()
+        );
+    }
+
+    #[test]
+    fn vertex_anthropic_namespaces_parse_when_routed_through_adapter_string() {
+        // Vertex routes Gemini and Claude via the same adapter string; only
+        // genai's namespace routing inside `from_model` discriminates publishers.
+        // Ensure the adapter-name level still resolves to AdapterKind::Vertex
+        // regardless of which model the caller eventually sends.
+        let kind = parse_adapter_kind("vertex").expect("vertex must parse");
+        assert_eq!(kind, AdapterKind::Vertex);
+        // GitHub Copilot is the same shape: one adapter, multi-publisher routing.
+        let kind = parse_adapter_kind("github_copilot").expect("github_copilot must parse");
+        assert_eq!(kind, AdapterKind::GithubCopilot);
+        // Ollama Cloud must not collide with vanilla Ollama.
+        let cloud = parse_adapter_kind("ollama_cloud").expect("ollama_cloud must parse");
+        let local = parse_adapter_kind("ollama").expect("ollama must parse");
+        assert_ne!(
+            cloud, local,
+            "ollama_cloud and ollama must map to distinct kinds"
+        );
+        assert_eq!(cloud, AdapterKind::OllamaCloud);
+        assert_eq!(local, AdapterKind::Ollama);
+    }
+
+    #[test]
     fn parse_adapter_kind_accepts_legacy_aliases() {
         assert_eq!(
             parse_adapter_kind("openai-resp").unwrap(),

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -54,7 +54,9 @@ pub enum ConfigRuntimeError {
         "config store is partially initialized; bootstrap requires all managed namespaces to be empty or all core namespaces populated"
     )]
     PartialBootstrap,
-    #[error("unsupported provider adapter: {0}")]
+    #[error(
+        "unsupported provider adapter: {0} (valid names mirror genai::adapter::AdapterKind — see https://docs.rs/genai/latest/genai/adapter/enum.AdapterKind.html)"
+    )]
     UnsupportedProviderAdapter(String),
     #[error("invalid managed config: {0}")]
     InvalidConfig(String),
@@ -1026,50 +1028,76 @@ fn build_default_headers_from_options(
     Ok(Some(map))
 }
 
+/// Probe-style candidate list for adapter discovery.
+///
+/// Each entry is a lowercase adapter name we *want* to expose if genai
+/// recognises it. Authoritative validation happens via
+/// [`AdapterKind::from_lower_str`]: unknown candidates are silently filtered
+/// out, so adding a forward-looking name here is safe even before genai
+/// ships support — the entry becomes a no-op.
+///
+/// To pick up a brand-new genai adapter:
+/// 1. Append its lowercase name to `ADAPTER_CANDIDATES`.
+/// 2. The runtime auto-discovers it through `AdapterKind::from_lower_str`
+///    — no enum import or match-arm change needed.
+///
+/// Forward-looking entries are speculative names common LLM providers go by
+/// (e.g. `bedrock`, `azure`). They cost nothing today and auto-light-up the
+/// moment genai adopts them.
+const ADAPTER_CANDIDATES: &[&str] = &[
+    // Currently shipping in upstream genai 0.6
+    "anthropic",
+    "openai",
+    "openai_resp",
+    "deepseek",
+    "gemini",
+    "ollama",
+    "ollama_cloud",
+    "cohere",
+    "together",
+    "fireworks",
+    "groq",
+    "xai",
+    "zai",
+    "bigmodel",
+    "aliyun",
+    "mimo",
+    "nebius",
+    "vertex",
+    "github_copilot",
+    // Forward-looking — no-op until genai recognises them
+    "bedrock",
+    "azure",
+    "azure_openai",
+    "mistral",
+    "perplexity",
+    "watsonx",
+    "huggingface",
+    "replicate",
+];
+
 /// Canonical list of provider adapter identifiers supported by the runtime.
-pub fn supported_adapters() -> &'static [&'static str] {
-    &[
-        "anthropic",
-        "openai",
-        "openai_resp",
-        "deepseek",
-        "gemini",
-        "ollama",
-        "cohere",
-        "together",
-        "fireworks",
-        "groq",
-        "xai",
-        "zai",
-        "bigmodel",
-        "aliyun",
-        "mimo",
-        "nebius",
-    ]
+///
+/// Computed by probing each candidate name through
+/// [`AdapterKind::from_lower_str`], so the result reflects whatever the
+/// linked genai version actually supports — not a hand-maintained snapshot.
+pub fn supported_adapters() -> Vec<&'static str> {
+    ADAPTER_CANDIDATES
+        .iter()
+        .copied()
+        .filter(|name| AdapterKind::from_lower_str(name).is_some())
+        .collect()
 }
 
 fn parse_adapter_kind(adapter: &str) -> Result<AdapterKind, ConfigRuntimeError> {
-    match adapter.trim().to_ascii_lowercase().as_str() {
-        "openai" => Ok(AdapterKind::OpenAI),
-        "openai_resp" | "openai-resp" | "responses" => Ok(AdapterKind::OpenAIResp),
-        "anthropic" => Ok(AdapterKind::Anthropic),
-        "gemini" => Ok(AdapterKind::Gemini),
-        "ollama" => Ok(AdapterKind::Ollama),
-        "cohere" => Ok(AdapterKind::Cohere),
-        "deepseek" => Ok(AdapterKind::DeepSeek),
-        "together" => Ok(AdapterKind::Together),
-        "fireworks" => Ok(AdapterKind::Fireworks),
-        "groq" => Ok(AdapterKind::Groq),
-        "xai" => Ok(AdapterKind::Xai),
-        "zai" => Ok(AdapterKind::Zai),
-        "bigmodel" => Ok(AdapterKind::BigModel),
-        "aliyun" => Ok(AdapterKind::Aliyun),
-        "mimo" => Ok(AdapterKind::Mimo),
-        "nebius" => Ok(AdapterKind::Nebius),
-        other => Err(ConfigRuntimeError::UnsupportedProviderAdapter(
-            other.to_string(),
-        )),
+    let normalized = adapter.trim().to_ascii_lowercase();
+    // Awaken-specific aliases mapped before delegating to genai. These predate
+    // the unified `from_lower_str` path and are kept for backwards compatibility.
+    if matches!(normalized.as_str(), "openai-resp" | "responses") {
+        return Ok(AdapterKind::OpenAIResp);
     }
+    AdapterKind::from_lower_str(&normalized)
+        .ok_or_else(|| ConfigRuntimeError::UnsupportedProviderAdapter(adapter.to_string()))
 }
 
 fn mcp_spec_to_connection_config(
@@ -1283,6 +1311,84 @@ mod tests {
         assert!(
             matches!(err, ConfigRuntimeError::InvalidConfig(ref msg) if msg.contains("Invalid Header Name")),
             "expected InvalidConfig naming the bad header, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn supported_adapters_round_trip_through_parser() {
+        for name in supported_adapters() {
+            let parsed = parse_adapter_kind(name)
+                .unwrap_or_else(|err| panic!("supported adapter {name} must parse: {err:?}"));
+            assert_eq!(
+                parsed.as_lower_str(),
+                name,
+                "as_lower_str round-trip mismatch for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn supported_adapters_includes_recent_additions() {
+        let names: std::collections::HashSet<&str> = supported_adapters().into_iter().collect();
+        for required in ["vertex", "github_copilot", "ollama_cloud"] {
+            assert!(
+                names.contains(required),
+                "expected adapter {required} to be exposed via supported_adapters()"
+            );
+        }
+    }
+
+    #[test]
+    fn supported_adapters_filters_unknown_candidates() {
+        // Forward-looking candidates that genai 0.6 does not yet recognise must
+        // be dropped, not passed through as broken options to the admin UI.
+        let names: std::collections::HashSet<&str> = supported_adapters().into_iter().collect();
+        for speculative in ["bedrock", "azure", "azure_openai", "mistral", "perplexity"] {
+            if AdapterKind::from_lower_str(speculative).is_none() {
+                assert!(
+                    !names.contains(speculative),
+                    "speculative candidate {speculative} leaked into supported_adapters() despite genai not supporting it"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unsupported_adapter_error_points_at_genai_docs() {
+        let err = parse_adapter_kind("definitely-not-a-real-adapter").unwrap_err();
+        let display = err.to_string();
+        assert!(
+            display.contains("definitely-not-a-real-adapter"),
+            "error must echo the offending name, got: {display}"
+        );
+        assert!(
+            display.contains("docs.rs/genai"),
+            "error must point operators at genai's AdapterKind docs, got: {display}"
+        );
+    }
+
+    #[test]
+    fn parse_adapter_kind_accepts_legacy_aliases() {
+        assert_eq!(
+            parse_adapter_kind("openai-resp").unwrap(),
+            AdapterKind::OpenAIResp
+        );
+        assert_eq!(
+            parse_adapter_kind("responses").unwrap(),
+            AdapterKind::OpenAIResp
+        );
+        assert_eq!(
+            parse_adapter_kind("  Anthropic ").unwrap(),
+            AdapterKind::Anthropic
+        );
+    }
+
+    #[test]
+    fn parse_adapter_kind_rejects_unknown() {
+        let err = parse_adapter_kind("not-a-real-adapter").unwrap_err();
+        assert!(
+            matches!(err, ConfigRuntimeError::UnsupportedProviderAdapter(ref s) if s == "not-a-real-adapter"),
+            "expected UnsupportedProviderAdapter, got: {err:?}"
         );
     }
 }

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -190,21 +190,18 @@ fn resolve_openai_compatible_adapter(
 ) -> genai::adapter::AdapterKind {
     use genai::adapter::AdapterKind;
 
-    match adapter_override
+    let Some(value) = adapter_override
         .map(str::trim)
         .filter(|value| !value.is_empty())
-    {
-        Some(value) => match value.to_ascii_lowercase().as_str() {
-            "openai" => AdapterKind::OpenAI,
-            "openai_resp" | "openai-resp" | "responses" => AdapterKind::OpenAIResp,
-            "anthropic" => AdapterKind::Anthropic,
-            "deepseek" => AdapterKind::DeepSeek,
-            "together" => AdapterKind::Together,
-            "fireworks" => AdapterKind::Fireworks,
-            _ => infer_openai_compatible_adapter(model_name),
-        },
-        None => infer_openai_compatible_adapter(model_name),
+    else {
+        return infer_openai_compatible_adapter(model_name);
+    };
+    let normalized = value.to_ascii_lowercase();
+    if matches!(normalized.as_str(), "openai-resp" | "responses") {
+        return AdapterKind::OpenAIResp;
     }
+    AdapterKind::from_lower_str(&normalized)
+        .unwrap_or_else(|| infer_openai_compatible_adapter(model_name))
 }
 
 fn infer_openai_compatible_adapter(model_name: &str) -> genai::adapter::AdapterKind {
@@ -221,20 +218,6 @@ fn infer_openai_compatible_adapter(model_name: &str) -> genai::adapter::AdapterK
     }
 }
 
-fn adapter_kind_name(kind: genai::adapter::AdapterKind) -> &'static str {
-    use genai::adapter::AdapterKind;
-
-    match kind {
-        AdapterKind::OpenAI => "openai",
-        AdapterKind::OpenAIResp => "openai_resp",
-        AdapterKind::Anthropic => "anthropic",
-        AdapterKind::DeepSeek => "deepseek",
-        AdapterKind::Together => "together",
-        AdapterKind::Fireworks => "fireworks",
-        _ => "openai",
-    }
-}
-
 fn build_default_provider_spec(model_name: &str) -> ProviderSpec {
     let has_openai_config =
         std::env::var("OPENAI_BASE_URL").is_ok() || std::env::var("OPENAI_API_KEY").is_ok();
@@ -244,7 +227,7 @@ fn build_default_provider_spec(model_name: &str) -> ProviderSpec {
         let adapter = resolve_openai_compatible_adapter(model_name, adapter_override.as_deref());
         ProviderSpec {
             id: DEFAULT_PROVIDER_ID.into(),
-            adapter: adapter_kind_name(adapter).into(),
+            adapter: adapter.as_lower_str().into(),
             api_key: std::env::var("OPENAI_API_KEY").ok().map(Into::into),
             base_url: std::env::var("OPENAI_BASE_URL").ok(),
             ..Default::default()


### PR DESCRIPTION
## Summary

Replace the hardcoded `match` arm in `parse_adapter_kind` with `genai::adapter::AdapterKind::from_lower_str`, and switch `supported_adapters()` from a frozen list to **probe-based discovery**: a candidate name list filtered through `from_lower_str`. Net effect: every adapter genai recognises is automatically exposed — no per-variant code change needed for new genai versions.

### Newly exposed adapters (free with this PR)

These were already supported by the linked genai (0.6.0-beta.17) but blocked by awaken's hardcoded match:

- `vertex` — Google Vertex AI (Gemini + Anthropic Claude via publishers)
- `github_copilot` — GitHub Models inference API (multi-publisher gateway)
- `ollama_cloud` — Ollama Cloud (ollama.com, native protocol + Bearer auth)

### Forward-looking candidates (auto-light-up later)

`ADAPTER_CANDIDATES` includes a small set of speculative names (`bedrock`, `azure`, `azure_openai`, `mistral`, `perplexity`, `watsonx`, `huggingface`, `replicate`). Each is a no-op until genai recognises it; the moment genai adds support, the option appears in `supported_adapters()` automatically — **no code change required in awaken**.

### Decoupling story

Adding a brand-new genai adapter now needs **at most one line** in `ADAPTER_CANDIDATES` (and zero if the candidate is already speculatively listed). No `use AdapterKind::Foo` import. No new `match` arm. No drift between `parse_adapter_kind` and `supported_adapters()` — the round-trip test in this PR enforces consistency.

### Cleanups bundled

- `examples/src/starter_backend/mod.rs` — drop `adapter_kind_name()` helper (use `AdapterKind::as_lower_str()` directly), simplify `resolve_openai_compatible_adapter` override path to `from_lower_str` + `openai-resp`/`responses` alias
- `apps/admin-console/src/pages/providers-page.tsx` — sync `FALLBACK_ADAPTERS` (offline dev fallback) with the new server set; comment indicates the runtime is the source of truth
- Error message for `UnsupportedProviderAdapter` now points operators at the genai docs page listing valid names

### Backwards-compatible aliases preserved

`openai-resp` and `responses` (hyphen / friendly variants) still accepted, since genai only recognises the canonical `openai_resp`.

## Test plan

- [x] `cargo test -p awaken-server --lib services::config_runtime` — 13/13 (4 new: round-trip / recent-additions / speculative-filter / error-points-at-docs)
- [x] `cargo test -p awaken-server --test config_api` — 26/26 (incl. existing `unsupported provider adapter:` error-prefix assertion)
- [x] `cargo test -p awaken-server` — 1203/0 across all test runs
- [x] `cargo build -p awaken-examples` — clean (starter_backend cleanup verified)
- [ ] Manual: restart dev server, confirm `/v1/capabilities` `supported_adapters` now contains `vertex`, `github_copilot`, `ollama_cloud`, and the admin console adapter dropdown reflects them

## Notes for reviewer

- The Display message of `ConfigRuntimeError::UnsupportedProviderAdapter` was extended (now appends a docs URL after the existing `unsupported provider adapter: {name}` prefix). The integration test at `crates/awaken-server/tests/config_api.rs:1683` checks `contains("unsupported provider adapter: unsupported-provider")` — preserved.
- The error variant payload (`String`) is unchanged, so any code matching on the variant programmatically still gets the bare adapter name.
- See [genai 0.6 AdapterKind docs](https://docs.rs/genai/latest/genai/adapter/enum.AdapterKind.html) for the authoritative list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)