### PR TITLE
🔒 chore(admin-console): bump fast-uri to 3.1.2

### DIFF
--- a/apps/admin-console/package-lock.json
+++ b/apps/admin-console/package-lock.json
@@ -4904,9 +4904,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- Bumps `fast-uri` from 3.1.0 to 3.1.2 in `apps/admin-console/package-lock.json`
- Resolves the high-severity advisories blocking `Admin Console npm Audit` on every PR:
  - GHSA-q3j6-qgpj-74h6 (path traversal via percent-encoded dot segments)
  - GHSA-v39h-62p7-jpjc (host confusion via percent-encoded authority delimiters)

## Test plan

- [x] `cd apps/admin-console && npm audit --audit-level=high --omit=dev` → `found 0 vulnerabilities`
- [x] `cd apps/admin-console && npm install && npm run build` → succeeds
- [ ] CI `Admin Console npm Audit` job passes