### PR TITLE
feat: config-store unification (envelope + seed protocol + patch overrides) + post-Phase-3 cleanup

### DIFF
--- a/apps/admin-console/src/components/form-components.tsx
+++ b/apps/admin-console/src/components/form-components.tsx
@@ -5,21 +5,59 @@ export function Field({
   children,
   required = false,
   error,
+  overridden = false,
+  onReset,
+  resetLabel,
 }: {
   label: string;
   children: ReactNode;
   required?: boolean;
   error?: string | null;
+  overridden?: boolean;
+  onReset?: () => void;
+  resetLabel?: string;
 }) {
   // The required marker is rendered via the ::after pseudo-element so it
   // appears visually without contributing to label.textContent — RTL's
   // getByLabelText matches on textContent, not accessible name.
   const labelClassName = required
-    ? "mb-1.5 block text-sm font-medium text-fg-soft after:ml-0.5 after:text-tone-error after:content-['*']"
-    : "mb-1.5 block text-sm font-medium text-fg-soft";
+    ? "text-sm font-medium text-fg-soft after:ml-0.5 after:text-tone-error after:content-['*']"
+    : "text-sm font-medium text-fg-soft";
+  // The label-text + reset-button pair lives outside <label> because <button>
+  // is a labelable element — nesting it would steal the implicit label
+  // association from the wrapped form control.
+  if (onReset) {
+    return (
+      <div className="block">
+        <div className="mb-1.5 flex items-center gap-1.5">
+          <span className={labelClassName}>{label}</span>
+          {overridden ? (
+            <button
+              type="button"
+              onClick={onReset}
+              aria-label={resetLabel ?? `Reset ${label} to default`}
+              title={resetLabel ?? `Reset ${label} to default`}
+              className="inline-flex h-5 w-5 items-center justify-center rounded-full text-xs text-tone-warn transition hover:bg-tone-warn/15"
+            >
+              ↺
+            </button>
+          ) : null}
+        </div>
+        <label className="block">
+          <span className="sr-only">{label}</span>
+          {children}
+        </label>
+        {error ? (
+          <span role="alert" className="mt-1 block text-xs text-tone-error">
+            {error}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
   return (
     <label className="block">
-      <span className={labelClassName}>{label}</span>
+      <span className={`mb-1.5 block ${labelClassName}`}>{label}</span>
       {children}
       {error ? (
         <span role="alert" className="mt-1 block text-xs text-tone-error">

--- a/apps/admin-console/src/components/tool-selector.tsx
+++ b/apps/admin-console/src/components/tool-selector.tsx
@@ -16,8 +16,9 @@ interface ToolSelectorProps {
   title: string;
   /// Free-form caption explaining the semantics.
   description: string;
-  /// `undefined` = mode "all"; explicit list = mode "custom".
-  value: string[] | undefined;
+  /// `undefined` or `null` = mode "all"; explicit list = mode "custom".
+  /// (Backend serializes `Option<Vec<String>>` as JSON null, so accept both.)
+  value: string[] | null | undefined;
   onChange: (next: string[] | undefined) => void;
   tools: ToolInfo[];
   /// Default mode. "include" matches `allowed_tools` semantics where

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -1,12 +1,15 @@
+/// Backend serializes `Option<Vec<String>>` as JSON `null` when None, which
+/// becomes JS `null` after parsing. Treat null and undefined identically as
+/// "no explicit list set" — the default-all sentinel for inclusion semantics.
 export function isToolAllowed(
-  allowedTools: string[] | undefined,
+  allowedTools: string[] | null | undefined,
   toolId: string,
 ): boolean {
   return allowedTools ? allowedTools.includes(toolId) : true;
 }
 
 export function nextAllowedTools(
-  allowedTools: string[] | undefined,
+  allowedTools: string[] | null | undefined,
   allToolIds: string[],
   toolId: string,
   checked: boolean,
@@ -26,14 +29,14 @@ export function nextAllowedTools(
   return baseAllowed.filter((id) => id !== toolId);
 }
 
-/// Inclusion semantics — `undefined` (or missing) means "every tool"; an
-/// explicit array means "only these tools".
+/// Inclusion semantics — `undefined`/`null` (or missing) means "every tool";
+/// an explicit array means "only these tools".
 export type ToolSelectionMode = "all" | "custom";
 
 export function toolSelectionMode(
-  allowedTools: string[] | undefined,
+  allowedTools: string[] | null | undefined,
 ): ToolSelectionMode {
-  return allowedTools === undefined ? "all" : "custom";
+  return allowedTools == null ? "all" : "custom";
 }
 
 /// Switch between modes without losing user data. When toggling to "all",
@@ -41,12 +44,12 @@ export function toolSelectionMode(
 /// the current list is preserved, falling back to *all* known tools so
 /// the resulting custom set has the same effective behaviour as "all".
 export function applyToolSelectionMode(
-  current: string[] | undefined,
+  current: string[] | null | undefined,
   mode: ToolSelectionMode,
   allToolIds: string[],
 ): string[] | undefined {
   if (mode === "all") return undefined;
-  if (current !== undefined) return current;
+  if (current != null) return current;
   return [...allToolIds];
 }
 
@@ -147,7 +150,7 @@ const SOURCE_ORDER: Record<ToolSourceKind, number> = {
 /// value, preserving the inclusion semantics: when every tool ends up
 /// selected we collapse to `undefined`.
 export function setGroupSelection(
-  allowedTools: string[] | undefined,
+  allowedTools: string[] | null | undefined,
   allToolIds: string[],
   groupToolIds: string[],
   selected: boolean,
@@ -175,7 +178,7 @@ export function setGroupSelection(
 /// Returns the selection state of a group: "all" if every tool in the
 /// group is selected, "none" if zero, or "some" otherwise.
 export function groupSelectionState(
-  allowedTools: string[] | undefined,
+  allowedTools: string[] | null | undefined,
   groupToolIds: string[],
 ): "all" | "some" | "none" {
   if (groupToolIds.length === 0) return "none";

--- a/apps/admin-console/src/lib/config-api.test.ts
+++ b/apps/admin-console/src/lib/config-api.test.ts
@@ -4,6 +4,8 @@ import {
   BACKEND_URL,
   ConfigApiError,
   configApi,
+  deriveSourceState,
+  type RecordMeta,
   type RestoreResponse,
 } from "./config-api";
 import {
@@ -301,5 +303,51 @@ describe("configApi", () => {
         },
       ],
     });
+  });
+});
+
+// ── deriveSourceState ─────────────────────────────────────────────────────────
+
+function makeMeta(overrides?: Partial<RecordMeta>): RecordMeta {
+  return {
+    source: { kind: "builtin", binary_version: "1.0" },
+    hidden: false,
+    user_overrides: null,
+    created_at: 0,
+    updated_at: 0,
+    ...overrides,
+  };
+}
+
+describe("deriveSourceState", () => {
+  it("returns 'builtin' for a builtin record with no overrides", () => {
+    const meta = makeMeta({ source: { kind: "builtin", binary_version: "1.0" } });
+    expect(deriveSourceState(meta)).toBe("builtin");
+  });
+
+  it("returns 'customized' for a builtin record with non-empty user_overrides", () => {
+    const meta = makeMeta({
+      source: { kind: "builtin", binary_version: "1.0" },
+      user_overrides: { system_prompt: "custom" },
+    });
+    expect(deriveSourceState(meta)).toBe("customized");
+  });
+
+  it("returns 'builtin' for a builtin record with empty user_overrides object", () => {
+    const meta = makeMeta({
+      source: { kind: "builtin", binary_version: "1.0" },
+      user_overrides: {},
+    });
+    expect(deriveSourceState(meta)).toBe("builtin");
+  });
+
+  it("returns 'user' for a user-created record", () => {
+    const meta = makeMeta({ source: { kind: "user" } });
+    expect(deriveSourceState(meta)).toBe("user");
+  });
+
+  it("returns 'user' defensively when source is missing (malformed payload)", () => {
+    const meta = makeMeta({ source: undefined as unknown as RecordMeta["source"] });
+    expect(deriveSourceState(meta)).toBe("user");
   });
 });

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -17,8 +17,8 @@ export interface AgentSpec {
   max_continuation_retries?: number;
   plugin_ids?: string[];
   sections?: Record<string, unknown>;
-  allowed_tools?: string[];
-  excluded_tools?: string[];
+  allowed_tools?: string[] | null;
+  excluded_tools?: string[] | null;
   delegates?: string[];
   reasoning_effort?: string | number | null;
   created_at?: number;
@@ -196,6 +196,41 @@ export interface AgentRuntimeSnapshot {
 }
 
 export type RestoreResponse = Record<string, unknown>;
+
+// ── Record provenance types (mirrors Rust RecordMeta / RecordSource) ─────────
+
+export type RecordSource =
+  | { kind: "builtin"; binary_version: string }
+  | { kind: "user" };
+
+export interface RecordMeta {
+  source: RecordSource;
+  hidden: boolean;
+  user_overrides?: Record<string, unknown> | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface ConfigMetaItem {
+  id: string;
+  meta: RecordMeta;
+}
+
+/** Three-state derivation. Pure function — no fetch required. */
+export type ConfigSourceState = "builtin" | "customized" | "user";
+
+export function deriveSourceState(meta: RecordMeta): ConfigSourceState {
+  // Defensive: handle missing source (e.g. unexpected server response shape).
+  if (!meta.source || meta.source.kind === "user") return "user";
+  if (
+    meta.user_overrides &&
+    typeof meta.user_overrides === "object" &&
+    Object.keys(meta.user_overrides).length > 0
+  ) {
+    return "customized";
+  }
+  return "builtin";
+}
 
 export interface ListResponse<T> {
   namespace: string;
@@ -435,5 +470,33 @@ export const configApi = {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ version }),
       },
+    ),
+
+  getMeta: (namespace: string, id: string) =>
+    fetchJson<RecordMeta>(`${configUrl(namespace, id)}/meta`),
+
+  listMeta: (namespace: string) =>
+    fetchJson<ConfigMetaItem[]>(`${configUrl(namespace)}/meta`),
+
+  patchAgentOverrides: (id: string, patch: Record<string, unknown>) =>
+    fetchJson<unknown>(
+      `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(id)}/overrides`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(patch),
+      },
+    ),
+
+  clearAgentOverrides: (id: string) =>
+    fetchJson<unknown>(
+      `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(id)}/overrides`,
+      { method: "DELETE" },
+    ),
+
+  clearAgentOverrideField: (id: string, field: string) =>
+    fetchJson<unknown>(
+      `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(id)}/overrides/${encodeURIComponent(field)}`,
+      { method: "DELETE" },
     ),
 };

--- a/apps/admin-console/src/lib/i18n/en.ts
+++ b/apps/admin-console/src/lib/i18n/en.ts
@@ -127,6 +127,15 @@ export const en = {
     sortLabel: "last modified",
     searchPh: "Search by id, model, or plugin…",
     noMatches: "No agents match the current filter.",
+    source: {
+      builtin: "Built-in",
+      customized: "Customized",
+      userDefined: "User-defined",
+    },
+    resetOverrides: "Reset to defaults",
+    resetOverridesConfirm: "Reset all customizations on this agent?",
+    resetOverrideField: "Reset to default",
+    resetOverrideFieldDone: "Reset \"{{field}}\" to default",
   },
   audit: {
     title: "Audit Log",

--- a/apps/admin-console/src/lib/i18n/zh-CN.ts
+++ b/apps/admin-console/src/lib/i18n/zh-CN.ts
@@ -126,6 +126,15 @@ export const zhCN: Dict = {
     sortLabel: "最后修改",
     searchPh: "按 ID、模型、插件搜索…",
     noMatches: "没有智能体符合当前筛选条件。",
+    source: {
+      builtin: "内置",
+      customized: "已定制",
+      userDefined: "用户自建",
+    },
+    resetOverrides: "重置为默认",
+    resetOverridesConfirm: "重置此 Agent 的所有定制?",
+    resetOverrideField: "重置为默认",
+    resetOverrideFieldDone: "已重置 \"{{field}}\" 为默认",
   },
   audit: {
     title: "审计日志",

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
   RouterProvider,
   createMemoryRouter,
@@ -390,5 +390,434 @@ describe("agent editor History tab auto-refresh after Save", () => {
     await screen.findByText("hash2");
 
     expect(auditCallCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── Source badge + reset button ──────────────────────────────────────────────
+
+function buildEditorFetchMock(
+  agentId: string,
+  agentBody: Record<string, unknown>,
+  metaBody: Record<string, unknown> | null,
+) {
+  return vi.fn(async (url: string) => {
+    if (String(url).includes("/v1/capabilities")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          }),
+      };
+    }
+    // GET meta endpoint — must be checked before the general agent URL check
+    if (String(url).endsWith(`/v1/config/agents/${agentId}/meta`)) {
+      if (!metaBody) return { ok: false, status: 404, text: async () => "" };
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(metaBody),
+      };
+    }
+    // GET / PUT agent
+    if (String(url).includes(`/v1/config/agents/${agentId}`)) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(agentBody),
+      };
+    }
+    // DELETE overrides
+    if (String(url).includes(`/v1/config/agents/${agentId}/overrides`)) {
+      return { ok: true, status: 200, text: async () => JSON.stringify(agentBody) };
+    }
+    if (String(url).includes("/v1/audit-log")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ items: [] }),
+      };
+    }
+    return { ok: false, status: 404, text: async () => "" };
+  });
+}
+
+describe("agent editor source badges", () => {
+  it("shows Built-in badge for a builtin agent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock(
+        "my-builtin",
+        { id: "my-builtin", model_id: "m1", system_prompt: "", max_rounds: 8 },
+        {
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          user_overrides: null,
+          created_at: 0,
+          updated_at: 0,
+        },
+      ),
+    );
+
+    renderEditorRoute("/agents/my-builtin");
+    await screen.findByText(/Edit my-builtin/i);
+    expect(screen.getByText("Built-in")).toBeDefined();
+  });
+
+  it("shows Customized badge and Reset to defaults button for customized agent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock(
+        "my-customized",
+        { id: "my-customized", model_id: "m1", system_prompt: "custom", max_rounds: 8 },
+        {
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          user_overrides: { system_prompt: "custom" },
+          created_at: 0,
+          updated_at: 0,
+        },
+      ),
+    );
+
+    renderEditorRoute("/agents/my-customized");
+    await screen.findByText(/Edit my-customized/i);
+    expect(screen.getByText("Customized")).toBeDefined();
+    expect(screen.getByRole("button", { name: /reset to defaults/i })).toBeDefined();
+  });
+
+  it("does not show Reset button for builtin agent with no overrides", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock(
+        "pure-builtin",
+        { id: "pure-builtin", model_id: "m1", system_prompt: "", max_rounds: 8 },
+        {
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          user_overrides: null,
+          created_at: 0,
+          updated_at: 0,
+        },
+      ),
+    );
+
+    renderEditorRoute("/agents/pure-builtin");
+    await screen.findByText(/Edit pure-builtin/i);
+    expect(screen.queryByRole("button", { name: /reset to defaults/i })).toBeNull();
+  });
+
+  it("shows User-defined badge for user-created agent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock(
+        "user-def",
+        { id: "user-def", model_id: "m1", system_prompt: "", max_rounds: 8 },
+        {
+          source: { kind: "user" },
+          hidden: false,
+          user_overrides: null,
+          created_at: 0,
+          updated_at: 0,
+        },
+      ),
+    );
+
+    renderEditorRoute("/agents/user-def");
+    await screen.findByText(/Edit user-def/i);
+    expect(screen.getByText("User-defined")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /reset to defaults/i })).toBeNull();
+  });
+
+  it("calls clearAgentOverrides and refetches on reset confirm", async () => {
+    let deleteOverridesCalled = false;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).includes("/v1/capabilities")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              agents: [],
+              tools: [],
+              plugins: [],
+              skills: [],
+              models: [],
+              providers: [],
+              namespaces: [],
+            }),
+        };
+      }
+      if (
+        String(url).includes("/v1/config/agents/reset-me/overrides") &&
+        (init as RequestInit | undefined)?.method === "DELETE"
+      ) {
+        deleteOverridesCalled = true;
+        return { ok: true, status: 200, text: async () => JSON.stringify({ id: "reset-me", model_id: "m1", system_prompt: "", max_rounds: 8 }) };
+      }
+      if (String(url).endsWith("/v1/config/agents/reset-me/meta")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              source: { kind: "builtin", binary_version: "1.0" },
+              hidden: false,
+              user_overrides: { system_prompt: "custom" },
+              created_at: 0,
+              updated_at: 0,
+            }),
+        };
+      }
+      if (String(url).includes("/v1/config/agents/reset-me")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({ id: "reset-me", model_id: "m1", system_prompt: "custom", max_rounds: 8 }),
+        };
+      }
+      if (String(url).includes("/v1/audit-log")) {
+        return { ok: true, status: 200, text: async () => JSON.stringify({ items: [] }) };
+      }
+      return { ok: false, status: 404, text: async () => "" };
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditorRoute("/agents/reset-me");
+    await screen.findByText(/Edit reset-me/i);
+    expect(screen.getByText("Customized")).toBeDefined();
+
+    const resetBtn = screen.getByRole("button", { name: /reset to defaults/i });
+    fireEvent.click(resetBtn);
+
+    // Confirm dialog appears — wait for it, then click the last "Reset to defaults" button
+    // (the dialog's confirm button, not the page trigger).
+    await waitFor(() => {
+      const buttons = screen.getAllByRole("button", { name: /reset to defaults/i });
+      expect(buttons.length).toBeGreaterThan(1);
+    });
+    const allReset = screen.getAllByRole("button", { name: /reset to defaults/i });
+    fireEvent.click(allReset[allReset.length - 1]);
+
+    await waitFor(() => {
+      expect(deleteOverridesCalled).toBe(true);
+    });
+  });
+});
+
+// ── Save → PATCH vs PUT branching ────────────────────────────────────────────
+
+describe("agent editor Save → PATCH vs PUT branching", () => {
+  it("Save calls PATCH /overrides for Builtin records", async () => {
+    const agentId = "builtin-agent";
+    const agentBody = {
+      id: agentId,
+      model_id: "m1",
+      system_prompt: "original",
+      max_rounds: 8,
+      plugin_ids: [],
+      sections: {},
+      delegates: [],
+    };
+    const metaBody = {
+      source: { kind: "builtin", binary_version: "1.0" },
+      hidden: false,
+      user_overrides: null,
+      created_at: 0,
+      updated_at: 0,
+    };
+
+    let patchCalled = false;
+    let patchBody: Record<string, unknown> = {};
+    let putCalled = false;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const u = String(url);
+        if (u.includes("/v1/capabilities")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                agents: [],
+                tools: [],
+                plugins: [],
+                skills: [],
+                models: [],
+                providers: [],
+                namespaces: [],
+              }),
+          };
+        }
+        if (u.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(metaBody),
+          };
+        }
+        if (u.includes(`/v1/config/agents/${agentId}/overrides`) && init?.method === "PATCH") {
+          patchCalled = true;
+          patchBody = JSON.parse((init.body as string) ?? "{}") as Record<string, unknown>;
+          // Return the updated spec after patch
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({ ...agentBody, system_prompt: "updated-prompt" }),
+          };
+        }
+        if (u.includes(`/v1/config/agents/${agentId}`) && init?.method === "PUT") {
+          putCalled = true;
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(agentBody),
+          };
+        }
+        if (u.includes(`/v1/config/agents/${agentId}`)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(agentBody),
+          };
+        }
+        if (u.includes("/v1/audit-log")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ items: [] }),
+          };
+        }
+        return { ok: false, status: 404, text: async () => "" };
+      }),
+    );
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+
+    // Edit the system prompt (a patchable field)
+    const promptTextarea = screen.getByRole("textbox", { name: /system prompt/i });
+    fireEvent.change(promptTextarea, { target: { value: "updated-prompt" } });
+
+    // Click Save
+    const saveBtn = screen.getAllByRole("button", { name: /^save$/i })[0];
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(patchCalled).toBe(true);
+    });
+
+    expect(putCalled).toBe(false);
+    expect(patchBody).toMatchObject({ system_prompt: "updated-prompt" });
+  });
+
+  it("Save calls PUT /agents/:id for User records", async () => {
+    const agentId = "user-agent";
+    const agentBody = {
+      id: agentId,
+      model_id: "m1",
+      system_prompt: "original",
+      max_rounds: 8,
+      plugin_ids: [],
+      sections: {},
+      delegates: [],
+    };
+    const metaBody = {
+      source: { kind: "user" },
+      hidden: false,
+      user_overrides: null,
+      created_at: 0,
+      updated_at: 0,
+    };
+
+    let putCalled = false;
+    let patchCalled = false;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const u = String(url);
+        if (u.includes("/v1/capabilities")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({
+                agents: [],
+                tools: [],
+                plugins: [],
+                skills: [],
+                models: [],
+                providers: [],
+                namespaces: [],
+              }),
+          };
+        }
+        if (u.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(metaBody),
+          };
+        }
+        if (u.includes(`/v1/config/agents/${agentId}/overrides`) && init?.method === "PATCH") {
+          patchCalled = true;
+          return { ok: true, status: 200, text: async () => JSON.stringify(agentBody) };
+        }
+        if (u.includes(`/v1/config/agents/${agentId}`) && init?.method === "PUT") {
+          putCalled = true;
+          return {
+            ok: true,
+            status: 200,
+            text: async () =>
+              JSON.stringify({ ...agentBody, system_prompt: "updated-prompt" }),
+          };
+        }
+        if (u.includes(`/v1/config/agents/${agentId}`)) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(agentBody),
+          };
+        }
+        if (u.includes("/v1/audit-log")) {
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify({ items: [] }),
+          };
+        }
+        return { ok: false, status: 404, text: async () => "" };
+      }),
+    );
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+
+    // Edit the system prompt
+    const promptTextarea = screen.getByRole("textbox", { name: /system prompt/i });
+    fireEvent.change(promptTextarea, { target: { value: "updated-prompt" } });
+
+    // Click Save
+    const saveBtn = screen.getAllByRole("button", { name: /^save$/i })[0];
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(putCalled).toBe(true);
+    });
+
+    expect(patchCalled).toBe(false);
   });
 });

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -5,7 +5,14 @@ import {
   useParams,
   useSearchParams,
 } from "react-router";
-import { type AgentSpec, type Capabilities, configApi } from "@/lib/config-api";
+import {
+  type AgentSpec,
+  type Capabilities,
+  type ConfigSourceState,
+  type RecordMeta,
+  configApi,
+  deriveSourceState,
+} from "@/lib/config-api";
 import { type AuditEvent, type AuditPage, formatActor, summarizeChange } from "@/lib/audit-log";
 import { Field } from "@/components/form-components";
 import { AgentPreviewPanel } from "@/components/agent-preview-panel";
@@ -40,6 +47,34 @@ const EMPTY_AGENT: AgentSpec = {
   delegates: [],
 };
 
+const PATCHABLE_FIELDS: Array<keyof AgentSpec> = [
+  "model_id",
+  "system_prompt",
+  "max_rounds",
+  "max_continuation_retries",
+  "plugin_ids",
+  "sections",
+  "allowed_tools",
+  "excluded_tools",
+  "delegates",
+  "reasoning_effort",
+];
+
+function diffPatchableFields(
+  current: AgentSpec,
+  original: AgentSpec,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  for (const key of PATCHABLE_FIELDS) {
+    const a = current[key];
+    const b = original[key];
+    if (JSON.stringify(a) !== JSON.stringify(b)) {
+      patch[key] = a;
+    }
+  }
+  return patch;
+}
+
 export function AgentEditorPage() {
   const navigate = useNavigate();
   const { id } = useParams();
@@ -53,6 +88,8 @@ export function AgentEditorPage() {
 
   const [spec, setSpec] = useState<AgentSpec>({ ...EMPTY_AGENT });
   const [savedSpec, setSavedSpec] = useState<AgentSpec | null>(null);
+  const [originalSpec, setOriginalSpec] = useState<AgentSpec | null>(null);
+  const [agentMeta, setAgentMeta] = useState<RecordMeta | null>(null);
   const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
   const [loading, setLoading] = useState(!isNew);
   const [saving, setSaving] = useState(false);
@@ -61,6 +98,7 @@ export function AgentEditorPage() {
   const [errors, setErrors] = useState<Partial<Record<"id" | "model_id", string>>>({});
   const { t } = useTranslation();
   const toast = useToast();
+  const confirmDialog = useConfirmDialog();
 
   const isDirty = useMemo(() => {
     if (saving) return false;
@@ -77,6 +115,10 @@ export function AgentEditorPage() {
   }, [spec, savedSpec, isNew, saving]);
 
   useUnsavedChangesGuard({ enabled: isDirty });
+
+  const sourceState: ConfigSourceState | null = agentMeta
+    ? deriveSourceState(agentMeta)
+    : null;
 
   useEffect(() => {
     let cancelled = false;
@@ -104,7 +146,10 @@ export function AgentEditorPage() {
 
       setLoading(true);
       try {
-        const nextSpec = await configApi.get<AgentSpec>("agents", id);
+        const [nextSpec, nextMeta] = await Promise.all([
+          configApi.get<AgentSpec>("agents", id),
+          configApi.getMeta("agents", id).catch(() => null),
+        ]);
         if (!cancelled) {
           const hydrated = {
             sections: {},
@@ -114,6 +159,8 @@ export function AgentEditorPage() {
           };
           setSpec(hydrated);
           setSavedSpec(hydrated);
+          setOriginalSpec(hydrated);
+          setAgentMeta(nextMeta);
         }
       } catch (loadError) {
         if (!cancelled) {
@@ -168,8 +215,36 @@ export function AgentEditorPage() {
           payload,
         );
         setSavedSpec(created);
+        setOriginalSpec(created);
         toast.success(`Agent "${created.id}" created`);
         navigate(adminRoutes.agent(created.id), { replace: true });
+      } else if (sourceState === "builtin" || sourceState === "customized") {
+        // For Builtin/Customized records, use PATCH /overrides to preserve
+        // upgrade tracking. Only patchable fields are included.
+        const patch = diffPatchableFields(spec, originalSpec ?? spec);
+        if (Object.keys(patch).length === 0) {
+          // Nothing patchable changed; nothing to send.
+          toast.success(`Agent "${spec.id}" saved (no patchable changes)`);
+        } else {
+          await configApi.patchAgentOverrides(spec.id, patch);
+          // Refresh spec and meta so the badge updates correctly.
+          const [nextSpec, nextMeta] = await Promise.all([
+            configApi.get<AgentSpec>("agents", spec.id),
+            configApi.getMeta("agents", spec.id).catch(() => null),
+          ]);
+          const hydrated: AgentSpec = {
+            sections: {},
+            plugin_ids: [],
+            delegates: [],
+            ...nextSpec,
+          };
+          setSpec(hydrated);
+          setSavedSpec(hydrated);
+          setOriginalSpec(hydrated);
+          setAgentMeta(nextMeta);
+          toast.success(`Agent "${spec.id}" saved`);
+          setHistoryRefreshKey((k) => k + 1);
+        }
       } else {
         const updated = await configApi.update<typeof payload, AgentSpec>(
           "agents",
@@ -178,6 +253,7 @@ export function AgentEditorPage() {
         );
         setSpec(updated);
         setSavedSpec(updated);
+        setOriginalSpec(updated);
         toast.success(`Agent "${updated.id}" saved`);
         setHistoryRefreshKey((k) => k + 1);
       }
@@ -187,6 +263,58 @@ export function AgentEditorPage() {
       );
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function handleResetOverrides() {
+    if (!id) return;
+    const accepted = await confirmDialog({
+      title: t("agents.resetOverrides"),
+      description: t("agents.resetOverridesConfirm"),
+      confirmLabel: t("agents.resetOverrides"),
+      tone: "destructive",
+    });
+    if (!accepted) return;
+    try {
+      await configApi.clearAgentOverrides(id);
+      // Re-fetch spec and meta after reset.
+      const [nextSpec, nextMeta] = await Promise.all([
+        configApi.get<AgentSpec>("agents", id),
+        configApi.getMeta("agents", id).catch(() => null),
+      ]);
+      const hydrated: AgentSpec = { sections: {}, plugin_ids: [], delegates: [], ...nextSpec };
+      setSpec(hydrated);
+      setSavedSpec(hydrated);
+      setOriginalSpec(hydrated);
+      setAgentMeta(nextMeta);
+      toast.success(`Agent "${id}" overrides cleared`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function handleResetField(field: string) {
+    if (!id) return;
+    try {
+      await configApi.clearAgentOverrideField(id, field);
+      const [nextSpec, nextMeta] = await Promise.all([
+        configApi.get<AgentSpec>("agents", id),
+        configApi.getMeta("agents", id).catch(() => null),
+      ]);
+      const hydrated: AgentSpec = {
+        sections: {},
+        plugin_ids: [],
+        delegates: [],
+        ...nextSpec,
+      };
+      setSpec(hydrated);
+      setSavedSpec(hydrated);
+      setOriginalSpec(hydrated);
+      setAgentMeta(nextMeta);
+      toast.success(t("agents.resetOverrideFieldDone", { field }));
+      setHistoryRefreshKey((k) => k + 1);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -250,6 +378,13 @@ export function AgentEditorPage() {
   }
 
   const reasoningMode = reasoningEffortMode(spec.reasoning_effort);
+
+  const overriddenFields = useMemo(() => {
+    const overrides = agentMeta?.user_overrides;
+    if (!overrides || typeof overrides !== "object") return new Set<string>();
+    return new Set(Object.keys(overrides));
+  }, [agentMeta]);
+  const isCustomized = sourceState === "customized";
 
   const configurablePlugins = (capabilities?.plugins ?? []).filter(
     (plugin) => plugin.config_schemas.length > 0,
@@ -327,6 +462,8 @@ export function AgentEditorPage() {
         onSave={() => void handleSave()}
         activeTab={activeTab}
         onTabChange={setActiveTab}
+        sourceState={sourceState}
+        onResetOverrides={() => void handleResetOverrides()}
       />
 
       <div className="grid gap-6 px-6 py-6 md:px-8 xl:grid-cols-[minmax(0,1fr),24rem]">
@@ -348,6 +485,9 @@ export function AgentEditorPage() {
                   updateField={updateField}
                   reasoningMode={reasoningMode}
                   errors={errors}
+                  canResetFields={!isNew && isCustomized}
+                  overriddenFields={overriddenFields}
+                  onResetField={(field) => void handleResetField(field)}
                 />
               )}
               {tab.id === "tools" && (
@@ -625,6 +765,30 @@ function formatDiffValue(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
+function EditorSourceBadge({ state }: { state: ConfigSourceState }) {
+  const { t } = useTranslation();
+  if (state === "builtin") {
+    return (
+      <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-fg-soft">
+        {t("agents.source.builtin")}
+      </span>
+    );
+  }
+  if (state === "customized") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+        {t("agents.source.customized")}
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full bg-soft px-2 py-0.5 text-xs font-medium text-fg">
+      {t("agents.source.userDefined")}
+    </span>
+  );
+}
+
 function StickyEditorHeader({
   isNew,
   agentId,
@@ -634,6 +798,8 @@ function StickyEditorHeader({
   onSave,
   activeTab,
   onTabChange,
+  sourceState,
+  onResetOverrides,
 }: {
   isNew: boolean;
   agentId: string;
@@ -643,6 +809,8 @@ function StickyEditorHeader({
   onSave: () => void;
   activeTab: AgentEditorTabId;
   onTabChange: (next: AgentEditorTabId) => void;
+  sourceState: ConfigSourceState | null;
+  onResetOverrides: () => void;
 }) {
   const { t } = useTranslation();
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
@@ -704,7 +872,19 @@ function StickyEditorHeader({
                 {t("editor.upToDate")}
               </span>
             ) : null}
+            {!isNew && sourceState && <EditorSourceBadge state={sourceState} />}
           </h2>
+          {!isNew && sourceState === "customized" && (
+            <div className="mt-1">
+              <button
+                type="button"
+                onClick={onResetOverrides}
+                className="text-xs font-medium text-tone-error transition hover:underline"
+              >
+                {t("agents.resetOverrides")}
+              </button>
+            </div>
+          )}
         </div>
         {(isDirty || isNew) ? null : (
           <button
@@ -775,6 +955,9 @@ function BasicsPanel({
   updateField,
   reasoningMode,
   errors,
+  canResetFields,
+  overriddenFields,
+  onResetField,
 }: {
   spec: AgentSpec;
   capabilities: Capabilities | null;
@@ -782,7 +965,21 @@ function BasicsPanel({
   updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
   reasoningMode: ReturnType<typeof reasoningEffortMode>;
   errors?: Partial<Record<"id" | "model_id", string>>;
+  canResetFields?: boolean;
+  overriddenFields?: Set<string>;
+  onResetField?: (field: string) => void;
 }) {
+  const { t } = useTranslation();
+  const fieldResetProps = (field: string) => {
+    if (!canResetFields || !overriddenFields?.has(field) || !onResetField) {
+      return {};
+    }
+    return {
+      overridden: true,
+      onReset: () => onResetField(field),
+      resetLabel: t("agents.resetOverrideField"),
+    } as const;
+  };
   return (
     <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
       <h3 className="text-lg font-semibold text-fg-strong">Basics</h3>
@@ -797,7 +994,12 @@ function BasicsPanel({
             className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong disabled:bg-muted disabled:text-fg-soft aria-[invalid=true]:border-tone-error"
           />
         </Field>
-        <Field label="Model" required error={errors?.model_id}>
+        <Field
+          label="Model"
+          required
+          error={errors?.model_id}
+          {...fieldResetProps("model_id")}
+        >
           <select
             value={String(spec.model_id ?? "")}
             aria-invalid={Boolean(errors?.model_id)}
@@ -812,7 +1014,7 @@ function BasicsPanel({
             ))}
           </select>
         </Field>
-        <Field label="Max rounds">
+        <Field label="Max rounds" {...fieldResetProps("max_rounds")}>
           <input
             type="number"
             min={1}
@@ -823,7 +1025,10 @@ function BasicsPanel({
             className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
           />
         </Field>
-        <Field label="Max continuation retries">
+        <Field
+          label="Max continuation retries"
+          {...fieldResetProps("max_continuation_retries")}
+        >
           <input
             type="number"
             min={0}
@@ -913,7 +1118,7 @@ function BasicsPanel({
       </div>
 
       <div className="mt-4">
-        <Field label="System prompt">
+        <Field label="System prompt" {...fieldResetProps("system_prompt")}>
           <textarea
             value={String(spec.system_prompt ?? "")}
             onChange={(event) => updateField("system_prompt", event.target.value)}

--- a/apps/admin-console/src/pages/agents-page.test.tsx
+++ b/apps/admin-console/src/pages/agents-page.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from "react-router";
+import { appRoutes } from "../app";
+import { AuthProvider } from "../components/auth-provider";
+import { ConfirmDialogProvider } from "../components/confirm-dialog";
+import { ToastProvider } from "../components/toast-provider";
+import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
+
+function agentItem(id: string, modelId = "bootstrap") {
+  return {
+    id,
+    model_id: modelId,
+    system_prompt: "test",
+    max_rounds: 8,
+    plugin_ids: [],
+    delegates: [],
+    updated_at: 1_700_000_000,
+  };
+}
+
+function metaItem(
+  id: string,
+  sourceKind: "builtin" | "user",
+  userOverrides?: Record<string, unknown>,
+) {
+  return {
+    id,
+    meta: {
+      source:
+        sourceKind === "builtin"
+          ? { kind: "builtin", binary_version: "test" }
+          : { kind: "user" },
+      hidden: false,
+      user_overrides: userOverrides ?? null,
+      created_at: 0,
+      updated_at: 0,
+    },
+  };
+}
+
+function buildFetchMock(
+  agents: ReturnType<typeof agentItem>[],
+  metaItems: ReturnType<typeof metaItem>[],
+) {
+  return vi.fn(async (url: string | URL | Request) => {
+    const href =
+      typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+
+    if (href.includes("/v1/capabilities")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          }),
+      };
+    }
+
+    // Runtime stats — not enabled in test
+    if (href.includes("/runtime-stats")) {
+      return { ok: false, status: 503, text: async () => "" };
+    }
+
+    // List agents meta
+    if (href.includes("/v1/config/agents/meta")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(metaItems),
+      };
+    }
+
+    // List agents
+    if (href.includes("/v1/config/agents")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({ namespace: "agents", items: agents, offset: 0, limit: 100 }),
+      };
+    }
+
+    return { ok: false, status: 404, text: async () => "" };
+  });
+}
+
+function renderAgentsPage() {
+  const router = createMemoryRouter(createRoutesFromElements(appRoutes()), {
+    initialEntries: ["/agents"],
+  });
+  render(
+    <ToastProvider>
+      <ConfirmDialogProvider>
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
+      </ConfirmDialogProvider>
+    </ToastProvider>,
+  );
+}
+
+beforeEach(() => {
+  // no-op localStorage
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  __resetAuthInterceptorForTesting();
+});
+
+describe("AgentsPage source badges", () => {
+  it("shows Built-in badge for builtin agent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [agentItem("builtin-agent")],
+        [metaItem("builtin-agent", "builtin")],
+      ),
+    );
+
+    renderAgentsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("builtin-agent")).toBeDefined();
+    });
+    expect(screen.getByText("Built-in")).toBeDefined();
+  });
+
+  it("shows Customized badge for builtin agent with overrides", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [agentItem("customized-agent")],
+        [metaItem("customized-agent", "builtin", { system_prompt: "custom" })],
+      ),
+    );
+
+    renderAgentsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("customized-agent")).toBeDefined();
+    });
+    expect(screen.getByText("Customized")).toBeDefined();
+  });
+
+  it("shows User-defined badge for user-created agent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [agentItem("user-agent")],
+        [metaItem("user-agent", "user")],
+      ),
+    );
+
+    renderAgentsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("user-agent")).toBeDefined();
+    });
+    expect(screen.getByText("User-defined")).toBeDefined();
+  });
+
+  it("shows mixed badges when agents have different source states", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [agentItem("a-builtin"), agentItem("a-user"), agentItem("a-custom")],
+        [
+          metaItem("a-builtin", "builtin"),
+          metaItem("a-user", "user"),
+          metaItem("a-custom", "builtin", { system_prompt: "x" }),
+        ],
+      ),
+    );
+
+    renderAgentsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("a-builtin")).toBeDefined();
+    });
+    expect(screen.getByText("Built-in")).toBeDefined();
+    expect(screen.getByText("User-defined")).toBeDefined();
+    expect(screen.getByText("Customized")).toBeDefined();
+  });
+
+  it("renders no badge when meta fetch fails gracefully", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [agentItem("some-agent")],
+        // meta list returns empty — simulates endpoint not available
+        [],
+      ),
+    );
+
+    renderAgentsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("some-agent")).toBeDefined();
+    });
+    // No badge rendered when metaMap has no entry
+    expect(screen.queryByText("Built-in")).toBeNull();
+    expect(screen.queryByText("User-defined")).toBeNull();
+  });
+});

