### PR TITLE
Harden admin config, tools overrides, and security coverage

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,43 @@
+name: Security
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  rustsec-audit:
+    name: RustSec Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Audit Rust dependencies
+        run: |
+          # Existing transitive advisories in the locked graph are ignored here;
+          # new advisories still fail the job through --deny warnings.
+          cargo audit --deny warnings \
+            --ignore RUSTSEC-2023-0071 \
+            --ignore RUSTSEC-2025-0111 \
+            --ignore RUSTSEC-2025-0134 \
+            --ignore RUSTSEC-2026-0097
+
+  admin-console-npm-audit:
+    name: Admin Console npm Audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/admin-console
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/admin-console/package-lock.json
+      - run: npm ci
+      - run: npm audit --audit-level=high --omit=dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,23 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  admin-console-build-test:
+    name: Admin Console Build + Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/admin-console
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/admin-console/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
   msrv:
     name: MSRV Check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "subtle",
  "tempfile",
  "testcontainers",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ jsonschema = "0.45"
 parking_lot = "0.12"
 proptest = "1"
 secrecy = { version = "0.10", features = ["serde"] }
+subtle = "2.6"
 tokio-util = { version = "0.7", features = ["compat"] }
 
 [workspace.lints.rust]

--- a/apps/admin-console/src/app.tsx
+++ b/apps/admin-console/src/app.tsx
@@ -77,6 +77,16 @@ const AuditLogPage = lazy(async () => {
   return { default: module.AuditLogPage };
 });
 
+const ToolsPage = lazy(async () => {
+  const module = await import("./pages/tools-page");
+  return { default: module.ToolsPage };
+});
+
+const ToolEditorPage = lazy(async () => {
+  const module = await import("./pages/tool-editor-page");
+  return { default: module.ToolEditorPage };
+});
+
 /// Routes are declared once and reused via the data router so that v7
 /// hooks like `useBlocker` work. `<Routes>` (kept exported for tests
 /// that prefer the legacy router) renders the same structure.
@@ -192,6 +202,22 @@ export function appRoutes() {
           element={
             <RouteLoader>
               <AuditLogPage />
+            </RouteLoader>
+          }
+        />
+        <Route
+          path="tools"
+          element={
+            <RouteLoader>
+              <ToolsPage />
+            </RouteLoader>
+          }
+        />
+        <Route
+          path="tools/:id"
+          element={
+            <RouteLoader>
+              <ToolEditorPage />
             </RouteLoader>
           }
         />

--- a/apps/admin-console/src/lib/config-api.test.ts
+++ b/apps/admin-console/src/lib/config-api.test.ts
@@ -351,3 +351,35 @@ describe("deriveSourceState", () => {
     expect(deriveSourceState(meta)).toBe("user");
   });
 });
+
+describe("tool overrides client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("PATCH posts to /v1/config/tools/:id/overrides", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: "echo", description: "patched" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await configApi.patchToolOverrides("echo", { description: "patched" });
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toMatch(/\/v1\/config\/tools\/echo\/overrides$/);
+    expect((fetchMock.mock.calls[0]![1] as RequestInit).method).toBe("PATCH");
+  });
+
+  it("DELETE clears all overrides", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: "echo", description: "stock" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await configApi.clearToolOverrides("echo");
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toMatch(/\/v1\/config\/tools\/echo\/overrides$/);
+    expect((fetchMock.mock.calls[0]![1] as RequestInit).method).toBe("DELETE");
+  });
+});

--- a/apps/admin-console/src/lib/config-api.test.ts
+++ b/apps/admin-console/src/lib/config-api.test.ts
@@ -150,6 +150,7 @@ describe("configUrl encoding", () => {
 describe("configApi", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("returns undefined for successful deletes", async () => {
@@ -200,6 +201,46 @@ describe("configApi", () => {
     expect(new Headers(init.headers).get("authorization")).toBe(
       "Bearer stored-token",
     );
+  });
+
+  it("uses stored bearer token before the dev env token", async () => {
+    vi.stubEnv("VITE_ADMIN_BEARER_TOKEN", "stale-env-token");
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ namespace: "agents", items: [] }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === ADMIN_TOKEN_STORAGE_KEY ? "fresh-stored-token" : null,
+    });
+
+    await configApi.list("agents");
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(new Headers(init.headers).get("authorization")).toBe(
+      "Bearer fresh-stored-token",
+    );
+  });
+
+  it("ignores VITE_ADMIN_BEARER_TOKEN in production builds", async () => {
+    vi.stubEnv("PROD", true);
+    vi.stubEnv("VITE_ADMIN_BEARER_TOKEN", "must-not-ship-token");
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ namespace: "agents", items: [] }),
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubGlobal("localStorage", {
+      getItem: () => null,
+    });
+
+    await configApi.list("agents");
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit | undefined;
+    expect(init?.headers).toBeUndefined();
   });
 
   it("retries with a fresh token when the unauthorized handler returns one", async () => {

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -69,6 +69,13 @@ export interface ProviderRecord extends Omit<ProviderSpec, "api_key"> {
   has_api_key?: boolean;
 }
 
+export interface ProviderTestResponse {
+  ok: boolean;
+  latency_ms: number;
+  network_tested: boolean;
+  error?: string;
+}
+
 export interface McpRestartPolicy {
   enabled?: boolean;
   max_attempts?: number;
@@ -316,16 +323,23 @@ function adminBearerToken(override?: string): string | undefined {
     return override.trim();
   }
 
-  const envToken = import.meta.env.VITE_ADMIN_BEARER_TOKEN;
-  if (typeof envToken === "string" && envToken.trim().length > 0) {
-    return envToken.trim();
-  }
-
   if (typeof globalThis.localStorage === "undefined") {
-    return undefined;
+    return devEnvAdminBearerToken();
   }
   const stored = globalThis.localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY);
-  return stored?.trim() || undefined;
+  const storedToken = stored?.trim();
+  if (storedToken) {
+    return storedToken;
+  }
+  return devEnvAdminBearerToken();
+}
+
+function devEnvAdminBearerToken(): string | undefined {
+  if (import.meta.env.PROD) {
+    return undefined;
+  }
+  const envToken = import.meta.env.VITE_ADMIN_BEARER_TOKEN;
+  return typeof envToken === "string" ? envToken.trim() || undefined : undefined;
 }
 
 function withAdminAuth(init?: RequestInit, override?: string): RequestInit | undefined {
@@ -408,7 +422,7 @@ export const configApi = {
     ),
 
   testProvider: (id: string) =>
-    fetchJson<{ ok: boolean; latency_ms: number; error?: string }>(
+    fetchJson<ProviderTestResponse>(
       `${BACKEND_URL}/v1/providers/${encodeURIComponent(id)}/test`,
       { method: "POST" },
     ),

--- a/apps/admin-console/src/lib/config-api.ts
+++ b/apps/admin-console/src/lib/config-api.ts
@@ -25,6 +25,14 @@ export interface AgentSpec {
   updated_at?: number;
 }
 
+export interface ToolSpec {
+  id: string;
+  name: string;
+  description: string;
+  category?: string | null;
+  parameters_schema?: unknown;
+}
+
 export interface ModelBindingSpec {
   id: string;
   provider_id: string;
@@ -499,4 +507,32 @@ export const configApi = {
       `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(id)}/overrides/${encodeURIComponent(field)}`,
       { method: "DELETE" },
     ),
+
+  patchToolOverrides: (id: string, patch: { description?: string | null }) =>
+    fetchJson<ToolSpec>(
+      `${BACKEND_URL}/v1/config/tools/${encodeURIComponent(id)}/overrides`,
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(patch),
+      },
+    ),
+
+  clearToolOverrides: (id: string) =>
+    fetchJson<ToolSpec>(
+      `${BACKEND_URL}/v1/config/tools/${encodeURIComponent(id)}/overrides`,
+      { method: "DELETE" },
+    ),
+
+  clearToolOverrideField: (id: string, field: string) =>
+    fetchJson<ToolSpec>(
+      `${BACKEND_URL}/v1/config/tools/${encodeURIComponent(id)}/overrides/${encodeURIComponent(field)}`,
+      { method: "DELETE" },
+    ),
+
+  listTools: () =>
+    fetchJson<ListResponse<ToolSpec>>(`${BACKEND_URL}/v1/config/tools`),
+
+  getTool: (id: string) =>
+    fetchJson<ToolSpec>(configUrl("tools", id)),
 };

--- a/apps/admin-console/src/lib/i18n/en.ts
+++ b/apps/admin-console/src/lib/i18n/en.ts
@@ -23,6 +23,7 @@ export const en = {
       providers: "Providers",
       mcp: "MCP Servers",
       skills: "Skills",
+      tools: "Tools",
       dashboard: "Dashboard",
       audit: "Audit Log",
       evals: "Eval Reports",
@@ -340,6 +341,19 @@ export const en = {
     callerHint: "Users can invoke this skill from the chat surface",
     modelHint: "Model can autonomously invoke this skill",
     counter: "{{shown}} of {{total}} shown",
+  },
+  tools: {
+    list: {
+      title: "Tools",
+      filterOverridden: "Show only customized",
+    },
+    editor: {
+      builtin: "Built-in",
+      userOverride: "User override",
+      effective: "Effective",
+      revert: "Revert to default",
+      lengthWarning: "Long descriptions dilute model attention. Consider moving rules into the agent's system prompt.",
+    },
   },
   evals: {
     title: "Eval Reports",

--- a/apps/admin-console/src/lib/i18n/en.ts
+++ b/apps/admin-console/src/lib/i18n/en.ts
@@ -252,7 +252,7 @@ export const en = {
       credentialsKind: "Credentials type",
       saJson: "Service account JSON",
       saJsonPh: "Paste the full JSON downloaded from GCP IAM",
-      saJsonHint: "Awaken signs JWTs and refreshes OAuth tokens automatically. Stored encrypted at rest.",
+      saJsonHint: "Awaken signs JWTs and refreshes OAuth tokens automatically. Redacted in the UI and audit payloads.",
     },
     credentialsKind: {
       bearer: "Static bearer / API key",

--- a/apps/admin-console/src/lib/i18n/zh-CN.ts
+++ b/apps/admin-console/src/lib/i18n/zh-CN.ts
@@ -251,7 +251,7 @@ export const zhCN: Dict = {
       credentialsKind: "凭证类型",
       saJson: "Service Account JSON",
       saJsonPh: "粘贴从 GCP IAM 下载的完整 JSON",
-      saJsonHint: "Awaken 自动签发 JWT 并刷新 OAuth token；加密存储。",
+      saJsonHint: "Awaken 自动签发 JWT 并刷新 OAuth token；在界面和审计 payload 中脱敏。",
     },
     credentialsKind: {
       bearer: "静态 Bearer / API 密钥",

--- a/apps/admin-console/src/lib/i18n/zh-CN.ts
+++ b/apps/admin-console/src/lib/i18n/zh-CN.ts
@@ -22,6 +22,7 @@ export const zhCN: Dict = {
       providers: "供应商",
       mcp: "MCP 服务",
       skills: "技能",
+      tools: "工具",
       dashboard: "总览",
       audit: "审计日志",
       evals: "评测报告",
@@ -339,6 +340,19 @@ export const zhCN: Dict = {
     callerHint: "用户可在聊天界面调用此技能",
     modelHint: "模型可自主调用此技能",
     counter: "共 {{total}} 条，显示 {{shown}} 条",
+  },
+  tools: {
+    list: {
+      title: "工具",
+      filterOverridden: "仅显示自定义工具",
+    },
+    editor: {
+      builtin: "内置",
+      userOverride: "用户覆盖",
+      effective: "生效",
+      revert: "恢复默认",
+      lengthWarning: "过长的描述会稀释模型注意力，复杂规则建议放在 Agent 的 system prompt 中。",
+    },
   },
   evals: {
     title: "评测报告",

--- a/apps/admin-console/src/lib/nav.ts
+++ b/apps/admin-console/src/lib/nav.ts
@@ -50,6 +50,7 @@ export const navGroups: (NavGroup & { groupKey: string })[] = [
       { id: "models", path: adminRoutes.models, label: "Models", labelKey: "nav.items.models" } as NavItemKeyed,
       { id: "mcp-servers", path: adminRoutes.mcpServers, label: "MCP Servers", healthSource: "mcp", labelKey: "nav.items.mcp" } as NavItemKeyed,
       { id: "skills", path: adminRoutes.skills, label: "Skills", badge: "ro", labelKey: "nav.items.skills" } as NavItemKeyed,
+      { id: "tools", path: adminRoutes.tools, label: "Tools", labelKey: "nav.items.tools" } as NavItemKeyed,
     ] as NavItem[],
   },
   {

--- a/apps/admin-console/src/lib/routes.ts
+++ b/apps/admin-console/src/lib/routes.ts
@@ -11,6 +11,8 @@ export const adminRoutes = {
   mcpServers: "/mcp-servers",
   mcpServer: (id: string) => `/mcp-servers/${encodeURIComponent(id)}`,
   skill: (id: string) => `/skills/${encodeURIComponent(id)}`,
+  tools: "/tools",
+  tool: (id: string) => `/tools/${encodeURIComponent(id)}`,
   assistant: "/assistant",
   evalReports: "/eval-reports",
   auditLog: "/audit-log",

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -60,17 +60,21 @@ afterEach(() => {
 });
 
 describe("agent editor tab ARIA semantics", () => {
+  async function waitForBasicsPanel() {
+    await screen.findByLabelText("Agent ID", undefined, { timeout: 5000 });
+  }
+
   it("renders a tablist with correct role", async () => {
     renderEditorRoute("/agents/new");
     // Wait for the page to render (Agent ID field indicates Basics panel is shown)
-    await screen.findByLabelText("Agent ID");
+    await waitForBasicsPanel();
     const tablist = screen.getByRole("tablist");
     expect(tablist).toBeDefined();
   });
 
   it("each tab has role=tab and aria-selected reflects active state", async () => {
     renderEditorRoute("/agents/new");
-    await screen.findByLabelText("Agent ID");
+    await waitForBasicsPanel();
 
     const tabs = screen.getAllByRole("tab");
     expect(tabs.length).toBe(6);
@@ -89,7 +93,7 @@ describe("agent editor tab ARIA semantics", () => {
 
   it("active tab has tabIndex=0 and inactive tabs have tabIndex=-1", async () => {
     renderEditorRoute("/agents/new");
-    await screen.findByLabelText("Agent ID");
+    await waitForBasicsPanel();
 
     const basicsTab = screen.getByRole("tab", { name: "Basics" });
     expect(basicsTab.getAttribute("tabindex")).toBe("0");

--- a/apps/admin-console/src/pages/providers-page.test.tsx
+++ b/apps/admin-console/src/pages/providers-page.test.tsx
@@ -63,7 +63,7 @@ function stubFetch(overrides?: Record<string, unknown>) {
 
     // test provider
     if (urlStr.includes("/v1/providers/") && urlStr.endsWith("/test") && method === "POST") {
-      const defaults = { ok: true, latency_ms: 42 };
+      const defaults = { ok: true, latency_ms: 42, network_tested: false };
       return {
         ok: true,
         status: 200,
@@ -132,7 +132,7 @@ describe("ProvidersPage — Test connection button", () => {
     expect(screen.getByRole("button", { name: /test connection/i })).toBeDefined();
   });
 
-  it("calls testProvider and shows success status badge on OK result", async () => {
+  it("calls testProvider and shows config-only success status badge on OK result", async () => {
     const fetchSpy = stubFetch({ ok: true, latency_ms: 55 });
     renderProviders();
 
@@ -147,13 +147,30 @@ describe("ProvidersPage — Test connection button", () => {
     });
 
     // status badge should appear
-    await screen.findByText(/OK — 55ms/i);
+    await screen.findByText(/Config OK — 55ms/i);
 
     // fetch was called with the test endpoint
     const testCall = fetchSpy.mock.calls.find(([url]) =>
       String(url).includes("/v1/providers/my-openai/test"),
     );
     expect(testCall).toBeDefined();
+  });
+
+  it("shows connection success status when the provider test reached the network", async () => {
+    stubFetch({ ok: true, latency_ms: 77, network_tested: true });
+    renderProviders();
+
+    const editButton = await screen.findByRole("button", { name: /edit/i });
+    fireEvent.click(editButton);
+
+    await screen.findByText(/edit provider/i);
+
+    const testBtn = screen.getByRole("button", { name: /test connection/i });
+    await act(async () => {
+      fireEvent.click(testBtn);
+    });
+
+    await screen.findByText(/Connection OK — 77ms/i);
   });
 
   it("blocks Save when required fields are empty and shows inline Required errors", async () => {

--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -6,6 +6,7 @@ import {
   configApi,
   type ProviderRecord,
   type ProviderSpec,
+  type ProviderTestResponse,
 } from "@/lib/config-api";
 import { useToast } from "@/components/toast-provider";
 import { useCrudPage } from "@/lib/use-crud-page";
@@ -95,6 +96,7 @@ const LIST_OPTIONS = {
 interface TestStatus {
   ok: boolean;
   latency_ms: number;
+  network_tested: boolean;
   error?: string;
   testedAt: number;
 }
@@ -112,6 +114,18 @@ function readCredentialsKind(
 ): CredentialsKind {
   const raw = options?.credentials_kind;
   return raw === "service_account_json" ? "service_account_json" : "bearer";
+}
+
+function providerTestSuccessLabel(result: ProviderTestResponse): string {
+  return result.network_tested
+    ? `Connection OK — ${result.latency_ms}ms`
+    : `Config OK — ${result.latency_ms}ms`;
+}
+
+function providerTestToastLabel(result: ProviderTestResponse): string {
+  return result.network_tested
+    ? `Provider connection OK (${result.latency_ms}ms)`
+    : `Provider config OK (${result.latency_ms}ms)`;
 }
 
 export function ProvidersPage() {
@@ -252,7 +266,7 @@ export function ProvidersPage() {
       if (testingIdRef.current !== id) return;
       setTestStatus({ ...result, testedAt: Date.now() });
       if (result.ok) {
-        toast.success(`Provider OK (${result.latency_ms}ms)`);
+        toast.success(providerTestToastLabel(result));
       } else {
         toast.error(result.error ?? "Provider test failed");
       }
@@ -260,7 +274,13 @@ export function ProvidersPage() {
       if (testingIdRef.current !== id) return;
       const message =
         err instanceof ConfigApiError ? err.message : "Provider test failed";
-      setTestStatus({ ok: false, latency_ms: 0, error: message, testedAt: Date.now() });
+      setTestStatus({
+        ok: false,
+        latency_ms: 0,
+        network_tested: false,
+        error: message,
+        testedAt: Date.now(),
+      });
       toast.error(message);
     } finally {
       if (testingIdRef.current === id) setTesting(false);
@@ -302,7 +322,11 @@ export function ProvidersPage() {
     try {
       const result = await configApi.testProvider(providerId);
       if (result.ok) {
-        toast.success(`${providerId} OK · ${result.latency_ms}ms`);
+        toast.success(
+          result.network_tested
+            ? `${providerId} connection OK · ${result.latency_ms}ms`
+            : `${providerId} config OK · ${result.latency_ms}ms`,
+        );
       } else {
         toast.error(`${providerId}: ${result.error ?? "test failed"}`);
       }
@@ -535,7 +559,7 @@ export function ProvidersPage() {
                   <>{t("providers.fields.saJsonHint")}</>
                 ) : (
                   <>
-                    Stored encrypted at rest. Submitting saves the new value and rotates the runtime client; in-flight requests continue with the prior key.
+                    Redacted in the UI and audit payloads. Submitting saves the new value and rotates the runtime client; in-flight requests continue with the prior key.
                   </>
                 )
               }
@@ -607,7 +631,7 @@ export function ProvidersPage() {
             >
               <span className="font-medium">
                 {testStatus.ok
-                  ? `OK — ${testStatus.latency_ms}ms`
+                  ? providerTestSuccessLabel(testStatus)
                   : `Failed${testStatus.error ? `: ${testStatus.error}` : ""}`}
               </span>
               <span className="ml-auto text-xs opacity-60">

--- a/apps/admin-console/src/pages/tool-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/tool-editor-page.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { ToolEditorPage } from "./tool-editor-page";
+
+const stockTool = {
+  id: "echo",
+  name: "Echo",
+  description: "Stock description",
+  category: "debug",
+  parameters_schema: {},
+};
+
+vi.mock("@/lib/config-api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/config-api")>("@/lib/config-api");
+  const tool = {
+    id: "echo",
+    name: "Echo",
+    description: "Stock description",
+    category: "debug",
+    parameters_schema: {},
+  };
+  return {
+    ...actual,
+    configApi: {
+      getTool: vi.fn().mockResolvedValue(tool),
+      getMeta: vi.fn().mockResolvedValue({
+        source: { kind: "builtin", binary_version: "v1" },
+        user_overrides: { description: "customized" },
+        hidden: false,
+        created_at: 0,
+        updated_at: 0,
+      }),
+      patchToolOverrides: vi.fn().mockResolvedValue({ ...tool, description: "patched" }),
+      clearToolOverrides: vi.fn().mockResolvedValue(tool),
+    },
+  };
+});
+
+function renderEditor() {
+  return render(
+    <MemoryRouter initialEntries={["/tools/echo"]}>
+      <Routes>
+        <Route path="/tools/:id" element={<ToolEditorPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ToolEditorPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows builtin and editable description side-by-side", async () => {
+    renderEditor();
+    await waitFor(() => expect(screen.getByDisplayValue("Stock description")).toBeDefined());
+    // Both the readonly builtin <p> and the editable textarea show the same text
+    const matches = screen.getAllByText("Stock description");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    // The builtin readonly view is a <p>
+    expect(matches.some((el) => el.tagName === "P")).toBe(true);
+  });
+
+  it("save button calls patchToolOverrides only with changed description", async () => {
+    const { configApi } = await import("@/lib/config-api");
+    renderEditor();
+    const textarea = await waitFor(() => screen.getByDisplayValue("Stock description"));
+    fireEvent.change(textarea, { target: { value: "Custom description" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => {
+      expect(configApi.patchToolOverrides).toHaveBeenCalledWith("echo", { description: "Custom description" });
+    });
+  });
+
+  it("revert button calls clearToolOverrides", async () => {
+    const { configApi } = await import("@/lib/config-api");
+    renderEditor();
+    await waitFor(() => screen.getByDisplayValue("Stock description"));
+    fireEvent.click(screen.getByRole("button", { name: /revert/i }));
+    await waitFor(() => {
+      expect(configApi.clearToolOverrides).toHaveBeenCalledWith("echo");
+    });
+  });
+
+  it("warns about long descriptions over 400 chars", async () => {
+    renderEditor();
+    const textarea = await waitFor(() => screen.getByDisplayValue("Stock description"));
+    fireEvent.change(textarea, { target: { value: "x".repeat(401) } });
+    expect(screen.getByText(/dilute|长描述|attention/i)).toBeDefined();
+  });
+});

--- a/apps/admin-console/src/pages/tool-editor-page.tsx
+++ b/apps/admin-console/src/pages/tool-editor-page.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import {
+  type ToolSpec,
+  type RecordMeta,
+  configApi,
+  deriveSourceState,
+} from "@/lib/config-api";
+import { adminRoutes } from "@/lib/routes";
+
+const SOFT_WARN_LEN = 400;
+
+export function ToolEditorPage() {
+  const { t } = useTranslation();
+  const { id = "" } = useParams();
+
+  const [builtin, setBuiltin] = useState<ToolSpec | null>(null);
+  const [meta, setMeta] = useState<RecordMeta | null>(null);
+  const [draft, setDraft] = useState<string>("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    Promise.all([configApi.getTool(id), configApi.getMeta("tools", id)]).then(
+      ([spec, m]) => {
+        if (!mounted) return;
+        setBuiltin(spec);
+        setMeta(m);
+        setDraft(spec.description);
+      },
+    );
+    return () => {
+      mounted = false;
+    };
+  }, [id]);
+
+  if (!builtin || !meta) return <p className="p-6 text-fg-soft">Loading…</p>;
+
+  const dirty = draft !== builtin.description;
+  const overLength = draft.length >= SOFT_WARN_LEN;
+
+  async function onSave() {
+    if (!dirty) return;
+    setSaving(true);
+    try {
+      const next = await configApi.patchToolOverrides(id, { description: draft });
+      const nextMeta = await configApi.getMeta("tools", id);
+      setBuiltin(next);
+      setMeta(nextMeta);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onRevert() {
+    setSaving(true);
+    try {
+      const next = await configApi.clearToolOverrides(id);
+      const nextMeta = await configApi.getMeta("tools", id);
+      setBuiltin(next);
+      setDraft(next.description);
+      setMeta(nextMeta);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-4 p-6">
+      <header className="flex items-center gap-3">
+        <Link to={adminRoutes.tools} className="text-fg-soft underline">
+          ← {t("tools.list.title", { defaultValue: "Tools" })}
+        </Link>
+        <h1 className="text-xl font-semibold">{builtin.name}</h1>
+        <span className="text-fg-faint text-sm">{builtin.id}</span>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="border border-line rounded p-3">
+          <h2 className="text-xs font-medium uppercase text-fg-soft">
+            {t("tools.editor.builtin", { defaultValue: "Built-in" })}
+          </h2>
+          <p className="mt-2 whitespace-pre-wrap text-sm text-fg-soft">
+            {builtin.description}
+          </p>
+        </div>
+        <div className="border border-line rounded p-3">
+          <h2 className="text-xs font-medium uppercase text-fg-soft">
+            {t("tools.editor.userOverride", { defaultValue: "User override" })}
+          </h2>
+          <textarea
+            className="mt-2 w-full min-h-[140px] rounded border border-line p-2 font-mono text-sm"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={saving}
+          />
+          <p className="mt-1 text-[11px] text-fg-faint">
+            {draft.length} chars
+          </p>
+          {overLength && (
+            <p className="mt-1 text-[11px] text-state-progress">
+              {t("tools.editor.lengthWarning", {
+                defaultValue:
+                  "Long descriptions dilute model attention. Consider moving rules into the agent's system prompt.",
+              })}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <footer className="flex gap-2">
+        <button
+          type="button"
+          className="rounded bg-fg-strong px-3 py-1.5 text-sm text-canvas disabled:opacity-50"
+          onClick={onSave}
+          disabled={!dirty || saving}
+        >
+          {t("common.save", { defaultValue: "Save" })}
+        </button>
+        <button
+          type="button"
+          className="rounded border border-line px-3 py-1.5 text-sm disabled:opacity-50"
+          onClick={onRevert}
+          disabled={saving || deriveSourceState(meta) !== "customized"}
+        >
+          {t("tools.editor.revert", { defaultValue: "Revert to default" })}
+        </button>
+      </footer>
+    </section>
+  );
+}

--- a/apps/admin-console/src/pages/tools-page.test.tsx
+++ b/apps/admin-console/src/pages/tools-page.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  RouterProvider,
+  createMemoryRouter,
+  createRoutesFromElements,
+} from "react-router";
+import { appRoutes } from "../app";
+import { AuthProvider } from "../components/auth-provider";
+import { ConfirmDialogProvider } from "../components/confirm-dialog";
+import { ToastProvider } from "../components/toast-provider";
+import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
+
+function toolItem(id: string, name: string, description?: string, category?: string) {
+  return { id, name, description: description ?? `${name} description`, category };
+}
+
+function metaItem(
+  id: string,
+  userOverrides?: Record<string, unknown>,
+) {
+  return {
+    id,
+    meta: {
+      source: { kind: "builtin", binary_version: "v1" },
+      hidden: false,
+      user_overrides: userOverrides ?? null,
+      created_at: 0,
+      updated_at: 0,
+    },
+  };
+}
+
+function buildFetchMock(
+  tools: ReturnType<typeof toolItem>[],
+  metaItems: ReturnType<typeof metaItem>[],
+) {
+  return vi.fn(async (url: string | URL | Request) => {
+    const href =
+      typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+
+    if (href.includes("/v1/capabilities")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          }),
+      };
+    }
+
+    if (href.includes("/runtime-stats")) {
+      return { ok: false, status: 503, text: async () => "" };
+    }
+
+    if (href.includes("/v1/config/tools/meta")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(metaItems),
+      };
+    }
+
+    if (href.includes("/v1/config/tools")) {
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({ namespace: "tools", items: tools, offset: 0, limit: 100 }),
+      };
+    }
+
+    return { ok: false, status: 404, text: async () => "" };
+  });
+}
+
+function renderToolsPage() {
+  const router = createMemoryRouter(createRoutesFromElements(appRoutes()), {
+    initialEntries: ["/tools"],
+  });
+  render(
+    <ToastProvider>
+      <ConfirmDialogProvider>
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
+      </ConfirmDialogProvider>
+    </ToastProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  __resetAuthInterceptorForTesting();
+});
+
+describe("ToolsPage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders one row per tool with the override indicator", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [
+          toolItem("echo", "Echo", "Stock echo", "debug"),
+          toolItem("shell", "Shell", "Run a shell command"),
+        ],
+        [
+          metaItem("echo", { description: "patched" }),
+          metaItem("shell"),
+        ],
+      ),
+    );
+
+    renderToolsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("echo")).toBeDefined();
+      expect(screen.getByText("shell")).toBeDefined();
+    });
+
+    // The "echo" row carries the override badge; "shell" does not.
+    const echoRow = screen.getByText("echo").closest("tr")!;
+    expect(echoRow.textContent).toMatch(/customized|overridden/i);
+  });
+
+  it("shows builtin label for tools without overrides", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [toolItem("grep", "Grep", "Search files")],
+        [metaItem("grep")],
+      ),
+    );
+
+    renderToolsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("grep")).toBeDefined();
+    });
+
+    const grepRow = screen.getByText("grep").closest("tr")!;
+    expect(grepRow.textContent).toMatch(/builtin/i);
+  });
+
+  it("renders category column and dash for missing category", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock(
+        [
+          toolItem("echo", "Echo", "Stock echo", "debug"),
+          toolItem("shell", "Shell", "Run a shell command", undefined),
+        ],
+        [metaItem("echo"), metaItem("shell")],
+      ),
+    );
+
+    renderToolsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("echo")).toBeDefined();
+    });
+
+    expect(screen.getByText("debug")).toBeDefined();
+    // shell has no category — should show "—"
+    const cells = screen.getAllByText("—");
+    expect(cells.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/admin-console/src/pages/tools-page.test.tsx
+++ b/apps/admin-console/src/pages/tools-page.test.tsx
@@ -175,4 +175,22 @@ describe("ToolsPage", () => {
     const cells = screen.getAllByText("—");
     expect(cells.length).toBeGreaterThan(0);
   });
+
+  it("renders server supplied tool text as inert text, not HTML", async () => {
+    const payload = `<img src=x onerror="globalThis.__xss = true">`;
+    vi.stubGlobal("fetch", buildFetchMock(
+      [toolItem("xss-tool", payload, payload, payload)],
+      [metaItem("xss-tool")],
+    ));
+
+    renderToolsPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("xss-tool")).toBeDefined();
+    });
+
+    expect(document.querySelector("img")).toBeNull();
+    expect((globalThis as unknown as { __xss?: boolean }).__xss).toBeUndefined();
+    expect(screen.getAllByText(payload).length).toBeGreaterThan(0);
+  });
 });

--- a/apps/admin-console/src/pages/tools-page.tsx
+++ b/apps/admin-console/src/pages/tools-page.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router";
+import { useTranslation } from "react-i18next";
+import {
+  type ToolSpec,
+  type ConfigMetaItem,
+  configApi,
+  deriveSourceState,
+} from "@/lib/config-api";
+import { adminRoutes } from "@/lib/routes";
+
+export function ToolsPage() {
+  const { t } = useTranslation();
+  const [items, setItems] = useState<ToolSpec[]>([]);
+  const [metaById, setMetaById] = useState<Record<string, ConfigMetaItem["meta"]>>({});
+  const [loading, setLoading] = useState(true);
+  const [filterOverridden, setFilterOverridden] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    Promise.all([configApi.listTools(), configApi.listMeta("tools")])
+      .then(([list, metas]) => {
+        if (!mounted) return;
+        setItems(list.items ?? []);
+        const map: Record<string, ConfigMetaItem["meta"]> = {};
+        for (const m of metas) map[m.id] = m.meta;
+        setMetaById(map);
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const filtered = filterOverridden
+    ? items.filter(
+        (tool) =>
+          deriveSourceState(metaById[tool.id] ?? ({} as never)) === "customized",
+      )
+    : items;
+
+  return (
+    <div className="mx-auto max-w-6xl p-6 md:p-8">
+      <div className="mb-4 flex items-end justify-between gap-4">
+        <h2 className="text-2xl font-semibold tracking-title-em text-fg-strong">
+          {t("tools.list.title", { defaultValue: "Tools" })}
+        </h2>
+        <label className="flex items-center gap-2 text-sm font-medium text-fg">
+          <input
+            type="checkbox"
+            checked={filterOverridden}
+            onChange={(e) => setFilterOverridden(e.target.checked)}
+          />
+          {t("tools.list.filterOverridden", { defaultValue: "Show only customized" })}
+        </label>
+      </div>
+
+      {loading ? (
+        <p className="text-fg-soft">Loading…</p>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-line bg-surface shadow-card">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b border-line">
+                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-[0.18em] text-fg-faint">
+                  ID
+                </th>
+                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-[0.18em] text-fg-faint">
+                  Name
+                </th>
+                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-[0.18em] text-fg-faint">
+                  Category
+                </th>
+                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-[0.18em] text-fg-faint">
+                  Description
+                </th>
+                <th className="px-5 py-3 text-left text-xs font-medium uppercase tracking-[0.18em] text-fg-faint">
+                  State
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-5 py-8 text-center text-sm text-fg-soft">
+                    {filterOverridden ? "No customized tools." : "No tools found."}
+                  </td>
+                </tr>
+              )}
+              {filtered.map((tool) => {
+                const meta = metaById[tool.id];
+                const state = meta ? deriveSourceState(meta) : "builtin";
+                return (
+                  <tr key={tool.id} className="border-t border-line text-sm text-fg">
+                    <td className="px-5 py-4 font-mono text-fg-strong">
+                      <Link to={adminRoutes.tool(tool.id)} className="hover:underline">
+                        {tool.id}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-4">{tool.name}</td>
+                    <td className="px-5 py-4 text-fg-soft">{tool.category ?? "—"}</td>
+                    <td className="max-w-md truncate px-5 py-4 text-fg-soft">
+                      {tool.description}
+                    </td>
+                    <td className="px-5 py-4">
+                      {state === "customized" ? (
+                        <span className="rounded-pill bg-state-progress px-2 py-0.5 text-[10px] uppercase">
+                          customized
+                        </span>
+                      ) : (
+                        <span className="text-[11px] text-fg-faint">builtin</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/awaken-contract/src/builtin_seed.rs
+++ b/crates/awaken-contract/src/builtin_seed.rs
@@ -9,6 +9,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::registry_spec::{AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec};
+use crate::tool_spec::ToolSpec;
 
 /// A single spec the binary wants to seed into ConfigStore.
 ///
@@ -23,6 +24,7 @@ pub enum BuiltinSpec {
     Provider(ProviderSpec),
     Model(ModelBindingSpec),
     McpServer(McpServerSpec),
+    Tool(ToolSpec),
 }
 
 impl BuiltinSpec {
@@ -46,6 +48,11 @@ impl BuiltinSpec {
         Self::McpServer(spec)
     }
 
+    /// Wrap a `ToolSpec`.
+    pub fn tool(spec: ToolSpec) -> Self {
+        Self::Tool(spec)
+    }
+
     /// ConfigStore namespace this spec belongs to.
     ///
     /// Must match the namespace strings used by `ConfigService` /
@@ -56,6 +63,7 @@ impl BuiltinSpec {
             Self::Provider(_) => "providers",
             Self::Model(_) => "models",
             Self::McpServer(_) => "mcp-servers",
+            Self::Tool(_) => "tools",
         }
     }
 
@@ -66,6 +74,7 @@ impl BuiltinSpec {
             Self::Provider(s) => &s.id,
             Self::Model(s) => &s.id,
             Self::McpServer(s) => &s.id,
+            Self::Tool(s) => &s.id,
         }
     }
 }
@@ -145,5 +154,29 @@ mod tests {
             BuiltinSpec::mcp_server(spec),
             BuiltinSpec::McpServer(_)
         ));
+    }
+
+    #[test]
+    fn constructor_tool_wraps() {
+        let spec = crate::tool_spec::ToolSpec {
+            id: "t1".into(),
+            name: "Tool 1".into(),
+            description: "x".into(),
+            ..Default::default()
+        };
+        assert!(matches!(BuiltinSpec::tool(spec), BuiltinSpec::Tool(_)));
+    }
+
+    #[test]
+    fn tool_namespace_and_id() {
+        let spec = crate::tool_spec::ToolSpec {
+            id: "t1".into(),
+            name: "x".into(),
+            description: "x".into(),
+            ..Default::default()
+        };
+        let bi = BuiltinSpec::tool(spec);
+        assert_eq!(bi.namespace(), "tools");
+        assert_eq!(bi.id(), "t1");
     }
 }

--- a/crates/awaken-contract/src/config_record.rs
+++ b/crates/awaken-contract/src/config_record.rs
@@ -32,6 +32,12 @@ pub struct RecordMeta {
     pub created_at: u64,
     #[serde(default)]
     pub updated_at: u64,
+    /// Monotonic revision number for optimistic concurrency control.
+    /// Bumped by `ConfigStore::put_if_revision` on each successful CAS write.
+    /// Legacy records deserialise as 0; first `put_if_revision(... expected=0)`
+    /// promotes them to 1.
+    #[serde(default)]
+    pub revision: u64,
 }
 
 /// Who wrote this record into ConfigStore.
@@ -82,6 +88,7 @@ impl RecordMeta {
             user_overrides: None,
             created_at: 0,
             updated_at: 0,
+            revision: 0,
         }
     }
 
@@ -94,6 +101,7 @@ impl RecordMeta {
             user_overrides: None,
             created_at: now,
             updated_at: now,
+            revision: 0,
         }
     }
 
@@ -108,10 +116,53 @@ impl RecordMeta {
             user_overrides: None,
             created_at: now,
             updated_at: now,
+            revision: 0,
         }
     }
 }
 
 fn is_envelope(value: &serde_json::Value) -> bool {
     matches!(value, serde_json::Value::Object(map) if map.contains_key("spec") && map.contains_key("meta"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_json_without_revision_deserialises_to_zero() {
+        // Simulate a legacy RecordMeta JSON that has no `revision` field.
+        let json = serde_json::json!({
+            "source": {"kind": "user"},
+            "hidden": false,
+            "created_at": 1000,
+            "updated_at": 2000
+        });
+        let meta: RecordMeta = serde_json::from_value(json).unwrap();
+        assert_eq!(meta.revision, 0);
+        assert_eq!(meta.created_at, 1000);
+        assert_eq!(meta.updated_at, 2000);
+    }
+
+    #[test]
+    fn round_trip_preserves_revision() {
+        let meta = RecordMeta {
+            source: RecordSource::User,
+            hidden: false,
+            user_overrides: None,
+            created_at: 100,
+            updated_at: 200,
+            revision: 7,
+        };
+        let serialized = serde_json::to_value(&meta).unwrap();
+        let deserialized: RecordMeta = serde_json::from_value(serialized).unwrap();
+        assert_eq!(deserialized.revision, 7);
+    }
+
+    #[test]
+    fn constructors_default_revision_to_zero() {
+        assert_eq!(RecordMeta::legacy_user().revision, 0);
+        assert_eq!(RecordMeta::new_user().revision, 0);
+        assert_eq!(RecordMeta::new_builtin("1.0.0").revision, 0);
+    }
 }

--- a/crates/awaken-contract/src/contract/audit_log.rs
+++ b/crates/awaken-contract/src/contract/audit_log.rs
@@ -12,6 +12,11 @@ pub enum AuditAction {
     Publish,
     Restore,
     SeedApply,
+    /// A patch/update was persisted to the store but the runtime apply
+    /// phase failed; the store write was rolled back locally. Emitted
+    /// before the rollback to give operators an immutable record of the
+    /// attempted change. See ADR-0029 §D11.
+    ApplyFailed,
 }
 
 /// A self-contained audit record for a single admin action.
@@ -42,6 +47,11 @@ pub struct AuditEvent {
     /// For `action = restore`: the ULID of the audit event that was restored from.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub restored_from: Option<String>,
+    /// For `action = apply_failed`: the runtime error that prevented the
+    /// apply from succeeding. Helps operators triage transient vs.
+    /// permanent failures across replicas.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[cfg(test)]
@@ -62,6 +72,7 @@ mod tests {
             ip: Some("127.0.0.1".to_string()),
             request_id: None,
             restored_from: None,
+            error: None,
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -82,6 +93,7 @@ mod tests {
             ip: None,
             request_id: None,
             restored_from: None,
+            error: None,
         };
 
         let value = serde_json::to_value(&event).unwrap();
@@ -124,6 +136,10 @@ mod tests {
             serde_json::to_value(AuditAction::SeedApply).unwrap(),
             json!("seed_apply")
         );
+        assert_eq!(
+            serde_json::to_value(AuditAction::ApplyFailed).unwrap(),
+            json!("apply_failed")
+        );
     }
 
     #[test]
@@ -136,6 +152,7 @@ mod tests {
             ("publish", AuditAction::Publish),
             ("restore", AuditAction::Restore),
             ("seed_apply", AuditAction::SeedApply),
+            ("apply_failed", AuditAction::ApplyFailed),
         ] {
             let parsed: AuditAction = serde_json::from_str(&format!("\"{s}\"")).unwrap();
             assert_eq!(parsed, expected);
@@ -155,6 +172,7 @@ mod tests {
             ip: None,
             request_id: None,
             restored_from: Some("01OLDULID00".to_string()),
+            error: None,
         };
 
         let serialized = serde_json::to_value(&event).unwrap();
@@ -179,6 +197,7 @@ mod tests {
             ip: None,
             request_id: None,
             restored_from: None,
+            error: None,
         };
 
         let value = serde_json::to_value(&event).unwrap();
@@ -200,5 +219,50 @@ mod tests {
         }"#;
         let event: AuditEvent = serde_json::from_str(json).unwrap();
         assert_eq!(event.restored_from, None);
+        assert_eq!(event.error, None);
+    }
+
+    #[test]
+    fn apply_failed_event_with_error_round_trip() {
+        let event = AuditEvent {
+            id: "01FAIL00000".to_string(),
+            ts: "2026-05-01T12:00:00Z".to_string(),
+            actor: "deadbeef01234567".to_string(),
+            action: AuditAction::ApplyFailed,
+            resource: "tools/echo/overrides".to_string(),
+            before: Some(json!({"description": "stock"})),
+            after: Some(json!({"description": "patched"})),
+            ip: None,
+            request_id: None,
+            restored_from: None,
+            error: Some("invalid model id".into()),
+        };
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert_eq!(serialized["action"], "apply_failed");
+        assert_eq!(serialized["error"], "invalid model id");
+        let parsed: AuditEvent = serde_json::from_value(serialized).unwrap();
+        assert_eq!(parsed, event);
+    }
+
+    #[test]
+    fn error_omitted_when_none() {
+        let event = AuditEvent {
+            id: "01OK00000".to_string(),
+            ts: "2026-05-01T00:00:00Z".to_string(),
+            actor: "anonymous".to_string(),
+            action: AuditAction::Update,
+            resource: "tools/echo/overrides".to_string(),
+            before: None,
+            after: None,
+            ip: None,
+            request_id: None,
+            restored_from: None,
+            error: None,
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert!(
+            value.get("error").is_none(),
+            "error must be omitted when None"
+        );
     }
 }

--- a/crates/awaken-contract/src/contract/config_store.rs
+++ b/crates/awaken-contract/src/contract/config_store.rs
@@ -25,10 +25,110 @@ pub trait ConfigStore: Send + Sync {
     /// Delete an entry. Missing entries are not an error.
     async fn delete(&self, namespace: &str, id: &str) -> Result<(), StorageError>;
 
+    /// Create an entry only when it does not already exist.
+    ///
+    /// Production stores should override this with an atomic implementation.
+    /// The default implementation is best-effort and exists for lightweight
+    /// test stores.
+    async fn put_if_absent(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &Value,
+    ) -> Result<(), StorageError> {
+        if self.exists(namespace, id).await? {
+            return Err(StorageError::AlreadyExists(format!("{namespace}/{id}")));
+        }
+        self.put(namespace, id, value).await
+    }
+
     /// Check whether an entry exists.
     async fn exists(&self, namespace: &str, id: &str) -> Result<bool, StorageError> {
         Ok(self.get(namespace, id).await?.is_some())
     }
+
+    /// Atomic compare-and-set on the record's `meta.revision`.
+    ///
+    /// Reads the existing record at `(namespace, id)`, extracts the integer
+    /// at JSON path `meta.revision` (defaulting to 0 if absent), and:
+    ///
+    /// - if it equals `expected_revision`, replaces the record with `value`
+    ///   and returns `Ok(())`.
+    /// - if it differs, returns
+    ///   `Err(StorageError::VersionConflict { expected, actual })`.
+    /// - if no existing record AND `expected_revision == 0`, creates the
+    ///   record (treats absence as revision 0).
+    ///
+    /// The new revision is the caller's responsibility: write `value` with
+    /// `meta.revision = expected_revision + 1` before calling this method.
+    /// The store does not modify the value it stores; it only enforces the
+    /// CAS predicate.
+    ///
+    /// **Implementations MUST guarantee atomicity** with respect to
+    /// concurrent `put` / `put_if_revision` / `delete` against the same
+    /// `(namespace, id)`. The default implementation here is best-effort
+    /// (read-then-put, racy across replicas) and is provided so existing
+    /// `ConfigStore` impls compile without modification — production-grade
+    /// stores must override.
+    async fn put_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &Value,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        let actual = self
+            .get(namespace, id)
+            .await?
+            .as_ref()
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
+        self.put(namespace, id, value).await
+    }
+
+    /// Delete only when the current record's `meta.revision` matches
+    /// `expected_revision`.
+    ///
+    /// Production stores must make this atomic with concurrent writes to the
+    /// same `(namespace, id)`. The default implementation is best-effort for
+    /// simple test stores.
+    async fn delete_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        let actual = self
+            .get(namespace, id)
+            .await?
+            .as_ref()
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
+        self.delete(namespace, id).await
+    }
+}
+
+/// Extract the `meta.revision` integer from a stored config document.
+///
+/// Returns `None` if the path does not exist or is not an integer (e.g. legacy
+/// bare-spec documents that predate the envelope format).
+pub fn extract_meta_revision(value: &Value) -> Option<u64> {
+    value
+        .get("meta")
+        .and_then(|m| m.get("revision"))
+        .and_then(|r| r.as_u64())
 }
 
 /// Type of config mutation that was published by a store notification.
@@ -71,6 +171,39 @@ mod tests {
     use tokio::sync::RwLock;
 
     use super::*;
+
+    // ── extract_meta_revision ────────────────────────────────────────
+
+    #[test]
+    fn extract_meta_revision_returns_some_for_valid_path() {
+        let value = serde_json::json!({"meta": {"revision": 42}});
+        assert_eq!(extract_meta_revision(&value), Some(42));
+    }
+
+    #[test]
+    fn extract_meta_revision_returns_none_for_missing_meta() {
+        let value = serde_json::json!({"spec": {"id": "foo"}});
+        assert_eq!(extract_meta_revision(&value), None);
+    }
+
+    #[test]
+    fn extract_meta_revision_returns_none_for_missing_revision_key() {
+        let value = serde_json::json!({"meta": {"source": {"kind": "user"}}});
+        assert_eq!(extract_meta_revision(&value), None);
+    }
+
+    #[test]
+    fn extract_meta_revision_returns_none_for_wrong_type() {
+        let value = serde_json::json!({"meta": {"revision": "not-a-number"}});
+        assert_eq!(extract_meta_revision(&value), None);
+    }
+
+    #[test]
+    fn extract_meta_revision_returns_none_for_bare_spec() {
+        // Legacy bare-spec shape (no envelope).
+        let value = serde_json::json!({"id": "agent-1", "name": "Alice"});
+        assert_eq!(extract_meta_revision(&value), None);
+    }
 
     #[derive(Debug, Default)]
     struct MemoryConfigStore {

--- a/crates/awaken-contract/src/lib.rs
+++ b/crates/awaken-contract/src/lib.rs
@@ -26,6 +26,8 @@ pub mod secret;
 pub mod state;
 pub mod thread;
 pub mod time;
+pub mod tool_spec;
+pub mod tool_spec_patch;
 
 // ── time ──
 pub use time::now_ms;
@@ -41,6 +43,9 @@ pub use model::{
 
 // ── agent spec patch ──
 pub use agent_spec_patch::{AgentSpecPatch, merge_agent_spec};
+
+// ── tool spec patch ──
+pub use tool_spec_patch::{ToolSpecPatch, merge_tool_spec};
 
 // ── registry spec (AgentSpec, PluginConfigKey) ──
 pub use registry_spec::{
@@ -84,6 +89,9 @@ pub use contract::tool_schema::{generate_tool_schema, sanitize_for_llm, validate
 
 // ── thread ──
 pub use thread::{Thread, ThreadMetadata};
+
+// ── tool spec ──
+pub use tool_spec::ToolSpec;
 
 // ── cancellation ──
 pub use cancellation::{CancellationHandle, CancellationToken};

--- a/crates/awaken-contract/src/tool_spec.rs
+++ b/crates/awaken-contract/src/tool_spec.rs
@@ -1,0 +1,49 @@
+//! Tool registry record. The `description` field is the only field exposed
+//! to the patch surface (ADR-0029); other fields are read-only snapshots
+//! taken from `ToolDescriptor` at seed time.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ToolSpec {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(default)]
+    pub parameters_schema: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_preserves_all_fields() {
+        let spec = ToolSpec {
+            id: "echo".into(),
+            name: "Echo".into(),
+            description: "Returns the input verbatim".into(),
+            category: Some("debug".into()),
+            parameters_schema: json!({ "type": "object", "properties": {} }),
+        };
+        let value = serde_json::to_value(&spec).unwrap();
+        let back: ToolSpec = serde_json::from_value(value).unwrap();
+        assert_eq!(spec, back);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let bad = json!({
+            "id": "x",
+            "name": "x",
+            "description": "x",
+            "garbage": 1
+        });
+        assert!(serde_json::from_value::<ToolSpec>(bad).is_err());
+    }
+}

--- a/crates/awaken-contract/src/tool_spec_patch.rs
+++ b/crates/awaken-contract/src/tool_spec_patch.rs
@@ -1,0 +1,79 @@
+//! Field-level override for [`ToolSpec`] (ADR-0029).
+//!
+//! Stored as JSON inside `RecordMeta::user_overrides` for built-in tool
+//! records. Only `description` is patchable today.
+
+use serde::{Deserialize, Serialize};
+
+use crate::tool_spec::ToolSpec;
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct ToolSpecPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl ToolSpecPatch {
+    pub fn is_empty(&self) -> bool {
+        self.description.is_none()
+    }
+}
+
+/// Apply a [`ToolSpecPatch`] on top of a [`ToolSpec`]. `None` keeps the base
+/// value, `Some(v)` replaces it. Read-only fields (id, name, category,
+/// parameters_schema) are untouched — patch shape statically excludes them.
+pub fn merge_tool_spec(base: ToolSpec, patch: ToolSpecPatch) -> ToolSpec {
+    ToolSpec {
+        description: patch.description.unwrap_or(base.description),
+        ..base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base() -> ToolSpec {
+        ToolSpec {
+            id: "echo".into(),
+            name: "Echo".into(),
+            description: "stock".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_patch_leaves_spec_unchanged() {
+        let merged = merge_tool_spec(base(), ToolSpecPatch::default());
+        assert_eq!(merged.description, "stock");
+    }
+
+    #[test]
+    fn description_override_replaces_base() {
+        let merged = merge_tool_spec(
+            base(),
+            ToolSpecPatch {
+                description: Some("custom".into()),
+            },
+        );
+        assert_eq!(merged.description, "custom");
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let bad = json!({"description": "x", "name": "renamed"});
+        assert!(serde_json::from_value::<ToolSpecPatch>(bad).is_err());
+    }
+
+    #[test]
+    fn null_description_decodes_as_clear() {
+        // null on Option<String> deserializes as None; the service layer
+        // treats null at the JSON-object level as "remove this field" but
+        // the patch type itself accepts null harmlessly.
+        let v = json!({"description": null});
+        let patch: ToolSpecPatch = serde_json::from_value(v).unwrap();
+        assert!(patch.description.is_none());
+    }
+}

--- a/crates/awaken-contract/tests/config_record.rs
+++ b/crates/awaken-contract/tests/config_record.rs
@@ -9,6 +9,7 @@ fn record_meta_user_overrides_serde_round_trip() {
         user_overrides: Some(json!({"x": 1})),
         created_at: 100,
         updated_at: 200,
+        revision: 0,
     };
     let value = serde_json::to_value(&meta).expect("serialize must succeed");
     let decoded: RecordMeta = serde_json::from_value(value).expect("deserialize must succeed");
@@ -69,6 +70,7 @@ fn envelope_round_trip_preserves_all_fields() {
         user_overrides: None,
         created_at: 1_000,
         updated_at: 2_000,
+        revision: 3,
     };
     let record = ConfigRecord {
         spec: sample_agent_spec(),

--- a/crates/awaken-runtime/src/credentials/broker.rs
+++ b/crates/awaken-runtime/src/credentials/broker.rs
@@ -9,11 +9,14 @@
 //!
 //! ## Architecture
 //! Two RwLocks:
-//! - `materials`: `provider_id → CredentialMaterial`. Updated on
-//!   [`register`](AwakenCredentialBroker::register) calls; read on every mint.
-//!   Hot read path: no contention under steady state.
-//! - `cache`: `(provider_id, scope) → Token`. Updated on each mint; read on
-//!   every `token_for`. Cache hits short-circuit before any lock upgrade.
+//! - `materials`: `provider_id → (generation, CredentialMaterial)`. Updated on
+//!   [`register`](AwakenCredentialBroker::register) and
+//!   [`deregister`](AwakenCredentialBroker::deregister); read on every mint.
+//!   The generation prevents in-flight mints from writing or returning tokens
+//!   after credential rotation/removal.
+//! - `cache`: `(provider_id, scope) → (generation, Token)`. Updated on each
+//!   mint; read on every `token_for`. Cache hits are accepted only when the
+//!   provider is still registered at the same generation.
 //!
 //! Single-flight is implemented with a per-key
 //! `tokio::sync::OnceCell` pattern: the first task to find a stale cache
@@ -114,9 +117,20 @@ struct FlightSlot {
     inflight: AsyncMutex<()>,
 }
 
+#[derive(Clone)]
+struct MaterialEntry {
+    generation: u64,
+    material: Option<CredentialMaterial>,
+}
+
+struct CachedToken {
+    generation: u64,
+    token: Token,
+}
+
 pub struct AwakenCredentialBroker {
-    materials: PlRwLock<HashMap<String, CredentialMaterial>>,
-    cache: PlRwLock<HashMap<CacheKey, Token>>,
+    materials: PlRwLock<HashMap<String, MaterialEntry>>,
+    cache: PlRwLock<HashMap<CacheKey, CachedToken>>,
     /// Per-key in-flight mutex map. Entries live for the lifetime of the
     /// broker; the value is a small struct so the memory footprint stays
     /// bounded by the number of distinct (provider_id, scope) pairs in
@@ -167,7 +181,11 @@ impl AwakenCredentialBroker {
     /// Whether this broker knows about `provider_id`. Useful for
     /// embedder-side assertions.
     pub fn is_registered(&self, provider_id: &str) -> bool {
-        self.materials.read().contains_key(provider_id)
+        self.materials
+            .read()
+            .get(provider_id)
+            .and_then(|entry| entry.material.as_ref())
+            .is_some()
     }
 
     fn flight_slot(&self, key: &CacheKey) -> Arc<FlightSlot> {
@@ -184,16 +202,36 @@ impl AwakenCredentialBroker {
         )
     }
 
-    /// Mint a token for the registered material. **No cache, no
-    /// single-flight** — the caller (`token_for`) wraps this with both.
-    async fn mint(&self, provider_id: &str, scope: &str) -> Result<Token, CredentialError> {
-        let material = self
-            .materials
+    fn material_snapshot(
+        &self,
+        provider_id: &str,
+    ) -> Result<(u64, CredentialMaterial), CredentialError> {
+        let materials = self.materials.read();
+        let entry = materials
+            .get(provider_id)
+            .ok_or_else(|| CredentialError::NotConfigured(provider_id.to_owned()))?;
+        let material = entry
+            .material
+            .clone()
+            .ok_or_else(|| CredentialError::NotConfigured(provider_id.to_owned()))?;
+        Ok((entry.generation, material))
+    }
+
+    fn generation_still_current(&self, provider_id: &str, generation: u64) -> bool {
+        self.materials
             .read()
             .get(provider_id)
-            .cloned()
-            .ok_or_else(|| CredentialError::NotConfigured(provider_id.to_owned()))?;
+            .is_some_and(|entry| entry.generation == generation && entry.material.is_some())
+    }
 
+    /// Mint a token for a material snapshot. **No cache, no single-flight** —
+    /// the caller (`token_for`) wraps this with both and validates the snapshot
+    /// generation before returning.
+    async fn mint_material(
+        &self,
+        scope: &str,
+        material: CredentialMaterial,
+    ) -> Result<Token, CredentialError> {
         // Dispatch via the Minter trait — no central match. Adding a new
         // cloud means a new Minter impl and a new CredentialMaterial
         // constructor, not editing the broker.
@@ -212,7 +250,17 @@ impl CredentialBroker for AwakenCredentialBroker {
     fn register(&self, provider_id: String, material: CredentialMaterial) {
         {
             let mut materials = self.materials.write();
-            materials.insert(provider_id.clone(), material);
+            let next_generation = materials
+                .get(&provider_id)
+                .map(|entry| entry.generation.saturating_add(1))
+                .unwrap_or(1);
+            materials.insert(
+                provider_id.clone(),
+                MaterialEntry {
+                    generation: next_generation,
+                    material: Some(material),
+                },
+            );
         }
         // Drop any cached tokens for this provider — material change means
         // they may have been signed by a key that's about to be revoked.
@@ -220,12 +268,14 @@ impl CredentialBroker for AwakenCredentialBroker {
         cache.retain(|key, _| key.provider_id != provider_id);
     }
 
-    /// Forget a provider entirely. Best-effort: in-flight mints for this
-    /// provider will still complete and write to the (now-orphaned)
-    /// cache; the next read will treat the entry as missing and return
-    /// [`CredentialError::NotConfigured`].
+    /// Forget a provider entirely. In-flight mints for this provider are
+    /// generation-checked before cache write/return, so they are discarded if
+    /// this deregistration wins the race.
     fn deregister(&self, provider_id: &str) {
-        self.materials.write().remove(provider_id);
+        if let Some(entry) = self.materials.write().get_mut(provider_id) {
+            entry.generation = entry.generation.saturating_add(1);
+            entry.material = None;
+        }
         self.cache
             .write()
             .retain(|key, _| key.provider_id != provider_id);
@@ -247,33 +297,62 @@ impl CredentialBroker for AwakenCredentialBroker {
             scope: scope.to_owned(),
         };
 
-        // 1. Cache fast path — short-circuit before touching any other lock.
-        if let Some(token) = self.cache.read().get(&key)
-            && !token.is_near_expiry(SAFETY_WINDOW)
-        {
-            return Ok(IssuedToken::from_token(token));
+        loop {
+            let (generation, _) = self.material_snapshot(provider_id)?;
+
+            // 1. Cache fast path. A cached token is valid only while the
+            // provider remains registered at the same material generation.
+            if let Some(cached) = self.cache.read().get(&key)
+                && cached.generation == generation
+                && !cached.token.is_near_expiry(SAFETY_WINDOW)
+            {
+                return Ok(IssuedToken::from_token(&cached.token));
+            }
+
+            // 2. Acquire the per-key single-flight slot.
+            let slot = self.flight_slot(&key);
+            let _guard = slot.inflight.lock().await;
+
+            // 3. Re-read material and cache under the slot — a concurrent
+            //    task may have populated it or an admin may have rotated
+            //    credentials while we were waiting.
+            let (generation, material) = match self.material_snapshot(provider_id) {
+                Ok(snapshot) => snapshot,
+                Err(err) => return Err(err),
+            };
+            if let Some(cached) = self.cache.read().get(&key)
+                && cached.generation == generation
+                && !cached.token.is_near_expiry(SAFETY_WINDOW)
+            {
+                return Ok(IssuedToken::from_token(&cached.token));
+            }
+
+            // 4. We are the elected refresher. Apply the bounded retry
+            //    policy. If credentials are rotated/removed while minting,
+            //    discard the result and loop against the current generation.
+            let fresh = self
+                .mint_with_retry(provider_id, scope, material.clone())
+                .await?;
+            if !self.generation_still_current(provider_id, generation) {
+                tracing::debug!(
+                    provider_id = %provider_id,
+                    scope = %scope,
+                    generation,
+                    "credential broker: discarded token minted from stale material generation"
+                );
+                continue;
+            }
+
+            let issued = IssuedToken::from_token(&fresh);
+            self.cache.write().insert(
+                key.clone(),
+                CachedToken {
+                    generation,
+                    token: fresh,
+                },
+            );
+            return Ok(issued);
         }
-
-        // 2. Acquire the per-key single-flight slot.
-        let slot = self.flight_slot(&key);
-        let _guard = slot.inflight.lock().await;
-
-        // 3. Re-check cache under the slot — a concurrent task may have
-        //    populated it while we were waiting for the lock.
-        if let Some(token) = self.cache.read().get(&key)
-            && !token.is_near_expiry(SAFETY_WINDOW)
-        {
-            return Ok(IssuedToken::from_token(token));
-        }
-
-        // 4. We are the elected refresher. Apply the bounded retry policy:
-        //    permanent errors short-circuit; transient errors back off and
-        //    retry up to `max_attempts` times. The cache write only happens
-        //    on the *successful* attempt.
-        let fresh = self.mint_with_retry(provider_id, scope).await?;
-        let issued = IssuedToken::from_token(&fresh);
-        self.cache.write().insert(key, fresh);
-        Ok(issued)
     }
 }
 
@@ -288,6 +367,7 @@ impl AwakenCredentialBroker {
         &self,
         provider_id: &str,
         scope: &str,
+        material: CredentialMaterial,
     ) -> Result<Token, CredentialError> {
         crate::retry::with_backoff(
             &self.retry_policy,
@@ -300,7 +380,10 @@ impl AwakenCredentialBroker {
                     "credential broker: transient mint error, retrying after backoff"
                 );
             },
-            || async move { self.mint(provider_id, scope).await },
+            || {
+                let material = material.clone();
+                async move { self.mint_material(scope, material).await }
+            },
         )
         .await
     }
@@ -309,7 +392,9 @@ impl AwakenCredentialBroker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::credentials::minter::Minter;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Notify;
 
     /// Test broker that counts mint calls — used to assert single-flight
     /// behaviour without spinning up an HTTP server.
@@ -353,6 +438,77 @@ mod tests {
         Token {
             bearer: awaken_contract::secret::RedactedString::new("tok"),
             expires_at: std::time::SystemTime::now() + Duration::from_secs(secs),
+        }
+    }
+
+    fn future_token_with(bearer: &str, secs: u64) -> Token {
+        Token {
+            bearer: awaken_contract::secret::RedactedString::new(bearer),
+            expires_at: std::time::SystemTime::now() + Duration::from_secs(secs),
+        }
+    }
+
+    #[derive(Debug)]
+    struct BlockingMinter {
+        bearer: &'static str,
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl Minter for BlockingMinter {
+        fn kind_label(&self) -> &'static str {
+            "test_blocking"
+        }
+
+        async fn mint(
+            &self,
+            _scope: &str,
+            _http: &reqwest::Client,
+        ) -> Result<Token, CredentialError> {
+            self.started.notify_one();
+            self.release.notified().await;
+            Ok(future_token_with(self.bearer, 3600))
+        }
+    }
+
+    fn blocking_material(
+        bearer: &'static str,
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    ) -> CredentialMaterial {
+        CredentialMaterial::from_minter(Arc::new(BlockingMinter {
+            bearer,
+            started,
+            release,
+        }))
+    }
+
+    #[derive(Debug)]
+    struct FailsOnceMinter {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Minter for FailsOnceMinter {
+        fn kind_label(&self) -> &'static str {
+            "test_fails_once"
+        }
+
+        async fn mint(
+            &self,
+            _scope: &str,
+            _http: &reqwest::Client,
+        ) -> Result<Token, CredentialError> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                return Err(CredentialError::PermanentUpstream {
+                    provider_id: "p".to_string(),
+                    status: 403,
+                    body: "rejected".to_string(),
+                });
+            }
+            Ok(future_token_with("after-failure", 3600))
         }
     }
 
@@ -453,6 +609,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_during_in_flight_mint_discards_stale_token() {
+        let broker = Arc::new(AwakenCredentialBroker::new());
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        broker.register(
+            "p".to_string(),
+            blocking_material("old", Arc::clone(&started), Arc::clone(&release)),
+        );
+
+        let task = {
+            let broker = Arc::clone(&broker);
+            tokio::spawn(async move { broker.token_for("p", "s").await })
+        };
+        started.notified().await;
+
+        broker.register(
+            "p".to_string(),
+            CredentialMaterial::static_bearer(awaken_contract::secret::RedactedString::new("new")),
+        );
+        release.notify_one();
+
+        let issued = task.await.unwrap().unwrap();
+        assert_eq!(issued.bearer(), "new");
+        assert_eq!(broker.token_for("p", "s").await.unwrap().bearer(), "new");
+    }
+
+    #[tokio::test]
+    async fn deregister_during_in_flight_mint_discards_stale_token() {
+        let broker = Arc::new(AwakenCredentialBroker::new());
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        broker.register(
+            "p".to_string(),
+            blocking_material("old", Arc::clone(&started), Arc::clone(&release)),
+        );
+
+        let task = {
+            let broker = Arc::clone(&broker);
+            tokio::spawn(async move { broker.token_for("p", "s").await })
+        };
+        started.notified().await;
+
+        broker.deregister("p");
+        release.notify_one();
+
+        let err = task.await.unwrap().unwrap_err();
+        assert!(matches!(err, CredentialError::NotConfigured(provider) if provider == "p"));
+        assert!(matches!(
+            broker.token_for("p", "s").await.unwrap_err(),
+            CredentialError::NotConfigured(provider) if provider == "p"
+        ));
+    }
+
+    #[tokio::test]
     async fn different_scopes_have_independent_cache_entries() {
         let broker = AwakenCredentialBroker::new();
         broker.register(
@@ -479,6 +689,107 @@ mod tests {
         assert_eq!(
             broker.token_for("p", "scope-b").await.unwrap().bearer(),
             "rotated"
+        );
+    }
+
+    #[tokio::test]
+    async fn mint_failures_are_not_cached_or_replayed_to_later_callers() {
+        let broker = AwakenCredentialBroker::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        broker.register(
+            "p".to_string(),
+            CredentialMaterial::from_minter(Arc::new(FailsOnceMinter {
+                calls: Arc::clone(&calls),
+            })),
+        );
+
+        let err = broker.token_for("p", "scope").await.unwrap_err();
+        assert!(matches!(
+            err,
+            CredentialError::PermanentUpstream { status: 403, .. }
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let issued = broker.token_for("p", "scope").await.unwrap();
+        assert_eq!(issued.bearer(), "after-failure");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "broker must mint again after a failed exchange instead of caching the error"
+        );
+
+        let cached = broker.token_for("p", "scope").await.unwrap();
+        assert_eq!(cached.bearer(), "after-failure");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "successful retry may be cached, but the failed exchange must not be"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_rotation_is_isolated_by_provider_and_scope() {
+        let broker = Arc::new(AwakenCredentialBroker::new());
+        let started = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        broker.register(
+            "rotating".to_string(),
+            blocking_material("old-rotating", Arc::clone(&started), Arc::clone(&release)),
+        );
+        broker.register(
+            "stable".to_string(),
+            CredentialMaterial::static_bearer(awaken_contract::secret::RedactedString::new(
+                "stable-token",
+            )),
+        );
+
+        let rotating_task = {
+            let broker = Arc::clone(&broker);
+            tokio::spawn(async move { broker.token_for("rotating", "scope-a").await })
+        };
+        started.notified().await;
+
+        assert_eq!(
+            broker
+                .token_for("stable", "scope-a")
+                .await
+                .unwrap()
+                .bearer(),
+            "stable-token",
+            "unrelated providers must remain readable while another provider is mid-mint"
+        );
+
+        broker.register(
+            "rotating".to_string(),
+            CredentialMaterial::static_bearer(awaken_contract::secret::RedactedString::new(
+                "new-rotating",
+            )),
+        );
+        release.notify_one();
+
+        let issued = rotating_task.await.unwrap().unwrap();
+        assert_eq!(
+            issued.bearer(),
+            "new-rotating",
+            "in-flight mint from the old generation must be discarded"
+        );
+        assert_eq!(
+            broker
+                .token_for("rotating", "scope-b")
+                .await
+                .unwrap()
+                .bearer(),
+            "new-rotating",
+            "rotation must apply to all scopes for the provider"
+        );
+        assert_eq!(
+            broker
+                .token_for("stable", "scope-b")
+                .await
+                .unwrap()
+                .bearer(),
+            "stable-token",
+            "rotation must not invalidate unrelated providers"
         );
     }
 

--- a/crates/awaken-runtime/src/credentials/google_oauth.rs
+++ b/crates/awaken-runtime/src/credentials/google_oauth.rs
@@ -26,7 +26,7 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
 
 use super::error::CredentialError;
-use super::material::GoogleServiceAccountKey;
+use super::material::{GoogleServiceAccountKey, validate_google_token_uri};
 use super::token::Token;
 
 /// JWT lifetime. Google accepts up to 3600s; using the maximum minimises
@@ -61,6 +61,8 @@ pub(super) async fn mint(
     scope: &str,
     http: &reqwest::Client,
 ) -> Result<Token, CredentialError> {
+    validate_token_uri_for_exchange(provider_id, &key.token_uri)?;
+
     let now_secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|e| CredentialError::SigningFailed {
@@ -131,6 +133,21 @@ pub(super) async fn mint(
     })
 }
 
+fn validate_token_uri_for_exchange(
+    provider_id: &str,
+    token_uri: &str,
+) -> Result<(), CredentialError> {
+    #[cfg(test)]
+    if token_uri.starts_with("http://127.0.0.1:") || token_uri.starts_with("http://[::1]:") {
+        return Ok(());
+    }
+
+    validate_google_token_uri(token_uri).map_err(|reason| CredentialError::InvalidMaterial {
+        provider_id: provider_id.to_owned(),
+        reason,
+    })
+}
+
 /// Discriminate retryable transport faults (DNS, connection reset, TLS
 /// handshake) from upstream-rejected requests. reqwest doesn't give us
 /// a clean enum so the only signal we have is whether a status code
@@ -165,6 +182,7 @@ fn classify_reqwest_error(provider_id: &str, e: reqwest::Error) -> CredentialErr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::credentials::material::GOOGLE_OAUTH_TOKEN_URI;
     use crate::credentials::material::GoogleServiceAccountKey;
     use awaken_contract::secret::RedactedString;
     use std::sync::Arc;
@@ -333,6 +351,18 @@ yJe99wYtUpHld4D+pLiyUnQ=
             "expected Network for unreachable endpoint, got {err:?}"
         );
         assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn mint_rejects_non_google_token_uri() {
+        let key = test_sa_key("https://custom.example/token");
+        let http = reqwest::Client::new();
+        let err = mint("p", &key, "s", &http).await.unwrap_err();
+        assert!(
+            matches!(err, CredentialError::InvalidMaterial { ref reason, .. } if reason.contains(GOOGLE_OAUTH_TOKEN_URI)),
+            "expected InvalidMaterial allowlist error, got {err:?}"
+        );
+        assert!(!err.is_retryable());
     }
 
     #[tokio::test]

--- a/crates/awaken-runtime/src/credentials/material.rs
+++ b/crates/awaken-runtime/src/credentials/material.rs
@@ -15,6 +15,8 @@ use serde_json::Value;
 
 use super::minter::{self, Minter};
 
+pub(crate) const GOOGLE_OAUTH_TOKEN_URI: &str = "https://oauth2.googleapis.com/token";
+
 /// Opaque carrier of a parsed credential.
 ///
 /// Internally holds an [`Arc<dyn Minter>`](Minter) — the broker dispatches
@@ -32,6 +34,11 @@ impl CredentialMaterial {
         Self {
             minter: minter::static_bearer_arc(bearer),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_minter(minter: Arc<dyn Minter>) -> Self {
+        Self { minter }
     }
 
     /// Google service-account material. Only available when the
@@ -81,7 +88,16 @@ pub struct GoogleServiceAccountKey {
 }
 
 fn default_token_uri() -> String {
-    "https://oauth2.googleapis.com/token".to_owned()
+    GOOGLE_OAUTH_TOKEN_URI.to_owned()
+}
+
+pub(crate) fn validate_google_token_uri(token_uri: &str) -> Result<(), String> {
+    if token_uri == GOOGLE_OAUTH_TOKEN_URI {
+        return Ok(());
+    }
+    Err(format!(
+        "service account JSON token_uri must be {GOOGLE_OAUTH_TOKEN_URI}; got '{token_uri}'"
+    ))
 }
 
 fn deserialize_redacted<'de, D>(d: D) -> Result<RedactedString, D::Error>
@@ -108,6 +124,7 @@ impl GoogleServiceAccountKey {
         if !key.private_key.expose_secret().contains("BEGIN") {
             return Err("'private_key' does not look like a PEM block".into());
         }
+        validate_google_token_uri(&key.token_uri)?;
         Ok(key)
     }
 }
@@ -455,13 +472,61 @@ mod tests {
     }
 
     #[test]
-    fn google_sa_key_parse_honours_explicit_token_uri() {
+    fn google_sa_key_parse_accepts_standard_explicit_token_uri() {
+        let json = r#"{
+            "client_email":"sa@p.iam.gserviceaccount.com",
+            "private_key":"-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+            "token_uri":"https://oauth2.googleapis.com/token"
+        }"#;
+        let key = GoogleServiceAccountKey::parse(json).unwrap();
+        assert_eq!(key.token_uri, GOOGLE_OAUTH_TOKEN_URI);
+    }
+
+    #[test]
+    fn google_sa_key_parse_rejects_custom_token_uri() {
         let json = r#"{
             "client_email":"sa@p.iam.gserviceaccount.com",
             "private_key":"-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
             "token_uri":"https://custom.example/token"
         }"#;
-        let key = GoogleServiceAccountKey::parse(json).unwrap();
-        assert_eq!(key.token_uri, "https://custom.example/token");
+        let err = GoogleServiceAccountKey::parse(json).unwrap_err();
+        assert!(
+            err.contains(GOOGLE_OAUTH_TOKEN_URI) && err.contains("custom.example"),
+            "expected token_uri allowlist error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn google_sa_key_parse_rejects_ssrf_token_uri_corpus() {
+        let corpus = [
+            "http://127.0.0.1/token",
+            "http://127.0.0.1:8080/token",
+            "http://localhost/token",
+            "http://[::1]/token",
+            "http://10.0.0.1/token",
+            "http://172.16.0.1/token",
+            "http://192.168.1.1/token",
+            "http://169.254.169.254/latest/meta-data",
+            "https://oauth2.googleapis.com.evil.example/token",
+            "https://oauth2.googleapis.com@evil.example/token",
+            "https://oauth2.googleapis.com./token",
+            "https://evil.example/redirect?next=https%3A%2F%2Foauth2.googleapis.com%2Ftoken",
+            "HTTPS://oauth2.googleapis.com/token",
+        ];
+
+        for token_uri in corpus {
+            let json = serde_json::json!({
+                "client_email": "sa@p.iam.gserviceaccount.com",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+                "token_uri": token_uri,
+            })
+            .to_string();
+            let err = GoogleServiceAccountKey::parse(&json)
+                .expect_err("non-allowlisted token_uri must be rejected");
+            assert!(
+                err.contains(GOOGLE_OAUTH_TOKEN_URI) && err.contains(token_uri),
+                "expected allowlist error mentioning canonical endpoint and rejected URI, got: {err}"
+            );
+        }
     }
 }

--- a/crates/awaken-runtime/src/registry/config.rs
+++ b/crates/awaken-runtime/src/registry/config.rs
@@ -168,7 +168,7 @@ mod tests {
                 &self,
                 _request: InferenceRequest,
             ) -> Result<StreamResult, InferenceExecutionError> {
-                unimplemented!()
+                Err(InferenceExecutionError::Provider("stub executor".into()))
             }
 
             fn name(&self) -> &str {

--- a/crates/awaken-server/Cargo.toml
+++ b/crates/awaken-server/Cargo.toml
@@ -42,6 +42,7 @@ agent-client-protocol = { workspace = true }
 tokio-util = { workspace = true }
 genai = { workspace = true }
 schemars = { workspace = true }
+subtle = { workspace = true }
 
 # MCP server
 mcp = { package = "model-context-protocol", version = "0.2", default-features = false, features = ["server", "client"] }

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -1,7 +1,7 @@
 //! Application state and server startup.
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock, Weak};
+use std::sync::Arc;
 use std::time::Instant;
 
 use awaken_contract::RedactedString;
@@ -18,13 +18,6 @@ use crate::transport::replay_buffer::EventReplayBuffer;
 
 pub type ReplayBufferEntry = (Arc<EventReplayBuffer>, Instant);
 pub type ReplayBufferMap = Arc<Mutex<HashMap<String, ReplayBufferEntry>>>;
-type AdminApiConfigRegistry = HashMap<
-    usize,
-    (
-        Weak<Mutex<HashMap<String, ReplayBufferEntry>>>,
-        AdminApiConfig,
-    ),
->;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -223,13 +216,8 @@ fn default_max_concurrent() -> usize {
     100
 }
 
-const ADMIN_API_BEARER_TOKEN_ENV: &str = "AWAKEN_ADMIN_API_BEARER_TOKEN";
+pub const ADMIN_API_BEARER_TOKEN_ENV: &str = "AWAKEN_ADMIN_API_BEARER_TOKEN";
 const ADMIN_CORS_ALLOWED_ORIGINS_ENV: &str = "AWAKEN_ADMIN_CORS_ALLOWED_ORIGINS";
-static ADMIN_API_CONFIGS: OnceLock<Mutex<AdminApiConfigRegistry>> = OnceLock::new();
-
-fn admin_api_config_registry() -> &'static Mutex<AdminApiConfigRegistry> {
-    ADMIN_API_CONFIGS.get_or_init(|| Mutex::new(HashMap::new()))
-}
 
 fn admin_api_bearer_token_from_env() -> Option<RedactedString> {
     std::env::var(ADMIN_API_BEARER_TOKEN_ENV)
@@ -261,15 +249,7 @@ fn default_admin_cors_allowed_origins() -> Vec<String> {
 }
 
 pub(crate) fn admin_api_config(state: &AppState) -> AdminApiConfig {
-    let key = Arc::as_ptr(&state.replay_buffers) as usize;
-    let mut config = {
-        let mut registry = admin_api_config_registry().lock();
-        registry.retain(|_, (weak, _)| weak.upgrade().is_some());
-        registry
-            .get(&key)
-            .map(|(_, config)| config.clone())
-            .unwrap_or_default()
-    };
+    let mut config = state.admin_api_config.clone();
 
     if let Some(token) = admin_api_bearer_token_from_env() {
         config.bearer_token = Some(token);
@@ -279,14 +259,6 @@ pub(crate) fn admin_api_config(state: &AppState) -> AdminApiConfig {
     }
 
     config
-}
-
-fn admin_api_config_for_replay_buffers(replay_buffers: &ReplayBufferMap, config: AdminApiConfig) {
-    let key = Arc::as_ptr(replay_buffers) as usize;
-    let weak = Arc::downgrade(replay_buffers);
-    let mut registry = admin_api_config_registry().lock();
-    registry.retain(|_, (weak, _)| weak.upgrade().is_some());
-    registry.insert(key, (weak, config));
 }
 
 fn admin_cors_allowed_origins_for_state(state: &AppState) -> Vec<String> {
@@ -344,6 +316,8 @@ pub struct AppState {
     /// this single instance so token caches and metrics are unified
     /// (vs. each `build_genai_provider_executor` call creating its own).
     pub credential_broker: Arc<dyn awaken_runtime::credentials::CredentialBroker>,
+    /// Admin/configuration API policy for this state.
+    admin_api_config: AdminApiConfig,
 }
 
 impl AppState {
@@ -370,6 +344,7 @@ impl AppState {
             audit_log: None,
             started_at: Instant::now(),
             credential_broker: Arc::new(awaken_runtime::credentials::AwakenCredentialBroker::new()),
+            admin_api_config: AdminApiConfig::default(),
         }
     }
 
@@ -417,8 +392,8 @@ impl AppState {
 
     /// Attach admin/configuration API security settings without changing the
     /// 0.2-compatible `ServerConfig` struct shape.
-    pub fn with_admin_api_config(self, config: AdminApiConfig) -> Self {
-        admin_api_config_for_replay_buffers(&self.replay_buffers, config);
+    pub fn with_admin_api_config(mut self, config: AdminApiConfig) -> Self {
+        self.admin_api_config = config;
         self
     }
 
@@ -620,9 +595,7 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
     crate::metrics::install_recorder();
 
     let addr = state.config.address.clone();
-    validate_admin_surface(&state)?;
     let timeout = std::time::Duration::from_secs(state.config.shutdown.timeout_secs);
-    let max_concurrent = state.config.max_concurrent_requests;
     let mailbox_lifecycle = match state.config.mailbox_lifecycle {
         MailboxLifecycleMode::Auto => {
             let cleanup_state = state.clone();
@@ -648,11 +621,7 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("listening on {addr}");
 
-    let admin_cors = admin_cors_layer(&state)?;
-    let app = crate::routes::build_router(&state)
-        .layer(tower::limit::ConcurrencyLimitLayer::new(max_concurrent))
-        .layer(admin_cors)
-        .with_state(state);
+    let app = build_service_router(state)?;
 
     let result = serve_with_shutdown(listener, app, timeout).await;
     if let Some(mailbox_lifecycle) = mailbox_lifecycle
@@ -663,7 +632,23 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
     result
 }
 
-fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
+/// Build the production HTTP router for an [`AppState`].
+///
+/// This is the shared entry point for embedders that need to bind their own
+/// listener or add outer layers. It applies the same admin-surface validation,
+/// concurrency limit, admin CORS policy, route composition, and state wiring as
+/// [`serve`].
+pub fn build_service_router(state: AppState) -> std::io::Result<axum::Router> {
+    validate_admin_surface(&state)?;
+    let max_concurrent = state.config.max_concurrent_requests;
+    let admin_cors = admin_cors_layer(&state)?;
+    Ok(crate::routes::build_router(&state)
+        .layer(tower::limit::ConcurrencyLimitLayer::new(max_concurrent))
+        .layer(admin_cors)
+        .with_state(state))
+}
+
+pub fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
     let admin = admin_api_config(state);
     if !admin.expose_config_routes {
         return Ok(());
@@ -689,7 +674,7 @@ fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
     ))
 }
 
-fn admin_cors_layer(state: &AppState) -> std::io::Result<tower_http::cors::CorsLayer> {
+pub fn admin_cors_layer(state: &AppState) -> std::io::Result<tower_http::cors::CorsLayer> {
     use axum::http::{HeaderValue, Method, header};
     use tower_http::cors::CorsLayer;
 
@@ -721,6 +706,50 @@ fn admin_cors_layer(state: &AppState) -> std::io::Result<tower_http::cors::CorsL
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn state_for_admin_surface_test(address: &str, admin_api_config: AdminApiConfig) -> AppState {
+        use crate::mailbox::{Mailbox, MailboxConfig};
+        use awaken_runtime::AgentRuntime;
+        use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
+
+        struct StubResolver;
+        impl awaken_runtime::AgentResolver for StubResolver {
+            fn resolve(
+                &self,
+                agent_id: &str,
+            ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
+                Err(awaken_runtime::RuntimeError::AgentNotFound {
+                    agent_id: agent_id.to_string(),
+                })
+            }
+        }
+
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let store = Arc::new(InMemoryStore::new());
+        let mailbox_store = Arc::new(InMemoryMailboxStore::new());
+        let mailbox = Arc::new(Mailbox::new(
+            runtime.clone(),
+            mailbox_store,
+            store.clone(),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+
+        let config = ServerConfig {
+            address: address.to_string(),
+            ..ServerConfig::default()
+        };
+
+        AppState::new(
+            runtime,
+            mailbox,
+            store.clone() as Arc<dyn ThreadRunStore>,
+            Arc::new(StubResolver),
+            config,
+        )
+        .with_config_store(store as Arc<dyn ConfigStore>)
+        .with_admin_api_config(admin_api_config)
+    }
 
     #[test]
     fn admin_api_config_default_exposes_config_routes() {
@@ -759,57 +788,56 @@ mod tests {
 
     #[test]
     fn validate_admin_surface_short_circuits_when_routes_disabled() {
-        use crate::mailbox::{Mailbox, MailboxConfig};
-        use awaken_contract::contract::config_store::ConfigStore;
-        use awaken_runtime::AgentRuntime;
-        use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
-
-        struct StubResolver;
-        impl awaken_runtime::AgentResolver for StubResolver {
-            fn resolve(
-                &self,
-                agent_id: &str,
-            ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
-                Err(awaken_runtime::RuntimeError::AgentNotFound {
-                    agent_id: agent_id.to_string(),
-                })
-            }
-        }
-
-        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
-        let store = Arc::new(InMemoryStore::new());
-        let mailbox_store = Arc::new(InMemoryMailboxStore::new());
-        let mailbox = Arc::new(Mailbox::new(
-            runtime.clone(),
-            mailbox_store,
-            store.clone(),
-            "test".to_string(),
-            MailboxConfig::default(),
-        ));
-
-        // Non-loopback bind, no bearer token, *with* a config store —
-        // historically this would refuse to start. The toggle should
-        // short-circuit that check.
-        let config = ServerConfig {
-            address: "0.0.0.0:3000".to_string(),
-            ..ServerConfig::default()
-        };
-
-        let state = AppState::new(
-            runtime,
-            mailbox,
-            store.clone() as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
-            Arc::new(StubResolver),
-            config,
-        )
-        .with_config_store(store as Arc<dyn ConfigStore>)
-        .with_admin_api_config(AdminApiConfig {
-            expose_config_routes: false,
-            ..AdminApiConfig::default()
-        });
+        let state = state_for_admin_surface_test(
+            "0.0.0.0:3000",
+            AdminApiConfig {
+                expose_config_routes: false,
+                ..AdminApiConfig::default()
+            },
+        );
 
         validate_admin_surface(&state)
             .expect("disabling config routes must waive the bearer-token requirement");
+    }
+
+    #[test]
+    fn build_service_router_rejects_non_loopback_admin_surface_without_token() {
+        let state = state_for_admin_surface_test("0.0.0.0:3000", AdminApiConfig::default());
+
+        let error = build_service_router(state).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains(ADMIN_API_BEARER_TOKEN_ENV),
+            "error should name the required env var, got: {error}"
+        );
+    }
+
+    #[test]
+    fn build_service_router_allows_non_loopback_admin_surface_with_token() {
+        let state = state_for_admin_surface_test(
+            "0.0.0.0:3000",
+            AdminApiConfig {
+                bearer_token: Some(RedactedString::new("admin-token")),
+                ..AdminApiConfig::default()
+            },
+        );
+
+        let _ = build_service_router(state)
+            .expect("bearer token must allow non-loopback admin surface");
+    }
+
+    #[test]
+    fn build_service_router_allows_non_loopback_when_admin_surface_disabled() {
+        let state = state_for_admin_surface_test(
+            "0.0.0.0:3000",
+            AdminApiConfig {
+                expose_config_routes: false,
+                ..AdminApiConfig::default()
+            },
+        );
+
+        let _ = build_service_router(state)
+            .expect("disabled admin surface must not require a bearer token");
     }
 
     #[test]

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -656,7 +656,7 @@ pub fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
     if admin.bearer_token.is_some() {
         return Ok(());
     }
-    if state.config_store.is_none() && state.config_runtime_manager.is_none() {
+    if !admin_surface_has_sensitive_state(state) {
         return Ok(());
     }
 
@@ -669,9 +669,17 @@ pub fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
     Err(std::io::Error::new(
         std::io::ErrorKind::PermissionDenied,
         format!(
-            "admin/config APIs require {ADMIN_API_BEARER_TOKEN_ENV} when binding a non-loopback address"
+            "admin APIs require {ADMIN_API_BEARER_TOKEN_ENV} when binding a non-loopback address"
         ),
     ))
+}
+
+fn admin_surface_has_sensitive_state(state: &AppState) -> bool {
+    state.config_store.is_some()
+        || state.config_runtime_manager.is_some()
+        || state.audit_log.is_some()
+        || state.runtime_stats.is_some()
+        || state.skill_catalog_provider.is_some()
 }
 
 pub fn admin_cors_layer(state: &AppState) -> std::io::Result<tower_http::cors::CorsLayer> {
@@ -803,6 +811,60 @@ mod tests {
     #[test]
     fn build_service_router_rejects_non_loopback_admin_surface_without_token() {
         let state = state_for_admin_surface_test("0.0.0.0:3000", AdminApiConfig::default());
+
+        let error = build_service_router(state).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains(ADMIN_API_BEARER_TOKEN_ENV),
+            "error should name the required env var, got: {error}"
+        );
+    }
+
+    #[test]
+    fn build_service_router_rejects_runtime_stats_admin_surface_without_token() {
+        let mut state = state_for_admin_surface_test("0.0.0.0:3000", AdminApiConfig::default());
+        state.config_store = None;
+        state.config_runtime_manager = None;
+        state.runtime_stats = Some(Arc::new(RuntimeStatsRegistry::new()));
+
+        let error = build_service_router(state).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains(ADMIN_API_BEARER_TOKEN_ENV),
+            "error should name the required env var, got: {error}"
+        );
+    }
+
+    #[test]
+    fn build_service_router_rejects_audit_log_admin_surface_without_token() {
+        let mut state = state_for_admin_surface_test("0.0.0.0:3000", AdminApiConfig::default());
+        state.config_store = None;
+        state.config_runtime_manager = None;
+        state.audit_log = Some(Arc::new(AuditLogger::new(Arc::new(
+            awaken_stores::InMemoryStore::new(),
+        ))));
+
+        let error = build_service_router(state).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains(ADMIN_API_BEARER_TOKEN_ENV),
+            "error should name the required env var, got: {error}"
+        );
+    }
+
+    #[test]
+    fn build_service_router_rejects_skill_catalog_admin_surface_without_token() {
+        struct EmptySkillCatalog;
+        impl SkillCatalogProvider for EmptySkillCatalog {
+            fn list_skills(&self) -> Vec<SkillCatalogEntry> {
+                Vec::new()
+            }
+        }
+
+        let mut state = state_for_admin_surface_test("0.0.0.0:3000", AdminApiConfig::default());
+        state.config_store = None;
+        state.config_runtime_manager = None;
+        state.skill_catalog_provider = Some(Arc::new(EmptySkillCatalog));
 
         let error = build_service_router(state).unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -57,6 +57,14 @@ pub fn config_routes() -> Router<AppState> {
             "/v1/config/agents/:id/overrides/:field",
             delete_route(clear_agent_override_field_handler),
         )
+        .route(
+            "/v1/config/tools/:id/overrides",
+            patch(patch_tool_overrides_handler).delete(clear_tool_overrides_handler),
+        )
+        .route(
+            "/v1/config/tools/:id/overrides/:field",
+            delete_route(clear_tool_override_field_handler),
+        )
         .route("/v1/providers/:id/test", post(test_provider_connection))
         .route("/v1/mcp-servers/:id/status", get(get_mcp_server_status))
         .route("/v1/mcp-servers/:id/restart", post(post_mcp_server_restart))
@@ -468,7 +476,7 @@ async fn list_audit_log(
 }
 
 #[derive(Debug)]
-enum ConfigRouteError {
+pub(crate) enum ConfigRouteError {
     Api(ApiError),
     Unauthorized(String),
 }
@@ -490,7 +498,10 @@ impl IntoResponse for ConfigRouteError {
     }
 }
 
-fn ensure_admin_auth(state: &AppState, headers: &HeaderMap) -> Result<(), ConfigRouteError> {
+pub(crate) fn ensure_admin_auth(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<(), ConfigRouteError> {
     let config = crate::app::admin_api_config(state);
     ensure_admin_auth_for_token(config.bearer_token.as_ref(), headers)
 }
@@ -587,6 +598,79 @@ async fn clear_agent_override_field_handler(
     };
     match service
         .clear_agent_override_field(&id, &field, &headers)
+        .await
+    {
+        Ok(spec) => Json(spec).into_response(),
+        Err(ConfigServiceError::OverridesNotSupportedForUserRecord) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": ConfigServiceError::OverridesNotSupportedForUserRecord.to_string() })),
+        )
+            .into_response(),
+        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
+}
+
+async fn patch_tool_overrides_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<Value>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service.patch_tool_overrides(&id, body, &headers).await {
+        Ok(spec) => Json(spec).into_response(),
+        Err(ConfigServiceError::OverridesNotSupportedForUserRecord) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": ConfigServiceError::OverridesNotSupportedForUserRecord.to_string() })),
+        )
+            .into_response(),
+        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
+}
+
+async fn clear_tool_overrides_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service.clear_tool_overrides(&id, &headers).await {
+        Ok(spec) => Json(spec).into_response(),
+        Err(ConfigServiceError::OverridesNotSupportedForUserRecord) => (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": ConfigServiceError::OverridesNotSupportedForUserRecord.to_string() })),
+        )
+            .into_response(),
+        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+    }
+}
+
+async fn clear_tool_override_field_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path((id, field)): Path<(String, String)>,
+) -> Response {
+    if let Err(err) = ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    let service = match ConfigService::new(&state) {
+        Ok(s) => s,
+        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+    };
+    match service
+        .clear_tool_override_field(&id, &field, &headers)
         .await
     {
         Ok(spec) => Json(spec).into_response(),
@@ -1052,6 +1136,153 @@ mod tests {
             let app = build_test_app().await;
             let (status, _body) = test_provider(&app, "no-such-provider").await;
             assert_eq!(status, StatusCode::NOT_FOUND);
+        }
+
+        struct StubTool {
+            id: String,
+            desc: String,
+        }
+        #[async_trait]
+        impl awaken_contract::contract::tool::Tool for StubTool {
+            fn descriptor(&self) -> awaken_contract::contract::tool::ToolDescriptor {
+                awaken_contract::contract::tool::ToolDescriptor::new(
+                    self.id.clone(),
+                    self.id.clone(),
+                    self.desc.clone(),
+                )
+            }
+            async fn execute(
+                &self,
+                _args: serde_json::Value,
+                _ctx: &awaken_contract::contract::tool::ToolCallContext,
+            ) -> Result<
+                awaken_contract::contract::tool::ToolOutput,
+                awaken_contract::contract::tool::ToolError,
+            > {
+                Ok(awaken_contract::contract::tool::ToolResult::success(
+                    &self.id,
+                    serde_json::json!({}),
+                )
+                .into())
+            }
+        }
+
+        async fn build_test_app_with_tool(id: &str, description: &str) -> axum::Router {
+            use awaken_contract::ToolSpec;
+
+            let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
+            let runtime = Arc::new(
+                AgentRuntimeBuilder::new()
+                    .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+                    .with_tool(
+                        id,
+                        Arc::new(StubTool {
+                            id: id.into(),
+                            desc: description.into(),
+                        }),
+                    )
+                    .with_thread_run_store(thread_store.clone())
+                    .build()
+                    .expect("build runtime"),
+            );
+
+            let manager = Arc::new(
+                ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+                    .expect("config runtime manager")
+                    .with_provider_factory(Arc::new(TestProviderFactory)),
+            );
+            let seed = BuiltinSeedSet {
+                binary_version: "test".to_string(),
+                specs: vec![
+                    BuiltinSpec::provider(ProviderSpec {
+                        id: "bootstrap".into(),
+                        adapter: "stub".into(),
+                        ..Default::default()
+                    }),
+                    BuiltinSpec::model(ModelBindingSpec {
+                        id: "bootstrap".into(),
+                        provider_id: "bootstrap".into(),
+                        upstream_model: "bootstrap-model".into(),
+                        created_at: None,
+                        updated_at: None,
+                    }),
+                    BuiltinSpec::agent(bootstrap_agent()),
+                    BuiltinSpec::tool(ToolSpec {
+                        id: id.into(),
+                        name: id.into(),
+                        description: description.into(),
+                        ..Default::default()
+                    }),
+                ],
+            };
+            manager.apply_seed(&seed).await.expect("apply_seed");
+            manager.apply().await.expect("publish config");
+
+            let resolver = runtime.resolver_arc();
+            let mailbox = Arc::new(Mailbox::new(
+                runtime.clone(),
+                Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+                thread_store.clone(),
+                "route-test-tool".into(),
+                MailboxConfig::default(),
+            ));
+            let state = AppState::new(
+                runtime,
+                mailbox,
+                thread_store,
+                resolver,
+                ServerConfig::default(),
+            )
+            .with_config_store(config_store)
+            .with_config_runtime_manager(manager);
+
+            build_router(&state).with_state(state)
+        }
+
+        #[tokio::test]
+        async fn patch_tool_overrides_route_applies_description() {
+            let app = build_test_app_with_tool("echo", "stock").await;
+            let req = Request::builder()
+                .method("PATCH")
+                .uri("/v1/config/tools/echo/overrides")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"description":"patched"}"#))
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+            let body: Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["description"], "patched");
+        }
+
+        #[tokio::test]
+        async fn patch_tool_overrides_route_404_for_unknown_id() {
+            let app = build_test_app().await;
+            let req = Request::builder()
+                .method("PATCH")
+                .uri("/v1/config/tools/nope/overrides")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"description":"x"}"#))
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        }
+
+        #[tokio::test]
+        async fn create_tool_route_returns_422() {
+            let app = build_test_app().await;
+            let req = Request::builder()
+                .method("POST")
+                .uri("/v1/config/tools")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"id":"x","name":"x","description":"x"}"#))
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            // Task 6 emits ConfigServiceError::InvalidPayload, which the
+            // existing `map_service_error` maps to 400 BAD_REQUEST. The plan
+            // mentioned 422 nominally; 400 is what actually gets emitted.
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         }
     }
 }

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -5,6 +5,7 @@ use axum::routing::{delete as delete_route, get, patch, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use subtle::ConstantTimeEq;
 
 #[derive(Deserialize, Default)]
 struct DeleteParams {
@@ -513,11 +514,17 @@ fn ensure_admin_auth_for_token(
     let Some(expected) = expected else {
         return Ok(());
     };
-    let Some(auth) = headers.get(axum::http::header::AUTHORIZATION) else {
+    let mut auth_values = headers.get_all(axum::http::header::AUTHORIZATION).iter();
+    let Some(auth) = auth_values.next() else {
         return Err(ConfigRouteError::Unauthorized(
             "admin authentication required".into(),
         ));
     };
+    if auth_values.next().is_some() {
+        return Err(ConfigRouteError::Unauthorized(
+            "multiple Authorization headers are not allowed".into(),
+        ));
+    }
     let auth = auth
         .to_str()
         .map_err(|_| ConfigRouteError::Unauthorized("invalid Authorization header".into()))?;
@@ -529,7 +536,12 @@ fn ensure_admin_auth_for_token(
             "Authorization header must use Bearer authentication".into(),
         ));
     };
-    if token != expected.expose_secret() {
+    if token
+        .as_bytes()
+        .ct_eq(expected.expose_secret().as_bytes())
+        .unwrap_u8()
+        != 1
+    {
         return Err(ConfigRouteError::Unauthorized(
             "invalid admin bearer token".into(),
         ));
@@ -744,6 +756,61 @@ mod tests {
             HeaderValue::from_static("Bearer secret"),
         );
         assert!(ensure_admin_auth_for_token(Some(&expected), &headers).is_ok());
+    }
+
+    #[test]
+    fn admin_auth_rejects_ambiguous_or_malformed_bearer_headers_without_leaking_secret() {
+        let expected = RedactedString::from("secret-value-that-must-not-leak");
+        let cases = [
+            "Bearer",
+            "Bearer ",
+            "Bearer\tsecret-value-that-must-not-leak",
+            "Token secret-value-that-must-not-leak",
+            "bearer wrong-token",
+            "Bearer secret-value-that-must-not-leak extra",
+        ];
+
+        for value in cases {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                header::AUTHORIZATION,
+                HeaderValue::from_str(value).expect("valid header value"),
+            );
+            let err = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
+            let ConfigRouteError::Unauthorized(message) = &err else {
+                panic!("expected Unauthorized for {value:?}, got {err:?}");
+            };
+            assert!(
+                !message.contains(expected.expose_secret()),
+                "unauthorized error leaked secret for {value:?}: {message}"
+            );
+            let response = err.into_response();
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "case {value:?}"
+            );
+        }
+
+        let mut headers = HeaderMap::new();
+        headers.append(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer secret-value-that-must-not-leak"),
+        );
+        headers.append(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer different"),
+        );
+        let err = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
+        let ConfigRouteError::Unauthorized(message) = &err else {
+            panic!("expected Unauthorized for duplicate headers, got {err:?}");
+        };
+        assert!(
+            !message.contains(expected.expose_secret()),
+            "duplicate-header error leaked secret: {message}"
+        );
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     // ── delete 409 / force integration tests ──────────────────────────────
@@ -1063,6 +1130,10 @@ mod tests {
                 body["latency_ms"].is_number(),
                 "expected latency_ms to be a number"
             );
+            assert_eq!(
+                body["network_tested"], false,
+                "build-time failures do not reach the network"
+            );
         }
 
         #[tokio::test]
@@ -1128,6 +1199,10 @@ mod tests {
             let (status, body) = test_provider(&app, "prov-openai").await;
             assert_eq!(status, StatusCode::OK, "body: {body}");
             assert_eq!(body["ok"], true, "expected ok=true for openai adapter");
+            assert_eq!(
+                body["network_tested"], false,
+                "bearer/env provider probe validates config only"
+            );
             assert!(body.get("error").is_none(), "should have no error field");
         }
 

--- a/crates/awaken-server/src/event_relay.rs
+++ b/crates/awaken-server/src/event_relay.rs
@@ -28,8 +28,12 @@ where
     async_stream::stream! {
         // Emit prologue
         for item in encoder.prologue() {
-            if let Ok(bytes) = serde_json::to_vec(&item) {
-                yield bytes;
+            match serde_json::to_vec(&item) {
+                Ok(bytes) => yield bytes,
+                Err(error) => tracing::warn!(
+                    error = %error,
+                    "failed to serialize relay prologue item"
+                ),
             }
         }
 
@@ -38,8 +42,12 @@ where
         while let Some(event) = event_stream.next().await {
             let is_terminal = event.is_terminal();
             for item in encoder.transcode(&event) {
-                if let Ok(bytes) = serde_json::to_vec(&item) {
-                    yield bytes;
+                match serde_json::to_vec(&item) {
+                    Ok(bytes) => yield bytes,
+                    Err(error) => tracing::warn!(
+                        error = %error,
+                        "failed to serialize relay event item"
+                    ),
                 }
             }
             if is_terminal {
@@ -49,8 +57,12 @@ where
 
         // Emit epilogue
         for item in encoder.epilogue() {
-            if let Ok(bytes) = serde_json::to_vec(&item) {
-                yield bytes;
+            match serde_json::to_vec(&item) {
+                Ok(bytes) => yield bytes,
+                Err(error) => tracing::warn!(
+                    error = %error,
+                    "failed to serialize relay epilogue item"
+                ),
             }
         }
     }

--- a/crates/awaken-server/src/message_convert.rs
+++ b/crates/awaken-server/src/message_convert.rs
@@ -1,11 +1,17 @@
 //! Shared message conversion for protocol handlers.
 
+use awaken_contract::contract::content::{ContentBlock, extract_text};
 use awaken_contract::contract::message::Message;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaKind {
+    Image,
+    Audio,
+    Video,
+    Document,
+}
+
 /// Convert protocol-agnostic role+content pairs to Messages.
-///
-/// Each protocol handler extracts `(role, content)` from its native type
-/// and calls this shared function. Unknown roles are silently dropped.
 pub fn convert_role_content_pairs(
     pairs: impl IntoIterator<Item = (String, String)>,
 ) -> Vec<Message> {
@@ -15,9 +21,135 @@ pub fn convert_role_content_pairs(
             "user" => Some(Message::user(content)),
             "assistant" => Some(Message::assistant(content)),
             "system" => Some(Message::system(content)),
-            _ => None,
+            other => {
+                tracing::warn!(role = other, "dropping message with unsupported role");
+                None
+            }
         })
         .collect()
+}
+
+pub fn message_from_role_blocks(
+    role: &str,
+    blocks: Vec<ContentBlock>,
+    include_assistant: bool,
+) -> Option<Message> {
+    if blocks.is_empty() {
+        return None;
+    }
+    match role {
+        "user" => Some(Message::user_with_content(blocks)),
+        "system" => Some(Message::system(extract_text(&blocks))),
+        "assistant" if include_assistant => Some(Message::assistant(extract_text(&blocks))),
+        "assistant" => None,
+        other => {
+            tracing::warn!(role = other, "dropping message with unsupported role");
+            None
+        }
+    }
+}
+
+pub fn parse_data_uri(url: &str) -> Option<(String, String)> {
+    let rest = url.strip_prefix("data:")?;
+    let (meta, data) = rest.split_once(',')?;
+    let media_type = meta.strip_suffix(";base64")?;
+    Some((media_type.to_string(), data.to_string()))
+}
+
+pub fn infer_media_type_from_url(url: &str) -> String {
+    let lower = url.to_ascii_lowercase();
+    if lower.ends_with(".png") {
+        "image/png"
+    } else if lower.ends_with(".jpg") || lower.ends_with(".jpeg") {
+        "image/jpeg"
+    } else if lower.ends_with(".gif") {
+        "image/gif"
+    } else if lower.ends_with(".webp") {
+        "image/webp"
+    } else if lower.ends_with(".mp3") {
+        "audio/mpeg"
+    } else if lower.ends_with(".wav") {
+        "audio/wav"
+    } else if lower.ends_with(".ogg") {
+        "audio/ogg"
+    } else if lower.ends_with(".mp4") {
+        "video/mp4"
+    } else if lower.ends_with(".webm") {
+        "video/webm"
+    } else if lower.ends_with(".pdf") {
+        "application/pdf"
+    } else if lower.ends_with(".json") {
+        "application/json"
+    } else if lower.ends_with(".txt") || lower.ends_with(".md") {
+        "text/plain"
+    } else {
+        "application/octet-stream"
+    }
+    .to_string()
+}
+
+pub fn infer_media_kind(media_type: &str) -> MediaKind {
+    if media_type.starts_with("image/") {
+        MediaKind::Image
+    } else if media_type.starts_with("audio/") {
+        MediaKind::Audio
+    } else if media_type.starts_with("video/") {
+        MediaKind::Video
+    } else {
+        MediaKind::Document
+    }
+}
+
+pub fn content_block_from_url(
+    kind: MediaKind,
+    url: impl Into<String>,
+    title: Option<String>,
+) -> ContentBlock {
+    let url = url.into();
+    match kind {
+        MediaKind::Image => ContentBlock::image_url(url),
+        MediaKind::Audio => ContentBlock::audio_url(url),
+        MediaKind::Video => ContentBlock::video_url(url),
+        MediaKind::Document => ContentBlock::document_url(url, title),
+    }
+}
+
+pub fn content_block_from_base64(
+    kind: MediaKind,
+    media_type: impl Into<String>,
+    data: impl Into<String>,
+    title: Option<String>,
+) -> ContentBlock {
+    let media_type = media_type.into();
+    let data = data.into();
+    match kind {
+        MediaKind::Image => ContentBlock::image_base64(media_type, data),
+        MediaKind::Audio => ContentBlock::audio_base64(media_type, data),
+        MediaKind::Video => ContentBlock::video_base64(media_type, data),
+        MediaKind::Document => ContentBlock::document_base64(media_type, data, title),
+    }
+}
+
+pub fn content_block_from_media_url(
+    url: impl Into<String>,
+    media_type: Option<&str>,
+    title: Option<String>,
+) -> ContentBlock {
+    let url = url.into();
+    let media_type = media_type
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| infer_media_type_from_url(&url));
+    content_block_from_url(infer_media_kind(&media_type), url, title)
+}
+
+pub fn content_block_from_media_base64(
+    data: impl Into<String>,
+    media_type: impl Into<String>,
+    title: Option<String>,
+) -> ContentBlock {
+    let media_type = media_type.into();
+    content_block_from_base64(infer_media_kind(&media_type), media_type, data, title)
 }
 
 #[cfg(test)]

--- a/crates/awaken-server/src/protocols/a2a/http.rs
+++ b/crates/awaken-server/src/protocols/a2a/http.rs
@@ -2857,6 +2857,12 @@ mod tests {
     }
 
     #[test]
+    fn message_conversion_drops_internal_messages() {
+        let message = AwakenMessage::internal_system("do not expose");
+        assert!(awaken_message_to_a2a_message(&message, "task-1", "thread-1").is_none());
+    }
+
+    #[test]
     fn parse_task_action_segment_accepts_spec_suffixes() {
         assert_eq!(
             parse_task_action_segment("task-1:cancel").unwrap(),

--- a/crates/awaken-server/src/protocols/a2a/http.rs
+++ b/crates/awaken-server/src/protocols/a2a/http.rs
@@ -35,6 +35,9 @@ pub use awaken_protocol_a2a::{
 
 use crate::app::AppState;
 use crate::http_sse::{format_sse_data, sse_body_stream, sse_response};
+use crate::message_convert::{
+    content_block_from_media_base64, content_block_from_media_url, infer_media_type_from_url,
+};
 use awaken_runtime::RunRequest;
 
 const A2A_VERSION: &str = "1.0";
@@ -2671,36 +2674,7 @@ fn a2a_part_to_content_block(part: &Part) -> Result<ContentBlock, A2aError> {
 }
 
 fn url_part_to_content_block(url: &str, part: &Part) -> ContentBlock {
-    let media_type = part
-        .media_type
-        .clone()
-        .unwrap_or_else(|| infer_media_type_from_url(url));
-    if media_type.starts_with("image/") {
-        ContentBlock::Image {
-            source: ImageSource::Url {
-                url: url.to_string(),
-            },
-        }
-    } else if media_type.starts_with("audio/") {
-        ContentBlock::Audio {
-            source: AudioSource::Url {
-                url: url.to_string(),
-            },
-        }
-    } else if media_type.starts_with("video/") {
-        ContentBlock::Video {
-            source: VideoSource::Url {
-                url: url.to_string(),
-            },
-        }
-    } else {
-        ContentBlock::Document {
-            source: DocumentSource::Url {
-                url: url.to_string(),
-            },
-            title: part.filename.clone(),
-        }
-    }
+    content_block_from_media_url(url, part.media_type.as_deref(), part.filename.clone())
 }
 
 fn raw_part_to_content_block(raw: &str, part: &Part) -> ContentBlock {
@@ -2708,59 +2682,7 @@ fn raw_part_to_content_block(raw: &str, part: &Part) -> ContentBlock {
         .media_type
         .clone()
         .unwrap_or_else(|| "application/octet-stream".to_string());
-    if media_type.starts_with("image/") {
-        ContentBlock::Image {
-            source: ImageSource::Base64 {
-                media_type,
-                data: raw.to_string(),
-            },
-        }
-    } else if media_type.starts_with("audio/") {
-        ContentBlock::Audio {
-            source: AudioSource::Base64 {
-                media_type,
-                data: raw.to_string(),
-            },
-        }
-    } else if media_type.starts_with("video/") {
-        ContentBlock::Video {
-            source: VideoSource::Base64 {
-                media_type,
-                data: raw.to_string(),
-            },
-        }
-    } else {
-        ContentBlock::Document {
-            source: DocumentSource::Base64 {
-                media_type,
-                data: raw.to_string(),
-            },
-            title: part.filename.clone(),
-        }
-    }
-}
-
-fn infer_media_type_from_url(url: &str) -> String {
-    let lower = url.to_ascii_lowercase();
-    if lower.ends_with(".png") {
-        "image/png".to_string()
-    } else if lower.ends_with(".jpg") || lower.ends_with(".jpeg") {
-        "image/jpeg".to_string()
-    } else if lower.ends_with(".gif") {
-        "image/gif".to_string()
-    } else if lower.ends_with(".webp") {
-        "image/webp".to_string()
-    } else if lower.ends_with(".mp3") {
-        "audio/mpeg".to_string()
-    } else if lower.ends_with(".wav") {
-        "audio/wav".to_string()
-    } else if lower.ends_with(".mp4") {
-        "video/mp4".to_string()
-    } else if lower.ends_with(".pdf") {
-        "application/pdf".to_string()
-    } else {
-        "application/octet-stream".to_string()
-    }
+    content_block_from_media_base64(raw, media_type, part.filename.clone())
 }
 
 fn awaken_message_to_a2a_message(

--- a/crates/awaken-server/src/protocols/acp/stdio.rs
+++ b/crates/awaken-server/src/protocols/acp/stdio.rs
@@ -17,9 +17,9 @@ use awaken_runtime::AgentRuntime;
 
 use super::encoder::{AcpEncoder, AcpOutput};
 use super::types::{
-    AgentCapabilities, ContentBlock, EmbeddedResource, EmbeddedResourceResource, Implementation,
-    InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest,
-    PromptResponse, RequestPermissionResponse, ResourceLink,
+    AgentCapabilities, AudioContent, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
+    ImageContent, Implementation, InitializeRequest, InitializeResponse, NewSessionRequest,
+    NewSessionResponse, PromptRequest, PromptResponse, RequestPermissionResponse, ResourceLink,
 };
 
 struct SessionState {
@@ -242,7 +242,12 @@ impl acp::Agent for AcpAgent {
 }
 
 fn build_initialize_response(request: InitializeRequest) -> InitializeResponse {
-    let capabilities = AgentCapabilities::new();
+    let capabilities = AgentCapabilities::new().prompt_capabilities(
+        agent_client_protocol_schema::PromptCapabilities::new()
+            .image(true)
+            .audio(true)
+            .embedded_context(true),
+    );
     InitializeResponse::new(request.protocol_version)
         .agent_capabilities(capabilities)
         .agent_info(Implementation::new("awaken-acp", env!("CARGO_PKG_VERSION")))
@@ -412,12 +417,8 @@ fn prompt_blocks_to_message_content(
             ContentBlock::Resource(resource) => {
                 content.push(embedded_resource_to_runtime_content(resource)?);
             }
-            ContentBlock::Image(_) => {
-                return Err("image prompt content is not supported by this ACP server".to_string());
-            }
-            ContentBlock::Audio(_) => {
-                return Err("audio prompt content is not supported by this ACP server".to_string());
-            }
+            ContentBlock::Image(image) => content.push(image_content_to_runtime_content(image)),
+            ContentBlock::Audio(audio) => content.push(audio_content_to_runtime_content(audio)),
             _ => return Err("unsupported ACP prompt content block".to_string()),
         }
     }
@@ -440,7 +441,7 @@ fn embedded_resource_to_runtime_content(
             let media_type = blob
                 .mime_type
                 .clone()
-                .unwrap_or_else(|| infer_media_type_from_uri(&blob.uri));
+                .unwrap_or_else(|| crate::message_convert::infer_media_type_from_url(&blob.uri));
             Ok(RuntimeContentBlock::document_base64(
                 media_type,
                 blob.blob.clone(),
@@ -451,14 +452,17 @@ fn embedded_resource_to_runtime_content(
     }
 }
 
-fn infer_media_type_from_uri(uri: &str) -> String {
-    match Path::new(uri).extension().and_then(|ext| ext.to_str()) {
-        Some("png") => "image/png".to_string(),
-        Some("jpg") | Some("jpeg") => "image/jpeg".to_string(),
-        Some("gif") => "image/gif".to_string(),
-        Some("pdf") => "application/pdf".to_string(),
-        _ => "application/octet-stream".to_string(),
+fn image_content_to_runtime_content(image: &ImageContent) -> RuntimeContentBlock {
+    if image.data.is_empty()
+        && let Some(uri) = image.uri.as_ref()
+    {
+        return RuntimeContentBlock::image_url(uri.clone());
     }
+    RuntimeContentBlock::image_base64(image.mime_type.clone(), image.data.clone())
+}
+
+fn audio_content_to_runtime_content(audio: &AudioContent) -> RuntimeContentBlock {
+    RuntimeContentBlock::audio_base64(audio.mime_type.clone(), audio.data.clone())
 }
 
 fn path_title(uri: &str) -> Option<String> {

--- a/crates/awaken-server/src/protocols/ag_ui/http.rs
+++ b/crates/awaken-server/src/protocols/ag_ui/http.rs
@@ -121,16 +121,7 @@ fn convert_messages(msgs: Vec<AgUiMessage>) -> Vec<Message> {
     msgs.into_iter()
         .filter_map(|m| {
             let blocks = parse_ag_ui_content(&m.content)?;
-            match m.role.as_str() {
-                "user" => Some(Message::user_with_content(blocks)),
-                "assistant" => Some(Message::assistant(
-                    awaken_contract::contract::content::extract_text(&blocks),
-                )),
-                "system" => Some(Message::system(
-                    awaken_contract::contract::content::extract_text(&blocks),
-                )),
-                _ => None,
-            }
+            crate::message_convert::message_from_role_blocks(m.role.as_str(), blocks, true)
         })
         .collect()
 }
@@ -166,34 +157,28 @@ fn input_part_to_block(
     part: super::types::InputContentPart,
 ) -> Option<awaken_contract::contract::content::ContentBlock> {
     use super::types::{InputContentPart, InputContentSource};
-    use awaken_contract::contract::content::ContentBlock;
+    use crate::message_convert::{MediaKind, content_block_from_base64, content_block_from_url};
+
+    fn source_to_block(
+        kind: MediaKind,
+        source: InputContentSource,
+    ) -> Option<awaken_contract::contract::content::ContentBlock> {
+        Some(match source {
+            InputContentSource::Data { value, mime_type } => {
+                content_block_from_base64(kind, mime_type, value, None)
+            }
+            InputContentSource::Url { value, .. } => content_block_from_url(kind, value, None),
+        })
+    }
 
     match part {
-        InputContentPart::Text { text } => Some(ContentBlock::text(text)),
-        InputContentPart::Image { source, .. } => Some(match source {
-            InputContentSource::Data { value, mime_type } => {
-                ContentBlock::image_base64(mime_type, value)
-            }
-            InputContentSource::Url { value, .. } => ContentBlock::image_url(value),
-        }),
-        InputContentPart::Audio { source, .. } => Some(match source {
-            InputContentSource::Data { value, mime_type } => {
-                ContentBlock::audio_base64(mime_type, value)
-            }
-            InputContentSource::Url { value, .. } => ContentBlock::audio_url(value),
-        }),
-        InputContentPart::Video { source, .. } => Some(match source {
-            InputContentSource::Data { value, mime_type } => {
-                ContentBlock::video_base64(mime_type, value)
-            }
-            InputContentSource::Url { value, .. } => ContentBlock::video_url(value),
-        }),
-        InputContentPart::Document { source, .. } => Some(match source {
-            InputContentSource::Data { value, mime_type } => {
-                ContentBlock::document_base64(mime_type, value, None)
-            }
-            InputContentSource::Url { value, .. } => ContentBlock::document_url(value, None),
-        }),
+        InputContentPart::Text { text } => {
+            Some(awaken_contract::contract::content::ContentBlock::text(text))
+        }
+        InputContentPart::Image { source, .. } => source_to_block(MediaKind::Image, source),
+        InputContentPart::Audio { source, .. } => source_to_block(MediaKind::Audio, source),
+        InputContentPart::Video { source, .. } => source_to_block(MediaKind::Video, source),
+        InputContentPart::Document { source, .. } => source_to_block(MediaKind::Document, source),
     }
 }
 

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/request.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/request.rs
@@ -15,6 +15,11 @@ use awaken_contract::contract::storage::{RunRecord, RunWaitingState, ThreadRunSt
 use awaken_contract::contract::suspension::{ResumeDecisionAction, ToolCallResume};
 use awaken_contract::registry_spec::AgentSpec;
 
+use crate::message_convert::{
+    content_block_from_media_base64, content_block_from_media_url, message_from_role_blocks,
+    parse_data_uri,
+};
+
 // ── AI SDK v6 wire types ────────────────────────────────────────────
 //
 // Maps directly to the TypeScript `UIMessage` / `UIMessagePart` types
@@ -213,14 +218,6 @@ pub(crate) fn process_preview_chat_request(
 
 // ── Internal helpers ────────────────────────────────────────────────
 
-/// Parse a data-URI of the form `data:<media_type>;base64,<data>`.
-fn parse_data_uri(url: &str) -> Option<(String, String)> {
-    let rest = url.strip_prefix("data:")?;
-    let (meta, data) = rest.split_once(",")?;
-    let media_type = meta.strip_suffix(";base64")?;
-    Some((media_type.to_string(), data.to_string()))
-}
-
 pub(crate) fn part_kind(part: &Value) -> Option<&str> {
     part.get("type").and_then(Value::as_str)
 }
@@ -231,23 +228,9 @@ fn part_to_content_block(part: &Value) -> Option<ContentBlock> {
         UIPart::Text { text } => Some(ContentBlock::text(text.as_str())),
         UIPart::File { url, media_type } => {
             if let Some((mime, data)) = parse_data_uri(&url) {
-                if mime.starts_with("image/") {
-                    Some(ContentBlock::image_base64(mime, data))
-                } else if mime.starts_with("audio/") {
-                    Some(ContentBlock::audio_base64(mime, data))
-                } else if mime.starts_with("video/") {
-                    Some(ContentBlock::video_base64(mime, data))
-                } else {
-                    Some(ContentBlock::document_base64(mime, data, None))
-                }
-            } else if media_type.starts_with("image/") {
-                Some(ContentBlock::image_url(url.as_str()))
-            } else if media_type.starts_with("audio/") {
-                Some(ContentBlock::audio_url(url.as_str()))
-            } else if media_type.starts_with("video/") {
-                Some(ContentBlock::video_url(url.as_str()))
+                Some(content_block_from_media_base64(data, mime, None))
             } else {
-                Some(ContentBlock::document_url(url.as_str(), None))
+                Some(content_block_from_media_url(url, Some(&media_type), None))
             }
         }
         _ => None,
@@ -273,19 +256,7 @@ fn convert_messages_internal(msgs: Vec<UIMessage>, include_assistant: bool) -> V
         .filter_map(|m| {
             let blocks: Vec<ContentBlock> =
                 m.parts.iter().filter_map(part_to_content_block).collect();
-            if blocks.is_empty() {
-                return None;
-            }
-            let mut msg = match m.role.as_str() {
-                "user" => Message::user_with_content(blocks),
-                "system" => {
-                    Message::system(awaken_contract::contract::content::extract_text(&blocks))
-                }
-                "assistant" if include_assistant => {
-                    Message::assistant(awaken_contract::contract::content::extract_text(&blocks))
-                }
-                _ => return None,
-            };
+            let mut msg = message_from_role_blocks(m.role.as_str(), blocks, include_assistant)?;
             // Preserve frontend ID for deduplication; fall back to generated UUID.
             if let Some(id) = m.id {
                 msg.id = Some(id);

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -1,7 +1,7 @@
 //! Axum router setup — unified route registration.
 
 use axum::extract::{Path, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::middleware;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
@@ -113,7 +113,7 @@ pub fn build_router(state: &AppState) -> Router<AppState> {
         .merge(mcp_routes());
 
     if state.admin_api_config().expose_config_routes {
-        router = router.merge(config_routes());
+        router = router.merge(admin_routes());
     }
 
     router
@@ -125,7 +125,6 @@ fn health_routes() -> Router<AppState> {
     Router::new()
         .route("/health", get(health_ready))
         .route("/health/live", get(health_live))
-        .route("/v1/system/info", get(system_info))
 }
 
 fn thread_routes() -> Router<AppState> {
@@ -160,6 +159,11 @@ fn run_routes() -> Router<AppState> {
         .route("/v1/threads/:id/runs", get(list_thread_runs))
         .route("/v1/threads/:id/runs/active", get(active_thread_run))
         .route("/v1/threads/:id/runs/latest", get(latest_thread_run))
+}
+
+fn admin_routes() -> Router<AppState> {
+    config_routes()
+        .route("/v1/system/info", get(system_info))
         .route("/v1/agents/:id/runtime-stats", get(get_agent_runtime_stats))
         .route("/v1/agents/runtime-stats", get(list_agents_runtime_stats))
 }
@@ -183,9 +187,13 @@ struct RuntimeStatsQuery {
 #[tracing::instrument(skip(state))]
 async fn get_agent_runtime_stats(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(id): Path<String>,
     Query(params): Query<RuntimeStatsQuery>,
 ) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
     let Some(registry) = state.runtime_stats.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -218,7 +226,10 @@ async fn get_agent_runtime_stats(
 /// sorted by `agent_id`. Returns `{"agents":[...]}` (or 503 when the
 /// registry is missing).
 #[tracing::instrument(skip(state))]
-async fn list_agents_runtime_stats(State(state): State<AppState>) -> Response {
+async fn list_agents_runtime_stats(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
     let Some(registry) = state.runtime_stats.as_ref() else {
         return (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -251,7 +262,10 @@ async fn health_live() -> impl IntoResponse {
 /// string would mislead. Embedders that need to expose the concrete backend
 /// can decorate `AppState` with their own field and a separate route.
 #[tracing::instrument(skip(state))]
-async fn system_info(State(state): State<AppState>) -> Response {
+async fn system_info(State(state): State<AppState>, headers: HeaderMap) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
     let uptime_secs = state.started_at.elapsed().as_secs();
     Json(json!({
         "version": env!("CARGO_PKG_VERSION"),
@@ -1586,6 +1600,64 @@ mod tests {
                 StatusCode::NOT_FOUND,
                 "disabled config routes must not be mounted"
             );
+        }
+
+        #[tokio::test]
+        async fn admin_routes_return_404_when_admin_surface_disabled() {
+            use crate::app::AdminApiConfig;
+            use axum::http::StatusCode;
+
+            let state = make_app_state().with_admin_api_config(AdminApiConfig {
+                expose_config_routes: false,
+                ..AdminApiConfig::default()
+            });
+            let app = build_router(&state).with_state(state);
+
+            for uri in [
+                "/v1/system/info",
+                "/v1/agents/runtime-stats",
+                "/v1/agents/default/runtime-stats",
+            ] {
+                let req = axum::http::Request::builder()
+                    .uri(uri)
+                    .body(axum::body::Body::empty())
+                    .unwrap();
+                let resp = app.clone().oneshot(req).await.unwrap();
+                assert_eq!(
+                    resp.status(),
+                    StatusCode::NOT_FOUND,
+                    "{uri} must not be mounted when the admin surface is disabled"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn admin_routes_require_bearer_token_when_configured() {
+            use crate::app::AdminApiConfig;
+            use awaken_contract::RedactedString;
+            use axum::http::{StatusCode, header};
+
+            let token = RedactedString::new("admin-token");
+            let state = make_app_state().with_admin_api_config(AdminApiConfig {
+                bearer_token: Some(token),
+                ..AdminApiConfig::default()
+            });
+            let app = build_router(&state).with_state(state);
+
+            let req = axum::http::Request::builder()
+                .uri("/v1/system/info")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+            let req = axum::http::Request::builder()
+                .uri("/v1/system/info")
+                .header(header::AUTHORIZATION, "Bearer admin-token")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
         }
 
         #[tokio::test]

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -120,6 +120,7 @@ impl AuditLogger {
             ip,
             request_id,
             restored_from: None,
+            error: None,
         };
 
         let value = match serde_json::to_value(&event) {
@@ -142,6 +143,61 @@ impl AuditLogger {
             .and_then(|v| v.as_str().map(str::to_string))
             .unwrap_or_else(|| "unknown".to_string());
         metrics::counter!("awaken_audit_events_total", "action" => action_label).increment(1);
+    }
+
+    /// Emit an `ApplyFailed` audit event with an attached error string.
+    ///
+    /// Best-effort — same failure semantics as [`AuditLogger::emit`].
+    pub async fn emit_apply_failed(
+        &self,
+        resource: &str,
+        before: Option<Value>,
+        after: Option<Value>,
+        error_msg: String,
+        headers: &HeaderMap,
+    ) {
+        let id = ulid::Ulid::new().to_string();
+        let ts = Utc::now().to_rfc3339();
+        let actor = derive_actor(headers);
+        let ip = extract_client_ip(headers);
+        let request_id = headers
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+
+        let before = before.map(redact_secrets);
+        let after = after.map(redact_secrets);
+
+        let event = AuditEvent {
+            id: id.clone(),
+            ts,
+            actor,
+            action: AuditAction::ApplyFailed,
+            resource: resource.to_string(),
+            before,
+            after,
+            ip,
+            request_id,
+            restored_from: None,
+            error: Some(error_msg),
+        };
+
+        let value = match serde_json::to_value(&event) {
+            Ok(v) => v,
+            Err(error) => {
+                tracing::warn!(error = %error, "audit: failed to serialize apply_failed event");
+                metrics::counter!("awaken_audit_write_failures_total").increment(1);
+                return;
+            }
+        };
+
+        if let Err(error) = self.store.put(AUDIT_NAMESPACE, &id, &value).await {
+            tracing::warn!(error = %error, "audit: failed to write apply_failed event");
+            metrics::counter!("awaken_audit_write_failures_total").increment(1);
+            return;
+        }
+
+        metrics::counter!("awaken_audit_events_total", "action" => "apply_failed").increment(1);
     }
 
     /// Look up a single audit event by its ULID id.
@@ -186,6 +242,7 @@ impl AuditLogger {
             ip,
             request_id,
             restored_from: Some(restored_from),
+            error: None,
         };
 
         let value = match serde_json::to_value(&event) {
@@ -253,6 +310,7 @@ impl AuditLogger {
                 ip: None,
                 request_id: None,
                 restored_from: None,
+                error: None,
             };
 
             let value = match serde_json::to_value(&event) {
@@ -834,6 +892,7 @@ mod tests {
             unchanged: vec![],
             deleted,
             preserved_user: vec![],
+            preserved_overridden: vec![],
         }
     }
 

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -485,6 +485,8 @@ pub fn redact_secrets(value: Value) -> Value {
                 let lower = key.to_lowercase();
                 if lower.contains("api_key")
                     || lower.contains("bearer")
+                    || lower.contains("credential")
+                    || lower.contains("private_key")
                     || lower.contains("token")
                     || lower.contains("password")
                     || lower.contains("secret")
@@ -715,6 +717,50 @@ mod tests {
         assert_eq!(output["flag"], true);
         assert_eq!(output["nothing"], Value::Null);
         assert_eq!(output["secret"], "***");
+    }
+
+    #[test]
+    fn redact_secrets_credential_corpus_is_case_insensitive_and_recursive() {
+        let input = json!({
+            "adapter_options": {
+                "credentials_kind": "service_account_json",
+                "nested": [{
+                    "PRIVATE_KEY": "-----BEGIN PRIVATE KEY-----\nraw\n-----END PRIVATE KEY-----",
+                    "refreshToken": "rt-123",
+                    "client_secret": "client-secret",
+                    "safe_label": "visible"
+                }]
+            },
+            "env": {
+                "GOOGLE_APPLICATION_CREDENTIALS": "/tmp/key.json",
+                "PASSWORD": "p",
+                "TOKEN": "t"
+            }
+        });
+
+        let output = redact_secrets(input);
+        let rendered = serde_json::to_string(&output).unwrap();
+        for leaked in [
+            "raw",
+            "rt-123",
+            "client-secret",
+            "/tmp/key.json",
+            "\"p\"",
+            "\"t\"",
+        ] {
+            assert!(
+                !rendered.contains(leaked),
+                "redacted audit payload leaked {leaked:?}: {rendered}"
+            );
+        }
+        assert_eq!(
+            output["adapter_options"]["credentials_kind"], "***",
+            "credential discriminator should be redacted in audit payloads"
+        );
+        assert_eq!(
+            output["adapter_options"]["nested"][0]["safe_label"], "visible",
+            "non-secret fields should remain useful"
+        );
     }
 
     // ── emit ──────────────────────────────────────────────────────────────

--- a/crates/awaken-server/src/services/builtin_seed.rs
+++ b/crates/awaken-server/src/services/builtin_seed.rs
@@ -23,6 +23,11 @@ pub struct SeedReport {
     pub unchanged: Vec<RecordRef>,
     pub deleted: Vec<RecordRef>,
     pub preserved_user: Vec<RecordRef>,
+    /// Builtin records orphaned by this seed (id no longer registered) but
+    /// carrying a non-empty `user_overrides`. Marked `hidden=true` instead
+    /// of being deleted, so re-introducing the spec in a later binary
+    /// transparently restores the override.
+    pub preserved_overridden: Vec<RecordRef>,
 }
 
 /// Identifies a single record in a ConfigStore.
@@ -58,19 +63,22 @@ pub enum SeedError {
 /// - No existing record → create new Builtin record. (created)
 /// - Existing Builtin, same binary_version, spec equal → no-op. (unchanged)
 /// - Existing Builtin, same binary_version, spec differs → replace spec, refresh updated_at. (updated)
-/// - Existing Builtin, different binary_version → replace spec + version, preserve hidden, refresh updated_at. (updated)
+/// - Existing Builtin, different binary_version → replace spec + version, clear hidden, refresh updated_at. (updated)
 /// - Existing User → leave entirely untouched. (preserved_user)
 ///
-/// After processing seed entries, scans all four spec namespaces
-/// (`agents`, `providers`, `models`, `mcp-servers`) and deletes any
-/// Builtin record whose ID is not in this seed (orphan cleanup).
+/// After processing seed entries, scans all five spec namespaces
+/// (`agents`, `providers`, `models`, `mcp-servers`, `tools`) and processes
+/// each Builtin record whose ID is not in this seed:
+///
+/// - If it carries a `user_overrides` payload → marks it `hidden=true` instead
+///   of deleting, so re-introducing the spec in a later binary transparently
+///   restores the override (preserved_overridden).
+/// - Otherwise → hard-deletes it (deleted).
+///
 /// User records are never deleted by orphan cleanup.
 ///
-/// **Concurrency precondition:** Must not run concurrently with any other
-/// writer to the four spec namespaces (`agents`, `providers`, `models`,
-/// `mcp-servers`). Intended for boot-time invocation before
-/// `ConfigRuntimeManager::apply()`. With this precondition, the
-/// snapshot-then-delete orphan-cleanup pattern is safe.
+/// Seed writes use ConfigStore CAS primitives so a concurrent writer surfaces as
+/// a storage conflict instead of silently overwriting records.
 pub async fn apply_builtin_seed(
     store: &dyn ConfigStore,
     seed: &BuiltinSeedSet,
@@ -96,11 +104,14 @@ pub async fn apply_builtin_seed(
         match existing_raw {
             None => {
                 // Create new Builtin record.
-                let record = ConfigRecord {
+                let mut record = ConfigRecord {
                     spec: new_spec_value,
                     meta: RecordMeta::new_builtin(&seed.binary_version),
                 };
-                store.put(namespace, id, &record.to_value()?).await?;
+                record.meta.revision = 1;
+                store
+                    .put_if_absent(namespace, id, &record.to_value()?)
+                    .await?;
                 report.created.push(RecordRef::new(namespace, id));
             }
             Some(raw) => {
@@ -122,21 +133,33 @@ pub async fn apply_builtin_seed(
                             report.unchanged.push(RecordRef::new(namespace, id));
                         } else {
                             // Update: refresh spec and/or version; preserve
-                            // hidden flag, user_overrides, and created_at.
+                            // user_overrides and created_at.
+                            // Reintroducing a previously-orphaned spec clears
+                            // `hidden`; the user override (if any) flows
+                            // through unchanged.
                             let now = awaken_contract::time::now_ms();
+                            let expected_revision = existing.meta.revision;
                             let record = ConfigRecord {
                                 spec: new_spec_value,
                                 meta: RecordMeta {
                                     source: RecordSource::Builtin {
                                         binary_version: seed.binary_version.clone(),
                                     },
-                                    hidden: existing.meta.hidden,
+                                    hidden: false,
                                     user_overrides: existing.meta.user_overrides,
                                     created_at: existing.meta.created_at,
                                     updated_at: now,
+                                    revision: expected_revision + 1,
                                 },
                             };
-                            store.put(namespace, id, &record.to_value()?).await?;
+                            store
+                                .put_if_revision(
+                                    namespace,
+                                    id,
+                                    &record.to_value()?,
+                                    expected_revision,
+                                )
+                                .await?;
                             report.updated.push(RecordRef::new(namespace, id));
                         }
                     }
@@ -185,10 +208,34 @@ pub async fn apply_builtin_seed(
             offset += page_len;
         }
 
-        // Pass 2: delete all candidates collected above.
+        // Pass 2: delete or hide each candidate based on whether it carries
+        // a user override. Hard-delete records with no override; soft-delete
+        // (hidden=true) records that DO have an override so that re-introducing
+        // the spec in a later binary transparently restores the override.
         for id in candidates {
-            store.delete(namespace, &id).await?;
-            report.deleted.push(RecordRef::new(namespace, &id));
+            let Some(raw) = store.get(namespace, &id).await? else {
+                continue;
+            };
+            let mut record: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw)?;
+            let expected_revision = record.meta.revision;
+
+            if record.meta.user_overrides.is_some() {
+                // Soft-delete: preserve the override under hidden=true.
+                record.meta.hidden = true;
+                record.meta.updated_at = awaken_contract::time::now_ms();
+                record.meta.revision = expected_revision + 1;
+                store
+                    .put_if_revision(namespace, &id, &record.to_value()?, expected_revision)
+                    .await?;
+                report
+                    .preserved_overridden
+                    .push(RecordRef::new(namespace, &id));
+            } else {
+                store
+                    .delete_if_revision(namespace, &id, expected_revision)
+                    .await?;
+                report.deleted.push(RecordRef::new(namespace, &id));
+            }
         }
     }
 
@@ -207,6 +254,7 @@ fn builtin_spec_to_value(spec: &BuiltinSpec) -> Result<serde_json::Value, serde_
         BuiltinSpec::Provider(s) => serde_json::to_value(s),
         BuiltinSpec::Model(s) => serde_json::to_value(s),
         BuiltinSpec::McpServer(s) => serde_json::to_value(s),
+        BuiltinSpec::Tool(s) => serde_json::to_value(s),
     }
 }
 
@@ -499,7 +547,7 @@ mod tests {
     // ── test 8 ───────────────────────────────────────────────────────────────
 
     #[tokio::test]
-    async fn hidden_flag_preserved_across_upgrade() {
+    async fn reintroduced_spec_clears_hidden_flag() {
         let s = store();
 
         apply_builtin_seed(
@@ -509,7 +557,7 @@ mod tests {
         .await
         .unwrap();
 
-        // Set hidden = true on stored record.
+        // Set hidden = true on stored record (simulates an orphan-preserved state).
         let raw = s.get("agents", "a1").await.unwrap().unwrap();
         let mut rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
         rec.meta.hidden = true;
@@ -517,7 +565,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Apply v2 with new content.
+        // Apply v2 with new content — reintroduces the spec, must clear hidden.
         apply_builtin_seed(
             &s,
             &seed_v2(vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v2")))]),
@@ -527,7 +575,7 @@ mod tests {
 
         let raw = s.get("agents", "a1").await.unwrap().unwrap();
         let rec: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
-        assert!(rec.meta.hidden, "hidden flag must be preserved");
+        assert!(!rec.meta.hidden, "reintroduced spec must clear hidden");
         assert_eq!(
             rec.meta.source,
             RecordSource::Builtin {
@@ -731,5 +779,126 @@ mod tests {
                 "{ns}/{id} must be removed from the store"
             );
         }
+    }
+
+    // ── test 13 ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_with_override_is_hidden_not_deleted() {
+        let store = InMemoryStore::new();
+        // Apply v1 seeding agent "a1" then patch in a user override.
+        let v1 = seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec(
+            "a1",
+            "v1-prompt",
+        )))]);
+        apply_builtin_seed(&store, &v1).await.unwrap();
+
+        // Set user override directly on the stored envelope.
+        let raw = store.get("agents", "a1").await.unwrap().unwrap();
+        let mut record: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        record.meta.user_overrides = Some(serde_json::json!({"system_prompt": "patched"}));
+        store
+            .put("agents", "a1", &record.to_value().unwrap())
+            .await
+            .unwrap();
+
+        // Apply v2 seed without "a1" — orphan path triggers.
+        let v2 = BuiltinSeedSet {
+            binary_version: "v2".into(),
+            specs: vec![],
+        };
+        let report = apply_builtin_seed(&store, &v2).await.unwrap();
+
+        // The orphan was preserved, not deleted.
+        assert!(
+            report
+                .preserved_overridden
+                .iter()
+                .any(|r| r.namespace == "agents" && r.id == "a1")
+        );
+        assert!(!report.deleted.iter().any(|r| r.id == "a1"));
+
+        // Record still exists, hidden=true, override intact.
+        let raw = store.get("agents", "a1").await.unwrap().unwrap();
+        let record: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert!(record.meta.hidden);
+        assert_eq!(
+            record.meta.user_overrides,
+            Some(serde_json::json!({"system_prompt": "patched"}))
+        );
+    }
+
+    // ── test 14 ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn orphan_without_override_is_hard_deleted() {
+        let store = InMemoryStore::new();
+        let v1 = seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec(
+            "a1",
+            "v1-prompt",
+        )))]);
+        apply_builtin_seed(&store, &v1).await.unwrap();
+
+        // Apply v2 with no specs — orphan with no override.
+        let v2 = BuiltinSeedSet {
+            binary_version: "v2".into(),
+            specs: vec![],
+        };
+        let report = apply_builtin_seed(&store, &v2).await.unwrap();
+
+        assert!(
+            report
+                .deleted
+                .iter()
+                .any(|r| r.namespace == "agents" && r.id == "a1")
+        );
+        assert!(report.preserved_overridden.is_empty());
+        assert!(store.get("agents", "a1").await.unwrap().is_none());
+    }
+
+    // ── test 15 ──────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn reintroduced_spec_clears_hidden_and_keeps_override() {
+        let store = InMemoryStore::new();
+        // v1 seed + override, then v2 orphans it (hidden), then v3 brings it back.
+        let v1 = seed_v1(vec![BuiltinSpec::Agent(Box::new(agent_spec(
+            "a1",
+            "v1-prompt",
+        )))]);
+        apply_builtin_seed(&store, &v1).await.unwrap();
+
+        let raw = store.get("agents", "a1").await.unwrap().unwrap();
+        let mut record: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        record.meta.user_overrides = Some(serde_json::json!({"system_prompt": "patched"}));
+        store
+            .put("agents", "a1", &record.to_value().unwrap())
+            .await
+            .unwrap();
+
+        // v2: orphan
+        let v2 = BuiltinSeedSet {
+            binary_version: "v2".into(),
+            specs: vec![],
+        };
+        apply_builtin_seed(&store, &v2).await.unwrap();
+        let raw = store.get("agents", "a1").await.unwrap().unwrap();
+        let record: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert!(record.meta.hidden, "should be hidden after v2 orphans it");
+
+        // v3: re-introduce a1 with new prompt.
+        let v3 = BuiltinSeedSet {
+            binary_version: "v3".into(),
+            specs: vec![BuiltinSpec::Agent(Box::new(agent_spec("a1", "v3-prompt")))],
+        };
+        apply_builtin_seed(&store, &v3).await.unwrap();
+        let raw = store.get("agents", "a1").await.unwrap().unwrap();
+        let record: ConfigRecord<serde_json::Value> = ConfigRecord::from_value(raw).unwrap();
+        assert!(!record.meta.hidden, "reintroduced spec must be live again");
+        assert_eq!(
+            record.meta.user_overrides,
+            Some(serde_json::json!({"system_prompt": "patched"})),
+            "override must survive the orphan→reintroduce cycle"
+        );
     }
 }

--- a/crates/awaken-server/src/services/config_envelope.rs
+++ b/crates/awaken-server/src/services/config_envelope.rs
@@ -6,7 +6,7 @@
 
 use awaken_contract::{
     AgentSpec, AgentSpecPatch, ConfigRecord, McpServerSpec, ModelBindingSpec, ProviderSpec,
-    RecordMeta, merge_agent_spec,
+    RecordMeta, ToolSpec, ToolSpecPatch, merge_agent_spec, merge_tool_spec,
 };
 use serde_json::Value;
 
@@ -29,6 +29,13 @@ impl ApplyPatch for AgentSpec {
     type Patch = AgentSpecPatch;
     fn apply(self, patch: AgentSpecPatch) -> Self {
         merge_agent_spec(self, patch)
+    }
+}
+
+impl ApplyPatch for ToolSpec {
+    type Patch = ToolSpecPatch;
+    fn apply(self, patch: ToolSpecPatch) -> Self {
+        merge_tool_spec(self, patch)
     }
 }
 
@@ -83,6 +90,7 @@ pub(crate) fn extract_timestamps(spec: &Value) -> (u64, u64) {
 /// The spec's own `created_at`/`updated_at` are lifted into `RecordMeta` for
 /// provenance. This does **not** modify the spec itself — the spec timestamps
 /// remain authoritative for UI display.
+#[cfg(test)]
 pub(crate) fn wrap_user(spec: &Value) -> Result<Value, serde_json::Error> {
     let (created_at, updated_at) = extract_timestamps(spec);
     let mut meta = RecordMeta::new_user();
@@ -115,6 +123,7 @@ pub(crate) fn wrap_builtin(spec: &Value, binary_version: &str) -> Result<Value, 
 ///
 /// Used for rollback paths where the value being restored may have been
 /// written by an earlier writer (envelope) or an older binary (bare spec).
+#[cfg(test)]
 pub(crate) fn ensure_envelope(value: Value) -> Result<Value, serde_json::Error> {
     if value.is_object()
         && value
@@ -312,5 +321,42 @@ mod tests {
             err.is_err(),
             "unknown field in overrides must produce a decode error"
         );
+    }
+
+    #[test]
+    fn apply_overrides_for_tool_spec_replaces_description_when_some() {
+        use awaken_contract::ToolSpec;
+        let spec = ToolSpec {
+            id: "echo".into(),
+            name: "Echo".into(),
+            description: "stock".into(),
+            ..Default::default()
+        };
+        let overrides = json!({"description": "custom"});
+        let result = apply_overrides(spec, Some(&overrides)).unwrap();
+        assert_eq!(result.description, "custom");
+    }
+
+    #[test]
+    fn apply_overrides_for_tool_spec_keeps_base_when_none() {
+        use awaken_contract::ToolSpec;
+        let spec = ToolSpec {
+            id: "echo".into(),
+            description: "stock".into(),
+            ..Default::default()
+        };
+        let result = apply_overrides(spec, None).unwrap();
+        assert_eq!(result.description, "stock");
+    }
+
+    #[test]
+    fn apply_overrides_for_tool_spec_rejects_unknown_field() {
+        use awaken_contract::ToolSpec;
+        let spec = ToolSpec {
+            id: "echo".into(),
+            ..Default::default()
+        };
+        let bad = json!({"name": "renamed"});
+        assert!(apply_overrides(spec, Some(&bad)).is_err());
     }
 }

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -41,6 +41,7 @@ const NS_AGENTS: &str = "agents";
 const NS_MODELS: &str = "models";
 const NS_PROVIDERS: &str = "providers";
 const NS_MCP_SERVERS: &str = "mcp-servers";
+const NS_TOOLS: &str = "tools";
 
 /// Per-provider executor cache entry: the spec used to build the cached
 /// executor and the executor itself.
@@ -321,6 +322,7 @@ struct ManagedConfigSnapshot {
     models: Vec<ModelBindingSpec>,
     agents: Vec<AgentSpec>,
     mcp_servers: Vec<McpServerSpec>,
+    tools: Vec<awaken_contract::ToolSpec>,
     fingerprint: u64,
 }
 
@@ -581,12 +583,40 @@ impl ConfigRuntimeManager {
         }
     }
 
+    /// Snapshot the static tool registry into [`BuiltinSpec::Tool`] entries.
+    ///
+    /// Callers splice these into their `BuiltinSeedSet::specs` to make every
+    /// registered tool a first-class config record (ADR-0029). Dynamic
+    /// (MCP-sourced) tools are intentionally excluded — they are governed by
+    /// the MCP namespace lifecycle.
+    pub fn snapshot_tool_specs(&self) -> Vec<awaken_contract::BuiltinSpec> {
+        let mut out = Vec::new();
+        for id in self.tools.tool_ids() {
+            let Some(tool) = self.tools.get_tool(&id) else {
+                continue;
+            };
+            let descriptor = tool.descriptor();
+            out.push(awaken_contract::BuiltinSpec::tool(
+                awaken_contract::ToolSpec {
+                    id: descriptor.id,
+                    name: descriptor.name,
+                    description: descriptor.description,
+                    category: descriptor.category,
+                    parameters_schema: descriptor.parameters,
+                },
+            ));
+        }
+        out.sort_by(|a, b| a.id().cmp(b.id()));
+        out
+    }
+
     async fn publish(&self, managed: ManagedConfigSnapshot) -> Result<u64, ConfigRuntimeError> {
         let prepared_mcp = self.prepare_mcp_registry(&managed.mcp_servers).await?;
         let candidate = match self.compile_registry_set(
             &managed.providers,
             &managed.models,
             &managed.agents,
+            &managed.tools,
             prepared_mcp.tool_registry.clone(),
         ) {
             Ok(candidate) => candidate,
@@ -833,12 +863,14 @@ impl ConfigRuntimeManager {
         let model_values = self.load_namespace_entries(NS_MODELS).await?;
         let agent_values = self.load_namespace_entries(NS_AGENTS).await?;
         let mcp_values = self.load_namespace_entries(NS_MCP_SERVERS).await?;
+        let tool_values = self.load_namespace_entries(NS_TOOLS).await?;
 
         let fingerprint = fingerprint_config(&[
             (NS_PROVIDERS, &provider_values),
             (NS_MODELS, &model_values),
             (NS_AGENTS, &agent_values),
             (NS_MCP_SERVERS, &mcp_values),
+            (NS_TOOLS, &tool_values),
         ])?;
 
         Ok(ManagedConfigSnapshot {
@@ -846,6 +878,7 @@ impl ConfigRuntimeManager {
             models: deserialize_namespace(&model_values)?,
             agents: deserialize_namespace(&agent_values)?,
             mcp_servers: deserialize_namespace(&mcp_values)?,
+            tools: deserialize_namespace(&tool_values)?,
             fingerprint,
         })
     }
@@ -882,6 +915,7 @@ impl ConfigRuntimeManager {
         providers: &[ProviderSpec],
         models: &[ModelBindingSpec],
         agents: &[AgentSpec],
+        tool_specs: &[awaken_contract::ToolSpec],
         dynamic_tools: Option<Arc<dyn ToolRegistry>>,
     ) -> Result<RegistrySet, ConfigRuntimeError> {
         let mut provider_registry = MapProviderRegistry::new();
@@ -927,7 +961,18 @@ impl ConfigRuntimeManager {
             None => local_agents,
         };
 
-        let tools = self.compose_tool_registry(dynamic_tools)?;
+        let overrides: std::collections::HashMap<String, String> = tool_specs
+            .iter()
+            .filter_map(|spec| {
+                let live = self.tools.get_tool(&spec.id)?;
+                if live.descriptor().description != spec.description {
+                    Some((spec.id.clone(), spec.description.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let tools = self.compose_tool_registry(dynamic_tools, overrides)?;
 
         Ok(RegistrySet {
             agents,
@@ -942,12 +987,24 @@ impl ConfigRuntimeManager {
     fn compose_tool_registry(
         &self,
         dynamic_tools: Option<Arc<dyn ToolRegistry>>,
+        description_overrides: std::collections::HashMap<String, String>,
     ) -> Result<Arc<dyn ToolRegistry>, ConfigRuntimeError> {
-        let Some(dynamic_tools) = dynamic_tools else {
-            return Ok(Arc::clone(&self.tools));
+        let base: Arc<dyn ToolRegistry> = if description_overrides.is_empty() {
+            Arc::clone(&self.tools)
+        } else {
+            Arc::new(
+                crate::services::tool_overrides::DescriptionOverrideRegistry::new(
+                    Arc::clone(&self.tools),
+                    description_overrides,
+                ),
+            ) as Arc<dyn ToolRegistry>
         };
 
-        let base_ids: HashSet<_> = self.tools.tool_ids().into_iter().collect();
+        let Some(dynamic_tools) = dynamic_tools else {
+            return Ok(base);
+        };
+
+        let base_ids: HashSet<_> = base.tool_ids().into_iter().collect();
         for tool_id in dynamic_tools.tool_ids() {
             if base_ids.contains(&tool_id) {
                 return Err(ConfigRuntimeError::InvalidConfig(format!(
@@ -956,10 +1013,7 @@ impl ConfigRuntimeManager {
             }
         }
 
-        Ok(Arc::new(OverlayToolRegistry::new(
-            Arc::clone(&self.tools),
-            dynamic_tools,
-        )) as Arc<dyn ToolRegistry>)
+        Ok(Arc::new(OverlayToolRegistry::new(base, dynamic_tools)) as Arc<dyn ToolRegistry>)
     }
 
     fn validate_candidate(
@@ -2800,5 +2854,209 @@ mod tests {
             spec.max_rounds, 10,
             "max_rounds must use v2 base (not overridden)"
         );
+    }
+
+    /// Build an `AgentRuntime` with one stub tool registered plus a
+    /// `ConfigRuntimeManager` backed by an `InMemoryStore`. Seeds a minimal
+    /// provider/model/agent/tool set and calls `apply_seed`.
+    ///
+    /// Returns `(manager, runtime, store)` so callers can write to the store
+    /// directly without needing a `#[cfg(test)]` accessor.
+    async fn bootstrap_with_static_tool(
+        tool_id: &str,
+        tool_description: &str,
+    ) -> (
+        Arc<ConfigRuntimeManager>,
+        Arc<awaken_runtime::AgentRuntime>,
+        Arc<dyn awaken_contract::contract::config_store::ConfigStore>,
+    ) {
+        use awaken_contract::contract::executor::{
+            InferenceExecutionError, InferenceRequest, LlmExecutor,
+        };
+        use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+        use awaken_contract::contract::tool::{
+            Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
+        };
+        use awaken_contract::{
+            BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec, ToolSpec,
+        };
+        use awaken_stores::InMemoryStore;
+        use serde_json::json;
+
+        struct Stub;
+        #[async_trait::async_trait]
+        impl LlmExecutor for Stub {
+            async fn execute(
+                &self,
+                _: InferenceRequest,
+            ) -> Result<StreamResult, InferenceExecutionError> {
+                Ok(StreamResult {
+                    content: vec![],
+                    tool_calls: vec![],
+                    usage: Some(TokenUsage::default()),
+                    stop_reason: Some(StopReason::EndTurn),
+                    has_incomplete_tool_calls: false,
+                })
+            }
+            fn name(&self) -> &str {
+                "stub"
+            }
+        }
+
+        struct StubTool {
+            id: String,
+            description: String,
+        }
+        #[async_trait::async_trait]
+        impl Tool for StubTool {
+            fn descriptor(&self) -> ToolDescriptor {
+                ToolDescriptor::new(&self.id, &self.id, &self.description)
+            }
+            async fn execute(
+                &self,
+                _args: serde_json::Value,
+                _ctx: &ToolCallContext,
+            ) -> Result<ToolOutput, ToolError> {
+                Ok(ToolResult::success(&self.id, json!({})).into())
+            }
+        }
+
+        struct StubFactory;
+        impl ProviderExecutorFactory for StubFactory {
+            fn build(
+                &self,
+                _spec: &ProviderSpec,
+            ) -> Result<Arc<dyn awaken_contract::contract::executor::LlmExecutor>, ConfigRuntimeError>
+            {
+                Ok(Arc::new(Stub))
+            }
+        }
+
+        let store = Arc::new(InMemoryStore::new())
+            as Arc<dyn awaken_contract::contract::config_store::ConfigStore>;
+        let thread_store = Arc::new(InMemoryStore::new());
+
+        let runtime = Arc::new(
+            awaken_runtime::builder::AgentRuntimeBuilder::new()
+                .with_provider("boot", Arc::new(Stub))
+                .with_model_binding(
+                    "boot",
+                    awaken_runtime::registry::traits::ModelBinding {
+                        provider_id: "boot".into(),
+                        upstream_model: "boot-model".into(),
+                    },
+                )
+                .with_tool(
+                    tool_id,
+                    Arc::new(StubTool {
+                        id: tool_id.to_owned(),
+                        description: tool_description.to_owned(),
+                    }),
+                )
+                .with_thread_run_store(thread_store)
+                .build()
+                .expect("build runtime"),
+        );
+
+        let manager = Arc::new(
+            ConfigRuntimeManager::new(runtime.clone(), store.clone())
+                .expect("manager")
+                .with_provider_factory(Arc::new(StubFactory)),
+        );
+
+        let seed = BuiltinSeedSet {
+            binary_version: "test".to_owned(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "test-prov".into(),
+                    adapter: "openai".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec {
+                    id: "test-model".into(),
+                    provider_id: "test-prov".into(),
+                    upstream_model: "gpt-4o".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "agent-using-echo".into(),
+                    model_id: "test-model".into(),
+                    system_prompt: "you are a test".into(),
+                    max_rounds: 1,
+                    allowed_tools: None,
+                    endpoint: None,
+                    ..Default::default()
+                })),
+                BuiltinSpec::Tool(ToolSpec {
+                    id: tool_id.to_owned(),
+                    name: tool_id.to_owned(),
+                    description: tool_description.to_owned(),
+                    ..Default::default()
+                }),
+            ],
+        };
+        manager.apply_seed(&seed).await.expect("apply_seed");
+
+        (manager, runtime, store)
+    }
+
+    #[tokio::test]
+    async fn tool_description_override_applied_to_resolved_agent() {
+        let (manager, runtime, store) =
+            bootstrap_with_static_tool("echo", "stock description").await;
+
+        manager.apply().await.expect("initial apply");
+
+        let envelope = serde_json::json!({
+            "spec": {
+                "id": "echo",
+                "name": "Echo",
+                "description": "stock description",
+                "category": null,
+                "parameters_schema": {}
+            },
+            "meta": {
+                "source": { "kind": "builtin", "binary_version": "test" },
+                "user_overrides": { "description": "patched description" },
+                "hidden": false,
+                "created_at": 1,
+                "updated_at": 2
+            }
+        });
+        awaken_contract::contract::config_store::ConfigStore::put(
+            store.as_ref(),
+            "tools",
+            "echo",
+            &envelope,
+        )
+        .await
+        .expect("write override");
+
+        manager.apply().await.expect("apply with override");
+
+        let resolver = runtime.resolver_arc();
+        let resolved = resolver.resolve("agent-using-echo").expect("resolve");
+        let descs = resolved.tool_descriptors();
+        let echo = descs
+            .iter()
+            .find(|d| d.id == "echo")
+            .expect("echo descriptor present");
+        assert_eq!(echo.description, "patched description");
+    }
+
+    #[tokio::test]
+    async fn snapshot_tool_specs_emits_one_entry_per_registered_tool() {
+        let (manager, _runtime, _store) =
+            bootstrap_with_static_tool("echo", "stock description").await;
+        let specs = manager.snapshot_tool_specs();
+        assert_eq!(specs.len(), 1);
+        match &specs[0] {
+            awaken_contract::BuiltinSpec::Tool(t) => {
+                assert_eq!(t.id, "echo");
+                assert_eq!(t.description, "stock description");
+            }
+            other => panic!("expected Tool variant, got {other:?}"),
+        }
     }
 }

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -144,6 +144,7 @@ pub enum RestoreError {
 pub struct ProviderTestResult {
     pub ok: bool,
     pub latency_ms: u64,
+    pub network_tested: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
@@ -1230,6 +1231,7 @@ impl<'a> ConfigService<'a> {
             return Ok(ProviderTestResult {
                 ok: false,
                 latency_ms,
+                network_tested: false,
                 error: Some(e.to_string()),
             });
         }
@@ -1246,22 +1248,26 @@ impl<'a> ConfigService<'a> {
                 return Ok(ProviderTestResult {
                     ok: true,
                     latency_ms,
+                    network_tested: false,
                     error: None,
                 });
             }
         };
+        let mut network_tested = false;
         if matches!(
             kind,
             awaken_runtime::credentials::CredentialKind::GoogleServiceAccountJson
         ) {
             let scope = "https://www.googleapis.com/auth/cloud-platform";
             let mint_start = Instant::now();
+            network_tested = true;
             let mint_result = broker.token_for(&spec.id, scope).await;
             latency_ms = latency_ms.saturating_add(mint_start.elapsed().as_millis() as u64);
             if let Err(err) = mint_result {
                 return Ok(ProviderTestResult {
                     ok: false,
                     latency_ms,
+                    network_tested,
                     error: Some(err.to_string()),
                 });
             }
@@ -1270,6 +1276,7 @@ impl<'a> ConfigService<'a> {
         Ok(ProviderTestResult {
             ok: true,
             latency_ms,
+            network_tested,
             error: None,
         })
     }

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -6,7 +6,7 @@ use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::storage::StorageError;
 use awaken_contract::{
     AgentSpec, AgentSpecPatch, ConfigRecord, McpServerSpec, ModelBindingSpec, ProviderSpec,
-    RecordSource, now_ms,
+    RecordMeta, RecordSource, ToolSpec, ToolSpecPatch, now_ms,
 };
 use axum::http::HeaderMap;
 use serde_json::{Map, Value, json};
@@ -14,7 +14,7 @@ use serde_json::{Map, Value, json};
 use crate::app::AppState;
 use crate::services::audit_log::AuditLogger;
 use crate::services::config_envelope::{
-    apply_overrides, ensure_envelope, spec_field, unwrap_spec, wrap_user,
+    apply_overrides, extract_timestamps, spec_field, unwrap_spec,
 };
 
 use super::config_runtime::ConfigRuntimeError;
@@ -25,23 +25,25 @@ pub enum ConfigNamespace {
     Models,
     Providers,
     McpServers,
+    Tools,
 }
 
 impl ConfigNamespace {
-    /// All four managed namespaces in a fixed order.
-    pub const ALL: [Self; 4] = [
+    /// All five managed namespaces in a fixed order.
+    pub const ALL: [Self; 5] = [
         Self::Agents,
         Self::Providers,
         Self::Models,
         Self::McpServers,
+        Self::Tools,
     ];
 
-    /// Slice over all four namespace variants.
+    /// Slice over all five namespace variants.
     pub fn all() -> &'static [Self] {
         &Self::ALL
     }
 
-    /// Iterator over the `&'static str` names of all four namespaces.
+    /// Iterator over the `&'static str` names of all five namespaces.
     pub fn iter_str() -> impl Iterator<Item = &'static str> + 'static {
         Self::ALL.iter().copied().map(Self::as_str)
     }
@@ -52,6 +54,7 @@ impl ConfigNamespace {
             "models" => Ok(Self::Models),
             "providers" => Ok(Self::Providers),
             "mcp-servers" => Ok(Self::McpServers),
+            "tools" => Ok(Self::Tools),
             _ => Err(ConfigServiceError::UnknownNamespace(value.to_string())),
         }
     }
@@ -62,6 +65,7 @@ impl ConfigNamespace {
             Self::Models => "models",
             Self::Providers => "providers",
             Self::McpServers => "mcp-servers",
+            Self::Tools => "tools",
         }
     }
 
@@ -71,6 +75,7 @@ impl ConfigNamespace {
             Self::Models => schemars::schema_for!(ModelBindingSpec),
             Self::Providers => schemars::schema_for!(ProviderSpec),
             Self::McpServers => schemars::schema_for!(McpServerSpec),
+            Self::Tools => schemars::schema_for!(ToolSpec),
         };
         serde_json::to_value(schema)
             .map_err(|error| ConfigServiceError::Serialization(error.to_string()))
@@ -253,7 +258,8 @@ impl<'a> ConfigService<'a> {
                 { "namespace": "agents", "schema": ConfigNamespace::Agents.schema_json()? },
                 { "namespace": "models", "schema": ConfigNamespace::Models.schema_json()? },
                 { "namespace": "providers", "schema": ConfigNamespace::Providers.schema_json()? },
-                { "namespace": "mcp-servers", "schema": ConfigNamespace::McpServers.schema_json()? }
+                { "namespace": "mcp-servers", "schema": ConfigNamespace::McpServers.schema_json()? },
+                { "namespace": "tools", "schema": ConfigNamespace::Tools.schema_json()? }
             ],
         }))
     }
@@ -353,6 +359,11 @@ impl<'a> ConfigService<'a> {
         body: Value,
         headers: &HeaderMap,
     ) -> Result<Value, ConfigServiceError> {
+        if matches!(namespace, ConfigNamespace::Tools) {
+            return Err(ConfigServiceError::InvalidPayload(
+                "tools namespace is read-only; use PATCH /v1/config/tools/:id/overrides".into(),
+            ));
+        }
         let manager = self.runtime_manager()?;
         let _apply_guard = manager.lock_apply().await;
         let (id, body) = self.prepare_body(namespace, None, body).await?;
@@ -365,7 +376,14 @@ impl<'a> ConfigService<'a> {
         }
 
         let result = self
-            .persist_and_apply_locked(manager.as_ref(), namespace, &id, None, body.clone())
+            .persist_and_apply_locked(
+                manager.as_ref(),
+                namespace,
+                &id,
+                None,
+                body.clone(),
+                headers,
+            )
             .await?;
 
         self.emit_audit(
@@ -388,6 +406,11 @@ impl<'a> ConfigService<'a> {
         body: Value,
         headers: &HeaderMap,
     ) -> Result<Value, ConfigServiceError> {
+        if matches!(namespace, ConfigNamespace::Tools) {
+            return Err(ConfigServiceError::InvalidPayload(
+                "tools namespace is read-only; use PATCH /v1/config/tools/:id/overrides".into(),
+            ));
+        }
         let manager = self.runtime_manager()?;
         let _apply_guard = manager.lock_apply().await;
         let (body_id, body) = self.prepare_body(namespace, Some(id), body).await?;
@@ -405,6 +428,7 @@ impl<'a> ConfigService<'a> {
                 id,
                 previous.clone(),
                 body.clone(),
+                headers,
             )
             .await?;
 
@@ -428,6 +452,11 @@ impl<'a> ConfigService<'a> {
         force: bool,
         headers: &HeaderMap,
     ) -> Result<(), ConfigServiceError> {
+        if matches!(namespace, ConfigNamespace::Tools) {
+            return Err(ConfigServiceError::InvalidPayload(
+                "tools namespace is read-only; use PATCH /v1/config/tools/:id/overrides".into(),
+            ));
+        }
         let manager = self.runtime_manager()?;
         let _apply_guard = manager.lock_apply().await;
         let previous = self
@@ -445,16 +474,32 @@ impl<'a> ConfigService<'a> {
             }
         }
 
-        self.store.delete(namespace.as_str(), id).await?;
+        let expected_revision = ConfigRecord::<Value>::from_value(previous.clone())
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?
+            .meta
+            .revision;
+        self.cas_delete_record(namespace, id, expected_revision)
+            .await?;
         let apply_result = manager
             .apply_locked()
             .await
             .map(|_| ())
             .map_err(map_runtime_error);
         if let Err(error) = apply_result {
-            let env = ensure_envelope(previous)
-                .map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store.put(namespace.as_str(), id, &env).await?;
+            self.emit_audit_apply_failed(
+                namespace,
+                id,
+                "",
+                Some(unwrap_spec(previous.clone())),
+                None,
+                error.to_string(),
+                headers,
+            )
+            .await;
+            let mut rollback = ConfigRecord::<Value>::from_value(previous.clone())
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+            self.insert_record_absent(namespace, id, &mut rollback, expected_revision + 1)
+                .await?;
             return Err(error);
         }
 
@@ -523,7 +568,7 @@ impl<'a> ConfigService<'a> {
                 .before
                 .clone()
                 .ok_or(RestoreError::NoPayload(event.action.clone()))?,
-            A::Restart | A::SeedApply => return Err(RestoreError::NotRestorable),
+            A::Restart | A::SeedApply | A::ApplyFailed => return Err(RestoreError::NotRestorable),
         };
 
         // Single store read: determines both existence and the pre-restore snapshot.
@@ -548,9 +593,16 @@ impl<'a> ConfigService<'a> {
                     format!("restored payload id '{body_id}' does not match URL id '{id}'"),
                 )));
             }
-            self.persist_and_apply_locked(manager.as_ref(), namespace, id, before.clone(), prepared)
-                .await
-                .map_err(RestoreError::Service)?
+            self.persist_and_apply_locked(
+                manager.as_ref(),
+                namespace,
+                id,
+                before.clone(),
+                prepared,
+                headers,
+            )
+            .await
+            .map_err(RestoreError::Service)?
         } else {
             // Resource does not exist — restore from a deleted state.
             // We need to preserve created_at from the restored payload.
@@ -592,6 +644,7 @@ impl<'a> ConfigService<'a> {
                 &body_id,
                 None,
                 prepared.clone(),
+                headers,
             )
             .await
             .map_err(RestoreError::Service)?
@@ -657,7 +710,9 @@ impl<'a> ConfigService<'a> {
                     .collect();
                 Ok(refs)
             }
-            ConfigNamespace::Agents | ConfigNamespace::McpServers => Ok(vec![]),
+            ConfigNamespace::Agents | ConfigNamespace::McpServers | ConfigNamespace::Tools => {
+                Ok(vec![])
+            }
         }
     }
 
@@ -699,6 +754,30 @@ impl<'a> ConfigService<'a> {
         audit.emit(action, &resource, before, after, headers).await;
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn emit_audit_apply_failed(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+        suffix: &str,
+        before: Option<Value>,
+        after: Option<Value>,
+        error_msg: String,
+        headers: &HeaderMap,
+    ) {
+        let Some(audit) = &self.audit else {
+            return;
+        };
+        let resource = if suffix.is_empty() {
+            format!("{}/{}", namespace.as_str(), id)
+        } else {
+            format!("{}/{}/{}", namespace.as_str(), id, suffix)
+        };
+        audit
+            .emit_apply_failed(&resource, before, after, error_msg, headers)
+            .await;
+    }
+
     fn runtime_manager(
         &self,
     ) -> Result<&Arc<crate::services::config_runtime::ConfigRuntimeManager>, ConfigServiceError>
@@ -709,6 +788,108 @@ impl<'a> ConfigService<'a> {
             .ok_or(ConfigServiceError::NotEnabled)
     }
 
+    fn user_record_from_body(body: &Value) -> ConfigRecord<Value> {
+        let (created_at, updated_at) = extract_timestamps(body);
+        let mut meta = RecordMeta::new_user();
+        if created_at != 0 {
+            meta.created_at = created_at;
+        }
+        if updated_at != 0 {
+            meta.updated_at = updated_at;
+        }
+        ConfigRecord {
+            spec: body.clone(),
+            meta,
+        }
+    }
+
+    fn storage_write_error(
+        namespace: ConfigNamespace,
+        id: &str,
+        error: StorageError,
+    ) -> ConfigServiceError {
+        match error {
+            StorageError::AlreadyExists(_) => ConfigServiceError::Conflict(format!(
+                "{}/{} already exists",
+                namespace.as_str(),
+                id
+            )),
+            StorageError::VersionConflict { expected, actual } => {
+                ConfigServiceError::Conflict(format!(
+                    "{}/{} was modified by another writer (expected revision {expected}, found {actual}); retry the mutation",
+                    namespace.as_str(),
+                    id,
+                ))
+            }
+            other => ConfigServiceError::Storage(other),
+        }
+    }
+
+    async fn insert_record_absent<T: serde::Serialize + serde::de::DeserializeOwned>(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+        record: &mut ConfigRecord<T>,
+        revision: u64,
+    ) -> Result<u64, ConfigServiceError> {
+        record.meta.revision = revision;
+        let envelope = record
+            .to_value()
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+        self.store
+            .put_if_absent(namespace.as_str(), id, &envelope)
+            .await
+            .map(|()| revision)
+            .map_err(|error| Self::storage_write_error(namespace, id, error))
+    }
+
+    /// Write `record` using `put_if_revision`, bumping `meta.revision` from
+    /// `expected_revision`. Returns the new revision on success or
+    /// `ConfigServiceError::Conflict` on CAS mismatch.
+    async fn cas_put_record<T: serde::Serialize + serde::de::DeserializeOwned>(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+        record: &mut ConfigRecord<T>,
+        expected_revision: u64,
+    ) -> Result<u64, ConfigServiceError> {
+        let next_revision = expected_revision.saturating_add(1);
+        record.meta.revision = next_revision;
+        let envelope = record
+            .to_value()
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+        self.store
+            .put_if_revision(namespace.as_str(), id, &envelope, expected_revision)
+            .await
+            .map(|()| next_revision)
+            .map_err(|error| Self::storage_write_error(namespace, id, error))
+    }
+
+    async fn cas_delete_record(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+        expected_revision: u64,
+    ) -> Result<(), ConfigServiceError> {
+        self.store
+            .delete_if_revision(namespace.as_str(), id, expected_revision)
+            .await
+            .map_err(|error| Self::storage_write_error(namespace, id, error))
+    }
+
+    async fn rollback_to_raw_after_revision(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+        raw: Value,
+        expected_revision: u64,
+    ) -> Result<u64, ConfigServiceError> {
+        let mut rollback = ConfigRecord::<Value>::from_value(raw)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+        self.cas_put_record(namespace, id, &mut rollback, expected_revision)
+            .await
+    }
+
     async fn persist_and_apply_locked(
         &self,
         manager: &crate::services::config_runtime::ConfigRuntimeManager,
@@ -716,10 +897,24 @@ impl<'a> ConfigService<'a> {
         id: &str,
         previous: Option<Value>,
         body: Value,
+        headers: &HeaderMap,
     ) -> Result<Value, ConfigServiceError> {
         self.validate_payload(namespace, &body)?;
-        let envelope = wrap_user(&body).map_err(|e| StorageError::Serialization(e.to_string()))?;
-        self.store.put(namespace.as_str(), id, &envelope).await?;
+        let mut record = Self::user_record_from_body(&body);
+        let write_revision = match previous.as_ref() {
+            Some(previous) => {
+                let expected_revision = ConfigRecord::<Value>::from_value(previous.clone())
+                    .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?
+                    .meta
+                    .revision;
+                self.cas_put_record(namespace, id, &mut record, expected_revision)
+                    .await?
+            }
+            None => {
+                self.insert_record_absent(namespace, id, &mut record, 1)
+                    .await?
+            }
+        };
 
         let apply_result = manager
             .apply_locked()
@@ -727,13 +922,25 @@ impl<'a> ConfigService<'a> {
             .map(|_| ())
             .map_err(map_runtime_error);
         if let Err(error) = apply_result {
+            self.emit_audit_apply_failed(
+                namespace,
+                id,
+                "",
+                previous.as_ref().map(|p| unwrap_spec(p.clone())),
+                Some(unwrap_spec(body.clone())),
+                error.to_string(),
+                headers,
+            )
+            .await;
             match previous {
                 Some(previous) => {
-                    let env = ensure_envelope(previous)
-                        .map_err(|e| StorageError::Serialization(e.to_string()))?;
-                    self.store.put(namespace.as_str(), id, &env).await?;
+                    self.rollback_to_raw_after_revision(namespace, id, previous, write_revision)
+                        .await?;
                 }
-                None => self.store.delete(namespace.as_str(), id).await?,
+                None => {
+                    self.cas_delete_record(namespace, id, write_revision)
+                        .await?
+                }
             }
             return Err(error);
         }
@@ -776,7 +983,7 @@ impl<'a> ConfigService<'a> {
                 self.normalize_mcp_server_payload(path_id, &mut object)
                     .await?;
             }
-            ConfigNamespace::Agents | ConfigNamespace::Models => {}
+            ConfigNamespace::Agents | ConfigNamespace::Models | ConfigNamespace::Tools => {}
         }
 
         let now = SystemTime::now()
@@ -924,6 +1131,9 @@ impl<'a> ConfigService<'a> {
                     }
                 }
             }
+            ConfigNamespace::Tools => {
+                let _: ToolSpec = from_value(body)?;
+            }
         }
         Ok(())
     }
@@ -967,7 +1177,7 @@ impl<'a> ConfigService<'a> {
                 }
                 Ok(Value::Object(object))
             }
-            ConfigNamespace::Agents | ConfigNamespace::Models => Ok(value),
+            ConfigNamespace::Agents | ConfigNamespace::Models | ConfigNamespace::Tools => Ok(value),
         }
     }
 
@@ -1121,6 +1331,8 @@ impl<'a> ConfigService<'a> {
             return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
         }
 
+        let expected_revision = record.meta.revision;
+
         // Validate incoming body field names via AgentSpecPatch (deny_unknown_fields).
         // We use a separate check for null values: replace nulls with a dummy value
         // so that deny_unknown_fields can still catch unknown field names.
@@ -1183,11 +1395,8 @@ impl<'a> ConfigService<'a> {
         record.meta.user_overrides = proposed_overrides;
         record.meta.updated_at = now_ms();
 
-        let envelope = record
-            .to_value()
-            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
-        self.store
-            .put(ConfigNamespace::Agents.as_str(), id, &envelope)
+        let write_revision = self
+            .cas_put_record(ConfigNamespace::Agents, id, &mut record, expected_revision)
             .await?;
 
         let apply_result = manager
@@ -1196,11 +1405,17 @@ impl<'a> ConfigService<'a> {
             .map(|_| ())
             .map_err(map_runtime_error);
         if let Err(error) = apply_result {
-            // Roll back to the original envelope.
-            let rollback =
-                ensure_envelope(raw).map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store
-                .put(ConfigNamespace::Agents.as_str(), id, &rollback)
+            self.emit_audit_apply_failed(
+                ConfigNamespace::Agents,
+                id,
+                "overrides",
+                Some(before.clone()),
+                None,
+                error.to_string(),
+                headers,
+            )
+            .await;
+            self.rollback_to_raw_after_revision(ConfigNamespace::Agents, id, raw, write_revision)
                 .await?;
             return Err(error);
         }
@@ -1256,6 +1471,8 @@ impl<'a> ConfigService<'a> {
                 .map_err(|e| ConfigServiceError::Serialization(e.to_string()));
         }
 
+        let expected_revision = record.meta.revision;
+
         let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
             .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
         let before = serde_json::to_value(&before_spec)
@@ -1264,11 +1481,8 @@ impl<'a> ConfigService<'a> {
         record.meta.user_overrides = None;
         record.meta.updated_at = now_ms();
 
-        let envelope = record
-            .to_value()
-            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
-        self.store
-            .put(ConfigNamespace::Agents.as_str(), id, &envelope)
+        let write_revision = self
+            .cas_put_record(ConfigNamespace::Agents, id, &mut record, expected_revision)
             .await?;
 
         let apply_result = manager
@@ -1277,10 +1491,17 @@ impl<'a> ConfigService<'a> {
             .map(|_| ())
             .map_err(map_runtime_error);
         if let Err(error) = apply_result {
-            let rollback =
-                ensure_envelope(raw).map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store
-                .put(ConfigNamespace::Agents.as_str(), id, &rollback)
+            self.emit_audit_apply_failed(
+                ConfigNamespace::Agents,
+                id,
+                "overrides",
+                Some(before.clone()),
+                None,
+                error.to_string(),
+                headers,
+            )
+            .await;
+            self.rollback_to_raw_after_revision(ConfigNamespace::Agents, id, raw, write_revision)
                 .await?;
             return Err(error);
         }
@@ -1330,6 +1551,8 @@ impl<'a> ConfigService<'a> {
             return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
         }
 
+        let expected_revision = record.meta.revision;
+
         let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
             .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
         let before = serde_json::to_value(&before_spec)
@@ -1375,11 +1598,8 @@ impl<'a> ConfigService<'a> {
         };
         record.meta.updated_at = now_ms();
 
-        let envelope = record
-            .to_value()
-            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
-        self.store
-            .put(ConfigNamespace::Agents.as_str(), id, &envelope)
+        let write_revision = self
+            .cas_put_record(ConfigNamespace::Agents, id, &mut record, expected_revision)
             .await?;
 
         let apply_result = manager
@@ -1388,10 +1608,17 @@ impl<'a> ConfigService<'a> {
             .map(|_| ())
             .map_err(map_runtime_error);
         if let Err(error) = apply_result {
-            let rollback =
-                ensure_envelope(raw).map_err(|e| StorageError::Serialization(e.to_string()))?;
-            self.store
-                .put(ConfigNamespace::Agents.as_str(), id, &rollback)
+            self.emit_audit_apply_failed(
+                ConfigNamespace::Agents,
+                id,
+                &format!("overrides/{field}"),
+                Some(before.clone()),
+                None,
+                error.to_string(),
+                headers,
+            )
+            .await;
+            self.rollback_to_raw_after_revision(ConfigNamespace::Agents, id, raw, write_revision)
                 .await?;
             return Err(error);
         }
@@ -1414,6 +1641,350 @@ impl<'a> ConfigService<'a> {
 
         Ok(after)
     }
+
+    /// PATCH /v1/config/tools/:id/overrides — see ADR-0029.
+    pub async fn patch_tool_overrides(
+        &self,
+        id: &str,
+        body: Value,
+        headers: &HeaderMap,
+    ) -> Result<Value, ConfigServiceError> {
+        const MAX_DESCRIPTION_LEN: usize = 4096;
+
+        let manager = self.runtime_manager()?;
+        let _apply_guard = manager.lock_apply().await;
+
+        let raw = self
+            .store
+            .get(ConfigNamespace::Tools.as_str(), id)
+            .await?
+            .ok_or_else(|| ConfigServiceError::NotFound(format!("tools/{id}")))?;
+
+        let mut record = ConfigRecord::<ToolSpec>::from_value(raw.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        if matches!(record.meta.source, RecordSource::User) {
+            return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
+        }
+
+        let expected_revision = record.meta.revision;
+
+        let body_map = match &body {
+            Value::Object(m) => m,
+            _ => {
+                return Err(ConfigServiceError::InvalidPayload(
+                    "expected JSON object body".into(),
+                ));
+            }
+        };
+
+        // Schema validation: deny_unknown_fields catches bad field names.
+        let _: ToolSpecPatch = serde_json::from_value(body.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        // Value validation (non-empty trim, length cap).
+        if let Some(Value::String(s)) = body_map.get("description") {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return Err(ConfigServiceError::InvalidPayload(
+                    "description must be non-empty".into(),
+                ));
+            }
+            if s.len() > MAX_DESCRIPTION_LEN {
+                return Err(ConfigServiceError::InvalidPayload(format!(
+                    "description exceeds {MAX_DESCRIPTION_LEN}-byte limit"
+                )));
+            }
+        }
+
+        // Shallow merge into existing user_overrides; null = clear.
+        let mut existing_map: Map<String, Value> = record
+            .meta
+            .user_overrides
+            .as_ref()
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        for (k, v) in body_map {
+            if v.is_null() {
+                existing_map.remove(k);
+            } else {
+                existing_map.insert(k.clone(), v.clone());
+            }
+        }
+
+        // Re-validate the merged overrides shape.
+        let merged_value = Value::Object(existing_map.clone());
+        let _: ToolSpecPatch = serde_json::from_value(merged_value.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        let proposed_overrides: Option<Value> = if existing_map.is_empty() {
+            None
+        } else {
+            Some(merged_value.clone())
+        };
+
+        if proposed_overrides == record.meta.user_overrides {
+            let effective_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            return serde_json::to_value(&effective_spec)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()));
+        }
+
+        let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let before = serde_json::to_value(&before_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        record.meta.user_overrides = proposed_overrides;
+        record.meta.updated_at = now_ms();
+
+        let write_revision = self
+            .cas_put_record(ConfigNamespace::Tools, id, &mut record, expected_revision)
+            .await?;
+
+        if let Err(error) = manager
+            .apply_locked()
+            .await
+            .map(|_| ())
+            .map_err(map_runtime_error)
+        {
+            self.emit_audit_apply_failed(
+                ConfigNamespace::Tools,
+                id,
+                "overrides",
+                Some(before.clone()),
+                None,
+                error.to_string(),
+                headers,
+            )
+            .await;
+            self.rollback_to_raw_after_revision(ConfigNamespace::Tools, id, raw, write_revision)
+                .await?;
+            return Err(error);
+        }
+
+        let after_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let after = serde_json::to_value(&after_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        self.emit_audit_with_suffix(
+            AuditAction::Update,
+            ConfigNamespace::Tools,
+            id,
+            "overrides",
+            Some(before),
+            Some(after.clone()),
+            headers,
+        )
+        .await;
+
+        Ok(after)
+    }
+
+    /// DELETE /v1/config/tools/:id/overrides
+    ///
+    /// Clears all user overrides from a Builtin tool record. Returns the
+    /// effective ToolSpec (which is now the bare base spec, no overrides).
+    pub async fn clear_tool_overrides(
+        &self,
+        id: &str,
+        headers: &HeaderMap,
+    ) -> Result<Value, ConfigServiceError> {
+        let manager = self.runtime_manager()?;
+        let _apply_guard = manager.lock_apply().await;
+
+        let raw = self
+            .store
+            .get(ConfigNamespace::Tools.as_str(), id)
+            .await?
+            .ok_or_else(|| ConfigServiceError::NotFound(format!("tools/{id}")))?;
+
+        let mut record = ConfigRecord::<ToolSpec>::from_value(raw.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        if matches!(record.meta.source, RecordSource::User) {
+            return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
+        }
+
+        // Short-circuit: if overrides are already None, this is a no-op — skip
+        // the store write, apply_locked, and audit emit.
+        if record.meta.user_overrides.is_none() {
+            return serde_json::to_value(&record.spec)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()));
+        }
+
+        let expected_revision = record.meta.revision;
+
+        let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let before = serde_json::to_value(&before_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        record.meta.user_overrides = None;
+        record.meta.updated_at = now_ms();
+
+        let write_revision = self
+            .cas_put_record(ConfigNamespace::Tools, id, &mut record, expected_revision)
+            .await?;
+
+        let apply_result = manager
+            .apply_locked()
+            .await
+            .map(|_| ())
+            .map_err(map_runtime_error);
+        if let Err(error) = apply_result {
+            self.emit_audit_apply_failed(
+                ConfigNamespace::Tools,
+                id,
+                "overrides",
+                Some(before.clone()),
+                None,
+                error.to_string(),
+                headers,
+            )
+            .await;
+            self.rollback_to_raw_after_revision(ConfigNamespace::Tools, id, raw, write_revision)
+                .await?;
+            return Err(error);
+        }
+
+        let after = serde_json::to_value(&record.spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        self.emit_audit_with_suffix(
+            AuditAction::Update,
+            ConfigNamespace::Tools,
+            id,
+            "overrides",
+            Some(before),
+            Some(after.clone()),
+            headers,
+        )
+        .await;
+
+        Ok(after)
+    }
+
+    /// DELETE /v1/config/tools/:id/overrides/:field
+    ///
+    /// Removes a single field from the user overrides of a Builtin tool record.
+    /// Returns 400 if `field` is not a recognized ToolSpecPatch field.
+    /// Idempotent: if the field is not present in user_overrides, returns the
+    /// current effective spec without writing to the store or emitting an audit event.
+    pub async fn clear_tool_override_field(
+        &self,
+        id: &str,
+        field: &str,
+        headers: &HeaderMap,
+    ) -> Result<Value, ConfigServiceError> {
+        let manager = self.runtime_manager()?;
+        let _apply_guard = manager.lock_apply().await;
+
+        let raw = self
+            .store
+            .get(ConfigNamespace::Tools.as_str(), id)
+            .await?
+            .ok_or_else(|| ConfigServiceError::NotFound(format!("tools/{id}")))?;
+
+        let mut record = ConfigRecord::<ToolSpec>::from_value(raw.clone())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+
+        if matches!(record.meta.source, RecordSource::User) {
+            return Err(ConfigServiceError::OverridesNotSupportedForUserRecord);
+        }
+
+        let expected_revision = record.meta.revision;
+
+        let before_spec = apply_overrides(record.spec.clone(), record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let before = serde_json::to_value(&before_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        // Validate that field is recognized by ToolSpecPatch before mutating.
+        // Use a null probe: `ToolSpecPatch` accepts null for all Option fields, and
+        // deny_unknown_fields will reject unknown field names.
+        let probe = Value::Object({
+            let mut m = Map::new();
+            m.insert(field.to_string(), Value::Null);
+            m
+        });
+        let _: ToolSpecPatch = serde_json::from_value(probe).map_err(|_| {
+            ConfigServiceError::InvalidPayload(format!("unknown override field: {field}"))
+        })?;
+
+        // Remove the field from existing overrides.
+        let mut existing_map: Map<String, Value> = record
+            .meta
+            .user_overrides
+            .as_ref()
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+
+        // Short-circuit: if the field is not present in overrides, this is a no-op —
+        // skip the store write, apply_locked, and audit emit.
+        if !existing_map.contains_key(field) {
+            let effective_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            return serde_json::to_value(&effective_spec)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()));
+        }
+
+        existing_map.remove(field);
+
+        let merged_value = Value::Object(existing_map.clone());
+        record.meta.user_overrides = if existing_map.is_empty() {
+            None
+        } else {
+            Some(merged_value)
+        };
+        record.meta.updated_at = now_ms();
+
+        let write_revision = self
+            .cas_put_record(ConfigNamespace::Tools, id, &mut record, expected_revision)
+            .await?;
+
+        let apply_result = manager
+            .apply_locked()
+            .await
+            .map(|_| ())
+            .map_err(map_runtime_error);
+        if let Err(error) = apply_result {
+            self.emit_audit_apply_failed(
+                ConfigNamespace::Tools,
+                id,
+                &format!("overrides/{field}"),
+                Some(before.clone()),
+                None,
+                error.to_string(),
+                headers,
+            )
+            .await;
+            self.rollback_to_raw_after_revision(ConfigNamespace::Tools, id, raw, write_revision)
+                .await?;
+            return Err(error);
+        }
+
+        let after_spec = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+            .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+        let after = serde_json::to_value(&after_spec)
+            .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?;
+
+        self.emit_audit_with_suffix(
+            AuditAction::Update,
+            ConfigNamespace::Tools,
+            id,
+            &format!("overrides/{field}"),
+            Some(before),
+            Some(after.clone()),
+            headers,
+        )
+        .await;
+
+        Ok(after)
+    }
 }
 
 /// Return the effective spec Value for a stored entry, applying `user_overrides`
@@ -1421,14 +1992,25 @@ impl<'a> ConfigService<'a> {
 ///
 /// For non-Agent namespaces this is equivalent to `unwrap_spec`.
 fn effective_spec(namespace: ConfigNamespace, value: Value) -> Result<Value, ConfigServiceError> {
-    if namespace != ConfigNamespace::Agents {
-        return Ok(unwrap_spec(value));
+    match namespace {
+        ConfigNamespace::Agents => {
+            let record = ConfigRecord::<AgentSpec>::from_value(value)
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            let effective = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            serde_json::to_value(&effective)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()))
+        }
+        ConfigNamespace::Tools => {
+            let record = ConfigRecord::<ToolSpec>::from_value(value)
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            let effective = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
+                .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+            serde_json::to_value(&effective)
+                .map_err(|e| ConfigServiceError::Serialization(e.to_string()))
+        }
+        _ => Ok(unwrap_spec(value)),
     }
-    let record = ConfigRecord::<AgentSpec>::from_value(value)
-        .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
-    let effective = apply_overrides(record.spec, record.meta.user_overrides.as_ref())
-        .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
-    serde_json::to_value(&effective).map_err(|e| ConfigServiceError::Serialization(e.to_string()))
 }
 
 /// Classify a tool's source from its id.
@@ -2127,7 +2709,7 @@ mod tests {
     #[test]
     fn namespace_all_lists_every_variant() {
         let all = ConfigNamespace::all();
-        assert_eq!(all.len(), 4, "exactly four namespaces");
+        assert_eq!(all.len(), 5, "exactly five namespaces");
 
         // Each variant must appear exactly once.
         let has = |v: ConfigNamespace| all.iter().filter(|&&x| x == v).count();
@@ -2135,11 +2717,12 @@ mod tests {
         assert_eq!(has(ConfigNamespace::Providers), 1);
         assert_eq!(has(ConfigNamespace::Models), 1);
         assert_eq!(has(ConfigNamespace::McpServers), 1);
+        assert_eq!(has(ConfigNamespace::Tools), 1);
     }
 
     #[test]
     fn namespace_all_matches_builtin_spec_namespace() {
-        use awaken_contract::{BuiltinSpec, McpServerSpec};
+        use awaken_contract::{BuiltinSpec, McpServerSpec, ToolSpec};
 
         for &ns in ConfigNamespace::all() {
             let spec = match ns {
@@ -2163,6 +2746,12 @@ mod tests {
                 }),
                 ConfigNamespace::McpServers => BuiltinSpec::McpServer(McpServerSpec {
                     id: "x".into(),
+                    ..Default::default()
+                }),
+                ConfigNamespace::Tools => BuiltinSpec::Tool(ToolSpec {
+                    id: "x".into(),
+                    name: "x".into(),
+                    description: "x".into(),
                     ..Default::default()
                 }),
             };
@@ -2502,6 +3091,648 @@ mod tests {
         assert!(
             after_obj.contains_key("id"),
             "audit 'after' must contain spec field 'id'"
+        );
+    }
+
+    #[test]
+    fn config_namespace_parses_tools() {
+        assert_eq!(
+            ConfigNamespace::parse("tools").unwrap(),
+            ConfigNamespace::Tools
+        );
+        assert_eq!(ConfigNamespace::Tools.as_str(), "tools");
+    }
+
+    #[test]
+    fn config_namespace_all_includes_tools() {
+        assert!(ConfigNamespace::ALL.contains(&ConfigNamespace::Tools));
+    }
+
+    #[test]
+    fn config_namespace_schema_for_tools_is_object() {
+        let schema = ConfigNamespace::Tools.schema_json().expect("schema");
+        // schemars 0.8: top-level object schema shape
+        assert!(schema.get("$defs").is_some() || schema.get("type").is_some());
+    }
+
+    #[tokio::test]
+    async fn tools_namespace_rejects_create() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store).await;
+        let service = ConfigService::new(&state).expect("config service");
+        let body = json!({"id": "x", "name": "x", "description": "x"});
+        let err = service
+            .create(ConfigNamespace::Tools, body, &axum::http::HeaderMap::new())
+            .await
+            .expect_err("tools namespace must reject create");
+        match err {
+            ConfigServiceError::InvalidPayload(msg) => assert!(msg.contains("tools")),
+            other => panic!("expected InvalidPayload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tools_namespace_rejects_update() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store).await;
+        let service = ConfigService::new(&state).expect("config service");
+        let body = json!({"id": "x", "name": "x", "description": "x"});
+        let err = service
+            .update(
+                ConfigNamespace::Tools,
+                "x",
+                body,
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect_err("tools namespace must reject update");
+        match err {
+            ConfigServiceError::InvalidPayload(msg) => assert!(msg.contains("tools")),
+            other => panic!("expected InvalidPayload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tools_namespace_rejects_delete() {
+        let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let (state, _manager) = build_state(config_store).await;
+        let service = ConfigService::new(&state).expect("config service");
+        let err = service
+            .delete(
+                ConfigNamespace::Tools,
+                "x",
+                false,
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect_err("tools namespace must reject delete");
+        match err {
+            ConfigServiceError::InvalidPayload(msg) => assert!(msg.contains("tools")),
+            other => panic!("expected InvalidPayload, got {other:?}"),
+        }
+    }
+
+    // ── patch_tool_overrides helpers ──────────────────────────────────────────
+
+    use crate::services::audit_log::{AuditLogger, AuditQuery};
+    use awaken_contract::ToolSpec;
+    use awaken_contract::contract::audit_log::AuditEvent;
+    use awaken_contract::contract::tool::{
+        Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
+    };
+
+    struct StubTool {
+        id: String,
+        desc: String,
+    }
+
+    #[async_trait]
+    impl Tool for StubTool {
+        fn descriptor(&self) -> ToolDescriptor {
+            ToolDescriptor::new(self.id.clone(), self.id.clone(), self.desc.clone())
+        }
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+            _ctx: &ToolCallContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolResult::success(&self.id, serde_json::json!({})).into())
+        }
+    }
+
+    async fn build_test_service_with_tool(
+        id: &str,
+        description: &str,
+    ) -> (ConfigService<'static>, Arc<AuditLogger>) {
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec, RecordMeta};
+
+        let config_store: Arc<dyn awaken_contract::contract::config_store::ConfigStore> =
+            Arc::new(awaken_stores::InMemoryStore::new());
+        let audit_store: Arc<dyn awaken_contract::contract::config_store::ConfigStore> =
+            Arc::new(awaken_stores::InMemoryStore::new());
+        let audit_logger = Arc::new(AuditLogger::new(audit_store));
+
+        let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let runtime = Arc::new(
+            AgentRuntimeBuilder::new()
+                .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+                .with_thread_run_store(thread_store.clone())
+                .with_tool(
+                    id,
+                    Arc::new(StubTool {
+                        id: id.to_string(),
+                        desc: description.to_string(),
+                    }),
+                )
+                .build()
+                .expect("build runtime"),
+        );
+
+        let manager = Arc::new(
+            crate::services::config_runtime::ConfigRuntimeManager::new(
+                runtime.clone(),
+                config_store.clone(),
+            )
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(TestProviderFactory)),
+        );
+        let resolver = runtime.resolver_arc();
+        let seed = BuiltinSeedSet {
+            binary_version: "test".to_string(),
+            specs: vec![
+                BuiltinSpec::provider(ProviderSpec {
+                    id: "bootstrap".into(),
+                    adapter: "stub".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::model(awaken_contract::ModelBindingSpec {
+                    id: "bootstrap".into(),
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::agent(bootstrap_agent()),
+            ],
+        };
+        manager.apply_seed(&seed).await.expect("apply_seed");
+        manager.apply().await.expect("publish config");
+
+        // Write a Builtin ConfigRecord for the tool directly into the store.
+        let tool_spec = ToolSpec {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: description.to_string(),
+            ..Default::default()
+        };
+        let mut meta = RecordMeta::new_builtin("test");
+        meta.user_overrides = None;
+        meta.revision = 1;
+        let record = awaken_contract::ConfigRecord {
+            spec: tool_spec,
+            meta,
+        };
+        let envelope = record.to_value().expect("serialize tool record");
+        awaken_contract::contract::config_store::ConfigStore::put_if_absent(
+            config_store.as_ref(),
+            "tools",
+            id,
+            &envelope,
+        )
+        .await
+        .expect("put tool record");
+
+        let mailbox = Arc::new(crate::mailbox::Mailbox::new(
+            runtime.clone(),
+            Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+            thread_store.clone(),
+            "tool-override-test".into(),
+            crate::mailbox::MailboxConfig::default(),
+        ));
+        let state = AppState::new(
+            runtime,
+            mailbox,
+            thread_store,
+            resolver,
+            crate::app::ServerConfig::default(),
+        )
+        .with_config_store(config_store)
+        .with_config_runtime_manager(manager)
+        .with_audit_log(audit_logger.clone());
+
+        // SAFETY: state is owned for the duration of the test; the 'static bound is
+        // satisfied by leaking the Box – acceptable in tests only.
+        let state: &'static AppState = Box::leak(Box::new(state));
+        let service = ConfigService::new(state).expect("config service");
+        (service, audit_logger)
+    }
+
+    async fn recent_audit_events(audit_logger: &AuditLogger, resource: &str) -> Vec<AuditEvent> {
+        let page = audit_logger
+            .query(AuditQuery::default())
+            .await
+            .expect("audit query");
+        page.items
+            .into_iter()
+            .filter(|e| e.resource == resource || e.resource.starts_with(&format!("{resource}/")))
+            .collect()
+    }
+
+    // ── patch_tool_overrides tests ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn patch_tool_overrides_replaces_description_and_emits_audit() {
+        let (service, audit_logger) =
+            build_test_service_with_tool("echo", "stock description").await;
+        let patch = serde_json::json!({"description": "custom override"});
+        let after = service
+            .patch_tool_overrides("echo", patch, &axum::http::HeaderMap::new())
+            .await
+            .expect("patch ok");
+        assert_eq!(after["description"], "custom override");
+        assert_eq!(after["id"], "echo");
+        let events: Vec<AuditEvent> = recent_audit_events(&audit_logger, "tools/echo").await;
+        let event = events
+            .iter()
+            .find(|e| e.action == awaken_contract::AuditAction::Update)
+            .expect("audit event missing");
+        assert_eq!(event.resource, "tools/echo/overrides");
+        let before = event.before.as_ref().expect("before payload missing");
+        let after_payload = event.after.as_ref().expect("after payload missing");
+        assert_eq!(before["description"], "stock description");
+        assert_eq!(after_payload["description"], "custom override");
+    }
+
+    #[tokio::test]
+    async fn get_tools_merges_overrides_into_effective_spec() {
+        // Regression for the bug where `effective_spec` only merged for
+        // Agents, leaving Tools' GET endpoint returning the unpatched
+        // description even though the override was persisted in meta.
+        let (service, _audit_logger) =
+            build_test_service_with_tool("echo", "stock description").await;
+        service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"description": "patched"}),
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect("patch ok");
+        let value = service
+            .get(ConfigNamespace::Tools, "echo")
+            .await
+            .expect("get ok")
+            .expect("present");
+        assert_eq!(value["description"], "patched");
+    }
+
+    #[tokio::test]
+    async fn patch_tool_overrides_404_for_unknown_id() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "x").await;
+        let err = service
+            .patch_tool_overrides(
+                "nope",
+                serde_json::json!({"description": "x"}),
+                &Default::default(),
+            )
+            .await
+            .expect_err("unknown id");
+        assert!(matches!(err, ConfigServiceError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn patch_tool_overrides_422_for_unknown_field() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "x").await;
+        let err = service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"name": "renamed"}),
+                &Default::default(),
+            )
+            .await
+            .expect_err("unknown field");
+        assert!(matches!(err, ConfigServiceError::InvalidPayload(_)));
+    }
+
+    #[tokio::test]
+    async fn patch_tool_overrides_rejects_empty_description() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "x").await;
+        let err = service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"description": ""}),
+                &Default::default(),
+            )
+            .await
+            .expect_err("empty description");
+        assert!(matches!(err, ConfigServiceError::InvalidPayload(_)));
+    }
+
+    #[tokio::test]
+    async fn patch_tool_overrides_rejects_overlong_description() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "x").await;
+        let too_long = "x".repeat(4097);
+        let err = service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"description": too_long}),
+                &Default::default(),
+            )
+            .await
+            .expect_err("overlong");
+        assert!(matches!(err, ConfigServiceError::InvalidPayload(_)));
+    }
+
+    #[tokio::test]
+    async fn clear_tool_overrides_reverts_to_builtin() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "stock").await;
+        service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"description": "custom"}),
+                &Default::default(),
+            )
+            .await
+            .unwrap();
+        let after = service
+            .clear_tool_overrides("echo", &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(after["description"], "stock");
+    }
+
+    #[tokio::test]
+    async fn clear_tool_overrides_idempotent_when_already_empty() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "stock").await;
+        let after = service
+            .clear_tool_overrides("echo", &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(after["description"], "stock");
+    }
+
+    #[tokio::test]
+    async fn clear_tool_override_field_unknown_returns_422() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "stock").await;
+        let err = service
+            .clear_tool_override_field("echo", "garbage", &Default::default())
+            .await
+            .expect_err("unknown field");
+        assert!(matches!(err, ConfigServiceError::InvalidPayload(_)));
+    }
+
+    #[tokio::test]
+    async fn clear_tool_override_field_known_clears_only_that_field() {
+        let (service, _audit_logger) = build_test_service_with_tool("echo", "stock").await;
+        service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"description": "custom"}),
+                &Default::default(),
+            )
+            .await
+            .unwrap();
+        let after = service
+            .clear_tool_override_field("echo", "description", &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(after["description"], "stock");
+    }
+
+    // ── CAS / revision tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn patch_tool_overrides_bumps_revision() {
+        let (service, _audit) = build_test_service_with_tool("echo", "stock").await;
+
+        let meta_before = service
+            .get_meta(ConfigNamespace::Tools, "echo")
+            .await
+            .expect("get_meta")
+            .expect("present");
+        assert_eq!(
+            meta_before.revision, 1,
+            "fresh seed must start at revision 1"
+        );
+
+        service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"description": "patched"}),
+                &Default::default(),
+            )
+            .await
+            .expect("first patch ok");
+
+        let meta_after = service
+            .get_meta(ConfigNamespace::Tools, "echo")
+            .await
+            .expect("get_meta")
+            .expect("present");
+        assert!(
+            meta_after.revision > meta_before.revision,
+            "patch must bump revision: before={}, after={}",
+            meta_before.revision,
+            meta_after.revision,
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_tool_overrides_conflict_on_stale_revision() {
+        use awaken_contract::ConfigRecord;
+
+        let (service, _audit) = build_test_service_with_tool("echo", "stock").await;
+
+        let store = service.store.clone();
+        let raw = awaken_contract::contract::config_store::ConfigStore::get(
+            store.as_ref(),
+            "tools",
+            "echo",
+        )
+        .await
+        .expect("read")
+        .expect("present");
+
+        let mut stale_record = ConfigRecord::<awaken_contract::ToolSpec>::from_value(raw.clone())
+            .expect("parse record");
+        let stale_expected = stale_record.meta.revision;
+
+        let mut concurrent_record =
+            ConfigRecord::<awaken_contract::ToolSpec>::from_value(raw).expect("parse current");
+        concurrent_record.spec.description = "concurrent".into();
+        concurrent_record.meta.revision = stale_expected + 1;
+        let concurrent_envelope = concurrent_record.to_value().expect("serialize concurrent");
+        awaken_contract::contract::config_store::ConfigStore::put_if_revision(
+            store.as_ref(),
+            "tools",
+            "echo",
+            &concurrent_envelope,
+            stale_expected,
+        )
+        .await
+        .expect("concurrent writer succeeds");
+
+        stale_record.spec.description = "stale".into();
+        let err = service
+            .cas_put_record(
+                ConfigNamespace::Tools,
+                "echo",
+                &mut stale_record,
+                stale_expected,
+            )
+            .await
+            .expect_err("stale write must conflict");
+        assert!(matches!(err, ConfigServiceError::Conflict(_)));
+
+        let meta_final = service
+            .get_meta(ConfigNamespace::Tools, "echo")
+            .await
+            .expect("get_meta final")
+            .expect("present final");
+        assert_eq!(
+            meta_final.revision,
+            stale_expected + 1,
+            "stale writer must not advance the stored revision"
+        );
+    }
+
+    // ── ApplyFailed audit emission tests ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn patch_tool_overrides_apply_failure_emits_apply_failed_audit_event() {
+        use awaken_contract::{BuiltinSeedSet, BuiltinSpec, RecordMeta};
+
+        // Step 1: seed a config store with a builtin tool, apply successfully.
+        let config_store: Arc<dyn awaken_contract::contract::config_store::ConfigStore> =
+            Arc::new(awaken_stores::InMemoryStore::new());
+        let audit_store: Arc<dyn awaken_contract::contract::config_store::ConfigStore> =
+            Arc::new(awaken_stores::InMemoryStore::new());
+        let audit_logger = Arc::new(AuditLogger::new(audit_store));
+
+        let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
+        let runtime = Arc::new(
+            AgentRuntimeBuilder::new()
+                .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+                .with_thread_run_store(thread_store.clone())
+                .with_tool(
+                    "echo",
+                    Arc::new(StubTool {
+                        id: "echo".to_string(),
+                        desc: "stock".to_string(),
+                    }),
+                )
+                .build()
+                .expect("build runtime"),
+        );
+
+        let manager_ok = Arc::new(
+            crate::services::config_runtime::ConfigRuntimeManager::new(
+                runtime.clone(),
+                config_store.clone(),
+            )
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(TestProviderFactory)),
+        );
+        let seed = BuiltinSeedSet {
+            binary_version: "test".to_string(),
+            specs: vec![
+                BuiltinSpec::provider(ProviderSpec {
+                    id: "bootstrap".into(),
+                    adapter: "stub".into(),
+                    ..Default::default()
+                }),
+                BuiltinSpec::model(awaken_contract::ModelBindingSpec {
+                    id: "bootstrap".into(),
+                    provider_id: "bootstrap".into(),
+                    upstream_model: "bootstrap-model".into(),
+                    created_at: None,
+                    updated_at: None,
+                }),
+                BuiltinSpec::agent(bootstrap_agent()),
+            ],
+        };
+        manager_ok.apply_seed(&seed).await.expect("apply_seed");
+        manager_ok.apply().await.expect("initial apply");
+
+        // Write a builtin tool record directly.
+        let tool_spec = ToolSpec {
+            id: "echo".to_string(),
+            name: "echo".to_string(),
+            description: "stock".to_string(),
+            ..Default::default()
+        };
+        let mut meta = RecordMeta::new_builtin("test");
+        meta.user_overrides = None;
+        meta.revision = 1;
+        let record = awaken_contract::ConfigRecord {
+            spec: tool_spec,
+            meta,
+        };
+        let envelope = record.to_value().expect("serialize tool record");
+        awaken_contract::contract::config_store::ConfigStore::put_if_absent(
+            config_store.as_ref(),
+            "tools",
+            "echo",
+            &envelope,
+        )
+        .await
+        .expect("put tool record");
+
+        // Step 2: build a second manager with FailingProviderFactory over the same store.
+        let runtime_failing = Arc::new(
+            AgentRuntimeBuilder::new()
+                .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+                .with_thread_run_store(thread_store.clone())
+                .build()
+                .expect("build failing runtime"),
+        );
+        let manager_failing = Arc::new(
+            crate::services::config_runtime::ConfigRuntimeManager::new(
+                runtime_failing.clone(),
+                config_store.clone(),
+            )
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(FailingProviderFactory)),
+        );
+        let mailbox = Arc::new(crate::mailbox::Mailbox::new(
+            runtime_failing.clone(),
+            Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+            thread_store.clone(),
+            "apply-failed-test".into(),
+            crate::mailbox::MailboxConfig::default(),
+        ));
+        let state = AppState::new(
+            runtime_failing.clone(),
+            mailbox,
+            thread_store,
+            runtime_failing.resolver_arc(),
+            crate::app::ServerConfig::default(),
+        )
+        .with_config_store(config_store.clone())
+        .with_config_runtime_manager(manager_failing)
+        .with_audit_log(audit_logger.clone());
+
+        let state: &'static AppState = Box::leak(Box::new(state));
+        let service = ConfigService::new(state).expect("failing config service");
+
+        // Step 3: attempt patch_tool_overrides — apply_locked fails.
+        let result = service
+            .patch_tool_overrides(
+                "echo",
+                serde_json::json!({"description": "patched"}),
+                &axum::http::HeaderMap::new(),
+            )
+            .await;
+        assert!(result.is_err(), "patch must fail when apply_locked fails");
+
+        // Step 4: assert ApplyFailed event was emitted with the correct fields.
+        let page = audit_logger
+            .query(crate::services::audit_log::AuditQuery::default())
+            .await
+            .expect("audit query");
+        let failed_events: Vec<_> = page
+            .items
+            .iter()
+            .filter(|e| e.action == awaken_contract::AuditAction::ApplyFailed)
+            .collect();
+        assert_eq!(
+            failed_events.len(),
+            1,
+            "exactly one ApplyFailed event must be emitted"
+        );
+        let ev = &failed_events[0];
+        assert!(
+            ev.resource.contains("tools/echo"),
+            "resource must reference tools/echo, got: {}",
+            ev.resource
+        );
+        assert!(
+            ev.error.is_some(),
+            "ApplyFailed event must carry an error string"
+        );
+        assert!(
+            ev.before.is_some(),
+            "ApplyFailed event must carry the before spec"
         );
     }
 }

--- a/crates/awaken-server/src/services/mod.rs
+++ b/crates/awaken-server/src/services/mod.rs
@@ -6,3 +6,4 @@ pub mod config_service;
 pub mod run_control_service;
 pub mod run_service;
 pub mod thread_service;
+pub mod tool_overrides;

--- a/crates/awaken-server/src/services/tool_overrides.rs
+++ b/crates/awaken-server/src/services/tool_overrides.rs
@@ -1,0 +1,144 @@
+//! Description-override layer for the tool registry.
+//!
+//! Wraps an existing `Arc<dyn ToolRegistry>` and rewrites each looked-up
+//! tool's `descriptor().description` to the operator-supplied override.
+//! The underlying `Tool::execute` is forwarded unchanged.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::tool::{
+    Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput,
+};
+use awaken_runtime::registry::ToolRegistry;
+use serde_json::Value;
+
+pub(crate) struct DescriptionOverrideTool {
+    inner: Arc<dyn Tool>,
+    description: String,
+}
+
+impl DescriptionOverrideTool {
+    pub fn new(inner: Arc<dyn Tool>, description: String) -> Self {
+        Self { inner, description }
+    }
+}
+
+#[async_trait]
+impl Tool for DescriptionOverrideTool {
+    fn descriptor(&self) -> ToolDescriptor {
+        let mut d = self.inner.descriptor();
+        d.description = self.description.clone();
+        d
+    }
+    fn validate_args(&self, args: &Value) -> Result<(), ToolError> {
+        self.inner.validate_args(args)
+    }
+    async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+        self.inner.execute(args, ctx).await
+    }
+}
+
+pub(crate) struct DescriptionOverrideRegistry {
+    base: Arc<dyn ToolRegistry>,
+    /// tool_id -> override description
+    overrides: HashMap<String, String>,
+}
+
+impl DescriptionOverrideRegistry {
+    pub fn new(base: Arc<dyn ToolRegistry>, overrides: HashMap<String, String>) -> Self {
+        Self { base, overrides }
+    }
+}
+
+impl ToolRegistry for DescriptionOverrideRegistry {
+    fn get_tool(&self, id: &str) -> Option<Arc<dyn Tool>> {
+        let inner = self.base.get_tool(id)?;
+        match self.overrides.get(id) {
+            Some(desc) => Some(Arc::new(DescriptionOverrideTool::new(inner, desc.clone()))),
+            None => Some(inner),
+        }
+    }
+    fn tool_ids(&self) -> Vec<String> {
+        self.base.tool_ids()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::tool::{ToolDescriptor, ToolResult};
+    use serde_json::json;
+
+    struct StaticTool;
+
+    #[async_trait]
+    impl Tool for StaticTool {
+        fn descriptor(&self) -> ToolDescriptor {
+            ToolDescriptor::new("echo", "Echo", "stock description")
+        }
+        async fn execute(
+            &self,
+            _args: Value,
+            _ctx: &ToolCallContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolResult::success("echo", json!({})).into())
+        }
+    }
+
+    /// Lightweight in-test ToolRegistry over a single tool.
+    struct OneToolRegistry {
+        id: String,
+        tool: Arc<dyn Tool>,
+    }
+
+    impl ToolRegistry for OneToolRegistry {
+        fn get_tool(&self, id: &str) -> Option<Arc<dyn Tool>> {
+            if id == self.id {
+                Some(Arc::clone(&self.tool))
+            } else {
+                None
+            }
+        }
+        fn tool_ids(&self) -> Vec<String> {
+            vec![self.id.clone()]
+        }
+    }
+
+    fn base_registry() -> Arc<dyn ToolRegistry> {
+        Arc::new(OneToolRegistry {
+            id: "echo".into(),
+            tool: Arc::new(StaticTool),
+        })
+    }
+
+    #[test]
+    fn override_replaces_description_for_matching_id() {
+        let mut overrides = HashMap::new();
+        overrides.insert("echo".into(), "patched".into());
+        let reg = DescriptionOverrideRegistry::new(base_registry(), overrides);
+        let tool = reg.get_tool("echo").unwrap();
+        assert_eq!(tool.descriptor().description, "patched");
+        assert_eq!(tool.descriptor().id, "echo");
+    }
+
+    #[test]
+    fn passes_through_when_no_override_for_id() {
+        let reg = DescriptionOverrideRegistry::new(base_registry(), HashMap::new());
+        let tool = reg.get_tool("echo").unwrap();
+        assert_eq!(tool.descriptor().description, "stock description");
+    }
+
+    #[test]
+    fn tool_ids_passes_through_to_base() {
+        let reg = DescriptionOverrideRegistry::new(base_registry(), HashMap::new());
+        assert_eq!(reg.tool_ids(), vec!["echo".to_string()]);
+    }
+
+    #[test]
+    fn unknown_id_returns_none() {
+        let reg = DescriptionOverrideRegistry::new(base_registry(), HashMap::new());
+        assert!(reg.get_tool("nope").is_none());
+    }
+}

--- a/crates/awaken-server/src/transport/transcoder.rs
+++ b/crates/awaken-server/src/transport/transcoder.rs
@@ -16,10 +16,12 @@ where
     encoder
         .transcode(event)
         .into_iter()
-        .filter_map(|item| {
-            serde_json::to_string(&item)
-                .ok()
-                .map(|json| format_sse_data(&json))
+        .filter_map(|item| match serde_json::to_string(&item) {
+            Ok(json) => Some(format_sse_data(&json)),
+            Err(error) => {
+                tracing::warn!(error = %error, "failed to serialize transcoded event");
+                None
+            }
         })
         .collect()
 }
@@ -33,10 +35,12 @@ where
     encoder
         .prologue()
         .into_iter()
-        .filter_map(|item| {
-            serde_json::to_string(&item)
-                .ok()
-                .map(|json| format_sse_data(&json))
+        .filter_map(|item| match serde_json::to_string(&item) {
+            Ok(json) => Some(format_sse_data(&json)),
+            Err(error) => {
+                tracing::warn!(error = %error, "failed to serialize transcoder prologue");
+                None
+            }
         })
         .collect()
 }
@@ -50,10 +54,12 @@ where
     encoder
         .epilogue()
         .into_iter()
-        .filter_map(|item| {
-            serde_json::to_string(&item)
-                .ok()
-                .map(|json| format_sse_data(&json))
+        .filter_map(|item| match serde_json::to_string(&item) {
+            Ok(json) => Some(format_sse_data(&json)),
+            Err(error) => {
+                tracing::warn!(error = %error, "failed to serialize transcoder epilogue");
+                None
+            }
         })
         .collect()
 }

--- a/crates/awaken-server/tests/admin_security.rs
+++ b/crates/awaken-server/tests/admin_security.rs
@@ -1,0 +1,236 @@
+//! Security regression tests for the shared admin HTTP surface.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
+use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+use awaken_contract::registry_spec::{AgentSpec, ModelBindingSpec, ProviderSpec};
+use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
+use awaken_ext_observability::RuntimeStatsRegistry;
+use awaken_runtime::builder::AgentRuntimeBuilder;
+use awaken_server::app::{AdminApiConfig, AppState, ServerConfig};
+use awaken_server::mailbox::{Mailbox, MailboxConfig};
+use awaken_server::routes::build_router;
+use awaken_server::services::audit_log::AuditLogger;
+use awaken_server::services::config_runtime::{
+    ConfigRuntimeError, ConfigRuntimeManager, ProviderExecutorFactory,
+};
+use awaken_stores::InMemoryStore;
+use axum::body::{Body, to_bytes};
+use axum::http::{Method, Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+const ADMIN_TOKEN: &str = "super-secret-admin-token";
+
+struct ImmediateExecutor;
+
+#[async_trait]
+impl LlmExecutor for ImmediateExecutor {
+    async fn execute(
+        &self,
+        _request: InferenceRequest,
+    ) -> Result<StreamResult, InferenceExecutionError> {
+        Ok(StreamResult {
+            content: vec![],
+            tool_calls: vec![],
+            usage: Some(TokenUsage::default()),
+            stop_reason: Some(StopReason::EndTurn),
+            has_incomplete_tool_calls: false,
+        })
+    }
+
+    fn name(&self) -> &str {
+        "immediate"
+    }
+}
+
+struct TestProviderFactory;
+
+impl ProviderExecutorFactory for TestProviderFactory {
+    fn build(&self, spec: &ProviderSpec) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
+        if spec.adapter.eq_ignore_ascii_case("stub") {
+            return Ok(Arc::new(ImmediateExecutor));
+        }
+        Err(ConfigRuntimeError::UnsupportedProviderAdapter(
+            spec.adapter.clone(),
+        ))
+    }
+}
+
+fn bootstrap_agent() -> AgentSpec {
+    AgentSpec {
+        id: "bootstrap".into(),
+        model_id: "bootstrap".into(),
+        system_prompt: "bootstrap".into(),
+        max_rounds: 1,
+        ..Default::default()
+    }
+}
+
+async fn build_secure_admin_router() -> axum::Router {
+    let config_store = Arc::new(InMemoryStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+            .with_thread_run_store(thread_store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+
+    let audit_logger = Arc::new(AuditLogger::new(config_store.clone()));
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(TestProviderFactory))
+            .with_audit_log(audit_logger.clone()),
+    );
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+                created_at: None,
+                updated_at: None,
+            }),
+            BuiltinSpec::agent(bootstrap_agent()),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
+    manager.apply().await.expect("apply");
+
+    let resolver = runtime.resolver_arc();
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        thread_store.clone(),
+        "admin-security-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime,
+        mailbox,
+        thread_store,
+        resolver,
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager)
+    .with_audit_log(audit_logger)
+    .with_runtime_stats(Arc::new(RuntimeStatsRegistry::new()))
+    .with_admin_api_config(AdminApiConfig {
+        bearer_token: Some(ADMIN_TOKEN.into()),
+        ..Default::default()
+    });
+
+    build_router(&state).with_state(state)
+}
+
+async fn request(
+    app: &axum::Router,
+    method: Method,
+    uri: &str,
+    body: Option<Value>,
+    auth_headers: &[String],
+) -> (StatusCode, String) {
+    let mut builder = Request::builder().method(method).uri(uri);
+    for value in auth_headers {
+        builder = builder.header("authorization", value.as_str());
+    }
+
+    let request = if let Some(body) = body {
+        builder
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("request")
+    } else {
+        builder.body(Body::empty()).expect("request")
+    };
+
+    let response = app.clone().oneshot(request).await.expect("response");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("body");
+    let body = String::from_utf8_lossy(&bytes).into_owned();
+    (status, body)
+}
+
+#[tokio::test]
+async fn admin_routes_reject_missing_wrong_and_ambiguous_authorization_before_handler_logic() {
+    let app = build_secure_admin_router().await;
+    let routes = [
+        (Method::GET, "/v1/system/info", None),
+        (Method::GET, "/v1/agents/runtime-stats", None),
+        (Method::GET, "/v1/agents/bootstrap/runtime-stats", None),
+        (Method::GET, "/v1/capabilities", None),
+        (Method::GET, "/v1/config/providers", None),
+        (Method::GET, "/v1/config/providers/$schema", None),
+        (Method::GET, "/v1/agents", None),
+        (Method::GET, "/v1/audit-log", None),
+        (
+            Method::POST,
+            "/v1/config/providers",
+            Some(json!({"id": "attack", "adapter": "stub"})),
+        ),
+        (
+            Method::PUT,
+            "/v1/config/providers/bootstrap",
+            Some(json!({"id": "bootstrap", "adapter": "stub"})),
+        ),
+        (Method::DELETE, "/v1/config/providers/bootstrap", None),
+    ];
+
+    for (method, uri, body) in routes {
+        let valid_header = format!("Bearer {ADMIN_TOKEN}");
+        let tab_header = format!("Bearer\t{ADMIN_TOKEN}");
+        for headers in [
+            Vec::new(),
+            vec!["Bearer wrong-token".to_string()],
+            vec![valid_header.clone(), "Bearer wrong-token".to_string()],
+            vec![tab_header.clone()],
+        ] {
+            let (status, response_body) =
+                request(&app, method.clone(), uri, body.clone(), &headers).await;
+            assert_eq!(
+                status,
+                StatusCode::UNAUTHORIZED,
+                "{method} {uri} with headers {headers:?} returned {status}: {response_body}"
+            );
+            assert!(
+                !response_body.contains(ADMIN_TOKEN),
+                "401 body must not leak the configured token: {response_body}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn valid_bearer_reaches_admin_handlers_without_auth_failure() {
+    let app = build_secure_admin_router().await;
+    let header = format!("Bearer {ADMIN_TOKEN}");
+
+    for uri in [
+        "/v1/system/info",
+        "/v1/agents/runtime-stats",
+        "/v1/config/providers",
+        "/v1/audit-log",
+    ] {
+        let (status, body) =
+            request(&app, Method::GET, uri, None, std::slice::from_ref(&header)).await;
+        assert_ne!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "valid bearer must pass auth for {uri}: {body}"
+        );
+    }
+}

--- a/crates/awaken-server/tests/audit_log_routes.rs
+++ b/crates/awaken-server/tests/audit_log_routes.rs
@@ -250,6 +250,42 @@ async fn list_returns_events_after_create() {
 }
 
 #[tokio::test]
+async fn audit_log_redacts_provider_secret_materials() {
+    let app = build_test_app_with_audit(None).await;
+
+    let provider_secret = r#"{
+        "client_email":"sa@project.iam.gserviceaccount.com",
+        "private_key":"-----BEGIN PRIVATE KEY-----\nprovider-private-key\n-----END PRIVATE KEY-----",
+        "token_uri":"https://oauth2.googleapis.com/token"
+    }"#;
+    let status = create_config(
+        &app,
+        "providers",
+        &json!({
+            "id": "secret-provider",
+            "adapter": "stub",
+            "api_key": provider_secret
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = get_audit_log(&app, "limit=20").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let rendered = body.to_string();
+    for secret in [
+        "provider-private-key",
+        "BEGIN PRIVATE KEY",
+        "sa@project.iam.gserviceaccount.com",
+    ] {
+        assert!(
+            !rendered.contains(secret),
+            "audit log leaked secret fragment {secret:?}: {rendered}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn filter_by_resource_returns_only_matching_events() {
     let app = build_test_app_with_audit(None).await;
 

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -826,6 +826,60 @@ async fn provider_secret_is_redacted_and_preserved_on_update() {
 }
 
 #[tokio::test]
+async fn provider_service_account_shaped_secret_is_never_returned_by_admin_api() {
+    let app = make_app().await;
+    let service_account_json = r#"{
+        "client_email":"sa@project.iam.gserviceaccount.com",
+        "private_key":"-----BEGIN PRIVATE KEY-----\nsa-private-material\n-----END PRIVATE KEY-----",
+        "token_uri":"https://oauth2.googleapis.com/token"
+    }"#;
+
+    let (status, created) = request_json(
+        &app.router,
+        Method::POST,
+        "/v1/config/providers",
+        Some(json!({
+            "id": "sa-shaped",
+            "adapter": "stub",
+            "api_key": service_account_json
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, fetched) = request_json(
+        &app.router,
+        Method::GET,
+        "/v1/config/providers/sa-shaped",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, listed) =
+        request_json(&app.router, Method::GET, "/v1/config/providers", None).await;
+    assert_eq!(status, StatusCode::OK);
+
+    for payload in [created, fetched, listed] {
+        let rendered = payload.to_string();
+        for secret in [
+            "sa-private-material",
+            "BEGIN PRIVATE KEY",
+            "sa@project.iam.gserviceaccount.com",
+        ] {
+            assert!(
+                !rendered.contains(secret),
+                "admin API response leaked provider secret fragment {secret:?}: {rendered}"
+            );
+        }
+        assert!(
+            rendered.contains("has_api_key"),
+            "response should expose only a boolean/key-presence marker: {rendered}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn mcp_servers_are_redacted_and_publish_live_tools() {
     let app = make_app().await;
 

--- a/crates/awaken-server/tests/restore_routes.rs
+++ b/crates/awaken-server/tests/restore_routes.rs
@@ -385,6 +385,7 @@ async fn restore_restart_event_returns_422() {
         ip: None,
         request_id: None,
         restored_from: None,
+        error: None,
     };
     config_store
         .put(
@@ -693,6 +694,7 @@ async fn restore_rejects_seed_apply_event() {
         ip: None,
         request_id: None,
         restored_from: None,
+        error: None,
     };
     config_store
         .put(
@@ -816,43 +818,4 @@ async fn restore_on_customized_record_restores_spec_only() {
         body["id"], "bootstrap",
         "restored spec must preserve agent id; body: {body}"
     );
-}
-
-/// Restore from a Publish audit event restores `event.after` as the resource state.
-///
-/// # Why ignored
-///
-/// The publish flow described in ADR-0025 is not yet implemented. There is no API
-/// endpoint or service method that emits a `Publish` audit event, so it is not
-/// possible to construct one through the normal execution path. Synthesising a fake
-/// Publish event directly in the store would test the plumbing without validating
-/// that real publish events have the correct shape; that would give false confidence.
-///
-/// Enable this test once the publish endpoint from ADR-0025 is implemented and
-/// `AuditAction::Publish` events are produced by the real code path.
-#[tokio::test]
-#[ignore = "publish flow (ADR-0025) not yet implemented; enable once publish endpoint exists"]
-async fn restore_from_publish_event_uses_after() {
-    let app = build_test_app().await;
-
-    // Create an agent so there is at least one version on record.
-    let (status, _) = post_json(
-        &app,
-        "/v1/config/agents",
-        &json!({
-            "id": "publish-restore-agent",
-            "model_id": "bootstrap",
-            "system_prompt": "published version",
-            "max_rounds": 1
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::CREATED);
-
-    // TODO: call the publish endpoint once it exists to emit a real Publish event,
-    // then retrieve its ULID from the audit log, call restore with it, and assert:
-    //   - response body matches event.after
-    //   - audit log has exactly one new entry of action=restore
-    //   - restored_from references the publish event ULID
-    todo!("wire up publish endpoint from ADR-0025")
 }

--- a/crates/awaken-stores/src/file.rs
+++ b/crates/awaken-stores/src/file.rs
@@ -2057,4 +2057,117 @@ mod tests {
         store.delete_if_revision("ns", "k", 7).await.unwrap();
         assert!(ConfigStore::get(&store, "ns", "k").await.unwrap().is_none());
     }
+
+    #[tokio::test]
+    async fn file_store_put_if_revision_is_atomic_across_store_instances() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_contract::contract::storage::StorageError;
+
+        const WRITERS: usize = 16;
+        let td = TempDir::new().unwrap();
+        let barrier = Arc::new(Barrier::new(WRITERS));
+        let mut handles = Vec::with_capacity(WRITERS);
+
+        for i in 0..WRITERS {
+            let path = td.path().to_path_buf();
+            let barrier = Arc::clone(&barrier);
+            handles.push(tokio::spawn(async move {
+                let store = FileStore::new(path);
+                let value = serde_json::json!({
+                    "spec": {"id": "race", "winner": i},
+                    "meta": {"source": {"kind": "user"}, "revision": 1}
+                });
+                barrier.wait().await;
+                store.put_if_revision("ns", "race", &value, 0).await
+            }));
+        }
+
+        let results = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|result| result.expect("task join"))
+            .collect::<Vec<_>>();
+        let successes = results.iter().filter(|result| result.is_ok()).count();
+        let conflicts = results
+            .iter()
+            .filter(|result| {
+                matches!(
+                    result,
+                    Err(StorageError::VersionConflict {
+                        expected: 0,
+                        actual: 1
+                    })
+                )
+            })
+            .count();
+
+        assert_eq!(successes, 1, "exactly one concurrent create may win");
+        assert_eq!(
+            conflicts,
+            WRITERS - 1,
+            "every losing create must observe the winning revision"
+        );
+
+        let store = FileStore::new(td.path());
+        let stored = ConfigStore::get(&store, "ns", "race")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored["meta"]["revision"], 1);
+    }
+
+    #[tokio::test]
+    async fn file_store_delete_and_update_same_revision_are_mutually_exclusive() {
+        use awaken_contract::contract::config_store::ConfigStore;
+
+        let td = TempDir::new().unwrap();
+        let seed_store = FileStore::new(td.path());
+        let value_r1 = serde_json::json!({
+            "spec": {"id": "duel", "value": 1},
+            "meta": {"source": {"kind": "user"}, "revision": 1}
+        });
+        seed_store
+            .put_if_revision("ns", "duel", &value_r1, 0)
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let delete_path = td.path().to_path_buf();
+        let update_path = td.path().to_path_buf();
+        let delete_barrier = Arc::clone(&barrier);
+        let update_barrier = Arc::clone(&barrier);
+
+        let delete = tokio::spawn(async move {
+            let store = FileStore::new(delete_path);
+            delete_barrier.wait().await;
+            store.delete_if_revision("ns", "duel", 1).await
+        });
+        let update = tokio::spawn(async move {
+            let store = FileStore::new(update_path);
+            let value_r2 = serde_json::json!({
+                "spec": {"id": "duel", "value": 2},
+                "meta": {"source": {"kind": "user"}, "revision": 2}
+            });
+            update_barrier.wait().await;
+            store.put_if_revision("ns", "duel", &value_r2, 1).await
+        });
+
+        let delete_ok = delete.await.unwrap().is_ok();
+        let update_ok = update.await.unwrap().is_ok();
+        assert_ne!(
+            delete_ok, update_ok,
+            "same-revision delete and update must not both succeed or both fail"
+        );
+
+        let store = FileStore::new(td.path());
+        let stored = ConfigStore::get(&store, "ns", "duel").await.unwrap();
+        if delete_ok {
+            assert!(stored.is_none(), "successful delete must remove the record");
+        } else {
+            assert_eq!(
+                stored.expect("successful update must leave record")["meta"]["revision"],
+                2
+            );
+        }
+    }
 }

--- a/crates/awaken-stores/src/file.rs
+++ b/crates/awaken-stores/src/file.rs
@@ -13,7 +13,7 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, OnceLock, Weak};
 
 use async_trait::async_trait;
-use awaken_contract::contract::config_store::ConfigStore;
+use awaken_contract::contract::config_store::{ConfigStore, extract_meta_revision};
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::profile_store::{ProfileEntry, ProfileOwner, ProfileStore};
 use awaken_contract::contract::storage::{
@@ -31,6 +31,11 @@ use tokio::sync::Mutex;
 pub struct FileStore {
     base_path: PathBuf,
     hierarchy_lock: Arc<Mutex<()>>,
+    /// In-process mutex serialising config CAS (read-check-write) operations.
+    ///
+    /// FileStore's CAS is process-local; cross-process atomicity is not
+    /// guaranteed. For multi-process deployments use PostgresStore.
+    config_cas_lock: Arc<Mutex<()>>,
 }
 
 impl FileStore {
@@ -48,6 +53,7 @@ impl FileStore {
         cleanup_orphan_checkpoint_backups_sync(&base_path);
         Self {
             hierarchy_lock: shared_hierarchy_lock(&base_path),
+            config_cas_lock: shared_config_cas_lock(&base_path),
             base_path,
         }
     }
@@ -224,6 +230,25 @@ impl FileStore {
 
         Ok(())
     }
+}
+
+fn shared_config_cas_lock(base_path: &Path) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<std::sync::Mutex<HashMap<String, Weak<Mutex<()>>>>> = OnceLock::new();
+
+    let key = hierarchy_lock_key(base_path);
+    let locks = LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut guard = locks
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.retain(|_, lock| lock.strong_count() > 0);
+
+    if let Some(lock) = guard.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+
+    let lock = Arc::new(Mutex::new(()));
+    guard.insert(key, Arc::downgrade(&lock));
+    lock
 }
 
 fn shared_hierarchy_lock(base_path: &Path) -> Arc<Mutex<()>> {
@@ -1159,15 +1184,101 @@ impl ConfigStore for FileStore {
     ) -> Result<(), StorageError> {
         validate_id(namespace, "config namespace")?;
         validate_id(id, "config id")?;
+        let _guard = self.config_cas_lock.lock().await;
         let payload = serde_json::to_string_pretty(value)
             .map_err(|error| StorageError::Serialization(error.to_string()))?;
         atomic_write(&self.config_dir(namespace), &format!("{id}.json"), &payload).await
     }
 
+    async fn put_if_absent(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &serde_json::Value,
+    ) -> Result<(), StorageError> {
+        validate_id(namespace, "config namespace")?;
+        validate_id(id, "config id")?;
+        let _guard = self.config_cas_lock.lock().await;
+        let payload = serde_json::to_string_pretty(value)
+            .map_err(|error| StorageError::Serialization(error.to_string()))?;
+        atomic_write_exclusive(
+            &self.config_dir(namespace),
+            &format!("{id}.json"),
+            &payload,
+            &format!("{namespace}/{id}"),
+        )
+        .await
+    }
+
     async fn delete(&self, namespace: &str, id: &str) -> Result<(), StorageError> {
         validate_id(namespace, "config namespace")?;
         validate_id(id, "config id")?;
+        let _guard = self.config_cas_lock.lock().await;
         let path = self.config_dir(namespace).join(format!("{id}.json"));
+        if path.exists() {
+            tokio::fs::remove_file(&path)
+                .await
+                .map_err(|error| StorageError::Io(error.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Atomic compare-and-set for the config revision field.
+    ///
+    /// Atomicity is in-process only (via `config_cas_lock`). Cross-process
+    /// writers to the same file-system path are not protected. For multi-process
+    /// deployments use `PostgresStore` which uses `SELECT FOR UPDATE`.
+    async fn put_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &serde_json::Value,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        validate_id(namespace, "config namespace")?;
+        validate_id(id, "config id")?;
+        let _guard = self.config_cas_lock.lock().await;
+
+        // Re-read under the lock to avoid TOCTOU.
+        let path = self.config_dir(namespace).join(format!("{id}.json"));
+        let existing: Option<serde_json::Value> = read_json(&path).await?;
+        let actual = existing
+            .as_ref()
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
+
+        let payload = serde_json::to_string_pretty(value)
+            .map_err(|error| StorageError::Serialization(error.to_string()))?;
+        atomic_write(&self.config_dir(namespace), &format!("{id}.json"), &payload).await
+    }
+
+    async fn delete_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        validate_id(namespace, "config namespace")?;
+        validate_id(id, "config id")?;
+        let _guard = self.config_cas_lock.lock().await;
+        let path = self.config_dir(namespace).join(format!("{id}.json"));
+        let existing: Option<serde_json::Value> = read_json(&path).await?;
+        let actual = existing
+            .as_ref()
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
         if path.exists() {
             tokio::fs::remove_file(&path)
                 .await
@@ -1872,5 +1983,78 @@ mod tests {
 
         // Bob's entries are isolated
         assert_eq!(ProfileStore::list(&store, &bob).await.unwrap().len(), 1);
+    }
+
+    // ── ConfigStore::put_if_revision ──
+
+    #[tokio::test]
+    async fn file_store_put_if_revision_basic() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_contract::contract::storage::StorageError;
+
+        let td = TempDir::new().unwrap();
+        let store = FileStore::new(td.path());
+
+        let value_r1 = serde_json::json!({"spec": {"id": "k"}, "meta": {"source": {"kind": "user"}, "revision": 1}});
+        // Insert: no record, expected=0 → succeeds.
+        store
+            .put_if_revision("ns", "k", &value_r1, 0)
+            .await
+            .unwrap();
+        let stored = ConfigStore::get(&store, "ns", "k").await.unwrap().unwrap();
+        assert_eq!(stored["meta"]["revision"], 1);
+
+        // Conflict: expected=0 again should fail.
+        let err = store
+            .put_if_revision("ns", "k", &value_r1, 0)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::VersionConflict {
+                expected: 0,
+                actual: 1
+            }
+        ));
+
+        // Correct CAS: expected=1 → update to revision 2.
+        let value_r2 = serde_json::json!({"spec": {"id": "k"}, "meta": {"source": {"kind": "user"}, "revision": 2}});
+        store
+            .put_if_revision("ns", "k", &value_r2, 1)
+            .await
+            .unwrap();
+        let stored = ConfigStore::get(&store, "ns", "k").await.unwrap().unwrap();
+        assert_eq!(stored["meta"]["revision"], 2);
+    }
+
+    #[tokio::test]
+    async fn file_store_put_if_absent_and_delete_if_revision() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_contract::contract::storage::StorageError;
+
+        let td = TempDir::new().unwrap();
+        let store = FileStore::new(td.path());
+
+        let value = serde_json::json!({
+            "spec": {"id": "k"},
+            "meta": {"source": {"kind": "user"}, "revision": 7}
+        });
+        store.put_if_absent("ns", "k", &value).await.unwrap();
+
+        let err = store.put_if_absent("ns", "k", &value).await.unwrap_err();
+        assert!(matches!(err, StorageError::AlreadyExists(id) if id == "ns/k"));
+
+        let err = store.delete_if_revision("ns", "k", 6).await.unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::VersionConflict {
+                expected: 6,
+                actual: 7
+            }
+        ));
+        assert!(ConfigStore::get(&store, "ns", "k").await.unwrap().is_some());
+
+        store.delete_if_revision("ns", "k", 7).await.unwrap();
+        assert!(ConfigStore::get(&store, "ns", "k").await.unwrap().is_none());
     }
 }

--- a/crates/awaken-stores/src/memory.rs
+++ b/crates/awaken-stores/src/memory.rs
@@ -3,7 +3,10 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use awaken_contract::contract::config_store::ConfigStore;
+use awaken_contract::contract::config_store::{
+    ConfigChangeEvent, ConfigChangeKind, ConfigChangeNotifier, ConfigChangeSubscriber, ConfigStore,
+    extract_meta_revision,
+};
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::profile_store::{ProfileEntry, ProfileOwner, ProfileStore};
 use awaken_contract::contract::storage::{
@@ -19,7 +22,7 @@ use tokio::sync::RwLock;
 ///
 /// Uses `tokio::sync::RwLock` for async-safe concurrent access.
 /// Data lives only in memory and is lost when the store is dropped.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct InMemoryStore {
     threads: RwLock<HashMap<String, Thread>>,
     runs: RwLock<HashMap<String, RunRecord>>,
@@ -29,12 +32,28 @@ pub struct InMemoryStore {
     profiles: RwLock<HashMap<ProfileOwner, HashMap<String, ProfileEntry>>>,
     /// Config entries keyed by namespace then ID.
     configs: RwLock<HashMap<String, HashMap<String, Value>>>,
+    /// Broadcast sender for config change notifications.
+    config_change_tx: tokio::sync::broadcast::Sender<ConfigChangeEvent>,
 }
 
 impl InMemoryStore {
     /// Create a new empty in-memory store.
     pub fn new() -> Self {
-        Self::default()
+        let (config_change_tx, _) = tokio::sync::broadcast::channel(256);
+        Self {
+            threads: RwLock::new(HashMap::new()),
+            runs: RwLock::new(HashMap::new()),
+            messages: RwLock::new(HashMap::new()),
+            profiles: RwLock::new(HashMap::new()),
+            configs: RwLock::new(HashMap::new()),
+            config_change_tx,
+        }
+    }
+}
+
+impl Default for InMemoryStore {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -454,6 +473,33 @@ impl ConfigStore for InMemoryStore {
             .entry(namespace.to_string())
             .or_default()
             .insert(id.to_string(), value.clone());
+        drop(guard);
+        let _ = self.config_change_tx.send(ConfigChangeEvent {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+            kind: ConfigChangeKind::Put,
+        });
+        Ok(())
+    }
+
+    async fn put_if_absent(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &Value,
+    ) -> Result<(), StorageError> {
+        let mut guard = self.configs.write().await;
+        let entries = guard.entry(namespace.to_string()).or_default();
+        if entries.contains_key(id) {
+            return Err(StorageError::AlreadyExists(format!("{namespace}/{id}")));
+        }
+        entries.insert(id.to_string(), value.clone());
+        drop(guard);
+        let _ = self.config_change_tx.send(ConfigChangeEvent {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+            kind: ConfigChangeKind::Put,
+        });
         Ok(())
     }
 
@@ -462,7 +508,110 @@ impl ConfigStore for InMemoryStore {
         if let Some(entries) = guard.get_mut(namespace) {
             entries.remove(id);
         }
+        drop(guard);
+        let _ = self.config_change_tx.send(ConfigChangeEvent {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+            kind: ConfigChangeKind::Delete,
+        });
         Ok(())
+    }
+
+    async fn put_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &Value,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        let mut guard = self.configs.write().await;
+        let actual = guard
+            .get(namespace)
+            .and_then(|entries| entries.get(id))
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
+        guard
+            .entry(namespace.to_string())
+            .or_default()
+            .insert(id.to_string(), value.clone());
+        drop(guard);
+        let _ = self.config_change_tx.send(ConfigChangeEvent {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+            kind: ConfigChangeKind::Put,
+        });
+        Ok(())
+    }
+
+    async fn delete_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        let mut guard = self.configs.write().await;
+        let actual = guard
+            .get(namespace)
+            .and_then(|entries| entries.get(id))
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
+        if let Some(entries) = guard.get_mut(namespace) {
+            entries.remove(id);
+        }
+        drop(guard);
+        let _ = self.config_change_tx.send(ConfigChangeEvent {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+            kind: ConfigChangeKind::Delete,
+        });
+        Ok(())
+    }
+}
+
+// ── ConfigChangeNotifier ────────────────────────────────────────────
+
+#[async_trait]
+impl ConfigChangeNotifier for InMemoryStore {
+    async fn subscribe(&self) -> Result<Box<dyn ConfigChangeSubscriber>, StorageError> {
+        Ok(Box::new(InMemoryConfigChangeSubscriber {
+            rx: self.config_change_tx.subscribe(),
+        }))
+    }
+}
+
+struct InMemoryConfigChangeSubscriber {
+    rx: tokio::sync::broadcast::Receiver<ConfigChangeEvent>,
+}
+
+#[async_trait]
+impl ConfigChangeSubscriber for InMemoryConfigChangeSubscriber {
+    async fn next(&mut self) -> Result<ConfigChangeEvent, StorageError> {
+        match self.rx.recv().await {
+            Ok(event) => Ok(event),
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                tracing::warn!(skipped, "in-memory config notifier lagged");
+                Ok(ConfigChangeEvent {
+                    namespace: String::new(),
+                    id: String::new(),
+                    kind: ConfigChangeKind::Put,
+                })
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                Err(StorageError::Io("config change channel closed".into()))
+            }
+        }
     }
 }
 
@@ -905,5 +1054,207 @@ mod tests {
 
         // Clear again is idempotent
         store.clear_owner(&alice).await.unwrap();
+    }
+
+    // ── ConfigChangeNotifier ──
+
+    // ── ConfigStore::put_if_revision ──
+
+    #[tokio::test]
+    async fn put_if_revision_succeeds_when_revision_matches() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        let store = InMemoryStore::new();
+
+        // First write: no existing record, expected=0 → insert at revision 1.
+        let value_r1 = serde_json::json!({"spec": {"id": "a"}, "meta": {"source": {"kind": "user"}, "revision": 1}});
+        store
+            .put_if_revision("ns", "a", &value_r1, 0)
+            .await
+            .unwrap();
+        let stored = ConfigStore::get(&store, "ns", "a").await.unwrap().unwrap();
+        assert_eq!(stored["meta"]["revision"], 1);
+
+        // Second write: expected=1 → update to revision 2.
+        let value_r2 = serde_json::json!({"spec": {"id": "a"}, "meta": {"source": {"kind": "user"}, "revision": 2}});
+        store
+            .put_if_revision("ns", "a", &value_r2, 1)
+            .await
+            .unwrap();
+        let stored = ConfigStore::get(&store, "ns", "a").await.unwrap().unwrap();
+        assert_eq!(stored["meta"]["revision"], 2);
+    }
+
+    #[tokio::test]
+    async fn put_if_revision_returns_conflict_on_mismatch() {
+        use awaken_contract::contract::storage::StorageError;
+        let store = InMemoryStore::new();
+
+        // Insert a record at revision 1.
+        let value_r1 =
+            serde_json::json!({"spec": {}, "meta": {"source": {"kind": "user"}, "revision": 1}});
+        store.put("ns", "b", &value_r1).await.unwrap();
+
+        // Try with wrong expected revision.
+        let err = store
+            .put_if_revision("ns", "b", &value_r1, 5)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::VersionConflict {
+                expected: 5,
+                actual: 1
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn put_if_absent_inserts_once_and_reports_existing() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_contract::contract::storage::StorageError;
+
+        let store = InMemoryStore::new();
+        let value = serde_json::json!({
+            "spec": {"id": "new"},
+            "meta": {"source": {"kind": "user"}, "revision": 1}
+        });
+
+        store.put_if_absent("ns", "new", &value).await.unwrap();
+
+        let err = store.put_if_absent("ns", "new", &value).await.unwrap_err();
+        assert!(matches!(err, StorageError::AlreadyExists(id) if id == "ns/new"));
+
+        let stored = ConfigStore::get(&store, "ns", "new")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored, value);
+    }
+
+    #[tokio::test]
+    async fn delete_if_revision_removes_only_matching_revision() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_contract::contract::storage::StorageError;
+
+        let store = InMemoryStore::new();
+        let value = serde_json::json!({
+            "spec": {"id": "delete-me"},
+            "meta": {"source": {"kind": "user"}, "revision": 3}
+        });
+        store.put("ns", "delete-me", &value).await.unwrap();
+
+        let err = store
+            .delete_if_revision("ns", "delete-me", 2)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::VersionConflict {
+                expected: 2,
+                actual: 3
+            }
+        ));
+        assert!(
+            ConfigStore::get(&store, "ns", "delete-me")
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        store
+            .delete_if_revision("ns", "delete-me", 3)
+            .await
+            .unwrap();
+        assert!(
+            ConfigStore::get(&store, "ns", "delete-me")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn put_if_revision_handles_concurrent_writers() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        use awaken_contract::contract::storage::StorageError;
+        use std::sync::Arc;
+
+        let store = Arc::new(InMemoryStore::new());
+
+        // Seed with revision 0 (absence treated as 0).
+        const N: usize = 20;
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let s = store.clone();
+            handles.push(tokio::spawn(async move {
+                let value = serde_json::json!({"spec": {}, "meta": {"source": {"kind": "user"}, "revision": 1}});
+                s.put_if_revision("ns", "concurrent", &value, 0).await
+            }));
+        }
+
+        let results: Vec<_> = futures::future::join_all(handles)
+            .await
+            .into_iter()
+            .map(|r| r.unwrap())
+            .collect();
+
+        let successes = results.iter().filter(|r| r.is_ok()).count();
+        let conflicts = results
+            .iter()
+            .filter(|r| matches!(r, Err(StorageError::VersionConflict { expected: 0, .. })))
+            .count();
+
+        assert_eq!(successes, 1, "exactly one writer should succeed");
+        assert_eq!(conflicts, N - 1, "all others should get VersionConflict");
+
+        let stored = ConfigStore::get(store.as_ref(), "ns", "concurrent")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored["meta"]["revision"], 1);
+    }
+
+    #[tokio::test]
+    async fn config_change_notifier_emits_on_put_and_delete() {
+        use awaken_contract::contract::config_store::{
+            ConfigChangeKind, ConfigChangeNotifier, ConfigStore,
+        };
+        let store = InMemoryStore::new();
+        let mut sub = store.subscribe().await.unwrap();
+
+        store
+            .put("agents", "a1", &serde_json::json!({"hello": "world"}))
+            .await
+            .unwrap();
+        let event = sub.next().await.unwrap();
+        assert_eq!(event.namespace, "agents");
+        assert_eq!(event.id, "a1");
+        assert!(matches!(event.kind, ConfigChangeKind::Put));
+
+        ConfigStore::delete(&store, "agents", "a1").await.unwrap();
+        let event = sub.next().await.unwrap();
+        assert_eq!(event.namespace, "agents");
+        assert_eq!(event.id, "a1");
+        assert!(matches!(event.kind, ConfigChangeKind::Delete));
+    }
+
+    #[tokio::test]
+    async fn config_change_notifier_supports_multiple_subscribers() {
+        use awaken_contract::contract::config_store::ConfigChangeNotifier;
+        let store = InMemoryStore::new();
+        let mut sub_a = store.subscribe().await.unwrap();
+        let mut sub_b = store.subscribe().await.unwrap();
+
+        store
+            .put("tools", "echo", &serde_json::json!({}))
+            .await
+            .unwrap();
+
+        let a = sub_a.next().await.unwrap();
+        let b = sub_b.next().await.unwrap();
+        assert_eq!(a.namespace, "tools");
+        assert_eq!(b.namespace, "tools");
+        assert_eq!(a.id, "echo");
+        assert_eq!(b.id, "echo");
     }
 }

--- a/crates/awaken-stores/src/memory.rs
+++ b/crates/awaken-stores/src/memory.rs
@@ -1215,6 +1215,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_and_update_same_revision_are_mutually_exclusive() {
+        use awaken_contract::contract::config_store::ConfigStore;
+        use std::sync::Arc;
+
+        let store = Arc::new(InMemoryStore::new());
+        let value_r1 = serde_json::json!({
+            "spec": {"id": "duel", "value": 1},
+            "meta": {"source": {"kind": "user"}, "revision": 1}
+        });
+        store
+            .put_if_revision("ns", "duel", &value_r1, 0)
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let delete_store = Arc::clone(&store);
+        let update_store = Arc::clone(&store);
+        let delete_barrier = Arc::clone(&barrier);
+        let update_barrier = Arc::clone(&barrier);
+
+        let delete = tokio::spawn(async move {
+            delete_barrier.wait().await;
+            delete_store.delete_if_revision("ns", "duel", 1).await
+        });
+        let update = tokio::spawn(async move {
+            let value_r2 = serde_json::json!({
+                "spec": {"id": "duel", "value": 2},
+                "meta": {"source": {"kind": "user"}, "revision": 2}
+            });
+            update_barrier.wait().await;
+            update_store
+                .put_if_revision("ns", "duel", &value_r2, 1)
+                .await
+        });
+
+        let delete_ok = delete.await.unwrap().is_ok();
+        let update_ok = update.await.unwrap().is_ok();
+        assert_ne!(
+            delete_ok, update_ok,
+            "same-revision delete and update must be serialized by CAS"
+        );
+
+        let stored = ConfigStore::get(store.as_ref(), "ns", "duel")
+            .await
+            .unwrap();
+        if delete_ok {
+            assert!(stored.is_none(), "successful delete must remove the record");
+        } else {
+            assert_eq!(
+                stored.expect("successful update must leave record")["meta"]["revision"],
+                2
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn config_change_notifier_emits_on_put_and_delete() {
         use awaken_contract::contract::config_store::{
             ConfigChangeKind, ConfigChangeNotifier, ConfigStore,

--- a/crates/awaken-stores/src/postgres.rs
+++ b/crates/awaken-stores/src/postgres.rs
@@ -5,6 +5,7 @@
 use async_trait::async_trait;
 use awaken_contract::contract::config_store::{
     ConfigChangeEvent, ConfigChangeKind, ConfigChangeNotifier, ConfigChangeSubscriber, ConfigStore,
+    extract_meta_revision,
 };
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::storage::{
@@ -1205,6 +1206,13 @@ impl ConfigStore for PostgresStore {
             .await
             .map_err(|error| StorageError::Io(error.to_string()))?;
 
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))")
+            .bind(namespace)
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?;
+
         let sql = format!(
             "INSERT INTO {} (namespace, id, data) VALUES ($1, $2, $3)
              ON CONFLICT (namespace, id) DO UPDATE SET data = $3, updated_at = now()",
@@ -1237,11 +1245,79 @@ impl ConfigStore for PostgresStore {
         Ok(())
     }
 
+    async fn put_if_absent(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &serde_json::Value,
+    ) -> Result<(), StorageError> {
+        self.ensure_schema().await?;
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?;
+
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))")
+            .bind(namespace)
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?;
+
+        let sql = format!(
+            "INSERT INTO {} (namespace, id, data) VALUES ($1, $2, $3)",
+            self.configs_table
+        );
+        let result = sqlx::query(&sql)
+            .bind(namespace)
+            .bind(id)
+            .bind(value)
+            .execute(&mut *tx)
+            .await;
+        if let Err(error) = result {
+            if error
+                .as_database_error()
+                .and_then(|db_error| db_error.code())
+                .as_deref()
+                == Some("23505")
+            {
+                return Err(StorageError::AlreadyExists(format!("{namespace}/{id}")));
+            }
+            return Err(StorageError::Io(error.to_string()));
+        }
+
+        let payload = serde_json::to_string(&ConfigChangeEvent {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+            kind: ConfigChangeKind::Put,
+        })
+        .map_err(|error| StorageError::Serialization(error.to_string()))?;
+        sqlx::query("SELECT pg_notify($1, $2)")
+            .bind(&self.config_notify_channel)
+            .bind(payload)
+            .execute(&mut *tx)
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?;
+        Ok(())
+    }
+
     async fn delete(&self, namespace: &str, id: &str) -> Result<(), StorageError> {
         self.ensure_schema().await?;
         let mut tx = self
             .pool
             .begin()
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?;
+
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))")
+            .bind(namespace)
+            .bind(id)
+            .execute(&mut *tx)
             .await
             .map_err(|error| StorageError::Io(error.to_string()))?;
 
@@ -1274,6 +1350,162 @@ impl ConfigStore for PostgresStore {
         tx.commit()
             .await
             .map_err(|error| StorageError::Io(error.to_string()))?;
+        Ok(())
+    }
+
+    async fn put_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        value: &serde_json::Value,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        self.ensure_schema().await?;
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))")
+            .bind(namespace)
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        // Lock the row (or its absence) so that concurrent writers cannot race
+        // between the read and the upsert within this transaction.
+        let select_sql = format!(
+            "SELECT data FROM {} WHERE namespace = $1 AND id = $2 FOR UPDATE",
+            self.configs_table
+        );
+        let row: Option<(serde_json::Value,)> = sqlx::query_as(&select_sql)
+            .bind(namespace)
+            .bind(id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        let actual = row
+            .as_ref()
+            .map(|(v,)| v)
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
+
+        let upsert_sql = format!(
+            "INSERT INTO {} (namespace, id, data) VALUES ($1, $2, $3) \
+             ON CONFLICT (namespace, id) DO UPDATE SET data = EXCLUDED.data, updated_at = now()",
+            self.configs_table
+        );
+        sqlx::query(&upsert_sql)
+            .bind(namespace)
+            .bind(id)
+            .bind(value)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        // Fire NOTIFY inside the same transaction, matching put semantics.
+        let payload = serde_json::to_string(&ConfigChangeEvent {
+            namespace: namespace.to_string(),
+            id: id.to_string(),
+            kind: ConfigChangeKind::Put,
+        })
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        sqlx::query("SELECT pg_notify($1, $2)")
+            .bind(&self.config_notify_channel)
+            .bind(payload)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn delete_if_revision(
+        &self,
+        namespace: &str,
+        id: &str,
+        expected_revision: u64,
+    ) -> Result<(), StorageError> {
+        self.ensure_schema().await?;
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))")
+            .bind(namespace)
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        let select_sql = format!(
+            "SELECT data FROM {} WHERE namespace = $1 AND id = $2 FOR UPDATE",
+            self.configs_table
+        );
+        let row: Option<(serde_json::Value,)> = sqlx::query_as(&select_sql)
+            .bind(namespace)
+            .bind(id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        let actual = row
+            .as_ref()
+            .map(|(v,)| v)
+            .and_then(extract_meta_revision)
+            .unwrap_or(0);
+        if actual != expected_revision {
+            return Err(StorageError::VersionConflict {
+                expected: expected_revision,
+                actual,
+            });
+        }
+
+        let delete_sql = format!(
+            "DELETE FROM {} WHERE namespace = $1 AND id = $2",
+            self.configs_table
+        );
+        let result = sqlx::query(&delete_sql)
+            .bind(namespace)
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+
+        if result.rows_affected() > 0 {
+            let payload = serde_json::to_string(&ConfigChangeEvent {
+                namespace: namespace.to_string(),
+                id: id.to_string(),
+                kind: ConfigChangeKind::Delete,
+            })
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+            sqlx::query("SELECT pg_notify($1, $2)")
+                .bind(&self.config_notify_channel)
+                .bind(payload)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| StorageError::Io(e.to_string()))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
         Ok(())
     }
 }
@@ -1491,5 +1723,40 @@ mod tests {
         assert_eq!(loaded_msgs.len(), 1);
         let loaded_run = store.load_run(&run.run_id).await.unwrap().unwrap();
         assert_eq!(loaded_run.thread_id, thread_id);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PG_TEST_URL"]
+    async fn put_if_revision_atomic_cas() {
+        let url = std::env::var("PG_TEST_URL")
+            .unwrap_or_else(|_| "postgres://localhost/awaken_test".to_string());
+        let pool = PgPool::connect(&url).await.unwrap();
+        let store = PostgresStore::with_prefix(pool, "test_cas");
+        store.ensure_schema().await.unwrap();
+
+        let v1 = serde_json::json!({"spec": {"id": "cas-key"}, "meta": {"source": {"kind": "user"}, "revision": 1}});
+        // First write: no record → expected 0 succeeds.
+        store
+            .put_if_revision("cas_ns", "cas-key", &v1, 0)
+            .await
+            .unwrap();
+        let stored = ConfigStore::get(&store, "cas_ns", "cas-key")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored["meta"]["revision"], 1);
+
+        // Conflict: re-try with expected 0 should fail.
+        let err = store
+            .put_if_revision("cas_ns", "cas-key", &v1, 0)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StorageError::VersionConflict {
+                expected: 0,
+                actual: 1
+            }
+        ));
     }
 }

--- a/docs/adr/0023-admin-api-surface-and-exposure-policy.md
+++ b/docs/adr/0023-admin-api-surface-and-exposure-policy.md
@@ -17,8 +17,9 @@ Until now the access policy lived implicitly across three places:
 1. `AdminApiConfig::bearer_token` — optional bearer required by every
    handler via `ensure_admin_auth`.
 2. `validate_admin_surface` — refuses to start the server when binding a
-   non-loopback address without a bearer token, *if* a config store or
-   runtime manager is attached.
+   non-loopback address without a bearer token, *if* a sensitive admin
+   subsystem is attached (`ConfigStore`, runtime manager, audit log,
+   runtime stats, or skill catalog).
 3. `build_router` — unconditionally merges `config_routes()`.
 
 This ad-hoc structure has two problems:
@@ -95,8 +96,8 @@ upstream gate, not a replacement.
   the framework refusing to start.
 - The default surface is unchanged: defaults remain
   `expose_config_routes = true` and `bearer_token = None`, with the
-  loopback / bearer requirement enforced at startup when a config store
-  or runtime manager is attached.
+  loopback / bearer requirement enforced at startup when a sensitive
+  admin subsystem is attached.
 - `build_router` now requires `&AppState` so it can read the effective
   admin policy at compose time. Test code constructs an `AppState` and
   passes it; the API change is mechanical.

--- a/docs/adr/0029-tool-description-override.md
+++ b/docs/adr/0029-tool-description-override.md
@@ -1,0 +1,299 @@
+# ADR-0029: Tool Description Override
+
+- **Status**: Accepted
+- **Date**: 2026-05-05
+- **Depends on**: ADR-0010, ADR-0014, ADR-0023, ADR-0024, ADR-0026
+
+## Context
+
+Operators can already override built-in agent specs through the
+`PATCH /v1/config/agents/:id/overrides` surface that landed alongside the
+admin console refresh. The same mental model — a `ConfigRecord<T>` envelope
+with a `Builtin` source and optional `user_overrides` JSON merged at
+read-time — is the right shape for tuning the descriptions that registered
+tools advertise to the model.
+
+Tool descriptions are a first-class prompt-engineering surface for tool-using
+LLMs:
+
+- They disambiguate adjacent tools (`read_file` vs `read_database`).
+- They encode non-obvious constraints ("paths are project-relative",
+  "max 1000 results") that the schema cannot express.
+- They allow domain/locale alignment so descriptions speak the agent's
+  vocabulary instead of generic English.
+- They give operators a no-deploy lever to correct misleading wording when
+  an agent misroutes calls in production.
+
+Today every tool's description is a hard-coded string returned by
+`Tool::descriptor()` and there is no path to change it without rebuilding
+the binary.
+
+## Non-Goals
+
+- **Per-agent overrides.** Per-agent variation belongs in the agent's
+  `system_prompt`, not in description fan-out. Layering per-agent overrides
+  on top of this design is a strict additive future step, not in scope here.
+- **Schema or name overrides.** `parameters_schema` and `id`/`name` are part
+  of the calling contract. Allowing UI edits would silently break tool
+  invocation. Out of scope.
+- **Authoring new tools from the UI.** Tools are still registered in code
+  via the `Tool` trait. The UI tunes metadata of code-registered tools only.
+- **Replacing system prompts.** Long, rule-laden tool descriptions dilute
+  attention. The UI surfaces a soft length warning that pushes operators to
+  put complex behaviour rules in the agent's system prompt rather than the
+  description.
+
+## Decisions
+
+### D1: `Tool` becomes a first-class `ConfigRecord` kind
+
+A new `ToolSpec` is added to `awaken-contract`, stored in `ConfigStore`
+under namespace `tools` with `source: Builtin { binary_version }`. The
+record envelope, audit hooks, restore semantics (ADR-0028) and listing API
+(ADR-0023) all apply uniformly.
+
+```rust
+// crates/awaken-contract/src/tool_spec.rs
+pub struct ToolSpec {
+    pub id: ToolId,                 // canonical key, sourced from ToolDescriptor.id
+    pub name: String,                // read-only display label
+    pub description: String,         // the tunable field
+    pub category: Option<String>,
+    pub parameters_schema: Value,    // read-only snapshot, for UI + audit context
+}
+```
+
+User-created tools are not allowed; `RecordSource::User` is rejected by the
+service layer with 422 for namespace `tools`.
+
+### D2: Patch surface — `description` only
+
+```rust
+// crates/awaken-contract/src/tool_spec_patch.rs
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolSpecPatch {
+    pub description: Option<String>,
+}
+impl Patchable<ToolSpec> for ToolSpecPatch { /* merge_tool_spec */ }
+```
+
+`merge_tool_spec(spec, patch)` follows the same `Option`-as-inheritance
+convention as `merge_agent_spec`: `None` keeps the built-in value, `Some(v)`
+replaces it. `deny_unknown_fields` keeps the surface forward-compatible —
+adding a new patchable field later is purely additive and rejects stale
+clients early.
+
+Validation rules applied in `ConfigService::patch_tool_overrides`:
+
+- `description` must be non-empty after trim.
+- Length hard-cap: 4096 bytes (defensive; UI surfaces a soft warning at
+  ≥ 400 chars).
+- No control characters except `\n`.
+
+### D3: Seed protocol
+
+At startup `SpecRegistry` enumerates registered tools and writes a
+`ConfigRecord<ToolSpec>` for each, taking the live `ToolDescriptor` as the
+built-in payload. The existing idempotent seed protocol handles version
+bumps automatically: when `binary_version` advances, the built-in payload is
+refreshed but `user_overrides` is preserved.
+
+### D4: HTTP API
+
+| Method   | Path                                              | Purpose                                  |
+|----------|---------------------------------------------------|------------------------------------------|
+| `GET`    | `/v1/config/tools`                                | List with effective specs, paginated     |
+| `GET`    | `/v1/config/tools/:id`                            | Effective (post-merge) spec              |
+| `GET`    | `/v1/config/tools/:id/meta`                       | `RecordMeta` including raw overrides     |
+| `PATCH`  | `/v1/config/tools/:id/overrides`                  | Shallow-merge new patch into overrides   |
+| `DELETE` | `/v1/config/tools/:id/overrides`                  | Clear all overrides (revert to built-in) |
+| `DELETE` | `/v1/config/tools/:id/overrides/:field`           | Clear a single override field            |
+
+There is no `POST` or `PUT` for `tools` — built-in is the only allowed
+source. The single-field `DELETE` is provided for symmetry with agents and
+forward-compatibility with future patchable fields; today only `description`
+is accepted.
+
+All routes are behind `ensure_admin_auth` (ADR-0023).
+
+### D5: Runtime application point
+
+The override is applied at registry compile time, in the same call chain
+that already merges agent overrides:
+
+```
+PATCH /v1/config/tools/:id/overrides
+  └─> ConfigService::patch_tool_overrides
+       └─> apply_locked()
+            ├─> load_managed_config()
+            │    └─> deserialize_namespace()
+            │         └─> apply_overrides() merges ToolSpecPatch
+            ├─> compile_registry_set()
+            │    └─> for each tool: take Tool::descriptor(), substitute
+            │        description from the merged ToolSpec, store the
+            │        patched ToolDescriptor in the snapshot
+            └─> replace_registry_set()  // RwLock-backed atomic swap
+```
+
+The `Tool` trait is **not** modified. The override lives on the
+`ToolDescriptor` stored in the registry snapshot, alongside the unchanged
+`Arc<dyn Tool>` whose `invoke()` behaviour is untouched.
+
+### D6: Hot-reload semantics
+
+Mirrors the existing agent override behaviour exactly:
+
+| Dimension                            | Agent override | Tool description override |
+|--------------------------------------|----------------|----------------------------|
+| Trigger                              | PATCH → `apply_locked` → snapshot replace | same |
+| Merge point                          | `apply_overrides` in `deserialize_namespace` | same |
+| Synchronisation                      | `Arc<RwLock<RegistrySnapshot>>` | same |
+| New-run effect after PATCH           | immediate, no restart | immediate, no restart |
+| In-flight run effect after PATCH     | not applied — `ResolvedAgent` is captured at run start and reused | identical |
+| Blast radius of a single PATCH       | full registry set recompile + atomic swap | identical |
+
+The "in-flight run is unaffected" property is a known and intentional
+behaviour of the existing config pipeline (ADR-0014). It is documented here
+explicitly so future readers do not treat it as a tool-specific quirk.
+
+### D7: Audit
+
+Reuses `AuditEvent` with `resource = "tools/:id"` and the standard
+`before` / `after` payloads carrying the **effective** `ToolSpec`. The
+restore endpoint from ADR-0028 works for `tools` resources without
+modification because the patch flow goes through the same envelope path.
+
+### D8: Admin console UI
+
+A new top-level Tools section is added to the admin console, sibling to
+Agents:
+
+- **List page** `/tools` — every registered tool, columns: id, name,
+  category, "overridden?" indicator, `updated_at`. Filter: show only
+  overridden tools.
+- **Editor page** `/tools/:id` — three-view layout reused from the agent
+  editor:
+  - **Built-in** (read-only): the binary-shipped description.
+  - **User override** (editable): the patch payload.
+  - **Effective** (read-only preview): post-merge result, identical to what
+    the LLM will see.
+  - "Revert to default" button calls `DELETE …/overrides`.
+  - Live character count with a soft warning at ≥ 400 chars: "Long
+    descriptions dilute model attention. Consider moving rules into the
+    agent's system prompt."
+
+Diff/save logic reuses the `diffPatchableFields()` pattern that lives in
+`apps/admin-console/src/pages/agent-editor-page.tsx`; the API client
+(`apps/admin-console/src/lib/config-api.ts`) gains
+`patchToolOverrides(id, patch)` mirroring `patchAgentOverrides`.
+
+### D9: Orphan handling on tool removal
+
+When a tool is removed from the binary (no longer registered) the seed
+protocol, applied universally to every namespace, takes one of two paths:
+
+- If the existing `ConfigRecord<ToolSpec>` has a non-empty
+  `meta.user_overrides`, the seed marks `meta.hidden = true` instead of
+  deleting it. The runtime's `deserialize_namespace` skips hidden
+  records, so the tool is invisible to resolution; the override is
+  preserved for forensic and recovery purposes.
+- Otherwise the record is hard-deleted.
+
+Re-introducing the spec in a later binary version automatically clears
+`hidden = false`, restoring the tool to the runtime with the user
+override still applied. This soft-delete-with-revival cycle is the
+mechanism that makes rolling deploys safe even when a tool's id changes
+or temporarily disappears from a partial rollout.
+
+`hidden` is reserved for orphan-preservation today; user-toggleable hide
+would need a separate signal. See `crates/awaken-server/src/services/builtin_seed.rs`.
+
+### D10: Validation surface
+
+`ConfigService::patch_tool_overrides` rejects with 422 when:
+
+- The target tool id is not currently registered (no orphan patching).
+- The description fails the validation rules from D2.
+- The body contains fields other than `description` (deny_unknown_fields).
+- The caller attempts a `RecordSource::User` payload via PATCH.
+
+A patch that yields an empty `user_overrides` after merge is normalised to
+`None` so the meta surface stays clean.
+
+### D11: Distributed deployment
+
+The override mechanism inherits the existing config pipeline's distributed
+semantics. The same caveats and operational guidance apply uniformly to
+every namespace (agents, providers, models, mcp-servers, tools).
+
+**Cross-instance propagation.** Each replica maintains its own in-memory
+`Arc<RwLock<RegistrySnapshot>>`. A `PATCH` updates only the receiving
+replica's snapshot; followers pick up the change via
+`start_periodic_refresh` (default cadence is operator-supplied; the
+starter backend uses 5 s). Stores that implement
+`ConfigChangeNotifier` (e.g. Postgres LISTEN/NOTIFY, Redis pub/sub) push
+events through `ConfigRuntimeManager::start_change_listener`, reducing
+the cross-replica latency to single-digit milliseconds; periodic refresh
+remains the safety net.
+
+**Concurrent admin writes.** `lock_apply()` is an in-process mutex. Two
+replicas receiving simultaneous `PATCH`es to the same record can race a
+read-modify-write in the shared `ConfigStore`; the second write wins. For
+multi-replica admin traffic this ADR recommends sticky-session routing
+(L7 cookie or consistent hash on `Authorization`) until a future
+revision adds optimistic concurrency (revision number on `RecordMeta`
+plus a CAS `put_if_revision` method on `ConfigStore`).
+
+**Boot-time seed contention.** The seed protocol's documented
+precondition is single-writer. Multi-replica deploys must run
+`apply_seed` on exactly one replica per cluster. The starter backend
+exposes this contract through the `--leader-seed` /
+`AWAKEN_LEADER_SEED` flag (default `true` for back-compat); operators
+running multiple replicas set it to `false` on followers, which then
+rely on `start_periodic_refresh` (or the change notifier) to absorb the
+leader's writes. Combined with the soft-delete-on-orphan behaviour
+described in D9, this keeps user overrides safe across rolling
+upgrades that change the registered tool/agent set.
+
+**In-flight runs.** A run captures its `ResolvedAgent` at start; mid-run
+override changes do not affect it. Any replica's in-flight runs see the
+description present at run start. Restarting affected runs is required
+for immediate-effect propagation. This is the established behaviour
+documented in ADR-0014; no tool-specific change.
+
+**Apply rollback.** When `apply_locked` fails after a store write, the
+local replica rolls back the envelope. Other replicas that have already
+absorbed the in-flight write through `periodic_refresh` only see the
+rollback on their next refresh. The window is bounded by the refresh
+interval. Audit emission for apply-failure is a future improvement
+(operator visibility, not correctness).
+
+## Alternatives Considered
+
+**Per-agent description overrides as the primary mechanism.** Rejected as
+the default surface: it conflates "the tool's own metadata" with "how a
+specific agent talks about that tool", which is what `system_prompt` already
+expresses. Layering it on top later is purely additive — adding
+`tool_description_overrides: HashMap<ToolId, String>` to `AgentSpecPatch`
+would not require any change to this design.
+
+**Storing overrides outside `ConfigStore`.** Rejected because it would
+fragment the audit, restore, version-switching and seeding mechanisms that
+already cover all spec kinds uniformly.
+
+**Allowing `name` and `category` to be patchable.** Out of scope for this
+ADR. `name` may be the tool-calling protocol identifier in some integrations
+and changing it could break invocation; `category` is a UI grouping concern
+that we do not yet have a story for. Both can be added later without
+breaking changes thanks to `deny_unknown_fields` on the patch type.
+
+## Open Questions
+
+- Should the soft length threshold be operator-configurable per
+  installation? Defaulting to 400 chars based on rule-of-thumb for current
+  tool-using models; revisit if telemetry shows operators routinely
+  approving longer descriptions.
+- Localisation: a single `description` string assumes one
+  audience-language-at-a-time. Multi-language tooling would extend the
+  patch shape later (e.g. `description: Map<Locale, String>`).

--- a/docs/book/src/how-to/use-admin-console.md
+++ b/docs/book/src/how-to/use-admin-console.md
@@ -11,7 +11,7 @@ For the technical inventory of every screen and widget, see
 - A running `awaken-server` reachable from your browser. The default URL is
   `http://127.0.0.1:38080`.
 - An admin bearer token. Set it on the server via either:
-  - `AWAKEN_ADMIN_BEARER_TOKEN` environment variable, or
+  - `AWAKEN_ADMIN_API_BEARER_TOKEN` environment variable, or
   - `AdminApiConfig.bearer_token` field in the server config.
 - The admin console dev server (`apps/admin-console`) running locally — or a
   production build served behind your edge.
@@ -19,7 +19,7 @@ For the technical inventory of every screen and widget, see
 ```sh
 # Terminal 1 — runtime
 AWAKEN_HTTP_ADDR=127.0.0.1:38080 \
-AWAKEN_ADMIN_BEARER_TOKEN=dev-token \
+AWAKEN_ADMIN_API_BEARER_TOKEN=dev-token \
 cargo run -p ai-sdk-starter-agent
 
 # Terminal 2 — admin console

--- a/docs/book/src/operate.md
+++ b/docs/book/src/operate.md
@@ -16,7 +16,8 @@ Two orthogonal levers, both detailed in the
 [config reference](./reference/config.md):
 
 - `AdminApiConfig.bearer_token` (or `AWAKEN_ADMIN_API_BEARER_TOKEN`) protects
-  `/v1/capabilities`, `/v1/config/*`, and `/v1/agents*`.
+  `/v1/capabilities`, `/v1/config/*`, `/v1/agents*`, `/v1/system/info`,
+  `/v1/audit-log`, and runtime-stats endpoints.
 - `AdminApiConfig.expose_config_routes = false` drops the admin CRUD routes
   entirely when configuration is owned by an external pipeline.
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -275,9 +275,9 @@ pub struct AdminApiConfig {
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `bearer_token` | `Option<RedactedString>` | `None` | Requires `Authorization: Bearer ...` for `/v1/capabilities`, `/v1/config/*`, and `/v1/agents*` when set. Redacts itself in `Debug`/`Display`; call `expose_secret()` to read the value. JSON wire format remains a plain string |
+| `bearer_token` | `Option<RedactedString>` | `None` | Requires `Authorization: Bearer ...` for the admin surface when set: `/v1/capabilities`, `/v1/config/*`, `/v1/agents*`, `/v1/system/info`, `/v1/audit-log`, and runtime-stats endpoints. Redacts itself in `Debug`/`Display`; call `expose_secret()` to read the value. JSON wire format remains a plain string |
 | `cors_allowed_origins` | `Vec<String>` | `["http://127.0.0.1:3002", "http://localhost:3002"]` | Browser origins allowed by the admin CORS layer |
-| `expose_config_routes` | `bool` | `true` | Whether the server mounts the `/v1/config/*` and `/v1/agents` admin CRUD routes. Set to `false` to drop those routes entirely when configuration is driven through an external RBAC/audit pipeline. `/v1/capabilities` remains available so frontends can still discover registered components |
+| `expose_config_routes` | `bool` | `true` | Whether the server mounts the admin/configuration HTTP surface. Set to `false` to drop those routes entirely when configuration is driven through an external RBAC/audit pipeline |
 
 Environment variables override the `AppState` admin settings:
 

--- a/docs/book/src/zh-CN/operate.md
+++ b/docs/book/src/zh-CN/operate.md
@@ -15,7 +15,8 @@
 两个互不相关的开关，详见 [配置参考](./reference/config.md)：
 
 - `AdminApiConfig.bearer_token`（或 `AWAKEN_ADMIN_API_BEARER_TOKEN`）保护
-  `/v1/capabilities`、`/v1/config/*`、`/v1/agents*`。
+  `/v1/capabilities`、`/v1/config/*`、`/v1/agents*`、`/v1/system/info`、
+  `/v1/audit-log` 和 runtime-stats 端点。
 - `AdminApiConfig.expose_config_routes = false` 把 admin CRUD 路由整组卸下，
   适合配置由外部流水线管理的部署。
 

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -242,9 +242,9 @@ pub struct AdminApiConfig {
 
 | 字段 | 类型 | 默认值 | 说明 |
 |---|---|---|---|
-| `bearer_token` | `Option<RedactedString>` | `None` | 设置后，`/v1/capabilities`、`/v1/config/*` 和 `/v1/agents*` 要求 `Authorization: Bearer ...`。`Debug`/`Display` 自动遮蔽，需要明文请调用 `expose_secret()`；JSON 序列化保持普通字符串 |
+| `bearer_token` | `Option<RedactedString>` | `None` | 设置后，admin surface 要求 `Authorization: Bearer ...`：`/v1/capabilities`、`/v1/config/*`、`/v1/agents*`、`/v1/system/info`、`/v1/audit-log` 和 runtime-stats 端点。`Debug`/`Display` 自动遮蔽，需要明文请调用 `expose_secret()`；JSON 序列化保持普通字符串 |
 | `cors_allowed_origins` | `Vec<String>` | `["http://127.0.0.1:3002", "http://localhost:3002"]` | admin CORS layer 允许的浏览器来源 |
-| `expose_config_routes` | `bool` | `true` | 是否挂载 `/v1/config/*` 与 `/v1/agents` 这套 admin CRUD 路由。当配置由外部 RBAC/审计流水线管理时设为 `false`，可以彻底隐藏这部分 HTTP 表面；`/v1/capabilities` 仍保持暴露以便前端发现已注册组件 |
+| `expose_config_routes` | `bool` | `true` | 是否挂载 admin/configuration HTTP surface。当配置由外部 RBAC/审计流水线管理时设为 `false`，可以彻底隐藏这部分 HTTP 表面 |
 
 环境变量会覆盖 `AppState` 上的 admin 配置：
 

--- a/e2e/playwright.admin.config.ts
+++ b/e2e/playwright.admin.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `AWAKEN_STORAGE_DIR=${adminStorageDir} AWAKEN_ADMIN_BEARER_TOKEN=${TEST_ADMIN_TOKEN} cargo run -p ai-sdk-starter-agent`,
+      command: `AWAKEN_STORAGE_DIR=${adminStorageDir} AWAKEN_ADMIN_API_BEARER_TOKEN=${TEST_ADMIN_TOKEN} cargo run -p ai-sdk-starter-agent`,
       cwd: '..',
       port: 38080,
       timeout: 120_000,

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -50,10 +50,9 @@ use awaken_runtime::policies::{
 };
 use awaken_server::app::{
     AppState, ServerConfig, SkillCatalogArgument, SkillCatalogContext, SkillCatalogEntry,
-    SkillCatalogProvider,
+    SkillCatalogProvider, build_service_router, serve_with_shutdown,
 };
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
-use awaken_server::routes::build_router;
 use awaken_server::services::config_runtime::{
     ConfigRuntimeError, ConfigRuntimeManager, ProviderExecutorFactory,
 };
@@ -113,6 +112,24 @@ pub struct StarterBackendArgs {
     /// Reasoning effort level: none, low, medium, high, max, or a numeric budget.
     #[arg(long, env = "AGENT_REASONING_EFFORT")]
     pub reasoning_effort: Option<String>,
+
+    /// When true (default), this replica runs `manager.apply_seed(...)` at
+    /// boot. Set to false on non-leader replicas in multi-replica deploys
+    /// so only the leader writes Builtin records to the shared ConfigStore;
+    /// followers rely on `start_periodic_refresh` (and any future
+    /// `ConfigChangeNotifier`) to pull the seeded state.
+    ///
+    /// Seed writes use ConfigStore CAS, but a single seed writer still avoids
+    /// unnecessary startup conflicts in multi-replica deployments.
+    #[arg(
+        long,
+        env = "AWAKEN_LEADER_SEED",
+        default_value_t = true,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
+    pub leader_seed: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1095,24 +1112,39 @@ Always greet the user warmly and ask how you can help today.
         for mcp in &managed_mcp_servers {
             specs.push(BuiltinSpec::mcp_server(mcp.clone()));
         }
+        // Tool description records (ADR-0029): seed every registered tool so
+        // the admin UI can surface and override them. Must come AFTER the
+        // ConfigRuntimeManager is built (it owns the static tool registry).
+        for tool_spec in config_runtime_manager.snapshot_tool_specs() {
+            specs.push(tool_spec);
+        }
         BuiltinSeedSet {
             binary_version: env!("CARGO_PKG_VERSION").to_string(),
             specs,
         }
     };
 
-    let seed_report = config_runtime_manager
-        .apply_seed(&seed)
-        .await
-        .expect("failed to apply built-in seed");
-    tracing::info!(
-        created = seed_report.created.len(),
-        updated = seed_report.updated.len(),
-        unchanged = seed_report.unchanged.len(),
-        deleted = seed_report.deleted.len(),
-        preserved_user = seed_report.preserved_user.len(),
-        "built-in seed applied"
-    );
+    if args.leader_seed {
+        let seed_report = config_runtime_manager
+            .apply_seed(&seed)
+            .await
+            .expect("failed to apply built-in seed");
+        tracing::info!(
+            leader = true,
+            created = seed_report.created.len(),
+            updated = seed_report.updated.len(),
+            unchanged = seed_report.unchanged.len(),
+            deleted = seed_report.deleted.len(),
+            preserved_user = seed_report.preserved_user.len(),
+            preserved_overridden = seed_report.preserved_overridden.len(),
+            "built-in seed applied"
+        );
+    } else {
+        tracing::info!(
+            leader = false,
+            "non-leader replica: skipping apply_seed; relying on periodic_refresh + ConfigStore catch-up"
+        );
+    }
 
     let config_version = config_runtime_manager
         .apply()
@@ -1160,17 +1192,8 @@ Always greet the user warmly and ask how you can help today.
             as Arc<dyn SkillCatalogProvider>,
     );
 
-    let state = if let Ok(token) = std::env::var("AWAKEN_ADMIN_BEARER_TOKEN") {
-        if !token.is_empty() {
-            state.with_admin_api_bearer_token(token)
-        } else {
-            state
-        }
-    } else {
-        state
-    };
-
-    let mut app = build_router(&state).with_state(state);
+    let shutdown_timeout = Duration::from_secs(state.config.shutdown.timeout_secs);
+    let mut app = build_service_router(state).expect("failed to build server router");
 
     if config.enable_cors {
         let cors = CorsLayer::new()
@@ -1189,10 +1212,7 @@ Always greet the user warmly and ask how you can help today.
         "starter backend listening"
     );
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async {
-            let _ = tokio::signal::ctrl_c().await;
-        })
+    serve_with_shutdown(listener, app, shutdown_timeout)
         .await
         .expect("server crashed");
 }
@@ -1339,5 +1359,24 @@ mod build_genai_client_tests {
             resolve_openai_compatible_adapter("gpt-5.4", Some("unknown")),
             AdapterKind::OpenAIResp
         );
+    }
+
+    #[test]
+    fn leader_seed_flag_defaults_true() {
+        use clap::Parser as _;
+        let args = super::StarterBackendArgs::parse_from(["binary"]);
+        assert!(
+            args.leader_seed,
+            "default must be true for single-replica back-compat"
+        );
+    }
+
+    #[test]
+    fn leader_seed_flag_can_be_disabled_via_env() {
+        use clap::Parser as _;
+        // Use the long-form flag rather than env to avoid global env contention
+        // in parallel tests.
+        let args = super::StarterBackendArgs::parse_from(["binary", "--leader-seed=false"]);
+        assert!(!args.leader_seed);
     }
 }


### PR DESCRIPTION
## Summary
- add CAS-backed managed config records, tools namespace, and tool description override APIs
- add Admin Console tools list/editor flow and restore/audit/runtime integration updates
- harden admin auth, CredentialBroker rotation/cache behavior, Google service-account token URI validation, secret redaction, and security audit gates

## Diff vs origin/main
- rebased on `origin/main`
- commit history reduced from 32 PR commits to 4 atomic commits
- removed the process-oriented planning doc from the PR; kept the architecture ADR/book updates
- 64 files changed: 7,103 insertions / 1,378 deletions

## Verification
- `cargo test --workspace --all-targets --locked`
- `cargo clippy --workspace --lib --bins --examples --locked -- -D clippy::correctness`
- `cargo fmt --all -- --check`
- `cargo test -p awaken-server --test admin_security --locked`
- `npm test`
- `npm run build`
- `npm test -- --run src/lib/config-api.test.ts src/pages/tools-page.test.tsx`
- `npm audit --audit-level=high --omit=dev`
- `bash scripts/test-book.sh`
- `cargo audit --deny warnings --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111 --ignore RUSTSEC-2025-0134 --ignore RUSTSEC-2026-0097`

## Security note
The new security workflow blocks new RustSec advisories while explicitly ignoring the current known transitive/upstream advisories listed above.