--- a/apps/admin-console/src/pages/agents-page.tsx
+++ b/apps/admin-console/src/pages/agents-page.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router";
-import { type AgentRuntimeSnapshot, type AgentSpec, configApi } from "@/lib/config-api";
+import {
+  type AgentRuntimeSnapshot,
+  type AgentSpec,
+  type ConfigMetaItem,
+  type ConfigSourceState,
+  configApi,
+  deriveSourceState,
+} from "@/lib/config-api";
 import { useConfirmDialog } from "@/components/confirm-dialog";
 import { useToast } from "@/components/toast-provider";
 import {
@@ -55,6 +62,7 @@ const COLUMNS: SortableColumn<AgentSortKey>[] = [
   { key: "model_id", label: "Model" },
   { key: "plugin_count", label: "Plugins" },
   { key: "updated_at", label: "Last modified" },
+  { key: null, label: "Source" },
   { key: null, label: "Inferences (24h)" },
   { key: null, label: "Actions" },
 ];
@@ -74,6 +82,7 @@ export function AgentsPage() {
   const [modelFilter, setModelFilter] = useState<string>("any");
   const [pluginFilter, setPluginFilter] = useState<string>("any");
   const [modifiedRange, setModifiedRange] = useState<ModifiedRange>("any");
+  const [metaMap, setMetaMap] = useState<Map<string, ConfigSourceState>>(new Map());
   const [runtimeStats, setRuntimeStats] = useState<
     Map<string, AgentRuntimeSnapshot> | null
   >(null);
@@ -87,8 +96,18 @@ export function AgentsPage() {
     async function load() {
       setLoading(true);
       try {
-        const response = await configApi.list<AgentSpec>("agents");
-        if (!cancelled) setAgents(response.items);
+        const [agentResponse, metaItems] = await Promise.all([
+          configApi.list<AgentSpec>("agents"),
+          configApi.listMeta("agents").catch(() => [] as ConfigMetaItem[]),
+        ]);
+        if (!cancelled) {
+          setAgents(agentResponse.items);
+          const map = new Map<string, ConfigSourceState>();
+          for (const item of metaItems) {
+            map.set(item.id, deriveSourceState(item.meta));
+          }
+          setMetaMap(map);
+        }
       } catch (loadError) {
         if (!cancelled) {
           toast.error(
@@ -354,6 +373,9 @@ export function AgentsPage() {
                     <td className="px-5 py-4 text-fg-soft">
                       {formatRelativeTime(agent.updated_at)}
                     </td>
+                    <td className="px-5 py-4">
+                      <SourceBadge state={metaMap.get(agent.id)} />
+                    </td>
                     <td className="px-5 py-4 font-mono text-fg">
                       <InferenceCount
                         snapshot={runtimeStats?.get(agent.id)}
@@ -399,6 +421,32 @@ export function AgentsPage() {
         )}
       </div>
     </div>
+  );
+}
+
+function SourceBadge({ state }: { state: ConfigSourceState | undefined }) {
+  const { t } = useTranslation();
+  if (!state) return null;
+  if (state === "builtin") {
+    return (
+      <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-fg-soft">
+        {t("agents.source.builtin")}
+      </span>
+    );
+  }
+  if (state === "customized") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+        {t("agents.source.customized")}
+      </span>
+    );
+  }
+  // user
+  return (
+    <span className="inline-flex items-center rounded-full bg-soft px-2 py-0.5 text-xs font-medium text-fg">
+      {t("agents.source.userDefined")}
+    </span>
   );
 }
 

--- a/crates/awaken-contract/src/agent_spec_patch.rs
+++ b/crates/awaken-contract/src/agent_spec_patch.rs
@@ -1,0 +1,132 @@
+//! Field-level override for [`AgentSpec`].
+//!
+//! Stored as JSON inside [`RecordMeta::user_overrides`] for built-in agents.
+//! Each field is `Option<T>`: `None` = inherit base, `Some(_)` = override.
+//! Merge happens at read time via [`merge_agent_spec`].
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::contract::inference::ReasoningEffort;
+use crate::registry_spec::AgentSpec;
+
+/// Patch for built-in agent customization.
+///
+/// Phase 3 ships override support for the most commonly tweaked fields.
+/// Adding more fields later is purely additive — `Option` defaults to `None`,
+/// existing patches decode unchanged.
+///
+/// `#[serde(deny_unknown_fields)]` rejects payloads containing field names
+/// that don't exist on this struct, preventing silent drift when callers
+/// misspell or target deprecated fields.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentSpecPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_rounds: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_continuation_retries: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plugin_ids: Option<Vec<String>>,
+    /// Per-key shallow merge: patch keys override base keys; un-patched
+    /// keys preserved from base. To delete a base key, set its value to
+    /// JSON `null` in this map (handled at merge time).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sections: Option<HashMap<String, Value>>,
+    /// Whitelist of tool IDs. `Some([..])` overrides; `None` keeps base.
+    /// To revert to base "all tools", DELETE the override field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    /// Blacklist of tool IDs. Same semantics as `allowed_tools`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub excluded_tools: Option<Vec<String>>,
+    /// Sub-agent IDs this agent can delegate to. `Some([..])` overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delegates: Option<Vec<String>>,
+    /// Reasoning effort override. `Some(_)` overrides; `None` keeps base.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+}
+
+impl AgentSpecPatch {
+    /// True when no field is set — equivalent to "no override".
+    pub fn is_empty(&self) -> bool {
+        self.model_id.is_none()
+            && self.system_prompt.is_none()
+            && self.max_rounds.is_none()
+            && self.max_continuation_retries.is_none()
+            && self.plugin_ids.is_none()
+            && self.sections.is_none()
+            && self.allowed_tools.is_none()
+            && self.excluded_tools.is_none()
+            && self.delegates.is_none()
+            && self.reasoning_effort.is_none()
+    }
+}
+
+/// Apply a [`AgentSpecPatch`] on top of a base [`AgentSpec`], producing the
+/// effective spec passed to the resolver.
+///
+/// Semantics:
+/// - Scalar fields (`model_id`, `system_prompt`, `max_rounds`,
+///   `max_continuation_retries`): patch's value if `Some`, else base.
+/// - `plugin_ids`: replace whole list when patch is `Some`.
+/// - `sections`: per-key shallow merge. Patch keys override base keys.
+///   A patch value of JSON `null` deletes the corresponding base key.
+/// - All other fields pass through from `base` unchanged (id, allowed_tools,
+///   excluded_tools, reasoning_effort, context_policy, endpoint, delegates,
+///   active_hook_filter, registry, created_at, updated_at).
+pub fn merge_agent_spec(base: AgentSpec, patch: AgentSpecPatch) -> AgentSpec {
+    AgentSpec {
+        id: base.id,
+        model_id: patch.model_id.unwrap_or(base.model_id),
+        system_prompt: patch.system_prompt.unwrap_or(base.system_prompt),
+        max_rounds: patch.max_rounds.unwrap_or(base.max_rounds),
+        max_continuation_retries: patch
+            .max_continuation_retries
+            .unwrap_or(base.max_continuation_retries),
+        plugin_ids: patch.plugin_ids.unwrap_or(base.plugin_ids),
+        sections: merge_sections(base.sections, patch.sections),
+        // Override-aware fields: patch's value when present, else base.
+        // For Option<T> fields, patch=Some(value) sets the override; to
+        // revert to base's None, callers use the per-field DELETE endpoint.
+        allowed_tools: patch.allowed_tools.map(Some).unwrap_or(base.allowed_tools),
+        excluded_tools: patch
+            .excluded_tools
+            .map(Some)
+            .unwrap_or(base.excluded_tools),
+        delegates: patch.delegates.unwrap_or(base.delegates),
+        reasoning_effort: patch
+            .reasoning_effort
+            .map(Some)
+            .unwrap_or(base.reasoning_effort),
+        // Pass-through (no patch support):
+        context_policy: base.context_policy,
+        active_hook_filter: base.active_hook_filter,
+        endpoint: base.endpoint,
+        registry: base.registry,
+        created_at: base.created_at,
+        updated_at: base.updated_at,
+    }
+}
+
+fn merge_sections(
+    mut base: HashMap<String, Value>,
+    patch: Option<HashMap<String, Value>>,
+) -> HashMap<String, Value> {
+    let Some(patch) = patch else { return base };
+    for (key, value) in patch {
+        if value.is_null() {
+            base.remove(&key);
+        } else {
+            base.insert(key, value);
+        }
+    }
+    base
+}

--- a/crates/awaken-contract/src/builtin_seed.rs
+++ b/crates/awaken-contract/src/builtin_seed.rs
@@ -1,0 +1,149 @@
+//! Carrier types for binary-supplied built-in specs ("seed").
+//!
+//! At startup a binary may declare a set of specs it wants present in
+//! ConfigStore. The seed protocol (see `awaken_server::services::builtin_seed`)
+//! upserts these idempotently and prunes obsolete builtins, while leaving
+//! user-written entries untouched. This module defines only the data
+//! describing a seed; the protocol lives in `awaken-server`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::registry_spec::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
+
+/// A single spec the binary wants to seed into ConfigStore.
+///
+/// The variant determines the target ConfigStore namespace.
+///
+/// `Agent` is heap-allocated via `Box` because `AgentSpec` is significantly
+/// larger than the other variants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BuiltinSpec {
+    Agent(Box<AgentSpec>),
+    Provider(ProviderSpec),
+    Model(ModelBindingSpec),
+    McpServer(McpServerSpec),
+}
+
+impl BuiltinSpec {
+    /// Wrap an `AgentSpec` (heap-allocates per `clippy::large_enum_variant`).
+    pub fn agent(spec: AgentSpec) -> Self {
+        Self::Agent(Box::new(spec))
+    }
+
+    /// Wrap a `ProviderSpec`.
+    pub fn provider(spec: ProviderSpec) -> Self {
+        Self::Provider(spec)
+    }
+
+    /// Wrap a `ModelBindingSpec`.
+    pub fn model(spec: ModelBindingSpec) -> Self {
+        Self::Model(spec)
+    }
+
+    /// Wrap a `McpServerSpec`.
+    pub fn mcp_server(spec: McpServerSpec) -> Self {
+        Self::McpServer(spec)
+    }
+
+    /// ConfigStore namespace this spec belongs to.
+    ///
+    /// Must match the namespace strings used by `ConfigService` /
+    /// `ConfigNamespace::as_str()`.
+    pub fn namespace(&self) -> &'static str {
+        match self {
+            Self::Agent(_) => "agents",
+            Self::Provider(_) => "providers",
+            Self::Model(_) => "models",
+            Self::McpServer(_) => "mcp-servers",
+        }
+    }
+
+    /// ID under which the spec is stored in its namespace.
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Agent(s) => &s.id,
+            Self::Provider(s) => &s.id,
+            Self::Model(s) => &s.id,
+            Self::McpServer(s) => &s.id,
+        }
+    }
+}
+
+/// A complete seed payload: the binary's version tag plus all specs it
+/// wants present.
+///
+/// `binary_version` is compared against existing Builtin records' version
+/// tag to decide whether to refresh them on this boot. Two binaries with
+/// the same version string but different seed contents will trigger the
+/// "same-version edit" path (acceptable for dev loop; production releases
+/// should bump the version string).
+#[derive(Debug, Clone)]
+pub struct BuiltinSeedSet {
+    pub binary_version: String,
+    pub specs: Vec<BuiltinSpec>,
+}
+
+impl BuiltinSeedSet {
+    /// Convenience: an empty seed for a given version (useful in tests
+    /// and for binaries that ship no built-ins).
+    pub fn empty(binary_version: impl Into<String>) -> Self {
+        Self {
+            binary_version: binary_version.into(),
+            specs: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructor_agent_wraps_in_box() {
+        let spec = AgentSpec {
+            id: "a1".to_owned(),
+            model_id: "gpt-4o".to_owned(),
+            system_prompt: "hi".to_owned(),
+            ..Default::default()
+        };
+        assert!(matches!(BuiltinSpec::agent(spec), BuiltinSpec::Agent(_)));
+    }
+
+    #[test]
+    fn constructor_provider_wraps() {
+        let spec = ProviderSpec {
+            id: "p1".to_owned(),
+            adapter: "openai".to_owned(),
+            ..Default::default()
+        };
+        assert!(matches!(
+            BuiltinSpec::provider(spec),
+            BuiltinSpec::Provider(_)
+        ));
+    }
+
+    #[test]
+    fn constructor_model_wraps() {
+        let spec = ModelBindingSpec {
+            id: "m1".to_owned(),
+            provider_id: "openai".to_owned(),
+            upstream_model: "gpt-4o".to_owned(),
+            created_at: None,
+            updated_at: None,
+        };
+        assert!(matches!(BuiltinSpec::model(spec), BuiltinSpec::Model(_)));
+    }
+
+    #[test]
+    fn constructor_mcp_server_wraps() {
+        let spec = McpServerSpec {
+            id: "mcp1".to_owned(),
+            ..Default::default()
+        };
+        assert!(matches!(
+            BuiltinSpec::mcp_server(spec),
+            BuiltinSpec::McpServer(_)
+        ));
+    }
+}

--- a/crates/awaken-contract/src/config_record.rs
+++ b/crates/awaken-contract/src/config_record.rs
@@ -1,0 +1,109 @@
+//! Metadata envelope wrapping any spec stored in ConfigStore.
+//!
+//! Today most ConfigStore entries are bare specs (e.g. `AgentSpec` JSON).
+//! Phase 1 introduces this envelope so we can carry provenance (was this
+//! seeded by the binary, or written by a user?) and lifecycle flags
+//! (`hidden`) without breaking existing on-disk data. The decoder accepts
+//! both shapes; the encoder always emits the envelope.
+
+use serde::{Deserialize, Serialize};
+
+/// Wrapper carrying a spec plus provenance + lifecycle metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigRecord<T> {
+    pub spec: T,
+    pub meta: RecordMeta,
+}
+
+/// Provenance + lifecycle metadata for a stored spec.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecordMeta {
+    pub source: RecordSource,
+    #[serde(default)]
+    pub hidden: bool,
+    /// Milliseconds since UNIX epoch (see `crate::time::now_ms`).
+    /// `0` is a sentinel meaning "unknown / pre-envelope legacy entry".
+    #[serde(default)]
+    pub created_at: u64,
+    #[serde(default)]
+    pub updated_at: u64,
+}
+
+/// Who wrote this record into ConfigStore.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RecordSource {
+    /// Written by binary startup seed; `binary_version` lets the next boot
+    /// detect upgrades and refresh non-user-touched fields.
+    Builtin { binary_version: String },
+    /// Written by a user via UI/HTTP (or a script). Never overwritten by seed.
+    User,
+}
+
+impl<T: serde::de::DeserializeOwned> ConfigRecord<T> {
+    /// Decode a JSON value, accepting either the new envelope shape OR a
+    /// legacy bare-spec shape (in which case the record is synthesized as
+    /// `RecordSource::User`, `hidden = false`, timestamps = `0`).
+    ///
+    /// Detection rule: a value is the envelope if it is an object containing
+    /// both `"spec"` and `"meta"` keys.
+    pub fn from_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        if is_envelope(&value) {
+            serde_json::from_value(value)
+        } else {
+            let spec: T = serde_json::from_value(value)?;
+            Ok(Self {
+                spec,
+                meta: RecordMeta::legacy_user(),
+            })
+        }
+    }
+}
+
+impl<T: Serialize> ConfigRecord<T> {
+    /// Encode as the new envelope JSON. Always emits the envelope shape.
+    pub fn to_value(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+impl RecordMeta {
+    /// Synthesize metadata for a legacy bare-spec entry. Timestamps are `0`
+    /// to mark them as unknown.
+    pub fn legacy_user() -> Self {
+        Self {
+            source: RecordSource::User,
+            hidden: false,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    /// Construct a fresh User record with current timestamps.
+    pub fn new_user() -> Self {
+        let now = crate::time::now_ms();
+        Self {
+            source: RecordSource::User,
+            hidden: false,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Construct a fresh Builtin record with current timestamps.
+    pub fn new_builtin(binary_version: impl Into<String>) -> Self {
+        let now = crate::time::now_ms();
+        Self {
+            source: RecordSource::Builtin {
+                binary_version: binary_version.into(),
+            },
+            hidden: false,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+fn is_envelope(value: &serde_json::Value) -> bool {
+    matches!(value, serde_json::Value::Object(map) if map.contains_key("spec") && map.contains_key("meta"))
+}

--- a/crates/awaken-contract/src/config_record.rs
+++ b/crates/awaken-contract/src/config_record.rs
@@ -21,6 +21,11 @@ pub struct RecordMeta {
     pub source: RecordSource,
     #[serde(default)]
     pub hidden: bool,
+    /// Field-level overrides for Builtin records (Phase 3).
+    /// Decoded by spec-type-specific helpers downstream; opaque at this layer.
+    /// `None` for User records and for Builtin records that have not been customized.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_overrides: Option<serde_json::Value>,
     /// Milliseconds since UNIX epoch (see `crate::time::now_ms`).
     /// `0` is a sentinel meaning "unknown / pre-envelope legacy entry".
     #[serde(default)]
@@ -74,6 +79,7 @@ impl RecordMeta {
         Self {
             source: RecordSource::User,
             hidden: false,
+            user_overrides: None,
             created_at: 0,
             updated_at: 0,
         }
@@ -85,6 +91,7 @@ impl RecordMeta {
         Self {
             source: RecordSource::User,
             hidden: false,
+            user_overrides: None,
             created_at: now,
             updated_at: now,
         }
@@ -98,6 +105,7 @@ impl RecordMeta {
                 binary_version: binary_version.into(),
             },
             hidden: false,
+            user_overrides: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/awaken-contract/src/contract/audit_log.rs
+++ b/crates/awaken-contract/src/contract/audit_log.rs
@@ -11,6 +11,7 @@ pub enum AuditAction {
     Restart,
     Publish,
     Restore,
+    SeedApply,
 }
 
 /// A self-contained audit record for a single admin action.
@@ -119,6 +120,10 @@ mod tests {
             serde_json::to_value(AuditAction::Restore).unwrap(),
             json!("restore")
         );
+        assert_eq!(
+            serde_json::to_value(AuditAction::SeedApply).unwrap(),
+            json!("seed_apply")
+        );
     }
 
     #[test]
@@ -130,6 +135,7 @@ mod tests {
             ("restart", AuditAction::Restart),
             ("publish", AuditAction::Publish),
             ("restore", AuditAction::Restore),
+            ("seed_apply", AuditAction::SeedApply),
         ] {
             let parsed: AuditAction = serde_json::from_str(&format!("\"{s}\"")).unwrap();
             assert_eq!(parsed, expected);

--- a/crates/awaken-contract/src/contract/executor.rs
+++ b/crates/awaken-contract/src/contract/executor.rs
@@ -136,7 +136,7 @@ impl InterruptSnapshot {
                 continue;
             }
             match serde_json::from_str::<serde_json::Value>(&args_json) {
-                Ok(arguments) if !(arguments.is_null() && !args_json.is_empty()) => {
+                Ok(arguments) if !arguments.is_null() || args_json.is_empty() => {
                     completed.push(ToolCall::new(id, name, arguments));
                 }
                 _ => {

--- a/crates/awaken-contract/src/lib.rs
+++ b/crates/awaken-contract/src/lib.rs
@@ -12,8 +12,10 @@
 
 #![allow(missing_docs)]
 
+pub mod builtin_seed;
 pub mod cancellation;
 pub mod config_loader;
+pub mod config_record;
 pub mod contract;
 mod error;
 pub mod model;
@@ -87,3 +89,9 @@ pub use periodic_refresh::PeriodicRefresher;
 
 // ── audit log ──
 pub use contract::audit_log::{AuditAction, AuditEvent};
+
+// ── config record envelope ──
+pub use config_record::{ConfigRecord, RecordMeta, RecordSource};
+
+// ── builtin seed ──
+pub use builtin_seed::{BuiltinSeedSet, BuiltinSpec};

--- a/crates/awaken-contract/src/lib.rs
+++ b/crates/awaken-contract/src/lib.rs
@@ -12,6 +12,7 @@
 
 #![allow(missing_docs)]
 
+pub mod agent_spec_patch;
 pub mod builtin_seed;
 pub mod cancellation;
 pub mod config_loader;
@@ -37,6 +38,9 @@ pub use model::{
     EffectSpec, FailedScheduledActions, JsonValue, PendingScheduledActions, Phase,
     ScheduledActionSpec, TypedEffect,
 };
+
+// ── agent spec patch ──
+pub use agent_spec_patch::{AgentSpecPatch, merge_agent_spec};
 
 // ── registry spec (AgentSpec, PluginConfigKey) ──
 pub use registry_spec::{

--- a/crates/awaken-contract/tests/agent_spec_patch.rs
+++ b/crates/awaken-contract/tests/agent_spec_patch.rs
@@ -1,0 +1,312 @@
+use std::collections::HashMap;
+
+use awaken_contract::{AgentSpec, AgentSpecPatch, merge_agent_spec};
+use serde_json::{Value, json};
+
+fn base_spec() -> AgentSpec {
+    AgentSpec {
+        id: "test".into(),
+        model_id: "m".into(),
+        system_prompt: "p".into(),
+        ..Default::default()
+    }
+}
+
+// 1. default_is_empty
+#[test]
+fn default_is_empty() {
+    assert!(AgentSpecPatch::default().is_empty());
+}
+
+// 2. is_empty_false_when_any_field_set
+#[test]
+fn is_empty_false_when_any_field_set() {
+    let patch = AgentSpecPatch {
+        model_id: Some("x".into()),
+        ..Default::default()
+    };
+    assert!(!patch.is_empty());
+
+    let patch = AgentSpecPatch {
+        system_prompt: Some("sp".into()),
+        ..Default::default()
+    };
+    assert!(!patch.is_empty());
+
+    let patch = AgentSpecPatch {
+        max_rounds: Some(5),
+        ..Default::default()
+    };
+    assert!(!patch.is_empty());
+
+    let patch = AgentSpecPatch {
+        max_continuation_retries: Some(3),
+        ..Default::default()
+    };
+    assert!(!patch.is_empty());
+
+    let patch = AgentSpecPatch {
+        plugin_ids: Some(vec!["a".into()]),
+        ..Default::default()
+    };
+    assert!(!patch.is_empty());
+
+    let patch = AgentSpecPatch {
+        sections: Some(HashMap::new()),
+        ..Default::default()
+    };
+    assert!(!patch.is_empty());
+}
+
+// 3. serde_round_trip_full_patch
+#[test]
+fn serde_round_trip_full_patch() {
+    let mut sections = HashMap::new();
+    sections.insert("key1".to_string(), json!({"nested": true}));
+    sections.insert("key2".to_string(), json!(42));
+
+    let patch = AgentSpecPatch {
+        model_id: Some("claude-opus".into()),
+        system_prompt: Some("You are helpful.".into()),
+        max_rounds: Some(10),
+        max_continuation_retries: Some(3),
+        plugin_ids: Some(vec!["plugin-a".into(), "plugin-b".into()]),
+        sections: Some(sections),
+        allowed_tools: Some(vec!["weather".into()]),
+        excluded_tools: Some(vec!["dangerous".into()]),
+        delegates: Some(vec!["delegate-a".into()]),
+        reasoning_effort: None,
+    };
+
+    let json_str = serde_json::to_string(&patch).unwrap();
+    let decoded: AgentSpecPatch = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(patch, decoded);
+}
+
+// 4. serde_omits_none_fields
+#[test]
+fn serde_omits_none_fields() {
+    let patch = AgentSpecPatch::default();
+    let json_str = serde_json::to_string(&patch).unwrap();
+    let value: Value = serde_json::from_str(&json_str).unwrap();
+    // Should be empty object — no null fields
+    assert_eq!(value, json!({}));
+}
+
+// 5. serde_rejects_unknown_field
+#[test]
+fn serde_rejects_unknown_field() {
+    let result = serde_json::from_str::<AgentSpecPatch>(r#"{"unknown_field": 1}"#);
+    assert!(result.is_err(), "expected error for unknown field");
+}
+
+// 6. merge_returns_base_when_patch_is_empty
+#[test]
+fn merge_returns_base_when_patch_is_empty() {
+    let base = base_spec();
+    let base_value = serde_json::to_value(&base).unwrap();
+    let result = merge_agent_spec(base, AgentSpecPatch::default());
+    let result_value = serde_json::to_value(&result).unwrap();
+    assert_eq!(base_value, result_value);
+}
+
+// 7. merge_overrides_model_id
+#[test]
+fn merge_overrides_model_id() {
+    let base = AgentSpec {
+        model_id: "A".into(),
+        ..base_spec()
+    };
+    let patch = AgentSpecPatch {
+        model_id: Some("B".into()),
+        ..Default::default()
+    };
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.model_id, "B");
+}
+
+// 8. merge_overrides_system_prompt
+#[test]
+fn merge_overrides_system_prompt() {
+    let base = AgentSpec {
+        system_prompt: "old prompt".into(),
+        ..base_spec()
+    };
+    let patch = AgentSpecPatch {
+        system_prompt: Some("new prompt".into()),
+        ..Default::default()
+    };
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.system_prompt, "new prompt");
+}
+
+// 9. merge_overrides_max_rounds
+#[test]
+fn merge_overrides_max_rounds() {
+    let base = AgentSpec {
+        max_rounds: 5,
+        ..base_spec()
+    };
+    let patch = AgentSpecPatch {
+        max_rounds: Some(20),
+        ..Default::default()
+    };
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.max_rounds, 20);
+}
+
+// 10. merge_overrides_max_continuation_retries
+#[test]
+fn merge_overrides_max_continuation_retries() {
+    let base = AgentSpec {
+        max_continuation_retries: 1,
+        ..base_spec()
+    };
+    let patch = AgentSpecPatch {
+        max_continuation_retries: Some(5),
+        ..Default::default()
+    };
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.max_continuation_retries, 5);
+}
+
+// 11. merge_replaces_plugin_ids_when_patch_some
+#[test]
+fn merge_replaces_plugin_ids_when_patch_some() {
+    let base = AgentSpec {
+        plugin_ids: vec!["a".into(), "b".into(), "c".into()],
+        ..base_spec()
+    };
+    let patch = AgentSpecPatch {
+        plugin_ids: Some(vec!["d".into()]),
+        ..Default::default()
+    };
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.plugin_ids, vec!["d"]);
+}
+
+// 12. merge_keeps_plugin_ids_when_patch_none
+#[test]
+fn merge_keeps_plugin_ids_when_patch_none() {
+    let base = AgentSpec {
+        plugin_ids: vec!["a".into(), "b".into()],
+        ..base_spec()
+    };
+    let patch = AgentSpecPatch {
+        plugin_ids: None,
+        ..Default::default()
+    };
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.plugin_ids, vec!["a", "b"]);
+}
+
+// 13. merge_sections_per_key_overlay
+#[test]
+fn merge_sections_per_key_overlay() {
+    let mut base_sections = HashMap::new();
+    base_sections.insert("x".to_string(), json!(1));
+    base_sections.insert("y".to_string(), json!(2));
+
+    let base = AgentSpec {
+        sections: base_sections,
+        ..base_spec()
+    };
+
+    let mut patch_sections = HashMap::new();
+    patch_sections.insert("y".to_string(), json!(99));
+
+    let patch = AgentSpecPatch {
+        sections: Some(patch_sections),
+        ..Default::default()
+    };
+
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.sections.get("x"), Some(&json!(1)));
+    assert_eq!(result.sections.get("y"), Some(&json!(99)));
+    assert_eq!(result.sections.len(), 2);
+}
+
+// 14. merge_sections_null_value_deletes_key
+#[test]
+fn merge_sections_null_value_deletes_key() {
+    let mut base_sections = HashMap::new();
+    base_sections.insert("x".to_string(), json!(1));
+    base_sections.insert("y".to_string(), json!(2));
+
+    let base = AgentSpec {
+        sections: base_sections,
+        ..base_spec()
+    };
+
+    let mut patch_sections = HashMap::new();
+    patch_sections.insert("y".to_string(), Value::Null);
+
+    let patch = AgentSpecPatch {
+        sections: Some(patch_sections),
+        ..Default::default()
+    };
+
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.sections.get("x"), Some(&json!(1)));
+    assert!(
+        !result.sections.contains_key("y"),
+        "y should have been deleted"
+    );
+    assert_eq!(result.sections.len(), 1);
+}
+
+// 15. merge_sections_keeps_base_when_patch_none
+#[test]
+fn merge_sections_keeps_base_when_patch_none() {
+    let mut base_sections = HashMap::new();
+    base_sections.insert("x".to_string(), json!(1));
+
+    let base = AgentSpec {
+        sections: base_sections,
+        ..base_spec()
+    };
+
+    let patch = AgentSpecPatch {
+        sections: None,
+        ..Default::default()
+    };
+
+    let result = merge_agent_spec(base, patch);
+    assert_eq!(result.sections.get("x"), Some(&json!(1)));
+}
+
+// 16. merge_preserves_pass_through_fields
+#[test]
+fn merge_preserves_pass_through_fields() {
+    use awaken_contract::registry_spec::RemoteEndpoint;
+    use std::collections::HashSet;
+
+    let mut active_hook_filter = HashSet::new();
+    active_hook_filter.insert("hook-plugin".to_string());
+
+    let base = AgentSpec {
+        id: "my-agent".into(),
+        model_id: "m".into(),
+        system_prompt: "p".into(),
+        allowed_tools: Some(vec!["tool-a".into()]),
+        excluded_tools: Some(vec!["tool-b".into()]),
+        reasoning_effort: None,
+        context_policy: None,
+        endpoint: Some(RemoteEndpoint {
+            base_url: "https://example.com".into(),
+            ..Default::default()
+        }),
+        delegates: vec!["sub-agent".into()],
+        active_hook_filter,
+        registry: Some("cloud".into()),
+        created_at: Some(1_000_000),
+        updated_at: Some(2_000_000),
+        ..Default::default()
+    };
+
+    let base_value = serde_json::to_value(&base).unwrap();
+    let result = merge_agent_spec(base, AgentSpecPatch::default());
+    let result_value = serde_json::to_value(&result).unwrap();
+
+    assert_eq!(base_value, result_value);
+}

--- a/crates/awaken-contract/tests/builtin_seed.rs
+++ b/crates/awaken-contract/tests/builtin_seed.rs
@@ -1,0 +1,184 @@
+use awaken_contract::registry_spec::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
+use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn agent_spec() -> AgentSpec {
+    AgentSpec {
+        id: "test-agent".into(),
+        model_id: "m".into(),
+        system_prompt: "p".into(),
+        ..Default::default()
+    }
+}
+
+fn provider_spec() -> ProviderSpec {
+    ProviderSpec {
+        id: "openai".into(),
+        adapter: "openai".into(),
+        ..Default::default()
+    }
+}
+
+fn model_binding_spec() -> ModelBindingSpec {
+    ModelBindingSpec {
+        id: "gpt-4o".into(),
+        provider_id: "openai".into(),
+        upstream_model: "gpt-4o-mini".into(),
+        created_at: None,
+        updated_at: None,
+    }
+}
+
+fn mcp_server_spec() -> McpServerSpec {
+    McpServerSpec {
+        id: "test-mcp".into(),
+        ..Default::default()
+    }
+}
+
+// ── namespace() ──────────────────────────────────────────────────────────────
+
+#[test]
+fn namespace_returns_expected_string_for_each_variant() {
+    assert_eq!(
+        BuiltinSpec::Agent(Box::new(agent_spec())).namespace(),
+        "agents"
+    );
+    assert_eq!(
+        BuiltinSpec::Provider(provider_spec()).namespace(),
+        "providers"
+    );
+    assert_eq!(
+        BuiltinSpec::Model(model_binding_spec()).namespace(),
+        "models"
+    );
+    assert_eq!(
+        BuiltinSpec::McpServer(mcp_server_spec()).namespace(),
+        "mcp-servers"
+    );
+}
+
+// ── id() ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn id_delegates_to_inner_spec_for_each_variant() {
+    assert_eq!(
+        BuiltinSpec::Agent(Box::new(agent_spec())).id(),
+        "test-agent"
+    );
+    assert_eq!(BuiltinSpec::Provider(provider_spec()).id(), "openai");
+    assert_eq!(BuiltinSpec::Model(model_binding_spec()).id(), "gpt-4o");
+    assert_eq!(BuiltinSpec::McpServer(mcp_server_spec()).id(), "test-mcp");
+}
+
+// ── serde round-trip ─────────────────────────────────────────────────────────
+
+#[test]
+fn serde_roundtrip_agent() {
+    let original = BuiltinSpec::Agent(Box::new(agent_spec()));
+    let value = serde_json::to_value(&original).unwrap();
+    let decoded: BuiltinSpec = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(
+        value,
+        serde_json::to_value(&decoded).unwrap(),
+        "Agent round-trip mismatch"
+    );
+}
+
+#[test]
+fn serde_roundtrip_provider() {
+    let original = BuiltinSpec::Provider(provider_spec());
+    let value = serde_json::to_value(&original).unwrap();
+    let decoded: BuiltinSpec = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(
+        value,
+        serde_json::to_value(&decoded).unwrap(),
+        "Provider round-trip mismatch"
+    );
+}
+
+#[test]
+fn serde_roundtrip_model() {
+    let original = BuiltinSpec::Model(model_binding_spec());
+    let value = serde_json::to_value(&original).unwrap();
+    let decoded: BuiltinSpec = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(
+        value,
+        serde_json::to_value(&decoded).unwrap(),
+        "Model round-trip mismatch"
+    );
+}
+
+#[test]
+fn serde_roundtrip_mcp_server() {
+    let original = BuiltinSpec::McpServer(mcp_server_spec());
+    let value = serde_json::to_value(&original).unwrap();
+    let decoded: BuiltinSpec = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(
+        value,
+        serde_json::to_value(&decoded).unwrap(),
+        "McpServer round-trip mismatch"
+    );
+}
+
+// ── tag discriminator ────────────────────────────────────────────────────────
+
+#[test]
+fn tag_discriminator_is_kind_with_snake_case_names() {
+    let agent_value = serde_json::to_value(BuiltinSpec::Agent(Box::new(agent_spec()))).unwrap();
+    assert_eq!(
+        agent_value["kind"].as_str(),
+        Some("agent"),
+        "Agent kind tag mismatch"
+    );
+
+    let mcp_value = serde_json::to_value(BuiltinSpec::McpServer(mcp_server_spec())).unwrap();
+    assert_eq!(
+        mcp_value["kind"].as_str(),
+        Some("mcp_server"),
+        "McpServer kind tag mismatch"
+    );
+
+    let provider_value = serde_json::to_value(BuiltinSpec::Provider(provider_spec())).unwrap();
+    assert_eq!(
+        provider_value["kind"].as_str(),
+        Some("provider"),
+        "Provider kind tag mismatch"
+    );
+
+    let model_value = serde_json::to_value(BuiltinSpec::Model(model_binding_spec())).unwrap();
+    assert_eq!(
+        model_value["kind"].as_str(),
+        Some("model"),
+        "Model kind tag mismatch"
+    );
+}
+
+// ── mixed-variant Vec ────────────────────────────────────────────────────────
+
+#[test]
+fn mixed_variant_vec_round_trips() {
+    let specs = vec![
+        BuiltinSpec::Agent(Box::new(agent_spec())),
+        BuiltinSpec::Provider(provider_spec()),
+        BuiltinSpec::Model(model_binding_spec()),
+        BuiltinSpec::McpServer(mcp_server_spec()),
+    ];
+    let original_value = serde_json::to_value(&specs).unwrap();
+    let decoded: Vec<BuiltinSpec> = serde_json::from_value(original_value.clone()).unwrap();
+    assert_eq!(
+        original_value,
+        serde_json::to_value(&decoded).unwrap(),
+        "mixed-variant Vec round-trip mismatch"
+    );
+}
+
+// ── BuiltinSeedSet::empty ────────────────────────────────────────────────────
+
+#[test]
+fn builtin_seed_set_empty_constructs_valid_empty_seed() {
+    let seed = BuiltinSeedSet::empty("1.2.3");
+    assert_eq!(seed.binary_version, "1.2.3");
+    assert!(seed.specs.is_empty());
+}

--- a/crates/awaken-contract/tests/config_record.rs
+++ b/crates/awaken-contract/tests/config_record.rs
@@ -1,6 +1,55 @@
 use awaken_contract::{AgentSpec, ConfigRecord, RecordMeta, RecordSource};
 use serde_json::json;
 
+#[test]
+fn record_meta_user_overrides_serde_round_trip() {
+    let meta = RecordMeta {
+        source: RecordSource::User,
+        hidden: false,
+        user_overrides: Some(json!({"x": 1})),
+        created_at: 100,
+        updated_at: 200,
+    };
+    let value = serde_json::to_value(&meta).expect("serialize must succeed");
+    let decoded: RecordMeta = serde_json::from_value(value).expect("deserialize must succeed");
+    assert_eq!(decoded.user_overrides, Some(json!({"x": 1})));
+}
+
+#[test]
+fn record_meta_user_overrides_omitted_when_none() {
+    let meta = RecordMeta::new_user();
+    let value = serde_json::to_value(&meta).expect("serialize must succeed");
+    let obj = value.as_object().expect("must be object");
+    assert!(
+        !obj.contains_key("user_overrides"),
+        "user_overrides must be absent from JSON when None"
+    );
+}
+
+#[test]
+fn legacy_envelope_without_user_overrides_decodes_cleanly() {
+    let value = json!({
+        "spec": {
+            "id": "x",
+            "model_id": "y",
+            "system_prompt": "z",
+        },
+        "meta": {
+            "source": { "kind": "user" },
+            "hidden": false,
+            "created_at": 100,
+            "updated_at": 200,
+        }
+    });
+
+    let decoded =
+        ConfigRecord::<AgentSpec>::from_value(value).expect("legacy envelope must decode cleanly");
+    assert_eq!(
+        decoded.meta.user_overrides, None,
+        "user_overrides must default to None when absent from JSON"
+    );
+}
+
 fn sample_agent_spec() -> AgentSpec {
     AgentSpec {
         id: "x".into(),
@@ -17,6 +66,7 @@ fn envelope_round_trip_preserves_all_fields() {
             binary_version: "1.2.3".into(),
         },
         hidden: true,
+        user_overrides: None,
         created_at: 1_000,
         updated_at: 2_000,
     };

--- a/crates/awaken-contract/tests/config_record.rs
+++ b/crates/awaken-contract/tests/config_record.rs
@@ -1,0 +1,168 @@
+use awaken_contract::{AgentSpec, ConfigRecord, RecordMeta, RecordSource};
+use serde_json::json;
+
+fn sample_agent_spec() -> AgentSpec {
+    AgentSpec {
+        id: "x".into(),
+        model_id: "y".into(),
+        system_prompt: "z".into(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn envelope_round_trip_preserves_all_fields() {
+    let meta = RecordMeta {
+        source: RecordSource::Builtin {
+            binary_version: "1.2.3".into(),
+        },
+        hidden: true,
+        created_at: 1_000,
+        updated_at: 2_000,
+    };
+    let record = ConfigRecord {
+        spec: sample_agent_spec(),
+        meta,
+    };
+
+    let value = record.to_value().expect("to_value must succeed");
+    let decoded = ConfigRecord::<AgentSpec>::from_value(value).expect("from_value must succeed");
+
+    // AgentSpec does not implement PartialEq; compare via JSON instead.
+    let original_spec_json = serde_json::to_value(&record.spec).unwrap();
+    let decoded_spec_json = serde_json::to_value(&decoded.spec).unwrap();
+    assert_eq!(decoded_spec_json, original_spec_json);
+    assert_eq!(decoded.meta, record.meta);
+}
+
+#[test]
+fn decode_envelope_json_containing_spec_and_meta() {
+    let value = json!({
+        "spec": {
+            "id": "x",
+            "model_id": "y",
+            "system_prompt": "z",
+        },
+        "meta": {
+            "source": { "kind": "user" },
+            "hidden": false,
+            "created_at": 500,
+            "updated_at": 600,
+        }
+    });
+
+    let decoded = ConfigRecord::<AgentSpec>::from_value(value).expect("from_value must succeed");
+    assert_eq!(decoded.spec.id, "x");
+    assert_eq!(decoded.spec.model_id, "y");
+    assert_eq!(decoded.meta.source, RecordSource::User);
+    assert!(!decoded.meta.hidden);
+    assert_eq!(decoded.meta.created_at, 500);
+    assert_eq!(decoded.meta.updated_at, 600);
+}
+
+#[test]
+fn decode_bare_spec_json_yields_legacy_user_record() {
+    let spec = sample_agent_spec();
+    let bare = serde_json::to_value(&spec).expect("serialize must succeed");
+
+    let decoded = ConfigRecord::<AgentSpec>::from_value(bare).expect("from_value must succeed");
+    assert_eq!(decoded.meta.source, RecordSource::User);
+    assert!(!decoded.meta.hidden);
+    assert_eq!(decoded.meta.created_at, 0);
+    assert_eq!(decoded.meta.updated_at, 0);
+}
+
+#[test]
+fn decode_envelope_tolerates_unknown_extra_fields_under_meta() {
+    let value = json!({
+        "spec": {
+            "id": "x",
+            "model_id": "y",
+            "system_prompt": "z",
+        },
+        "meta": {
+            "source": { "kind": "user" },
+            "hidden": false,
+            "created_at": 100,
+            "updated_at": 200,
+            "some_future_field": "x",
+        }
+    });
+
+    let result = ConfigRecord::<AgentSpec>::from_value(value);
+    assert!(
+        result.is_ok(),
+        "unknown fields under meta must not cause failure"
+    );
+}
+
+#[test]
+fn hidden_defaults_to_false_when_absent() {
+    let value = json!({
+        "spec": {
+            "id": "x",
+            "model_id": "y",
+            "system_prompt": "z",
+        },
+        "meta": {
+            "source": { "kind": "user" },
+            "created_at": 0,
+            "updated_at": 0,
+        }
+    });
+
+    let decoded = ConfigRecord::<AgentSpec>::from_value(value).expect("from_value must succeed");
+    assert!(!decoded.meta.hidden);
+}
+
+#[test]
+fn record_source_tagged_enum_round_trip() {
+    let builtin = RecordSource::Builtin {
+        binary_version: "X".into(),
+    };
+    let builtin_json = serde_json::to_value(&builtin).expect("serialize must succeed");
+    assert_eq!(builtin_json["kind"], "builtin");
+    assert_eq!(builtin_json["binary_version"], "X");
+
+    let user = RecordSource::User;
+    let user_json = serde_json::to_value(&user).expect("serialize must succeed");
+    assert_eq!(user_json["kind"], "user");
+    // User variant must not have extra fields
+    assert!(user_json.as_object().is_some_and(|m| m.len() == 1));
+}
+
+#[test]
+fn encoder_always_emits_envelope() {
+    let record = ConfigRecord {
+        spec: sample_agent_spec(),
+        meta: RecordMeta::new_user(),
+    };
+
+    let value = record.to_value().expect("to_value must succeed");
+    let obj = value.as_object().expect("must be an object");
+    assert!(obj.contains_key("spec"), "envelope must contain 'spec' key");
+    assert!(obj.contains_key("meta"), "envelope must contain 'meta' key");
+}
+
+#[test]
+fn new_user_and_new_builtin_set_non_zero_timestamps() {
+    let user_meta = RecordMeta::new_user();
+    assert!(
+        user_meta.created_at > 0,
+        "new_user created_at must be non-zero"
+    );
+    assert!(
+        user_meta.updated_at > 0,
+        "new_user updated_at must be non-zero"
+    );
+
+    let builtin_meta = RecordMeta::new_builtin("2.0.0");
+    assert!(
+        builtin_meta.created_at > 0,
+        "new_builtin created_at must be non-zero"
+    );
+    assert!(
+        builtin_meta.updated_at > 0,
+        "new_builtin updated_at must be non-zero"
+    );
+}

--- a/crates/awaken-ext-observability/src/runtime_stats.rs
+++ b/crates/awaken-ext-observability/src/runtime_stats.rs
@@ -183,10 +183,11 @@ impl RuntimeStatsRegistry {
         let buckets = match window {
             None => return Some(self.snapshot_from_buckets(agent_id, &agent.buckets)),
             Some(d) => {
-                let n = ((d.as_nanos() + self.bucket_window.as_nanos() - 1)
-                    / self.bucket_window.as_nanos())
-                .max(1)
-                .min(self.bucket_count as u128) as usize;
+                let n = d
+                    .as_nanos()
+                    .div_ceil(self.bucket_window.as_nanos())
+                    .max(1)
+                    .min(self.bucket_count as u128) as usize;
                 let skip = agent.buckets.len().saturating_sub(n);
                 let slice: VecDeque<_> = agent.buckets.iter().skip(skip).cloned().collect();
                 slice
@@ -205,10 +206,11 @@ impl RuntimeStatsRegistry {
     ) -> AgentRuntimeSnapshot {
         let mut snap = self.snapshot_from_buckets(agent_id, buckets);
         if let Some(d) = window {
-            let n = ((d.as_nanos() + self.bucket_window.as_nanos() - 1)
-                / self.bucket_window.as_nanos())
-            .max(1)
-            .min(self.bucket_count as u128) as usize;
+            let n = d
+                .as_nanos()
+                .div_ceil(self.bucket_window.as_nanos())
+                .max(1)
+                .min(self.bucket_count as u128) as usize;
             snap.window_seconds = (self.bucket_window * n as u32).as_secs();
         }
         snap

--- a/crates/awaken-runtime/src/engine/retry.rs
+++ b/crates/awaken-runtime/src/engine/retry.rs
@@ -211,10 +211,10 @@ impl RetryingExecutor {
                     return Ok(result);
                 }
                 Err(err) => {
-                    if err.counts_toward_circuit_breaker() {
-                        if let Some(ref cb) = self.circuit_breaker {
-                            cb.record_failure(&request.upstream_model);
-                        }
+                    if err.counts_toward_circuit_breaker()
+                        && let Some(ref cb) = self.circuit_breaker
+                    {
+                        cb.record_failure(&request.upstream_model);
                     }
                     if !is_retryable(&err) {
                         return Err(err);
@@ -268,10 +268,10 @@ impl RetryingExecutor {
                     return Ok(stream);
                 }
                 Err(err) => {
-                    if err.counts_toward_circuit_breaker() {
-                        if let Some(ref cb) = self.circuit_breaker {
-                            cb.record_failure(&request.upstream_model);
-                        }
+                    if err.counts_toward_circuit_breaker()
+                        && let Some(ref cb) = self.circuit_breaker
+                    {
+                        cb.record_failure(&request.upstream_model);
                     }
                     if !is_retryable(&err) {
                         return Err(err);

--- a/crates/awaken-runtime/src/loop_runner/inference.rs
+++ b/crates/awaken-runtime/src/loop_runner/inference.rs
@@ -357,6 +357,8 @@ fn push_continuation(request: &mut InferenceRequest, assistant_prefix: String) {
 /// Drive a single `execute_stream` call to completion, returning one of
 /// three outcomes. The mid-stream error-to-`InterruptCause` classification
 /// lives here.
+// internal stream-driving helper; argument grouping into a struct would add wrapper noise without reducing call complexity
+#[allow(clippy::too_many_arguments)]
 async fn drive_one_stream(
     agent: &ResolvedAgent,
     request: InferenceRequest,
@@ -2194,27 +2196,29 @@ mod tests {
         // The executor was called exactly once, with a request whose
         // messages end in `assistant("half-written answer")` +
         // `user(<continuation prompt>)` — the R1 restore pattern.
-        let reqs = captured.lock().unwrap();
-        assert_eq!(reqs.len(), 1);
-        let last_two: Vec<_> = reqs[0]
-            .messages
-            .iter()
-            .rev()
-            .take(2)
-            .rev()
-            .cloned()
-            .collect();
-        assert_eq!(last_two.len(), 2);
-        assert_eq!(
-            last_two[0].text(),
-            "half-written answer",
-            "assistant prefix must carry saved partial text"
-        );
-        assert!(
-            last_two[1].text().contains("interrupted mid-stream"),
-            "user continuation prompt must follow the prefix, got: {}",
-            last_two[1].text()
-        );
+        {
+            let reqs = captured.lock().unwrap();
+            assert_eq!(reqs.len(), 1);
+            let last_two: Vec<_> = reqs[0]
+                .messages
+                .iter()
+                .rev()
+                .take(2)
+                .rev()
+                .cloned()
+                .collect();
+            assert_eq!(last_two.len(), 2);
+            assert_eq!(
+                last_two[0].text(),
+                "half-written answer",
+                "assistant prefix must carry saved partial text"
+            );
+            assert!(
+                last_two[1].text().contains("interrupted mid-stream"),
+                "user continuation prompt must follow the prefix, got: {}",
+                last_two[1].text()
+            );
+        } // drop MutexGuard before the await below
 
         // The fresh attempt's output wins: the text is whatever the
         // resumed attempt produced.

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -458,15 +458,24 @@ impl AppState {
     /// If `audit_log_enabled` is `false` or no config store is attached, this
     /// is a no-op.  Also spawns the background retention sweeper task.
     #[must_use]
-    pub fn with_audit_log_from_config(self) -> Self {
+    pub fn with_audit_log_from_config(mut self) -> Self {
         let admin_config = admin_api_config(&self);
         if !admin_config.audit_log_enabled {
             return self;
         }
-        let Some(store) = self.config_store.clone() else {
-            return self;
+
+        let logger = match &self.audit_log {
+            Some(existing) => existing.clone(),
+            None => {
+                let Some(store) = self.config_store.clone() else {
+                    return self;
+                };
+                let new_logger = Arc::new(AuditLogger::new(store));
+                self.audit_log = Some(new_logger.clone());
+                new_logger
+            }
         };
-        let logger = Arc::new(AuditLogger::new(store));
+
         let logger_for_sweeper = logger.clone();
         let retention_days = admin_config.audit_retention_days;
         let sweep_interval = effective_sweep_interval(admin_config.audit_sweep_interval_secs);
@@ -488,7 +497,7 @@ impl AppState {
                 }
             }
         });
-        self.with_audit_log(logger)
+        self
     }
 
     /// Insert a replay buffer for the given key, tracking creation time.
@@ -989,5 +998,61 @@ mod tests {
         // Values 1–9 should warn but still be used as-is.
         let duration = effective_sweep_interval(5);
         assert_eq!(duration, std::time::Duration::from_secs(5));
+    }
+
+    // ── with_audit_log_from_config reuses pre-set logger ───────────────────
+
+    #[tokio::test]
+    async fn with_audit_log_from_config_reuses_preset_logger() {
+        use crate::mailbox::{Mailbox, MailboxConfig};
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_runtime::AgentRuntime;
+        use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
+
+        struct StubResolver;
+        impl awaken_runtime::AgentResolver for StubResolver {
+            fn resolve(
+                &self,
+                agent_id: &str,
+            ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
+                Err(awaken_runtime::RuntimeError::AgentNotFound {
+                    agent_id: agent_id.to_string(),
+                })
+            }
+        }
+
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let store = Arc::new(InMemoryStore::new());
+        let mailbox_store = Arc::new(InMemoryMailboxStore::new());
+        let mailbox = Arc::new(Mailbox::new(
+            runtime.clone(),
+            mailbox_store,
+            store.clone(),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let preset_logger = Arc::new(AuditLogger::new(store.clone() as Arc<dyn ConfigStore>));
+        let preset_ptr = Arc::as_ptr(&preset_logger);
+
+        let state = AppState::new(
+            runtime,
+            mailbox,
+            store.clone() as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
+            Arc::new(StubResolver),
+            ServerConfig::default(),
+        )
+        .with_config_store(store as Arc<dyn ConfigStore>)
+        .with_audit_log(preset_logger)
+        .with_audit_log_from_config();
+
+        let stored = state
+            .audit_log
+            .expect("audit_log must be Some after with_audit_log_from_config");
+        assert_eq!(
+            Arc::as_ptr(&stored),
+            preset_ptr,
+            "with_audit_log_from_config must reuse the pre-set AuditLogger instance"
+        );
     }
 }

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -1,7 +1,7 @@
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{delete as delete_route, get, patch, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -44,9 +44,19 @@ pub fn config_routes() -> Router<AppState> {
             get(get_config).put(put_config).delete(delete_config),
         )
         .route("/v1/config/:namespace/:id/restore", post(restore_config))
+        .route("/v1/config/:namespace/:id/meta", get(get_config_meta))
+        .route("/v1/config/:namespace/meta", get(list_config_meta))
         .route("/v1/config/:namespace/$schema", get(get_schema))
         .route("/v1/agents", get(list_agents))
         .route("/v1/agents/:id", get(get_agent))
+        .route(
+            "/v1/config/agents/:id/overrides",
+            patch(patch_agent_overrides_handler).delete(clear_agent_overrides_handler),
+        )
+        .route(
+            "/v1/config/agents/:id/overrides/:field",
+            delete_route(clear_agent_override_field_handler),
+        )
         .route("/v1/providers/:id/test", post(test_provider_connection))
         .route("/v1/mcp-servers/:id/status", get(get_mcp_server_status))
         .route("/v1/mcp-servers/:id/restart", post(post_mcp_server_restart))
@@ -187,6 +197,42 @@ async fn get_config_inner(
         .map_err(map_service_error)?
         .ok_or_else(|| ApiError::NotFound(format!("{}/{}", namespace.as_str(), id)))?;
     Ok(Json(value))
+}
+
+async fn get_config_meta(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((namespace, id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ConfigRouteError> {
+    ensure_admin_auth(&state, &headers)?;
+    let namespace = ConfigNamespace::parse(&namespace).map_err(map_service_error)?;
+    let service = ConfigService::new(&state).map_err(map_service_error)?;
+    let meta = service
+        .get_meta(namespace, &id)
+        .await
+        .map_err(map_service_error)?
+        .ok_or_else(|| ApiError::NotFound(format!("{}/{}", namespace.as_str(), id)))?;
+    Ok(Json(meta))
+}
+
+async fn list_config_meta(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(namespace): Path<String>,
+    Query(params): Query<ListParams>,
+) -> Result<impl IntoResponse, ConfigRouteError> {
+    ensure_admin_auth(&state, &headers)?;
+    let namespace = ConfigNamespace::parse(&namespace).map_err(map_service_error)?;
+    let service = ConfigService::new(&state).map_err(map_service_error)?;
+    let items = service
+        .list_meta(namespace, params.offset, params.limit)
+        .await
+        .map_err(map_service_error)?;
+    let response: Vec<_> = items
+        .into_iter()
+        .map(|(id, meta)| json!({ "id": id, "meta": meta }))
+        .collect();
+    Ok(Json(response))
 }
 
 async fn put_config(
@@ -480,6 +526,79 @@ fn ensure_admin_auth_for_token(
     Ok(())
 }
 
+async fn patch_agent_overrides_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<Value>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service.patch_agent_overrides(&id, body, &headers).await {
+        Ok(spec) => Json(spec).into_response(),
+        Err(ConfigServiceError::OverridesNotSupportedForUserRecord) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": ConfigServiceError::OverridesNotSupportedForUserRecord.to_string() })),
+        )
+            .into_response(),
+        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
+}
+
+async fn clear_agent_overrides_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service.clear_agent_overrides(&id, &headers).await {
+        Ok(spec) => Json(spec).into_response(),
+        Err(ConfigServiceError::OverridesNotSupportedForUserRecord) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": ConfigServiceError::OverridesNotSupportedForUserRecord.to_string() })),
+        )
+            .into_response(),
+        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
+}
+
+async fn clear_agent_override_field_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((id, field)): Path<(String, String)>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service
+        .clear_agent_override_field(&id, &field, &headers)
+        .await
+    {
+        Ok(spec) => Json(spec).into_response(),
+        Err(ConfigServiceError::OverridesNotSupportedForUserRecord) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": ConfigServiceError::OverridesNotSupportedForUserRecord.to_string() })),
+        )
+            .into_response(),
+        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
+}
+
 fn map_service_error(error: ConfigServiceError) -> ApiError {
     match error {
         ConfigServiceError::NotEnabled | ConfigServiceError::InvalidPayload(_) => {
@@ -497,6 +616,10 @@ fn map_service_error(error: ConfigServiceError) -> ApiError {
         | ConfigServiceError::Storage(_) => ApiError::Internal(error.to_string()),
         // Blocked is matched inline in delete_config before reaching this function.
         ConfigServiceError::Blocked { .. } => ApiError::Conflict(error.to_string()),
+        // OverridesNotSupportedForUserRecord is matched inline in patch/clear handlers.
+        ConfigServiceError::OverridesNotSupportedForUserRecord => {
+            ApiError::BadRequest(error.to_string())
+        }
     }
 }
 

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -549,7 +549,9 @@ mod tests {
             InferenceExecutionError, InferenceRequest, LlmExecutor,
         };
         use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
-        use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+        use awaken_contract::{
+            AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec,
+        };
         use awaken_runtime::builder::AgentRuntimeBuilder;
         use awaken_runtime::registry::traits::ModelBinding;
         use axum::body::Body;
@@ -562,7 +564,6 @@ mod tests {
         use crate::mailbox::{Mailbox, MailboxConfig};
         use crate::routes::build_router;
         use crate::services::config_runtime::{ConfigRuntimeManager, ProviderExecutorFactory};
-        use crate::services::config_service::ConfigNamespace;
 
         struct ImmediateExecutor;
 
@@ -621,14 +622,6 @@ mod tests {
             let runtime = Arc::new(
                 AgentRuntimeBuilder::new()
                     .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-                    .with_model_binding(
-                        "bootstrap",
-                        ModelBinding {
-                            provider_id: "bootstrap".into(),
-                            upstream_model: "bootstrap-model".into(),
-                        },
-                    )
-                    .with_agent_spec(bootstrap_agent())
                     .with_thread_run_store(thread_store.clone())
                     .build()
                     .expect("build runtime"),
@@ -639,25 +632,25 @@ mod tests {
                     .expect("config runtime manager")
                     .with_provider_factory(Arc::new(TestProviderFactory)),
             );
-            manager
-                .bootstrap_if_empty(
-                    &[ProviderSpec {
+            let seed = BuiltinSeedSet {
+                binary_version: "test".to_string(),
+                specs: vec![
+                    BuiltinSpec::provider(ProviderSpec {
                         id: "bootstrap".into(),
                         adapter: "stub".into(),
                         ..Default::default()
-                    }],
-                    &[ModelBindingSpec {
+                    }),
+                    BuiltinSpec::model(ModelBindingSpec {
                         id: "bootstrap".into(),
                         provider_id: "bootstrap".into(),
                         upstream_model: "bootstrap-model".into(),
                         created_at: None,
                         updated_at: None,
-                    }],
-                    &[bootstrap_agent()],
-                    &[],
-                )
-                .await
-                .expect("bootstrap config store");
+                    }),
+                    BuiltinSpec::agent(bootstrap_agent()),
+                ],
+            };
+            manager.apply_seed(&seed).await.expect("apply_seed");
             manager.apply().await.expect("publish config");
 
             let resolver = runtime.resolver_arc();

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -18,7 +18,7 @@ use sha2::Digest;
 pub const AUDIT_NAMESPACE: &str = "_audit";
 
 /// Query parameters for listing audit events.
-#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct AuditQuery {
     /// Include only events at or after this timestamp (RFC 3339).
     #[serde(default)]
@@ -41,6 +41,20 @@ pub struct AuditQuery {
     /// Opaque keyset cursor from a previous response.
     #[serde(default)]
     pub cursor: Option<String>,
+}
+
+impl Default for AuditQuery {
+    fn default() -> Self {
+        Self {
+            since: None,
+            until: None,
+            action: None,
+            resource: None,
+            actor: None,
+            limit: default_audit_limit(),
+            cursor: None,
+        }
+    }
 }
 
 fn default_audit_limit() -> usize {
@@ -313,6 +327,7 @@ impl AuditLogger {
                 }
                 if let Some(ref resource) = filter.resource
                     && &event.resource != resource
+                    && !event.resource.starts_with(&format!("{resource}/"))
                 {
                     return false;
                 }

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -192,6 +192,74 @@ impl AuditLogger {
         metrics::counter!("awaken_audit_events_total", "action" => "restore").increment(1);
     }
 
+    /// Emit one audit event per non-empty bucket of a seed-apply report.
+    ///
+    /// Boot-time emission has no HeaderMap; actor is recorded as "system:seed".
+    /// Best-effort — same failure semantics as [`AuditLogger::emit`].
+    ///
+    /// Skips entirely if the report has no created/updated/deleted entries
+    /// (idempotent re-runs produce no audit noise).
+    pub async fn emit_seed_report(&self, report: &crate::services::builtin_seed::SeedReport) {
+        use awaken_contract::AuditAction;
+        let buckets: [(&str, &[crate::services::builtin_seed::RecordRef]); 3] = [
+            ("created", &report.created),
+            ("updated", &report.updated),
+            ("deleted", &report.deleted),
+        ];
+        let mut ulid_gen = ulid::Generator::new();
+        for (label, entries) in buckets {
+            if entries.is_empty() {
+                continue;
+            }
+            let id = ulid_gen
+                .generate()
+                .unwrap_or_else(|_| ulid::Ulid::new())
+                .to_string();
+            let ts = Utc::now().to_rfc3339();
+            let after_payload = serde_json::json!({
+                "bucket": label,
+                "count": entries.len(),
+                // Cap the sample list so very large seeds don't bloat the audit log.
+                "sample": entries
+                    .iter()
+                    .take(20)
+                    .map(|r| format!("{}/{}", r.namespace, r.id))
+                    .collect::<Vec<_>>(),
+                "truncated": entries.len() > 20,
+            });
+
+            let event = AuditEvent {
+                id: id.clone(),
+                ts,
+                actor: "system:seed".to_string(),
+                action: AuditAction::SeedApply,
+                resource: format!("seed:{label}"),
+                before: None,
+                after: Some(after_payload),
+                ip: None,
+                request_id: None,
+                restored_from: None,
+            };
+
+            let value = match serde_json::to_value(&event) {
+                Ok(v) => v,
+                Err(error) => {
+                    tracing::warn!(error = %error, "audit: failed to serialize seed event");
+                    metrics::counter!("awaken_audit_write_failures_total").increment(1);
+                    continue;
+                }
+            };
+
+            if let Err(error) = self.store.put(AUDIT_NAMESPACE, &id, &value).await {
+                tracing::warn!(error = %error, "audit: failed to write seed event");
+                metrics::counter!("awaken_audit_write_failures_total").increment(1);
+                continue;
+            }
+
+            metrics::counter!("awaken_audit_events_total", "action" => "seed_apply").increment(1);
+        }
+    }
+
     /// Query audit events with optional filters and keyset pagination.
     ///
     /// Returns `Err` if `filter.cursor` is present but not valid base64.
@@ -729,6 +797,93 @@ mod tests {
             .unwrap();
         assert_eq!(page2.items.len(), 2);
         assert!(page2.next_cursor.is_none());
+    }
+
+    // ── emit_seed_report ─────────────────────────────────────────────────
+
+    fn make_record_ref(namespace: &str, id: &str) -> crate::services::builtin_seed::RecordRef {
+        crate::services::builtin_seed::RecordRef {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+        }
+    }
+
+    fn make_seed_report(
+        created: Vec<crate::services::builtin_seed::RecordRef>,
+        updated: Vec<crate::services::builtin_seed::RecordRef>,
+        deleted: Vec<crate::services::builtin_seed::RecordRef>,
+    ) -> crate::services::builtin_seed::SeedReport {
+        crate::services::builtin_seed::SeedReport {
+            created,
+            updated,
+            unchanged: vec![],
+            deleted,
+            preserved_user: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn seed_apply_emits_event_per_non_empty_bucket() {
+        let logger = make_logger();
+        let report = make_seed_report(
+            vec![
+                make_record_ref("agents", "agent-a"),
+                make_record_ref("agents", "agent-b"),
+            ],
+            vec![],
+            vec![make_record_ref("models", "old-model")],
+        );
+        logger.emit_seed_report(&report).await;
+
+        let page = logger
+            .query(AuditQuery {
+                limit: 100,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 2, "one event per non-empty bucket");
+
+        // Both events must have the SeedApply action and system:seed actor.
+        for event in &page.items {
+            assert_eq!(event.action, AuditAction::SeedApply);
+            assert_eq!(event.actor, "system:seed");
+        }
+
+        // Check that resources match the expected bucket names (order may vary).
+        let resources: std::collections::HashSet<_> =
+            page.items.iter().map(|e| e.resource.as_str()).collect();
+        assert!(resources.contains("seed:created"));
+        assert!(resources.contains("seed:deleted"));
+    }
+
+    #[tokio::test]
+    async fn seed_apply_idempotent_run_emits_no_audit() {
+        let logger = make_logger();
+        let report = make_seed_report(vec![], vec![], vec![]);
+        logger.emit_seed_report(&report).await;
+
+        let page = logger.query(AuditQuery::default()).await.unwrap();
+        assert_eq!(page.items.len(), 0, "empty report must emit no events");
+    }
+
+    #[tokio::test]
+    async fn seed_apply_truncates_sample_at_20() {
+        let logger = make_logger();
+        let created: Vec<_> = (0..25)
+            .map(|i| make_record_ref("agents", &format!("agent-{i}")))
+            .collect();
+        let report = make_seed_report(created, vec![], vec![]);
+        logger.emit_seed_report(&report).await;
+
+        let page = logger.query(AuditQuery::default()).await.unwrap();
+        assert_eq!(page.items.len(), 1);
+
+        let after = page.items[0].after.as_ref().unwrap();
+        let sample = after["sample"].as_array().unwrap();
+        assert_eq!(sample.len(), 20, "sample must be capped at 20");
+        assert_eq!(after["truncated"], true);
+        assert_eq!(after["count"], 25);
     }
 
     // ── prune_before ──────────────────────────────────────────────────────

--- a/crates/awaken-server/src/services/builtin_seed.rs
+++ b/crates/awaken-server/src/services/builtin_seed.rs
@@ -1,0 +1,685 @@
+//! Protocol for applying a [`BuiltinSeedSet`] to a [`ConfigStore`].
+//!
+//! See [`apply_builtin_seed`] for the full semantics.
+
+use std::collections::{HashMap, HashSet};
+
+use awaken_contract::contract::storage::StorageError;
+use awaken_contract::{
+    BuiltinSeedSet, BuiltinSpec, ConfigRecord, ConfigStore, RecordMeta, RecordSource,
+};
+
+use crate::services::config_service::ConfigNamespace;
+
+const SEED_LIST_PAGE_SIZE: usize = 256;
+
+// ── public types ─────────────────────────────────────────────────────────────
+
+/// Report produced by [`apply_builtin_seed`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SeedReport {
+    pub created: Vec<RecordRef>,
+    pub updated: Vec<RecordRef>,
+    pub unchanged: Vec<RecordRef>,
+    pub deleted: Vec<RecordRef>,
+    pub preserved_user: Vec<RecordRef>,
+}
+
+/// Identifies a single record in a ConfigStore.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordRef {
+    pub namespace: String,
+    pub id: String,
+}
+
+impl RecordRef {
+    fn new(namespace: &str, id: &str) -> Self {
+        Self {
+            namespace: namespace.to_owned(),
+            id: id.to_owned(),
+        }
+    }
+}
+
+/// Errors returned by [`apply_builtin_seed`].
+#[derive(Debug, thiserror::Error)]
+pub enum SeedError {
+    #[error("storage error: {0}")]
+    Storage(#[from] StorageError),
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+// ── apply_builtin_seed ────────────────────────────────────────────────────────
+
+/// Apply a seed to the given ConfigStore.
+///
+/// Behavior per spec in `seed.specs`:
+/// - No existing record → create new Builtin record. (created)
+/// - Existing Builtin, same binary_version, spec equal → no-op. (unchanged)
+/// - Existing Builtin, same binary_version, spec differs → replace spec, refresh updated_at. (updated)
+/// - Existing Builtin, different binary_version → replace spec + version, preserve hidden, refresh updated_at. (updated)
+/// - Existing User → leave entirely untouched. (preserved_user)
+///
+/// After processing seed entries, scans all four spec namespaces
+/// (`agents`, `providers`, `models`, `mcp-servers`) and deletes any
+/// Builtin record whose ID is not in this seed (orphan cleanup).
+/// User records are never deleted by orphan cleanup.
+///
+/// **Concurrency precondition:** Must not run concurrently with any other
+/// writer to the four spec namespaces (`agents`, `providers`, `models`,
+/// `mcp-servers`). Intended for boot-time invocation before
+/// `ConfigRuntimeManager::apply()`. With this precondition, the
+/// snapshot-then-delete orphan-cleanup pattern is safe.
+pub async fn apply_builtin_seed(
+    store: &dyn ConfigStore,
+    seed: &BuiltinSeedSet,
+) -> Result<SeedReport, SeedError> {
+    let mut report = SeedReport::default();
+
+    // Track seeded (namespace, id) pairs for orphan cleanup.
+    let mut seeded: HashMap<&str, HashSet<String>> = HashMap::new();
+    for ns in ConfigNamespace::iter_str() {
+        seeded.insert(ns, HashSet::new());
+    }
+
+    // ── Phase 1: upsert seed entries ────────────────────────────────────────
+    for spec in &seed.specs {
+        let namespace = spec.namespace();
+        let id = spec.id();
+        let new_spec_value = builtin_spec_to_value(spec)?;
+
+        seeded.entry(namespace).or_default().insert(id.to_owned());
+
+        let existing_raw = store.get(namespace, id).await?;
+
+        match existing_raw {
+            None => {
+                // Create new Builtin record.
+                let record = ConfigRecord {
+                    spec: new_spec_value,
+                    meta: RecordMeta::new_builtin(&seed.binary_version),
+                };
+                store.put(namespace, id, &record.to_value()?).await?;
+                report.created.push(RecordRef::new(namespace, id));
+            }
+            Some(raw) => {
+                let existing: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw)?;
+
+                match &existing.meta.source {
+                    RecordSource::User => {
+                        // Never touch user records.
+                        report.preserved_user.push(RecordRef::new(namespace, id));
+                    }
+                    RecordSource::Builtin {
+                        binary_version: stored_version,
+                    } => {
+                        let same_version = stored_version == &seed.binary_version;
+                        let same_spec = existing.spec == new_spec_value;
+
+                        if same_version && same_spec {
+                            // No-op.
+                            report.unchanged.push(RecordRef::new(namespace, id));
+                        } else {
+                            // Update: refresh spec and/or version; preserve
+                            // hidden flag and created_at.
+                            let now = awaken_contract::time::now_ms();
+                            let record = ConfigRecord {
+                                spec: new_spec_value,
+                                meta: RecordMeta {
+                                    source: RecordSource::Builtin {
+                                        binary_version: seed.binary_version.clone(),
+                                    },
+                                    hidden: existing.meta.hidden,
+                                    created_at: existing.meta.created_at,
+                                    updated_at: now,
+                                },
+                            };
+                            store.put(namespace, id, &record.to_value()?).await?;
+                            report.updated.push(RecordRef::new(namespace, id));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Phase 2: orphan cleanup ──────────────────────────────────────────────
+    //
+    // Two-pass snapshot-then-delete to avoid the pagination skew that
+    // interleaved deletes would cause: deleting a record shifts later entries
+    // forward in the store's ordering, so a single combined loop would skip
+    // records that move into already-visited slots.
+    //
+    // Pass 1 (read-only): collect all deletion candidates into a Vec.
+    // Pass 2 (write): delete each candidate.
+    //
+    // Safe under the boot-time single-writer precondition documented above.
+    for namespace in ConfigNamespace::iter_str() {
+        let empty = HashSet::new();
+        let seeded_ids: &HashSet<String> = seeded.get(namespace).unwrap_or(&empty);
+
+        // Pass 1: snapshot deletion candidates.
+        let mut candidates: Vec<String> = Vec::new();
+        let mut offset = 0usize;
+        loop {
+            let page = store.list(namespace, offset, SEED_LIST_PAGE_SIZE).await?;
+            let page_len = page.len();
+
+            for (id, raw) in page {
+                if seeded_ids.contains(&id) {
+                    continue;
+                }
+                // Decode to check source; legacy bare-spec becomes User.
+                let record: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw)?;
+                if matches!(record.meta.source, RecordSource::Builtin { .. }) {
+                    candidates.push(id);
+                }
+                // User records (including legacy-bare ones) are left alone.
+            }
+
+            if page_len < SEED_LIST_PAGE_SIZE {
+                break;
+            }
+            offset += page_len;
+        }
+
+        // Pass 2: delete all candidates collected above.
+        for id in candidates {
+            store.delete(namespace, &id).await?;
+            report.deleted.push(RecordRef::new(namespace, &id));
+        }
+    }
+
+    Ok(report)
+}
+
+// ── helper ───────────────────────────────────────────────────────────────────
+
+/// Extract the inner spec JSON from a [`BuiltinSpec`].
+///
+/// The wire format stored in the envelope's `spec` field is the plain inner
+/// spec (e.g. `AgentSpec` JSON), not the tagged `BuiltinSpec` form.
+fn builtin_spec_to_value(spec: &BuiltinSpec) -> Result<serde_json::Value, serde_json::Error> {
+    match spec {
+        BuiltinSpec::Agent(s) => serde_json::to_value(s.as_ref()),
+        BuiltinSpec::Provider(s) => serde_json::to_value(s),
+        BuiltinSpec::Model(s) => serde_json::to_value(s),
+        BuiltinSpec::McpServer(s) => serde_json::to_value(s),
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::config_record::ConfigRecord;
+    use awaken_contract::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
+    use awaken_stores::memory::InMemoryStore;
+
+    // ── spec constructors ────────────────────────────────────────────────────
+
+    fn agent_spec(id: &str, prompt: &str) -> AgentSpec {
+        AgentSpec {
+            id: id.to_owned(),
+            model_id: "gpt-4o".to_owned(),
+            system_prompt: prompt.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn provider_spec(id: &str) -> ProviderSpec {
+        ProviderSpec {
+            id: id.to_owned(),
+            adapter: "openai".to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn model_spec(id: &str) -> ModelBindingSpec {
+        ModelBindingSpec {
+            id: id.to_owned(),
+            provider_id: "openai".to_owned(),
+            upstream_model: "gpt-4o".to_owned(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn mcp_spec(id: &str) -> McpServerSpec {
+        McpServerSpec {
+            id: id.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn seed_v1(specs: Vec<BuiltinSpec>) -> BuiltinSeedSet {
+        BuiltinSeedSet {
+            binary_version: "v1".to_owned(),
+            specs,
+        }
+    }
+
+    fn seed_v2(specs: Vec<BuiltinSpec>) -> BuiltinSeedSet {
+        BuiltinSeedSet {
+            binary_version: "v2".to_owned(),
+            specs,
+        }
+    }
+
+    fn store() -> InMemoryStore {
+        InMemoryStore::new()
+    }
+
+    // ── test 1 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn cold_seed_creates_all_records() {
+        let s = store();
+        let seed = seed_v1(vec![
+            BuiltinSpec::Agent(Box::new(agent_spec("a1", "hello"))),
+            BuiltinSpec::Provider(provider_spec("p1")),
+            BuiltinSpec::Model(model_spec("m1")),
+        ]);
+
+        let report = apply_builtin_seed(&s, &seed).await.unwrap();
+
+        assert_eq!(report.created.len(), 3, "expected 3 created");
+        assert!(report.updated.is_empty());
+        assert!(report.unchanged.is_empty());
+        assert!(report.deleted.is_empty());
+        assert!(report.preserved_user.is_empty());
+
+        // Verify stored records have Builtin source.
+        for (ns, id) in [("agents", "a1"), ("providers", "p1"), ("models", "m1")] {
+            let raw = s.get(ns, id).await.unwrap().expect("record missing");
+            let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+            assert_eq!(
+                rec.meta.source,
+                RecordSource::Builtin {
+                    binary_version: "v1".to_owned()
+                }
+            );
+        }
+    }
+
+    // ── test 2 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn idempotent_re_apply_is_noop() {
+        let s = store();
+        let seed = seed_v1(vec![
+            BuiltinSpec::Agent(Box::new(agent_spec("a1", "hello"))),
+            BuiltinSpec::Provider(provider_spec("p1")),
+            BuiltinSpec::Model(model_spec("m1")),
+        ]);
+
+        apply_builtin_seed(&s, &seed).await.unwrap();
+
+        // Read updated_at before second apply.
+        let raw_before = s.get("agents", "a1").await.unwrap().unwrap();
+        let rec_before: ConfigRecord<serde_json::Value> =
+            ConfigRecord::from_value(raw_before).unwrap();
+        let updated_at_before = rec_before.meta.updated_at;
+
+        let report = apply_builtin_seed(&s, &seed).await.unwrap();
+
+        assert_eq!(report.unchanged.len(), 3, "expected 3 unchanged");
+        assert!(report.created.is_empty());
+        assert!(report.updated.is_empty());
+        assert!(report.deleted.is_empty());
+        assert!(report.preserved_user.is_empty());
+
+        // updated_at must not have changed.
+        let raw_after = s.get("agents", "a1").await.unwrap().unwrap();
+        let rec_after: ConfigRecord<serde_json::Value> =
+            ConfigRecord::from_value(raw_after).unwrap();
+        assert_eq!(rec_after.meta.updated_at, updated_at_before);
+    }
+
+    // ── test 3 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn same_version_edit_updates_record() {
+        let s = store();
+
+        apply_builtin_seed(
+            &s,
+            &seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec(
+                "a1",
+                "old prompt",
+            )))]),
+        )
+        .await
+        .unwrap();
+
+        let report = apply_builtin_seed(
+            &s,
+            &seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec(
+                "a1",
+                "new prompt",
+            )))]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.updated.len(), 1);
+        assert!(report.created.is_empty());
+        assert!(report.unchanged.is_empty());
+
+        let raw = s.get("agents", "a1").await.unwrap().unwrap();
+        let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert_eq!(rec.spec["system_prompt"], "new prompt");
+    }
+
+    // ── test 4 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn version_upgrade_refreshes_record() {
+        let s = store();
+
+        apply_builtin_seed(
+            &s,
+            &seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v1")))]),
+        )
+        .await
+        .unwrap();
+
+        let report = apply_builtin_seed(
+            &s,
+            &seed_v2(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v2")))]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.updated.len(), 1);
+
+        let raw = s.get("agents", "a1").await.unwrap().unwrap();
+        let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert_eq!(
+            rec.meta.source,
+            RecordSource::Builtin {
+                binary_version: "v2".to_owned()
+            }
+        );
+        assert_eq!(rec.spec["system_prompt"], "v2");
+    }
+
+    // ── test 5 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn user_record_preserved_through_seed() {
+        let s = store();
+
+        // Pre-populate user record.
+        let user_record = ConfigRecord {
+            spec: serde_json::to_value(agent_spec("coder", "user version")).unwrap(),
+            meta: RecordMeta::new_user(),
+        };
+        s.put("agents", "coder", &user_record.to_value().unwrap())
+            .await
+            .unwrap();
+
+        let report = apply_builtin_seed(
+            &s,
+            &seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec(
+                "coder",
+                "builtin version",
+            )))]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.preserved_user.len(), 1);
+        assert!(report.created.is_empty());
+        assert!(report.updated.is_empty());
+
+        // Original record still intact.
+        let raw = s.get("agents", "coder").await.unwrap().unwrap();
+        let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert_eq!(rec.meta.source, RecordSource::User);
+        assert_eq!(rec.spec["system_prompt"], "user version");
+    }
+
+    // ── test 6 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_builtin_cleaned() {
+        let s = store();
+
+        apply_builtin_seed(
+            &s,
+            &seed_v1(vec![
+                BuiltinSpec::Agent(Box::new(agent_spec("a1", "a"))),
+                BuiltinSpec::Agent(Box::new(agent_spec("b1", "b"))),
+            ]),
+        )
+        .await
+        .unwrap();
+
+        // v2 seed only has a1.
+        let report = apply_builtin_seed(
+            &s,
+            &seed_v2(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "a")))]),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.deleted.len(), 1);
+        assert_eq!(report.deleted[0].id, "b1");
+
+        assert!(s.get("agents", "b1").await.unwrap().is_none());
+        assert!(s.get("agents", "a1").await.unwrap().is_some());
+    }
+
+    // ── test 7 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_cleanup_only_targets_builtin() {
+        let s = store();
+
+        // Pre-populate user record.
+        let user_record = ConfigRecord {
+            spec: serde_json::to_value(agent_spec("user-only", "user")).unwrap(),
+            meta: RecordMeta::new_user(),
+        };
+        s.put("agents", "user-only", &user_record.to_value().unwrap())
+            .await
+            .unwrap();
+
+        // Seed does NOT include user-only.
+        let report = apply_builtin_seed(&s, &seed_v1(vec![])).await.unwrap();
+
+        assert!(!report.deleted.iter().any(|r| r.id == "user-only"));
+        assert!(s.get("agents", "user-only").await.unwrap().is_some());
+    }
+
+    // ── test 8 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn hidden_flag_preserved_across_upgrade() {
+        let s = store();
+
+        apply_builtin_seed(
+            &s,
+            &seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v1")))]),
+        )
+        .await
+        .unwrap();
+
+        // Set hidden = true on stored record.
+        let raw = s.get("agents", "a1").await.unwrap().unwrap();
+        let mut rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        rec.meta.hidden = true;
+        s.put("agents", "a1", &rec.to_value().unwrap())
+            .await
+            .unwrap();
+
+        // Apply v2 with new content.
+        apply_builtin_seed(
+            &s,
+            &seed_v2(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v2")))]),
+        )
+        .await
+        .unwrap();
+
+        let raw = s.get("agents", "a1").await.unwrap().unwrap();
+        let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert!(rec.meta.hidden, "hidden flag must be preserved");
+        assert_eq!(
+            rec.meta.source,
+            RecordSource::Builtin {
+                binary_version: "v2".to_owned()
+            }
+        );
+        assert_eq!(rec.spec["system_prompt"], "v2");
+    }
+
+    // ── test 9 ───────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn mixed_namespace_seed_routes_correctly() {
+        let s = store();
+
+        let seed = seed_v1(vec![
+            BuiltinSpec::Agent(Box::new(agent_spec("agent-1", "hi"))),
+            BuiltinSpec::Provider(provider_spec("prov-1")),
+            BuiltinSpec::Model(model_spec("model-1")),
+            BuiltinSpec::McpServer(mcp_spec("mcp-1")),
+        ]);
+
+        let report = apply_builtin_seed(&s, &seed).await.unwrap();
+        assert_eq!(report.created.len(), 4);
+
+        // Each spec lands in the correct namespace.
+        assert!(s.get("agents", "agent-1").await.unwrap().is_some());
+        assert!(s.get("providers", "prov-1").await.unwrap().is_some());
+        assert!(s.get("models", "model-1").await.unwrap().is_some());
+        assert!(s.get("mcp-servers", "mcp-1").await.unwrap().is_some());
+
+        // Wrong namespace: not there.
+        assert!(s.get("providers", "agent-1").await.unwrap().is_none());
+    }
+
+    // ── test 10 ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn legacy_bare_spec_treated_as_user_during_seed() {
+        let s = store();
+
+        // Write bare AgentSpec (no envelope) directly to the store.
+        let bare = serde_json::to_value(agent_spec("legacy", "bare")).unwrap();
+        s.put("agents", "legacy", &bare).await.unwrap();
+
+        // Seed v1 does NOT contain "legacy".
+        let report = apply_builtin_seed(
+            &s,
+            &seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec(
+                "other", "other",
+            )))]),
+        )
+        .await
+        .unwrap();
+
+        // Orphan cleanup must not touch legacy (decoded as User).
+        assert!(!report.deleted.iter().any(|r| r.id == "legacy"));
+        assert!(s.get("agents", "legacy").await.unwrap().is_some());
+    }
+
+    // ── test 11 ──────────────────────────────────────────────────────────────
+
+    /// Regression test for the pagination skew bug: interleaving deletes with
+    /// list() calls caused records past the first page boundary to be skipped.
+    /// This test inserts 300 Builtin records (> SEED_LIST_PAGE_SIZE = 256),
+    /// then applies an empty seed and asserts all 300 are cleaned up.
+    #[tokio::test]
+    async fn orphan_cleanup_handles_more_than_one_page() {
+        const RECORD_COUNT: usize = 300;
+        assert!(
+            RECORD_COUNT > SEED_LIST_PAGE_SIZE,
+            "test must exceed page size to exercise the multi-page path"
+        );
+
+        let s = store();
+
+        // Insert 300 Builtin provider records directly (fast, minimal fields).
+        for i in 0..RECORD_COUNT {
+            let id = format!("prov-{i:04}");
+            let record = ConfigRecord {
+                spec: serde_json::to_value(provider_spec(&id)).unwrap(),
+                meta: RecordMeta::new_builtin("v1"),
+            };
+            s.put("providers", &id, &record.to_value().unwrap())
+                .await
+                .unwrap();
+        }
+
+        // Apply an empty v2 seed — none of the 300 records should survive.
+        let report = apply_builtin_seed(&s, &seed_v2(vec![])).await.unwrap();
+
+        assert_eq!(
+            report.deleted.len(),
+            RECORD_COUNT,
+            "all {RECORD_COUNT} orphans must be deleted, not just the first page"
+        );
+        assert!(report.created.is_empty());
+        assert!(report.updated.is_empty());
+        assert!(report.unchanged.is_empty());
+        assert!(report.preserved_user.is_empty());
+
+        // Spot-check a record from the second page is gone.
+        assert!(
+            s.get("providers", "prov-0256").await.unwrap().is_none(),
+            "record past first page boundary must also be deleted"
+        );
+    }
+
+    // ── test 12 ──────────────────────────────────────────────────────────────
+
+    /// Sanity check: orphan cleanup iterates every namespace via
+    /// `ConfigNamespace::iter_str()`. Pre-populate one Builtin orphan in each
+    /// of the four namespaces, apply an empty seed, and assert all four are
+    /// deleted — proving the loop visited every namespace.
+    #[tokio::test]
+    async fn orphan_cleanup_uses_config_namespace_iter() {
+        let s = store();
+
+        let namespaces_and_ids = [
+            ("agents", "orphan-agent"),
+            ("providers", "orphan-provider"),
+            ("models", "orphan-model"),
+            ("mcp-servers", "orphan-mcp"),
+        ];
+
+        for (ns, id) in namespaces_and_ids {
+            let spec_value = serde_json::json!({ "id": id, "ns": ns });
+            let record = ConfigRecord {
+                spec: spec_value,
+                meta: RecordMeta::new_builtin("v1"),
+            };
+            s.put(ns, id, &record.to_value().unwrap()).await.unwrap();
+        }
+
+        let report = apply_builtin_seed(&s, &seed_v1(vec![])).await.unwrap();
+
+        assert_eq!(
+            report.deleted.len(),
+            4,
+            "expected one deleted orphan per namespace"
+        );
+        for (ns, id) in namespaces_and_ids {
+            assert!(
+                report
+                    .deleted
+                    .iter()
+                    .any(|r| r.namespace == ns && r.id == id),
+                "deleted must contain {ns}/{id}"
+            );
+            assert!(
+                s.get(ns, id).await.unwrap().is_none(),
+                "{ns}/{id} must be removed from the store"
+            );
+        }
+    }
+}

--- a/crates/awaken-server/src/services/builtin_seed.rs
+++ b/crates/awaken-server/src/services/builtin_seed.rs
@@ -122,7 +122,7 @@ pub async fn apply_builtin_seed(
                             report.unchanged.push(RecordRef::new(namespace, id));
                         } else {
                             // Update: refresh spec and/or version; preserve
-                            // hidden flag and created_at.
+                            // hidden flag, user_overrides, and created_at.
                             let now = awaken_contract::time::now_ms();
                             let record = ConfigRecord {
                                 spec: new_spec_value,
@@ -131,6 +131,7 @@ pub async fn apply_builtin_seed(
                                         binary_version: seed.binary_version.clone(),
                                     },
                                     hidden: existing.meta.hidden,
+                                    user_overrides: existing.meta.user_overrides,
                                     created_at: existing.meta.created_at,
                                     updated_at: now,
                                 },
@@ -633,6 +634,55 @@ mod tests {
             s.get("providers", "prov-0256").await.unwrap().is_none(),
             "record past first page boundary must also be deleted"
         );
+    }
+
+    // ── test 11b ─────────────────────────────────────────────────────────────
+
+    /// user_overrides set on a Builtin record before a version upgrade must be
+    /// preserved after the upgrade, just like the `hidden` flag.
+    #[tokio::test]
+    async fn seed_upgrade_preserves_user_overrides() {
+        let s = store();
+
+        apply_builtin_seed(
+            &s,
+            &seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v1")))]),
+        )
+        .await
+        .unwrap();
+
+        // Set user_overrides on the stored record.
+        let raw = s.get("agents", "a1").await.unwrap().unwrap();
+        let mut rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        rec.meta.user_overrides = Some(serde_json::json!({"system_prompt": "user-custom"}));
+        s.put("agents", "a1", &rec.to_value().unwrap())
+            .await
+            .unwrap();
+
+        // Apply v2 with a new spec.
+        apply_builtin_seed(
+            &s,
+            &seed_v2(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v2")))]),
+        )
+        .await
+        .unwrap();
+
+        let raw = s.get("agents", "a1").await.unwrap().unwrap();
+        let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert_eq!(
+            rec.meta.source,
+            RecordSource::Builtin {
+                binary_version: "v2".to_owned()
+            },
+            "binary_version must be updated to v2"
+        );
+        assert_eq!(
+            rec.meta.user_overrides,
+            Some(serde_json::json!({"system_prompt": "user-custom"})),
+            "user_overrides must be preserved across version upgrade"
+        );
+        // Base spec in store reflects v2 defaults.
+        assert_eq!(rec.spec["system_prompt"], "v2");
     }
 
     // ── test 12 ──────────────────────────────────────────────────────────────

--- a/crates/awaken-server/src/services/builtin_seed.rs
+++ b/crates/awaken-server/src/services/builtin_seed.rs
@@ -597,7 +597,7 @@ mod tests {
     #[tokio::test]
     async fn orphan_cleanup_handles_more_than_one_page() {
         const RECORD_COUNT: usize = 300;
-        assert!(
+        const _: () = assert!(
             RECORD_COUNT > SEED_LIST_PAGE_SIZE,
             "test must exceed page size to exercise the multi-page path"
         );

--- a/crates/awaken-server/src/services/config_envelope.rs
+++ b/crates/awaken-server/src/services/config_envelope.rs
@@ -1,0 +1,316 @@
+//! Shared helpers for ConfigRecord envelope reading/writing.
+//!
+//! Both the ConfigService writer path and the ConfigRuntimeManager bootstrap
+//! path operate on the envelope; centralizing the helpers here prevents
+//! drift and lets future Phase 3 patch logic reuse the same primitives.
+
+use awaken_contract::{
+    AgentSpec, AgentSpecPatch, ConfigRecord, McpServerSpec, ModelBindingSpec, ProviderSpec,
+    RecordMeta, merge_agent_spec,
+};
+use serde_json::Value;
+
+// ── ApplyPatch trait ──────────────────────────────────────────────────────────
+
+/// Spec types that support field-level patch overrides at read time.
+///
+/// Phase 3 implements this for `AgentSpec` (with `AgentSpecPatch`).
+/// Other spec types use [`NoPatch`] which is a no-op.
+pub(crate) trait ApplyPatch: Sized {
+    type Patch: serde::de::DeserializeOwned;
+    fn apply(self, patch: Self::Patch) -> Self;
+}
+
+/// No-op patch type for spec types that don't yet support overrides.
+#[derive(Debug, Default, serde::Deserialize)]
+pub(crate) struct NoPatch;
+
+impl ApplyPatch for AgentSpec {
+    type Patch = AgentSpecPatch;
+    fn apply(self, patch: AgentSpecPatch) -> Self {
+        merge_agent_spec(self, patch)
+    }
+}
+
+impl ApplyPatch for ProviderSpec {
+    type Patch = NoPatch;
+    fn apply(self, _patch: NoPatch) -> Self {
+        self
+    }
+}
+
+impl ApplyPatch for ModelBindingSpec {
+    type Patch = NoPatch;
+    fn apply(self, _patch: NoPatch) -> Self {
+        self
+    }
+}
+
+impl ApplyPatch for McpServerSpec {
+    type Patch = NoPatch;
+    fn apply(self, _patch: NoPatch) -> Self {
+        self
+    }
+}
+
+/// If `overrides` is `Some(json)`, decode it as `T::Patch` and merge into
+/// `spec`. Returns `Err` only if decode fails (forward compat: unknown
+/// fields cause `deny_unknown_fields` rejection — surfaces as decode error).
+///
+/// `None` overrides → `spec` returned unchanged.
+pub(crate) fn apply_overrides<T>(spec: T, overrides: Option<&Value>) -> Result<T, serde_json::Error>
+where
+    T: ApplyPatch,
+{
+    let Some(overrides) = overrides else {
+        return Ok(spec);
+    };
+    let patch: T::Patch = serde_json::from_value(overrides.clone())?;
+    Ok(spec.apply(patch))
+}
+
+/// Pull `created_at` and `updated_at` from a bare-spec or envelope-shaped Value.
+/// Returns (0, 0) when the spec layer doesn't carry timestamps.
+pub(crate) fn extract_timestamps(spec: &Value) -> (u64, u64) {
+    let created = spec.get("created_at").and_then(Value::as_u64).unwrap_or(0);
+    let updated = spec.get("updated_at").and_then(Value::as_u64).unwrap_or(0);
+    (created, updated)
+}
+
+/// Wrap a bare spec Value into a User-source envelope, lifting timestamps
+/// from the spec body if present.
+///
+/// The spec's own `created_at`/`updated_at` are lifted into `RecordMeta` for
+/// provenance. This does **not** modify the spec itself — the spec timestamps
+/// remain authoritative for UI display.
+pub(crate) fn wrap_user(spec: &Value) -> Result<Value, serde_json::Error> {
+    let (created_at, updated_at) = extract_timestamps(spec);
+    let mut meta = RecordMeta::new_user();
+    if created_at != 0 {
+        meta.created_at = created_at;
+    }
+    if updated_at != 0 {
+        meta.updated_at = updated_at;
+    }
+    let record = ConfigRecord {
+        spec: spec.clone(),
+        meta,
+    };
+    record.to_value()
+}
+
+/// Wrap a bare spec Value into a Builtin-source envelope.
+// Not yet called from production code; reserved for Task 130 patch logic.
+#[allow(dead_code)]
+pub(crate) fn wrap_builtin(spec: &Value, binary_version: &str) -> Result<Value, serde_json::Error> {
+    let record = ConfigRecord {
+        spec: spec.clone(),
+        meta: RecordMeta::new_builtin(binary_version),
+    };
+    record.to_value()
+}
+
+/// If `value` is already an envelope (object containing `spec` and `meta`),
+/// return it unchanged. Otherwise wrap as User per `wrap_user`.
+///
+/// Used for rollback paths where the value being restored may have been
+/// written by an earlier writer (envelope) or an older binary (bare spec).
+pub(crate) fn ensure_envelope(value: Value) -> Result<Value, serde_json::Error> {
+    if value.is_object()
+        && value
+            .as_object()
+            .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+    {
+        Ok(value)
+    } else {
+        wrap_user(&value)
+    }
+}
+
+/// If `value` is an envelope, return its `spec` field; otherwise return
+/// `value` unchanged. Used by callers that internally operate on bare specs.
+///
+/// Used to ensure audit `before`/`after` payloads always contain bare specs.
+pub(crate) fn unwrap_spec(value: Value) -> Value {
+    if value
+        .as_object()
+        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+    {
+        value.get("spec").cloned().unwrap_or(value)
+    } else {
+        value
+    }
+}
+
+/// Look up a top-level field on a value that may be either a bare spec or an envelope.
+pub(crate) fn spec_field<'a>(value: &'a Value, field: &str) -> Option<&'a Value> {
+    if value
+        .as_object()
+        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+    {
+        value.get("spec").and_then(|s| s.get(field))
+    } else {
+        value.get(field)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use awaken_contract::{ConfigRecord, RecordSource};
+    use serde_json::json;
+
+    use super::{
+        ensure_envelope, extract_timestamps, spec_field, unwrap_spec, wrap_builtin, wrap_user,
+    };
+
+    #[test]
+    fn wrap_user_creates_envelope_with_user_source() {
+        let spec = json!({"name": "test-agent"});
+        let result = wrap_user(&spec).unwrap();
+        let record: ConfigRecord<serde_json::Value> = serde_json::from_value(result).unwrap();
+        assert_eq!(record.meta.source, RecordSource::User);
+        assert_ne!(record.meta.created_at, 0);
+    }
+
+    #[test]
+    fn wrap_user_lifts_timestamps_from_spec() {
+        let spec = json!({"name": "test-agent", "created_at": 100u64, "updated_at": 200u64});
+        let result = wrap_user(&spec).unwrap();
+        let record: ConfigRecord<serde_json::Value> = serde_json::from_value(result).unwrap();
+        assert_eq!(record.meta.created_at, 100);
+        assert_eq!(record.meta.updated_at, 200);
+    }
+
+    #[test]
+    fn wrap_user_uses_now_when_spec_lacks_timestamps() {
+        let spec = json!({"name": "test-agent"});
+        let result = wrap_user(&spec).unwrap();
+        let record: ConfigRecord<serde_json::Value> = serde_json::from_value(result).unwrap();
+        assert_ne!(record.meta.created_at, 0);
+        assert_ne!(record.meta.updated_at, 0);
+    }
+
+    #[test]
+    fn wrap_builtin_creates_envelope_with_binary_version() {
+        let spec = json!({"name": "builtin-model"});
+        let result = wrap_builtin(&spec, "v9.9.9").unwrap();
+        let record: ConfigRecord<serde_json::Value> = serde_json::from_value(result).unwrap();
+        match &record.meta.source {
+            RecordSource::Builtin { binary_version } => {
+                assert_eq!(binary_version, "v9.9.9");
+            }
+            other => panic!("expected Builtin source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ensure_envelope_passthrough_for_envelope() {
+        let spec = json!({"name": "test"});
+        let envelope = wrap_user(&spec).unwrap();
+        let result = ensure_envelope(envelope.clone()).unwrap();
+        assert_eq!(result, envelope);
+    }
+
+    #[test]
+    fn ensure_envelope_wraps_bare_spec() {
+        let spec = json!({"name": "test"});
+        let result = ensure_envelope(spec).unwrap();
+        assert!(result.get("spec").is_some());
+        assert!(result.get("meta").is_some());
+    }
+
+    #[test]
+    fn unwrap_spec_extracts_spec_layer() {
+        let spec = json!({"name": "test"});
+        let envelope = wrap_user(&spec).unwrap();
+        let result = unwrap_spec(envelope);
+        assert_eq!(result, spec);
+    }
+
+    #[test]
+    fn unwrap_spec_passthrough_for_bare() {
+        let spec = json!({"name": "test"});
+        let result = unwrap_spec(spec.clone());
+        assert_eq!(result, spec);
+    }
+
+    #[test]
+    fn spec_field_reads_envelope_spec() {
+        let spec = json!({"api_key": "x", "name": "test"});
+        let envelope = wrap_user(&spec).unwrap();
+        let result = spec_field(&envelope, "api_key");
+        assert_eq!(result, Some(&json!("x")));
+    }
+
+    #[test]
+    fn spec_field_reads_bare_spec() {
+        let spec = json!({"api_key": "x", "name": "test"});
+        let result = spec_field(&spec, "api_key");
+        assert_eq!(result, Some(&json!("x")));
+    }
+
+    #[test]
+    fn extract_timestamps_returns_zeros_for_missing() {
+        let spec = json!({"name": "test"});
+        assert_eq!(extract_timestamps(&spec), (0, 0));
+    }
+
+    // ── apply_overrides tests ─────────────────────────────────────────────────
+
+    use super::apply_overrides;
+    use awaken_contract::{AgentSpec, ProviderSpec};
+
+    fn minimal_agent_spec(id: &str) -> AgentSpec {
+        AgentSpec {
+            id: id.to_owned(),
+            model_id: "m".to_owned(),
+            system_prompt: "base-prompt".to_owned(),
+            max_rounds: 5,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_overrides_returns_spec_unchanged_when_overrides_none() {
+        let spec = minimal_agent_spec("a");
+        let result = apply_overrides(spec.clone(), None).unwrap();
+        assert_eq!(result.system_prompt, "base-prompt");
+        assert_eq!(result.max_rounds, 5);
+    }
+
+    #[test]
+    fn apply_overrides_merges_agent_spec_when_overrides_some() {
+        let spec = minimal_agent_spec("a");
+        let overrides = json!({"system_prompt": "patched"});
+        let result = apply_overrides(spec, Some(&overrides)).unwrap();
+        assert_eq!(result.system_prompt, "patched");
+        // Non-overridden field stays unchanged.
+        assert_eq!(result.max_rounds, 5);
+    }
+
+    #[test]
+    fn apply_overrides_for_provider_is_noop() {
+        let spec = ProviderSpec {
+            id: "p".to_owned(),
+            adapter: "openai".to_owned(),
+            ..Default::default()
+        };
+        // NoPatch deserializes an empty object; any non-empty JSON would fail
+        // if NoPatch had deny_unknown_fields, but it doesn't — it's a unit
+        // struct that ignores all fields.
+        let result = apply_overrides(spec.clone(), None).unwrap();
+        assert_eq!(result.id, "p");
+    }
+
+    #[test]
+    fn apply_overrides_propagates_decode_error_for_unknown_field() {
+        let spec = minimal_agent_spec("a");
+        // AgentSpecPatch has deny_unknown_fields, so this must fail.
+        let bad_overrides = json!({"unknown_field": 1});
+        let err = apply_overrides(spec, Some(&bad_overrides));
+        assert!(
+            err.is_err(),
+            "unknown field in overrides must produce a decode error"
+        );
+    }
+}

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -51,10 +51,6 @@ pub enum ConfigRuntimeError {
     #[error("runtime does not expose a configurable registry snapshot")]
     RuntimeNotConfigurable,
     #[error(
-        "config store is partially initialized; bootstrap requires all managed namespaces to be empty or all core namespaces populated"
-    )]
-    PartialBootstrap,
-    #[error(
         "unsupported provider adapter: {0} (valid names mirror genai::adapter::AdapterKind — see https://docs.rs/genai/latest/genai/adapter/enum.AdapterKind.html)"
     )]
     UnsupportedProviderAdapter(String),
@@ -68,13 +64,18 @@ pub enum ConfigRuntimeError {
     Storage(#[from] StorageError),
 }
 
+/// Holds A2A-discovered agent specs (those with `endpoint` or `registry`
+/// set). Built once from the runtime's pre-apply registry; subsequent
+/// `ConfigRuntimeManager::apply()` calls overlay these on top of the
+/// ConfigStore-derived registry. Pure code-defined regular agents flow
+/// only via ConfigStore (Phase 2 unification) and do NOT appear here.
 #[derive(Default)]
-struct RemoteAgentFallbackRegistry {
+struct DiscoveredAgentRegistry {
     exact: HashMap<String, AgentSpec>,
     plain: HashMap<String, AgentSpec>,
 }
 
-impl RemoteAgentFallbackRegistry {
+impl DiscoveredAgentRegistry {
     fn from_registry(registry: Arc<dyn AgentSpecRegistry>) -> Option<Arc<dyn AgentSpecRegistry>> {
         let mut exact = HashMap::new();
         let mut plain = HashMap::new();
@@ -98,7 +99,7 @@ impl RemoteAgentFallbackRegistry {
     }
 }
 
-impl AgentSpecRegistry for RemoteAgentFallbackRegistry {
+impl AgentSpecRegistry for DiscoveredAgentRegistry {
     fn get_agent(&self, id: &str) -> Option<AgentSpec> {
         self.exact
             .get(id)
@@ -142,7 +143,11 @@ macro_rules! overlay_registry {
     };
 }
 
-overlay_registry!(OverlayAgentRegistry, AgentSpecRegistry, get_agent -> Option<AgentSpec>, agent_ids);
+// AgentSpecRegistryWithDiscovery: ConfigStore-side agents (base) ⊕
+// runtime-discovered remote agents (overlay). Resolves a given id by
+// preferring base; falls through to discovery only if base does not
+// contain the id.
+overlay_registry!(AgentSpecRegistryWithDiscovery, AgentSpecRegistry, get_agent -> Option<AgentSpec>, agent_ids);
 overlay_registry!(OverlayToolRegistry, ToolRegistry, get_tool -> Option<Arc<dyn awaken_contract::contract::tool::Tool>>, tool_ids);
 
 #[derive(Clone)]
@@ -330,7 +335,10 @@ pub struct ConfigRuntimeManager {
     tools: Arc<dyn ToolRegistry>,
     plugins: Arc<dyn PluginSource>,
     backends: Arc<dyn BackendRegistry>,
-    remote_agents: Option<Arc<dyn AgentSpecRegistry>>,
+    /// Runtime A2A-discovery layer; merged on top of ConfigStore agents
+    /// at every `apply()`. None when no remote agents were registered
+    /// at builder time.
+    discovered_agents: Option<Arc<dyn AgentSpecRegistry>>,
     provider_factory: Arc<dyn ProviderExecutorFactory>,
     change_notifier: Option<Arc<dyn ConfigChangeNotifier>>,
     mcp_registry_factory: Arc<dyn McpRegistryFactory>,
@@ -350,6 +358,9 @@ pub struct ConfigRuntimeManager {
     /// into a single apply. Direct calls to [`Self::apply`] /
     /// [`Self::apply_if_changed`] are unaffected.
     min_apply_interval: Duration,
+    /// Optional audit logger — if set, `apply_seed` emits a `SeedApply` event
+    /// per non-empty bucket of the resulting [`SeedReport`].
+    audit_log: Option<Arc<crate::services::audit_log::AuditLogger>>,
 }
 
 impl ConfigRuntimeManager {
@@ -360,7 +371,7 @@ impl ConfigRuntimeManager {
         let registries = runtime
             .registry_set()
             .ok_or(ConfigRuntimeError::RuntimeNotConfigurable)?;
-        let remote_agents = RemoteAgentFallbackRegistry::from_registry(registries.agents.clone());
+        let discovered_agents = DiscoveredAgentRegistry::from_registry(registries.agents.clone());
 
         Ok(Self {
             runtime,
@@ -368,7 +379,7 @@ impl ConfigRuntimeManager {
             tools: registries.tools,
             plugins: registries.plugins,
             backends: registries.backends,
-            remote_agents,
+            discovered_agents,
             provider_factory: Arc::new(GenaiProviderExecutorFactory::default()),
             change_notifier: None,
             mcp_registry_factory: Arc::new(DefaultMcpRegistryFactory),
@@ -380,6 +391,7 @@ impl ConfigRuntimeManager {
             change_listener: Mutex::new(None),
             mcp_refresh_interval: RwLock::new(None),
             min_apply_interval: Duration::ZERO,
+            audit_log: None,
         })
     }
 
@@ -423,60 +435,39 @@ impl ConfigRuntimeManager {
         self
     }
 
-    pub async fn bootstrap_if_empty(
+    /// Attach an audit logger. When set, [`Self::apply_seed`] emits a
+    /// `SeedApply` audit event per non-empty bucket of the resulting report.
+    #[must_use]
+    pub fn with_audit_log(mut self, logger: Arc<crate::services::audit_log::AuditLogger>) -> Self {
+        self.audit_log = Some(logger);
+        self
+    }
+
+    /// Apply a built-in spec seed to the underlying ConfigStore.
+    ///
+    /// Idempotent and version-aware. See
+    /// [`apply_builtin_seed`](crate::services::builtin_seed::apply_builtin_seed)
+    /// for the full decision matrix and concurrency precondition.
+    ///
+    /// Holds the apply-lock; will block on a concurrent `apply()`/PUT/DELETE.
+    /// This ensures seed writes are serialized with runtime-registry publishes
+    /// so a concurrent HTTP write cannot race with the boot seed.
+    ///
+    /// Typical bootstrap sequence:
+    /// 1. `manager.apply_seed(&seed).await?` — write/refresh built-ins.
+    /// 2. `manager.apply().await?` — publish the resulting registry.
+    pub async fn apply_seed(
         &self,
-        providers: &[ProviderSpec],
-        models: &[ModelBindingSpec],
-        agents: &[AgentSpec],
-        mcp_servers: &[McpServerSpec],
-    ) -> Result<bool, ConfigRuntimeError> {
-        let has_providers = !self.store.list(NS_PROVIDERS, 0, 1).await?.is_empty();
-        let has_models = !self.store.list(NS_MODELS, 0, 1).await?.is_empty();
-        let has_agents = !self.store.list(NS_AGENTS, 0, 1).await?.is_empty();
-        let has_mcp_servers = !self.store.list(NS_MCP_SERVERS, 0, 1).await?.is_empty();
-
-        if has_providers || has_models || has_agents || has_mcp_servers {
-            if has_providers && has_models && has_agents {
-                return Ok(false);
-            }
-            return Err(ConfigRuntimeError::PartialBootstrap);
+        seed: &awaken_contract::BuiltinSeedSet,
+    ) -> Result<crate::services::builtin_seed::SeedReport, ConfigRuntimeError> {
+        let _guard = self.lock_apply().await;
+        let report = crate::services::builtin_seed::apply_builtin_seed(self.store.as_ref(), seed)
+            .await
+            .map_err(map_seed_error)?;
+        if let Some(audit) = &self.audit_log {
+            audit.emit_seed_report(&report).await;
         }
-
-        let bin_version = env!("CARGO_PKG_VERSION");
-        for provider in providers {
-            let json = serde_json::to_value(provider)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            let envelope = wrap_builtin(&json, bin_version)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store
-                .put(NS_PROVIDERS, &provider.id, &envelope)
-                .await?;
-        }
-        for model in models {
-            let json = serde_json::to_value(model)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            let envelope = wrap_builtin(&json, bin_version)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store.put(NS_MODELS, &model.id, &envelope).await?;
-        }
-        for agent in agents {
-            let json = serde_json::to_value(agent)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            let envelope = wrap_builtin(&json, bin_version)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store.put(NS_AGENTS, &agent.id, &envelope).await?;
-        }
-        for server in mcp_servers {
-            let json = serde_json::to_value(server)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            let envelope = wrap_builtin(&json, bin_version)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store
-                .put(NS_MCP_SERVERS, &server.id, &envelope)
-                .await?;
-        }
-
-        Ok(true)
+        Ok(report)
     }
 
     pub async fn apply(&self) -> Result<u64, ConfigRuntimeError> {
@@ -928,8 +919,8 @@ impl ConfigRuntimeManager {
         }
 
         let local_agents: Arc<dyn AgentSpecRegistry> = Arc::new(local_agents);
-        let agents = match &self.remote_agents {
-            Some(fallback) => Arc::new(OverlayAgentRegistry::new(
+        let agents = match &self.discovered_agents {
+            Some(fallback) => Arc::new(AgentSpecRegistryWithDiscovery::new(
                 local_agents,
                 Arc::clone(fallback),
             )) as Arc<dyn AgentSpecRegistry>,
@@ -1366,32 +1357,14 @@ fn canonicalize_value(value: &Value) -> Value {
     }
 }
 
-fn extract_timestamps_from_spec(spec: &Value) -> (u64, u64) {
-    let created = spec.get("created_at").and_then(Value::as_u64).unwrap_or(0);
-    let updated = spec.get("updated_at").and_then(Value::as_u64).unwrap_or(0);
-    (created, updated)
-}
-
-/// Wrap a bare spec `Value` in a `ConfigRecord` envelope with
-/// `RecordSource::Builtin { binary_version }`.
-///
-/// The spec's own `created_at`/`updated_at` are lifted into `RecordMeta` for
-/// provenance. The spec itself is not modified.
-fn wrap_builtin(spec: &Value, binary_version: &str) -> Result<Value, serde_json::Error> {
-    use awaken_contract::{ConfigRecord, RecordMeta};
-    let (created_at, updated_at) = extract_timestamps_from_spec(spec);
-    let mut meta = RecordMeta::new_builtin(binary_version);
-    if created_at != 0 {
-        meta.created_at = created_at;
+fn map_seed_error(error: crate::services::builtin_seed::SeedError) -> ConfigRuntimeError {
+    use crate::services::builtin_seed::SeedError;
+    match error {
+        SeedError::Storage(e) => ConfigRuntimeError::Storage(e),
+        SeedError::Serde(e) => {
+            ConfigRuntimeError::Storage(StorageError::Serialization(e.to_string()))
+        }
     }
-    if updated_at != 0 {
-        meta.updated_at = updated_at;
-    }
-    let record = ConfigRecord {
-        spec: spec.clone(),
-        meta,
-    };
-    record.to_value()
 }
 
 #[cfg(test)]
@@ -2036,16 +2009,119 @@ mod tests {
         );
     }
 
+    /// Replaces the former `bootstrap_if_empty` test.  Asserts that
+    /// `apply_seed` stores each spec as a ConfigRecord envelope whose
+    /// `meta.source` is `RecordSource::Builtin { binary_version }`.
     #[tokio::test]
-    async fn bootstrap_writes_builtin_envelope() {
+    async fn apply_seed_writes_builtin_envelope() {
+        use awaken_contract::{
+            BuiltinSeedSet, BuiltinSpec, ConfigRecord, ModelBindingSpec, ProviderSpec, RecordSource,
+        };
+
+        let bin_version = "test-env-ver".to_owned();
+        let (manager, store) = make_manager_with_store().await;
+
+        let seed = BuiltinSeedSet {
+            binary_version: bin_version.clone(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "p1".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "m1".into(),
+                    provider_id: "p1".into(),
+                    upstream_model: "m1-model".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "a1".into(),
+                    model_id: "m1".into(),
+                    system_prompt: "seed test".into(),
+                    max_rounds: 1,
+                    ..Default::default()
+                })),
+            ],
+        };
+
+        let report = manager.apply_seed(&seed).await.expect("apply_seed");
+        assert_eq!(report.created.len(), 3, "all three specs must be created");
+
+        // Verify provider envelope and Builtin source.
+        let raw_p = awaken_contract::contract::config_store::ConfigStore::get(
+            store.as_ref(),
+            "providers",
+            "p1",
+        )
+        .await
+        .expect("get provider")
+        .expect("provider present");
+
+        let p_obj = raw_p.as_object().expect("must be object");
+        assert!(p_obj.contains_key("spec"), "provider must have 'spec' key");
+        assert!(p_obj.contains_key("meta"), "provider must have 'meta' key");
+        let p_rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw_p).unwrap();
+        assert_eq!(
+            p_rec.meta.source,
+            RecordSource::Builtin {
+                binary_version: bin_version.clone()
+            },
+            "provider source must be Builtin with correct binary_version"
+        );
+
+        // Verify agent envelope.
+        let raw_a = awaken_contract::contract::config_store::ConfigStore::get(
+            store.as_ref(),
+            "agents",
+            "a1",
+        )
+        .await
+        .expect("get agent")
+        .expect("agent present");
+        let a_rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw_a).unwrap();
+        assert_eq!(
+            a_rec.meta.source,
+            RecordSource::Builtin {
+                binary_version: bin_version.clone()
+            },
+            "agent source must be Builtin"
+        );
+
+        // Verify model envelope.
+        let raw_m = awaken_contract::contract::config_store::ConfigStore::get(
+            store.as_ref(),
+            "models",
+            "m1",
+        )
+        .await
+        .expect("get model")
+        .expect("model present");
+        let m_rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw_m).unwrap();
+        assert_eq!(
+            m_rec.meta.source,
+            RecordSource::Builtin {
+                binary_version: bin_version
+            },
+            "model source must be Builtin"
+        );
+    }
+
+    // ── apply_seed tests ─────────────────────────────────────────────────────
+
+    /// Build a minimal ConfigRuntimeManager backed by an InMemoryStore.
+    /// Mirrors the pattern used by `bootstrap_writes_builtin_envelope`.
+    async fn make_manager_with_store() -> (
+        ConfigRuntimeManager,
+        Arc<dyn awaken_contract::contract::config_store::ConfigStore>,
+    ) {
         use awaken_contract::contract::executor::{
             InferenceExecutionError, InferenceRequest, LlmExecutor,
         };
         use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
         use awaken_stores::InMemoryStore;
-        use std::sync::Arc;
 
-        // Minimal executor for test runtime.
         struct Stub;
         #[async_trait::async_trait]
         impl LlmExecutor for Stub {
@@ -2066,24 +2142,8 @@ mod tests {
             }
         }
 
-        struct StubFactory;
-        impl ProviderExecutorFactory for StubFactory {
-            fn build(
-                &self,
-                spec: &ProviderSpec,
-            ) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
-                if spec.adapter.eq_ignore_ascii_case("stub") {
-                    return Ok(Arc::new(Stub));
-                }
-                Err(ConfigRuntimeError::UnsupportedProviderAdapter(
-                    spec.adapter.clone(),
-                ))
-            }
-        }
-
         let store = Arc::new(InMemoryStore::new())
             as Arc<dyn awaken_contract::contract::config_store::ConfigStore>;
-
         let thread_store = Arc::new(InMemoryStore::new());
         let runtime = Arc::new(
             awaken_runtime::builder::AgentRuntimeBuilder::new()
@@ -2106,89 +2166,159 @@ mod tests {
                 .build()
                 .expect("build runtime"),
         );
+        let manager = ConfigRuntimeManager::new(runtime, store.clone()).expect("manager");
+        (manager, store)
+    }
 
-        let manager = ConfigRuntimeManager::new(runtime, store.clone())
-            .expect("manager")
-            .with_provider_factory(Arc::new(StubFactory));
+    #[tokio::test]
+    async fn apply_seed_writes_builtin_records_to_store() {
+        use awaken_contract::{
+            BuiltinSeedSet, BuiltinSpec, ConfigRecord, ModelBindingSpec, ProviderSpec, RecordSource,
+        };
 
-        let bootstrapped = manager
-            .bootstrap_if_empty(
-                &[ProviderSpec {
-                    id: "p1".into(),
-                    adapter: "stub".into(),
-                    ..Default::default()
-                }],
-                &[ModelBindingSpec {
-                    id: "m1".into(),
-                    provider_id: "p1".into(),
-                    upstream_model: "m1-model".into(),
-                    created_at: None,
-                    updated_at: None,
-                }],
-                &[AgentSpec {
-                    id: "a1".into(),
-                    model_id: "m1".into(),
-                    system_prompt: "bootstrap test".into(),
+        let (manager, store) = make_manager_with_store().await;
+
+        let seed = BuiltinSeedSet {
+            binary_version: "v1-test".to_owned(),
+            specs: vec![
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "seed-agent".into(),
+                    model_id: "m".into(),
+                    system_prompt: "hello".into(),
                     max_rounds: 1,
                     ..Default::default()
-                }],
-                &[],
-            )
-            .await
-            .expect("bootstrap");
-        assert!(bootstrapped, "bootstrap must return true on empty store");
+                })),
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "seed-provider".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "seed-model".into(),
+                    provider_id: "seed-provider".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+            ],
+        };
 
-        // Check provider stored as envelope with builtin source
-        let raw_p = awaken_contract::contract::config_store::ConfigStore::get(
-            store.as_ref(),
-            "providers",
-            "p1",
-        )
-        .await
-        .expect("get provider")
-        .expect("provider present");
+        let report = manager.apply_seed(&seed).await.expect("apply_seed");
+        assert_eq!(report.created.len(), 3, "expected 3 created");
+        assert!(report.updated.is_empty());
+        assert!(report.unchanged.is_empty());
 
-        let p_obj = raw_p.as_object().expect("must be object");
-        assert!(p_obj.contains_key("spec"), "provider must have 'spec' key");
-        assert!(p_obj.contains_key("meta"), "provider must have 'meta' key");
-        assert_eq!(
-            raw_p["meta"]["source"]["kind"].as_str(),
-            Some("builtin"),
-            "provider source.kind must be 'builtin'"
-        );
-        let bin_ver = raw_p["meta"]["source"]["binary_version"]
-            .as_str()
-            .expect("binary_version must be present");
-        assert_eq!(bin_ver, env!("CARGO_PKG_VERSION"));
-
-        // Check agent
-        let raw_a = awaken_contract::contract::config_store::ConfigStore::get(
+        // Verify agent record stored with Builtin source and correct version.
+        let raw = awaken_contract::contract::config_store::ConfigStore::get(
             store.as_ref(),
             "agents",
-            "a1",
+            "seed-agent",
         )
         .await
         .expect("get agent")
-        .expect("agent present");
+        .expect("agent must be present");
+
+        let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
         assert_eq!(
-            raw_a["meta"]["source"]["kind"].as_str(),
-            Some("builtin"),
-            "agent source.kind must be 'builtin'"
+            rec.meta.source,
+            RecordSource::Builtin {
+                binary_version: "v1-test".to_owned()
+            },
+            "source must be Builtin with seed binary_version"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_seed_idempotent() {
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec};
+
+        let (manager, _store) = make_manager_with_store().await;
+
+        let seed = BuiltinSeedSet {
+            binary_version: "v1-idem".to_owned(),
+            specs: vec![
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "idem-agent".into(),
+                    model_id: "m".into(),
+                    system_prompt: "hello".into(),
+                    max_rounds: 1,
+                    ..Default::default()
+                })),
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "idem-provider".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "idem-model".into(),
+                    provider_id: "idem-provider".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+            ],
+        };
+
+        manager.apply_seed(&seed).await.expect("first apply_seed");
+        let report = manager.apply_seed(&seed).await.expect("second apply_seed");
+
+        assert_eq!(
+            report.unchanged.len(),
+            3,
+            "second call must report 3 unchanged"
+        );
+        assert!(report.created.is_empty());
+        assert!(report.updated.is_empty());
+    }
+
+    /// Verify that `apply_seed` holds `lock_apply` for its duration, so a
+    /// concurrent `apply()` blocks until the seed write completes.
+    ///
+    /// Strategy: acquire the lock manually, spawn `apply_seed` in a task, then
+    /// release the lock and confirm the task finishes cleanly.  This asserts
+    /// the lock is actually contended (the task cannot proceed while we hold it).
+    #[tokio::test]
+    async fn apply_seed_serializes_with_apply_lock() {
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec, ProviderSpec};
+        use std::sync::Arc;
+
+        let (manager, _store) = make_manager_with_store().await;
+        let manager = Arc::new(manager);
+
+        // Hold the apply-lock ourselves to block apply_seed.
+        let guard = manager.lock_apply().await;
+
+        let manager2 = Arc::clone(&manager);
+        let seed = BuiltinSeedSet {
+            binary_version: "lock-test".to_owned(),
+            specs: vec![BuiltinSpec::Provider(ProviderSpec {
+                id: "lock-prov".into(),
+                adapter: "openai".into(),
+                ..Default::default()
+            })],
+        };
+
+        let handle = tokio::spawn(async move {
+            manager2
+                .apply_seed(&seed)
+                .await
+                .expect("apply_seed in task")
+        });
+
+        // Give the spawned task a moment to reach lock acquisition and block.
+        tokio::task::yield_now().await;
+        assert!(
+            !handle.is_finished(),
+            "apply_seed must block while apply-lock is held"
         );
 
-        // Check model
-        let raw_m = awaken_contract::contract::config_store::ConfigStore::get(
-            store.as_ref(),
-            "models",
-            "m1",
-        )
-        .await
-        .expect("get model")
-        .expect("model present");
+        // Release the lock; the task should now be able to complete.
+        drop(guard);
+        let report = handle.await.expect("task must not panic");
         assert_eq!(
-            raw_m["meta"]["source"]["kind"].as_str(),
-            Some("builtin"),
-            "model source.kind must be 'builtin'"
+            report.created.len(),
+            1,
+            "seed record must be created after lock release"
         );
     }
 }

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -9,7 +9,7 @@ use awaken_contract::contract::config_store::{ConfigChangeNotifier, ConfigStore}
 use awaken_contract::contract::executor::LlmExecutor;
 use awaken_contract::contract::storage::StorageError;
 use awaken_contract::{
-    AgentSpec, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelBindingSpec,
+    AgentSpec, ConfigRecord, McpRestartPolicy, McpServerSpec, McpTransportKind, ModelBindingSpec,
     PeriodicRefresher, ProviderSpec,
 };
 use awaken_ext_mcp::{
@@ -442,25 +442,38 @@ impl ConfigRuntimeManager {
             return Err(ConfigRuntimeError::PartialBootstrap);
         }
 
+        let bin_version = env!("CARGO_PKG_VERSION");
         for provider in providers {
             let json = serde_json::to_value(provider)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store.put(NS_PROVIDERS, &provider.id, &json).await?;
+            let envelope = wrap_builtin(&json, bin_version)
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store
+                .put(NS_PROVIDERS, &provider.id, &envelope)
+                .await?;
         }
         for model in models {
             let json = serde_json::to_value(model)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store.put(NS_MODELS, &model.id, &json).await?;
+            let envelope = wrap_builtin(&json, bin_version)
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store.put(NS_MODELS, &model.id, &envelope).await?;
         }
         for agent in agents {
             let json = serde_json::to_value(agent)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store.put(NS_AGENTS, &agent.id, &json).await?;
+            let envelope = wrap_builtin(&json, bin_version)
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store.put(NS_AGENTS, &agent.id, &envelope).await?;
         }
         for server in mcp_servers {
             let json = serde_json::to_value(server)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store.put(NS_MCP_SERVERS, &server.id, &json).await?;
+            let envelope = wrap_builtin(&json, bin_version)
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store
+                .put(NS_MCP_SERVERS, &server.id, &envelope)
+                .await?;
         }
 
         Ok(true)
@@ -1299,14 +1312,17 @@ fn deserialize_namespace<T>(entries: &[(String, Value)]) -> Result<Vec<T>, Confi
 where
     T: serde::de::DeserializeOwned,
 {
-    entries
-        .iter()
-        .map(|(_, value)| {
-            serde_json::from_value(value.clone())
-                .map_err(|error| StorageError::Serialization(error.to_string()))
-                .map_err(ConfigRuntimeError::Storage)
-        })
-        .collect()
+    let mut out = Vec::with_capacity(entries.len());
+    for (_, value) in entries {
+        let record: ConfigRecord<T> = ConfigRecord::from_value(value.clone())
+            .map_err(|error| StorageError::Serialization(error.to_string()))
+            .map_err(ConfigRuntimeError::Storage)?;
+        if record.meta.hidden {
+            continue;
+        }
+        out.push(record.spec);
+    }
+    Ok(out)
 }
 
 fn fingerprint_config(
@@ -1348,6 +1364,34 @@ fn canonicalize_value(value: &Value) -> Value {
         }
         _ => value.clone(),
     }
+}
+
+fn extract_timestamps_from_spec(spec: &Value) -> (u64, u64) {
+    let created = spec.get("created_at").and_then(Value::as_u64).unwrap_or(0);
+    let updated = spec.get("updated_at").and_then(Value::as_u64).unwrap_or(0);
+    (created, updated)
+}
+
+/// Wrap a bare spec `Value` in a `ConfigRecord` envelope with
+/// `RecordSource::Builtin { binary_version }`.
+///
+/// The spec's own `created_at`/`updated_at` are lifted into `RecordMeta` for
+/// provenance. The spec itself is not modified.
+fn wrap_builtin(spec: &Value, binary_version: &str) -> Result<Value, serde_json::Error> {
+    use awaken_contract::{ConfigRecord, RecordMeta};
+    let (created_at, updated_at) = extract_timestamps_from_spec(spec);
+    let mut meta = RecordMeta::new_builtin(binary_version);
+    if created_at != 0 {
+        meta.created_at = created_at;
+    }
+    if updated_at != 0 {
+        meta.updated_at = updated_at;
+    }
+    let record = ConfigRecord {
+        spec: spec.clone(),
+        meta,
+    };
+    record.to_value()
 }
 
 #[cfg(test)]
@@ -1879,6 +1923,272 @@ mod tests {
         assert!(
             matches!(err, ConfigRuntimeError::UnsupportedProviderAdapter(ref s) if s == "not-a-real-adapter"),
             "expected UnsupportedProviderAdapter, got: {err:?}"
+        );
+    }
+
+    fn minimal_agent_spec(id: &str) -> AgentSpec {
+        AgentSpec {
+            id: id.into(),
+            model_id: "test-model".into(),
+            system_prompt: "test prompt".into(),
+            max_rounds: 1,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn deserialize_namespace_decodes_legacy_bare_spec() {
+        let spec = minimal_agent_spec("agent-a");
+        let value = serde_json::to_value(&spec).expect("serialization must succeed");
+        let entries = vec![("agent-a".to_string(), value)];
+        let result: Vec<AgentSpec> =
+            deserialize_namespace(&entries).expect("legacy bare spec must decode");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "agent-a");
+    }
+
+    #[test]
+    fn deserialize_namespace_decodes_envelope() {
+        use awaken_contract::ConfigRecord;
+        let spec = minimal_agent_spec("agent-b");
+        let record = ConfigRecord {
+            spec,
+            meta: awaken_contract::RecordMeta::new_user(),
+        };
+        let value = record
+            .to_value()
+            .expect("envelope serialization must succeed");
+        let entries = vec![("agent-b".to_string(), value)];
+        let result: Vec<AgentSpec> = deserialize_namespace(&entries).expect("envelope must decode");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "agent-b");
+    }
+
+    #[test]
+    fn deserialize_namespace_skips_hidden_envelope() {
+        use awaken_contract::{ConfigRecord, RecordMeta};
+        let visible = minimal_agent_spec("visible");
+        let hidden = minimal_agent_spec("hidden");
+
+        let mut hidden_meta = RecordMeta::new_user();
+        hidden_meta.hidden = true;
+
+        let visible_record = ConfigRecord {
+            spec: visible,
+            meta: RecordMeta::new_user(),
+        };
+        let hidden_record = ConfigRecord {
+            spec: hidden,
+            meta: hidden_meta,
+        };
+
+        let entries = vec![
+            (
+                "visible".to_string(),
+                visible_record.to_value().expect("serialize visible"),
+            ),
+            (
+                "hidden".to_string(),
+                hidden_record.to_value().expect("serialize hidden"),
+            ),
+        ];
+        let result: Vec<AgentSpec> = deserialize_namespace(&entries).expect("decode must succeed");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "visible");
+    }
+
+    #[test]
+    fn deserialize_namespace_mixes_legacy_and_envelope() {
+        use awaken_contract::ConfigRecord;
+        let bare_spec = minimal_agent_spec("bare");
+        let envelope_spec = minimal_agent_spec("envelope");
+
+        let bare_value = serde_json::to_value(&bare_spec).expect("serialize bare");
+        let envelope_record = ConfigRecord {
+            spec: envelope_spec,
+            meta: awaken_contract::RecordMeta::new_user(),
+        };
+        let envelope_value = envelope_record.to_value().expect("serialize envelope");
+
+        let entries = vec![
+            ("bare".to_string(), bare_value),
+            ("envelope".to_string(), envelope_value),
+        ];
+        let result: Vec<AgentSpec> =
+            deserialize_namespace(&entries).expect("mixed decode must succeed");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].id, "bare");
+        assert_eq!(result[1].id, "envelope");
+    }
+
+    #[test]
+    fn deserialize_namespace_propagates_decode_error() {
+        let bad_value = json!({"completely": "wrong"});
+        let entries = vec![("bad".to_string(), bad_value)];
+        let err = deserialize_namespace::<AgentSpec>(&entries)
+            .expect_err("invalid spec must produce an error");
+        assert!(
+            matches!(
+                err,
+                ConfigRuntimeError::Storage(StorageError::Serialization(_))
+            ),
+            "expected Storage(Serialization(_)), got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_writes_builtin_envelope() {
+        use awaken_contract::contract::executor::{
+            InferenceExecutionError, InferenceRequest, LlmExecutor,
+        };
+        use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+        use awaken_stores::InMemoryStore;
+        use std::sync::Arc;
+
+        // Minimal executor for test runtime.
+        struct Stub;
+        #[async_trait::async_trait]
+        impl LlmExecutor for Stub {
+            async fn execute(
+                &self,
+                _: InferenceRequest,
+            ) -> Result<StreamResult, InferenceExecutionError> {
+                Ok(StreamResult {
+                    content: vec![],
+                    tool_calls: vec![],
+                    usage: Some(TokenUsage::default()),
+                    stop_reason: Some(StopReason::EndTurn),
+                    has_incomplete_tool_calls: false,
+                })
+            }
+            fn name(&self) -> &str {
+                "stub"
+            }
+        }
+
+        struct StubFactory;
+        impl ProviderExecutorFactory for StubFactory {
+            fn build(
+                &self,
+                spec: &ProviderSpec,
+            ) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
+                if spec.adapter.eq_ignore_ascii_case("stub") {
+                    return Ok(Arc::new(Stub));
+                }
+                Err(ConfigRuntimeError::UnsupportedProviderAdapter(
+                    spec.adapter.clone(),
+                ))
+            }
+        }
+
+        let store = Arc::new(InMemoryStore::new())
+            as Arc<dyn awaken_contract::contract::config_store::ConfigStore>;
+
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(
+            awaken_runtime::builder::AgentRuntimeBuilder::new()
+                .with_provider("boot", Arc::new(Stub))
+                .with_model_binding(
+                    "boot",
+                    awaken_runtime::registry::traits::ModelBinding {
+                        provider_id: "boot".into(),
+                        upstream_model: "boot-model".into(),
+                    },
+                )
+                .with_agent_spec(AgentSpec {
+                    id: "boot".into(),
+                    model_id: "boot".into(),
+                    system_prompt: "boot".into(),
+                    max_rounds: 1,
+                    ..Default::default()
+                })
+                .with_thread_run_store(thread_store)
+                .build()
+                .expect("build runtime"),
+        );
+
+        let manager = ConfigRuntimeManager::new(runtime, store.clone())
+            .expect("manager")
+            .with_provider_factory(Arc::new(StubFactory));
+
+        let bootstrapped = manager
+            .bootstrap_if_empty(
+                &[ProviderSpec {
+                    id: "p1".into(),
+                    adapter: "stub".into(),
+                    ..Default::default()
+                }],
+                &[ModelBindingSpec {
+                    id: "m1".into(),
+                    provider_id: "p1".into(),
+                    upstream_model: "m1-model".into(),
+                    created_at: None,
+                    updated_at: None,
+                }],
+                &[AgentSpec {
+                    id: "a1".into(),
+                    model_id: "m1".into(),
+                    system_prompt: "bootstrap test".into(),
+                    max_rounds: 1,
+                    ..Default::default()
+                }],
+                &[],
+            )
+            .await
+            .expect("bootstrap");
+        assert!(bootstrapped, "bootstrap must return true on empty store");
+
+        // Check provider stored as envelope with builtin source
+        let raw_p = awaken_contract::contract::config_store::ConfigStore::get(
+            store.as_ref(),
+            "providers",
+            "p1",
+        )
+        .await
+        .expect("get provider")
+        .expect("provider present");
+
+        let p_obj = raw_p.as_object().expect("must be object");
+        assert!(p_obj.contains_key("spec"), "provider must have 'spec' key");
+        assert!(p_obj.contains_key("meta"), "provider must have 'meta' key");
+        assert_eq!(
+            raw_p["meta"]["source"]["kind"].as_str(),
+            Some("builtin"),
+            "provider source.kind must be 'builtin'"
+        );
+        let bin_ver = raw_p["meta"]["source"]["binary_version"]
+            .as_str()
+            .expect("binary_version must be present");
+        assert_eq!(bin_ver, env!("CARGO_PKG_VERSION"));
+
+        // Check agent
+        let raw_a = awaken_contract::contract::config_store::ConfigStore::get(
+            store.as_ref(),
+            "agents",
+            "a1",
+        )
+        .await
+        .expect("get agent")
+        .expect("agent present");
+        assert_eq!(
+            raw_a["meta"]["source"]["kind"].as_str(),
+            Some("builtin"),
+            "agent source.kind must be 'builtin'"
+        );
+
+        // Check model
+        let raw_m = awaken_contract::contract::config_store::ConfigStore::get(
+            store.as_ref(),
+            "models",
+            "m1",
+        )
+        .await
+        .expect("get model")
+        .expect("model present");
+        assert_eq!(
+            raw_m["meta"]["source"]["kind"].as_str(),
+            Some("builtin"),
+            "model source.kind must be 'builtin'"
         );
     }
 }

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -1301,7 +1301,7 @@ fn restart_policy_to_connection_policy(policy: &McpRestartPolicy) -> mcp::transp
 
 fn deserialize_namespace<T>(entries: &[(String, Value)]) -> Result<Vec<T>, ConfigRuntimeError>
 where
-    T: serde::de::DeserializeOwned,
+    T: serde::de::DeserializeOwned + crate::services::config_envelope::ApplyPatch,
 {
     let mut out = Vec::with_capacity(entries.len());
     for (_, value) in entries {
@@ -1311,7 +1311,13 @@ where
         if record.meta.hidden {
             continue;
         }
-        out.push(record.spec);
+        let effective = crate::services::config_envelope::apply_overrides(
+            record.spec,
+            record.meta.user_overrides.as_ref(),
+        )
+        .map_err(|error| StorageError::Serialization(error.to_string()))
+        .map_err(ConfigRuntimeError::Storage)?;
+        out.push(effective);
     }
     Ok(out)
 }
@@ -2319,6 +2325,480 @@ mod tests {
             report.created.len(),
             1,
             "seed record must be created after lock release"
+        );
+    }
+
+    /// ConfigStore (base) wins over discovered (overlay) for the same agent id;
+    /// discovery-only ids that are never seeded still resolve via the overlay.
+    #[tokio::test]
+    async fn discovered_agent_overlays_seeded_agent_with_same_id() {
+        use awaken_contract::registry_spec::RemoteEndpoint;
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
+
+        // Build the runtime with a pre-registered agent "shared" that has an
+        // endpoint (so DiscoveredAgentRegistry picks it up) and a distinct
+        // remote-only agent "remote-only" also with an endpoint.
+        struct Stub;
+        #[async_trait::async_trait]
+        impl awaken_contract::contract::executor::LlmExecutor for Stub {
+            async fn execute(
+                &self,
+                _: awaken_contract::contract::executor::InferenceRequest,
+            ) -> Result<
+                awaken_contract::contract::inference::StreamResult,
+                awaken_contract::contract::executor::InferenceExecutionError,
+            > {
+                Ok(awaken_contract::contract::inference::StreamResult {
+                    content: vec![],
+                    tool_calls: vec![],
+                    usage: Some(awaken_contract::contract::inference::TokenUsage::default()),
+                    stop_reason: Some(awaken_contract::contract::inference::StopReason::EndTurn),
+                    has_incomplete_tool_calls: false,
+                })
+            }
+            fn name(&self) -> &str {
+                "stub"
+            }
+        }
+
+        let store = Arc::new(awaken_stores::InMemoryStore::new())
+            as Arc<dyn awaken_contract::contract::config_store::ConfigStore>;
+        let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
+
+        // Register a "shared" agent with an endpoint (will be captured as discovered)
+        // and a "remote-only" agent with an endpoint.
+        let shared_discovered = AgentSpec {
+            id: "shared".into(),
+            model_id: "boot".into(),
+            system_prompt: "discovered-prompt".into(),
+            max_rounds: 1,
+            endpoint: Some(RemoteEndpoint {
+                base_url: "http://remote-shared/".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let remote_only = AgentSpec {
+            id: "remote-only".into(),
+            model_id: "boot".into(),
+            system_prompt: "remote-only-prompt".into(),
+            max_rounds: 1,
+            endpoint: Some(RemoteEndpoint {
+                base_url: "http://remote-only/".into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let runtime = Arc::new(
+            awaken_runtime::builder::AgentRuntimeBuilder::new()
+                .with_provider("boot", Arc::new(Stub))
+                .with_model_binding(
+                    "boot",
+                    awaken_runtime::registry::traits::ModelBinding {
+                        provider_id: "boot".into(),
+                        upstream_model: "boot-model".into(),
+                    },
+                )
+                .with_agent_spec(shared_discovered)
+                .with_agent_spec(remote_only)
+                .with_thread_run_store(thread_store)
+                .build()
+                .expect("build runtime"),
+        );
+
+        // Use a stub provider factory so provider executor construction always succeeds.
+        struct StubFactory;
+        impl ProviderExecutorFactory for StubFactory {
+            fn build(
+                &self,
+                _spec: &ProviderSpec,
+            ) -> Result<Arc<dyn awaken_contract::contract::executor::LlmExecutor>, ConfigRuntimeError>
+            {
+                Ok(Arc::new(Stub))
+            }
+        }
+
+        let manager = ConfigRuntimeManager::new(runtime.clone(), store.clone())
+            .expect("manager")
+            .with_provider_factory(Arc::new(StubFactory));
+
+        // Seed a provider + model + "shared" agent — NO endpoint on the agent,
+        // so it lives in ConfigStore only (plain Builtin, not discovered).
+        let seed = BuiltinSeedSet {
+            binary_version: "overlay-test".to_owned(),
+            specs: vec![
+                BuiltinSpec::Provider(awaken_contract::ProviderSpec {
+                    id: "boot-prov".into(),
+                    adapter: "stub".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(awaken_contract::ModelBindingSpec {
+                    id: "boot-model".into(),
+                    provider_id: "boot-prov".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "shared".into(),
+                    model_id: "boot-model".into(),
+                    system_prompt: "seeded-prompt".into(),
+                    max_rounds: 5,
+                    endpoint: None,
+                    ..Default::default()
+                })),
+            ],
+        };
+        manager.apply_seed(&seed).await.expect("apply_seed");
+        manager.apply().await.expect("apply");
+
+        // After apply, the active registry is installed in the runtime.
+        let snapshot = runtime.registry_snapshot().expect("registry snapshot");
+        let registry = &snapshot.registries().agents;
+
+        // "shared" → seeded (base) wins over discovered (overlay).
+        let shared_spec = registry.get_agent("shared").expect("shared must resolve");
+        let shared_json = serde_json::to_value(&shared_spec).expect("serialize");
+        assert_eq!(
+            shared_json["system_prompt"], "seeded-prompt",
+            "base (seeded) wins: system_prompt must be 'seeded-prompt', got {shared_json}"
+        );
+        assert_eq!(
+            shared_json["max_rounds"], 5,
+            "base (seeded) wins: max_rounds must be 5"
+        );
+
+        // "remote-only" → only in discovered layer; must still resolve.
+        let remote_spec = registry
+            .get_agent("remote-only")
+            .expect("remote-only must resolve via overlay");
+        let remote_json = serde_json::to_value(&remote_spec).expect("serialize");
+        assert_eq!(
+            remote_json["system_prompt"], "remote-only-prompt",
+            "discovery-only agent resolves via overlay"
+        );
+        assert_eq!(
+            remote_json["endpoint"]["base_url"], "http://remote-only/",
+            "endpoint base_url must be preserved"
+        );
+    }
+
+    // ── apply_overrides integration tests ────────────────────────────────────
+
+    /// Helper: build a minimal Builtin envelope for an AgentSpec with optional
+    /// user_overrides stored on the meta.
+    fn builtin_agent_record(
+        spec: &AgentSpec,
+        binary_version: &str,
+        user_overrides: Option<serde_json::Value>,
+    ) -> serde_json::Value {
+        use awaken_contract::{ConfigRecord, RecordMeta};
+        let mut meta = RecordMeta::new_builtin(binary_version);
+        meta.user_overrides = user_overrides;
+        let record = ConfigRecord {
+            spec: spec.clone(),
+            meta,
+        };
+        record.to_value().expect("envelope serialize must succeed")
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_merges_at_read() {
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
+
+        let (manager, store) = make_manager_with_store().await;
+
+        // Seed provider + model + agent so apply() can build a working registry.
+        let seed = BuiltinSeedSet {
+            binary_version: "v1".to_owned(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "p".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "m".into(),
+                    provider_id: "p".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "x".into(),
+                    model_id: "m".into(),
+                    system_prompt: "base-prompt".into(),
+                    max_rounds: 5,
+                    ..Default::default()
+                })),
+            ],
+        };
+        manager.apply_seed(&seed).await.expect("apply_seed");
+
+        // Overwrite the agent record directly in the store with user_overrides.
+        let base_spec = AgentSpec {
+            id: "x".into(),
+            model_id: "m".into(),
+            system_prompt: "base-prompt".into(),
+            max_rounds: 5,
+            ..Default::default()
+        };
+        let envelope =
+            builtin_agent_record(&base_spec, "v1", Some(json!({"system_prompt": "patched"})));
+        store
+            .put("agents", "x", &envelope)
+            .await
+            .expect("put must succeed");
+
+        manager.apply().await.expect("apply must succeed");
+
+        let snapshot = manager
+            .runtime
+            .registry_snapshot()
+            .expect("registry snapshot");
+        let spec = snapshot
+            .registries()
+            .agents
+            .get_agent("x")
+            .expect("agent x must resolve");
+        assert_eq!(
+            spec.system_prompt, "patched",
+            "user_overrides must be applied at read time"
+        );
+        // Non-overridden field stays as base.
+        assert_eq!(spec.max_rounds, 5);
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_no_user_overrides_uses_base() {
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
+
+        let (manager, store) = make_manager_with_store().await;
+
+        let seed = BuiltinSeedSet {
+            binary_version: "v1".to_owned(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "p".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "m".into(),
+                    provider_id: "p".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "y".into(),
+                    model_id: "m".into(),
+                    system_prompt: "base-prompt".into(),
+                    max_rounds: 3,
+                    ..Default::default()
+                })),
+            ],
+        };
+        manager.apply_seed(&seed).await.expect("apply_seed");
+
+        // Ensure the record has no overrides (seed already writes None).
+        let raw = store.get("agents", "y").await.unwrap().unwrap();
+        let rec: awaken_contract::ConfigRecord<serde_json::Value> =
+            awaken_contract::ConfigRecord::from_value(raw).unwrap();
+        assert!(rec.meta.user_overrides.is_none());
+
+        manager.apply().await.expect("apply must succeed");
+
+        let snapshot = manager
+            .runtime
+            .registry_snapshot()
+            .expect("registry snapshot");
+        let spec = snapshot
+            .registries()
+            .agents
+            .get_agent("y")
+            .expect("agent y must resolve");
+        assert_eq!(spec.system_prompt, "base-prompt");
+        assert_eq!(spec.max_rounds, 3);
+    }
+
+    #[tokio::test]
+    async fn apply_overrides_on_user_record_applies_overrides() {
+        // At read time, user_overrides is applied regardless of source.
+        // The semantic guard (only Builtin records should have overrides set)
+        // is enforced at the write path (Task 131), not at read time.
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
+        use awaken_contract::{ConfigRecord, RecordMeta};
+
+        let (manager, store) = make_manager_with_store().await;
+
+        // Seed supporting records but NOT the agent "z".
+        let seed = BuiltinSeedSet {
+            binary_version: "v1".to_owned(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "p".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "m".into(),
+                    provider_id: "p".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+            ],
+        };
+        manager.apply_seed(&seed).await.expect("apply_seed");
+
+        // Write a User-source record with user_overrides set (unusual in
+        // production but must work defensively at read time).
+        let user_spec = AgentSpec {
+            id: "z".into(),
+            model_id: "m".into(),
+            system_prompt: "user-base".into(),
+            max_rounds: 2,
+            ..Default::default()
+        };
+        let mut meta = RecordMeta::new_user();
+        meta.user_overrides = Some(json!({"system_prompt": "user-override"}));
+        let record = ConfigRecord {
+            spec: user_spec,
+            meta,
+        };
+        store
+            .put("agents", "z", &record.to_value().unwrap())
+            .await
+            .expect("put must succeed");
+
+        manager.apply().await.expect("apply must succeed");
+
+        let snapshot = manager
+            .runtime
+            .registry_snapshot()
+            .expect("registry snapshot");
+        let spec = snapshot
+            .registries()
+            .agents
+            .get_agent("z")
+            .expect("agent z must resolve");
+        // Overrides are applied even for User-source records at read time.
+        assert_eq!(
+            spec.system_prompt, "user-override",
+            "user_overrides applied at read time regardless of source (write-path enforcement is Task 131)"
+        );
+    }
+
+    #[tokio::test]
+    async fn version_upgrade_preserves_user_overrides() {
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
+
+        let (manager, store) = make_manager_with_store().await;
+
+        // Apply seed v1 with agent A.
+        let seed_v1 = BuiltinSeedSet {
+            binary_version: "v1".to_owned(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "p".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "m".into(),
+                    provider_id: "p".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "a".into(),
+                    model_id: "m".into(),
+                    system_prompt: "v1-prompt".into(),
+                    max_rounds: 5,
+                    ..Default::default()
+                })),
+            ],
+        };
+        manager.apply_seed(&seed_v1).await.expect("apply_seed v1");
+
+        // Manually set user_overrides on the stored record.
+        let raw = store.get("agents", "a").await.unwrap().unwrap();
+        let mut rec: awaken_contract::ConfigRecord<serde_json::Value> =
+            awaken_contract::ConfigRecord::from_value(raw).unwrap();
+        rec.meta.user_overrides = Some(json!({"system_prompt": "user-prompt"}));
+        store
+            .put("agents", "a", &rec.to_value().unwrap())
+            .await
+            .expect("put with overrides");
+
+        // Apply seed v2 with different defaults (new system_prompt + max_rounds).
+        let seed_v2 = BuiltinSeedSet {
+            binary_version: "v2".to_owned(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "p".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "m".into(),
+                    provider_id: "p".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "a".into(),
+                    model_id: "m".into(),
+                    system_prompt: "v2-prompt".into(),
+                    max_rounds: 10,
+                    ..Default::default()
+                })),
+            ],
+        };
+        manager.apply_seed(&seed_v2).await.expect("apply_seed v2");
+
+        // Assert store record: binary_version = v2, user_overrides preserved.
+        let raw = store.get("agents", "a").await.unwrap().unwrap();
+        let stored: awaken_contract::ConfigRecord<serde_json::Value> =
+            awaken_contract::ConfigRecord::from_value(raw).unwrap();
+        assert_eq!(
+            stored.meta.source,
+            awaken_contract::RecordSource::Builtin {
+                binary_version: "v2".to_owned()
+            },
+            "binary_version must be updated to v2"
+        );
+        assert_eq!(
+            stored.meta.user_overrides,
+            Some(json!({"system_prompt": "user-prompt"})),
+            "user_overrides must be preserved across version upgrade"
+        );
+        // Base spec in store uses v2 values.
+        assert_eq!(stored.spec["system_prompt"], "v2-prompt");
+        assert_eq!(stored.spec["max_rounds"], 10);
+
+        // Apply and resolve — effective spec should merge overrides onto v2 base.
+        manager.apply().await.expect("apply must succeed");
+        let snapshot = manager
+            .runtime
+            .registry_snapshot()
+            .expect("registry snapshot");
+        let spec = snapshot
+            .registries()
+            .agents
+            .get_agent("a")
+            .expect("agent a must resolve");
+        assert_eq!(
+            spec.system_prompt, "user-prompt",
+            "user override for system_prompt must be preserved after version upgrade"
+        );
+        assert_eq!(
+            spec.max_rounds, 10,
+            "max_rounds must use v2 base (not overridden)"
         );
     }
 }

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -4,7 +4,9 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use awaken_contract::AuditAction;
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::StorageError;
-use awaken_contract::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
+use awaken_contract::{
+    AgentSpec, ConfigRecord, McpServerSpec, ModelBindingSpec, ProviderSpec, RecordMeta,
+};
 use axum::http::HeaderMap;
 use serde_json::{Map, Value, json};
 
@@ -22,6 +24,24 @@ pub enum ConfigNamespace {
 }
 
 impl ConfigNamespace {
+    /// All four managed namespaces in a fixed order.
+    pub const ALL: [Self; 4] = [
+        Self::Agents,
+        Self::Providers,
+        Self::Models,
+        Self::McpServers,
+    ];
+
+    /// Slice over all four namespace variants.
+    pub fn all() -> &'static [Self] {
+        &Self::ALL
+    }
+
+    /// Iterator over the `&'static str` names of all four namespaces.
+    pub fn iter_str() -> impl Iterator<Item = &'static str> + 'static {
+        Self::ALL.iter().copied().map(Self::as_str)
+    }
+
     pub fn parse(value: &str) -> Result<Self, ConfigServiceError> {
         match value {
             "agents" => Ok(Self::Agents),
@@ -241,7 +261,7 @@ impl<'a> ConfigService<'a> {
         let values = self.store.list(namespace.as_str(), offset, limit).await?;
         values
             .into_iter()
-            .map(|(_, value)| self.redact_response(namespace, value))
+            .map(|(_, value)| self.redact_response(namespace, unwrap_spec(value)))
             .collect()
     }
 
@@ -252,7 +272,7 @@ impl<'a> ConfigService<'a> {
     ) -> Result<Option<Value>, ConfigServiceError> {
         let value = self.store.get(namespace.as_str(), id).await?;
         value
-            .map(|value| self.redact_response(namespace, value))
+            .map(|value| self.redact_response(namespace, unwrap_spec(value)))
             .transpose()
     }
 
@@ -347,7 +367,7 @@ impl<'a> ConfigService<'a> {
             AuditAction::Update,
             namespace,
             id,
-            previous,
+            previous.map(unwrap_spec),
             Some(body),
             headers,
         )
@@ -387,7 +407,9 @@ impl<'a> ConfigService<'a> {
             .map(|_| ())
             .map_err(map_runtime_error);
         if let Err(error) = apply_result {
-            self.store.put(namespace.as_str(), id, &previous).await?;
+            let env = ensure_envelope(previous)
+                .map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store.put(namespace.as_str(), id, &env).await?;
             return Err(error);
         }
 
@@ -395,7 +417,7 @@ impl<'a> ConfigService<'a> {
             AuditAction::Delete,
             namespace,
             id,
-            Some(previous),
+            Some(unwrap_spec(previous)),
             None,
             headers,
         )
@@ -534,7 +556,7 @@ impl<'a> ConfigService<'a> {
             audit
                 .emit_restore(
                     &resource,
-                    before,
+                    before.map(unwrap_spec),
                     Some(payload),
                     version.to_string(),
                     headers,
@@ -561,8 +583,7 @@ impl<'a> ConfigService<'a> {
                 let refs = models
                     .into_iter()
                     .filter(|(_, value)| {
-                        value
-                            .get("provider_id")
+                        spec_field(&value, "provider_id")
                             .and_then(Value::as_str)
                             .is_some_and(|pid| pid == id)
                     })
@@ -578,8 +599,7 @@ impl<'a> ConfigService<'a> {
                 let refs = agents
                     .into_iter()
                     .filter(|(_, value)| {
-                        value
-                            .get("model_id")
+                        spec_field(&value, "model_id")
                             .and_then(Value::as_str)
                             .is_some_and(|mid| mid == id)
                     })
@@ -630,7 +650,8 @@ impl<'a> ConfigService<'a> {
         body: Value,
     ) -> Result<Value, ConfigServiceError> {
         self.validate_payload(namespace, &body)?;
-        self.store.put(namespace.as_str(), id, &body).await?;
+        let envelope = wrap_user(&body).map_err(|e| StorageError::Serialization(e.to_string()))?;
+        self.store.put(namespace.as_str(), id, &envelope).await?;
 
         let apply_result = manager
             .apply_locked()
@@ -639,7 +660,11 @@ impl<'a> ConfigService<'a> {
             .map_err(map_runtime_error);
         if let Err(error) = apply_result {
             match previous {
-                Some(previous) => self.store.put(namespace.as_str(), id, &previous).await?,
+                Some(previous) => {
+                    let env = ensure_envelope(previous)
+                        .map_err(|e| StorageError::Serialization(e.to_string()))?;
+                    self.store.put(namespace.as_str(), id, &env).await?;
+                }
                 None => self.store.delete(namespace.as_str(), id).await?,
             }
             return Err(error);
@@ -697,9 +722,20 @@ impl<'a> ConfigService<'a> {
             object.insert("updated_at".into(), Value::Number(now.into()));
         } else {
             // Update: preserve existing created_at if present; always refresh updated_at.
+            // The stored value may be either a bare spec or a ConfigRecord envelope
+            // ({"spec": {...}, "meta": {...}}); extract created_at from whichever layer
+            // holds it.
             if !object.contains_key("created_at") {
                 if let Ok(Some(existing)) = self.store.get(namespace.as_str(), &id).await {
-                    if let Some(existing_created_at) = existing
+                    let spec_layer = if existing
+                        .as_object()
+                        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+                    {
+                        existing.get("spec").cloned().unwrap_or(existing)
+                    } else {
+                        existing
+                    };
+                    if let Some(existing_created_at) = spec_layer
                         .as_object()
                         .and_then(|obj| obj.get("created_at"))
                         .cloned()
@@ -744,7 +780,17 @@ impl<'a> ConfigService<'a> {
         else {
             return Ok(());
         };
-        let Some(existing_object) = existing.as_object() else {
+        // The stored value may be either a bare spec or a ConfigRecord envelope.
+        // Navigate into spec if needed before accessing fields.
+        let spec_value = if existing
+            .as_object()
+            .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+        {
+            existing.get("spec").cloned().unwrap_or(existing)
+        } else {
+            existing
+        };
+        let Some(existing_object) = spec_value.as_object() else {
             return Ok(());
         };
         if let Some(existing_key) = existing_object.get("api_key") {
@@ -899,8 +945,9 @@ impl<'a> ConfigService<'a> {
             .await?
             .ok_or_else(|| ConfigServiceError::NotFound(format!("providers/{id}")))?;
 
-        let spec: ProviderSpec = serde_json::from_value(raw)
-            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let spec: ProviderSpec = ConfigRecord::<ProviderSpec>::from_value(raw)
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))
+            .map(|r| r.spec)?;
 
         // Construction probe: catches adapter parsing, material parsing,
         // header validation, and any other build-time check. Reuses the
@@ -982,7 +1029,16 @@ impl<'a> ConfigService<'a> {
         else {
             return Ok(());
         };
-        let Some(existing_object) = existing.as_object() else {
+        // The stored value may be either a bare spec or a ConfigRecord envelope.
+        let spec_value = if existing
+            .as_object()
+            .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+        {
+            existing.get("spec").cloned().unwrap_or(existing)
+        } else {
+            existing
+        };
+        let Some(existing_object) = spec_value.as_object() else {
             return Ok(());
         };
         if let Some(existing_env) = existing_object.get("env") {
@@ -1035,6 +1091,78 @@ where
 {
     serde_json::from_value(value.clone())
         .map_err(|error| ConfigServiceError::InvalidPayload(error.to_string()))
+}
+
+/// Extract the spec from a stored value, unwrapping a ConfigRecord envelope
+/// if present.  Returns the value unchanged for legacy bare-spec entries.
+///
+/// Used to ensure audit `before`/`after` payloads always contain bare specs.
+fn unwrap_spec(value: Value) -> Value {
+    if value
+        .as_object()
+        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+    {
+        value.get("spec").cloned().unwrap_or(value)
+    } else {
+        value
+    }
+}
+
+/// Get a field from a stored value, transparently handling both bare spec
+/// and `ConfigRecord` envelope forms.
+fn spec_field<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
+    if value
+        .as_object()
+        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+    {
+        value.get("spec").and_then(|s| s.get(key))
+    } else {
+        value.get(key)
+    }
+}
+
+fn extract_timestamps(spec: &Value) -> (u64, u64) {
+    let created = spec.get("created_at").and_then(Value::as_u64).unwrap_or(0);
+    let updated = spec.get("updated_at").and_then(Value::as_u64).unwrap_or(0);
+    (created, updated)
+}
+
+/// Wrap a bare spec `Value` in a `ConfigRecord` envelope with `RecordSource::User`.
+///
+/// The spec's own `created_at`/`updated_at` are lifted into `RecordMeta` for
+/// provenance. This does **not** modify the spec itself — the spec timestamps
+/// remain authoritative for UI display.
+fn wrap_user(spec: &Value) -> Result<Value, serde_json::Error> {
+    let (created_at, updated_at) = extract_timestamps(spec);
+    let mut meta = RecordMeta::new_user();
+    if created_at != 0 {
+        meta.created_at = created_at;
+    }
+    if updated_at != 0 {
+        meta.updated_at = updated_at;
+    }
+    let record = ConfigRecord {
+        spec: spec.clone(),
+        meta,
+    };
+    record.to_value()
+}
+
+/// If `value` is already a `ConfigRecord` envelope (has both `"spec"` and
+/// `"meta"` keys), return it as-is.  Otherwise wrap it via `wrap_user`.
+///
+/// Used for rollback paths where the value being restored may have been
+/// written by an earlier writer (envelope) or an older binary (bare spec).
+fn ensure_envelope(value: Value) -> Result<Value, serde_json::Error> {
+    if value.is_object()
+        && value
+            .as_object()
+            .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
+    {
+        Ok(value)
+    } else {
+        wrap_user(&value)
+    }
 }
 
 #[cfg(test)]
@@ -1341,10 +1469,15 @@ mod tests {
         let stored = ConfigStore::get(config_store.as_ref(), "providers", "serialized")
             .await
             .expect("read provider after create");
+        // The stored value is now a ConfigRecord envelope; extract id from spec layer.
         assert_eq!(
             stored
                 .as_ref()
-                .and_then(|value| value.get("id"))
+                .and_then(|value| {
+                    // Prefer spec layer for envelope, fall back to bare spec.
+                    value.get("spec").or(Some(value))
+                })
+                .and_then(|spec| spec.get("id"))
                 .and_then(Value::as_str),
             Some("serialized")
         );
@@ -1572,6 +1705,58 @@ mod tests {
             .expect("force delete should succeed");
     }
 
+    // ── ConfigNamespace::all() / iter_str() tests ─────────────────────────
+
+    #[test]
+    fn namespace_all_lists_every_variant() {
+        let all = ConfigNamespace::all();
+        assert_eq!(all.len(), 4, "exactly four namespaces");
+
+        // Each variant must appear exactly once.
+        let has = |v: ConfigNamespace| all.iter().filter(|&&x| x == v).count();
+        assert_eq!(has(ConfigNamespace::Agents), 1);
+        assert_eq!(has(ConfigNamespace::Providers), 1);
+        assert_eq!(has(ConfigNamespace::Models), 1);
+        assert_eq!(has(ConfigNamespace::McpServers), 1);
+    }
+
+    #[test]
+    fn namespace_all_matches_builtin_spec_namespace() {
+        use awaken_contract::{BuiltinSpec, McpServerSpec};
+
+        for &ns in ConfigNamespace::all() {
+            let spec = match ns {
+                ConfigNamespace::Agents => BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "x".into(),
+                    model_id: "m".into(),
+                    system_prompt: "s".into(),
+                    ..Default::default()
+                })),
+                ConfigNamespace::Providers => BuiltinSpec::Provider(ProviderSpec {
+                    id: "x".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                ConfigNamespace::Models => BuiltinSpec::Model(ModelBindingSpec {
+                    id: "x".into(),
+                    provider_id: "p".into(),
+                    upstream_model: "m".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                ConfigNamespace::McpServers => BuiltinSpec::McpServer(McpServerSpec {
+                    id: "x".into(),
+                    ..Default::default()
+                }),
+            };
+            assert_eq!(
+                spec.namespace(),
+                ns.as_str(),
+                "BuiltinSpec::namespace() drifted from ConfigNamespace::as_str() for {ns:?}"
+            );
+        }
+    }
+
     // ── audit integration tests ────────────────────────────────────────────
 
     mod audit_integration {
@@ -1726,5 +1911,191 @@ mod tests {
             .unwrap();
             assert!(audit_entries.is_empty());
         }
+    }
+
+    // ── ConfigRecord envelope tests ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn put_emits_envelope_with_user_meta() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("service");
+
+        service
+            .create(
+                ConfigNamespace::Agents,
+                json!({
+                    "id": "env-agent",
+                    "model_id": "bootstrap",
+                    "system_prompt": "test",
+                    "max_rounds": 1
+                }),
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect("create agent");
+
+        let raw = awaken_contract::contract::config_store::ConfigStore::get(
+            config_store.as_ref(),
+            "agents",
+            "env-agent",
+        )
+        .await
+        .expect("store read")
+        .expect("entry present");
+
+        let obj = raw.as_object().expect("must be JSON object");
+        assert!(
+            obj.contains_key("spec"),
+            "stored value must have 'spec' key"
+        );
+        assert!(
+            obj.contains_key("meta"),
+            "stored value must have 'meta' key"
+        );
+
+        let meta = &raw["meta"];
+        assert_eq!(
+            meta["source"]["kind"].as_str(),
+            Some("user"),
+            "source.kind must be 'user'"
+        );
+        assert_ne!(
+            meta["created_at"].as_u64(),
+            Some(0),
+            "created_at must be non-zero"
+        );
+    }
+
+    #[tokio::test]
+    async fn put_existing_envelope_preserves_created_at() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("service");
+
+        service
+            .create(
+                ConfigNamespace::Agents,
+                json!({
+                    "id": "ts-agent",
+                    "model_id": "bootstrap",
+                    "system_prompt": "v1",
+                    "max_rounds": 1
+                }),
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect("create agent");
+
+        // Read back created_at from envelope
+        let first = awaken_contract::contract::config_store::ConfigStore::get(
+            config_store.as_ref(),
+            "agents",
+            "ts-agent",
+        )
+        .await
+        .expect("read")
+        .expect("present");
+        let created_at_1 = first["meta"]["created_at"].as_u64().expect("created_at");
+
+        // Sleep briefly so updated_at will differ
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        service
+            .update(
+                ConfigNamespace::Agents,
+                "ts-agent",
+                json!({
+                    "id": "ts-agent",
+                    "model_id": "bootstrap",
+                    "system_prompt": "v2",
+                    "max_rounds": 1
+                }),
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect("update agent");
+
+        let second = awaken_contract::contract::config_store::ConfigStore::get(
+            config_store.as_ref(),
+            "agents",
+            "ts-agent",
+        )
+        .await
+        .expect("read")
+        .expect("present");
+
+        let created_at_2 = second["meta"]["created_at"]
+            .as_u64()
+            .expect("created_at after update");
+        let updated_at_2 = second["meta"]["updated_at"]
+            .as_u64()
+            .expect("updated_at after update");
+
+        assert_eq!(
+            created_at_1, created_at_2,
+            "created_at must be preserved across updates"
+        );
+        assert!(
+            updated_at_2 >= created_at_2,
+            "updated_at must be >= created_at after update"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires force-apply-failure hook not yet available in test harness"]
+    async fn delete_rollback_re_emits_envelope() {
+        // This test requires a way to configure the runtime manager to fail
+        // apply() after delete so we can observe the rollback path writing an
+        // envelope. The current test harness has no such hook. When that
+        // infrastructure is added, verify that the rolled-back store entry has
+        // both "spec" and "meta" keys.
+        panic!("test infrastructure for force-apply-failure not yet available")
+    }
+
+    #[tokio::test]
+    async fn audit_payload_is_bare_spec_not_envelope() {
+        use crate::services::audit_log::{AuditLogger, AuditQuery};
+
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+        let state = state.with_audit_log(audit_logger.clone());
+
+        let service = ConfigService::new(&state).expect("service");
+        service
+            .create(
+                ConfigNamespace::Agents,
+                json!({
+                    "id": "audit-env-agent",
+                    "model_id": "bootstrap",
+                    "system_prompt": "audit test",
+                    "max_rounds": 1
+                }),
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect("create");
+
+        let page = audit_logger
+            .query(AuditQuery::default())
+            .await
+            .expect("query");
+        assert_eq!(page.items.len(), 1);
+
+        let after = page.items[0].after.as_ref().expect("after must be present");
+        let after_obj = after.as_object().expect("after must be JSON object");
+        assert!(
+            !after_obj.contains_key("meta"),
+            "audit 'after' must not contain 'meta' key (must be bare spec)"
+        );
+        assert!(
+            !after_obj.contains_key("spec"),
+            "audit 'after' must not contain 'spec' wrapper key (must be bare spec)"
+        );
+        assert!(
+            after_obj.contains_key("id"),
+            "audit 'after' must contain spec field 'id'"
+        );
     }
 }

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -5,13 +5,17 @@ use awaken_contract::AuditAction;
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::StorageError;
 use awaken_contract::{
-    AgentSpec, ConfigRecord, McpServerSpec, ModelBindingSpec, ProviderSpec, RecordMeta,
+    AgentSpec, AgentSpecPatch, ConfigRecord, McpServerSpec, ModelBindingSpec, ProviderSpec,
+    RecordSource, now_ms,
 };
 use axum::http::HeaderMap;
 use serde_json::{Map, Value, json};
 
 use crate::app::AppState;
 use crate::services::audit_log::AuditLogger;
+use crate::services::config_envelope::{
+    apply_overrides, ensure_envelope, spec_field, unwrap_spec, wrap_user,
+};
 
 use super::config_runtime::ConfigRuntimeError;
 
@@ -100,6 +104,8 @@ pub enum ConfigServiceError {
     Apply(String),
     #[error("blocked: {used_by:?} record(s) depend on this resource")]
     Blocked { used_by: Vec<DependentRef> },
+    #[error("overrides are not supported for user-source records; use PUT to update")]
+    OverridesNotSupportedForUserRecord,
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
 }
@@ -261,7 +267,7 @@ impl<'a> ConfigService<'a> {
         let values = self.store.list(namespace.as_str(), offset, limit).await?;
         values
             .into_iter()
-            .map(|(_, value)| self.redact_response(namespace, unwrap_spec(value)))
+            .map(|(_, value)| self.redact_response(namespace, effective_spec(namespace, value)?))
             .collect()
     }
 
@@ -272,8 +278,47 @@ impl<'a> ConfigService<'a> {
     ) -> Result<Option<Value>, ConfigServiceError> {
         let value = self.store.get(namespace.as_str(), id).await?;
         value
-            .map(|value| self.redact_response(namespace, unwrap_spec(value)))
+            .map(|value| self.redact_response(namespace, effective_spec(namespace, value)?))
             .transpose()
+    }
+
+    /// Return just the `RecordMeta` for a stored entry. Returns `None` when
+    /// the record does not exist.  Does not apply redaction (meta contains no
+    /// secrets) and does not apply overrides (meta is the raw provenance).
+    pub async fn get_meta(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+    ) -> Result<Option<awaken_contract::RecordMeta>, ConfigServiceError> {
+        let value = self.store.get(namespace.as_str(), id).await?;
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        // For non-Agent namespaces the envelope may not have been written yet
+        // (legacy bare-spec). ConfigRecord::from_value handles both shapes.
+        let meta = awaken_contract::ConfigRecord::<Value>::from_value(value)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?
+            .meta;
+        Ok(Some(meta))
+    }
+
+    /// Return `RecordMeta` for every record in the namespace. Pairs are
+    /// `(id, RecordMeta)`.
+    pub async fn list_meta(
+        &self,
+        namespace: ConfigNamespace,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, awaken_contract::RecordMeta)>, ConfigServiceError> {
+        let values = self.store.list(namespace.as_str(), offset, limit).await?;
+        let mut out = Vec::with_capacity(values.len());
+        for (id, value) in values {
+            let meta = awaken_contract::ConfigRecord::<Value>::from_value(value)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?
+                .meta;
+            out.push((id, meta));
+        }
+        Ok(out)
     }
 
     /// Dry-run validation. Runs the same `prepare_body` + `validate_payload`
@@ -457,9 +502,11 @@ impl<'a> ConfigService<'a> {
             .map_err(RestoreError::Storage)?
             .ok_or(RestoreError::VersionNotFound)?;
 
-        // Verify cross-resource guard.
+        // Verify cross-resource guard. Override events for this same record carry
+        // a `/overrides[/{field}]` suffix; treat them as in-scope.
         let expected_resource = format!("{}/{}", namespace.as_str(), id);
-        if event.resource != expected_resource {
+        let expected_prefix = format!("{expected_resource}/");
+        if event.resource != expected_resource && !event.resource.starts_with(&expected_prefix) {
             return Err(RestoreError::ResourceMismatch {
                 event_resource: event.resource.clone(),
                 expected: expected_resource,
@@ -626,8 +673,29 @@ impl<'a> ConfigService<'a> {
         after: Option<Value>,
         headers: &HeaderMap,
     ) {
-        let Some(audit) = &self.audit else { return };
-        let resource = format!("{}/{}", namespace.as_str(), id);
+        self.emit_audit_with_suffix(action, namespace, id, "", before, after, headers)
+            .await;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn emit_audit_with_suffix(
+        &self,
+        action: AuditAction,
+        namespace: ConfigNamespace,
+        id: &str,
+        suffix: &str,
+        before: Option<Value>,
+        after: Option<Value>,
+        headers: &HeaderMap,
+    ) {
+        let Some(audit) = &self.audit else {
+            return;
+        };
+        let resource = if suffix.is_empty() {
+            format!("{}/{}", namespace.as_str(), id)
+        } else {
+            format!("{}/{}/{}", namespace.as_str(), id, suffix)
+        };
         audit.emit(action, &resource, before, after, headers).await;
     }
 
@@ -1025,6 +1093,342 @@ impl<'a> ConfigService<'a> {
         }
         Ok(())
     }
+
+    /// PATCH /v1/config/agents/:id/overrides
+    ///
+    /// Merges the patch body into the existing `user_overrides` of a Builtin
+    /// agent record. Null-valued keys in the patch remove overrides; non-null
+    /// keys overwrite. Returns the effective AgentSpec after the merge.
+    pub async fn patch_agent_overrides(
+        &self,
+        id: &str,
+        body: Value,
+        headers: &HeaderMap,
+    ) -> Result<Value, ConfigServiceError> {
+        let manager = self.runtime_manager()?;
+        let _apply_guard = manager.lock_apply().await;
+
+        let raw = self
+            .store
+            .get(ConfigNamespace::Agents.as_str(), id)
+            .await?
+            .ok_or_else(|| ConfigServiceError::NotFound(format!("agents/{id}")))?;
+
+        let mut record = ConfigRecord::<AgentSpec>::from_value(raw.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        if matches!(record.meta.source, RecordSource::User) {
+            return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
+        }
+
+        // Validate incoming body field names via AgentSpecPatch (deny_unknown_fields).
+        // We use a separate check for null values: replace nulls with a dummy value
+        // so that deny_unknown_fields can still catch unknown field names.
+        let body_map = match &body {
+            Value::Object(m) => m,
+            _ => {
+                return Err(ConfigServiceError::InvalidPayload(
+                    "expected JSON object body".into(),
+                ));
+            }
+        };
+        // Null values for Option fields are valid (they mean "clear this override").
+        // Pass the body as-is; deny_unknown_fields catches unknown field names.
+        let _: AgentSpecPatch = serde_json::from_value(body.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        // Merge patch INTO existing user_overrides (shallow key-level merge).
+        // Use the raw body Value to preserve nulls (null = clear the key).
+        let mut existing_map: Map<String, Value> = record
+            .meta
+            .user_overrides
+            .as_ref()
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+
+        for (k, v) in body_map {
+            if v.is_null() {
+                existing_map.remove(k);
+            } else {
+                existing_map.insert(k.clone(), v.clone());
+            }
+        }
+
+        // Validate the merged overrides by round-tripping through AgentSpecPatch.
+        let merged_value = Value::Object(existing_map.clone());
+        let _: AgentSpecPatch = serde_json::from_value(merged_value.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        let proposed_overrides: Option<Value> = if existing_map.is_empty() {
+            None
+        } else {
+            Some(merged_value.clone())
+        };
+
+        // Short-circuit: if the proposed overrides are identical to existing ones,
+        // skip the store write, apply_locked, and audit emit — it's a no-op.
+        if proposed_overrides == record.meta.user_overrides {
+            let effective_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            return serde_json::to_value(&effective_spec)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()));
+        }
+
+        let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let before = serde_json::to_value(&before_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        record.meta.user_overrides = proposed_overrides;
+        record.meta.updated_at = now_ms();
+
+        let envelope = record
+            .to_value()
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+        self.store
+            .put(ConfigNamespace::Agents.as_str(), id, &envelope)
+            .await?;
+
+        let apply_result = manager
+            .apply_locked()
+            .await
+            .map(|_| ())
+            .map_err(map_runtime_error);
+        if let Err(error) = apply_result {
+            // Roll back to the original envelope.
+            let rollback =
+                ensure_envelope(raw).map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store
+                .put(ConfigNamespace::Agents.as_str(), id, &rollback)
+                .await?;
+            return Err(error);
+        }
+
+        let after_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let after = serde_json::to_value(&after_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        self.emit_audit_with_suffix(
+            AuditAction::Update,
+            ConfigNamespace::Agents,
+            id,
+            "overrides",
+            Some(before),
+            Some(after.clone()),
+            headers,
+        )
+        .await;
+
+        Ok(after)
+    }
+
+    /// DELETE /v1/config/agents/:id/overrides
+    ///
+    /// Clears all user overrides from a Builtin agent record. Returns the
+    /// effective AgentSpec (which is now the bare base spec, no overrides).
+    pub async fn clear_agent_overrides(
+        &self,
+        id: &str,
+        headers: &HeaderMap,
+    ) -> Result<Value, ConfigServiceError> {
+        let manager = self.runtime_manager()?;
+        let _apply_guard = manager.lock_apply().await;
+
+        let raw = self
+            .store
+            .get(ConfigNamespace::Agents.as_str(), id)
+            .await?
+            .ok_or_else(|| ConfigServiceError::NotFound(format!("agents/{id}")))?;
+
+        let mut record = ConfigRecord::<AgentSpec>::from_value(raw.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        if matches!(record.meta.source, RecordSource::User) {
+            return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
+        }
+
+        // Short-circuit: if overrides are already None, this is a no-op — skip
+        // the store write, apply_locked, and audit emit.
+        if record.meta.user_overrides.is_none() {
+            return serde_json::to_value(&record.spec)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()));
+        }
+
+        let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let before = serde_json::to_value(&before_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        record.meta.user_overrides = None;
+        record.meta.updated_at = now_ms();
+
+        let envelope = record
+            .to_value()
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+        self.store
+            .put(ConfigNamespace::Agents.as_str(), id, &envelope)
+            .await?;
+
+        let apply_result = manager
+            .apply_locked()
+            .await
+            .map(|_| ())
+            .map_err(map_runtime_error);
+        if let Err(error) = apply_result {
+            let rollback =
+                ensure_envelope(raw).map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store
+                .put(ConfigNamespace::Agents.as_str(), id, &rollback)
+                .await?;
+            return Err(error);
+        }
+
+        let after = serde_json::to_value(&record.spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        self.emit_audit_with_suffix(
+            AuditAction::Update,
+            ConfigNamespace::Agents,
+            id,
+            "overrides",
+            Some(before),
+            Some(after.clone()),
+            headers,
+        )
+        .await;
+
+        Ok(after)
+    }
+
+    /// DELETE /v1/config/agents/:id/overrides/:field
+    ///
+    /// Removes a single field from the user overrides of a Builtin agent record.
+    /// Returns 400 if `field` is not a recognized AgentSpecPatch field.
+    /// Idempotent: if the field is not present in user_overrides, returns the
+    /// current effective spec without writing to the store or emitting an audit event.
+    pub async fn clear_agent_override_field(
+        &self,
+        id: &str,
+        field: &str,
+        headers: &HeaderMap,
+    ) -> Result<Value, ConfigServiceError> {
+        let manager = self.runtime_manager()?;
+        let _apply_guard = manager.lock_apply().await;
+
+        let raw = self
+            .store
+            .get(ConfigNamespace::Agents.as_str(), id)
+            .await?
+            .ok_or_else(|| ConfigServiceError::NotFound(format!("agents/{id}")))?;
+
+        let mut record = ConfigRecord::<AgentSpec>::from_value(raw.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        if matches!(record.meta.source, RecordSource::User) {
+            return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
+        }
+
+        let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let before = serde_json::to_value(&before_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        // Validate that field is recognized by AgentSpecPatch before mutating.
+        // Use a null probe: `AgentSpecPatch` accepts null for all Option fields, and
+        // deny_unknown_fields will reject unknown field names.
+        let probe = Value::Object({
+            let mut m = Map::new();
+            m.insert(field.to_string(), Value::Null);
+            m
+        });
+        let _: AgentSpecPatch = serde_json::from_value(probe).map_err(|_| {
+            ConfigServiceError::InvalidPayload(format!("unknown override field: {field}"))
+        })?;
+
+        // Remove the field from existing overrides.
+        let mut existing_map: Map<String, Value> = record
+            .meta
+            .user_overrides
+            .as_ref()
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+
+        // Short-circuit: if the field is not present in overrides, this is a no-op —
+        // skip the store write, apply_locked, and audit emit.
+        if !existing_map.contains_key(field) {
+            let effective_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            return serde_json::to_value(&effective_spec)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()));
+        }
+
+        existing_map.remove(field);
+
+        let merged_value = Value::Object(existing_map.clone());
+        record.meta.user_overrides = if existing_map.is_empty() {
+            None
+        } else {
+            Some(merged_value)
+        };
+        record.meta.updated_at = now_ms();
+
+        let envelope = record
+            .to_value()
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+        self.store
+            .put(ConfigNamespace::Agents.as_str(), id, &envelope)
+            .await?;
+
+        let apply_result = manager
+            .apply_locked()
+            .await
+            .map(|_| ())
+            .map_err(map_runtime_error);
+        if let Err(error) = apply_result {
+            let rollback =
+                ensure_envelope(raw).map_err(|e| StorageError::Serialization(e.to_string()))?;
+            self.store
+                .put(ConfigNamespace::Agents.as_str(), id, &rollback)
+                .await?;
+            return Err(error);
+        }
+
+        let after_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let after = serde_json::to_value(&after_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        self.emit_audit_with_suffix(
+            AuditAction::Update,
+            ConfigNamespace::Agents,
+            id,
+            &format!("overrides/{field}"),
+            Some(before),
+            Some(after.clone()),
+            headers,
+        )
+        .await;
+
+        Ok(after)
+    }
+}
+
+/// Return the effective spec Value for a stored entry, applying `user_overrides`
+/// when the namespace supports it (currently only Agents).
+///
+/// For non-Agent namespaces this is equivalent to `unwrap_spec`.
+fn effective_spec(namespace: ConfigNamespace, value: Value) -> Result<Value, ConfigServiceError> {
+    if namespace != ConfigNamespace::Agents {
+        return Ok(unwrap_spec(value));
+    }
+    let record = ConfigRecord::<AgentSpec>::from_value(value)
+        .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+    let effective = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+        .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+    serde_json::to_value(&effective).map_err(|e| ConfigServiceError::Serialization(e.to_string()))
 }
 
 /// Classify a tool's source from its id.
@@ -1069,78 +1473,6 @@ where
 {
     serde_json::from_value(value.clone())
         .map_err(|error| ConfigServiceError::InvalidPayload(error.to_string()))
-}
-
-/// Extract the spec from a stored value, unwrapping a ConfigRecord envelope
-/// if present.  Returns the value unchanged for legacy bare-spec entries.
-///
-/// Used to ensure audit `before`/`after` payloads always contain bare specs.
-fn unwrap_spec(value: Value) -> Value {
-    if value
-        .as_object()
-        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
-    {
-        value.get("spec").cloned().unwrap_or(value)
-    } else {
-        value
-    }
-}
-
-/// Get a field from a stored value, transparently handling both bare spec
-/// and `ConfigRecord` envelope forms.
-fn spec_field<'a>(value: &'a Value, key: &str) -> Option<&'a Value> {
-    if value
-        .as_object()
-        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
-    {
-        value.get("spec").and_then(|s| s.get(key))
-    } else {
-        value.get(key)
-    }
-}
-
-fn extract_timestamps(spec: &Value) -> (u64, u64) {
-    let created = spec.get("created_at").and_then(Value::as_u64).unwrap_or(0);
-    let updated = spec.get("updated_at").and_then(Value::as_u64).unwrap_or(0);
-    (created, updated)
-}
-
-/// Wrap a bare spec `Value` in a `ConfigRecord` envelope with `RecordSource::User`.
-///
-/// The spec's own `created_at`/`updated_at` are lifted into `RecordMeta` for
-/// provenance. This does **not** modify the spec itself — the spec timestamps
-/// remain authoritative for UI display.
-fn wrap_user(spec: &Value) -> Result<Value, serde_json::Error> {
-    let (created_at, updated_at) = extract_timestamps(spec);
-    let mut meta = RecordMeta::new_user();
-    if created_at != 0 {
-        meta.created_at = created_at;
-    }
-    if updated_at != 0 {
-        meta.updated_at = updated_at;
-    }
-    let record = ConfigRecord {
-        spec: spec.clone(),
-        meta,
-    };
-    record.to_value()
-}
-
-/// If `value` is already a `ConfigRecord` envelope (has both `"spec"` and
-/// `"meta"` keys), return it as-is.  Otherwise wrap it via `wrap_user`.
-///
-/// Used for rollback paths where the value being restored may have been
-/// written by an earlier writer (envelope) or an older binary (bare spec).
-fn ensure_envelope(value: Value) -> Result<Value, serde_json::Error> {
-    if value.is_object()
-        && value
-            .as_object()
-            .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
-    {
-        Ok(value)
-    } else {
-        wrap_user(&value)
-    }
 }
 
 #[cfg(test)]

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -476,7 +476,7 @@ impl<'a> ConfigService<'a> {
                 .before
                 .clone()
                 .ok_or(RestoreError::NoPayload(event.action.clone()))?,
-            A::Restart => return Err(RestoreError::NotRestorable),
+            A::Restart | A::SeedApply => return Err(RestoreError::NotRestorable),
         };
 
         // Single store read: determines both existence and the pre-restore snapshot.
@@ -727,14 +727,7 @@ impl<'a> ConfigService<'a> {
             // holds it.
             if !object.contains_key("created_at") {
                 if let Ok(Some(existing)) = self.store.get(namespace.as_str(), &id).await {
-                    let spec_layer = if existing
-                        .as_object()
-                        .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
-                    {
-                        existing.get("spec").cloned().unwrap_or(existing)
-                    } else {
-                        existing
-                    };
+                    let spec_layer = unwrap_spec(existing);
                     if let Some(existing_created_at) = spec_layer
                         .as_object()
                         .and_then(|obj| obj.get("created_at"))
@@ -782,14 +775,7 @@ impl<'a> ConfigService<'a> {
         };
         // The stored value may be either a bare spec or a ConfigRecord envelope.
         // Navigate into spec if needed before accessing fields.
-        let spec_value = if existing
-            .as_object()
-            .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
-        {
-            existing.get("spec").cloned().unwrap_or(existing)
-        } else {
-            existing
-        };
+        let spec_value = unwrap_spec(existing);
         let Some(existing_object) = spec_value.as_object() else {
             return Ok(());
         };
@@ -1030,14 +1016,7 @@ impl<'a> ConfigService<'a> {
             return Ok(());
         };
         // The stored value may be either a bare spec or a ConfigRecord envelope.
-        let spec_value = if existing
-            .as_object()
-            .is_some_and(|m| m.contains_key("spec") && m.contains_key("meta"))
-        {
-            existing.get("spec").cloned().unwrap_or(existing)
-        } else {
-            existing
-        };
+        let spec_value = unwrap_spec(existing);
         let Some(existing_object) = spec_value.as_object() else {
             return Ok(());
         };
@@ -1065,8 +1044,7 @@ fn classify_tool_source(id: &str) -> Value {
 fn map_runtime_error(error: ConfigRuntimeError) -> ConfigServiceError {
     match error {
         ConfigRuntimeError::UnsupportedProviderAdapter(_)
-        | ConfigRuntimeError::InvalidConfig(_)
-        | ConfigRuntimeError::PartialBootstrap => {
+        | ConfigRuntimeError::InvalidConfig(_) => {
             ConfigServiceError::InvalidPayload(error.to_string())
         }
         ConfigRuntimeError::RuntimeNotConfigurable
@@ -1177,7 +1155,7 @@ mod tests {
         InferenceExecutionError, InferenceRequest, LlmExecutor,
     };
     use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
-    use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+    use awaken_contract::{AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec};
     use awaken_runtime::builder::AgentRuntimeBuilder;
     use awaken_runtime::registry::traits::ModelBinding;
     use serde_json::{Value, json};
@@ -1323,14 +1301,6 @@ mod tests {
         let runtime = Arc::new(
             AgentRuntimeBuilder::new()
                 .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-                .with_model_binding(
-                    "bootstrap",
-                    ModelBinding {
-                        provider_id: "bootstrap".into(),
-                        upstream_model: "bootstrap-model".into(),
-                    },
-                )
-                .with_agent_spec(bootstrap_agent())
                 .with_thread_run_store(thread_store.clone())
                 .build()
                 .expect("build runtime"),
@@ -1342,25 +1312,25 @@ mod tests {
                 .with_provider_factory(Arc::new(TestProviderFactory)),
         );
         let resolver = runtime.resolver_arc();
-        manager
-            .bootstrap_if_empty(
-                &[ProviderSpec {
+        let seed = BuiltinSeedSet {
+            binary_version: "test".to_string(),
+            specs: vec![
+                BuiltinSpec::provider(ProviderSpec {
                     id: "bootstrap".into(),
                     adapter: "stub".into(),
                     ..Default::default()
-                }],
-                &[ModelBindingSpec {
+                }),
+                BuiltinSpec::model(ModelBindingSpec {
                     id: "bootstrap".into(),
                     provider_id: "bootstrap".into(),
                     upstream_model: "bootstrap-model".into(),
                     created_at: None,
                     updated_at: None,
-                }],
-                &[bootstrap_agent()],
-                &[],
-            )
-            .await
-            .expect("bootstrap config store");
+                }),
+                BuiltinSpec::agent(bootstrap_agent()),
+            ],
+        };
+        manager.apply_seed(&seed).await.expect("apply_seed");
         manager.apply().await.expect("publish config");
 
         let mailbox = Arc::new(Mailbox::new(
@@ -2040,17 +2010,6 @@ mod tests {
             updated_at_2 >= created_at_2,
             "updated_at must be >= created_at after update"
         );
-    }
-
-    #[tokio::test]
-    #[ignore = "requires force-apply-failure hook not yet available in test harness"]
-    async fn delete_rollback_re_emits_envelope() {
-        // This test requires a way to configure the runtime manager to fail
-        // apply() after delete so we can observe the rollback path writing an
-        // envelope. The current test harness has no such hook. When that
-        // infrastructure is added, verify that the rolled-back store entry has
-        // both "spec" and "meta" keys.
-        panic!("test infrastructure for force-apply-failure not yet available")
     }
 
     #[tokio::test]

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -630,7 +630,7 @@ impl<'a> ConfigService<'a> {
                 let refs = models
                     .into_iter()
                     .filter(|(_, value)| {
-                        spec_field(&value, "provider_id")
+                        spec_field(value, "provider_id")
                             .and_then(Value::as_str)
                             .is_some_and(|pid| pid == id)
                     })
@@ -646,7 +646,7 @@ impl<'a> ConfigService<'a> {
                 let refs = agents
                     .into_iter()
                     .filter(|(_, value)| {
-                        spec_field(&value, "model_id")
+                        spec_field(value, "model_id")
                             .and_then(Value::as_str)
                             .is_some_and(|mid| mid == id)
                     })
@@ -2005,6 +2005,121 @@ mod tests {
             )
             .await
             .expect("force delete should succeed");
+    }
+
+    struct FailingProviderFactory;
+
+    impl ProviderExecutorFactory for FailingProviderFactory {
+        fn build(
+            &self,
+            _spec: &ProviderSpec,
+        ) -> Result<Arc<dyn LlmExecutor>, crate::services::config_runtime::ConfigRuntimeError>
+        {
+            Err(
+                crate::services::config_runtime::ConfigRuntimeError::InvalidConfig(
+                    "forced failure for rollback test".into(),
+                ),
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_rollback_re_emits_envelope() {
+        // Step 1: build a manager with the succeeding TestProviderFactory and PUT a provider.
+        let config_store: Arc<dyn awaken_contract::contract::config_store::ConfigStore> =
+            Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store.clone()).await;
+        let service = ConfigService::new(&state).expect("config service");
+
+        service
+            .create(
+                ConfigNamespace::Providers,
+                json!({ "id": "rollback-prov", "adapter": "stub" }),
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect("create rollback-prov");
+
+        // Step 2: verify the stored record is already an envelope (precondition).
+        let stored_before = ConfigStore::get(config_store.as_ref(), "providers", "rollback-prov")
+            .await
+            .expect("read before delete")
+            .expect("provider must exist");
+        assert!(
+            stored_before.get("spec").is_some(),
+            "stored record must be envelope-shaped before delete (has 'spec' key)"
+        );
+
+        // Step 3: build a second manager over the same store, with FailingProviderFactory.
+        let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let runtime_failing = Arc::new(
+            AgentRuntimeBuilder::new()
+                .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+                .with_thread_run_store(thread_store.clone())
+                .build()
+                .expect("build runtime"),
+        );
+        let manager_failing = Arc::new(
+            crate::services::config_runtime::ConfigRuntimeManager::new(
+                runtime_failing.clone(),
+                config_store.clone(),
+            )
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(FailingProviderFactory)),
+        );
+
+        let mailbox_failing = Arc::new(crate::mailbox::Mailbox::new(
+            runtime_failing.clone(),
+            Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+            thread_store.clone(),
+            "rollback-test".into(),
+            crate::mailbox::MailboxConfig::default(),
+        ));
+        let state_failing = crate::app::AppState::new(
+            runtime_failing.clone(),
+            mailbox_failing,
+            thread_store,
+            runtime_failing.resolver_arc(),
+            crate::app::ServerConfig::default(),
+        )
+        .with_config_store(config_store.clone())
+        .with_config_runtime_manager(manager_failing);
+
+        // Step 4: attempt DELETE via the failing service — apply_locked will fail.
+        let service_failing = ConfigService::new(&state_failing).expect("failing config service");
+        let delete_result = service_failing
+            .delete(
+                ConfigNamespace::Providers,
+                "rollback-prov",
+                true,
+                &axum::http::HeaderMap::new(),
+            )
+            .await;
+
+        assert!(
+            delete_result.is_err(),
+            "delete must fail when apply_locked fails"
+        );
+
+        // Step 5: assert the store still has the provider AND it is envelope-shaped.
+        let stored_after = ConfigStore::get(config_store.as_ref(), "providers", "rollback-prov")
+            .await
+            .expect("read after delete")
+            .expect("provider must have been rolled back");
+
+        assert!(
+            stored_after.get("spec").is_some(),
+            "rolled-back record must be envelope-shaped (has 'spec' key)"
+        );
+        assert!(
+            stored_after.get("meta").is_some(),
+            "rolled-back record must be envelope-shaped (has 'meta' key)"
+        );
+        assert_eq!(
+            stored_after["spec"]["id"],
+            Value::String("rollback-prov".into()),
+            "rolled-back spec must preserve the original provider id"
+        );
     }
 
     // ── ConfigNamespace::all() / iter_str() tests ─────────────────────────

--- a/crates/awaken-server/src/services/mod.rs
+++ b/crates/awaken-server/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod audit_log;
+pub mod builtin_seed;
 pub mod config_runtime;
 pub mod config_service;
 pub mod run_control_service;

--- a/crates/awaken-server/src/services/mod.rs
+++ b/crates/awaken-server/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit_log;
 pub mod builtin_seed;
+pub mod config_envelope;
 pub mod config_runtime;
 pub mod config_service;
 pub mod run_control_service;

--- a/crates/awaken-server/tests/audit_log_routes.rs
+++ b/crates/awaken-server/tests/audit_log_routes.rs
@@ -342,3 +342,103 @@ async fn malformed_cursor_returns_400() {
         "body must contain error: invalid cursor"
     );
 }
+
+/// The `apply_seed` boot call emits `SeedApply` events that are visible
+/// when the audit log is queried with `action=seed_apply`.
+///
+/// The audit logger must be attached to the manager BEFORE `apply_seed` so that
+/// the manager's `emit_seed_report` call fires.
+#[tokio::test]
+async fn seed_apply_event_visible_via_http_query() {
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+
+    let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+
+    // Attach audit to manager BEFORE apply_seed so emit_seed_report fires.
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(TestProviderFactory))
+            .with_audit_log(audit_logger.clone()),
+    );
+
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
+    manager.apply().await.expect("apply");
+
+    let resolver = runtime.resolver_arc();
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "seed-audit-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime,
+        mailbox,
+        thread_store,
+        resolver,
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager)
+    .with_audit_log(audit_logger);
+
+    let app = build_router(&state).with_state(state);
+
+    let (status, body) = get_audit_log(&app, "action=seed_apply").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let items = body["items"].as_array().expect("items array");
+    assert!(
+        !items.is_empty(),
+        "at least one seed_apply event must be present; body: {body}"
+    );
+
+    // Every returned event must have action=seed_apply, actor=system:seed,
+    // and a resource starting with "seed:".
+    for item in items {
+        assert_eq!(
+            item["action"].as_str(),
+            Some("seed_apply"),
+            "action must be seed_apply; got {item}"
+        );
+        assert_eq!(
+            item["actor"].as_str(),
+            Some("system:seed"),
+            "actor must be system:seed; got {item}"
+        );
+        assert!(
+            item["resource"]
+                .as_str()
+                .is_some_and(|r| r.starts_with("seed:")),
+            "resource must start with 'seed:'; got {item}"
+        );
+    }
+}

--- a/crates/awaken-server/tests/audit_log_routes.rs
+++ b/crates/awaken-server/tests/audit_log_routes.rs
@@ -5,9 +5,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
-use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+use awaken_contract::{AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec};
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
@@ -73,14 +72,6 @@ async fn build_test_app_with_audit(token: Option<&str>) -> axum::Router {
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model_binding(
-                "bootstrap",
-                ModelBinding {
-                    provider_id: "bootstrap".into(),
-                    upstream_model: "bootstrap-model".into(),
-                },
-            )
-            .with_agent_spec(bootstrap_agent())
             .with_thread_run_store(thread_store.clone())
             .build()
             .expect("build runtime"),
@@ -91,25 +82,25 @@ async fn build_test_app_with_audit(token: Option<&str>) -> axum::Router {
             .expect("config runtime manager")
             .with_provider_factory(Arc::new(TestProviderFactory)),
     );
-    manager
-        .bootstrap_if_empty(
-            &[ProviderSpec {
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
                 id: "bootstrap".into(),
                 adapter: "stub".into(),
                 ..Default::default()
-            }],
-            &[ModelBindingSpec {
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
                 id: "bootstrap".into(),
                 provider_id: "bootstrap".into(),
                 upstream_model: "bootstrap-model".into(),
                 created_at: None,
                 updated_at: None,
-            }],
-            &[bootstrap_agent()],
-            &[],
-        )
-        .await
-        .expect("bootstrap");
+            }),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
     manager.apply().await.expect("apply");
 
     let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
@@ -145,14 +136,6 @@ async fn build_test_app_without_audit() -> axum::Router {
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model_binding(
-                "bootstrap",
-                ModelBinding {
-                    provider_id: "bootstrap".into(),
-                    upstream_model: "bootstrap-model".into(),
-                },
-            )
-            .with_agent_spec(bootstrap_agent())
             .with_thread_run_store(thread_store.clone())
             .build()
             .expect("build runtime"),
@@ -162,25 +145,25 @@ async fn build_test_app_without_audit() -> axum::Router {
             .expect("manager")
             .with_provider_factory(Arc::new(TestProviderFactory)),
     );
-    manager
-        .bootstrap_if_empty(
-            &[ProviderSpec {
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
                 id: "bootstrap".into(),
                 adapter: "stub".into(),
                 ..Default::default()
-            }],
-            &[ModelBindingSpec {
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
                 id: "bootstrap".into(),
                 provider_id: "bootstrap".into(),
                 upstream_model: "bootstrap-model".into(),
                 created_at: None,
                 updated_at: None,
-            }],
-            &[bootstrap_agent()],
-            &[],
-        )
-        .await
-        .expect("bootstrap");
+            }),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
     manager.apply().await.expect("apply");
 
     let resolver = runtime.resolver_arc();

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2033,3 +2033,516 @@ async fn mcp_restart_returns_404_for_unknown_server() {
     // The manager returns "no MCP registry is active" → 503.
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
 }
+
+// ── Agent override endpoint tests ──────────────────────────────────────────
+
+/// Seed a builtin agent with `system_prompt` for override tests.
+/// Uses the already-seeded "bootstrap" agent from `make_app`.
+async fn patch_overrides(router: &axum::Router, id: &str, body: Value) -> (StatusCode, Value) {
+    request_json(
+        router,
+        Method::PATCH,
+        &format!("/v1/config/agents/{id}/overrides"),
+        Some(body),
+    )
+    .await
+}
+
+async fn delete_overrides(router: &axum::Router, id: &str) -> (StatusCode, Value) {
+    request_json(
+        router,
+        Method::DELETE,
+        &format!("/v1/config/agents/{id}/overrides"),
+        None,
+    )
+    .await
+}
+
+async fn delete_override_field(
+    router: &axum::Router,
+    id: &str,
+    field: &str,
+) -> (StatusCode, Value) {
+    request_json(
+        router,
+        Method::DELETE,
+        &format!("/v1/config/agents/{id}/overrides/{field}"),
+        None,
+    )
+    .await
+}
+
+async fn get_agent_spec(router: &axum::Router, id: &str) -> (StatusCode, Value) {
+    request_json(
+        router,
+        Method::GET,
+        &format!("/v1/config/agents/{id}"),
+        None,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn patch_overrides_on_builtin_returns_effective_spec() {
+    let app = make_app().await;
+
+    // The "bootstrap" agent is seeded as Builtin.
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"system_prompt": "patched"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["system_prompt"], "patched");
+
+    // Verify the store has user_overrides set.
+    use awaken_contract::contract::config_store::ConfigStore;
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    let overrides = &raw["meta"]["user_overrides"];
+    assert_eq!(overrides["system_prompt"], "patched");
+
+    // GET should also return the patched effective spec.
+    let (get_status, get_body) = get_agent_spec(&app.router, "bootstrap").await;
+    assert_eq!(get_status, StatusCode::OK);
+    assert_eq!(get_body["system_prompt"], "patched");
+}
+
+#[tokio::test]
+async fn patch_overrides_merges_with_existing_overrides() {
+    let app = make_app().await;
+
+    // First patch: system_prompt
+    let (s1, _) = patch_overrides(&app.router, "bootstrap", json!({"system_prompt": "p1"})).await;
+    assert_eq!(s1, StatusCode::OK);
+
+    // Second patch: max_rounds
+    let (s2, body) = patch_overrides(&app.router, "bootstrap", json!({"max_rounds": 99})).await;
+    assert_eq!(s2, StatusCode::OK, "body: {body}");
+    assert_eq!(body["system_prompt"], "p1");
+    assert_eq!(body["max_rounds"], 99);
+}
+
+#[tokio::test]
+async fn patch_overrides_null_clears_field() {
+    let app = make_app().await;
+
+    // Patch both fields.
+    patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"system_prompt": "p1", "max_rounds": 99}),
+    )
+    .await;
+
+    // Null-out max_rounds.
+    let (status, body) =
+        patch_overrides(&app.router, "bootstrap", json!({"max_rounds": null})).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["system_prompt"], "p1");
+    // max_rounds should be reset to the base value (not 99).
+    assert_ne!(body["max_rounds"], 99);
+
+    // Store should only have system_prompt in user_overrides.
+    use awaken_contract::contract::config_store::ConfigStore;
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    let overrides = &raw["meta"]["user_overrides"];
+    assert_eq!(overrides["system_prompt"], "p1");
+    assert!(
+        overrides.get("max_rounds").is_none() || overrides["max_rounds"].is_null(),
+        "max_rounds must not remain in user_overrides"
+    );
+}
+
+#[tokio::test]
+async fn patch_overrides_rejects_unknown_field() {
+    let app = make_app().await;
+
+    let (status, body) =
+        patch_overrides(&app.router, "bootstrap", json!({"unknown_field": "x"})).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+}
+
+#[tokio::test]
+async fn patch_overrides_on_user_record_returns_422() {
+    let app = make_app().await;
+
+    // Create a User-source agent via PUT (regular create).
+    let (create_status, _) = request_json(
+        &app.router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "user-agent-422",
+            "model_id": "bootstrap",
+            "system_prompt": "hello",
+            "max_rounds": 1
+        })),
+    )
+    .await;
+    assert_eq!(create_status, StatusCode::CREATED);
+
+    let (status, body) =
+        patch_overrides(&app.router, "user-agent-422", json!({"system_prompt": "x"})).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
+}
+
+#[tokio::test]
+async fn patch_overrides_on_missing_agent_returns_404() {
+    let app = make_app().await;
+
+    let (status, _body) = patch_overrides(
+        &app.router,
+        "nonexistent-agent",
+        json!({"system_prompt": "x"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn delete_all_overrides_resets_to_builtin() {
+    let app = make_app().await;
+
+    // Set some overrides first.
+    patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"system_prompt": "customized"}),
+    )
+    .await;
+
+    // Delete all overrides.
+    let (status, body) = delete_overrides(&app.router, "bootstrap").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    // Store record should have user_overrides = None.
+    use awaken_contract::contract::config_store::ConfigStore;
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    assert!(
+        raw["meta"].get("user_overrides").is_none() || raw["meta"]["user_overrides"].is_null(),
+        "user_overrides must be None after delete all"
+    );
+
+    // Effective spec should be back to the seed value.
+    let (get_status, get_body) = get_agent_spec(&app.router, "bootstrap").await;
+    assert_eq!(get_status, StatusCode::OK);
+    assert_eq!(get_body["system_prompt"], "agent bootstrap");
+}
+
+#[tokio::test]
+async fn delete_one_override_field_resets_only_that_field() {
+    let app = make_app().await;
+
+    // Set two overrides.
+    patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"system_prompt": "p1", "max_rounds": 99}),
+    )
+    .await;
+
+    // Delete only max_rounds.
+    let (status, body) = delete_override_field(&app.router, "bootstrap", "max_rounds").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    // system_prompt override is preserved.
+    assert_eq!(body["system_prompt"], "p1");
+    // max_rounds is back to base (not 99).
+    assert_ne!(body["max_rounds"], 99);
+}
+
+#[tokio::test]
+async fn audit_event_emitted_for_patch_and_delete() {
+    use awaken_server::services::audit_log::{AuditLogger, AuditQuery};
+    use awaken_server::services::config_service::ConfigService;
+
+    // Test audit via direct service calls (bypassing HTTP routing) to verify
+    // that patch/clear methods emit Update audit events.
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(
+            runtime.clone(),
+            config_store.clone() as Arc<dyn ConfigStore>,
+        )
+        .expect("manager")
+        .with_provider_factory(Arc::new(TestProviderFactory)),
+    );
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }),
+            BuiltinSpec::agent(agent_spec("bootstrap", "bootstrap")),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
+    manager.apply().await.expect("apply");
+
+    let audit_logger = Arc::new(AuditLogger::new(
+        config_store.clone() as Arc<dyn ConfigStore>
+    ));
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "override-audit-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = awaken_server::app::AppState::new(
+        runtime.clone(),
+        mailbox,
+        thread_store,
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store.clone() as Arc<dyn ConfigStore>)
+    .with_config_runtime_manager(manager)
+    .with_audit_log(audit_logger.clone());
+
+    let headers = axum::http::HeaderMap::new();
+
+    // 1. PATCH overrides
+    let service = ConfigService::new(&state).expect("service");
+    service
+        .patch_agent_overrides("bootstrap", json!({"system_prompt": "audited"}), &headers)
+        .await
+        .expect("patch_agent_overrides");
+
+    // Verify state has audit_log
+    assert!(state.audit_log.is_some(), "state should have audit_log");
+
+    // 2. DELETE all overrides
+    let service = ConfigService::new(&state).expect("service");
+    service
+        .clear_agent_overrides("bootstrap", &headers)
+        .await
+        .expect("clear_agent_overrides");
+
+    // Check count after step 2
+    let after_clear = audit_logger
+        .query(AuditQuery::default())
+        .await
+        .expect("after_clear query");
+    assert!(
+        after_clear.items.len() >= 2,
+        "should have 2 events after clear, got {}: {:?}",
+        after_clear.items.len(),
+        after_clear
+            .items
+            .iter()
+            .map(|e| format!("{:?}@{}", e.action, e.resource))
+            .collect::<Vec<_>>()
+    );
+
+    // 3. PATCH again
+    let service = ConfigService::new(&state).expect("service");
+    service
+        .patch_agent_overrides(
+            "bootstrap",
+            json!({"system_prompt": "p1", "max_rounds": 5}),
+            &headers,
+        )
+        .await
+        .expect("patch_agent_overrides 2");
+
+    // 4. DELETE single field
+    let service = ConfigService::new(&state).expect("service");
+    service
+        .clear_agent_override_field("bootstrap", "max_rounds", &headers)
+        .await
+        .expect("clear_agent_override_field");
+
+    // Query audit log — expect at least 3 Update events for agents/bootstrap.
+    let page = audit_logger
+        .query(AuditQuery {
+            action: Some(awaken_contract::AuditAction::Update),
+            ..Default::default()
+        })
+        .await
+        .expect("audit query");
+
+    // Override mutations now emit with resource path including the
+    // `/overrides[/{field}]` suffix per Phase 3 spec.
+    let agent_updates: Vec<_> = page
+        .items
+        .iter()
+        .filter(|e| {
+            e.resource == "agents/bootstrap/overrides"
+                || e.resource.starts_with("agents/bootstrap/overrides/")
+        })
+        .collect();
+    assert_eq!(
+        agent_updates.len(),
+        4,
+        "expected exactly one Update per non-no-op mutation (patch + clear-all + patch + clear-field), got {} (all: {:?})",
+        agent_updates.len(),
+        page.items
+            .iter()
+            .map(|e| format!("{:?}@{}", e.action, e.resource))
+            .collect::<Vec<_>>()
+    );
+
+    // Specifically: 2 PATCH calls + 1 DELETE all + 1 DELETE field.
+    let single_field_updates: Vec<_> = page
+        .items
+        .iter()
+        .filter(|e| e.resource == "agents/bootstrap/overrides/max_rounds")
+        .collect();
+    assert_eq!(
+        single_field_updates.len(),
+        1,
+        "expected one Update for the per-field DELETE, got {}",
+        single_field_updates.len()
+    );
+}
+
+// ── GET /v1/config/:ns/:id/meta ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_meta_returns_source_and_overrides_for_builtin() {
+    let app = make_app().await;
+
+    // The bootstrap agent is seeded as Builtin.
+    let (status, body) = request_json(
+        &app.router,
+        Method::GET,
+        "/v1/config/agents/bootstrap/meta",
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        body["source"]["kind"], "builtin",
+        "source.kind must be 'builtin'"
+    );
+    assert!(
+        body["source"]["binary_version"].is_string(),
+        "binary_version must be present"
+    );
+    // No overrides on a freshly seeded builtin.
+    assert!(
+        body.get("user_overrides").is_none() || body["user_overrides"].is_null(),
+        "user_overrides should be absent or null for a pristine builtin"
+    );
+}
+
+#[tokio::test]
+async fn get_meta_returns_user_source_for_user_record() {
+    let app = make_app().await;
+
+    // Create a user record.
+    let (create_status, _) = request_json(
+        &app.router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({ "id": "user-agent-meta", "model_id": "bootstrap", "system_prompt": "test", "max_rounds": 1 })),
+    )
+    .await;
+    assert_eq!(create_status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &app.router,
+        Method::GET,
+        "/v1/config/agents/user-agent-meta/meta",
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        body["source"]["kind"], "user",
+        "user-created record must have source.kind 'user'"
+    );
+}
+
+#[tokio::test]
+async fn get_meta_returns_404_for_missing() {
+    let app = make_app().await;
+
+    let (status, _) = request_json(
+        &app.router,
+        Method::GET,
+        "/v1/config/agents/no-such-agent/meta",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+// ── GET /v1/config/:ns/meta ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_meta_returns_all_records_with_source() {
+    let app = make_app().await;
+
+    // Create a user agent.
+    let (create_status, _) = request_json(
+        &app.router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({ "id": "user-list-meta", "model_id": "bootstrap", "system_prompt": "hi", "max_rounds": 1 })),
+    )
+    .await;
+    assert_eq!(create_status, StatusCode::CREATED);
+
+    let (status, body) =
+        request_json(&app.router, Method::GET, "/v1/config/agents/meta", None).await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let items = body.as_array().expect("body must be a JSON array");
+    assert!(
+        !items.is_empty(),
+        "list/meta must return at least one entry"
+    );
+
+    // Every item must have id and meta.source.kind.
+    for item in items {
+        assert!(item["id"].is_string(), "each item must have an id string");
+        let kind = item["meta"]["source"]["kind"].as_str();
+        assert!(
+            matches!(kind, Some("builtin") | Some("user")),
+            "source.kind must be 'builtin' or 'user', got: {kind:?}"
+        );
+    }
+
+    // Confirm both the builtin seed and our user record appear.
+    let bootstrap = items.iter().find(|i| i["id"] == "bootstrap");
+    assert!(
+        bootstrap.is_some(),
+        "bootstrap builtin must be in list/meta"
+    );
+    assert_eq!(bootstrap.unwrap()["meta"]["source"]["kind"], "builtin");
+
+    let user_rec = items.iter().find(|i| i["id"] == "user-list-meta");
+    assert!(user_rec.is_some(), "user-list-meta must be in list/meta");
+    assert_eq!(user_rec.unwrap()["meta"]["source"]["kind"], "user");
+}

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -15,7 +15,9 @@ use awaken_contract::contract::storage::StorageError;
 use awaken_contract::contract::tool::{
     Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
 };
-use awaken_contract::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
+use awaken_contract::{
+    AgentSpec, BuiltinSeedSet, BuiltinSpec, McpServerSpec, ModelBindingSpec, ProviderSpec,
+};
 #[cfg(feature = "permission")]
 use awaken_ext_permission::{PermissionConfigKey, PermissionPlugin, ToolPermissionBehavior};
 use awaken_runtime::AgentRuntime;
@@ -26,7 +28,6 @@ use awaken_runtime::context::CompactionConfigKey;
 use awaken_runtime::engine::RetryConfigKey;
 use awaken_runtime::registry::ToolRegistry;
 use awaken_runtime::registry::memory::MapToolRegistry;
-use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{
     AdminApiConfig, AppState, ServerConfig, SkillCatalogArgument, SkillCatalogContext,
     SkillCatalogEntry, SkillCatalogProvider,
@@ -549,30 +550,9 @@ async fn make_runtime_manager_custom(
     Arc<ConfigRuntimeManager>,
 ) {
     let store = Arc::new(InMemoryStore::new());
-    let bootstrap_provider = ProviderSpec {
-        id: "bootstrap".into(),
-        adapter: "stub".into(),
-        ..Default::default()
-    };
-    let bootstrap_model = ModelBindingSpec {
-        id: "bootstrap".into(),
-        provider_id: "bootstrap".into(),
-        upstream_model: "bootstrap-model".into(),
-        created_at: None,
-        updated_at: None,
-    };
-    let bootstrap_agent = agent_spec("bootstrap", "bootstrap");
 
     let builder = AgentRuntimeBuilder::new()
         .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-        .with_model_binding(
-            "bootstrap",
-            ModelBinding {
-                provider_id: "bootstrap".into(),
-                upstream_model: "bootstrap-model".into(),
-            },
-        )
-        .with_agent_spec(bootstrap_agent.clone())
         .with_thread_run_store(store.clone());
     #[cfg(feature = "permission")]
     let builder = if register_permission_plugin {
@@ -597,15 +577,25 @@ async fn make_runtime_manager_custom(
         manager = manager.with_mcp_refresh_interval(interval);
     }
     let manager = Arc::new(manager);
-    manager
-        .bootstrap_if_empty(
-            std::slice::from_ref(&bootstrap_provider),
-            std::slice::from_ref(&bootstrap_model),
-            std::slice::from_ref(&bootstrap_agent),
-            &[],
-        )
-        .await
-        .expect("bootstrap config store");
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }),
+            BuiltinSpec::agent(agent_spec("bootstrap", "bootstrap")),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
     manager.apply().await.expect("publish config snapshot");
 
     (runtime, store, manager)
@@ -1772,31 +1762,10 @@ async fn change_listener_coalesces_event_bursts_within_min_apply_interval() {
     let factory = Arc::new(CountingProviderFactory::default());
     let notifier = Arc::new(TestConfigChangeNotifier::new());
     let store = Arc::new(InMemoryStore::new());
-    let bootstrap_provider = ProviderSpec {
-        id: "bootstrap".into(),
-        adapter: "stub".into(),
-        ..Default::default()
-    };
-    let bootstrap_model = ModelBindingSpec {
-        id: "bootstrap".into(),
-        provider_id: "bootstrap".into(),
-        upstream_model: "bootstrap-model".into(),
-        created_at: None,
-        updated_at: None,
-    };
-    let bootstrap_agent = agent_spec("bootstrap", "bootstrap");
 
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model_binding(
-                "bootstrap",
-                ModelBinding {
-                    provider_id: "bootstrap".into(),
-                    upstream_model: "bootstrap-model".into(),
-                },
-            )
-            .with_agent_spec(bootstrap_agent.clone())
             .with_thread_run_store(store.clone())
             .build()
             .expect("build runtime"),
@@ -1810,15 +1779,25 @@ async fn change_listener_coalesces_event_bursts_within_min_apply_interval() {
             .with_change_notifier(notifier.clone() as Arc<dyn ConfigChangeNotifier>)
             .with_min_apply_interval(Duration::from_millis(200)),
     );
-    manager
-        .bootstrap_if_empty(
-            std::slice::from_ref(&bootstrap_provider),
-            std::slice::from_ref(&bootstrap_model),
-            std::slice::from_ref(&bootstrap_agent),
-            &[],
-        )
-        .await
-        .expect("bootstrap config store");
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }),
+            BuiltinSpec::agent(agent_spec("bootstrap", "bootstrap")),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
     manager.apply().await.expect("initial apply");
     manager
         .start_periodic_refresh(Duration::from_secs(60))

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -828,6 +828,9 @@ async fn provider_secret_is_redacted_and_preserved_on_update() {
         .await
         .expect("read raw provider")
         .expect("provider should exist");
+    let stored = awaken_contract::ConfigRecord::<serde_json::Value>::from_value(stored)
+        .expect("decode envelope")
+        .spec;
     assert_eq!(stored["api_key"], "top-secret");
     assert_eq!(stored["base_url"], "https://provider.example.test");
 }
@@ -888,6 +891,9 @@ async fn mcp_servers_are_redacted_and_publish_live_tools() {
         .await
         .expect("read raw mcp config")
         .expect("mcp config should exist");
+    let stored = awaken_contract::ConfigRecord::<serde_json::Value>::from_value(stored)
+        .expect("decode envelope")
+        .spec;
     assert_eq!(stored["env"]["TOKEN"], "secret-token");
     assert_eq!(stored["args"], json!(["--updated"]));
 

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -11,7 +11,7 @@ use awaken_contract::contract::message::{Message, MessageMetadata};
 #[cfg(feature = "nats")]
 use awaken_contract::contract::storage::RunRecord;
 use awaken_contract::contract::storage::{RunStore, ThreadRunStore, ThreadStore};
-use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+use awaken_contract::{AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec};
 use awaken_runtime::AgentRuntime;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
@@ -107,21 +107,9 @@ async fn make_app<S>(store: Arc<S>, server_name: &str) -> TestApp<S>
 where
     S: ConfigStore + ThreadRunStore + Send + Sync + 'static,
 {
-    let bootstrap_provider = bootstrap_provider();
-    let bootstrap_model = bootstrap_model();
-    let bootstrap_agent = bootstrap_agent();
-
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model_binding(
-                "bootstrap",
-                ModelBinding {
-                    provider_id: "bootstrap".into(),
-                    upstream_model: "bootstrap-model".into(),
-                },
-            )
-            .with_agent_spec(bootstrap_agent.clone())
             .with_thread_run_store(store.clone() as Arc<dyn ThreadRunStore>)
             .build()
             .expect("build runtime"),
@@ -133,15 +121,15 @@ where
             .expect("config runtime manager")
             .with_provider_factory(Arc::new(StubProviderFactory)),
     );
-    manager
-        .bootstrap_if_empty(
-            std::slice::from_ref(&bootstrap_provider),
-            std::slice::from_ref(&bootstrap_model),
-            std::slice::from_ref(&bootstrap_agent),
-            &[],
-        )
-        .await
-        .expect("bootstrap config store");
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(bootstrap_provider()),
+            BuiltinSpec::model(bootstrap_model()),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
     manager.apply().await.expect("publish config snapshot");
 
     let mailbox = Arc::new(Mailbox::new(

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -484,6 +484,9 @@ async fn file_store_config_api_persists_and_publishes_runtime() {
         .await
         .expect("read persisted agent config");
     let stored_agent: Value = serde_json::from_str(&stored_agent).expect("agent config json");
+    let stored_agent = awaken_contract::ConfigRecord::<Value>::from_value(stored_agent)
+        .expect("decode envelope")
+        .spec;
     assert_eq!(stored_agent["id"], "file-agent");
 
     let resolved = app

--- a/crates/awaken-server/tests/restore_routes.rs
+++ b/crates/awaken-server/tests/restore_routes.rs
@@ -156,6 +156,20 @@ async fn put_json(app: &axum::Router, uri: &str, body: &Value) -> (StatusCode, V
     (status, body)
 }
 
+async fn patch_json(app: &axum::Router, uri: &str, body: &Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("PATCH")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
 async fn delete_resource(app: &axum::Router, uri: &str) -> StatusCode {
     let req = Request::builder()
         .method("DELETE")
@@ -616,6 +630,192 @@ async fn restore_audit_event_has_restored_from() {
     );
     assert_eq!(restore_ev["action"], "restore");
     assert!(restore_ev["after"]["system_prompt"] == "initial");
+}
+
+/// POSTing restore with a SeedApply event ULID returns 422 (NotRestorable).
+///
+/// Uses the same direct-store-write pattern as `restore_restart_event_returns_422`
+/// to produce a known-ULID SeedApply event without requiring audit-on-manager wiring.
+#[tokio::test]
+async fn restore_rejects_seed_apply_event() {
+    use awaken_contract::AuditAction;
+    use awaken_contract::AuditEvent;
+    use awaken_contract::contract::config_store::ConfigStore;
+    use awaken_server::services::audit_log::AUDIT_NAMESPACE;
+
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("manager")
+            .with_provider_factory(Arc::new(TestProviderFactory)),
+    );
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
+    manager.apply().await.expect("apply");
+
+    // Write a SeedApply event directly into the audit store.
+    // The resource must match the restore URL ("agents/bootstrap") so that
+    // ResourceMismatch is NOT raised and NotRestorable is the failure path.
+    let seed_apply_id = ulid::Ulid::new().to_string();
+    let seed_apply_event = AuditEvent {
+        id: seed_apply_id.clone(),
+        ts: chrono::Utc::now().to_rfc3339(),
+        actor: "system:seed".to_string(),
+        action: AuditAction::SeedApply,
+        resource: "agents/bootstrap".to_string(),
+        before: None,
+        after: Some(serde_json::json!({"bucket": "created", "count": 1})),
+        ip: None,
+        request_id: None,
+        restored_from: None,
+    };
+    config_store
+        .put(
+            AUDIT_NAMESPACE,
+            &seed_apply_id,
+            &serde_json::to_value(&seed_apply_event).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+    let resolver = runtime.resolver_arc();
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "seed-restore-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime,
+        mailbox,
+        thread_store,
+        resolver,
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager)
+    .with_audit_log(audit_logger);
+    let app = build_router(&state).with_state(state);
+
+    // POST restore with the SeedApply event ULID.
+    // The agent id in the URL doesn't matter — the event type check fires first.
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/bootstrap/restore",
+        &json!({ "version": seed_apply_id }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "NotRestorable must map to 422; body: {body}"
+    );
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("not restorable")),
+        "error body must mention 'not restorable': {body}"
+    );
+}
+
+/// Restoring a pre-customization version of a Builtin agent must not crash and
+/// must restore the spec content. User overrides are preserved as they are at
+/// restore time (conservative policy: restore only restores spec content, not
+/// the override state from the moment of the source audit event).
+#[tokio::test]
+async fn restore_on_customized_record_restores_spec_only() {
+    let app = build_test_app().await;
+
+    // Step 1: Seed a Builtin agent ("bootstrap") — already done by build_test_app.
+    // The bootstrap agent uses model_id="bootstrap" and system_prompt="bootstrap".
+
+    // Step 2: PATCH /overrides to set a user override on the Builtin agent.
+    let (status, _patch_body) = patch_json(
+        &app,
+        "/v1/config/agents/bootstrap/overrides",
+        &json!({"system_prompt": "user-prompt"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "PATCH overrides must succeed");
+
+    // Get the PATCH audit event ULID.
+    let audit = get_audit_log(&app, "resource=agents/bootstrap").await;
+    let items = audit["items"].as_array().expect("items");
+    let patch_event_id = items
+        .iter()
+        .find(|e| e["action"] == "update")
+        .and_then(|e| e["id"].as_str())
+        .expect("update (PATCH overrides) event")
+        .to_string();
+
+    // Step 3: PUT a full spec — this converts the record to User source, drops overrides.
+    let (status, _) = put_json(
+        &app,
+        "/v1/config/agents/bootstrap",
+        &json!({
+            "id": "bootstrap",
+            "model_id": "bootstrap",
+            "system_prompt": "full-put-prompt",
+            "max_rounds": 3
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "PUT must succeed");
+
+    // Step 4: POST /restore with the ULID of the PATCH event (step 2).
+    // Conservative policy: restoring a pre-customization version restores the
+    // spec content; user_overrides at restore time is whatever was set, not
+    // what it was at the source event's moment.
+    let (status, body) = post_json(
+        &app,
+        "/v1/config/agents/bootstrap/restore",
+        &json!({ "version": patch_event_id }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "restore of a pre-customization version must not crash; body: {body}"
+    );
+
+    // The restored spec content should reflect the state from the PATCH event's
+    // "after" payload. The exact prompt depends on what apply_overrides produced
+    // at that moment ("user-prompt" because PATCH was applied to the Builtin base).
+    assert!(
+        body["system_prompt"].is_string(),
+        "restored spec must have a system_prompt; body: {body}"
+    );
+    assert_eq!(
+        body["id"], "bootstrap",
+        "restored spec must preserve agent id; body: {body}"
+    );
 }
 
 /// Restore from a Publish audit event restores `event.after` as the resource state.

--- a/crates/awaken-server/tests/restore_routes.rs
+++ b/crates/awaken-server/tests/restore_routes.rs
@@ -5,9 +5,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
-use awaken_contract::{AgentSpec, ModelBindingSpec, ProviderSpec};
+use awaken_contract::{AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec};
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{AppState, ServerConfig};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
@@ -73,14 +72,6 @@ async fn build_test_app() -> axum::Router {
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model_binding(
-                "bootstrap",
-                ModelBinding {
-                    provider_id: "bootstrap".into(),
-                    upstream_model: "bootstrap-model".into(),
-                },
-            )
-            .with_agent_spec(bootstrap_agent())
             .with_thread_run_store(thread_store.clone())
             .build()
             .expect("build runtime"),
@@ -91,25 +82,25 @@ async fn build_test_app() -> axum::Router {
             .expect("config runtime manager")
             .with_provider_factory(Arc::new(TestProviderFactory)),
     );
-    manager
-        .bootstrap_if_empty(
-            &[ProviderSpec {
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
                 id: "bootstrap".into(),
                 adapter: "stub".into(),
                 ..Default::default()
-            }],
-            &[ModelBindingSpec {
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
                 id: "bootstrap".into(),
                 provider_id: "bootstrap".into(),
                 upstream_model: "bootstrap-model".into(),
                 created_at: None,
                 updated_at: None,
-            }],
-            &[bootstrap_agent()],
-            &[],
-        )
-        .await
-        .expect("bootstrap");
+            }),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
     manager.apply().await.expect("apply");
 
     let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
@@ -337,14 +328,6 @@ async fn restore_restart_event_returns_422() {
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(ImmediateExecutor))
-            .with_model_binding(
-                "bootstrap",
-                ModelBinding {
-                    provider_id: "bootstrap".into(),
-                    upstream_model: "bootstrap-model".into(),
-                },
-            )
-            .with_agent_spec(bootstrap_agent())
             .with_thread_run_store(thread_store.clone())
             .build()
             .expect("build runtime"),
@@ -354,25 +337,25 @@ async fn restore_restart_event_returns_422() {
             .expect("manager")
             .with_provider_factory(Arc::new(TestProviderFactory)),
     );
-    manager
-        .bootstrap_if_empty(
-            &[ProviderSpec {
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
                 id: "bootstrap".into(),
                 adapter: "stub".into(),
                 ..Default::default()
-            }],
-            &[ModelBindingSpec {
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
                 id: "bootstrap".into(),
                 provider_id: "bootstrap".into(),
                 upstream_model: "bootstrap-model".into(),
                 created_at: None,
                 updated_at: None,
-            }],
-            &[bootstrap_agent()],
-            &[],
-        )
-        .await
-        .expect("bootstrap");
+            }),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
     manager.apply().await.expect("apply");
 
     // Write a Restart event directly into the audit store.

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -1072,10 +1072,9 @@ Always greet the user warmly and ask how you can help today.
     let runtime = builder.build().expect("failed to build runtime");
     let runtime = Arc::new(runtime);
     let config_store = file_store.clone() as Arc<dyn ConfigStore>;
-    // Build an audit logger from the config store so seed-apply events are
-    // recorded at boot. The same store is later used by AppState when
-    // `with_audit_log_from_config` constructs its own logger instance.
-    let seed_audit_logger = Arc::new(awaken_server::services::audit_log::AuditLogger::new(
+    // Build a single audit logger shared by ConfigRuntimeManager (for seed-apply
+    // events at boot) and AppState (for all subsequent audit events).
+    let audit_logger = Arc::new(awaken_server::services::audit_log::AuditLogger::new(
         config_store.clone(),
     ));
     let config_runtime_manager = Arc::new(
@@ -1083,7 +1082,7 @@ Always greet the user warmly and ask how you can help today.
             .expect("failed to initialize config runtime manager")
             .with_provider_factory(provider_factory)
             .with_mcp_refresh_interval(Duration::from_secs(5))
-            .with_audit_log(seed_audit_logger),
+            .with_audit_log(audit_logger.clone()),
     );
 
     let seed = {
@@ -1154,6 +1153,7 @@ Always greet the user warmly and ask how you can help today.
     .with_config_runtime_manager(config_runtime_manager)
     .with_credential_broker(Arc::clone(&credential_broker))
     .with_runtime_stats(runtime_stats)
+    .with_audit_log(audit_logger)
     .with_audit_log_from_config()
     .with_skill_catalog_provider(
         Arc::new(RegistryBackedSkillCatalogProvider::new(skill_registry))

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -26,6 +26,7 @@ use awaken_contract::contract::tool::Tool;
 use awaken_contract::registry_spec::{
     AgentSpec, McpServerSpec, McpTransportKind, ModelBindingSpec, ProviderSpec,
 };
+use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
 use awaken_ext_deferred_tools::DeferredToolsPlugin;
 use awaken_ext_generative_ui::{
     A2uiPlugin, A2uiPromptConfig, A2uiPromptConfigKey, json_render, openui,
@@ -47,7 +48,6 @@ use awaken_runtime::plugins::Plugin;
 use awaken_runtime::policies::{
     ConsecutiveErrorsPolicy, StopConditionPlugin, StopPolicy, TimeoutPolicy, TokenBudgetPolicy,
 };
-use awaken_runtime::registry::traits::ModelBinding;
 use awaken_server::app::{
     AppState, ServerConfig, SkillCatalogArgument, SkillCatalogContext, SkillCatalogEntry,
     SkillCatalogProvider,
@@ -848,10 +848,6 @@ Deterministic compatibility directives:\n\
         created_at: None,
         updated_at: None,
     };
-    let executor = provider_factory
-        .build(&default_provider)
-        .expect("failed to build default provider executor");
-
     // -- MCP managed defaults --
 
     let managed_mcp_servers = if let Some(ref cmd_str) = args.mcp_server_cmd {
@@ -879,22 +875,10 @@ Deterministic compatibility directives:\n\
     // -- Builder --
 
     let mut builder = AgentRuntimeBuilder::new()
-        .with_provider(DEFAULT_PROVIDER_ID, executor)
-        .with_model_binding(
-            DEFAULT_MODEL_ID,
-            ModelBinding {
-                provider_id: default_model.provider_id.clone(),
-                upstream_model: default_model.upstream_model.clone(),
-            },
-        )
         .with_thread_run_store(file_store.clone() as Arc<dyn ThreadRunStore>)
         .with_profile_store(
             Arc::new(awaken_stores::InMemoryStore::default()) as Arc<dyn ProfileStore>
         );
-
-    for agent in &managed_agents {
-        builder = builder.with_agent_spec(agent.clone());
-    }
 
     for (id, tool) in &tools {
         builder = builder.with_tool(*id, Arc::clone(tool));
@@ -1088,31 +1072,54 @@ Always greet the user warmly and ask how you can help today.
     let runtime = builder.build().expect("failed to build runtime");
     let runtime = Arc::new(runtime);
     let config_store = file_store.clone() as Arc<dyn ConfigStore>;
+    // Build an audit logger from the config store so seed-apply events are
+    // recorded at boot. The same store is later used by AppState when
+    // `with_audit_log_from_config` constructs its own logger instance.
+    let seed_audit_logger = Arc::new(awaken_server::services::audit_log::AuditLogger::new(
+        config_store.clone(),
+    ));
     let config_runtime_manager = Arc::new(
         ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
             .expect("failed to initialize config runtime manager")
             .with_provider_factory(provider_factory)
-            .with_mcp_refresh_interval(Duration::from_secs(5)),
+            .with_mcp_refresh_interval(Duration::from_secs(5))
+            .with_audit_log(seed_audit_logger),
     );
 
-    let bootstrapped = config_runtime_manager
-        .bootstrap_if_empty(
-            std::slice::from_ref(&default_provider),
-            std::slice::from_ref(&default_model),
-            &managed_agents,
-            &managed_mcp_servers,
-        )
+    let seed = {
+        let mut specs: Vec<BuiltinSpec> = Vec::new();
+        specs.push(BuiltinSpec::provider(default_provider.clone()));
+        specs.push(BuiltinSpec::model(default_model.clone()));
+        for agent in &managed_agents {
+            specs.push(BuiltinSpec::agent(agent.clone()));
+        }
+        for mcp in &managed_mcp_servers {
+            specs.push(BuiltinSpec::mcp_server(mcp.clone()));
+        }
+        BuiltinSeedSet {
+            binary_version: env!("CARGO_PKG_VERSION").to_string(),
+            specs,
+        }
+    };
+
+    let seed_report = config_runtime_manager
+        .apply_seed(&seed)
         .await
-        .expect("failed to bootstrap managed config store");
+        .expect("failed to apply built-in seed");
+    tracing::info!(
+        created = seed_report.created.len(),
+        updated = seed_report.updated.len(),
+        unchanged = seed_report.unchanged.len(),
+        deleted = seed_report.deleted.len(),
+        preserved_user = seed_report.preserved_user.len(),
+        "built-in seed applied"
+    );
+
     let config_version = config_runtime_manager
         .apply()
         .await
         .expect("failed to publish managed config snapshot");
-    tracing::info!(
-        bootstrapped,
-        config_version,
-        "managed config snapshot published"
-    );
+    tracing::info!(config_version, "managed config snapshot published");
     config_runtime_manager
         .start_periodic_refresh(Duration::from_secs(5))
         .expect("failed to start managed config refresh");


### PR DESCRIPTION
## Summary

Three-phase architectural refactor that makes ConfigStore the single source of truth for static specs at the awaken-server layer, with field-level upgrade-following for built-in agents. Plus P1 cleanup of pre-existing clippy errors and a small wiring nit.

**Phase 1** — storage envelope + idempotent seed protocol (no behavior change for users)
**Phase 2** — server boot wires `apply_seed`; starter_backend + dual-path tests migrated; OverlayAgentRegistry → AgentSpecRegistryWithDiscovery; writer paths emit envelope
**Phase 3** — `AgentSpecPatch` + read-time merge; PATCH/DELETE override endpoints; UI three-state badges + reset button; full upgrade-following implemented
**P1** — workspace clippy clean; single AuditLogger instance; rollback-failure test infrastructure

## Highlights

- **Backward compatible**: existing sled deployments holding bare-spec entries continue to load via Phase 1's lazy decoder. No data migration required.
- **Behavior objects unchanged**: `Tool` / `Plugin` / `LlmExecutor` / `CredentialBroker` still register via `AgentRuntimeBuilder`. Only static specs flow through ConfigStore.
- **Discovery preserved**: A2A-discovered remote agents continue to work via the renamed `DiscoveredAgentRegistry`; only the merge layer's name and doc-comments changed.
- **Upgrade following**: an operator can tweak `system_prompt` on a built-in agent and have it survive a binary upgrade that bumps the underlying built-in defaults — only the un-tuned fields refresh to new values.

## Architecture

```
Code (binary entry, e.g. starter_backend)
  ├─ Builder.with_tool / with_plugin / with_credential_broker / with_remote_agents
  └─ BuiltinSeedSet { agents, providers, models, mcp_servers }
                       │
                       ▼  at boot
              apply_builtin_seed(store, seed)
                       │
                       ▼
       ConfigStore  ← single source of truth (envelope-format reads + writes)
                       │
                       ▼  ConfigRuntimeManager.apply()
       AgentSpecRegistryWithDiscovery (config base ⊕ A2A discovery overlay)
                       ▼
                   Resolver
```

Three observable record states (per `meta.source` × `meta.user_overrides`):

| `meta.source` | `meta.user_overrides` | UI label | Effective spec |
|---|---|---|---|
| `Builtin{v}` | None | **Built-in** | `record.spec` |
| `Builtin{v}` | Some(non-empty) | **Customized** | `merge(record.spec, patch)` |
| `User` | (ignored) | **User-defined** | `record.spec` |

## New types

- `awaken_contract::ConfigRecord<T>` — envelope `{spec, meta}` with backward-compat decoder
- `awaken_contract::RecordMeta { source, hidden, user_overrides, created_at, updated_at }`
- `awaken_contract::RecordSource::{Builtin{binary_version}, User}`
- `awaken_contract::BuiltinSpec` (discriminated over Agent/Provider/Model/McpServer) + `BuiltinSeedSet`
- `awaken_contract::AgentSpecPatch` + `merge_agent_spec`
- `awaken_server::services::config_envelope::{ApplyPatch, NoPatch, apply_overrides, wrap_user, wrap_builtin, ensure_envelope, unwrap_spec, spec_field, extract_timestamps}`
- `awaken_server::services::builtin_seed::{apply_builtin_seed, SeedReport, SeedError, RecordRef}`
- `AuditAction::SeedApply` + `AuditLogger::emit_seed_report`

## New endpoints

```
PATCH  /v1/config/agents/:id/overrides              merge patch into user_overrides
DELETE /v1/config/agents/:id/overrides              clear all user_overrides
DELETE /v1/config/agents/:id/overrides/:field       clear one override field
GET    /v1/config/:ns/:id/meta                      → RecordMeta
GET    /v1/config/:ns/meta                          → Vec<{id, meta}>
```

## What's removed

- `ConfigRuntimeManager::bootstrap_if_empty` (superseded by `apply_seed`)
- `ConfigRuntimeError::PartialBootstrap` (only emitted by the above)

## Pre-existing scope notes

- 4 commits at the bottom of this branch (`7b9935a43`, `68678ce23`, `06b4e03db`, `c7f2b019f`) are credential-broker work from PR #175/#176; rebasing on `main` after PR #176's squash-merge will drop them.
- The Phase 1 spec at `docs/superpowers/specs/2026-05-04-config-record-builtin-seed-design.md` documents the layered topology.
- Phase 2 spec: `docs/superpowers/specs/2026-05-04-config-store-unification-phase2-design.md`
- Phase 3 spec: `docs/superpowers/specs/2026-05-04-config-store-unification-phase3-design.md`

## Test plan

- [x] `cargo test --workspace` — 3076 tests, 0 failures
- [x] `pnpm vitest --run` (admin-console) — 540 tests, 0 failures
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (10 pre-existing errors fixed in same PR)
- [x] starter_backend smoke — cold boot creates 21 records; warm boot reports them all unchanged (idempotent)
- [x] starter_backend smoke — UI shows default agents as Built-in; PATCH `/overrides` makes them Customized; DELETE `/overrides` resets
- [ ] Reviewer to verify: rebase against current `main` to drop pre-merged broker commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)