### PR TITLE
Agent editor: fix data-loss + 7 UX gaps (G1-G9)

### DIFF
--- a/apps/admin-console/src/components/agent-preview-panel.test.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { UIMessage } from "@ai-sdk/react";
+import { MessageParts, hasRenderableContent } from "./agent-preview-panel";
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Build a `UIMessage` from an array of parts. Caller decides the shape so
+ *  each test case mirrors an AI SDK stream snapshot without relying on a
+ *  live backend.  */
+function uiMessage(parts: unknown[]): UIMessage {
+  return {
+    id: "m-1",
+    role: "assistant",
+    parts: parts as UIMessage["parts"],
+  } as UIMessage;
+}
+
+describe("MessageParts — AI SDK part states (R3 #5)", () => {
+  it("renders a non-empty text part", () => {
+    render(<MessageParts message={uiMessage([{ type: "text", text: "hello" }])} />);
+    expect(screen.getByText("hello")).toBeTruthy();
+  });
+
+  it("skips an empty text part rather than printing a blank bubble", () => {
+    render(<MessageParts message={uiMessage([{ type: "text", text: "" }])} />);
+    expect(screen.queryByText(/empty turn/)).toBeTruthy();
+  });
+
+  it("renders reasoning inside a collapsible details block", () => {
+    render(
+      <MessageParts
+        message={uiMessage([{ type: "reasoning", text: "let me think step by step" }])}
+      />,
+    );
+    expect(screen.getByText("Reasoning")).toBeTruthy();
+    expect(screen.getByText("let me think step by step")).toBeTruthy();
+  });
+
+  it("renders a `dynamic-tool` part as a ToolInvocation card with name + input", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "dynamic-tool",
+            toolName: "get_weather",
+            toolCallId: "call-abcd1234",
+            state: "input-streaming",
+            input: { city: "SF" },
+          },
+        ])}
+      />,
+    );
+    expect(screen.getByText("get_weather")).toBeTruthy();
+    expect(screen.getByText(/Calling/)).toBeTruthy();
+    expect(screen.getByText(/SF/)).toBeTruthy();
+  });
+
+  it("renders a typed `tool-<name>` part identical to dynamic-tool", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-get_weather",
+            state: "input-available",
+            input: { city: "NYC" },
+          },
+        ])}
+      />,
+    );
+    expect(screen.getByText("get_weather")).toBeTruthy();
+    expect(screen.getByText(/NYC/)).toBeTruthy();
+  });
+
+  it("renders `output-available` with the Done badge and an Output block", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-get_weather",
+            state: "output-available",
+            input: { city: "SF" },
+            output: { temp_c: 18 },
+          },
+        ])}
+      />,
+    );
+    expect(screen.getByText(/Done/)).toBeTruthy();
+    expect(screen.getByText(/temp_c/)).toBeTruthy();
+  });
+
+  it("renders `output-error` with the Error badge and errorText (not output)", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-get_weather",
+            state: "output-error",
+            input: { city: "??" },
+            output: "should not be visible",
+            errorText: "Tool execution failed: timeout",
+          },
+        ])}
+      />,
+    );
+    // Two Error labels render: the state badge ("Error") and the section
+    // heading above the errorText body. Both must be present.
+    expect(screen.getAllByText(/Error/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/Tool execution failed: timeout/)).toBeTruthy();
+    expect(screen.queryByText(/should not be visible/)).toBeNull();
+  });
+
+  it("renders `output-denied` with the Denied badge", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-Bash",
+            state: "output-denied",
+            input: { cmd: "rm -rf /" },
+          },
+        ])}
+      />,
+    );
+    expect(screen.getByText(/Denied/)).toBeTruthy();
+  });
+
+  it("renders `approval-requested` with the awaiting-approval badge", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-Bash",
+            state: "approval-requested",
+            input: { cmd: "ls" },
+          },
+        ])}
+      />,
+    );
+    expect(screen.getByText(/Awaiting approval/)).toBeTruthy();
+  });
+
+  it("skips `step-start` parts silently (no bubble content)", () => {
+    render(<MessageParts message={uiMessage([{ type: "step-start" }])} />);
+    expect(screen.getByText(/empty turn/)).toBeTruthy();
+  });
+
+  // R3 #6: unknown parts must not silently render an empty bubble — they go
+  // into the "unrecognized part" debug fallback so the user sees them.
+  it("collects unknown parts into a single debug fallback", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          { type: "source", url: "https://example.com" },
+          { type: "metadata", payload: 42 },
+        ])}
+      />,
+    );
+    const fallback = screen.getByTestId("message-unknown-parts");
+    expect(fallback).toBeTruthy();
+    expect(fallback.textContent ?? "").toContain("2 unrecognized parts");
+    expect(fallback.textContent ?? "").toContain("source");
+    expect(fallback.textContent ?? "").toContain("metadata");
+  });
+
+  it("mixes text + tool + unknown without losing any of them", () => {
+    render(
+      <MessageParts
+        message={uiMessage([
+          { type: "step-start" },
+          { type: "text", text: "Let me check the weather." },
+          {
+            type: "tool-get_weather",
+            state: "output-available",
+            input: { city: "SF" },
+            output: { temp_c: 18 },
+          },
+          { type: "metadata", payload: 1 },
+        ])}
+      />,
+    );
+    expect(screen.getByText("Let me check the weather.")).toBeTruthy();
+    expect(screen.getByText("get_weather")).toBeTruthy();
+    expect(screen.getByTestId("message-unknown-parts")).toBeTruthy();
+  });
+});
+
+describe("hasRenderableContent (R3 #6)", () => {
+  it("returns false for a message containing only step-start", () => {
+    expect(hasRenderableContent(uiMessage([{ type: "step-start" }]))).toBe(false);
+  });
+
+  it("returns false for an empty-text message", () => {
+    expect(hasRenderableContent(uiMessage([{ type: "text", text: "" }]))).toBe(false);
+  });
+
+  it("returns false for unknown parts only (no empty bubble for sources/metadata)", () => {
+    // This is the regression: previously `hasRenderableContent` returned
+    // true for anything non-step-start non-empty-text, so a message
+    // containing only metadata/source parts would draw an empty bubble.
+    expect(
+      hasRenderableContent(
+        uiMessage([
+          { type: "source", url: "https://example.com" },
+          { type: "metadata", payload: 42 },
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for a tool part even with no text", () => {
+    expect(
+      hasRenderableContent(
+        uiMessage([{ type: "tool-Bash", state: "input-streaming", input: {} }]),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for a non-empty reasoning part", () => {
+    expect(
+      hasRenderableContent(uiMessage([{ type: "reasoning", text: "thinking…" }])),
+    ).toBe(true);
+  });
+
+  it("returns true for a real text part", () => {
+    expect(hasRenderableContent(uiMessage([{ type: "text", text: "hi" }]))).toBe(true);
+  });
+});

--- a/apps/admin-console/src/components/agent-preview-panel.test.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.test.tsx
@@ -1,13 +1,56 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { UIMessage } from "@ai-sdk/react";
 import {
+  AgentPreviewPanel,
   MessageParts,
   hasRenderableContent,
   normalizePreviewAgent,
 } from "./agent-preview-panel";
 import type { AgentSpec, RemoteEndpoint } from "../lib/api/types";
+
+const previewHarness = vi.hoisted(() => ({
+  messages: [] as UIMessage[],
+  status: "ready" as "ready" | "submitted" | "streaming" | "error",
+  error: undefined as Error | undefined,
+  sendMessage: vi.fn(),
+  setMessages: vi.fn(),
+  useChat: vi.fn(),
+  drawerProps: [] as Array<{ agentId: string; open: boolean; onClose: () => void }>,
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: previewHarness.useChat,
+}));
+
+vi.mock("@/components/recent-traces-drawer", () => ({
+  RecentTracesDrawer: (props: { agentId: string; open: boolean; onClose: () => void }) => {
+    previewHarness.drawerProps.push(props);
+    return props.open ? (
+      <div data-testid="recent-traces-drawer" data-agent-id={props.agentId}>
+        Recent runs drawer
+      </div>
+    ) : null;
+  },
+}));
+
+beforeEach(() => {
+  previewHarness.messages = [];
+  previewHarness.status = "ready";
+  previewHarness.error = undefined;
+  previewHarness.drawerProps.length = 0;
+  previewHarness.sendMessage.mockClear();
+  previewHarness.setMessages.mockClear();
+  previewHarness.useChat.mockReset();
+  previewHarness.useChat.mockImplementation(() => ({
+    messages: previewHarness.messages,
+    sendMessage: previewHarness.sendMessage,
+    setMessages: previewHarness.setMessages,
+    status: previewHarness.status,
+    error: previewHarness.error,
+  }));
+});
 
 afterEach(() => {
   cleanup();
@@ -24,10 +67,39 @@ function uiMessage(parts: unknown[]): UIMessage {
   } as UIMessage;
 }
 
+function agentDraft(overrides: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    id: "saved-agent",
+    model_id: "research-default",
+    system_prompt: "You are a test agent.",
+    plugin_ids: [],
+    active_hook_filter: [],
+    sections: {},
+    delegates: [],
+    ...overrides,
+  };
+}
+
 describe("MessageParts — AI SDK part states (R3 #5)", () => {
   it("renders a non-empty text part", () => {
     render(<MessageParts message={uiMessage([{ type: "text", text: "hello" }])} />);
     expect(screen.getByText("hello")).toBeTruthy();
+  });
+
+  it("redacts credential patterns inside assistant text parts", () => {
+    const { container } = render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "text",
+            text: "upstream echoed Authorization: Bearer sk-real-secret-value",
+          },
+        ])}
+      />,
+    );
+    const dom = container.textContent ?? "";
+    expect(dom).not.toContain("sk-real-secret-value");
+    expect(dom).toContain("Authorization: ***");
   });
 
   it("skips an empty text part rather than printing a blank bubble", () => {
@@ -43,6 +115,22 @@ describe("MessageParts — AI SDK part states (R3 #5)", () => {
     );
     expect(screen.getByText("Reasoning")).toBeTruthy();
     expect(screen.getByText("let me think step by step")).toBeTruthy();
+  });
+
+  it("redacts credential patterns inside reasoning parts", () => {
+    const { container } = render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "reasoning",
+            text: "I should call the API with Bearer real-bearer-token-1234567890",
+          },
+        ])}
+      />,
+    );
+    const dom = container.textContent ?? "";
+    expect(dom).not.toContain("real-bearer-token-1234567890");
+    expect(dom).toContain("Bearer ***");
   });
 
   it("renders a `dynamic-tool` part as a ToolInvocation card with name + input", () => {
@@ -269,6 +357,33 @@ describe("MessageParts — AI SDK part states (R3 #5)", () => {
   });
 });
 
+describe("AgentPreviewPanel — redaction and trace gating", () => {
+  it("redacts transport/server error messages before rendering", () => {
+    previewHarness.error = new Error(
+      "preview failed with Authorization: Bearer sk-real-secret-value",
+    );
+    const { container } = render(<AgentPreviewPanel draft={agentDraft()} />);
+    const dom = container.textContent ?? "";
+    expect(dom).not.toContain("sk-real-secret-value");
+    expect(dom).toContain("Authorization: ***");
+  });
+
+  it("does not show Recent runs for a new unsaved draft with a fallback preview id", () => {
+    const { container } = render(<AgentPreviewPanel draft={agentDraft({ id: "   " })} />);
+    expect(container.textContent ?? "").toContain("draft-preview");
+    expect(screen.queryByTestId("open-recent-traces")).toBeNull();
+    const lastDrawerProps = previewHarness.drawerProps[previewHarness.drawerProps.length - 1];
+    expect(lastDrawerProps.agentId).toBe("");
+  });
+
+  it("opens Recent runs with the real saved agent id, not the preview fallback id", () => {
+    render(<AgentPreviewPanel draft={agentDraft({ id: " saved-agent " })} />);
+    fireEvent.click(screen.getByTestId("open-recent-traces"));
+    const drawer = screen.getByTestId("recent-traces-drawer");
+    expect(drawer.getAttribute("data-agent-id")).toBe("saved-agent");
+  });
+});
+
 describe("hasRenderableContent (R3 #6)", () => {
   it("returns false for a message containing only step-start", () => {
     expect(hasRenderableContent(uiMessage([{ type: "step-start" }]))).toBe(false);
@@ -296,23 +411,19 @@ describe("hasRenderableContent (R3 #6)", () => {
   });
 
   it("returns false when step-start is the only typed part — nothing to render", () => {
-    expect(
-      hasRenderableContent(uiMessage([{ type: "step-start" }, { type: "step-start" }])),
-    ).toBe(false);
+    expect(hasRenderableContent(uiMessage([{ type: "step-start" }, { type: "step-start" }]))).toBe(
+      false,
+    );
   });
 
   it("returns true for a tool part even with no text", () => {
     expect(
-      hasRenderableContent(
-        uiMessage([{ type: "tool-Bash", state: "input-streaming", input: {} }]),
-      ),
+      hasRenderableContent(uiMessage([{ type: "tool-Bash", state: "input-streaming", input: {} }])),
     ).toBe(true);
   });
 
   it("returns true for a non-empty reasoning part", () => {
-    expect(
-      hasRenderableContent(uiMessage([{ type: "reasoning", text: "thinking…" }])),
-    ).toBe(true);
+    expect(hasRenderableContent(uiMessage([{ type: "reasoning", text: "thinking…" }]))).toBe(true);
   });
 
   it("returns true for a real text part", () => {

--- a/apps/admin-console/src/components/agent-preview-panel.test.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.test.tsx
@@ -376,8 +376,20 @@ describe("AgentPreviewPanel — redaction and trace gating", () => {
     expect(lastDrawerProps.agentId).toBe("");
   });
 
+  it("does not show Recent runs for a new unsaved draft after the user enters an id", () => {
+    render(<AgentPreviewPanel draft={agentDraft({ id: "my-new-agent" })} />);
+    expect(screen.queryByTestId("open-recent-traces")).toBeNull();
+    const lastDrawerProps = previewHarness.drawerProps[previewHarness.drawerProps.length - 1];
+    expect(lastDrawerProps.agentId).toBe("");
+  });
+
   it("opens Recent runs with the real saved agent id, not the preview fallback id", () => {
-    render(<AgentPreviewPanel draft={agentDraft({ id: " saved-agent " })} />);
+    render(
+      <AgentPreviewPanel
+        draft={agentDraft({ id: " edited-draft-id " })}
+        traceAgentId=" saved-agent "
+      />,
+    );
     fireEvent.click(screen.getByTestId("open-recent-traces"));
     const drawer = screen.getByTestId("recent-traces-drawer");
     expect(drawer.getAttribute("data-agent-id")).toBe("saved-agent");

--- a/apps/admin-console/src/components/agent-preview-panel.test.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.test.tsx
@@ -2,7 +2,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { UIMessage } from "@ai-sdk/react";
-import { MessageParts, hasRenderableContent } from "./agent-preview-panel";
+import {
+  MessageParts,
+  hasRenderableContent,
+  normalizePreviewAgent,
+} from "./agent-preview-panel";
+import type { AgentSpec, RemoteEndpoint } from "../lib/api/types";
 
 afterEach(() => {
   cleanup();
@@ -312,5 +317,88 @@ describe("hasRenderableContent (R3 #6)", () => {
 
   it("returns true for a real text part", () => {
     expect(hasRenderableContent(uiMessage([{ type: "text", text: "hi" }]))).toBe(true);
+  });
+});
+
+// R14 — `/v1/ai-sdk/agent-previews/runs` rejects payloads carrying
+// `endpoint` or `registry` (the server forces local-only resolution to
+// stop a crafted draft from routing the run to an arbitrary backend or
+// skipping registry-membership checks). Builtin / customized records the
+// editor loads naturally carry `registry`, and any agent backed by a
+// remote backend carries `endpoint`. Without this strip, every preview
+// of such an agent fails with 400 — a hard regression for the most
+// common use case.
+describe("normalizePreviewAgent — strip endpoint/registry for preview (R14)", () => {
+  function previewSpec(overrides: Partial<AgentSpec> = {}): AgentSpec {
+    return {
+      id: "draft",
+      model_id: "research-default",
+      system_prompt: "You are a test agent.",
+      ...overrides,
+    };
+  }
+
+  const REMOTE_ENDPOINT: RemoteEndpoint = {
+    backend: "a2a",
+    base_url: "https://remote.example.com",
+    target: "remote-agent",
+    timeout_ms: 60_000,
+  };
+
+  it("strips endpoint from the payload", () => {
+    const draft = previewSpec({ endpoint: REMOTE_ENDPOINT });
+    const out = normalizePreviewAgent(draft);
+    expect(out.endpoint).toBeUndefined();
+    expect("endpoint" in out).toBe(false);
+  });
+
+  it("strips registry from the payload", () => {
+    const draft = previewSpec({ registry: "cloud" });
+    const out = normalizePreviewAgent(draft);
+    expect(out.registry).toBeUndefined();
+    expect("registry" in out).toBe(false);
+  });
+
+  it("strips both endpoint and registry simultaneously", () => {
+    const draft = previewSpec({ endpoint: REMOTE_ENDPOINT, registry: "cloud" });
+    const out = normalizePreviewAgent(draft);
+    expect("endpoint" in out).toBe(false);
+    expect("registry" in out).toBe(false);
+  });
+
+  it("preserves every other patchable field", () => {
+    const draft = previewSpec({
+      endpoint: REMOTE_ENDPOINT,
+      registry: "cloud",
+      plugin_ids: ["permission"],
+      active_hook_filter: ["permission"],
+      sections: { permission: { default_behavior: "ask" } },
+      delegates: ["other"],
+      allowed_tools: ["Bash"],
+      excluded_tools: ["Read"],
+      max_rounds: 16,
+      reasoning_effort: "high",
+    });
+    const out = normalizePreviewAgent(draft);
+    expect(out.plugin_ids).toEqual(["permission"]);
+    expect(out.active_hook_filter).toEqual(["permission"]);
+    expect(out.sections).toEqual({ permission: { default_behavior: "ask" } });
+    expect(out.delegates).toEqual(["other"]);
+    expect(out.allowed_tools).toEqual(["Bash"]);
+    expect(out.excluded_tools).toEqual(["Read"]);
+    expect(out.max_rounds).toBe(16);
+    expect(out.reasoning_effort).toBe("high");
+  });
+
+  it("defaults a blank id to 'draft-preview'", () => {
+    const out = normalizePreviewAgent(previewSpec({ id: "   " }));
+    expect(out.id).toBe("draft-preview");
+  });
+
+  it("does not mutate the source draft", () => {
+    const draft = previewSpec({ endpoint: REMOTE_ENDPOINT, registry: "cloud" });
+    const snapshot = JSON.parse(JSON.stringify(draft));
+    normalizePreviewAgent(draft);
+    expect(draft).toEqual(snapshot);
   });
 });

--- a/apps/admin-console/src/components/agent-preview-panel.test.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.test.tsx
@@ -113,6 +113,82 @@ describe("MessageParts — AI SDK part states (R3 #5)", () => {
     expect(screen.queryByText(/should not be visible/)).toBeNull();
   });
 
+  // R10 #5 — Tool input/output payloads can carry API keys / auth
+  // headers / cookies / JWTs. Until R10 they were JSON-stringified
+  // directly into the preview DOM; the redaction pipeline used by
+  // audit/trace/diff did not cover this code path.
+  it("redacts secret-bearing keys in tool input and output", () => {
+    const { container } = render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-call_api",
+            state: "output-available",
+            input: {
+              headers: { authorization: "Bearer real-token", cookie: "sid=raw" },
+              jwt: "raw-jwt",
+            },
+            output: { api_key: "raw-key", bearer: "raw-bearer", data: { ok: true } },
+          },
+        ])}
+      />,
+    );
+    const dom = container.textContent ?? "";
+    // None of the raw credential strings may appear in the DOM.
+    expect(dom).not.toContain("real-token");
+    expect(dom).not.toContain("sid=raw");
+    expect(dom).not.toContain("raw-jwt");
+    expect(dom).not.toContain("raw-key");
+    expect(dom).not.toContain("raw-bearer");
+    // The redacted placeholder shows up where the secrets used to be.
+    expect(dom).toContain("***");
+    // Non-secret data is preserved.
+    expect(dom).toContain('"ok": true');
+  });
+
+  // R12 #3 — Output paths missed by R10's object-only redaction:
+  // primitive string outputs, and `errorText` (rendered to a separate
+  // <pre>). Both pass through `redactSecretString` now.
+  it("redacts credential patterns inside a primitive string tool output", () => {
+    const { container } = render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-call_api",
+            state: "output-available",
+            input: {},
+            output:
+              "called with Authorization: Bearer sk-real-secret-value and api_key=raw-key-12345",
+          },
+        ])}
+      />,
+    );
+    const dom = container.textContent ?? "";
+    expect(dom).not.toContain("sk-real-secret-value");
+    expect(dom).not.toContain("raw-key-12345");
+    expect(dom).toContain("***");
+  });
+
+  it("redacts credential patterns inside tool errorText", () => {
+    const { container } = render(
+      <MessageParts
+        message={uiMessage([
+          {
+            type: "tool-call_api",
+            state: "output-error",
+            input: {},
+            errorText:
+              "request failed with Bearer real-bearer-token-1234567890 — body had api_key=raw-key",
+          },
+        ])}
+      />,
+    );
+    const dom = container.textContent ?? "";
+    expect(dom).not.toContain("real-bearer-token-1234567890");
+    expect(dom).not.toContain("raw-key");
+    expect(dom).toContain("Bearer ***");
+  });
+
   it("renders `output-denied` with the Denied badge", () => {
     render(
       <MessageParts
@@ -197,10 +273,13 @@ describe("hasRenderableContent (R3 #6)", () => {
     expect(hasRenderableContent(uiMessage([{ type: "text", text: "" }]))).toBe(false);
   });
 
-  it("returns false for unknown parts only (no empty bubble for sources/metadata)", () => {
-    // This is the regression: previously `hasRenderableContent` returned
-    // true for anything non-step-start non-empty-text, so a message
-    // containing only metadata/source parts would draw an empty bubble.
+  // R8 #4 — unknown-only message: MessageParts renders the unrecognized-
+  // parts collapsible fallback for these, so the bubble is informative
+  // (the user can expand and see what types arrived). Filtering them
+  // out at this gate would hide the diagnostic entirely. (PR #189
+  // description: "Unknown SDK parts collapse into an unrecognized part
+  // debug fallback".)
+  it("returns true for unknown parts only — they render the debug fallback", () => {
     expect(
       hasRenderableContent(
         uiMessage([
@@ -208,6 +287,12 @@ describe("hasRenderableContent (R3 #6)", () => {
           { type: "metadata", payload: 42 },
         ]),
       ),
+    ).toBe(true);
+  });
+
+  it("returns false when step-start is the only typed part — nothing to render", () => {
+    expect(
+      hasRenderableContent(uiMessage([{ type: "step-start" }, { type: "step-start" }])),
     ).toBe(false);
   });
 

--- a/apps/admin-console/src/components/agent-preview-panel.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.tsx
@@ -17,11 +17,19 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
   const [tracesOpen, setTracesOpen] = useState(false);
   const sendStartedAtRef = useRef<number | null>(null);
   const previewDraft = normalizePreviewAgent(draft);
+  const traceAgentId = draft.id.trim();
+  const canShowRecentRuns = traceAgentId.length > 0;
   const draftRef = useRef(previewDraft);
 
   useEffect(() => {
     draftRef.current = previewDraft;
   }, [previewDraft]);
+
+  useEffect(() => {
+    if (!canShowRecentRuns) {
+      setTracesOpen(false);
+    }
+  }, [canShowRecentRuns]);
 
   const transport = useMemo(
     () =>
@@ -88,7 +96,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
           Sandbox <span className="font-normal text-fg-soft">runs against current draft</span>
         </h3>
         <div className="flex items-center gap-3">
-          {previewDraft.id.trim().length > 0 ? (
+          {canShowRecentRuns ? (
             <button
               type="button"
               onClick={() => setTracesOpen(true)}
@@ -109,14 +117,15 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
       </div>
 
       <RecentTracesDrawer
-        agentId={previewDraft.id}
+        agentId={traceAgentId}
         open={tracesOpen}
         onClose={() => setTracesOpen(false)}
       />
 
       <div className="mt-3 rounded-md bg-code-bg px-3 py-2 font-mono text-[11px] leading-5 text-code-fg">
-        <span className="text-code-fg/70">id=</span>{previewDraft.id}{" "}
-        <span className="text-code-fg/70">model=</span>{previewDraft.model_id || "unassigned"}
+        <span className="text-code-fg/70">id=</span>
+        {previewDraft.id} <span className="text-code-fg/70">model=</span>
+        {previewDraft.model_id || "unassigned"}
       </div>
 
       <PreviewStatsBar messages={messages} latencyMs={lastLatencyMs} busy={busy} />
@@ -129,7 +138,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
 
       {error ? (
         <div className="mt-4 rounded-md border border-tone-error/30 bg-tone-error/10 px-4 py-3 text-sm text-tone-error">
-          {error.message}
+          {redactSecretString(error.message)}
         </div>
       ) : null}
 
@@ -151,9 +160,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
                     key={message.id}
                     className={[
                       "max-w-[92%] rounded-md px-4 py-3 text-sm leading-6 shadow-sm",
-                      isUser
-                        ? "ml-auto bg-accent text-accent-text"
-                        : "bg-surface text-fg",
+                      isUser ? "ml-auto bg-accent text-accent-text" : "bg-surface text-fg",
                     ].join(" ")}
                   >
                     <div
@@ -177,10 +184,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
           )}
         </div>
 
-        <form
-          onSubmit={handleSubmit}
-          className="border-t border-line bg-surface px-4 py-4"
-        >
+        <form onSubmit={handleSubmit} className="border-t border-line bg-surface px-4 py-4">
           <textarea
             value={input}
             onChange={(event) => setInput(event.target.value)}
@@ -190,10 +194,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
             className="w-full rounded-md border border-line-strong bg-surface px-4 py-3 text-sm text-fg-strong outline-none transition focus:border-line-strong disabled:bg-muted disabled:text-fg-soft"
           />
           <div className="mt-3 flex items-center justify-between gap-3">
-            <div
-              title={`Session ID: ${sessionId}`}
-              className="font-mono text-[10px] text-fg-faint"
-            >
+            <div title={`Session ID: ${sessionId}`} className="font-mono text-[10px] text-fg-faint">
               session · {sessionId.slice(-8)}
             </div>
             <button
@@ -245,9 +246,7 @@ function PreviewStatsBar({
 function StatCell({ label, value, title }: { label: string; value: string; title?: string }) {
   return (
     <div className="bg-surface px-3 py-2" title={title}>
-      <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
-        {label}
-      </div>
+      <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">{label}</div>
       <div className="mt-0.5 font-mono text-sm font-semibold text-fg-strong">{value}</div>
     </div>
   );
@@ -266,7 +265,7 @@ export function MessageParts({ message }: { message: UIMessage }) {
       if (typeof part.text === "string" && part.text.length > 0) {
         rendered.push(
           <div key={index} className="whitespace-pre-wrap break-words">
-            {part.text}
+            {redactSecretString(part.text)}
           </div>,
         );
       }
@@ -284,7 +283,7 @@ export function MessageParts({ message }: { message: UIMessage }) {
             Reasoning
           </summary>
           <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] text-fg">
-            {text}
+            {redactSecretString(text)}
           </pre>
         </details>,
       );
@@ -361,9 +360,7 @@ function ToolInvocation({ part }: { part: ToolPart }) {
         ) : null}
       </summary>
       <div className="border-t border-line px-3 py-2">
-        <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
-          Input
-        </div>
+        <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">Input</div>
         <pre className="mt-1 max-h-48 overflow-auto rounded-md bg-code-bg p-2 font-mono text-[11px] text-code-fg">
           {formatJson(part.input)}
         </pre>
@@ -487,11 +484,7 @@ export function normalizePreviewAgent(draft: AgentSpec): AgentSpec {
   // without this strip every preview of a registry-resident agent would
   // fail with `BadRequest`. The runtime preview is always local —
   // endpoint and registry are not meaningful here.
-  const {
-    endpoint: _endpoint,
-    registry: _registry,
-    ...localDraft
-  } = draft;
+  const { endpoint: _endpoint, registry: _registry, ...localDraft } = draft;
   return {
     ...localDraft,
     id: localDraft.id.trim() || "draft-preview",

--- a/apps/admin-console/src/components/agent-preview-panel.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.tsx
@@ -476,15 +476,30 @@ function formatJson(value: unknown): string {
   }
 }
 
-function normalizePreviewAgent(draft: AgentSpec): AgentSpec {
+export function normalizePreviewAgent(draft: AgentSpec): AgentSpec {
+  // Strip provenance / locality fields before sending to the preview
+  // endpoint. The server's `/v1/ai-sdk/agent-previews/runs` route returns
+  // 400 if either `endpoint` or `registry` is present in the payload —
+  // it forces the preview into the local-only resolve path so a crafted
+  // draft can't route the run to an arbitrary remote backend or skip
+  // registry-membership checks. Builtin / customized records loaded into
+  // the editor naturally carry `registry` (and may carry `endpoint`), so
+  // without this strip every preview of a registry-resident agent would
+  // fail with `BadRequest`. The runtime preview is always local —
+  // endpoint and registry are not meaningful here.
+  const {
+    endpoint: _endpoint,
+    registry: _registry,
+    ...localDraft
+  } = draft;
   return {
-    ...draft,
-    id: draft.id.trim() || "draft-preview",
-    model_id: String(draft.model_id ?? "").trim(),
-    system_prompt: String(draft.system_prompt ?? ""),
-    plugin_ids: [...(draft.plugin_ids ?? [])],
-    delegates: [...(draft.delegates ?? [])],
-    sections: { ...(draft.sections ?? {}) },
+    ...localDraft,
+    id: localDraft.id.trim() || "draft-preview",
+    model_id: String(localDraft.model_id ?? "").trim(),
+    system_prompt: String(localDraft.system_prompt ?? ""),
+    plugin_ids: [...(localDraft.plugin_ids ?? [])],
+    delegates: [...(localDraft.delegates ?? [])],
+    sections: { ...(localDraft.sections ?? {}) },
   };
 }
 

--- a/apps/admin-console/src/components/agent-preview-panel.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.tsx
@@ -3,21 +3,29 @@ import { useChat, type UIMessage } from "@ai-sdk/react";
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { agentPreviewRunUrl, type AgentSpec } from "@/lib/config-api";
 import { adminAuthHeaders } from "@/lib/api/http";
-import { redactSecretString, redactSecretsForDisplay } from "@/lib/agent-editor-helpers";
+import {
+  redactSecretString,
+  redactSecretsForDisplay,
+  safeErrorMessage,
+} from "@/lib/agent-editor-helpers";
 import { RecentTracesDrawer } from "@/components/recent-traces-drawer";
 
 interface AgentPreviewPanelProps {
   draft: AgentSpec;
+  traceAgentId?: string;
 }
 
-export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
+export function AgentPreviewPanel({
+  draft,
+  traceAgentId: rawTraceAgentId,
+}: AgentPreviewPanelProps) {
   const [sessionId, setSessionId] = useState(() => makePreviewSessionId());
   const [input, setInput] = useState("");
   const [lastLatencyMs, setLastLatencyMs] = useState<number | null>(null);
   const [tracesOpen, setTracesOpen] = useState(false);
   const sendStartedAtRef = useRef<number | null>(null);
   const previewDraft = normalizePreviewAgent(draft);
-  const traceAgentId = draft.id.trim();
+  const traceAgentId = rawTraceAgentId?.trim() ?? "";
   const canShowRecentRuns = traceAgentId.length > 0;
   const draftRef = useRef(previewDraft);
 
@@ -36,11 +44,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
       new DefaultChatTransport({
         api: agentPreviewRunUrl(),
         prepareSendMessagesRequest: ({ messages }) => ({
-          // R11 #1 — the preview route is admin-only on the server.
-          // Without this header the request 401s; resolving the token
-          // here (rather than in a static `headers` option) lets the
-          // resolver react to a freshly-saved bearer or a dev-env
-          // fallback at send time.
+          // Resolve auth at send time so a freshly-saved bearer is used.
           headers: adminAuthHeaders(),
           body: {
             threadId: sessionId,
@@ -138,7 +142,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
 
       {error ? (
         <div className="mt-4 rounded-md border border-tone-error/30 bg-tone-error/10 px-4 py-3 text-sm text-tone-error">
-          {redactSecretString(error.message)}
+          {safeErrorMessage(error)}
         </div>
       ) : null}
 
@@ -420,14 +424,8 @@ const TOOL_TONE_STYLE: Record<"neutral" | "info" | "success" | "warn" | "error",
 };
 
 export function hasRenderableContent(message: UIMessage): boolean {
-  // A bubble is worth drawing when MessageParts would emit at least one
-  // visible element. Mirrors the render path's three cases:
-  //   1. Known content with payload (text/reasoning/tool).
-  //   2. Unknown SDK type → collapsed into the unrecognized-parts debug
-  //      fallback. R8 #4: previously dropped here, which contradicted
-  //      the PR's "unknown parts collapse into a debug fallback" goal.
-  //   3. step-start / empty text / empty reasoning → MessageParts skips
-  //      these silently; nothing reaches the DOM.
+  // Mirrors MessageParts: known payloads and unknown SDK parts render; empty
+  // text/reasoning and step separators do not.
   return message.parts.some(isDisplayablePart);
 }
 

--- a/apps/admin-console/src/components/agent-preview-panel.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.tsx
@@ -245,10 +245,38 @@ function StatCell({ label, value, title }: { label: string; value: string; title
   );
 }
 
-function MessageParts({ message }: { message: UIMessage }) {
+/**
+ * Decide whether a `UIMessage.parts` entry has anything we render today.
+ * Shared by `MessageParts` (to choose what to draw) and
+ * `hasRenderableContent` (to decide whether to show a bubble at all) so
+ * the two cannot drift — drift produces empty bubbles for parts the
+ * renderer doesn't know about (e.g. AI SDK metadata / source parts).
+ */
+function isRenderablePart(part: unknown): boolean {
+  if (!part || typeof part !== "object" || !("type" in part)) return false;
+  const typed = part as { type: string; text?: unknown };
+  if (typed.type === "step-start") return false;
+  if (typed.type === "text") {
+    return typeof typed.text === "string" && typed.text.length > 0;
+  }
+  if (typed.type === "reasoning") {
+    return typeof typed.text === "string" && typed.text.length > 0;
+  }
+  if (typed.type === "dynamic-tool" || typed.type.startsWith("tool-")) {
+    return true;
+  }
+  return false;
+}
+
+export function MessageParts({ message }: { message: UIMessage }) {
   const rendered: ReactNode[] = [];
+  const unknownTypes: string[] = [];
   for (const [index, part] of message.parts.entries()) {
     if (!part || typeof part !== "object" || !("type" in part)) continue;
+    if (part.type === "step-start") {
+      // Visual separator between agent turns; no content.
+      continue;
+    }
     if (part.type === "text") {
       if (typeof part.text === "string" && part.text.length > 0) {
         rendered.push(
@@ -281,10 +309,29 @@ function MessageParts({ message }: { message: UIMessage }) {
       rendered.push(<ToolInvocation key={index} part={part as ToolPart} />);
       continue;
     }
-    if (part.type === "step-start") {
-      // Visual separator between agent turns; no content.
-      continue;
-    }
+    // Anything we don't render directly — metadata, source, file, future
+    // SDK additions — gets collected into a single collapsible debug
+    // fallback rather than producing an empty bubble.
+    unknownTypes.push(part.type);
+  }
+  if (unknownTypes.length > 0) {
+    rendered.push(
+      <details
+        key="__unknown_parts"
+        data-testid="message-unknown-parts"
+        className="rounded-md border border-dashed border-line bg-surface px-3 py-2 text-xs text-fg-soft"
+      >
+        <summary className="cursor-pointer text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
+          {unknownTypes.length} unrecognized part
+          {unknownTypes.length === 1 ? "" : "s"}
+        </summary>
+        <ul className="mt-2 list-disc pl-5 font-mono text-[11px] text-fg-soft">
+          {unknownTypes.map((typeName, i) => (
+            <li key={i}>{typeName}</li>
+          ))}
+        </ul>
+      </details>,
+    );
   }
   if (rendered.length === 0) {
     return (
@@ -387,15 +434,8 @@ const TOOL_TONE_STYLE: Record<"neutral" | "info" | "success" | "warn" | "error",
   error: "bg-tone-error/15 text-tone-error",
 };
 
-function hasRenderableContent(message: UIMessage): boolean {
-  return message.parts.some((part) => {
-    if (!part || typeof part !== "object" || !("type" in part)) return false;
-    if (part.type === "step-start") return false;
-    if (part.type === "text") {
-      return typeof part.text === "string" && part.text.length > 0;
-    }
-    return true;
-  });
+export function hasRenderableContent(message: UIMessage): boolean {
+  return message.parts.some(isRenderablePart);
 }
 
 function countToolCalls(message: UIMessage): number {

--- a/apps/admin-console/src/components/agent-preview-panel.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.tsx
@@ -1,7 +1,8 @@
 import { DefaultChatTransport } from "ai";
 import { useChat, type UIMessage } from "@ai-sdk/react";
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { agentPreviewRunUrl, type AgentSpec } from "@/lib/config-api";
+import { RecentTracesDrawer } from "@/components/recent-traces-drawer";
 
 interface AgentPreviewPanelProps {
   draft: AgentSpec;
@@ -10,6 +11,9 @@ interface AgentPreviewPanelProps {
 export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
   const [sessionId, setSessionId] = useState(() => makePreviewSessionId());
   const [input, setInput] = useState("");
+  const [lastLatencyMs, setLastLatencyMs] = useState<number | null>(null);
+  const [tracesOpen, setTracesOpen] = useState(false);
+  const sendStartedAtRef = useRef<number | null>(null);
   const previewDraft = normalizePreviewAgent(draft);
   const draftRef = useRef(previewDraft);
 
@@ -42,12 +46,21 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
     : "Select a model before starting a preview conversation.";
   const busy = status === "submitted" || status === "streaming";
 
+  useEffect(() => {
+    if (!busy && sendStartedAtRef.current !== null) {
+      setLastLatencyMs(Date.now() - sendStartedAtRef.current);
+      sendStartedAtRef.current = null;
+    }
+  }, [busy]);
+
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const text = input.trim();
     if (!text || busy || blockedReason) {
       return;
     }
+    sendStartedAtRef.current = Date.now();
+    setLastLatencyMs(null);
     sendMessage({ text });
     setInput("");
   }
@@ -56,6 +69,8 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
     setSessionId(makePreviewSessionId());
     setMessages([]);
     setInput("");
+    sendStartedAtRef.current = null;
+    setLastLatencyMs(null);
   }
 
   return (
@@ -64,19 +79,39 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
         <h3 className="text-sm font-semibold text-fg-strong">
           Sandbox <span className="font-normal text-fg-soft">runs against current draft</span>
         </h3>
-        <button
-          type="button"
-          onClick={handleReset}
-          className="text-xs font-medium text-fg-soft transition hover:text-fg-strong"
-        >
-          Reset
-        </button>
+        <div className="flex items-center gap-3">
+          {previewDraft.id.trim().length > 0 ? (
+            <button
+              type="button"
+              onClick={() => setTracesOpen(true)}
+              data-testid="open-recent-traces"
+              className="text-xs font-medium text-fg-soft transition hover:text-fg-strong"
+            >
+              Recent runs
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={handleReset}
+            className="text-xs font-medium text-fg-soft transition hover:text-fg-strong"
+          >
+            Reset
+          </button>
+        </div>
       </div>
+
+      <RecentTracesDrawer
+        agentId={previewDraft.id}
+        open={tracesOpen}
+        onClose={() => setTracesOpen(false)}
+      />
 
       <div className="mt-3 rounded-md bg-code-bg px-3 py-2 font-mono text-[11px] leading-5 text-code-fg">
         <span className="text-code-fg/70">id=</span>{previewDraft.id}{" "}
         <span className="text-code-fg/70">model=</span>{previewDraft.model_id || "unassigned"}
       </div>
+
+      <PreviewStatsBar messages={messages} latencyMs={lastLatencyMs} busy={busy} />
 
       {blockedReason ? (
         <div className="mt-4 rounded-md border border-tone-warn/35 bg-tone-warn/10 px-4 py-3 text-sm text-tone-warn">
@@ -99,8 +134,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
           ) : (
             <div className="space-y-3">
               {messages.map((message) => {
-                const text = extractMessageText(message);
-                if (!text) {
+                if (!hasRenderableContent(message)) {
                   return null;
                 }
                 const isUser = message.role === "user";
@@ -122,7 +156,7 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
                     >
                       {isUser ? "You" : "Agent"}
                     </div>
-                    <div className="whitespace-pre-wrap break-words">{text}</div>
+                    <MessageParts message={message} />
                   </div>
                 );
               })}
@@ -168,6 +202,221 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
   );
 }
 
+function PreviewStatsBar({
+  messages,
+  latencyMs,
+  busy,
+}: {
+  messages: UIMessage[];
+  latencyMs: number | null;
+  busy: boolean;
+}) {
+  const toolCalls = messages.reduce((acc, message) => acc + countToolCalls(message), 0);
+  const latencyLabel =
+    latencyMs !== null
+      ? latencyMs >= 1000
+        ? `${(latencyMs / 1000).toFixed(2)}s`
+        : `${latencyMs}ms`
+      : busy
+        ? "running…"
+        : "—";
+
+  return (
+    <div className="mt-3 grid grid-cols-3 gap-px overflow-hidden rounded-md border border-line bg-line text-[11px]">
+      <StatCell label="Messages" value={String(messages.length)} />
+      <StatCell label="Tool calls" value={String(toolCalls)} />
+      <StatCell
+        label="Last turn"
+        value={latencyLabel}
+        title="Wall-clock time from send to the model going idle"
+      />
+    </div>
+  );
+}
+
+function StatCell({ label, value, title }: { label: string; value: string; title?: string }) {
+  return (
+    <div className="bg-surface px-3 py-2" title={title}>
+      <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
+        {label}
+      </div>
+      <div className="mt-0.5 font-mono text-sm font-semibold text-fg-strong">{value}</div>
+    </div>
+  );
+}
+
+function MessageParts({ message }: { message: UIMessage }) {
+  const rendered: ReactNode[] = [];
+  for (const [index, part] of message.parts.entries()) {
+    if (!part || typeof part !== "object" || !("type" in part)) continue;
+    if (part.type === "text") {
+      if (typeof part.text === "string" && part.text.length > 0) {
+        rendered.push(
+          <div key={index} className="whitespace-pre-wrap break-words">
+            {part.text}
+          </div>,
+        );
+      }
+      continue;
+    }
+    if (part.type === "reasoning") {
+      const text = typeof part.text === "string" ? part.text : "";
+      if (text.length === 0) continue;
+      rendered.push(
+        <details
+          key={index}
+          className="rounded-md border border-line bg-soft px-3 py-2 text-xs text-fg-soft"
+        >
+          <summary className="cursor-pointer text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
+            Reasoning
+          </summary>
+          <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-[11px] text-fg">
+            {text}
+          </pre>
+        </details>,
+      );
+      continue;
+    }
+    if (part.type === "dynamic-tool" || part.type.startsWith("tool-")) {
+      rendered.push(<ToolInvocation key={index} part={part as ToolPart} />);
+      continue;
+    }
+    if (part.type === "step-start") {
+      // Visual separator between agent turns; no content.
+      continue;
+    }
+  }
+  if (rendered.length === 0) {
+    return (
+      <div className="text-xs italic text-fg-faint">
+        (empty turn — no text or tool parts emitted)
+      </div>
+    );
+  }
+  return <div className="space-y-2">{rendered}</div>;
+}
+
+interface ToolPart {
+  type: string;
+  toolName?: string;
+  toolCallId?: string;
+  state?: string;
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+}
+
+function ToolInvocation({ part }: { part: ToolPart }) {
+  const name = part.toolName ?? part.type.replace(/^tool-/, "") ?? "tool";
+  const state = part.state ?? "input-streaming";
+  const tone = TOOL_STATE_TONE[state] ?? "neutral";
+  return (
+    <details className="rounded-md border border-line bg-soft text-xs">
+      <summary className="flex cursor-pointer flex-wrap items-center gap-2 px-3 py-2">
+        <span
+          className={[
+            "rounded-pill px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-eyebrow",
+            TOOL_TONE_STYLE[tone],
+          ].join(" ")}
+        >
+          {TOOL_STATE_LABEL[state] ?? state}
+        </span>
+        <span className="font-mono text-fg-strong">{name}</span>
+        {part.toolCallId ? (
+          <span className="ml-auto font-mono text-[10px] text-fg-faint">
+            {part.toolCallId.slice(-8)}
+          </span>
+        ) : null}
+      </summary>
+      <div className="border-t border-line px-3 py-2">
+        <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
+          Input
+        </div>
+        <pre className="mt-1 max-h-48 overflow-auto rounded-md bg-code-bg p-2 font-mono text-[11px] text-code-fg">
+          {formatJson(part.input)}
+        </pre>
+        {part.errorText ? (
+          <>
+            <div className="mt-2 text-[10px] font-medium uppercase tracking-eyebrow text-tone-error">
+              Error
+            </div>
+            <pre className="mt-1 max-h-48 overflow-auto rounded-md border border-tone-error/30 bg-tone-error/10 p-2 font-mono text-[11px] text-tone-error">
+              {part.errorText}
+            </pre>
+          </>
+        ) : part.output !== undefined ? (
+          <>
+            <div className="mt-2 text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
+              Output
+            </div>
+            <pre className="mt-1 max-h-48 overflow-auto rounded-md bg-code-bg p-2 font-mono text-[11px] text-code-fg">
+              {formatJson(part.output)}
+            </pre>
+          </>
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+const TOOL_STATE_LABEL: Record<string, string> = {
+  "input-streaming": "Calling",
+  "input-available": "Calling",
+  "approval-requested": "Awaiting approval",
+  "approval-responded": "Approved",
+  "output-available": "Done",
+  "output-error": "Error",
+  "output-denied": "Denied",
+};
+
+const TOOL_STATE_TONE: Record<string, "neutral" | "info" | "success" | "warn" | "error"> = {
+  "input-streaming": "info",
+  "input-available": "info",
+  "approval-requested": "warn",
+  "approval-responded": "info",
+  "output-available": "success",
+  "output-error": "error",
+  "output-denied": "warn",
+};
+
+const TOOL_TONE_STYLE: Record<"neutral" | "info" | "success" | "warn" | "error", string> = {
+  neutral: "bg-muted text-fg-soft",
+  info: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  success: "bg-tone-success/15 text-tone-success",
+  warn: "bg-tone-warn/15 text-tone-warn",
+  error: "bg-tone-error/15 text-tone-error",
+};
+
+function hasRenderableContent(message: UIMessage): boolean {
+  return message.parts.some((part) => {
+    if (!part || typeof part !== "object" || !("type" in part)) return false;
+    if (part.type === "step-start") return false;
+    if (part.type === "text") {
+      return typeof part.text === "string" && part.text.length > 0;
+    }
+    return true;
+  });
+}
+
+function countToolCalls(message: UIMessage): number {
+  return message.parts.reduce((acc, part) => {
+    if (!part || typeof part !== "object" || !("type" in part)) return acc;
+    if (part.type === "dynamic-tool" || part.type.startsWith("tool-")) return acc + 1;
+    return acc;
+  }, 0);
+}
+
+function formatJson(value: unknown): string {
+  if (value === undefined) return "(no value)";
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
 function normalizePreviewAgent(draft: AgentSpec): AgentSpec {
   return {
     ...draft,
@@ -178,22 +427,6 @@ function normalizePreviewAgent(draft: AgentSpec): AgentSpec {
     delegates: [...(draft.delegates ?? [])],
     sections: { ...(draft.sections ?? {}) },
   };
-}
-
-function extractMessageText(message: UIMessage): string {
-  return message.parts
-    .flatMap((part) => {
-      if (!part || typeof part !== "object" || !("type" in part)) {
-        return [];
-      }
-      if (part.type !== "text") {
-        return [];
-      }
-      return typeof part.text === "string" && part.text.trim().length > 0
-        ? [part.text]
-        : [];
-    })
-    .join("");
 }
 
 function makePreviewSessionId(): string {

--- a/apps/admin-console/src/components/agent-preview-panel.tsx
+++ b/apps/admin-console/src/components/agent-preview-panel.tsx
@@ -2,6 +2,8 @@ import { DefaultChatTransport } from "ai";
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { agentPreviewRunUrl, type AgentSpec } from "@/lib/config-api";
+import { adminAuthHeaders } from "@/lib/api/http";
+import { redactSecretString, redactSecretsForDisplay } from "@/lib/agent-editor-helpers";
 import { RecentTracesDrawer } from "@/components/recent-traces-drawer";
 
 interface AgentPreviewPanelProps {
@@ -26,6 +28,12 @@ export function AgentPreviewPanel({ draft }: AgentPreviewPanelProps) {
       new DefaultChatTransport({
         api: agentPreviewRunUrl(),
         prepareSendMessagesRequest: ({ messages }) => ({
+          // R11 #1 — the preview route is admin-only on the server.
+          // Without this header the request 401s; resolving the token
+          // here (rather than in a static `headers` option) lets the
+          // resolver react to a freshly-saved bearer or a dev-env
+          // fallback at send time.
+          headers: adminAuthHeaders(),
           body: {
             threadId: sessionId,
             messages,
@@ -245,29 +253,6 @@ function StatCell({ label, value, title }: { label: string; value: string; title
   );
 }
 
-/**
- * Decide whether a `UIMessage.parts` entry has anything we render today.
- * Shared by `MessageParts` (to choose what to draw) and
- * `hasRenderableContent` (to decide whether to show a bubble at all) so
- * the two cannot drift — drift produces empty bubbles for parts the
- * renderer doesn't know about (e.g. AI SDK metadata / source parts).
- */
-function isRenderablePart(part: unknown): boolean {
-  if (!part || typeof part !== "object" || !("type" in part)) return false;
-  const typed = part as { type: string; text?: unknown };
-  if (typed.type === "step-start") return false;
-  if (typed.type === "text") {
-    return typeof typed.text === "string" && typed.text.length > 0;
-  }
-  if (typed.type === "reasoning") {
-    return typeof typed.text === "string" && typed.text.length > 0;
-  }
-  if (typed.type === "dynamic-tool" || typed.type.startsWith("tool-")) {
-    return true;
-  }
-  return false;
-}
-
 export function MessageParts({ message }: { message: UIMessage }) {
   const rendered: ReactNode[] = [];
   const unknownTypes: string[] = [];
@@ -388,7 +373,10 @@ function ToolInvocation({ part }: { part: ToolPart }) {
               Error
             </div>
             <pre className="mt-1 max-h-48 overflow-auto rounded-md border border-tone-error/30 bg-tone-error/10 p-2 font-mono text-[11px] text-tone-error">
-              {part.errorText}
+              {/* R12 #3 — tool error text often quotes the offending
+                  Authorization header / api_key in plaintext. Scrub
+                  before rendering. */}
+              {redactSecretString(part.errorText)}
             </pre>
           </>
         ) : part.output !== undefined ? (
@@ -435,7 +423,30 @@ const TOOL_TONE_STYLE: Record<"neutral" | "info" | "success" | "warn" | "error",
 };
 
 export function hasRenderableContent(message: UIMessage): boolean {
-  return message.parts.some(isRenderablePart);
+  // A bubble is worth drawing when MessageParts would emit at least one
+  // visible element. Mirrors the render path's three cases:
+  //   1. Known content with payload (text/reasoning/tool).
+  //   2. Unknown SDK type → collapsed into the unrecognized-parts debug
+  //      fallback. R8 #4: previously dropped here, which contradicted
+  //      the PR's "unknown parts collapse into a debug fallback" goal.
+  //   3. step-start / empty text / empty reasoning → MessageParts skips
+  //      these silently; nothing reaches the DOM.
+  return message.parts.some(isDisplayablePart);
+}
+
+function isDisplayablePart(part: unknown): boolean {
+  if (!part || typeof part !== "object" || !("type" in part)) return false;
+  const typed = part as { type: string; text?: unknown };
+  if (typed.type === "step-start") return false;
+  if (typed.type === "text" || typed.type === "reasoning") {
+    return typeof typed.text === "string" && typed.text.length > 0;
+  }
+  if (typed.type === "dynamic-tool" || typed.type.startsWith("tool-")) {
+    return true;
+  }
+  // Anything else lands in the unrecognized-parts debug fallback —
+  // worth showing the bubble for it.
+  return true;
 }
 
 function countToolCalls(message: UIMessage): number {
@@ -449,11 +460,19 @@ function countToolCalls(message: UIMessage): number {
 function formatJson(value: unknown): string {
   if (value === undefined) return "(no value)";
   if (value === null) return "null";
-  if (typeof value === "string") return value;
+  // R12 #3 — string outputs go through pattern-based credential
+  // scrubbing. A tool can return a plain-string payload (`"Authorization:
+  // Bearer sk-..."`) or a structured object; without this branch the
+  // object case was redacted by key but the string case rendered raw.
+  if (typeof value === "string") return redactSecretString(value);
+  // R10 #5 — tool inputs/outputs can carry API keys, authorization
+  // headers, cookies, JWTs etc. Same redaction pipeline used by audit /
+  // trace / diff so a credential never lands in the preview DOM.
+  const redacted = redactSecretsForDisplay(value);
   try {
-    return JSON.stringify(value, null, 2);
+    return JSON.stringify(redacted, null, 2);
   } catch {
-    return String(value);
+    return String(redacted);
   }
 }
 

--- a/apps/admin-console/src/components/recent-traces-drawer.test.tsx
+++ b/apps/admin-console/src/components/recent-traces-drawer.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RecentTracesDrawer } from "./recent-traces-drawer";
+import { tracesApi } from "@/lib/api/traces";
+
+function renderWithClient(ui: React.ReactElement) {
+  // Each test gets its own fresh client so caches don't leak between tests.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("RecentTracesDrawer (G7)", () => {
+  it("renders nothing when closed", () => {
+    renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open={false} onClose={() => {}} />,
+    );
+    expect(screen.queryByTestId("recent-traces-drawer")).toBeNull();
+  });
+
+  it("shows the not-configured state when listAgentTraces returns null", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue(null);
+    renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-traces-not-configured")).toBeTruthy();
+    });
+  });
+
+  it("shows the empty state when no runs are recorded", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({ runs: [] });
+    renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-traces-empty")).toBeTruthy();
+    });
+  });
+
+  it("renders the run list with status / experiment / variant / judge pills", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({
+      runs: [
+        {
+          run_id: "abc123def456789",
+          agent_id: "agent-a",
+          started_at: Math.floor(Date.now() / 1000) - 90,
+          ended_at: Math.floor(Date.now() / 1000) - 30,
+          prompt_ids: ["p1"],
+          final_status: "succeeded",
+          experiment_id: "exp-x",
+          variant_name: "v1",
+          judge_score: 0.87,
+        },
+        {
+          run_id: "deadbeefcafe9999",
+          agent_id: "agent-a",
+          started_at: Math.floor(Date.now() / 1000) - 10,
+          prompt_ids: [],
+        },
+      ],
+    });
+    renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("recent-traces-list")).toBeTruthy();
+    });
+    // First run: succeeded + exp + variant + judge pills.
+    expect(screen.getByText("succeeded")).toBeTruthy();
+    expect(screen.getByText("exp: exp-x")).toBeTruthy();
+    expect(screen.getByText("variant: v1")).toBeTruthy();
+    expect(screen.getByText(/judge: 0\.87/)).toBeTruthy();
+    // Second run: still-in-flight badge.
+    expect(screen.getByText("in flight")).toBeTruthy();
+  });
+
+  it("loads events when a run is selected and renders them", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({
+      runs: [
+        {
+          run_id: "run-1",
+          agent_id: "agent-a",
+          started_at: Math.floor(Date.now() / 1000),
+          prompt_ids: [],
+          final_status: "succeeded",
+        },
+      ],
+    });
+    vi.spyOn(tracesApi, "getTracePage").mockResolvedValue({
+      events: [
+        { kind: "run_start", ts: 1_000_000 },
+        { kind: "tool_call", ts: 1_000_005, payload: { tool: "Bash" } },
+      ],
+      total: 2,
+      next_offset: null,
+    });
+
+    renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
+    );
+    await waitFor(() => screen.getByTestId("recent-traces-list"));
+    fireEvent.click(screen.getByText(/run-1/));
+
+    // Wait for the events page to actually load — react-query needs a tick
+    // and another paint after the row click before the rows show up.
+    const rows = await waitFor(
+      () => {
+        const found = screen.queryAllByTestId("recent-traces-event-row");
+        if (found.length !== 2) throw new Error(`expected 2 rows, got ${found.length}`);
+        return found;
+      },
+      { timeout: 1500 },
+    );
+    expect(rows.length).toBe(2);
+    expect(screen.getByText("run_start")).toBeTruthy();
+    expect(screen.getByText("tool_call")).toBeTruthy();
+  });
+
+  it("clicking the scrim calls onClose", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({ runs: [] });
+    const onClose = vi.fn();
+    renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open onClose={onClose} />,
+    );
+    await waitFor(() => screen.getByTestId("recent-traces-drawer"));
+    fireEvent.click(screen.getByTestId("recent-traces-drawer-scrim"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/admin-console/src/components/recent-traces-drawer.test.tsx
+++ b/apps/admin-console/src/components/recent-traces-drawer.test.tsx
@@ -125,6 +125,56 @@ describe("RecentTracesDrawer (G7)", () => {
     expect(screen.getByText("tool_call")).toBeTruthy();
   });
 
+  it("loads and appends additional event pages", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({
+      runs: [
+        {
+          run_id: "run-paged",
+          agent_id: "agent-a",
+          started_at: Math.floor(Date.now() / 1000),
+          prompt_ids: [],
+          final_status: "succeeded",
+        },
+      ],
+    });
+    const getTracePage = vi.spyOn(tracesApi, "getTracePage");
+    getTracePage
+      .mockResolvedValueOnce({
+        events: [
+          { kind: "run_start", ts: 1_000_000 },
+          { kind: "tool_call", ts: 1_000_005 },
+        ],
+        total: 3,
+        next_offset: 2,
+      })
+      .mockResolvedValueOnce({
+        events: [{ kind: "run_finish", ts: 1_000_010 }],
+        total: 3,
+        next_offset: null,
+      });
+
+    renderWithClient(<RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />);
+    await waitFor(() => screen.getByTestId("recent-traces-list"));
+    fireEvent.click(screen.getByText(/run-paged/));
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId("recent-traces-event-row")).toHaveLength(2);
+    });
+    expect(screen.getByText("2 of 3 events loaded")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /load more/i }));
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId("recent-traces-event-row")).toHaveLength(3);
+    });
+    expect(getTracePage).toHaveBeenNthCalledWith(2, "run-paged", {
+      offset: 2,
+      limit: 1000,
+    });
+    expect(screen.getByText("run_finish")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /load more/i })).toBeNull();
+  });
+
   it("clicking the scrim calls onClose", async () => {
     vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({ runs: [] });
     const onClose = vi.fn();

--- a/apps/admin-console/src/components/recent-traces-drawer.test.tsx
+++ b/apps/admin-console/src/components/recent-traces-drawer.test.tsx
@@ -20,17 +20,13 @@ afterEach(() => {
 
 describe("RecentTracesDrawer (G7)", () => {
   it("renders nothing when closed", () => {
-    renderWithClient(
-      <RecentTracesDrawer agentId="agent-a" open={false} onClose={() => {}} />,
-    );
+    renderWithClient(<RecentTracesDrawer agentId="agent-a" open={false} onClose={() => {}} />);
     expect(screen.queryByTestId("recent-traces-drawer")).toBeNull();
   });
 
   it("shows the not-configured state when listAgentTraces returns null", async () => {
     vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue(null);
-    renderWithClient(
-      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
-    );
+    renderWithClient(<RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />);
     await waitFor(() => {
       expect(screen.getByTestId("recent-traces-not-configured")).toBeTruthy();
     });
@@ -38,12 +34,25 @@ describe("RecentTracesDrawer (G7)", () => {
 
   it("shows the empty state when no runs are recorded", async () => {
     vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({ runs: [] });
-    renderWithClient(
-      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
-    );
+    renderWithClient(<RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />);
     await waitFor(() => {
       expect(screen.getByTestId("recent-traces-empty")).toBeTruthy();
     });
+  });
+
+  it("redacts credential patterns from run list errors", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockRejectedValue(
+      new Error("trace failed with Cookie: session=raw-session-id"),
+    );
+
+    const { container } = renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
+    );
+
+    await screen.findByText(/Failed to load runs/i);
+    const dom = container.textContent ?? "";
+    expect(dom).toContain("Cookie: ***");
+    expect(dom).not.toContain("raw-session-id");
   });
 
   it("renders the run list with status / experiment / variant / judge pills", async () => {
@@ -68,9 +77,7 @@ describe("RecentTracesDrawer (G7)", () => {
         },
       ],
     });
-    renderWithClient(
-      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
-    );
+    renderWithClient(<RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />);
     await waitFor(() => {
       expect(screen.getByTestId("recent-traces-list")).toBeTruthy();
     });
@@ -104,9 +111,7 @@ describe("RecentTracesDrawer (G7)", () => {
       next_offset: null,
     });
 
-    renderWithClient(
-      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
-    );
+    renderWithClient(<RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />);
     await waitFor(() => screen.getByTestId("recent-traces-list"));
     fireEvent.click(screen.getByText(/run-1/));
 
@@ -123,6 +128,34 @@ describe("RecentTracesDrawer (G7)", () => {
     expect(rows.length).toBe(2);
     expect(screen.getByText("run_start")).toBeTruthy();
     expect(screen.getByText("tool_call")).toBeTruthy();
+  });
+
+  it("redacts credential patterns from event load errors", async () => {
+    vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({
+      runs: [
+        {
+          run_id: "run-error",
+          agent_id: "agent-a",
+          started_at: Math.floor(Date.now() / 1000),
+          prompt_ids: [],
+          final_status: "failed",
+        },
+      ],
+    });
+    vi.spyOn(tracesApi, "getTracePage").mockRejectedValue(
+      new Error("event fetch failed with api_key=raw-api-key-value"),
+    );
+
+    const { container } = renderWithClient(
+      <RecentTracesDrawer agentId="agent-a" open onClose={() => {}} />,
+    );
+    await waitFor(() => screen.getByTestId("recent-traces-list"));
+    fireEvent.click(screen.getByText(/run-error/));
+
+    await screen.findByText(/Failed to load events/i);
+    const dom = container.textContent ?? "";
+    expect(dom).toContain("api_key=***");
+    expect(dom).not.toContain("raw-api-key-value");
   });
 
   it("loads and appends additional event pages", async () => {
@@ -178,9 +211,7 @@ describe("RecentTracesDrawer (G7)", () => {
   it("clicking the scrim calls onClose", async () => {
     vi.spyOn(tracesApi, "listAgentTraces").mockResolvedValue({ runs: [] });
     const onClose = vi.fn();
-    renderWithClient(
-      <RecentTracesDrawer agentId="agent-a" open onClose={onClose} />,
-    );
+    renderWithClient(<RecentTracesDrawer agentId="agent-a" open onClose={onClose} />);
     await waitFor(() => screen.getByTestId("recent-traces-drawer"));
     fireEvent.click(screen.getByTestId("recent-traces-drawer-scrim"));
     expect(onClose).toHaveBeenCalled();

--- a/apps/admin-console/src/components/recent-traces-drawer.tsx
+++ b/apps/admin-console/src/components/recent-traces-drawer.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  tracesApi,
+  type TraceEvent,
+  type TracePage,
+  type TraceRunSummary,
+} from "@/lib/config-api";
+
+/**
+ * Side drawer that lists recent persisted runs for an agent and lets the
+ * operator drill into one to see the full event stream.
+ *
+ * Backed by ADR-0030 endpoints:
+ *   - `GET /v1/traces?agent_id=…` → list of `TraceRunSummary`
+ *   - `GET /v1/traces/:run_id`    → NDJSON page of trace events
+ *
+ * The endpoints are feature-gated server-side (`expose_trace_routes`).
+ * `tracesApi.listAgentTraces` returns `null` when the server isn't
+ * configured for trace persistence; the drawer surfaces that as a
+ * friendly "not configured" state rather than rendering an error.
+ */
+export function RecentTracesDrawer({
+  agentId,
+  open,
+  onClose,
+}: {
+  agentId: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    if (open) {
+      document.addEventListener("keydown", onKey);
+      return () => document.removeEventListener("keydown", onKey);
+    }
+    return undefined;
+  }, [open, onClose]);
+
+  // Reset the selected run when the drawer is closed so reopening starts
+  // from the list view.
+  useEffect(() => {
+    if (!open) setSelectedRunId(null);
+  }, [open]);
+
+  const listQuery = useQuery({
+    queryKey: ["traces", "list", agentId],
+    queryFn: () => tracesApi.listAgentTraces(agentId, { limit: 25 }),
+    enabled: open && agentId.trim().length > 0,
+    staleTime: 10_000,
+  });
+
+  if (!open) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Close trace drawer"
+        onClick={onClose}
+        data-testid="recent-traces-drawer-scrim"
+        className="fixed inset-0 z-40 bg-black/30"
+      />
+      <aside
+        role="dialog"
+        aria-label="Recent runs"
+        data-testid="recent-traces-drawer"
+        className="fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col border-l border-line bg-surface shadow-xl"
+      >
+        <header className="flex items-center justify-between border-b border-line px-4 py-3">
+          <div>
+            <h2 className="text-sm font-semibold text-fg-strong">Recent runs</h2>
+            <p className="text-[11px] text-fg-soft">
+              Agent <span className="font-mono">{agentId}</span> · latest 25
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-line-strong bg-soft px-2 py-1 text-xs text-fg-soft transition hover:bg-muted"
+          >
+            Close
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {selectedRunId ? (
+            <RunEventViewer runId={selectedRunId} onBack={() => setSelectedRunId(null)} />
+          ) : (
+            <RunList
+              loading={listQuery.isPending && listQuery.fetchStatus === "fetching"}
+              error={listQuery.error}
+              data={listQuery.data}
+              onSelect={(runId) => setSelectedRunId(runId)}
+            />
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}
+
+function RunList({
+  loading,
+  error,
+  data,
+  onSelect,
+}: {
+  loading: boolean;
+  error: unknown;
+  data: { runs: TraceRunSummary[] } | null | undefined;
+  onSelect: (runId: string) => void;
+}) {
+  if (loading) {
+    return (
+      <div className="px-4 py-6 text-xs text-fg-soft">Loading recent runs…</div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="px-4 py-6 text-xs text-tone-error">
+        Failed to load runs: {error instanceof Error ? error.message : String(error)}
+      </div>
+    );
+  }
+  if (data === null) {
+    return (
+      <div
+        className="px-4 py-6 text-xs text-fg-soft"
+        data-testid="recent-traces-not-configured"
+      >
+        Trace persistence is not enabled on this server build (
+        <span className="font-mono">expose_trace_routes=false</span> or no trace store
+        configured). Ask the operator to enable trace persistence to populate this view.
+      </div>
+    );
+  }
+  if (!data || data.runs.length === 0) {
+    return (
+      <div
+        className="px-4 py-6 text-xs text-fg-soft"
+        data-testid="recent-traces-empty"
+      >
+        No runs recorded for this agent yet. Run the sandbox or invoke the agent through
+        the API and a summary will appear here.
+      </div>
+    );
+  }
+  return (
+    <ul className="divide-y divide-line" data-testid="recent-traces-list">
+      {data.runs.map((run) => (
+        <li key={run.run_id}>
+          <button
+            type="button"
+            onClick={() => onSelect(run.run_id)}
+            className="flex w-full flex-col gap-1 px-4 py-3 text-left text-xs transition hover:bg-soft"
+          >
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="font-mono text-fg-strong">{run.run_id.slice(0, 16)}</span>
+              <span className="text-fg-soft">{formatRelativeTime(run.started_at)}</span>
+            </div>
+            <div className="flex flex-wrap gap-2 text-[10px] text-fg-soft">
+              {run.final_status ? (
+                <span className="rounded-pill bg-muted px-2 py-0.5 font-mono">
+                  {run.final_status}
+                </span>
+              ) : (
+                <span className="rounded-pill bg-tone-warn/15 px-2 py-0.5 font-mono text-tone-warn">
+                  in flight
+                </span>
+              )}
+              {run.experiment_id ? (
+                <span className="rounded-pill bg-muted px-2 py-0.5 font-mono">
+                  exp: {run.experiment_id}
+                </span>
+              ) : null}
+              {run.variant_name ? (
+                <span className="rounded-pill bg-muted px-2 py-0.5 font-mono">
+                  variant: {run.variant_name}
+                </span>
+              ) : null}
+              {typeof run.judge_score === "number" ? (
+                <span className="rounded-pill bg-muted px-2 py-0.5 font-mono">
+                  judge: {run.judge_score.toFixed(2)}
+                </span>
+              ) : null}
+            </div>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RunEventViewer({ runId, onBack }: { runId: string; onBack: () => void }) {
+  // Single-page fetch — server caps at 1000 events. For runs above the cap
+  // we surface that via a hint rather than auto-paging through, since
+  // operators typically only care about the head of the stream when
+  // checking what happened.
+  const eventsQuery = useQuery({
+    queryKey: ["traces", "events", runId],
+    queryFn: () => tracesApi.getTracePage(runId, { limit: 1000 }),
+    staleTime: 30_000,
+  });
+
+  return (
+    <div data-testid="recent-traces-events">
+      <div className="flex items-center gap-2 border-b border-line px-4 py-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-md border border-line-strong bg-soft px-2 py-1 text-[11px] text-fg-soft transition hover:bg-muted"
+        >
+          ← Back to runs
+        </button>
+        <span className="font-mono text-[11px] text-fg-strong">{runId}</span>
+      </div>
+      {eventsQuery.isPending && eventsQuery.fetchStatus === "fetching" ? (
+        <div className="px-4 py-6 text-xs text-fg-soft">Loading events…</div>
+      ) : eventsQuery.error ? (
+        <div className="px-4 py-6 text-xs text-tone-error">
+          Failed to load events:{" "}
+          {eventsQuery.error instanceof Error
+            ? eventsQuery.error.message
+            : String(eventsQuery.error)}
+        </div>
+      ) : (
+        <EventList page={eventsQuery.data ?? { events: [], total: 0, next_offset: null }} />
+      )}
+    </div>
+  );
+}
+
+function EventList({ page }: { page: TracePage }) {
+  const truncated = page.next_offset !== null;
+  return (
+    <>
+      <div className="px-4 py-2 text-[10px] uppercase tracking-eyebrow text-fg-soft">
+        {page.events.length} of {page.total} events
+        {truncated ? " (truncated — server caps at 1000 per page)" : ""}
+      </div>
+      <ul className="divide-y divide-line">
+        {page.events.map((event, index) => (
+          <li
+            key={index}
+            className="px-4 py-2 text-[11px]"
+            data-testid="recent-traces-event-row"
+          >
+            <EventRow event={event} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function EventRow({ event }: { event: TraceEvent }) {
+  const kind = typeof event.kind === "string" ? event.kind : "unknown";
+  return (
+    <details>
+      <summary className="flex cursor-pointer items-center gap-2">
+        <span className="rounded-pill bg-muted px-2 py-0.5 font-mono text-fg-soft">
+          {kind}
+        </span>
+        {typeof event.ts === "number" ? (
+          <span className="text-[10px] text-fg-faint">
+            {new Date(event.ts * 1000).toISOString()}
+          </span>
+        ) : null}
+      </summary>
+      <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-code-bg px-2 py-2 font-mono text-[10px] text-code-fg">
+        {JSON.stringify(event, null, 2)}
+      </pre>
+    </details>
+  );
+}
+
+function formatRelativeTime(seconds: number): string {
+  const nowMs = Date.now();
+  const thenMs = seconds * 1000;
+  const deltaSec = Math.max(0, Math.round((nowMs - thenMs) / 1000));
+  if (deltaSec < 60) return `${deltaSec}s ago`;
+  if (deltaSec < 3600) return `${Math.round(deltaSec / 60)}m ago`;
+  if (deltaSec < 86_400) return `${Math.round(deltaSec / 3600)}h ago`;
+  return new Date(thenMs).toISOString().slice(0, 10);
+}

--- a/apps/admin-console/src/components/recent-traces-drawer.tsx
+++ b/apps/admin-console/src/components/recent-traces-drawer.tsx
@@ -1,12 +1,8 @@
 import { useEffect, useState } from "react";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import {
-  tracesApi,
-  type TraceEvent,
-  type TracePage,
-  type TraceRunSummary,
-} from "@/lib/config-api";
+import { tracesApi, type TraceEvent, type TracePage, type TraceRunSummary } from "@/lib/config-api";
 import { redactSecretsForDisplay } from "@/lib/agent-editor-helpers";
+import { safeErrorMessage } from "@/lib/safe-error-message";
 
 const TRACE_EVENT_PAGE_LIMIT = 1000;
 
@@ -120,37 +116,29 @@ function RunList({
   onSelect: (runId: string) => void;
 }) {
   if (loading) {
-    return (
-      <div className="px-4 py-6 text-xs text-fg-soft">Loading recent runs…</div>
-    );
+    return <div className="px-4 py-6 text-xs text-fg-soft">Loading recent runs…</div>;
   }
   if (error) {
     return (
       <div className="px-4 py-6 text-xs text-tone-error">
-        Failed to load runs: {error instanceof Error ? error.message : String(error)}
+        Failed to load runs: {safeErrorMessage(error)}
       </div>
     );
   }
   if (data === null) {
     return (
-      <div
-        className="px-4 py-6 text-xs text-fg-soft"
-        data-testid="recent-traces-not-configured"
-      >
+      <div className="px-4 py-6 text-xs text-fg-soft" data-testid="recent-traces-not-configured">
         Trace persistence is not enabled on this server build (
-        <span className="font-mono">expose_trace_routes=false</span> or no trace store
-        configured). Ask the operator to enable trace persistence to populate this view.
+        <span className="font-mono">expose_trace_routes=false</span> or no trace store configured).
+        Ask the operator to enable trace persistence to populate this view.
       </div>
     );
   }
   if (!data || data.runs.length === 0) {
     return (
-      <div
-        className="px-4 py-6 text-xs text-fg-soft"
-        data-testid="recent-traces-empty"
-      >
-        No runs recorded for this agent yet. Run the sandbox or invoke the agent through
-        the API and a summary will appear here.
+      <div className="px-4 py-6 text-xs text-fg-soft" data-testid="recent-traces-empty">
+        No runs recorded for this agent yet. Run the sandbox or invoke the agent through the API and
+        a summary will appear here.
       </div>
     );
   }
@@ -230,10 +218,7 @@ function RunEventViewer({ runId, onBack }: { runId: string; onBack: () => void }
         <div className="px-4 py-6 text-xs text-fg-soft">Loading events…</div>
       ) : eventsQuery.error && page === undefined ? (
         <div className="px-4 py-6 text-xs text-tone-error">
-          Failed to load events:{" "}
-          {eventsQuery.error instanceof Error
-            ? eventsQuery.error.message
-            : String(eventsQuery.error)}
+          Failed to load events: {safeErrorMessage(eventsQuery.error)}
         </div>
       ) : page === null ? (
         // Server build lacks trace persistence (503). Distinct from
@@ -293,19 +278,14 @@ function EventList({
       </div>
       <ul className="divide-y divide-line">
         {page.events.map((event, index) => (
-          <li
-            key={index}
-            className="px-4 py-2 text-[11px]"
-            data-testid="recent-traces-event-row"
-          >
+          <li key={index} className="px-4 py-2 text-[11px]" data-testid="recent-traces-event-row">
             <EventRow event={event} />
           </li>
         ))}
       </ul>
       {loadError && page.events.length > 0 ? (
         <div className="px-4 py-2 text-[11px] text-tone-error">
-          Failed to load more events:{" "}
-          {loadError instanceof Error ? loadError.message : String(loadError)}
+          Failed to load more events: {safeErrorMessage(loadError)}
         </div>
       ) : null}
       {canLoadMore ? (
@@ -333,9 +313,7 @@ function EventRow({ event }: { event: TraceEvent }) {
   return (
     <details>
       <summary className="flex cursor-pointer items-center gap-2">
-        <span className="rounded-pill bg-muted px-2 py-0.5 font-mono text-fg-soft">
-          {kind}
-        </span>
+        <span className="rounded-pill bg-muted px-2 py-0.5 font-mono text-fg-soft">{kind}</span>
         {typeof event.ts === "number" ? (
           <span className="text-[10px] text-fg-faint">
             {new Date(event.ts * 1000).toISOString()}

--- a/apps/admin-console/src/components/recent-traces-drawer.tsx
+++ b/apps/admin-console/src/components/recent-traces-drawer.tsx
@@ -6,6 +6,7 @@ import {
   type TracePage,
   type TraceRunSummary,
 } from "@/lib/config-api";
+import { redactSecretsForDisplay } from "@/lib/agent-editor-helpers";
 
 /**
  * Side drawer that lists recent persisted runs for an agent and lets the
@@ -229,6 +230,15 @@ function RunEventViewer({ runId, onBack }: { runId: string; onBack: () => void }
             ? eventsQuery.error.message
             : String(eventsQuery.error)}
         </div>
+      ) : eventsQuery.data === null ? (
+        // Server build lacks trace persistence (503). Distinct from
+        // "0 events", which would be a successful empty page.
+        <div
+          className="px-4 py-6 text-xs text-fg-soft"
+          data-testid="recent-traces-events-unavailable"
+        >
+          Trace persistence is not configured on this server build.
+        </div>
       ) : (
         <EventList page={eventsQuery.data ?? { events: [], total: 0, next_offset: null }} />
       )}
@@ -261,6 +271,10 @@ function EventList({ page }: { page: TracePage }) {
 
 function EventRow({ event }: { event: TraceEvent }) {
   const kind = typeof event.kind === "string" ? event.kind : "unknown";
+  // Trace event payloads can carry serialized agent specs in fields like
+  // `agent_resolved.endpoint.auth`. Mask defensively before rendering;
+  // the wire `event` is unchanged for any caller that re-reads it.
+  const redacted = redactSecretsForDisplay(event);
   return (
     <details>
       <summary className="flex cursor-pointer items-center gap-2">
@@ -274,7 +288,7 @@ function EventRow({ event }: { event: TraceEvent }) {
         ) : null}
       </summary>
       <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-code-bg px-2 py-2 font-mono text-[10px] text-code-fg">
-        {JSON.stringify(event, null, 2)}
+        {JSON.stringify(redacted, null, 2)}
       </pre>
     </details>
   );

--- a/apps/admin-console/src/components/recent-traces-drawer.tsx
+++ b/apps/admin-console/src/components/recent-traces-drawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import {
   tracesApi,
   type TraceEvent,
@@ -7,6 +7,8 @@ import {
   type TraceRunSummary,
 } from "@/lib/config-api";
 import { redactSecretsForDisplay } from "@/lib/agent-editor-helpers";
+
+const TRACE_EVENT_PAGE_LIMIT = 1000;
 
 /**
  * Side drawer that lists recent persisted runs for an agent and lets the
@@ -199,15 +201,18 @@ function RunList({
 }
 
 function RunEventViewer({ runId, onBack }: { runId: string; onBack: () => void }) {
-  // Single-page fetch — server caps at 1000 events. For runs above the cap
-  // we surface that via a hint rather than auto-paging through, since
-  // operators typically only care about the head of the stream when
-  // checking what happened.
-  const eventsQuery = useQuery({
+  const eventsQuery = useInfiniteQuery({
     queryKey: ["traces", "events", runId],
-    queryFn: () => tracesApi.getTracePage(runId, { limit: 1000 }),
+    queryFn: ({ pageParam }) =>
+      tracesApi.getTracePage(runId, {
+        offset: pageParam,
+        limit: TRACE_EVENT_PAGE_LIMIT,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage?.next_offset ?? undefined,
     staleTime: 30_000,
   });
+  const page = combineTracePages(eventsQuery.data?.pages);
 
   return (
     <div data-testid="recent-traces-events">
@@ -221,16 +226,16 @@ function RunEventViewer({ runId, onBack }: { runId: string; onBack: () => void }
         </button>
         <span className="font-mono text-[11px] text-fg-strong">{runId}</span>
       </div>
-      {eventsQuery.isPending && eventsQuery.fetchStatus === "fetching" ? (
+      {eventsQuery.isPending && eventsQuery.fetchStatus === "fetching" && page === undefined ? (
         <div className="px-4 py-6 text-xs text-fg-soft">Loading events…</div>
-      ) : eventsQuery.error ? (
+      ) : eventsQuery.error && page === undefined ? (
         <div className="px-4 py-6 text-xs text-tone-error">
           Failed to load events:{" "}
           {eventsQuery.error instanceof Error
             ? eventsQuery.error.message
             : String(eventsQuery.error)}
         </div>
-      ) : eventsQuery.data === null ? (
+      ) : page === null ? (
         // Server build lacks trace persistence (503). Distinct from
         // "0 events", which would be a successful empty page.
         <div
@@ -240,19 +245,51 @@ function RunEventViewer({ runId, onBack }: { runId: string; onBack: () => void }
           Trace persistence is not configured on this server build.
         </div>
       ) : (
-        <EventList page={eventsQuery.data ?? { events: [], total: 0, next_offset: null }} />
+        <EventList
+          page={page ?? { events: [], total: 0, next_offset: null }}
+          canLoadMore={eventsQuery.hasNextPage}
+          loadingMore={eventsQuery.isFetchingNextPage}
+          loadError={eventsQuery.error}
+          onLoadMore={() => void eventsQuery.fetchNextPage()}
+        />
       )}
     </div>
   );
 }
 
-function EventList({ page }: { page: TracePage }) {
-  const truncated = page.next_offset !== null;
+function combineTracePages(
+  pages: Array<TracePage | null> | undefined,
+): TracePage | null | undefined {
+  if (!pages) return undefined;
+  if (pages.some((page) => page === null)) return null;
+  const loadedPages = pages as TracePage[];
+  const lastPage = loadedPages[loadedPages.length - 1];
+  const events = loadedPages.flatMap((page) => page.events);
+  return {
+    events,
+    total: lastPage?.total ?? events.length,
+    next_offset: lastPage?.next_offset ?? null,
+  };
+}
+
+function EventList({
+  page,
+  canLoadMore,
+  loadingMore,
+  loadError,
+  onLoadMore,
+}: {
+  page: TracePage;
+  canLoadMore: boolean;
+  loadingMore: boolean;
+  loadError: unknown;
+  onLoadMore: () => void;
+}) {
   return (
     <>
       <div className="px-4 py-2 text-[10px] uppercase tracking-eyebrow text-fg-soft">
         {page.events.length} of {page.total} events
-        {truncated ? " (truncated — server caps at 1000 per page)" : ""}
+        {canLoadMore ? " loaded" : ""}
       </div>
       <ul className="divide-y divide-line">
         {page.events.map((event, index) => (
@@ -265,6 +302,24 @@ function EventList({ page }: { page: TracePage }) {
           </li>
         ))}
       </ul>
+      {loadError && page.events.length > 0 ? (
+        <div className="px-4 py-2 text-[11px] text-tone-error">
+          Failed to load more events:{" "}
+          {loadError instanceof Error ? loadError.message : String(loadError)}
+        </div>
+      ) : null}
+      {canLoadMore ? (
+        <div className="border-t border-line px-4 py-3">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className="rounded-md border border-line-strong bg-surface px-3 py-1.5 text-xs font-medium text-fg-soft transition hover:bg-soft disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loadingMore ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/apps/admin-console/src/components/tool-selector.test.tsx
+++ b/apps/admin-console/src/components/tool-selector.test.tsx
@@ -21,7 +21,7 @@ const TOOLS: ToolInfo[] = [
 interface SelectorProps {
   title?: string;
   description?: string;
-  value?: string[] | undefined;
+  value?: string[] | null | undefined;
   onChange?: Mock;
   tools?: ToolInfo[];
   variant?: "include" | "exclude";
@@ -32,7 +32,7 @@ function renderSelector(overrides: SelectorProps = {}) {
   const props = {
     title: "Allowed Tools",
     description: "Configure which tools this agent can use.",
-    value: undefined as string[] | undefined,
+    value: undefined as string[] | null | undefined,
     onChange,
     tools: TOOLS,
     ...overrides,
@@ -140,10 +140,10 @@ describe("ToolSelector — group Select all / Clear buttons", () => {
     });
 
     expect(props.onChange).toHaveBeenCalledOnce();
-    // setGroupSelection with all builtin tools selected plus existing — all 6 tools = collapse to undefined
+    // setGroupSelection with all builtin tools selected plus existing — all 6 tools = collapse to explicit null
     const result = props.onChange.mock.calls[0][0];
-    // When every tool ends up selected, setGroupSelection returns undefined
-    expect(result).toBeUndefined();
+    // When every tool ends up selected, setGroupSelection returns null (explicit "all" override).
+    expect(result).toBeNull();
   });
 
   it("calls onChange excluding group tools when 'Clear' is clicked on the built-in group", () => {
@@ -202,6 +202,67 @@ describe("ToolSelector — variant='exclude' labels", () => {
     renderSelector({ value: undefined, variant: "exclude" });
 
     expect(screen.getByText(/No tools are explicitly excluded/)).toBeTruthy();
+  });
+});
+
+// R8 #1 — Regression suite for the exclude-variant data-loss bug. The
+// previous helpers were include-only: switching to "Custom exclusion"
+// from "Block none" would seed `excluded_tools` with every published
+// tool id, immediately stripping the agent of access to everything.
+describe("ToolSelector — variant='exclude' switching to Custom exclusion (R8 #1)", () => {
+  it("seeds custom mode with NO excluded tools (not the full tool list)", () => {
+    const { props } = renderSelector({ value: undefined, variant: "exclude" });
+
+    const customLabel = screen.getByText("Custom exclusion");
+    const customRadio = customLabel
+      .closest("label")!
+      .querySelector("input[type='radio']") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.click(customRadio);
+    });
+
+    expect(props.onChange).toHaveBeenCalledOnce();
+    const result = props.onChange.mock.calls[0][0];
+    // Must be `[]` — every published tool would mean "block all tools",
+    // i.e. the agent would lose access to everything immediately on
+    // mode toggle.
+    expect(result).toEqual([]);
+  });
+
+  it("checking a tool from the empty excluded set ADDS that one tool", () => {
+    const { props } = renderSelector({ value: [], variant: "exclude" });
+
+    const bashIdEl = screen.getByText("Bash");
+    const bashLabel = bashIdEl.closest("label")!;
+    const bashCheckbox = bashLabel.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(bashCheckbox.checked).toBe(false);
+
+    act(() => {
+      fireEvent.click(bashCheckbox);
+    });
+
+    expect(props.onChange).toHaveBeenCalledOnce();
+    const result = props.onChange.mock.calls[0][0];
+    // Old helper returned `undefined` here (no add path for exclude),
+    // silently dropping the user's click.
+    expect(result).toEqual(["Bash"]);
+  });
+
+  it("'Block none' radio emits explicit null (not undefined) so customized save overrides base", () => {
+    const { props } = renderSelector({ value: ["Bash"], variant: "exclude" });
+
+    const blockNoneLabel = screen.getByText("Block none");
+    const blockNoneRadio = blockNoneLabel
+      .closest("label")!
+      .querySelector("input[type='radio']") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.click(blockNoneRadio);
+    });
+
+    expect(props.onChange).toHaveBeenCalledOnce();
+    expect(props.onChange.mock.calls[0][0]).toBeNull();
   });
 });
 

--- a/apps/admin-console/src/components/tool-selector.tsx
+++ b/apps/admin-console/src/components/tool-selector.tsx
@@ -19,13 +19,17 @@ interface ToolSelectorProps {
   /// `undefined` or `null` = mode "all"; explicit list = mode "custom".
   /// (Backend serializes `Option<Vec<String>>` as JSON null, so accept both.)
   value: string[] | null | undefined;
-  onChange: (next: string[] | undefined) => void;
+  /// Selection changes emit `null` (not `undefined`) for the "all" /
+  /// "block none" radio. `null` is an explicit override on the wire,
+  /// which is what customized agents need — `undefined` would land in
+  /// the save-path's clear list and DELETE the override, re-inheriting
+  /// the base record's restricted list (R8 #1).
+  onChange: (next: string[] | null) => void;
   tools: ToolInfo[];
-  /// Default mode. "include" matches `allowed_tools` semantics where
-  /// undefined means "every tool". "exclude" matches `excluded_tools`
-  /// semantics where undefined means "exclude none" — but the storage
-  /// shape is identical (string[] | undefined), so we can reuse the
-  /// component with a different label set.
+  /// "include" matches `allowed_tools` semantics (default = every tool
+  /// allowed). "exclude" matches `excluded_tools` (default = no tool
+  /// excluded). The wire-shape is identical but checkbox semantics
+  /// invert — the helpers know the difference, so always pass `variant`.
   variant?: "include" | "exclude";
 }
 
@@ -91,15 +95,15 @@ export function ToolSelector({
   const labels = LABELS_BY_VARIANT[variant];
 
   function setMode(next: ToolSelectionMode) {
-    onChange(applyToolSelectionMode(value, next, allToolIds));
+    onChange(applyToolSelectionMode(value, next, allToolIds, variant));
   }
 
   function toggleTool(toolId: string, checked: boolean) {
-    onChange(nextAllowedTools(value, allToolIds, toolId, checked));
+    onChange(nextAllowedTools(value, allToolIds, toolId, checked, variant));
   }
 
   function toggleGroup(groupToolIds: string[], selected: boolean) {
-    onChange(setGroupSelection(value, allToolIds, groupToolIds, selected));
+    onChange(setGroupSelection(value, allToolIds, groupToolIds, selected, variant));
   }
 
   return (
@@ -186,7 +190,7 @@ export function ToolSelector({
             <div className="mt-4 space-y-5">
               {filteredGroups.map((group) => {
                 const groupIds = group.tools.map((tool) => tool.id);
-                const state = groupSelectionState(value, groupIds);
+                const state = groupSelectionState(value, groupIds, variant);
                 return (
                   <div
                     key={group.source.key}
@@ -198,7 +202,7 @@ export function ToolSelector({
                           {group.source.label}
                         </span>
                         <span className="text-xs text-fg-soft">
-                          {summariseSelection(state, groupIds.length, value, groupIds)}
+                          {summariseSelection(state, groupIds.length, value, groupIds, variant)}
                         </span>
                       </div>
                       <div className="flex gap-2 text-xs font-medium">
@@ -220,7 +224,7 @@ export function ToolSelector({
                     </div>
                     <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
                       {group.tools.map((tool) => {
-                        const checked = isToolAllowed(value, tool.id);
+                        const checked = isToolAllowed(value, tool.id, variant);
                         return (
                           <label
                             key={tool.id}
@@ -302,13 +306,14 @@ function summariseSelection(
   total: number,
   value: string[] | null | undefined,
   groupToolIds: string[],
+  variant: "include" | "exclude",
 ): string {
   if (total === 0) return "0 tools";
   if (state === "all") return `${total} of ${total} selected`;
   if (state === "none") return `0 of ${total} selected`;
   let selected = 0;
   for (const id of groupToolIds) {
-    if (isToolAllowed(value, id)) selected += 1;
+    if (isToolAllowed(value, id, variant)) selected += 1;
   }
   return `${selected} of ${total} selected`;
 }

--- a/apps/admin-console/src/lib/agent-editor-canonical.ts
+++ b/apps/admin-console/src/lib/agent-editor-canonical.ts
@@ -1,0 +1,33 @@
+/**
+ * Stable JSON encoding: deep-sorts object keys so structurally-equal values
+ * always serialize to the same string. Used as a building block for
+ * `deepEqualCanonical` so re-formatting / key-reordering of Raw JSON doesn't
+ * read as a locked-field change or trigger a spurious PATCH entry.
+ *
+ * Arrays preserve order (semantically significant). `undefined` collapses to
+ * `null` so `{a: undefined}` and `{}` are treated equivalently. JSON has no
+ * `undefined`, and field absence vs explicit-undefined should not surface as
+ * a diff in this editor.
+ */
+export function canonicalStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .map(([key, item]) => [key, canonicalize(item)] as const)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+/** Structural equality using `canonicalStringify`: order-insensitive for
+ *  object keys, order-sensitive for arrays. */
+export function deepEqualCanonical(a: unknown, b: unknown): boolean {
+  return canonicalStringify(a) === canonicalStringify(b);
+}

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -830,6 +830,109 @@ describe("redactSecretsForDisplay (R6 #B/#C — generic deep redact)", () => {
     expect(auth.weird_key).toBeNull();
     expect(auth.other).toBeUndefined();
   });
+
+  // R15 — Numeric LLM token-budget fields must NOT be masked. The
+  // previous implementation used `"token"` as an unconditional substring
+  // pattern; `normalizeSecretKey("max_context_tokens")` is
+  // `"maxcontexttokens"` which contains "token", so every Raw JSON view
+  // / DiffModal / audit snapshot rendered `context_policy` as
+  // `{max_context_tokens: "***", max_output_tokens: "***"}` — hiding
+  // legitimate numeric config. R15 splits `"token"` into an exact-match
+  // bucket plus compound `*_token` patterns so the substring approach
+  // stops biting context_policy / usage-counter fields.
+  describe("R15 — token substring no longer over-redacts numeric budgets", () => {
+    it("preserves max_context_tokens and max_output_tokens inside context_policy", () => {
+      const result = redactSecretsForDisplay({
+        context_policy: {
+          max_context_tokens: 200_000,
+          max_output_tokens: 16_384,
+          min_recent_messages: 10,
+          autocompact_threshold: null,
+        },
+      });
+      const policy = result.context_policy as Record<string, unknown>;
+      expect(policy.max_context_tokens).toBe(200_000);
+      expect(policy.max_output_tokens).toBe(16_384);
+      expect(policy.min_recent_messages).toBe(10);
+      expect(policy.autocompact_threshold).toBeNull();
+    });
+
+    it("preserves usage-counter token fields in trace / audit payloads", () => {
+      // LLM telemetry surfaces `input_tokens` / `output_tokens` /
+      // `total_tokens` / `token_count` — all numeric debug info that
+      // must remain readable in the admin console.
+      const event = {
+        kind: "after_inference",
+        payload: {
+          usage: {
+            input_tokens: 1234,
+            output_tokens: 567,
+            total_tokens: 1801,
+            token_count: 1801,
+            cached_input_tokens: 100,
+          },
+        },
+      };
+      const redacted = redactSecretsForDisplay(event);
+      const usage = (redacted.payload as Record<string, unknown>).usage as Record<
+        string,
+        unknown
+      >;
+      expect(usage.input_tokens).toBe(1234);
+      expect(usage.output_tokens).toBe(567);
+      expect(usage.total_tokens).toBe(1801);
+      expect(usage.token_count).toBe(1801);
+      expect(usage.cached_input_tokens).toBe(100);
+    });
+
+    it("still masks standalone `token` and `Token` keys", () => {
+      const value = { config: { token: "raw-bearer-value", Token: "raw-mixed-case" } };
+      const redacted = redactSecretsForDisplay(value);
+      const config = redacted.config as Record<string, unknown>;
+      expect(config.token).toBe("***");
+      expect(config.Token).toBe("***");
+    });
+
+    it("still masks compound `*_token` credential shapes", () => {
+      const value = {
+        auth_payload: {
+          access_token: "at-leaked",
+          refresh_token: "rt-leaked",
+          id_token: "it-leaked",
+          bearer_token: "bt-leaked",
+          auth_token: "auth-leaked",
+          session_token: "st-leaked",
+        },
+      };
+      const redacted = redactSecretsForDisplay(value);
+      const payload = redacted.auth_payload as Record<string, unknown>;
+      expect(payload.access_token).toBe("***");
+      expect(payload.refresh_token).toBe("***");
+      expect(payload.id_token).toBe("***");
+      expect(payload.bearer_token).toBe("***");
+      expect(payload.auth_token).toBe("***");
+      expect(payload.session_token).toBe("***");
+    });
+
+    it("still masks api_key / x-api-key / authorization / client_secret / private_key", () => {
+      const value = {
+        creds: {
+          api_key: "leaked-api-key",
+          "x-api-key": "leaked-x-key",
+          authorization: "Bearer leaked",
+          client_secret: "cs-leaked",
+          private_key: "pk-leaked",
+        },
+      };
+      const redacted = redactSecretsForDisplay(value);
+      const creds = redacted.creds as Record<string, unknown>;
+      expect(creds.api_key).toBe("***");
+      expect(creds["x-api-key"]).toBe("***");
+      expect(creds.authorization).toBe("***");
+      expect(creds.client_secret).toBe("***");
+      expect(creds.private_key).toBe("***");
+    });
+  });
 });
 
 describe("computeRedactedDiff", () => {

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -12,10 +12,12 @@ import {
   lockedFieldChange,
   mergeLockedFields,
   partitionActiveHookFilter,
+  redactAgentSpecForEditing,
   redactAgentSpecForDisplay,
   redactEndpointForDisplay,
   redactSecretString,
   redactSecretsForDisplay,
+  restoreUnchangedRedactions,
   togglePluginState,
   unknownAgentSpecFields,
 } from "./agent-editor-helpers";
@@ -47,9 +49,9 @@ describe("canonicalStringify / deepEqualCanonical", () => {
   });
 
   it("recursively sorts nested keys", () => {
-    expect(
-      canonicalStringify({ outer: { y: 2, x: 1 }, list: [{ b: 2, a: 1 }] }),
-    ).toBe(canonicalStringify({ list: [{ a: 1, b: 2 }], outer: { x: 1, y: 2 } }));
+    expect(canonicalStringify({ outer: { y: 2, x: 1 }, list: [{ b: 2, a: 1 }] })).toBe(
+      canonicalStringify({ list: [{ a: 1, b: 2 }], outer: { x: 1, y: 2 } }),
+    );
   });
 
   it("preserves array order (semantically significant)", () => {
@@ -192,6 +194,34 @@ describe("diffPatchableAgentFields", () => {
       sections: { foo: { b: 2, a: 1 } },
     };
     expect(diffPatchableAgentFields(current, original)).toEqual(EMPTY_PLAN);
+  });
+
+  it("emits sections as a per-key patch and uses null to delete inherited keys", () => {
+    const original = baseSpec({
+      sections: {
+        permission: { default_behavior: "ask", rules: [] },
+        oauth: { client_secret: "old-secret" },
+        unchanged: { enabled: true },
+      },
+    });
+    const current = baseSpec({
+      sections: {
+        oauth: { client_secret: "new-secret" },
+        unchanged: { enabled: true },
+        added: { mode: "strict" },
+      },
+    });
+
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: {
+        sections: {
+          permission: null,
+          oauth: { client_secret: "new-secret" },
+          added: { mode: "strict" },
+        },
+      },
+      clear: [],
+    });
   });
 
   it("emits context_policy when it changed (regression for G1)", () => {
@@ -419,9 +449,10 @@ describe("partitionActiveHookFilter", () => {
   });
 
   it("classifies entries with no matching plugin as stale", () => {
-    expect(
-      partitionActiveHookFilter(["permission", "ghost"], ["permission"]),
-    ).toEqual({ active: ["permission"], stale: ["ghost"] });
+    expect(partitionActiveHookFilter(["permission", "ghost"], ["permission"])).toEqual({
+      active: ["permission"],
+      stale: ["ghost"],
+    });
   });
 
   it("treats undefined filter as no entries", () => {
@@ -440,10 +471,7 @@ describe("partitionActiveHookFilter", () => {
 
   it("de-duplicates within the result while preserving first-seen order", () => {
     expect(
-      partitionActiveHookFilter(
-        ["permission", "permission", "ghost", "ghost"],
-        ["permission"],
-      ),
+      partitionActiveHookFilter(["permission", "permission", "ghost", "ghost"], ["permission"]),
     ).toEqual({ active: ["permission"], stale: ["ghost"] });
   });
 });
@@ -772,11 +800,7 @@ describe("redactSecretsForDisplay (R6 #B/#C — generic deep redact)", () => {
   it("redacts secret strings inside arrays of primitives", () => {
     const event = {
       payload: {
-        lines: [
-          "first line",
-          "Bearer abc123def456ghi789jkl",
-          "Cookie: session=raw-session-id",
-        ],
+        lines: ["first line", "Bearer abc123def456ghi789jkl", "Cookie: session=raw-session-id"],
       },
     };
     const redacted = redactSecretsForDisplay(event);
@@ -877,6 +901,47 @@ describe("redactAgentSpecForDisplay (R3 #1)", () => {
   });
 });
 
+describe("redactAgentSpecForEditing / restoreUnchangedRedactions", () => {
+  it("redacts sections secrets and restores unchanged redactions", () => {
+    const spec = baseSpec({
+      sections: {
+        oauth: { client_secret: "live-secret", label: "prod" },
+        observability: { api_key: "live-api-key" },
+      },
+    });
+
+    const { redacted, redactions } = redactAgentSpecForEditing(spec);
+    const serialized = JSON.stringify(redacted);
+
+    expect(serialized).not.toContain("live-secret");
+    expect(serialized).not.toContain("live-api-key");
+    expect((redacted.sections?.oauth as Record<string, unknown>).client_secret).toBe("***");
+    expect((redacted.sections?.observability as Record<string, unknown>).api_key).toBe("***");
+
+    const restored = restoreUnchangedRedactions(
+      JSON.parse(JSON.stringify(redacted)) as AgentSpec,
+      redactions,
+    );
+    expect((restored.sections?.oauth as Record<string, unknown>).client_secret).toBe("live-secret");
+    expect((restored.sections?.observability as Record<string, unknown>).api_key).toBe(
+      "live-api-key",
+    );
+  });
+
+  it("keeps a user-entered replacement instead of restoring the old secret", () => {
+    const spec = baseSpec({
+      sections: { oauth: { client_secret: "old-secret" } },
+    });
+    const { redacted, redactions } = redactAgentSpecForEditing(spec);
+    const parsed = JSON.parse(JSON.stringify(redacted)) as AgentSpec;
+    (parsed.sections?.oauth as Record<string, unknown>).client_secret = "new-secret";
+
+    const restored = restoreUnchangedRedactions(parsed, redactions);
+
+    expect((restored.sections?.oauth as Record<string, unknown>).client_secret).toBe("new-secret");
+  });
+});
+
 describe("ALLOWED_AGENT_FIELDS / unknownAgentSpecFields (R3 #3)", () => {
   it("includes identity, locked, and patchable fields", () => {
     expect(ALLOWED_AGENT_FIELDS).toEqual(
@@ -934,12 +999,18 @@ describe("ALLOWED_AGENT_FIELDS / unknownAgentSpecFields (R3 #3)", () => {
 describe("mergeLockedFields (R3 #1)", () => {
   it("overlays current spec's endpoint and registry onto parsed", () => {
     const spec = baseSpec({
-      endpoint: { base_url: "https://real.example.com", auth: { type: "bearer", bearer_token: "real" } },
+      endpoint: {
+        base_url: "https://real.example.com",
+        auth: { type: "bearer", bearer_token: "real" },
+      },
       registry: "cloud",
     });
     const parsed: Record<string, unknown> = {
       ...spec,
-      endpoint: { base_url: "https://real.example.com", auth: { type: "bearer", bearer_token: "***" } },
+      endpoint: {
+        base_url: "https://real.example.com",
+        auth: { type: "bearer", bearer_token: "***" },
+      },
       registry: "cloud",
     };
     const merged = mergeLockedFields(parsed, spec);
@@ -1081,7 +1152,7 @@ describe("Raw JSON locked-field check ordering (R5 #1)", () => {
     const displaySpec = redactAgentSpecForDisplay(spec);
     // Scenario: user changed `endpoint.base_url` in Raw JSON. The
     // textarea showed `***` for the bearer token; the user kept that
-    // placeholder but flipped the URL.
+    // redaction marker but flipped the URL.
     const parsed = {
       ...spec,
       endpoint: {
@@ -1102,7 +1173,7 @@ describe("Raw JSON locked-field check ordering (R5 #1)", () => {
     expect(lockedFieldChange(spec, buggyMerged)).toBeNull();
   });
 
-  it("display-spec compare allows the `***` placeholder to survive (no false positive)", () => {
+  it("display-spec compare allows the `***` redaction marker to survive (no false positive)", () => {
     const spec = baseSpec({
       endpoint: {
         base_url: "https://real.example.com",
@@ -1291,7 +1362,7 @@ describe("redactSecretString (R12 #3)", () => {
   });
 
   it("masks inline Bearer tokens", () => {
-    const out = redactSecretString('called with Bearer abc123def456ghi789jkl');
+    const out = redactSecretString("called with Bearer abc123def456ghi789jkl");
     expect(out).toContain("Bearer ***");
     expect(out).not.toContain("abc123def456ghi789jkl");
   });
@@ -1330,9 +1401,7 @@ describe("redactSecretString (R12 #3)", () => {
   });
 
   it("masks OpenAI-style sk- and Stripe-style sk_ keys", () => {
-    const out = redactSecretString(
-      "key1=sk-abcdefghijklmnop1234567890 key2=sk_live_abc123XYZ",
-    );
+    const out = redactSecretString("key1=sk-abcdefghijklmnop1234567890 key2=sk_live_abc123XYZ");
     expect(out).not.toContain("sk-abcdefghijklmnop1234567890");
     expect(out).not.toContain("sk_live_abc123XYZ");
   });
@@ -1347,8 +1416,6 @@ describe("redactSecretString (R12 #3)", () => {
     expect(redactSecretString("")).toBe("");
     // Defensive — the helper is called from formatJson which already
     // narrows to string, but defensive coding pays off if callers drift.
-    expect(redactSecretString(undefined as unknown as string)).toBe(
-      undefined as unknown as string,
-    );
+    expect(redactSecretString(undefined as unknown as string)).toBe(undefined as unknown as string);
   });
 });

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -1,0 +1,648 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentSpec, RemoteEndpoint } from "./api/types";
+import {
+  ALLOWED_AGENT_FIELDS,
+  PATCHABLE_AGENT_FIELDS,
+  canonicalStringify,
+  cloneAgentSpecForEditor,
+  deepEqualCanonical,
+  diffPatchableAgentFields,
+  lockedFieldChange,
+  mergeLockedFields,
+  partitionActiveHookFilter,
+  redactAgentSpecForDisplay,
+  redactEndpointForDisplay,
+  togglePluginState,
+  unknownAgentSpecFields,
+} from "./agent-editor-helpers";
+
+function baseSpec(overrides: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    id: "alpha",
+    model_id: "research-default",
+    system_prompt: "You are a test agent.",
+    max_rounds: 8,
+    plugin_ids: [],
+    active_hook_filter: [],
+    sections: {},
+    delegates: [],
+    ...overrides,
+  };
+}
+
+const REMOTE_ENDPOINT: RemoteEndpoint = {
+  backend: "a2a",
+  base_url: "https://remote.example.com",
+  target: "remote-agent",
+  timeout_ms: 60_000,
+};
+
+describe("canonicalStringify / deepEqualCanonical", () => {
+  it("sorts object keys deterministically", () => {
+    expect(canonicalStringify({ b: 2, a: 1 })).toBe(canonicalStringify({ a: 1, b: 2 }));
+  });
+
+  it("recursively sorts nested keys", () => {
+    expect(
+      canonicalStringify({ outer: { y: 2, x: 1 }, list: [{ b: 2, a: 1 }] }),
+    ).toBe(canonicalStringify({ list: [{ a: 1, b: 2 }], outer: { x: 1, y: 2 } }));
+  });
+
+  it("preserves array order (semantically significant)", () => {
+    expect(deepEqualCanonical(["a", "b"], ["b", "a"])).toBe(false);
+  });
+
+  it("treats undefined and absent equivalently", () => {
+    expect(deepEqualCanonical({ a: 1, b: undefined }, { a: 1 })).toBe(true);
+    expect(deepEqualCanonical({ a: 1 }, { a: 1, b: undefined })).toBe(true);
+  });
+
+  it("treats null and undefined equivalently at top level", () => {
+    expect(deepEqualCanonical(null, undefined)).toBe(true);
+  });
+
+  it("flags genuine structural differences", () => {
+    expect(deepEqualCanonical({ a: 1 }, { a: 2 })).toBe(false);
+    expect(deepEqualCanonical({ a: { b: 1 } }, { a: { b: 2 } })).toBe(false);
+  });
+});
+
+describe("lockedFieldChange", () => {
+  it("returns null when neither endpoint nor registry differs", () => {
+    const spec = baseSpec({ endpoint: REMOTE_ENDPOINT, registry: "cloud" });
+    const parsed = JSON.parse(JSON.stringify(spec));
+    expect(lockedFieldChange(spec, parsed)).toBeNull();
+  });
+
+  it("returns null when only object key order differs (regression for #5)", () => {
+    const spec = baseSpec({
+      endpoint: {
+        backend: "a2a",
+        base_url: "https://remote.example.com",
+        target: "remote-agent",
+        timeout_ms: 60_000,
+      },
+    });
+    // Same endpoint, keys re-ordered as a user editing Raw JSON would naturally do.
+    const reordered: Record<string, unknown> = {
+      ...spec,
+      endpoint: {
+        timeout_ms: 60_000,
+        target: "remote-agent",
+        base_url: "https://remote.example.com",
+        backend: "a2a",
+      },
+    };
+    expect(lockedFieldChange(spec, reordered)).toBeNull();
+  });
+
+  it("treats absent vs explicit null equivalently for endpoint", () => {
+    const spec = baseSpec();
+    expect(lockedFieldChange(spec, {})).toBeNull();
+    expect(lockedFieldChange(spec, { endpoint: null })).toBeNull();
+    expect(lockedFieldChange(spec, { endpoint: undefined })).toBeNull();
+  });
+
+  it("flags endpoint when the parsed value differs", () => {
+    const spec = baseSpec({ endpoint: REMOTE_ENDPOINT });
+    const parsed = {
+      ...spec,
+      endpoint: { ...REMOTE_ENDPOINT, base_url: "https://other.example.com" },
+    };
+    expect(lockedFieldChange(spec, parsed)).toBe("endpoint");
+  });
+
+  it("flags registry when the parsed value differs", () => {
+    const spec = baseSpec({ registry: "cloud" });
+    expect(lockedFieldChange(spec, { ...spec, registry: "local" })).toBe("registry");
+  });
+
+  it("flags endpoint before registry when both differ (stable order)", () => {
+    const spec = baseSpec({ endpoint: REMOTE_ENDPOINT, registry: "cloud" });
+    const parsed = {
+      ...spec,
+      endpoint: { ...REMOTE_ENDPOINT, base_url: "https://other.example.com" },
+      registry: "local",
+    };
+    expect(lockedFieldChange(spec, parsed)).toBe("endpoint");
+  });
+
+  it("flags registry being removed (cloud -> absent)", () => {
+    const spec = baseSpec({ registry: "cloud" });
+    expect(lockedFieldChange(spec, {})).toBe("registry");
+  });
+
+  it("flags registry being introduced (absent -> cloud)", () => {
+    const spec = baseSpec();
+    expect(lockedFieldChange(spec, { registry: "cloud" })).toBe("registry");
+  });
+});
+
+describe("diffPatchableAgentFields", () => {
+  it("returns an empty patch when nothing changed", () => {
+    const spec = baseSpec({
+      context_policy: {
+        max_context_tokens: 100,
+        max_output_tokens: 10,
+        min_recent_messages: 1,
+        enable_prompt_cache: true,
+      },
+      active_hook_filter: ["permission"],
+    });
+    expect(diffPatchableAgentFields(spec, spec)).toEqual({});
+  });
+
+  it("returns an empty patch when only object key order differs", () => {
+    // The original is what the server returned; the current is what the user
+    // sees after re-formatting via Raw JSON. Same shape, different key order.
+    const original = baseSpec({
+      context_policy: {
+        max_context_tokens: 100,
+        max_output_tokens: 10,
+        min_recent_messages: 1,
+        enable_prompt_cache: true,
+      },
+      sections: { foo: { a: 1, b: 2 } },
+    });
+    const current: AgentSpec = {
+      ...original,
+      context_policy: {
+        // Keys in different order.
+        enable_prompt_cache: true,
+        min_recent_messages: 1,
+        max_output_tokens: 10,
+        max_context_tokens: 100,
+      },
+      sections: { foo: { b: 2, a: 1 } },
+    };
+    expect(diffPatchableAgentFields(current, original)).toEqual({});
+  });
+
+  it("emits context_policy when it changed (regression for G1)", () => {
+    const original = baseSpec();
+    const current: AgentSpec = {
+      ...original,
+      context_policy: {
+        max_context_tokens: 222_222,
+        max_output_tokens: 16_384,
+        min_recent_messages: 10,
+        enable_prompt_cache: true,
+      },
+    };
+    const patch = diffPatchableAgentFields(current, original);
+    expect(patch).toHaveProperty("context_policy");
+    expect(patch.context_policy).toEqual(current.context_policy);
+  });
+
+  it("emits active_hook_filter when it changed (regression for G1)", () => {
+    const original = baseSpec({ active_hook_filter: [] });
+    const current: AgentSpec = {
+      ...original,
+      active_hook_filter: ["permission"],
+    };
+    const patch = diffPatchableAgentFields(current, original);
+    expect(patch).toEqual({ active_hook_filter: ["permission"] });
+  });
+
+  it("emits each patchable scalar when it changed", () => {
+    const original = baseSpec();
+    const current: AgentSpec = {
+      ...original,
+      model_id: "new-model",
+      system_prompt: "new",
+      max_rounds: 64,
+      max_continuation_retries: 5,
+      delegates: ["other-agent"],
+      allowed_tools: ["Bash"],
+      excluded_tools: ["Read"],
+      reasoning_effort: "high",
+      plugin_ids: ["permission", "reminder"],
+      sections: { permission: { default_behavior: "deny", rules: [] } },
+    };
+    const patch = diffPatchableAgentFields(current, original);
+    expect(Object.keys(patch).sort()).toEqual(
+      [
+        "allowed_tools",
+        "delegates",
+        "excluded_tools",
+        "max_continuation_retries",
+        "max_rounds",
+        "model_id",
+        "plugin_ids",
+        "reasoning_effort",
+        "sections",
+        "system_prompt",
+      ].sort(),
+    );
+  });
+
+  it("does not emit locked or non-patchable fields even when they differ", () => {
+    const original = baseSpec({ endpoint: REMOTE_ENDPOINT, registry: "cloud" });
+    const current: AgentSpec = {
+      ...original,
+      endpoint: { ...REMOTE_ENDPOINT, base_url: "https://changed.example.com" },
+      registry: "local",
+      id: "renamed-id",
+      created_at: 1,
+      updated_at: 2,
+    };
+    expect(diffPatchableAgentFields(current, original)).toEqual({});
+  });
+
+  it("every G1 field is in PATCHABLE_AGENT_FIELDS", () => {
+    // This list locks in the schema-level G1 fix and is the canonical answer
+    // to "what does the customized PATCH path actually persist?".
+    expect(PATCHABLE_AGENT_FIELDS).toContain("context_policy");
+    expect(PATCHABLE_AGENT_FIELDS).toContain("active_hook_filter");
+  });
+});
+
+describe("cloneAgentSpecForEditor", () => {
+  it("clears id, created_at, updated_at, registry, and endpoint", () => {
+    const source: AgentSpec = baseSpec({
+      id: "ingest",
+      created_at: 1_700_000_000_000,
+      updated_at: 1_700_000_500_000,
+      registry: "cloud",
+      endpoint: REMOTE_ENDPOINT,
+    });
+
+    const cloned = cloneAgentSpecForEditor(source);
+    expect(cloned.id).toBe("");
+    expect(cloned.created_at).toBeUndefined();
+    expect(cloned.updated_at).toBeUndefined();
+    expect(cloned.registry).toBeUndefined();
+    expect(cloned.endpoint).toBeUndefined();
+  });
+
+  it("preserves editable AgentSpec body (prompt, model_id, plugins, sections)", () => {
+    const source: AgentSpec = baseSpec({
+      id: "ingest",
+      system_prompt: "Be helpful.",
+      model_id: "research-default",
+      plugin_ids: ["permission", "reminder"],
+      active_hook_filter: ["permission"],
+      sections: { ingest: { mode: "planning" } },
+      endpoint: REMOTE_ENDPOINT,
+      registry: "cloud",
+    });
+
+    const cloned = cloneAgentSpecForEditor(source);
+    expect(cloned.system_prompt).toBe("Be helpful.");
+    expect(cloned.model_id).toBe("research-default");
+    expect(cloned.plugin_ids).toEqual(["permission", "reminder"]);
+    expect(cloned.active_hook_filter).toEqual(["permission"]);
+    expect(cloned.sections).toEqual({ ingest: { mode: "planning" } });
+  });
+
+  it("does not mutate the source spec", () => {
+    const source: AgentSpec = baseSpec({
+      id: "ingest",
+      registry: "cloud",
+      endpoint: REMOTE_ENDPOINT,
+      created_at: 1,
+      updated_at: 2,
+    });
+    const snapshot = JSON.parse(JSON.stringify(source));
+    cloneAgentSpecForEditor(source);
+    expect(source).toEqual(snapshot);
+  });
+});
+
+describe("togglePluginState", () => {
+  it("adds a plugin when not present", () => {
+    expect(togglePluginState(["permission"], [], "reminder")).toEqual({
+      plugin_ids: ["permission", "reminder"],
+      active_hook_filter: [],
+    });
+  });
+
+  it("removes a plugin when present", () => {
+    expect(togglePluginState(["permission", "reminder"], [], "reminder")).toEqual({
+      plugin_ids: ["permission"],
+      active_hook_filter: [],
+    });
+  });
+
+  it("prunes active_hook_filter when the plugin is removed", () => {
+    expect(
+      togglePluginState(["permission", "reminder"], ["permission", "reminder"], "reminder"),
+    ).toEqual({
+      plugin_ids: ["permission"],
+      active_hook_filter: ["permission"],
+    });
+  });
+
+  it("leaves active_hook_filter untouched when adding (no stale entry to prune)", () => {
+    expect(togglePluginState(["permission"], ["permission"], "reminder")).toEqual({
+      plugin_ids: ["permission", "reminder"],
+      active_hook_filter: ["permission"],
+    });
+  });
+
+  it("keeps active_hook_filter absent when it was absent and we add a plugin", () => {
+    const result = togglePluginState(["permission"], undefined, "reminder");
+    expect(result.plugin_ids).toEqual(["permission", "reminder"]);
+    expect(result.active_hook_filter).toBeUndefined();
+  });
+
+  it("keeps active_hook_filter absent when removing a plugin (avoids stray empty array)", () => {
+    const result = togglePluginState(["permission", "reminder"], undefined, "reminder");
+    expect(result.plugin_ids).toEqual(["permission"]);
+    expect(result.active_hook_filter).toBeUndefined();
+  });
+
+  it("treats undefined plugin_ids as empty", () => {
+    expect(togglePluginState(undefined, undefined, "permission")).toEqual({
+      plugin_ids: ["permission"],
+      active_hook_filter: undefined,
+    });
+  });
+
+  it("does not mutate the input arrays", () => {
+    const plugins = ["permission", "reminder"];
+    const filter = ["permission", "reminder"];
+    const pluginsSnapshot = [...plugins];
+    const filterSnapshot = [...filter];
+    togglePluginState(plugins, filter, "reminder");
+    expect(plugins).toEqual(pluginsSnapshot);
+    expect(filter).toEqual(filterSnapshot);
+  });
+});
+
+describe("partitionActiveHookFilter", () => {
+  it("classifies all entries as active when every id is loaded", () => {
+    expect(
+      partitionActiveHookFilter(["permission", "reminder"], ["permission", "reminder"]),
+    ).toEqual({ active: ["permission", "reminder"], stale: [] });
+  });
+
+  it("classifies entries with no matching plugin as stale", () => {
+    expect(
+      partitionActiveHookFilter(["permission", "ghost"], ["permission"]),
+    ).toEqual({ active: ["permission"], stale: ["ghost"] });
+  });
+
+  it("treats undefined filter as no entries", () => {
+    expect(partitionActiveHookFilter(undefined, ["permission"])).toEqual({
+      active: [],
+      stale: [],
+    });
+  });
+
+  it("treats undefined plugin_ids as all-stale", () => {
+    expect(partitionActiveHookFilter(["ghost"], undefined)).toEqual({
+      active: [],
+      stale: ["ghost"],
+    });
+  });
+
+  it("de-duplicates within the result while preserving first-seen order", () => {
+    expect(
+      partitionActiveHookFilter(
+        ["permission", "permission", "ghost", "ghost"],
+        ["permission"],
+      ),
+    ).toEqual({ active: ["permission"], stale: ["ghost"] });
+  });
+});
+
+describe("redactEndpointForDisplay", () => {
+  it("masks bearer_token but keeps non-secret fields", () => {
+    const endpoint: RemoteEndpoint = {
+      backend: "a2a",
+      base_url: "https://remote.example.com",
+      target: "remote-agent",
+      timeout_ms: 60_000,
+      auth: {
+        type: "bearer",
+        bearer_token: "super-secret-token",
+      },
+    };
+    const redacted = redactEndpointForDisplay(endpoint);
+    expect(redacted.base_url).toBe("https://remote.example.com");
+    expect(redacted.auth?.type).toBe("bearer");
+    expect(redacted.auth?.bearer_token).toBe("***");
+  });
+
+  it("masks api_key / authorization / secret / password / passphrase / credential", () => {
+    const endpoint: RemoteEndpoint = {
+      base_url: "https://x",
+      auth: {
+        type: "custom",
+        api_key: "k1",
+        apiKey: "k2",
+        authorization: "Bearer abc",
+        secret: "s",
+        password: "p",
+        passphrase: "pp",
+        credential: "c",
+        client_secret: "cs",
+        access_token: "at",
+        refresh_token: "rt",
+        id_token: "it",
+        private_key: "pk",
+        privateKey: "pk2",
+      },
+    };
+    const redacted = redactEndpointForDisplay(endpoint);
+    const auth = (redacted.auth ?? {}) as Record<string, unknown>;
+    for (const key of [
+      "api_key",
+      "apiKey",
+      "authorization",
+      "secret",
+      "password",
+      "passphrase",
+      "credential",
+      "client_secret",
+      "access_token",
+      "refresh_token",
+      "id_token",
+      "private_key",
+      "privateKey",
+    ]) {
+      expect(auth[key], `key ${key} should be redacted`).toBe("***");
+    }
+    expect(auth.type).toBe("custom");
+  });
+
+  it("redacts secret keys nested inside options", () => {
+    const endpoint: RemoteEndpoint = {
+      base_url: "https://x",
+      options: {
+        retry: 3,
+        headers: { Authorization: "Bearer leaked", "X-Trace": "ok" },
+      },
+    };
+    const redacted = redactEndpointForDisplay(endpoint);
+    const headers = (redacted.options?.headers ?? {}) as Record<string, unknown>;
+    expect(headers.Authorization).toBe("***");
+    expect(headers["X-Trace"]).toBe("ok");
+    expect(redacted.options?.retry).toBe(3);
+  });
+
+  it("preserves null / undefined values rather than replacing them with ***", () => {
+    const endpoint: RemoteEndpoint = {
+      base_url: "https://x",
+      auth: {
+        type: "none",
+        bearer_token: null as unknown as string,
+      },
+    };
+    const redacted = redactEndpointForDisplay(endpoint);
+    expect(redacted.auth?.bearer_token).toBeNull();
+  });
+
+  it("does not mutate the source endpoint", () => {
+    const endpoint: RemoteEndpoint = {
+      base_url: "https://x",
+      auth: { type: "bearer", bearer_token: "real-secret" },
+    };
+    const snapshot = JSON.parse(JSON.stringify(endpoint));
+    redactEndpointForDisplay(endpoint);
+    expect(endpoint).toEqual(snapshot);
+  });
+
+  it("is case-insensitive on key matching (Authorization, BearerToken, etc.)", () => {
+    const endpoint = {
+      base_url: "https://x",
+      auth: { type: "bearer", BearerToken: "abc", AUTHORIZATION: "z" },
+    } as unknown as RemoteEndpoint;
+    const redacted = redactEndpointForDisplay(endpoint);
+    const auth = redacted.auth as Record<string, unknown>;
+    expect(auth.BearerToken).toBe("***");
+    expect(auth.AUTHORIZATION).toBe("***");
+  });
+});
+
+describe("redactAgentSpecForDisplay (R3 #1)", () => {
+  it("returns the spec unchanged when no endpoint is set", () => {
+    const spec = baseSpec();
+    expect(redactAgentSpecForDisplay(spec)).toBe(spec);
+  });
+
+  it("redacts secret keys inside endpoint while preserving everything else", () => {
+    const spec = baseSpec({
+      endpoint: {
+        backend: "a2a",
+        base_url: "https://remote.example.com",
+        auth: { type: "bearer", bearer_token: "real-secret" },
+      },
+    });
+    const redacted = redactAgentSpecForDisplay(spec);
+    expect(redacted.id).toBe(spec.id);
+    expect(redacted.system_prompt).toBe(spec.system_prompt);
+    expect(redacted.endpoint?.base_url).toBe("https://remote.example.com");
+    expect(redacted.endpoint?.auth?.bearer_token).toBe("***");
+  });
+
+  it("does not mutate the source spec", () => {
+    const spec = baseSpec({
+      endpoint: { base_url: "https://x", auth: { type: "bearer", bearer_token: "abc" } },
+    });
+    const snapshot = JSON.parse(JSON.stringify(spec));
+    redactAgentSpecForDisplay(spec);
+    expect(spec).toEqual(snapshot);
+  });
+});
+
+describe("ALLOWED_AGENT_FIELDS / unknownAgentSpecFields (R3 #3)", () => {
+  it("includes identity, locked, and patchable fields", () => {
+    expect(ALLOWED_AGENT_FIELDS).toEqual(
+      expect.arrayContaining([
+        "id",
+        "created_at",
+        "updated_at",
+        "endpoint",
+        "registry",
+        ...PATCHABLE_AGENT_FIELDS,
+      ]),
+    );
+  });
+
+  it("returns an empty list for a fully-known spec object", () => {
+    const parsed: Record<string, unknown> = {
+      id: "a",
+      model_id: "m",
+      system_prompt: "p",
+      plugin_ids: ["permission"],
+      sections: {},
+      delegates: [],
+    };
+    expect(unknownAgentSpecFields(parsed)).toEqual([]);
+  });
+
+  it("flags top-level keys outside the allowlist", () => {
+    const parsed: Record<string, unknown> = {
+      id: "a",
+      model_id: "m",
+      system_prompt: "p",
+      surprise: 1,
+      future_field: { nested: true },
+    };
+    expect(unknownAgentSpecFields(parsed).sort()).toEqual(["future_field", "surprise"]);
+  });
+});
+
+describe("mergeLockedFields (R3 #1)", () => {
+  it("overlays current spec's endpoint and registry onto parsed", () => {
+    const spec = baseSpec({
+      endpoint: { base_url: "https://real.example.com", auth: { type: "bearer", bearer_token: "real" } },
+      registry: "cloud",
+    });
+    const parsed: Record<string, unknown> = {
+      ...spec,
+      endpoint: { base_url: "https://real.example.com", auth: { type: "bearer", bearer_token: "***" } },
+      registry: "cloud",
+    };
+    const merged = mergeLockedFields(parsed, spec);
+    expect(merged.endpoint).toEqual(spec.endpoint);
+    expect(merged.registry).toBe("cloud");
+  });
+
+  it("removes locked keys from parsed when the current spec has them absent", () => {
+    const spec = baseSpec();
+    const parsed: Record<string, unknown> = {
+      ...spec,
+      endpoint: { base_url: "ghost" },
+      registry: "drift",
+    };
+    const merged = mergeLockedFields(parsed, spec);
+    expect("endpoint" in merged).toBe(false);
+    expect("registry" in merged).toBe(false);
+  });
+
+  it("does not mutate inputs", () => {
+    const spec = baseSpec({ endpoint: { base_url: "https://x" } });
+    const parsed: Record<string, unknown> = { id: "p", endpoint: { base_url: "y" } };
+    const specSnap = JSON.parse(JSON.stringify(spec));
+    const parsedSnap = JSON.parse(JSON.stringify(parsed));
+    mergeLockedFields(parsed, spec);
+    expect(spec).toEqual(specSnap);
+    expect(parsed).toEqual(parsedSnap);
+  });
+});
+
+describe("active_hook_filter [] vs absent normalization (R3 #2)", () => {
+  it("does not emit a patch when active_hook_filter goes from absent to []", () => {
+    const original = baseSpec({ active_hook_filter: undefined });
+    const current: AgentSpec = { ...original, active_hook_filter: [] };
+    expect(diffPatchableAgentFields(current, original)).toEqual({});
+  });
+
+  it("does not emit a patch when active_hook_filter goes from [] to absent", () => {
+    const original = baseSpec({ active_hook_filter: [] });
+    const current: AgentSpec = { ...original, active_hook_filter: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({});
+  });
+
+  it("still emits the actual array when an entry is added", () => {
+    const original = baseSpec({ active_hook_filter: [] });
+    const current: AgentSpec = { ...original, active_hook_filter: ["permission"] };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      active_hook_filter: ["permission"],
+    });
+  });
+});

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -13,6 +13,8 @@ import {
   partitionActiveHookFilter,
   redactAgentSpecForDisplay,
   redactEndpointForDisplay,
+  redactSecretString,
+  redactSecretsForDisplay,
   togglePluginState,
   unknownAgentSpecFields,
 } from "./agent-editor-helpers";
@@ -140,7 +142,9 @@ describe("lockedFieldChange", () => {
 });
 
 describe("diffPatchableAgentFields", () => {
-  it("returns an empty patch when nothing changed", () => {
+  const EMPTY_PLAN = { patch: {}, clear: [] };
+
+  it("returns an empty plan when nothing changed", () => {
     const spec = baseSpec({
       context_policy: {
         max_context_tokens: 100,
@@ -150,10 +154,10 @@ describe("diffPatchableAgentFields", () => {
       },
       active_hook_filter: ["permission"],
     });
-    expect(diffPatchableAgentFields(spec, spec)).toEqual({});
+    expect(diffPatchableAgentFields(spec, spec)).toEqual(EMPTY_PLAN);
   });
 
-  it("returns an empty patch when only object key order differs", () => {
+  it("returns an empty plan when only object key order differs", () => {
     // The original is what the server returned; the current is what the user
     // sees after re-formatting via Raw JSON. Same shape, different key order.
     const original = baseSpec({
@@ -176,7 +180,7 @@ describe("diffPatchableAgentFields", () => {
       },
       sections: { foo: { b: 2, a: 1 } },
     };
-    expect(diffPatchableAgentFields(current, original)).toEqual({});
+    expect(diffPatchableAgentFields(current, original)).toEqual(EMPTY_PLAN);
   });
 
   it("emits context_policy when it changed (regression for G1)", () => {
@@ -190,9 +194,10 @@ describe("diffPatchableAgentFields", () => {
         enable_prompt_cache: true,
       },
     };
-    const patch = diffPatchableAgentFields(current, original);
-    expect(patch).toHaveProperty("context_policy");
-    expect(patch.context_policy).toEqual(current.context_policy);
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan.patch).toHaveProperty("context_policy");
+    expect(plan.patch.context_policy).toEqual(current.context_policy);
+    expect(plan.clear).toEqual([]);
   });
 
   it("emits active_hook_filter when it changed (regression for G1)", () => {
@@ -201,8 +206,9 @@ describe("diffPatchableAgentFields", () => {
       ...original,
       active_hook_filter: ["permission"],
     };
-    const patch = diffPatchableAgentFields(current, original);
-    expect(patch).toEqual({ active_hook_filter: ["permission"] });
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan.patch).toEqual({ active_hook_filter: ["permission"] });
+    expect(plan.clear).toEqual([]);
   });
 
   it("emits each patchable scalar when it changed", () => {
@@ -220,8 +226,8 @@ describe("diffPatchableAgentFields", () => {
       plugin_ids: ["permission", "reminder"],
       sections: { permission: { default_behavior: "deny", rules: [] } },
     };
-    const patch = diffPatchableAgentFields(current, original);
-    expect(Object.keys(patch).sort()).toEqual(
+    const plan = diffPatchableAgentFields(current, original);
+    expect(Object.keys(plan.patch).sort()).toEqual(
       [
         "allowed_tools",
         "delegates",
@@ -235,6 +241,7 @@ describe("diffPatchableAgentFields", () => {
         "system_prompt",
       ].sort(),
     );
+    expect(plan.clear).toEqual([]);
   });
 
   it("does not emit locked or non-patchable fields even when they differ", () => {
@@ -247,7 +254,7 @@ describe("diffPatchableAgentFields", () => {
       created_at: 1,
       updated_at: 2,
     };
-    expect(diffPatchableAgentFields(current, original)).toEqual({});
+    expect(diffPatchableAgentFields(current, original)).toEqual(EMPTY_PLAN);
   });
 
   it("every G1 field is in PATCHABLE_AGENT_FIELDS", () => {
@@ -332,6 +339,28 @@ describe("togglePluginState", () => {
       plugin_ids: ["permission"],
       active_hook_filter: ["permission"],
     });
+  });
+
+  // R10 #6 — Removing the LAST entry from a previously-non-empty
+  // active_hook_filter must collapse the field back to `undefined`,
+  // not leave it as a stray `[]`. Empty array means "all hooks run"
+  // (same as absent), but the dirty-tracking / patch-diff path can't
+  // distinguish between explicit-empty and "user just removed the
+  // last entry"; emitting `[]` would surface as a no-op override or a
+  // perpetual dirty draft.
+  it("collapses active_hook_filter to undefined when the prune empties it", () => {
+    const result = togglePluginState(["reminder"], ["reminder"], "reminder");
+    expect(result.plugin_ids).toEqual([]);
+    expect(result.active_hook_filter).toBeUndefined();
+  });
+
+  it("keeps active_hook_filter as `[]` if it was already empty before removal", () => {
+    // Distinguishes "user removed last filter entry just now" (collapse
+    // to undefined) from "filter was always explicit-empty" (preserve
+    // `[]` so we don't change shape under the user's feet).
+    const result = togglePluginState(["reminder"], [], "reminder");
+    expect(result.plugin_ids).toEqual([]);
+    expect(result.active_hook_filter).toEqual([]);
   });
 
   it("leaves active_hook_filter untouched when adding (no stale entry to prune)", () => {
@@ -517,6 +546,205 @@ describe("redactEndpointForDisplay", () => {
   });
 });
 
+describe("redactSecretsForDisplay (R6 #B/#C — generic deep redact)", () => {
+  it("masks secret keys inside an arbitrary audit `before` snapshot", () => {
+    // Audit events carry the full pre-mutation spec; they can include
+    // `endpoint.auth.bearer_token`. The deep redactor walks the whole
+    // tree, not just `endpoint` — so a future schema that nests
+    // credentials elsewhere also gets masked.
+    const before = {
+      id: "alpha",
+      endpoint: {
+        base_url: "https://remote",
+        auth: { type: "bearer", bearer_token: "leaked" },
+      },
+      sections: { permission: { rules: [] } },
+    };
+    const redacted = redactSecretsForDisplay(before);
+    expect(redacted.endpoint.auth.bearer_token).toBe("***");
+    expect(redacted.endpoint.base_url).toBe("https://remote");
+    expect(redacted.id).toBe("alpha");
+    // No accidental side-mutation.
+    expect(before.endpoint.auth.bearer_token).toBe("leaked");
+  });
+
+  it("masks credentials nested inside a trace event payload", () => {
+    const event = {
+      kind: "agent_resolved",
+      ts: 1_000,
+      payload: {
+        agent_id: "x",
+        endpoint: { auth: { api_key: "key-leaked", type: "bearer" } },
+      },
+    };
+    const redacted = redactSecretsForDisplay(event);
+    expect((redacted.payload.endpoint.auth as Record<string, unknown>).api_key).toBe("***");
+  });
+
+  it("passes through primitives and arrays unchanged", () => {
+    expect(redactSecretsForDisplay(42)).toBe(42);
+    expect(redactSecretsForDisplay("hello")).toBe("hello");
+    expect(redactSecretsForDisplay(null)).toBeNull();
+    expect(redactSecretsForDisplay(undefined)).toBeUndefined();
+    expect(redactSecretsForDisplay([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  // R10 #4 — Outside the `auth` default-deny context, the redactor
+  // relied purely on the pattern list and missed HTTP-flavored secret
+  // keys. Tool outputs, trace event payloads, and audit-log diffs can
+  // surface raw `headers.cookie` / `set-cookie` / `jwt` / `bearer` /
+  // `session_*` shapes without any `auth` wrapper.
+  it("masks cookie / set-cookie / jwt / bearer / session keys anywhere in the payload", () => {
+    const payload = {
+      response: {
+        headers: {
+          cookie: "sid=abc",
+          "set-cookie": "session=xyz",
+          "user-agent": "preserved",
+        },
+        body: {
+          jwt: "raw-jwt",
+          bearer: "raw-bearer",
+          session_id: "raw-session",
+          session: "raw-session",
+        },
+      },
+    };
+    const redacted = redactSecretsForDisplay(payload);
+    const headers = redacted.response.headers as Record<string, unknown>;
+    expect(headers.cookie).toBe("***");
+    expect(headers["set-cookie"]).toBe("***");
+    // Non-sensitive keys stay through.
+    expect(headers["user-agent"]).toBe("preserved");
+    const body = redacted.response.body as Record<string, unknown>;
+    expect(body.jwt).toBe("***");
+    expect(body.bearer).toBe("***");
+    expect(body.session).toBe("***");
+    expect(body.session_id).toBe("***");
+  });
+
+  it("masks access_key / accesskey in arbitrary contexts", () => {
+    const payload = {
+      adapter_options: { access_key: "raw-AK", accesskey: "raw-AK-alt" },
+    };
+    const redacted = redactSecretsForDisplay(payload);
+    const opts = redacted.adapter_options as Record<string, unknown>;
+    expect(opts.access_key).toBe("***");
+    expect(opts.accesskey).toBe("***");
+  });
+
+  // R8 #2 — `RemoteAuth` allows arbitrary keys, so a credential under
+  // `jwt` / `cookie` / `session` / `x-api-key` / `header` / `bearer` etc.
+  // would slip past the pattern list. Generic redact must apply
+  // default-deny when it recurses into an `auth` object so audit log,
+  // trace drawer, and DiffModal all match `redactEndpointForDisplay`'s
+  // strength.
+  it("default-denies non-pattern keys when recursing into an `auth` object", () => {
+    const event = {
+      payload: {
+        endpoint: {
+          auth: {
+            type: "bearer",
+            jwt: "raw-jwt-leaked",
+            cookie: "sid=abc",
+            session: "session-leaked",
+            "x-api-key": "raw-key",
+            header: "raw-header",
+            // Standalone `bearer` (no `_token` suffix) — pattern alone
+            // would miss this; default-deny covers it.
+            bearer: "raw-bearer-leaked",
+          },
+        },
+      },
+    };
+    const redacted = redactSecretsForDisplay(event);
+    const auth = redacted.payload.endpoint.auth as Record<string, unknown>;
+    expect(auth.type).toBe("bearer");
+    expect(auth.jwt).toBe("***");
+    expect(auth.cookie).toBe("***");
+    expect(auth.session).toBe("***");
+    expect(auth["x-api-key"]).toBe("***");
+    expect(auth.header).toBe("***");
+    expect(auth.bearer).toBe("***");
+  });
+
+  it("default-denies even when `auth` lives several levels deep in a trace span", () => {
+    const span = {
+      trace: {
+        context: {
+          attributes: {
+            endpoint: { auth: { type: "custom", weird_key: "leak" } },
+          },
+        },
+      },
+    };
+    const redacted = redactSecretsForDisplay(span);
+    expect(
+      (redacted.trace.context.attributes.endpoint.auth as Record<string, unknown>).weird_key,
+    ).toBe("***");
+  });
+
+  // R13 — Key-based redaction misses raw strings whose key isn't itself
+  // a credential pattern. Trace event payloads, audit `before`/`after`
+  // snapshots, and DiffModal stringify untrusted blobs as-is — a string
+  // field named `output` / `body` / `message` can carry `Authorization:`
+  // header lines, inline `Bearer …` tokens, JWTs, or `sk-…` keys. The
+  // generic redactor must apply `redactSecretString` to every primitive
+  // string so all display paths share one defensive layer.
+  it("masks secret-bearing patterns inside primitive string values", () => {
+    const event = {
+      kind: "tool_output",
+      payload: {
+        output: "Authorization: Bearer sk-real-secret-value-1234567890abcdef",
+        notes: "regular log line — should stay untouched",
+      },
+    };
+    const redacted = redactSecretsForDisplay(event);
+    const payload = redacted.payload as Record<string, unknown>;
+    expect(payload.output).not.toContain("sk-real-secret-value");
+    expect(payload.output).toContain("Authorization: ***");
+    expect(payload.notes).toBe("regular log line — should stay untouched");
+  });
+
+  it("redacts secret strings inside arrays of primitives", () => {
+    const event = {
+      payload: {
+        lines: [
+          "first line",
+          "Bearer abc123def456ghi789jkl",
+          "Cookie: session=raw-session-id",
+        ],
+      },
+    };
+    const redacted = redactSecretsForDisplay(event);
+    const lines = (redacted.payload as Record<string, unknown>).lines as string[];
+    expect(lines[0]).toBe("first line");
+    expect(lines[1]).toContain("Bearer ***");
+    expect(lines[1]).not.toContain("abc123def456ghi789jkl");
+    expect(lines[2]).toContain("Cookie: ***");
+    expect(lines[2]).not.toContain("raw-session-id");
+  });
+
+  it("redacts a top-level primitive string (passes through redactSecretString)", () => {
+    expect(redactSecretsForDisplay("Authorization: Bearer raw-token-1234567890")).toBe(
+      "Authorization: ***",
+    );
+  });
+
+  it("preserves null / undefined inside `auth` as semantic markers", () => {
+    const value = {
+      endpoint: {
+        auth: { type: "bearer", weird_key: null, other: undefined },
+      },
+    };
+    const redacted = redactSecretsForDisplay(value);
+    const auth = redacted.endpoint.auth as Record<string, unknown>;
+    expect(auth.type).toBe("bearer");
+    expect(auth.weird_key).toBeNull();
+    expect(auth.other).toBeUndefined();
+  });
+});
+
 describe("redactAgentSpecForDisplay (R3 #1)", () => {
   it("returns the spec unchanged when no endpoint is set", () => {
     const spec = baseSpec();
@@ -584,6 +812,22 @@ describe("ALLOWED_AGENT_FIELDS / unknownAgentSpecFields (R3 #3)", () => {
     };
     expect(unknownAgentSpecFields(parsed).sort()).toEqual(["future_field", "surprise"]);
   });
+
+  // R8 #6 — Drift guard: `ALLOWED_AGENT_FIELDS` is hand-maintained and the
+  // editor's Raw JSON Apply path rejects any top-level key not in this
+  // list. When `types.ts` (which mirrors the Rust `AgentSpec`) gains a
+  // new key, the allowlist must grow in lockstep — otherwise a legal
+  // wire-shape gets rejected as "unknown field". This assertion fails
+  // type-checking the moment a key appears on `AgentSpec` that isn't in
+  // `ALLOWED_AGENT_FIELDS`.
+  it("compile-time: ALLOWED_AGENT_FIELDS covers every AgentSpec key", () => {
+    type Known = (typeof ALLOWED_AGENT_FIELDS)[number];
+    type MissingKeys = Exclude<keyof AgentSpec, Known>;
+    // If `MissingKeys` resolves to anything other than `never`, this
+    // assignment fails the typecheck — surfacing the drift in CI.
+    const _check: MissingKeys extends never ? true : never = true;
+    expect(_check).toBe(true);
+  });
 });
 
 describe("mergeLockedFields (R3 #1)", () => {
@@ -626,23 +870,384 @@ describe("mergeLockedFields (R3 #1)", () => {
 });
 
 describe("active_hook_filter [] vs absent normalization (R3 #2)", () => {
+  const EMPTY_PLAN = { patch: {}, clear: [] };
   it("does not emit a patch when active_hook_filter goes from absent to []", () => {
     const original = baseSpec({ active_hook_filter: undefined });
     const current: AgentSpec = { ...original, active_hook_filter: [] };
-    expect(diffPatchableAgentFields(current, original)).toEqual({});
+    expect(diffPatchableAgentFields(current, original)).toEqual(EMPTY_PLAN);
   });
 
   it("does not emit a patch when active_hook_filter goes from [] to absent", () => {
     const original = baseSpec({ active_hook_filter: [] });
     const current: AgentSpec = { ...original, active_hook_filter: undefined };
-    expect(diffPatchableAgentFields(current, original)).toEqual({});
+    expect(diffPatchableAgentFields(current, original)).toEqual(EMPTY_PLAN);
   });
 
   it("still emits the actual array when an entry is added", () => {
     const original = baseSpec({ active_hook_filter: [] });
     const current: AgentSpec = { ...original, active_hook_filter: ["permission"] };
     expect(diffPatchableAgentFields(current, original)).toEqual({
-      active_hook_filter: ["permission"],
+      patch: { active_hook_filter: ["permission"] },
+      clear: [],
     });
+  });
+});
+
+describe("active_hook_filter override semantics (R13)", () => {
+  // Per `agent_spec_patch.rs::merge_patch`, the override layer for
+  // `active_hook_filter` is `patch.unwrap_or(base)` — i.e. absent override
+  // means "inherit base" and `Some([])` means "no filter, override base".
+  // The runtime engine (`phase/engine.rs::filter_hooks`) then treats the
+  // resolved set: `is_empty() || contains(plugin_id)` ⇒ empty means all
+  // hooks run. So an "All plugins" intent on a customized record with a
+  // non-empty base filter MUST land as `patch: { active_hook_filter: [] }`
+  // — a CLEAR would inherit the base filter, reversing the user's choice.
+  it("absent → absent: no diff", () => {
+    const original = baseSpec({ active_hook_filter: undefined });
+    const current: AgentSpec = { ...original, active_hook_filter: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({ patch: {}, clear: [] });
+  });
+
+  it("[] → []: no diff", () => {
+    const original = baseSpec({ active_hook_filter: [] });
+    const current: AgentSpec = { ...original, active_hook_filter: [] };
+    expect(diffPatchableAgentFields(current, original)).toEqual({ patch: {}, clear: [] });
+  });
+
+  it("absent → []: no diff (wire-equivalent)", () => {
+    const original = baseSpec({ active_hook_filter: undefined });
+    const current: AgentSpec = { ...original, active_hook_filter: [] };
+    expect(diffPatchableAgentFields(current, original)).toEqual({ patch: {}, clear: [] });
+  });
+
+  it("[] → absent: no diff (wire-equivalent)", () => {
+    const original = baseSpec({ active_hook_filter: [] });
+    const current: AgentSpec = { ...original, active_hook_filter: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({ patch: {}, clear: [] });
+  });
+
+  it("['permission'] → ['permission','reminder']: patches the new array", () => {
+    const original = baseSpec({ active_hook_filter: ["permission"] });
+    const current: AgentSpec = {
+      ...original,
+      active_hook_filter: ["permission", "reminder"],
+    };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: { active_hook_filter: ["permission", "reminder"] },
+      clear: [],
+    });
+  });
+
+  it("['permission'] → absent: emits patch [] (override base 'All plugins')", () => {
+    // User had a saved filter, then clicked "All plugins" — the UI emits
+    // `undefined` (or `[]`). The diff MUST emit `patch: []` so the
+    // override flips the customized record's filter to empty regardless
+    // of base. Emitting CLEAR here would inherit base's filter (if any)
+    // and silently undo the user's intent.
+    const original = baseSpec({ active_hook_filter: ["permission"] });
+    const current: AgentSpec = { ...original, active_hook_filter: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: { active_hook_filter: [] },
+      clear: [],
+    });
+  });
+
+  it("['permission'] → []: emits patch [] (override base 'All plugins')", () => {
+    const original = baseSpec({ active_hook_filter: ["permission"] });
+    const current: AgentSpec = { ...original, active_hook_filter: [] };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: { active_hook_filter: [] },
+      clear: [],
+    });
+  });
+});
+
+describe("Raw JSON locked-field check ordering (R5 #1)", () => {
+  // The Raw JSON `handleApply` must compare the parsed payload against
+  // the REDACTED display spec FIRST, then overlay real locked-field
+  // values. If the order is reversed (overlay first, then compare),
+  // `mergeLockedFields` overwrites `parsed.endpoint` with `spec.endpoint`
+  // and the subsequent `lockedFieldChange` always reads "equal" — user
+  // edits to `endpoint.base_url` / `endpoint.auth.*` / `registry` get
+  // silently dropped on Apply success.
+  it("display-spec lockedFieldChange catches base_url edits the buggy order would miss", () => {
+    const spec = baseSpec({
+      endpoint: {
+        base_url: "https://real.example.com",
+        auth: { type: "bearer", bearer_token: "real-secret" },
+      },
+    });
+    const displaySpec = redactAgentSpecForDisplay(spec);
+    // Scenario: user changed `endpoint.base_url` in Raw JSON. The
+    // textarea showed `***` for the bearer token; the user kept that
+    // placeholder but flipped the URL.
+    const parsed = {
+      ...spec,
+      endpoint: {
+        base_url: "https://evil.example.com",
+        auth: { type: "bearer", bearer_token: "***" },
+      },
+    } as Record<string, unknown>;
+
+    // The CORRECT order — compare display vs parsed before any merge —
+    // catches the edit.
+    expect(lockedFieldChange(displaySpec, parsed)).toBe("endpoint");
+
+    // The BUGGY order — overlay first, then compare against the
+    // overlaid payload — silently accepts the edit. This assertion
+    // documents the regression vector so a future refactor that
+    // re-introduces the merge-then-compare order trips this test.
+    const buggyMerged = mergeLockedFields(parsed, spec);
+    expect(lockedFieldChange(spec, buggyMerged)).toBeNull();
+  });
+
+  it("display-spec compare allows the `***` placeholder to survive (no false positive)", () => {
+    const spec = baseSpec({
+      endpoint: {
+        base_url: "https://real.example.com",
+        auth: { type: "bearer", bearer_token: "real-secret" },
+      },
+    });
+    const displaySpec = redactAgentSpecForDisplay(spec);
+    // The textarea was seeded from `displaySpec`. The user touched
+    // nothing in `endpoint` so `parsed.endpoint` == `displaySpec.endpoint`.
+    const parsed = JSON.parse(JSON.stringify(displaySpec)) as Record<string, unknown>;
+    expect(lockedFieldChange(displaySpec, parsed)).toBeNull();
+  });
+
+  it("flags registry changes the same way endpoint changes are flagged", () => {
+    const spec = baseSpec({ registry: "cloud" });
+    const displaySpec = redactAgentSpecForDisplay(spec);
+    const parsed = { ...spec, registry: "evil-registry" } as Record<string, unknown>;
+    expect(lockedFieldChange(displaySpec, parsed)).toBe("registry");
+  });
+
+  it("flags endpoint removal (locked field deletion is still a locked change)", () => {
+    const spec = baseSpec({ endpoint: { base_url: "https://x" } });
+    const displaySpec = redactAgentSpecForDisplay(spec);
+    const parsed = JSON.parse(JSON.stringify(displaySpec)) as Record<string, unknown>;
+    delete parsed.endpoint;
+    expect(lockedFieldChange(displaySpec, parsed)).toBe("endpoint");
+  });
+});
+
+describe("clear vs patch routing (R6 #A — supersedes R5 #2)", () => {
+  // R5 emitted `null` in the patch when a field went to undefined. That
+  // prevented data loss (JSON.stringify no longer dropped the key) but
+  // left an explicit-null override behind for nullable fields, so the
+  // "customized" badge stuck on even after a revert. R6 splits the diff
+  // into `patch` (upserts, including explicit nulls the user really set)
+  // and `clear` (fields the Save flow will DELETE per-field) — this is
+  // the semantic the backend's `clearAgentOverrideField` endpoint exists
+  // to express.
+  it("routes a cleared `reasoning_effort` to the clear list (revert override)", () => {
+    const original = baseSpec({ reasoning_effort: "high" });
+    const current: AgentSpec = { ...original, reasoning_effort: undefined };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan).toEqual({ patch: {}, clear: ["reasoning_effort"] });
+  });
+
+  // R13 — `active_hook_filter` carries an `All plugins` semantic that CLEAR
+  // cannot express. On a customized record whose base has
+  // `active_hook_filter: ["permission"]`, emitting CLEAR would delete the
+  // override and inherit the base's filter — the opposite of what a user
+  // who just clicked "All plugins" intended. Emit `patch: []` instead so
+  // the override layer turns filtering off regardless of base. See also
+  // the dedicated "active_hook_filter override semantics" describe block
+  // below.
+  it("routes turning off filtering for `active_hook_filter` to patch [] (not clear)", () => {
+    const original = baseSpec({ active_hook_filter: ["permission", "reminder"] });
+    const current: AgentSpec = { ...original, active_hook_filter: undefined };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan).toEqual({ patch: { active_hook_filter: [] }, clear: [] });
+  });
+
+  it("routes plugin_ids removal to the clear list", () => {
+    const original = baseSpec({ plugin_ids: ["permission"] });
+    const current: AgentSpec = { ...original, plugin_ids: undefined };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan).toEqual({ patch: {}, clear: ["plugin_ids"] });
+  });
+
+  it("routes allowed_tools revert to the clear list (nullable Option)", () => {
+    const original = baseSpec({ allowed_tools: ["Bash"] });
+    const current: AgentSpec = { ...original, allowed_tools: undefined };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan).toEqual({ patch: {}, clear: ["allowed_tools"] });
+  });
+
+  it("preserves explicit null in the patch when the user disabled a nullable field", () => {
+    // Toggling "Apply custom policy" off sets the value to `null` (not
+    // `undefined`). That's "explicit null override", semantically distinct
+    // from "revert" — the user is saying "this agent has no context
+    // policy even if the base had one". Route to patch, not clear.
+    const original = baseSpec({ context_policy: { max_context_tokens: 1000 } as never });
+    const current: AgentSpec = { ...original, context_policy: null };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan).toEqual({ patch: { context_policy: null }, clear: [] });
+  });
+
+  it("turning off filtering via empty array also routes to patch [] (not clear)", () => {
+    const original = baseSpec({ active_hook_filter: ["permission"] });
+    const current: AgentSpec = { ...original, active_hook_filter: [] };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan).toEqual({ patch: { active_hook_filter: [] }, clear: [] });
+  });
+
+  it("the full revert scenario routes every cleared field to the clear list", () => {
+    // `active_hook_filter` is intentionally absent from this scenario —
+    // its override semantics are tested separately (turning filtering off
+    // becomes `patch: []`, not clear). Every other patchable field still
+    // follows the clear-on-undefined rule.
+    const original = baseSpec({
+      plugin_ids: ["permission"],
+      delegates: ["other-agent"],
+      allowed_tools: ["Bash"],
+      excluded_tools: ["Read"],
+      reasoning_effort: "high",
+    });
+    const current: AgentSpec = {
+      ...original,
+      plugin_ids: undefined,
+      delegates: undefined,
+      allowed_tools: undefined,
+      excluded_tools: undefined,
+      reasoning_effort: undefined,
+    };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan.patch).toEqual({});
+    expect(plan.clear.sort()).toEqual(
+      ["plugin_ids", "delegates", "allowed_tools", "excluded_tools", "reasoning_effort"].sort(),
+    );
+  });
+
+  // R13 — When a saved customized agent has an explicit `null` override
+  // (e.g. `context_policy: null` meaning "no context policy even if base
+  // has one"), and the user deletes the field from Raw JSON, the draft
+  // value becomes `undefined`. canonical equality maps both `null` and
+  // `undefined` to `null`, so an order of "equal? then clear-if-undefined"
+  // mis-classifies this as a no-op — neither emitting a CLEAR nor patching
+  // — and the saved override stays as explicit-null forever. Clear must
+  // be detected BEFORE canonical equality.
+  it("routes explicit null -> undefined to clear (context_policy)", () => {
+    const original = baseSpec({ context_policy: null });
+    const current: AgentSpec = { ...original, context_policy: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: {},
+      clear: ["context_policy"],
+    });
+  });
+
+  it("routes explicit null -> undefined to clear (allowed_tools)", () => {
+    const original = baseSpec({ allowed_tools: null });
+    const current: AgentSpec = { ...original, allowed_tools: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: {},
+      clear: ["allowed_tools"],
+    });
+  });
+
+  it("routes explicit null -> undefined to clear (excluded_tools)", () => {
+    const original = baseSpec({ excluded_tools: null });
+    const current: AgentSpec = { ...original, excluded_tools: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: {},
+      clear: ["excluded_tools"],
+    });
+  });
+
+  it("routes explicit null -> undefined to clear (reasoning_effort)", () => {
+    const original = baseSpec({ reasoning_effort: null });
+    const current: AgentSpec = { ...original, reasoning_effort: undefined };
+    expect(diffPatchableAgentFields(current, original)).toEqual({
+      patch: {},
+      clear: ["reasoning_effort"],
+    });
+  });
+
+  it("does not put unchanged scalars in either bucket", () => {
+    const spec = baseSpec({ model_id: "same" });
+    const plan = diffPatchableAgentFields(spec, spec);
+    expect(plan).toEqual({ patch: {}, clear: [] });
+  });
+
+  it("routes a value change to patch, not clear", () => {
+    const original = baseSpec({ model_id: "old" });
+    const current: AgentSpec = { ...original, model_id: "new" };
+    const plan = diffPatchableAgentFields(current, original);
+    expect(plan).toEqual({ patch: { model_id: "new" }, clear: [] });
+  });
+});
+
+// R12 #3 — Pattern-based string redaction for sandbox tool output /
+// errorText (paths where the key-based redactor doesn't apply because
+// the payload is a raw string, not a structured object).
+describe("redactSecretString (R12 #3)", () => {
+  it("masks `Authorization: <value>` lines wholesale", () => {
+    const out = redactSecretString("Authorization: Bearer sk-real-secret-value");
+    expect(out).not.toContain("sk-real-secret-value");
+    expect(out).toContain("Authorization: ***");
+  });
+
+  it("masks inline Bearer tokens", () => {
+    const out = redactSecretString('called with Bearer abc123def456ghi789jkl');
+    expect(out).toContain("Bearer ***");
+    expect(out).not.toContain("abc123def456ghi789jkl");
+  });
+
+  it("masks Cookie / Set-Cookie header lines", () => {
+    const a = redactSecretString("Cookie: session=raw-session-id");
+    expect(a).not.toContain("raw-session-id");
+    expect(a).toContain("Cookie: ***");
+
+    const b = redactSecretString("Set-Cookie: sid=raw-sid; Path=/");
+    expect(b).not.toContain("raw-sid");
+    expect(b).toContain("Set-Cookie: ***");
+  });
+
+  it("masks key=value pairs for common credential field names", () => {
+    const out = redactSecretString(
+      "request: api_key=sk-test access_token=xyz123 password=hunter2 jwt=eyJabc",
+    );
+    expect(out).not.toContain("sk-test");
+    expect(out).not.toContain("xyz123");
+    expect(out).not.toContain("hunter2");
+    expect(out).toContain("api_key=***");
+    expect(out).toContain("access_token=***");
+    expect(out).toContain("password=***");
+    // `jwt=...` matched by key-pair (not the JWT regex since `eyJabc`
+    // alone isn't a full JWT).
+    expect(out).toContain("jwt=***");
+  });
+
+  it("masks JWT-shaped tokens", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const out = redactSecretString(`got token ${jwt} from auth`);
+    expect(out).not.toContain(jwt);
+    expect(out).toContain("***");
+  });
+
+  it("masks OpenAI-style sk- and Stripe-style sk_ keys", () => {
+    const out = redactSecretString(
+      "key1=sk-abcdefghijklmnop1234567890 key2=sk_live_abc123XYZ",
+    );
+    expect(out).not.toContain("sk-abcdefghijklmnop1234567890");
+    expect(out).not.toContain("sk_live_abc123XYZ");
+  });
+
+  it("returns the input unchanged when no credential pattern matches", () => {
+    expect(redactSecretString("regular tool output, nothing secret")).toBe(
+      "regular tool output, nothing secret",
+    );
+  });
+
+  it("handles empty / non-string input defensively", () => {
+    expect(redactSecretString("")).toBe("");
+    // Defensive — the helper is called from formatJson which already
+    // narrows to string, but defensive coding pays off if callers drift.
+    expect(redactSecretString(undefined as unknown as string)).toBe(
+      undefined as unknown as string,
+    );
   });
 });

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -99,11 +99,21 @@ describe("lockedFieldChange", () => {
     expect(lockedFieldChange(spec, reordered)).toBeNull();
   });
 
-  it("treats absent vs explicit null equivalently for endpoint", () => {
+  // Contract pin (R14): for a locked field whose current spec value is
+  // "no value", the three Raw JSON writings { absent, null, undefined }
+  // are equivalent. Re-typing `endpoint: null` to "make the absence
+  // explicit" must be a no-op, not a "locked field changed" error.
+  // This is intentional normalization, not a silent drop — see the
+  // JSDoc on `lockedFieldChange` for the full rationale. Position B
+  // (presence-aware) was considered and rejected because it produces
+  // user-visible errors for semantically-equivalent edits.
+  it("locked-field normalization: absent ≡ explicit null ≡ explicit undefined", () => {
     const spec = baseSpec();
     expect(lockedFieldChange(spec, {})).toBeNull();
     expect(lockedFieldChange(spec, { endpoint: null })).toBeNull();
     expect(lockedFieldChange(spec, { endpoint: undefined })).toBeNull();
+    expect(lockedFieldChange(spec, { registry: null })).toBeNull();
+    expect(lockedFieldChange(spec, { registry: undefined })).toBeNull();
   });
 
   it("flags endpoint when the parsed value differs", () => {

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -1215,6 +1215,15 @@ describe("ALLOWED_AGENT_FIELDS / unknownAgentSpecFields (R3 #3)", () => {
     expect(PATCHABLE_AGENT_FIELDS.filter((field) => !rustFieldSet.has(field))).toEqual([]);
   });
 
+  it("documents endpoint as backend-patchable but editor-locked", () => {
+    const rustPatchFields = new Set(rustAgentSpecPatchFields());
+
+    expect(rustPatchFields.has("endpoint")).toBe(true);
+    expect(ALLOWED_AGENT_FIELDS).toContain("endpoint");
+    expect(LOCKED_AGENT_FIELDS).toContain("endpoint");
+    expect(PATCHABLE_AGENT_FIELDS).not.toContain("endpoint");
+  });
+
   // R8 #6 — Drift guard: `ALLOWED_AGENT_FIELDS` is hand-maintained and the
   // editor's Raw JSON Apply path rejects any top-level key not in this
   // list. When `types.ts` (which mirrors the Rust `AgentSpec`) gains a

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   PATCHABLE_AGENT_FIELDS,
   canonicalStringify,
   cloneAgentSpecForEditor,
+  computeRedactedDiff,
   deepEqualCanonical,
   diffPatchableAgentFields,
   lockedFieldChange,
@@ -591,6 +592,58 @@ describe("redactSecretsForDisplay (R6 #B/#C — generic deep redact)", () => {
     expect((redacted.payload.endpoint.auth as Record<string, unknown>).api_key).toBe("***");
   });
 
+  it("masks hyphenated API key headers in arbitrary trace payloads", () => {
+    const payload = {
+      response: {
+        headers: {
+          "x-api-key": "raw-x-api-key",
+          "api-key": "raw-api-key",
+          "content-type": "application/json",
+        },
+      },
+    };
+    const redacted = redactSecretsForDisplay(payload);
+    const headers = redacted.response.headers as Record<string, unknown>;
+    expect(headers["x-api-key"]).toBe("***");
+    expect(headers["api-key"]).toBe("***");
+    expect(headers["content-type"]).toBe("application/json");
+  });
+
+  it("masks hyphenated API keys inside endpoint option headers", () => {
+    const payload = {
+      endpoint: {
+        options: {
+          headers: {
+            "x-api-key": "raw-nested-key",
+            "user-agent": "awaken-admin",
+          },
+        },
+      },
+    };
+    const redacted = redactSecretsForDisplay(payload);
+    const headers = redacted.endpoint.options.headers as Record<string, unknown>;
+    expect(headers["x-api-key"]).toBe("***");
+    expect(headers["user-agent"]).toBe("awaken-admin");
+  });
+
+  it("masks request and response auth header aliases", () => {
+    const payload = {
+      request_headers: {
+        "x-auth-token": "raw-auth-token",
+        accept: "application/json",
+      },
+      response_headers: {
+        "set-cookie": "sid=raw-session",
+        "cache-control": "no-store",
+      },
+    };
+    const redacted = redactSecretsForDisplay(payload);
+    expect(redacted.request_headers["x-auth-token"]).toBe("***");
+    expect(redacted.request_headers.accept).toBe("application/json");
+    expect(redacted.response_headers["set-cookie"]).toBe("***");
+    expect(redacted.response_headers["cache-control"]).toBe("no-store");
+  });
+
   it("passes through primitives and arrays unchanged", () => {
     expect(redactSecretsForDisplay(42)).toBe(42);
     expect(redactSecretsForDisplay("hello")).toBe("hello");
@@ -752,6 +805,44 @@ describe("redactSecretsForDisplay (R6 #B/#C — generic deep redact)", () => {
     expect(auth.type).toBe("bearer");
     expect(auth.weird_key).toBeNull();
     expect(auth.other).toBeUndefined();
+  });
+});
+
+describe("computeRedactedDiff", () => {
+  it("reports secret-only changes while returning only redacted values", () => {
+    const changes = computeRedactedDiff(
+      { sections: { oauth: { client_secret: "old-client-secret" } } },
+      { sections: { oauth: { client_secret: "new-client-secret" } } },
+    );
+    expect(changes).toEqual([
+      {
+        path: "sections.oauth.client_secret",
+        before: "***",
+        after: "***",
+        redactedValueChanged: true,
+      },
+    ]);
+    const serialized = JSON.stringify(changes);
+    expect(serialized).not.toContain("old-client-secret");
+    expect(serialized).not.toContain("new-client-secret");
+  });
+
+  it("preserves normal before and after values for non-secret changes", () => {
+    expect(
+      computeRedactedDiff(
+        { sections: { ui: { theme: "light" } } },
+        {
+          sections: { ui: { theme: "dark" } },
+        },
+      ),
+    ).toEqual([
+      {
+        path: "sections.ui.theme",
+        before: "light",
+        after: "dark",
+        redactedValueChanged: false,
+      },
+    ]);
   });
 });
 

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 
 import type { AgentSpec, RemoteEndpoint } from "./api/types";
 import {
   ALLOWED_AGENT_FIELDS,
+  LOCKED_AGENT_FIELDS,
   PATCHABLE_AGENT_FIELDS,
   canonicalStringify,
   cloneAgentSpecForEditor,
@@ -42,6 +44,24 @@ const REMOTE_ENDPOINT: RemoteEndpoint = {
   target: "remote-agent",
   timeout_ms: 60_000,
 };
+
+function rustAgentSpecPatchFields(): string[] {
+  const source = readFileSync(
+    new URL("../../../../crates/awaken-contract/src/agent_spec_patch.rs", import.meta.url),
+    "utf8",
+  );
+  const structMatch = source.match(/pub struct AgentSpecPatch \{([\s\S]*?)\n\}/);
+  if (!structMatch) {
+    throw new Error("Could not find AgentSpecPatch in Rust contract source.");
+  }
+  return [...structMatch[1].matchAll(/^\s*pub\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*:/gm)].map(
+    (match) => match[1],
+  );
+}
+
+function missingValues(source: readonly string[], expected: ReadonlySet<string>): string[] {
+  return source.filter((value) => !expected.has(value));
+}
 
 describe("canonicalStringify / deepEqualCanonical", () => {
   it("sorts object keys deterministically", () => {
@@ -874,10 +894,7 @@ describe("redactSecretsForDisplay (R6 #B/#C — generic deep redact)", () => {
         },
       };
       const redacted = redactSecretsForDisplay(event);
-      const usage = (redacted.payload as Record<string, unknown>).usage as Record<
-        string,
-        unknown
-      >;
+      const usage = (redacted.payload as Record<string, unknown>).usage as Record<string, unknown>;
       expect(usage.input_tokens).toBe(1234);
       expect(usage.output_tokens).toBe(567);
       expect(usage.total_tokens).toBe(1801);
@@ -1018,8 +1035,13 @@ describe("redactAgentSpecForEditing / restoreUnchangedRedactions", () => {
 
     expect(serialized).not.toContain("live-secret");
     expect(serialized).not.toContain("live-api-key");
-    expect((redacted.sections?.oauth as Record<string, unknown>).client_secret).toBe("***");
-    expect((redacted.sections?.observability as Record<string, unknown>).api_key).toBe("***");
+    const oauthMarker = (redacted.sections?.oauth as Record<string, unknown>).client_secret;
+    const observabilityMarker = (redacted.sections?.observability as Record<string, unknown>)
+      .api_key;
+    expect(oauthMarker).toMatch(/^__AWAKEN_REDACTED_SECRET_[a-f0-9]{8}__$/);
+    expect(observabilityMarker).toMatch(/^__AWAKEN_REDACTED_SECRET_[a-f0-9]{8}__$/);
+    expect(oauthMarker).not.toBe("***");
+    expect(observabilityMarker).not.toBe(oauthMarker);
 
     const restored = restoreUnchangedRedactions(
       JSON.parse(JSON.stringify(redacted)) as AgentSpec,
@@ -1042,6 +1064,40 @@ describe("redactAgentSpecForEditing / restoreUnchangedRedactions", () => {
     const restored = restoreUnchangedRedactions(parsed, redactions);
 
     expect((restored.sections?.oauth as Record<string, unknown>).client_secret).toBe("new-secret");
+  });
+
+  it("allows replacing a secret with the literal display mask", () => {
+    const spec = baseSpec({
+      sections: { oauth: { client_secret: "old-secret" } },
+    });
+    const { redacted, redactions } = redactAgentSpecForEditing(spec);
+    const parsed = JSON.parse(JSON.stringify(redacted)) as AgentSpec;
+    (parsed.sections?.oauth as Record<string, unknown>).client_secret = "***";
+
+    const restored = restoreUnchangedRedactions(parsed, redactions);
+
+    expect((restored.sections?.oauth as Record<string, unknown>).client_secret).toBe("***");
+  });
+
+  it("uses editing sentinels for secret patterns inside unkeyed strings", () => {
+    const spec = baseSpec({
+      sections: {
+        notes: "upstream echoed Authorization: Bearer sk-real-secret-value",
+      },
+    });
+    const { redacted, redactions } = redactAgentSpecForEditing(spec);
+    const marker = redacted.sections?.notes;
+
+    expect(marker).toMatch(/^__AWAKEN_REDACTED_SECRET_[a-f0-9]{8}__$/);
+    expect(marker).not.toBe("***");
+
+    const restored = restoreUnchangedRedactions(
+      JSON.parse(JSON.stringify(redacted)) as AgentSpec,
+      redactions,
+    );
+    expect(restored.sections?.notes).toBe(
+      "upstream echoed Authorization: Bearer sk-real-secret-value",
+    );
   });
 });
 
@@ -1080,6 +1136,17 @@ describe("ALLOWED_AGENT_FIELDS / unknownAgentSpecFields (R3 #3)", () => {
       future_field: { nested: true },
     };
     expect(unknownAgentSpecFields(parsed).sort()).toEqual(["future_field", "surprise"]);
+  });
+
+  it("runtime contract: frontend field lists cover Rust AgentSpecPatch fields", () => {
+    const rustPatchFields = rustAgentSpecPatchFields();
+    const allowedFields = new Set<string>(ALLOWED_AGENT_FIELDS);
+    const classifiedFields = new Set<string>([...PATCHABLE_AGENT_FIELDS, ...LOCKED_AGENT_FIELDS]);
+    const rustFieldSet = new Set(rustPatchFields);
+
+    expect(missingValues(rustPatchFields, allowedFields)).toEqual([]);
+    expect(missingValues(rustPatchFields, classifiedFields)).toEqual([]);
+    expect(PATCHABLE_AGENT_FIELDS.filter((field) => !rustFieldSet.has(field))).toEqual([]);
   });
 
   // R8 #6 — Drift guard: `ALLOWED_AGENT_FIELDS` is hand-maintained and the
@@ -1507,6 +1574,36 @@ describe("redactSecretString (R12 #3)", () => {
     const out = redactSecretString("key1=sk-abcdefghijklmnop1234567890 key2=sk_live_abc123XYZ");
     expect(out).not.toContain("sk-abcdefghijklmnop1234567890");
     expect(out).not.toContain("sk_live_abc123XYZ");
+  });
+
+  it("masks common GitHub, Slack, and AWS token families", () => {
+    const github = ["ghp", "abcdefghijklmnopqrstuvwxyz1234567890AB"].join("_");
+    const githubFineGrained = [
+      "github",
+      "pat",
+      "11ABCDEFG0",
+      "abcdefghijklmnopqrstuvwxyz1234567890",
+    ].join("_");
+    const slack = ["xoxb", "123456789012", "123456789012", "abcdefghijklmnopqrstuvwx"].join("-");
+    const aws = `AKIA${"IOSFODNN7EXAMPLE"}`;
+    const out = redactSecretString(`tokens ${github} ${githubFineGrained} ${slack} ${aws}`);
+
+    expect(out).not.toContain(github);
+    expect(out).not.toContain(githubFineGrained);
+    expect(out).not.toContain(slack);
+    expect(out).not.toContain(aws);
+  });
+
+  it("masks PEM private key blocks", () => {
+    const pem = [
+      "-----BEGIN PRIVATE KEY-----",
+      "MIIEvQIBADANBgkqhkiG9w0BAQEFAASC",
+      "-----END PRIVATE KEY-----",
+    ].join("\n");
+    const out = redactSecretString(`key:\n${pem}\nend`);
+
+    expect(out).not.toContain("MIIEvQIBADANBgkqhkiG9w0BAQEFAASC");
+    expect(out).toContain("***");
   });
 
   it("returns the input unchanged when no credential pattern matches", () => {

--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   LOCKED_AGENT_FIELDS,
   PATCHABLE_AGENT_FIELDS,
   canonicalStringify,
+  changedRedactionMarkerPaths,
   cloneAgentSpecForEditor,
   computeRedactedDiff,
   deepEqualCanonical,
@@ -949,6 +950,39 @@ describe("redactSecretsForDisplay (R6 #B/#C — generic deep redact)", () => {
       expect(creds.client_secret).toBe("***");
       expect(creds.private_key).toBe("***");
     });
+
+    it("masks compound api key fields without masking token budget fields", () => {
+      const value = {
+        sections: {
+          provider: {
+            openai_api_key: "openai-field-secret",
+            anthropicApiKey: "anthropic-field-secret",
+            provider_api_key: "provider-field-secret",
+            headers: {
+              "x-api-key": "header-field-secret",
+              "content-type": "application/json",
+            },
+            context_policy: {
+              max_context_tokens: 200_000,
+              max_output_tokens: 16_384,
+            },
+          },
+        },
+      };
+
+      const redacted = redactSecretsForDisplay(value);
+      const provider = redacted.sections.provider as Record<string, unknown>;
+      const headers = provider.headers as Record<string, unknown>;
+      const contextPolicy = provider.context_policy as Record<string, unknown>;
+
+      expect(provider.openai_api_key).toBe("***");
+      expect(provider.anthropicApiKey).toBe("***");
+      expect(provider.provider_api_key).toBe("***");
+      expect(headers["x-api-key"]).toBe("***");
+      expect(headers["content-type"]).toBe("application/json");
+      expect(contextPolicy.max_context_tokens).toBe(200_000);
+      expect(contextPolicy.max_output_tokens).toBe(16_384);
+    });
   });
 });
 
@@ -1098,6 +1132,38 @@ describe("redactAgentSpecForEditing / restoreUnchangedRedactions", () => {
     expect(restored.sections?.notes).toBe(
       "upstream echoed Authorization: Bearer sk-real-secret-value",
     );
+  });
+
+  it("detects edited Raw JSON values that still contain a redaction marker", () => {
+    const spec = baseSpec({
+      sections: {
+        gateway: {
+          note: "Authorization: Bearer raw-token-value-1234567890\nowner=team-a",
+        },
+      },
+    });
+    const { redacted, redactions } = redactAgentSpecForEditing(spec);
+    const parsed = JSON.parse(JSON.stringify(redacted)) as AgentSpec;
+    const gateway = parsed.sections?.gateway as Record<string, unknown>;
+    const marker = String(gateway.note);
+
+    gateway.note = `${marker}\nowner=team-b`;
+
+    expect(changedRedactionMarkerPaths(parsed, redactions)).toEqual(["sections.gateway.note"]);
+  });
+
+  it("does not flag unchanged markers or full secret replacements", () => {
+    const spec = baseSpec({
+      sections: { oauth: { client_secret: "old-secret-value" } },
+    });
+    const { redacted, redactions } = redactAgentSpecForEditing(spec);
+    expect(changedRedactionMarkerPaths(JSON.parse(JSON.stringify(redacted)), redactions)).toEqual(
+      [],
+    );
+
+    const parsed = JSON.parse(JSON.stringify(redacted)) as AgentSpec;
+    (parsed.sections?.oauth as Record<string, unknown>).client_secret = "new-secret-value";
+    expect(changedRedactionMarkerPaths(parsed, redactions)).toEqual([]);
   });
 });
 

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -6,6 +6,7 @@ import type { AgentSpec } from "./api/types";
 import { deepEqualCanonical } from "./agent-editor-canonical";
 
 export { canonicalStringify, deepEqualCanonical } from "./agent-editor-canonical";
+export { safeErrorMessage } from "./safe-error-message";
 export {
   changedRedactionMarkerPaths,
   computeRedactedDiff,

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -1,0 +1,352 @@
+/// Pure helpers used by `AgentEditorPage`. They are factored out here so they
+/// stay unit-testable without having to drive React Router + the page state
+/// machine, and so the JSON-editor / plugin-toggle / clone / patch-diff /
+/// remote-endpoint-display code paths share one canonical implementation.
+import type { AgentSpec, RemoteEndpoint } from "./api/types";
+
+/**
+ * Fields the editor cannot patch on a customized record:
+ *  - `endpoint`   — remote-endpoint provenance, not exposed by any form.
+ *  - `registry`   — runtime-locality marker; cloned records always become
+ *                   locally defined and the editor never edits this in place.
+ *
+ * The Raw JSON Apply path consults this list so a draft can't silently
+ * drift away from what Save can actually persist.
+ */
+export const LOCKED_AGENT_FIELDS = ["endpoint", "registry"] as const;
+export type LockedAgentField = (typeof LOCKED_AGENT_FIELDS)[number];
+
+/**
+ * Fields that can be PATCHed onto a builtin / customized record via
+ * `PATCH /v1/config/agents/:id/overrides`. `id` and `created_at` / `updated_at`
+ * are not user-editable; `endpoint` and `registry` are locked (see above).
+ *
+ * Kept in sync with the AgentSpec PATCH whitelist server-side. Every field
+ * the editor exposes in any form must appear here, otherwise edits to it
+ * silently drop on the customized save path (this is the G1 data-loss bug).
+ */
+export const PATCHABLE_AGENT_FIELDS: Array<keyof AgentSpec> = [
+  "model_id",
+  "system_prompt",
+  "max_rounds",
+  "max_continuation_retries",
+  "context_policy",
+  "plugin_ids",
+  "active_hook_filter",
+  "sections",
+  "allowed_tools",
+  "excluded_tools",
+  "delegates",
+  "reasoning_effort",
+];
+
+/**
+ * Stable JSON encoding: deep-sorts object keys so structurally-equal values
+ * always serialize to the same string. Used as a building block for
+ * `deepEqualCanonical` so re-formatting / key-reordering of Raw JSON doesn't
+ * read as a locked-field change or trigger a spurious PATCH entry.
+ *
+ * Arrays preserve order (semantically significant). `undefined` collapses to
+ * `null` so `{a: undefined}` and `{}` are treated equivalently — JSON has no
+ * `undefined` and field absence vs explicit-undefined should not surface as
+ * a diff in this editor.
+ */
+export function canonicalStringify(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === undefined || value === null) return null;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .map(([key, item]) => [key, canonicalize(item)] as const)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+/** Structural equality using `canonicalStringify` — order-insensitive for
+ *  object keys, order-sensitive for arrays. */
+export function deepEqualCanonical(a: unknown, b: unknown): boolean {
+  return canonicalStringify(a) === canonicalStringify(b);
+}
+
+/**
+ * Returns the name of the first locked field (`endpoint` or `registry`)
+ * whose value would change if `parsed` were applied, or `null` when both
+ * fields are unchanged. Uses canonical (key-order-insensitive) deep equality
+ * so that re-indenting / reordering keys in Raw JSON doesn't falsely flag a
+ * locked-field change.
+ */
+export function lockedFieldChange(
+  spec: AgentSpec,
+  parsed: Record<string, unknown>,
+): LockedAgentField | null {
+  for (const field of LOCKED_AGENT_FIELDS) {
+    if (!deepEqualCanonical(spec[field], parsed[field])) {
+      return field;
+    }
+  }
+  return null;
+}
+
+/**
+ * Normalize a patchable field value before comparison so wire-equivalent
+ * shapes don't read as a change. The only special case today is
+ * `active_hook_filter`: the Rust side marks it `skip_serializing_if =
+ * "HashSet::is_empty"`, so absent and `[]` round-trip identically. Without
+ * this, toggling the UI to "All" once would flip the spec from absent to
+ * `[]` and the customized PATCH path would emit a no-op `active_hook_filter:
+ * []` override.
+ */
+function normalizeForDiff(key: keyof AgentSpec, value: unknown): unknown {
+  if (key === "active_hook_filter" && Array.isArray(value) && value.length === 0) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Build the PATCH payload for a builtin / customized record save. Walks
+ * `PATCHABLE_AGENT_FIELDS` and emits any field whose canonical encoding
+ * differs from the original. Treats absent / undefined as equivalent and
+ * uses `normalizeForDiff` for fields whose empty shape is wire-equivalent
+ * to absent (so the UI cannot accidentally promote a default to an
+ * override).
+ *
+ * Returned record is suitable for `configApi.patchAgentOverrides`.
+ */
+export function diffPatchableAgentFields(
+  current: AgentSpec,
+  original: AgentSpec,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  for (const key of PATCHABLE_AGENT_FIELDS) {
+    const a = normalizeForDiff(key, current[key]);
+    const b = normalizeForDiff(key, original[key]);
+    if (!deepEqualCanonical(a, b)) {
+      patch[key] = current[key];
+    }
+  }
+  return patch;
+}
+
+/**
+ * Build the clone payload for `cloneFromExisting`. Strips provenance fields
+ * so the new record is treated as locally-defined and the user has to pick a
+ * fresh `id` before Save.
+ *
+ * `endpoint` is also cleared. Endpoint binds the agent to a specific remote
+ * backend and is not editable from this form — keeping it on a clone would
+ * silently re-target the new agent at the source's remote backend with no
+ * affordance to change it. Users who actually want a remote-backed clone
+ * must (re)configure the endpoint after cloning via a code path that
+ * exposes the form.
+ */
+export function cloneAgentSpecForEditor(source: AgentSpec): AgentSpec {
+  return {
+    ...source,
+    id: "",
+    created_at: undefined,
+    updated_at: undefined,
+    registry: undefined,
+    endpoint: undefined,
+  };
+}
+
+export interface PluginToggleResult {
+  plugin_ids: string[];
+  /**
+   * `undefined` means "field absent" — kept absent when it was absent
+   * before, so toggling never introduces an empty `active_hook_filter`
+   * field that would show up in the patch diff.
+   */
+  active_hook_filter: string[] | undefined;
+}
+
+/**
+ * Compute the next `plugin_ids` / `active_hook_filter` pair when the user
+ * toggles a plugin on or off. When a plugin is removed, drops the same id
+ * from `active_hook_filter` so re-enabling later doesn't silently pick up
+ * a stale filter entry.
+ */
+export function togglePluginState(
+  pluginIds: string[] | undefined,
+  activeHookFilter: string[] | undefined,
+  pluginId: string,
+): PluginToggleResult {
+  const current = pluginIds ?? [];
+  const removing = current.includes(pluginId);
+  const next = removing ? current.filter((id) => id !== pluginId) : [...current, pluginId];
+
+  const nextFilter =
+    removing && activeHookFilter
+      ? activeHookFilter.filter((id) => id !== pluginId)
+      : activeHookFilter;
+
+  return { plugin_ids: next, active_hook_filter: nextFilter };
+}
+
+export interface HookFilterPartition {
+  /** Filter entries that match a currently-loaded plugin. */
+  active: string[];
+  /**
+   * Filter entries with no matching plugin in `plugin_ids`. These would not
+   * gate any hook at runtime but stay in the saved record. The editor
+   * surfaces them so the user can clear them deliberately rather than
+   * silently dropping them.
+   */
+  stale: string[];
+}
+
+/**
+ * Split an `active_hook_filter` value against the agent's current
+ * `plugin_ids` so the UI can render valid entries as togglable rows and
+ * stale entries as a separate warning group.
+ */
+export function partitionActiveHookFilter(
+  filter: string[] | undefined,
+  pluginIds: string[] | undefined,
+): HookFilterPartition {
+  const filterValues = filter ?? [];
+  const pluginSet = new Set(pluginIds ?? []);
+  const active: string[] = [];
+  const stale: string[] = [];
+  const seen = new Set<string>();
+  for (const id of filterValues) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    if (pluginSet.has(id)) {
+      active.push(id);
+    } else {
+      stale.push(id);
+    }
+  }
+  return { active, stale };
+}
+
+/** Keys that always carry secret material when present in a `RemoteEndpoint`
+ *  auth object — masked when the editor displays an endpoint read-only.
+ *  Lowercased contains-match: covers `token`, `bearer_token`,
+ *  `access_token`, `refresh_token`, `id_token`, etc. */
+const SENSITIVE_AUTH_KEY_PATTERNS = [
+  "token",
+  "secret",
+  "password",
+  "passphrase",
+  "api_key",
+  "apikey",
+  "authorization",
+  "credential",
+  "private_key",
+  "privatekey",
+  "client_secret",
+];
+
+const REDACTED_PLACEHOLDER = "***";
+
+function isSensitiveKey(key: string): boolean {
+  const lowered = key.toLowerCase();
+  return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => lowered.includes(pattern));
+}
+
+function redactRecord(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(redactRecord);
+  if (typeof value === "object") {
+    const next: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      if (isSensitiveKey(key)) {
+        next[key] = inner === null || inner === undefined ? inner : REDACTED_PLACEHOLDER;
+      } else {
+        next[key] = redactRecord(inner);
+      }
+    }
+    return next;
+  }
+  return value;
+}
+
+/**
+ * Return a copy of `endpoint` with secret-bearing keys (`bearer_token`,
+ * `api_key`, `authorization`, etc.) replaced by `"***"`. The non-secret
+ * shape (`backend`, `base_url`, `target`, `timeout_ms`, auth `type`, etc.)
+ * is preserved so the read-only UI is still useful for verifying that an
+ * agent is wired to the expected remote, without leaking the credential
+ * into the admin DOM.
+ *
+ * Walks the entire endpoint (not just `auth`) defensively: any future
+ * schema addition that happens to carry credentials would still be masked
+ * by virtue of its key name.
+ */
+export function redactEndpointForDisplay(endpoint: RemoteEndpoint): RemoteEndpoint {
+  return redactRecord(endpoint) as RemoteEndpoint;
+}
+
+/**
+ * Return a copy of `spec` safe for display in the admin DOM: same shape,
+ * but `endpoint` (the only field today that can carry remote-backend
+ * credentials) is run through `redactEndpointForDisplay`. Used by the Raw
+ * JSON editor and history-restore confirm dialog so a real bearer token
+ * never lands in a textarea or a confirmation popover.
+ */
+export function redactAgentSpecForDisplay(spec: AgentSpec): AgentSpec {
+  if (!spec.endpoint) return spec;
+  return { ...spec, endpoint: redactEndpointForDisplay(spec.endpoint) };
+}
+
+/**
+ * The complete set of `AgentSpec` keys the editor knows how to round-trip.
+ * Combines identity (server-managed), locked (provenance / not editable),
+ * and patchable (user-editable) fields. Used by the Raw JSON Apply path to
+ * reject unknown top-level keys before they enter editor state and silently
+ * disappear on Save (which only persists `PATCHABLE_AGENT_FIELDS` on the
+ * customized PATCH path).
+ */
+export const ALLOWED_AGENT_FIELDS: ReadonlyArray<keyof AgentSpec> = [
+  "id",
+  "created_at",
+  "updated_at",
+  ...LOCKED_AGENT_FIELDS,
+  ...PATCHABLE_AGENT_FIELDS,
+];
+
+/**
+ * Returns the top-level keys of `parsed` that the editor cannot persist —
+ * either future fields the UI hasn't learned about yet, or typos. The
+ * caller should refuse the Apply rather than letting the field enter
+ * editor state and disappear on Save.
+ */
+export function unknownAgentSpecFields(parsed: Record<string, unknown>): string[] {
+  const allowed = new Set<string>(ALLOWED_AGENT_FIELDS);
+  return Object.keys(parsed).filter((key) => !allowed.has(key));
+}
+
+/**
+ * Overlay the current spec's locked fields (`endpoint`, `registry`) onto a
+ * parsed Raw JSON payload. The Raw JSON textarea shows a redacted view of
+ * locked fields, so users would either need to type real credentials back
+ * in to round-trip or `lockedFieldChange` would reject the apply on the
+ * `***` placeholder. By overlaying the real values before the
+ * locked-field-change check, redaction stays purely a display concern.
+ *
+ * Returns a shallow copy; never mutates the inputs.
+ */
+export function mergeLockedFields(
+  parsed: Record<string, unknown>,
+  spec: AgentSpec,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...parsed };
+  for (const field of LOCKED_AGENT_FIELDS) {
+    const current = spec[field];
+    if (current === undefined) {
+      delete merged[field];
+    } else {
+      merged[field] = current;
+    }
+  }
+  return merged;
+}

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -77,9 +77,32 @@ export function deepEqualCanonical(a: unknown, b: unknown): boolean {
 /**
  * Returns the name of the first locked field (`endpoint` or `registry`)
  * whose value would change if `parsed` were applied, or `null` when both
- * fields are unchanged. Uses canonical (key-order-insensitive) deep equality
- * so that re-indenting / reordering keys in Raw JSON doesn't falsely flag a
- * locked-field change.
+ * fields are unchanged.
+ *
+ * **Normalization contract**: this guard exists to stop the Raw JSON
+ * path from persisting locked-field edits the save flow can't carry. It
+ * uses canonical deep equality, which collapses three writings the
+ * runtime treats identically into one equivalence class:
+ *
+ *  - **key absent**       (`{}`)
+ *  - **key present, null** (`{"endpoint": null}`)
+ *  - **key present, undefined** (`{"endpoint": undefined}`)
+ *
+ * For locked fields whose current spec value is "no value" (absent / null),
+ * an Apply that writes `null` or removes the key is intentionally a no-op
+ * — not a "silent drop". The runtime, the customized PATCH layer (which
+ * does NOT include endpoint/registry in `PATCHABLE_AGENT_FIELDS`), and
+ * this guard all agree that those three forms mean the same thing.
+ * Without this normalization, a user re-typing `endpoint: null` to
+ * "make the absence explicit" would get rejected with a misleading
+ * "locked field changed" error.
+ *
+ * For locked fields with a real value (e.g. `endpoint.base_url = "..."`),
+ * any byte-level change to that value DOES surface here — the equivalence
+ * class above only collapses the empty cases.
+ *
+ * Also key-order-insensitive: re-indenting / reordering object keys in
+ * Raw JSON doesn't falsely flag a locked-field change.
  */
 export function lockedFieldChange(
   spec: AgentSpec,

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -7,6 +7,7 @@ import { deepEqualCanonical } from "./agent-editor-canonical";
 
 export { canonicalStringify, deepEqualCanonical } from "./agent-editor-canonical";
 export {
+  changedRedactionMarkerPaths,
   computeRedactedDiff,
   redactAgentSpecForDisplay,
   redactAgentSpecForEditing,

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -94,44 +94,86 @@ export function lockedFieldChange(
 }
 
 /**
- * Normalize a patchable field value before comparison so wire-equivalent
- * shapes don't read as a change. The only special case today is
- * `active_hook_filter`: the Rust side marks it `skip_serializing_if =
- * "HashSet::is_empty"`, so absent and `[]` round-trip identically. Without
- * this, toggling the UI to "All" once would flip the spec from absent to
- * `[]` and the customized PATCH path would emit a no-op `active_hook_filter:
- * []` override.
+ * Plan of changes that need to ride the wire to persist the user's draft
+ * against an existing builtin / customized agent record. Split into two
+ * lists because they target different endpoints:
+ *
+ *  - `patch`  → `PATCH /v1/config/agents/:id/overrides` with this map as the
+ *               body. Contains fields with concrete values, including
+ *               explicit `null` for nullable fields the user deliberately
+ *               disabled (e.g. `context_policy: null` meaning "no context
+ *               policy on this agent, even if the base had one").
+ *  - `clear`  → one `DELETE /v1/config/agents/:id/overrides/:field` per
+ *               entry. These are fields the user reverted to "use the base
+ *               value" — the `user_overrides` key gets removed entirely
+ *               rather than left as an explicit-null override that would
+ *               keep the "customized" badge on for no reason.
+ *
+ * Distinguishing the two is the difference between "explicit null
+ * override" and "no override". A naive `PATCH {field: null}` for every
+ * cleared field would mix the two: nullable fields would receive an
+ * `explicit-null` override (badge stays customized) instead of being
+ * cleared back to the builtin default.
  */
-function normalizeForDiff(key: keyof AgentSpec, value: unknown): unknown {
-  if (key === "active_hook_filter" && Array.isArray(value) && value.length === 0) {
-    return undefined;
-  }
-  return value;
+export interface AgentPatchPlan {
+  patch: Record<string, unknown>;
+  clear: Array<keyof AgentSpec>;
 }
 
 /**
- * Build the PATCH payload for a builtin / customized record save. Walks
- * `PATCHABLE_AGENT_FIELDS` and emits any field whose canonical encoding
- * differs from the original. Treats absent / undefined as equivalent and
- * uses `normalizeForDiff` for fields whose empty shape is wire-equivalent
- * to absent (so the UI cannot accidentally promote a default to an
- * override).
+ * Compute the changes a Save should apply to a builtin / customized
+ * record. Walks `PATCHABLE_AGENT_FIELDS` once and emits each field to
+ * exactly one of `patch` / `clear` / no-op.
  *
- * Returned record is suitable for `configApi.patchAgentOverrides`.
+ * Two ordering subtleties:
+ *
+ *  1. `active_hook_filter` is special-cased. The runtime engine treats
+ *     `[]` and absent identically on the resolved spec (both mean "all
+ *     hooks run"), but the customized PATCH layer treats them
+ *     differently: an absent override INHERITS the base's filter while
+ *     `Some([])` EXPLICITLY overrides it. A user who clicks "All
+ *     plugins" on a customized record whose base has a non-empty filter
+ *     wants the override to turn filtering off — emitting CLEAR there
+ *     would inherit the base filter and silently undo the choice. So
+ *     when `current` is empty (`undefined` or `[]`) and `original` is
+ *     non-empty, route to `patch: []` instead of `clear`. The
+ *     "inherit base" semantic isn't user-reachable through the form
+ *     today, so it's intentionally not represented here.
+ *
+ *  2. Clear-on-undefined is checked BEFORE `deepEqualCanonical`. The
+ *     canonical encoding collapses `null` and `undefined` (both → JSON
+ *     `null`), so a saved explicit-null override (e.g. `context_policy:
+ *     null` meaning "no policy even if base has one") edited away in
+ *     Raw JSON would read as "equal" under canonical comparison and the
+ *     override would stay stuck as explicit-null. Detecting clear
+ *     first routes `null → undefined` to the CLEAR list instead.
  */
 export function diffPatchableAgentFields(
   current: AgentSpec,
   original: AgentSpec,
-): Record<string, unknown> {
+): AgentPatchPlan {
   const patch: Record<string, unknown> = {};
+  const clear: Array<keyof AgentSpec> = [];
   for (const key of PATCHABLE_AGENT_FIELDS) {
-    const a = normalizeForDiff(key, current[key]);
-    const b = normalizeForDiff(key, original[key]);
-    if (!deepEqualCanonical(a, b)) {
-      patch[key] = current[key];
+    if (key === "active_hook_filter") {
+      const curArr = current.active_hook_filter ?? [];
+      const origArr = original.active_hook_filter ?? [];
+      if (deepEqualCanonical(curArr, origArr)) continue;
+      // `[]` is the "override base to All plugins" signal — see the
+      // doc comment above. Always route to `patch`, never to `clear`.
+      patch.active_hook_filter = curArr;
+      continue;
     }
+    const a = current[key];
+    const b = original[key];
+    if (a === undefined && b !== undefined) {
+      clear.push(key);
+      continue;
+    }
+    if (deepEqualCanonical(a, b)) continue;
+    patch[key] = a;
   }
-  return patch;
+  return { patch, clear };
 }
 
 /**
@@ -172,6 +214,11 @@ export interface PluginToggleResult {
  * toggles a plugin on or off. When a plugin is removed, drops the same id
  * from `active_hook_filter` so re-enabling later doesn't silently pick up
  * a stale filter entry.
+ *
+ * If the prune empties the filter, collapse `[]` back to `undefined` —
+ * the runtime treats both identically (`[]` = "all hooks run", same as
+ * absent) but the patch-diff path sees `[] != undefined` and would
+ * emit a no-op override. R10 #6.
  */
 export function togglePluginState(
   pluginIds: string[] | undefined,
@@ -182,10 +229,19 @@ export function togglePluginState(
   const removing = current.includes(pluginId);
   const next = removing ? current.filter((id) => id !== pluginId) : [...current, pluginId];
 
-  const nextFilter =
-    removing && activeHookFilter
-      ? activeHookFilter.filter((id) => id !== pluginId)
-      : activeHookFilter;
+  let nextFilter: string[] | undefined;
+  if (removing && activeHookFilter) {
+    const pruned = activeHookFilter.filter((id) => id !== pluginId);
+    // Distinguish two cases:
+    //   - filter was non-empty and now empty: collapse to undefined so
+    //     dirty tracking and PATCH diffing don't treat `[]` (semantic
+    //     "all hooks") as different from absent (also "all hooks").
+    //   - filter was `[]` already: keep `[]` so we don't silently
+    //     change an explicit-empty draft into absent.
+    nextFilter = pruned.length === 0 && activeHookFilter.length > 0 ? undefined : pruned;
+  } else {
+    nextFilter = activeHookFilter;
+  }
 
   return { plugin_ids: next, active_hook_filter: nextFilter };
 }
@@ -228,10 +284,13 @@ export function partitionActiveHookFilter(
   return { active, stale };
 }
 
-/** Keys that always carry secret material when present in a `RemoteEndpoint`
- *  auth object — masked when the editor displays an endpoint read-only.
- *  Lowercased contains-match: covers `token`, `bearer_token`,
- *  `access_token`, `refresh_token`, `id_token`, etc. */
+/** Keys that always carry secret material when seen anywhere in a
+ *  payload — masked by `redactSecretsForDisplay` regardless of context
+ *  (audit log diff, trace event payload, DiffModal). Lowercased
+ *  contains-match — `token` catches `bearer_token` / `access_token` /
+ *  `refresh_token` / `id_token`; `cookie` catches `cookie` /
+ *  `set-cookie` / `cookies`; `session` catches `session_id` /
+ *  `session-cookie`; etc. */
 const SENSITIVE_AUTH_KEY_PATTERNS = [
   "token",
   "secret",
@@ -244,6 +303,15 @@ const SENSITIVE_AUTH_KEY_PATTERNS = [
   "private_key",
   "privatekey",
   "client_secret",
+  // R10 #4 — broaden generic-redaction coverage to HTTP-flavored
+  // secret carriers that an `endpoint.auth` payload or a trace event
+  // can plausibly hold under arbitrary key names.
+  "cookie",
+  "jwt",
+  "bearer",
+  "session",
+  "access_key",
+  "accesskey",
 ];
 
 const REDACTED_PLACEHOLDER = "***";
@@ -253,16 +321,42 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => lowered.includes(pattern));
 }
 
-function redactRecord(value: unknown): unknown {
+function redactRecord(value: unknown, parentKey: string = ""): unknown {
   if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map(redactRecord);
+  // Primitive strings — Trace events / audit snapshots / DiffModal feed
+  // arbitrary payloads through this redactor. A `payload.output` /
+  // `body.message` field whose key name doesn't match the credential
+  // pattern list can still carry `Authorization: …` headers, inline
+  // `Bearer …` tokens, JWTs, `sk-…` keys, etc. Apply pattern-based
+  // string redaction so every display path that calls
+  // `redactSecretsForDisplay` shares one defensive layer.
+  if (typeof value === "string") return redactSecretString(value);
+  if (Array.isArray(value)) return value.map((item) => redactRecord(item, ""));
   if (typeof value === "object") {
+    // Default-deny on any nested `auth` object: `RemoteAuth` allows
+    // arbitrary keys, so a credential under `jwt` / `cookie` / `session` /
+    // `x-api-key` / `header` / `bearer` would slip past the pattern list
+    // below. When we recurse into a value whose key was `auth`, mask
+    // every entry except the human-readable `type` discriminator —
+    // mirrors `redactEndpointForDisplay` but applies wherever `auth`
+    // shows up in audit / trace / diff payloads.
+    if (parentKey === "auth") {
+      const safeAuth: Record<string, unknown> = {};
+      for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+        if (key === "type" || inner === null || inner === undefined) {
+          safeAuth[key] = inner;
+        } else {
+          safeAuth[key] = REDACTED_PLACEHOLDER;
+        }
+      }
+      return safeAuth;
+    }
     const next: Record<string, unknown> = {};
     for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
       if (isSensitiveKey(key)) {
         next[key] = inner === null || inner === undefined ? inner : REDACTED_PLACEHOLDER;
       } else {
-        next[key] = redactRecord(inner);
+        next[key] = redactRecord(inner, key);
       }
     }
     return next;
@@ -271,19 +365,101 @@ function redactRecord(value: unknown): unknown {
 }
 
 /**
- * Return a copy of `endpoint` with secret-bearing keys (`bearer_token`,
- * `api_key`, `authorization`, etc.) replaced by `"***"`. The non-secret
- * shape (`backend`, `base_url`, `target`, `timeout_ms`, auth `type`, etc.)
- * is preserved so the read-only UI is still useful for verifying that an
- * agent is wired to the expected remote, without leaking the credential
- * into the admin DOM.
+ * Return a copy of `endpoint` with secret-bearing fields masked to `"***"`.
+ * Two layers of defense:
  *
- * Walks the entire endpoint (not just `auth`) defensively: any future
- * schema addition that happens to carry credentials would still be masked
- * by virtue of its key name.
+ *   1. Pattern-based: walks the whole endpoint and masks any key whose name
+ *      matches a known credential pattern (`token`, `secret`, `password`,
+ *      `api_key`, `authorization`, `credential`, `private_key`, …). This
+ *      catches secrets that happen to live anywhere in the endpoint tree.
+ *   2. Default-deny on `endpoint.auth`: `RemoteAuth` has an index signature,
+ *      so a future schema addition could carry a credential under a key
+ *      name the pattern list doesn't know about (`cookie`, `jwt`, `header`,
+ *      etc.). For the `auth` object specifically, mask every key except
+ *      the human-readable `type` discriminator.
+ *
+ * Either layer alone would catch the documented secret keys; the
+ * combination is intentional for forward-compatibility with schema drift.
+ * The non-secret shape (`backend`, `base_url`, `target`, `timeout_ms`,
+ * `type`, etc.) is preserved so the read-only UI is still useful for
+ * verifying an agent is wired to the expected remote.
  */
 export function redactEndpointForDisplay(endpoint: RemoteEndpoint): RemoteEndpoint {
-  return redactRecord(endpoint) as RemoteEndpoint;
+  const generic = redactRecord(endpoint) as RemoteEndpoint;
+  if (!generic.auth || typeof generic.auth !== "object") {
+    return generic;
+  }
+  const auth = generic.auth as Record<string, unknown>;
+  const safeAuth: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(auth)) {
+    if (key === "type") {
+      // The discriminator is needed for the reader to understand the
+      // shape — it's not a credential.
+      safeAuth[key] = value;
+    } else if (value === null || value === undefined) {
+      // Preserve null / undefined as semantic markers — they signal
+      // "no value", not "redacted".
+      safeAuth[key] = value;
+    } else {
+      safeAuth[key] = REDACTED_PLACEHOLDER;
+    }
+  }
+  return { ...generic, auth: safeAuth as RemoteEndpoint["auth"] };
+}
+
+/**
+ * Recursively mask every secret-keyed field in an arbitrary value tree.
+ * Used by display paths that serialize structures we don't statically
+ * know the shape of — audit-log `before`/`after` snapshots (may carry a
+ * full `AgentSpec` including `endpoint.auth`), persisted trace events
+ * (payloads may include serialized agent specs), and history-restore
+ * confirmation dialogs.
+ */
+export function redactSecretsForDisplay<T>(value: T): T {
+  return redactRecord(value) as T;
+}
+
+/**
+ * Mask common credential patterns embedded in arbitrary text. Used by
+ * display paths that render raw string payloads — tool outputs, tool
+ * error messages — where the key-based redactor doesn't apply because
+ * there's no key/value structure to walk (R12 #3).
+ *
+ * Patterns covered (case-insensitive where reasonable):
+ *  - `Authorization: <value>` / `Cookie: <value>` / `Set-Cookie: <value>` (full line)
+ *  - `Bearer <token>` (inline anywhere in the string)
+ *  - `<api_key|access_key|access_token|client_secret|refresh_token|id_token|bearer_token|password|secret|token|jwt>=<value>`
+ *    (or with `:` separator) — masks the value
+ *  - JWT-shaped tokens: `eyJ<base64>.<base64>.<base64>`
+ *  - OpenAI-style `sk-…`, Stripe-style `sk_(live|test)_…`
+ *
+ * Intentionally conservative — false positives mask non-secret strings,
+ * which is the right trade-off for an admin-console display layer.
+ */
+export function redactSecretString(input: string): string {
+  if (typeof input !== "string" || input.length === 0) return input;
+  let result = input;
+  // Full-line header values.
+  result = result.replace(/Authorization\s*:\s*[^\r\n]+/gi, "Authorization: ***");
+  result = result.replace(/Set-Cookie\s*:\s*[^\r\n]+/gi, "Set-Cookie: ***");
+  result = result.replace(/(^|\s|;)Cookie\s*:\s*[^\r\n]+/gi, "$1Cookie: ***");
+  // Inline Bearer token.
+  result = result.replace(/Bearer\s+[A-Za-z0-9._\-+/=]{8,}/gi, "Bearer ***");
+  // key=value / key: value for known credential field names. Negative
+  // lookahead prevents re-masking already-redacted output.
+  result = result.replace(
+    /\b(api[_-]?key|access[_-]?key|access[_-]?token|client[_-]?secret|refresh[_-]?token|id[_-]?token|bearer[_-]?token|password|secret|token|jwt)\s*[:=]\s*(?!\*\*\*)[^\s,;"'&}]+/gi,
+    "$1=***",
+  );
+  // JWT — three dot-separated base64url segments starting with eyJ.
+  result = result.replace(
+    /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+    "***",
+  );
+  // OpenAI-style sk-<long>, Stripe-style sk_(live|test)_<long>.
+  result = result.replace(/\bsk-[A-Za-z0-9_-]{16,}/g, "***");
+  result = result.replace(/\bsk_(?:live|test)_[A-Za-z0-9]+/g, "***");
+  return result;
 }
 
 /**
@@ -327,11 +503,14 @@ export function unknownAgentSpecFields(parsed: Record<string, unknown>): string[
 
 /**
  * Overlay the current spec's locked fields (`endpoint`, `registry`) onto a
- * parsed Raw JSON payload. The Raw JSON textarea shows a redacted view of
- * locked fields, so users would either need to type real credentials back
- * in to round-trip or `lockedFieldChange` would reject the apply on the
- * `***` placeholder. By overlaying the real values before the
- * locked-field-change check, redaction stays purely a display concern.
+ * parsed Raw JSON payload AFTER the caller has compared the parsed draft
+ * against the redacted display copy. This order is load-bearing: merging
+ * BEFORE the compare would overwrite `parsed.endpoint` with `spec.endpoint`
+ * and the subsequent `lockedFieldChange` would always read "equal",
+ * silently dropping any user edit to `base_url` / `auth.*` / `target` /
+ * `registry`. The compare must run first against the redacted display
+ * spec; this merge then re-introduces the real credentials so the
+ * candidate carries the live values rather than the `***` placeholder.
  *
  * Returns a shallow copy; never mutates the inputs.
  */

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -171,13 +171,17 @@ export interface AgentPatchPlan {
  *     override would stay stuck as explicit-null. Detecting clear
  *     first routes `null → undefined` to the CLEAR list instead.
  */
-export function diffPatchableAgentFields(
-  current: AgentSpec,
-  original: AgentSpec,
-): AgentPatchPlan {
+export function diffPatchableAgentFields(current: AgentSpec, original: AgentSpec): AgentPatchPlan {
   const patch: Record<string, unknown> = {};
   const clear: Array<keyof AgentSpec> = [];
   for (const key of PATCHABLE_AGENT_FIELDS) {
+    if (key === "sections") {
+      const sectionsPatch = diffSectionsForPatch(current.sections, original.sections);
+      if (sectionsPatch) {
+        patch.sections = sectionsPatch;
+      }
+      continue;
+    }
     if (key === "active_hook_filter") {
       const curArr = current.active_hook_filter ?? [];
       const origArr = original.active_hook_filter ?? [];
@@ -197,6 +201,34 @@ export function diffPatchableAgentFields(
     patch[key] = a;
   }
   return { patch, clear };
+}
+
+function asSectionRecord(value: AgentSpec["sections"]): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined));
+}
+
+function diffSectionsForPatch(
+  current: AgentSpec["sections"],
+  original: AgentSpec["sections"],
+): Record<string, unknown> | null {
+  const currentSections = asSectionRecord(current);
+  const originalSections = asSectionRecord(original);
+  const patch: Record<string, unknown> = {};
+  const keys = new Set([...Object.keys(originalSections), ...Object.keys(currentSections)]);
+  for (const sectionKey of keys) {
+    const currentHas = Object.prototype.hasOwnProperty.call(currentSections, sectionKey);
+    const originalHas = Object.prototype.hasOwnProperty.call(originalSections, sectionKey);
+    if (!currentHas && originalHas) {
+      patch[sectionKey] = null;
+      continue;
+    }
+    if (!currentHas) continue;
+    const nextValue = currentSections[sectionKey];
+    if (originalHas && deepEqualCanonical(nextValue, originalSections[sectionKey])) continue;
+    patch[sectionKey] = nextValue;
+  }
+  return Object.keys(patch).length > 0 ? patch : null;
 }
 
 /**
@@ -347,6 +379,14 @@ const SENSITIVE_HEADER_KEY_PATTERNS = [
   "token",
 ];
 
+export type RedactionPathSegment = string | number;
+
+export interface RedactionEntry {
+  path: RedactionPathSegment[];
+  original: unknown;
+  redacted: unknown;
+}
+
 function normalizeSecretKey(key: string): string {
   return key.toLowerCase().replace(/[-_\s]/g, "");
 }
@@ -362,7 +402,33 @@ function isSensitiveHeaderKey(parentKey: string, key: string): boolean {
   return SENSITIVE_HEADER_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
 }
 
-function redactRecord(value: unknown, parentKey: string = ""): unknown {
+function cloneJsonValue<T>(value: T): T {
+  if (value === undefined || value === null) return value;
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) return value;
+  return JSON.parse(encoded) as T;
+}
+
+function recordRedaction(
+  redactions: RedactionEntry[] | undefined,
+  path: RedactionPathSegment[],
+  original: unknown,
+  redacted: unknown,
+) {
+  if (!redactions || deepEqualCanonical(original, redacted)) return;
+  redactions.push({
+    path: [...path],
+    original: cloneJsonValue(original),
+    redacted: cloneJsonValue(redacted),
+  });
+}
+
+function redactRecord(
+  value: unknown,
+  parentKey: string = "",
+  path: RedactionPathSegment[] = [],
+  redactions?: RedactionEntry[],
+): unknown {
   if (value === null || value === undefined) return value;
   // Primitive strings — Trace events / audit snapshots / DiffModal feed
   // arbitrary payloads through this redactor. A `payload.output` /
@@ -371,8 +437,14 @@ function redactRecord(value: unknown, parentKey: string = ""): unknown {
   // `Bearer …` tokens, JWTs, `sk-…` keys, etc. Apply pattern-based
   // string redaction so every display path that calls
   // `redactSecretsForDisplay` shares one defensive layer.
-  if (typeof value === "string") return redactSecretString(value);
-  if (Array.isArray(value)) return value.map((item) => redactRecord(item, ""));
+  if (typeof value === "string") {
+    const redacted = redactSecretString(value);
+    recordRedaction(redactions, path, value, redacted);
+    return redacted;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, index) => redactRecord(item, "", [...path, index], redactions));
+  }
   if (typeof value === "object") {
     // Default-deny on any nested `auth` object: `RemoteAuth` allows
     // arbitrary keys, so a credential under `jwt` / `cookie` / `session` /
@@ -388,16 +460,19 @@ function redactRecord(value: unknown, parentKey: string = ""): unknown {
           safeAuth[key] = inner;
         } else {
           safeAuth[key] = REDACTED_PLACEHOLDER;
+          recordRedaction(redactions, [...path, key], inner, REDACTED_PLACEHOLDER);
         }
       }
       return safeAuth;
     }
     const next: Record<string, unknown> = {};
     for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      const nextPath = [...path, key];
       if (isSensitiveKey(key) || isSensitiveHeaderKey(parentKey, key)) {
         next[key] = inner === null || inner === undefined ? inner : REDACTED_PLACEHOLDER;
+        recordRedaction(redactions, nextPath, inner, next[key]);
       } else {
-        next[key] = redactRecord(inner, key);
+        next[key] = redactRecord(inner, key, nextPath, redactions);
       }
     }
     return next;
@@ -458,6 +533,66 @@ export function redactEndpointForDisplay(endpoint: RemoteEndpoint): RemoteEndpoi
  */
 export function redactSecretsForDisplay<T>(value: T): T {
   return redactRecord(value) as T;
+}
+
+export interface RedactedAgentSpecForEditing {
+  redacted: AgentSpec;
+  redactions: RedactionEntry[];
+}
+
+export function redactAgentSpecForEditing(spec: AgentSpec): RedactedAgentSpecForEditing {
+  const redactions: RedactionEntry[] = [];
+  return {
+    redacted: redactRecord(spec, "", [], redactions) as AgentSpec,
+    redactions,
+  };
+}
+
+function readPath(root: unknown, path: readonly RedactionPathSegment[]) {
+  let current = root;
+  for (const segment of path) {
+    if (current === null || typeof current !== "object") {
+      return { found: false, value: undefined };
+    }
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+      return { found: false, value: undefined };
+    }
+    current = Array.isArray(current)
+      ? current[Number(segment)]
+      : (current as Record<string, unknown>)[String(segment)];
+  }
+  return { found: true, value: current };
+}
+
+function writePath(root: unknown, path: readonly RedactionPathSegment[], value: unknown): boolean {
+  if (path.length === 0) return false;
+  let current = root;
+  for (const segment of path.slice(0, -1)) {
+    if (current === null || typeof current !== "object") return false;
+    current = Array.isArray(current)
+      ? current[Number(segment)]
+      : (current as Record<string, unknown>)[String(segment)];
+  }
+  if (current === null || typeof current !== "object") return false;
+  const leaf = path[path.length - 1];
+  if (Array.isArray(current)) {
+    current[Number(leaf)] = cloneJsonValue(value);
+  } else {
+    (current as Record<string, unknown>)[String(leaf)] = cloneJsonValue(value);
+  }
+  return true;
+}
+
+export function restoreUnchangedRedactions<T>(parsed: T, redactions: readonly RedactionEntry[]): T {
+  if (redactions.length === 0) return parsed;
+  const restored = cloneJsonValue(parsed);
+  for (const redaction of redactions) {
+    const current = readPath(restored, redaction.path);
+    if (current.found && deepEqualCanonical(current.value, redaction.redacted)) {
+      writePath(restored, redaction.path, redaction.original);
+    }
+  }
+  return restored;
 }
 
 export interface RedactedFieldChange {
@@ -558,10 +693,7 @@ export function redactSecretString(input: string): string {
     "$1=***",
   );
   // JWT — three dot-separated base64url segments starting with eyJ.
-  result = result.replace(
-    /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
-    "***",
-  );
+  result = result.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "***");
   // OpenAI-style sk-<long>, Stripe-style sk_(live|test)_<long>.
   result = result.replace(/\bsk-[A-Za-z0-9_-]{16,}/g, "***");
   result = result.replace(/\bsk_(?:live|test)_[A-Za-z0-9]+/g, "***");
@@ -616,7 +748,7 @@ export function unknownAgentSpecFields(parsed: Record<string, unknown>): string[
  * silently dropping any user edit to `base_url` / `auth.*` / `target` /
  * `registry`. The compare must run first against the redacted display
  * spec; this merge then re-introduces the real credentials so the
- * candidate carries the live values rather than the `***` placeholder.
+ * candidate carries the live values rather than the `***` redaction.
  *
  * Returns a shallow copy; never mutates the inputs.
  */

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -117,26 +117,19 @@ export function lockedFieldChange(
 }
 
 /**
- * Plan of changes that need to ride the wire to persist the user's draft
- * against an existing builtin / customized agent record. Split into two
- * lists because they target different endpoints:
+ * Save plan for a builtin / customized record. Both lists ride a single
+ * `PATCH /v1/config/agents/:id/overrides` body shaped like
+ * `{...patch, _clear: [...clear]}`; the server applies upserts and
+ * clears in one `apply_locked` transaction (R11 #3, supersedes the
+ * earlier PATCH + N×DELETE flow).
  *
- *  - `patch`  → `PATCH /v1/config/agents/:id/overrides` with this map as the
- *               body. Contains fields with concrete values, including
- *               explicit `null` for nullable fields the user deliberately
- *               disabled (e.g. `context_policy: null` meaning "no context
- *               policy on this agent, even if the base had one").
- *  - `clear`  → one `DELETE /v1/config/agents/:id/overrides/:field` per
- *               entry. These are fields the user reverted to "use the base
- *               value" — the `user_overrides` key gets removed entirely
- *               rather than left as an explicit-null override that would
- *               keep the "customized" badge on for no reason.
- *
- * Distinguishing the two is the difference between "explicit null
- * override" and "no override". A naive `PATCH {field: null}` for every
- * cleared field would mix the two: nullable fields would receive an
- * `explicit-null` override (badge stays customized) instead of being
- * cleared back to the builtin default.
+ *  - `patch`  → top-level body keys. Includes explicit `null` for
+ *               nullable fields the user deliberately disabled (e.g.
+ *               `context_policy: null` = "no policy even if base had one").
+ *  - `clear`  → entries in the `_clear` array. Removes the field from
+ *               `user_overrides` so the resolved spec falls back to
+ *               the builtin default — distinct from "explicit null
+ *               override" which would keep the customized badge on.
  */
 export interface AgentPatchPlan {
   patch: Record<string, unknown>;
@@ -339,29 +332,23 @@ export function partitionActiveHookFilter(
   return { active, stale };
 }
 
-/** Keys that always carry secret material when seen anywhere in a
- *  payload — masked by `redactSecretsForDisplay` regardless of context
- *  (audit log diff, trace event payload, DiffModal). Keys are normalized
- *  before matching so `api_key`, `api-key`, and `x-api-key` all hit the
- *  same `apikey` pattern. */
+/** Exact-match buckets for short / ambiguous secret names where substring
+ *  matching would over-redact. R15: standalone `token` is a secret;
+ *  `max_context_tokens` (LLM budget) contains "token" but isn't one.
+ *  Keys are normalized via `normalizeSecretKey` before lookup. */
+const EXACT_SECRET_KEYS = new Set(["token", "apikey", "xapikey"]);
+
+/** Substring patterns specific enough to be safe; `token` is intentionally
+ *  excluded — see `EXACT_SECRET_KEYS`. Compound `*_token` shapes
+ *  (access_token, bearer_token, …) live below as their full form. */
 const SENSITIVE_AUTH_KEY_PATTERNS = [
-  "token",
-  "secret",
-  "password",
-  "passphrase",
-  "apikey",
-  "authorization",
-  "credential",
-  "privatekey",
-  "clientsecret",
-  // R10 #4 — broaden generic-redaction coverage to HTTP-flavored
-  // secret carriers that an `endpoint.auth` payload or a trace event
-  // can plausibly hold under arbitrary key names.
-  "cookie",
-  "jwt",
-  "bearer",
-  "session",
-  "accesskey",
+  "secret", "password", "passphrase", "authorization", "credential",
+  "privatekey", "clientsecret",
+  // R10 #4 — HTTP-flavored secret carriers under arbitrary key names.
+  "cookie", "jwt", "bearer", "session", "accesskey",
+  // R15 — compound token shapes; the standalone word "token" stays exact.
+  "accesstoken", "refreshtoken", "idtoken", "bearertoken",
+  "authtoken", "sessiontoken",
 ];
 
 const REDACTED_PLACEHOLDER = "***";
@@ -393,6 +380,7 @@ function normalizeSecretKey(key: string): string {
 
 function isSensitiveKey(key: string): boolean {
   const normalized = normalizeSecretKey(key);
+  if (EXACT_SECRET_KEYS.has(normalized)) return true;
   return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
 }
 

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -309,23 +309,19 @@ export function partitionActiveHookFilter(
 
 /** Keys that always carry secret material when seen anywhere in a
  *  payload — masked by `redactSecretsForDisplay` regardless of context
- *  (audit log diff, trace event payload, DiffModal). Lowercased
- *  contains-match — `token` catches `bearer_token` / `access_token` /
- *  `refresh_token` / `id_token`; `cookie` catches `cookie` /
- *  `set-cookie` / `cookies`; `session` catches `session_id` /
- *  `session-cookie`; etc. */
+ *  (audit log diff, trace event payload, DiffModal). Keys are normalized
+ *  before matching so `api_key`, `api-key`, and `x-api-key` all hit the
+ *  same `apikey` pattern. */
 const SENSITIVE_AUTH_KEY_PATTERNS = [
   "token",
   "secret",
   "password",
   "passphrase",
-  "api_key",
   "apikey",
   "authorization",
   "credential",
-  "private_key",
   "privatekey",
-  "client_secret",
+  "clientsecret",
   // R10 #4 — broaden generic-redaction coverage to HTTP-flavored
   // secret carriers that an `endpoint.auth` payload or a trace event
   // can plausibly hold under arbitrary key names.
@@ -333,15 +329,37 @@ const SENSITIVE_AUTH_KEY_PATTERNS = [
   "jwt",
   "bearer",
   "session",
-  "access_key",
   "accesskey",
 ];
 
 const REDACTED_PLACEHOLDER = "***";
 
+const HEADER_CONTAINER_KEYS = new Set(["headers", "requestheaders", "responseheaders"]);
+
+const SENSITIVE_HEADER_KEY_PATTERNS = [
+  "authorization",
+  "proxyauthorization",
+  "cookie",
+  "setcookie",
+  "apikey",
+  "xapikey",
+  "xauthtoken",
+  "token",
+];
+
+function normalizeSecretKey(key: string): string {
+  return key.toLowerCase().replace(/[-_\s]/g, "");
+}
+
 function isSensitiveKey(key: string): boolean {
-  const lowered = key.toLowerCase();
-  return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => lowered.includes(pattern));
+  const normalized = normalizeSecretKey(key);
+  return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+function isSensitiveHeaderKey(parentKey: string, key: string): boolean {
+  if (!HEADER_CONTAINER_KEYS.has(normalizeSecretKey(parentKey))) return false;
+  const normalized = normalizeSecretKey(key);
+  return SENSITIVE_HEADER_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
 }
 
 function redactRecord(value: unknown, parentKey: string = ""): unknown {
@@ -363,7 +381,7 @@ function redactRecord(value: unknown, parentKey: string = ""): unknown {
     // every entry except the human-readable `type` discriminator —
     // mirrors `redactEndpointForDisplay` but applies wherever `auth`
     // shows up in audit / trace / diff payloads.
-    if (parentKey === "auth") {
+    if (normalizeSecretKey(parentKey) === "auth") {
       const safeAuth: Record<string, unknown> = {};
       for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
         if (key === "type" || inner === null || inner === undefined) {
@@ -376,7 +394,7 @@ function redactRecord(value: unknown, parentKey: string = ""): unknown {
     }
     const next: Record<string, unknown> = {};
     for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
-      if (isSensitiveKey(key)) {
+      if (isSensitiveKey(key) || isSensitiveHeaderKey(parentKey, key)) {
         next[key] = inner === null || inner === undefined ? inner : REDACTED_PLACEHOLDER;
       } else {
         next[key] = redactRecord(inner, key);
@@ -440,6 +458,71 @@ export function redactEndpointForDisplay(endpoint: RemoteEndpoint): RemoteEndpoi
  */
 export function redactSecretsForDisplay<T>(value: T): T {
   return redactRecord(value) as T;
+}
+
+export interface RedactedFieldChange {
+  path: string;
+  before: unknown;
+  after: unknown;
+  redactedValueChanged: boolean;
+}
+
+/**
+ * Compute semantic changes from raw values, but return only redacted
+ * before/after payloads for rendering. This preserves secret-only changes
+ * in DiffModal without handing the DOM the original credential values.
+ */
+export function computeRedactedDiff(
+  prev: Record<string, unknown>,
+  curr: Record<string, unknown>,
+  base = "",
+): RedactedFieldChange[] {
+  return computeRedactedDiffFrom(
+    prev,
+    curr,
+    redactSecretsForDisplay(prev),
+    redactSecretsForDisplay(curr),
+    base,
+  );
+}
+
+function computeRedactedDiffFrom(
+  prev: Record<string, unknown>,
+  curr: Record<string, unknown>,
+  redactedPrev: Record<string, unknown>,
+  redactedCurr: Record<string, unknown>,
+  base: string,
+): RedactedFieldChange[] {
+  const out: RedactedFieldChange[] = [];
+  const keys = new Set([...Object.keys(prev ?? {}), ...Object.keys(curr ?? {})]);
+  for (const key of keys) {
+    const path = base ? `${base}.${key}` : key;
+    const beforeRaw = prev?.[key];
+    const afterRaw = curr?.[key];
+    const beforeDisplay = redactedPrev?.[key];
+    const afterDisplay = redactedCurr?.[key];
+    if (deepEqualCanonical(beforeRaw, afterRaw)) continue;
+    if (
+      isDiffRecord(beforeRaw) &&
+      isDiffRecord(afterRaw) &&
+      isDiffRecord(beforeDisplay) &&
+      isDiffRecord(afterDisplay)
+    ) {
+      out.push(...computeRedactedDiffFrom(beforeRaw, afterRaw, beforeDisplay, afterDisplay, path));
+    } else {
+      out.push({
+        path,
+        before: beforeDisplay,
+        after: afterDisplay,
+        redactedValueChanged: deepEqualCanonical(beforeDisplay, afterDisplay),
+      });
+    }
+  }
+  return out;
+}
+
+function isDiffRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 /**

--- a/apps/admin-console/src/lib/agent-editor-helpers.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.ts
@@ -2,7 +2,25 @@
 /// stay unit-testable without having to drive React Router + the page state
 /// machine, and so the JSON-editor / plugin-toggle / clone / patch-diff /
 /// remote-endpoint-display code paths share one canonical implementation.
-import type { AgentSpec, RemoteEndpoint } from "./api/types";
+import type { AgentSpec } from "./api/types";
+import { deepEqualCanonical } from "./agent-editor-canonical";
+
+export { canonicalStringify, deepEqualCanonical } from "./agent-editor-canonical";
+export {
+  computeRedactedDiff,
+  redactAgentSpecForDisplay,
+  redactAgentSpecForEditing,
+  redactEndpointForDisplay,
+  redactSecretString,
+  redactSecretsForDisplay,
+  restoreUnchangedRedactions,
+} from "./agent-secret-redaction";
+export type {
+  RedactedAgentSpecForEditing,
+  RedactedFieldChange,
+  RedactionEntry,
+  RedactionPathSegment,
+} from "./agent-secret-redaction";
 
 /**
  * Fields the editor cannot patch on a customized record:
@@ -39,40 +57,6 @@ export const PATCHABLE_AGENT_FIELDS: Array<keyof AgentSpec> = [
   "delegates",
   "reasoning_effort",
 ];
-
-/**
- * Stable JSON encoding: deep-sorts object keys so structurally-equal values
- * always serialize to the same string. Used as a building block for
- * `deepEqualCanonical` so re-formatting / key-reordering of Raw JSON doesn't
- * read as a locked-field change or trigger a spurious PATCH entry.
- *
- * Arrays preserve order (semantically significant). `undefined` collapses to
- * `null` so `{a: undefined}` and `{}` are treated equivalently — JSON has no
- * `undefined` and field absence vs explicit-undefined should not surface as
- * a diff in this editor.
- */
-export function canonicalStringify(value: unknown): string {
-  return JSON.stringify(canonicalize(value));
-}
-
-function canonicalize(value: unknown): unknown {
-  if (value === undefined || value === null) return null;
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (typeof value === "object") {
-    const entries = Object.entries(value as Record<string, unknown>)
-      .filter(([, item]) => item !== undefined)
-      .map(([key, item]) => [key, canonicalize(item)] as const)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
-    return Object.fromEntries(entries);
-  }
-  return value;
-}
-
-/** Structural equality using `canonicalStringify` — order-insensitive for
- *  object keys, order-sensitive for arrays. */
-export function deepEqualCanonical(a: unknown, b: unknown): boolean {
-  return canonicalStringify(a) === canonicalStringify(b);
-}
 
 /**
  * Returns the name of the first locked field (`endpoint` or `registry`)
@@ -332,374 +316,6 @@ export function partitionActiveHookFilter(
   return { active, stale };
 }
 
-/** Exact-match buckets for short / ambiguous secret names where substring
- *  matching would over-redact. R15: standalone `token` is a secret;
- *  `max_context_tokens` (LLM budget) contains "token" but isn't one.
- *  Keys are normalized via `normalizeSecretKey` before lookup. */
-const EXACT_SECRET_KEYS = new Set(["token", "apikey", "xapikey"]);
-
-/** Substring patterns specific enough to be safe; `token` is intentionally
- *  excluded — see `EXACT_SECRET_KEYS`. Compound `*_token` shapes
- *  (access_token, bearer_token, …) live below as their full form. */
-const SENSITIVE_AUTH_KEY_PATTERNS = [
-  "secret", "password", "passphrase", "authorization", "credential",
-  "privatekey", "clientsecret",
-  // R10 #4 — HTTP-flavored secret carriers under arbitrary key names.
-  "cookie", "jwt", "bearer", "session", "accesskey",
-  // R15 — compound token shapes; the standalone word "token" stays exact.
-  "accesstoken", "refreshtoken", "idtoken", "bearertoken",
-  "authtoken", "sessiontoken",
-];
-
-const REDACTED_PLACEHOLDER = "***";
-
-const HEADER_CONTAINER_KEYS = new Set(["headers", "requestheaders", "responseheaders"]);
-
-const SENSITIVE_HEADER_KEY_PATTERNS = [
-  "authorization",
-  "proxyauthorization",
-  "cookie",
-  "setcookie",
-  "apikey",
-  "xapikey",
-  "xauthtoken",
-  "token",
-];
-
-export type RedactionPathSegment = string | number;
-
-export interface RedactionEntry {
-  path: RedactionPathSegment[];
-  original: unknown;
-  redacted: unknown;
-}
-
-function normalizeSecretKey(key: string): string {
-  return key.toLowerCase().replace(/[-_\s]/g, "");
-}
-
-function isSensitiveKey(key: string): boolean {
-  const normalized = normalizeSecretKey(key);
-  if (EXACT_SECRET_KEYS.has(normalized)) return true;
-  return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
-}
-
-function isSensitiveHeaderKey(parentKey: string, key: string): boolean {
-  if (!HEADER_CONTAINER_KEYS.has(normalizeSecretKey(parentKey))) return false;
-  const normalized = normalizeSecretKey(key);
-  return SENSITIVE_HEADER_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
-}
-
-function cloneJsonValue<T>(value: T): T {
-  if (value === undefined || value === null) return value;
-  const encoded = JSON.stringify(value);
-  if (encoded === undefined) return value;
-  return JSON.parse(encoded) as T;
-}
-
-function recordRedaction(
-  redactions: RedactionEntry[] | undefined,
-  path: RedactionPathSegment[],
-  original: unknown,
-  redacted: unknown,
-) {
-  if (!redactions || deepEqualCanonical(original, redacted)) return;
-  redactions.push({
-    path: [...path],
-    original: cloneJsonValue(original),
-    redacted: cloneJsonValue(redacted),
-  });
-}
-
-function redactRecord(
-  value: unknown,
-  parentKey: string = "",
-  path: RedactionPathSegment[] = [],
-  redactions?: RedactionEntry[],
-): unknown {
-  if (value === null || value === undefined) return value;
-  // Primitive strings — Trace events / audit snapshots / DiffModal feed
-  // arbitrary payloads through this redactor. A `payload.output` /
-  // `body.message` field whose key name doesn't match the credential
-  // pattern list can still carry `Authorization: …` headers, inline
-  // `Bearer …` tokens, JWTs, `sk-…` keys, etc. Apply pattern-based
-  // string redaction so every display path that calls
-  // `redactSecretsForDisplay` shares one defensive layer.
-  if (typeof value === "string") {
-    const redacted = redactSecretString(value);
-    recordRedaction(redactions, path, value, redacted);
-    return redacted;
-  }
-  if (Array.isArray(value)) {
-    return value.map((item, index) => redactRecord(item, "", [...path, index], redactions));
-  }
-  if (typeof value === "object") {
-    // Default-deny on any nested `auth` object: `RemoteAuth` allows
-    // arbitrary keys, so a credential under `jwt` / `cookie` / `session` /
-    // `x-api-key` / `header` / `bearer` would slip past the pattern list
-    // below. When we recurse into a value whose key was `auth`, mask
-    // every entry except the human-readable `type` discriminator —
-    // mirrors `redactEndpointForDisplay` but applies wherever `auth`
-    // shows up in audit / trace / diff payloads.
-    if (normalizeSecretKey(parentKey) === "auth") {
-      const safeAuth: Record<string, unknown> = {};
-      for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
-        if (key === "type" || inner === null || inner === undefined) {
-          safeAuth[key] = inner;
-        } else {
-          safeAuth[key] = REDACTED_PLACEHOLDER;
-          recordRedaction(redactions, [...path, key], inner, REDACTED_PLACEHOLDER);
-        }
-      }
-      return safeAuth;
-    }
-    const next: Record<string, unknown> = {};
-    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
-      const nextPath = [...path, key];
-      if (isSensitiveKey(key) || isSensitiveHeaderKey(parentKey, key)) {
-        next[key] = inner === null || inner === undefined ? inner : REDACTED_PLACEHOLDER;
-        recordRedaction(redactions, nextPath, inner, next[key]);
-      } else {
-        next[key] = redactRecord(inner, key, nextPath, redactions);
-      }
-    }
-    return next;
-  }
-  return value;
-}
-
-/**
- * Return a copy of `endpoint` with secret-bearing fields masked to `"***"`.
- * Two layers of defense:
- *
- *   1. Pattern-based: walks the whole endpoint and masks any key whose name
- *      matches a known credential pattern (`token`, `secret`, `password`,
- *      `api_key`, `authorization`, `credential`, `private_key`, …). This
- *      catches secrets that happen to live anywhere in the endpoint tree.
- *   2. Default-deny on `endpoint.auth`: `RemoteAuth` has an index signature,
- *      so a future schema addition could carry a credential under a key
- *      name the pattern list doesn't know about (`cookie`, `jwt`, `header`,
- *      etc.). For the `auth` object specifically, mask every key except
- *      the human-readable `type` discriminator.
- *
- * Either layer alone would catch the documented secret keys; the
- * combination is intentional for forward-compatibility with schema drift.
- * The non-secret shape (`backend`, `base_url`, `target`, `timeout_ms`,
- * `type`, etc.) is preserved so the read-only UI is still useful for
- * verifying an agent is wired to the expected remote.
- */
-export function redactEndpointForDisplay(endpoint: RemoteEndpoint): RemoteEndpoint {
-  const generic = redactRecord(endpoint) as RemoteEndpoint;
-  if (!generic.auth || typeof generic.auth !== "object") {
-    return generic;
-  }
-  const auth = generic.auth as Record<string, unknown>;
-  const safeAuth: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(auth)) {
-    if (key === "type") {
-      // The discriminator is needed for the reader to understand the
-      // shape — it's not a credential.
-      safeAuth[key] = value;
-    } else if (value === null || value === undefined) {
-      // Preserve null / undefined as semantic markers — they signal
-      // "no value", not "redacted".
-      safeAuth[key] = value;
-    } else {
-      safeAuth[key] = REDACTED_PLACEHOLDER;
-    }
-  }
-  return { ...generic, auth: safeAuth as RemoteEndpoint["auth"] };
-}
-
-/**
- * Recursively mask every secret-keyed field in an arbitrary value tree.
- * Used by display paths that serialize structures we don't statically
- * know the shape of — audit-log `before`/`after` snapshots (may carry a
- * full `AgentSpec` including `endpoint.auth`), persisted trace events
- * (payloads may include serialized agent specs), and history-restore
- * confirmation dialogs.
- */
-export function redactSecretsForDisplay<T>(value: T): T {
-  return redactRecord(value) as T;
-}
-
-export interface RedactedAgentSpecForEditing {
-  redacted: AgentSpec;
-  redactions: RedactionEntry[];
-}
-
-export function redactAgentSpecForEditing(spec: AgentSpec): RedactedAgentSpecForEditing {
-  const redactions: RedactionEntry[] = [];
-  return {
-    redacted: redactRecord(spec, "", [], redactions) as AgentSpec,
-    redactions,
-  };
-}
-
-function readPath(root: unknown, path: readonly RedactionPathSegment[]) {
-  let current = root;
-  for (const segment of path) {
-    if (current === null || typeof current !== "object") {
-      return { found: false, value: undefined };
-    }
-    if (!Object.prototype.hasOwnProperty.call(current, segment)) {
-      return { found: false, value: undefined };
-    }
-    current = Array.isArray(current)
-      ? current[Number(segment)]
-      : (current as Record<string, unknown>)[String(segment)];
-  }
-  return { found: true, value: current };
-}
-
-function writePath(root: unknown, path: readonly RedactionPathSegment[], value: unknown): boolean {
-  if (path.length === 0) return false;
-  let current = root;
-  for (const segment of path.slice(0, -1)) {
-    if (current === null || typeof current !== "object") return false;
-    current = Array.isArray(current)
-      ? current[Number(segment)]
-      : (current as Record<string, unknown>)[String(segment)];
-  }
-  if (current === null || typeof current !== "object") return false;
-  const leaf = path[path.length - 1];
-  if (Array.isArray(current)) {
-    current[Number(leaf)] = cloneJsonValue(value);
-  } else {
-    (current as Record<string, unknown>)[String(leaf)] = cloneJsonValue(value);
-  }
-  return true;
-}
-
-export function restoreUnchangedRedactions<T>(parsed: T, redactions: readonly RedactionEntry[]): T {
-  if (redactions.length === 0) return parsed;
-  const restored = cloneJsonValue(parsed);
-  for (const redaction of redactions) {
-    const current = readPath(restored, redaction.path);
-    if (current.found && deepEqualCanonical(current.value, redaction.redacted)) {
-      writePath(restored, redaction.path, redaction.original);
-    }
-  }
-  return restored;
-}
-
-export interface RedactedFieldChange {
-  path: string;
-  before: unknown;
-  after: unknown;
-  redactedValueChanged: boolean;
-}
-
-/**
- * Compute semantic changes from raw values, but return only redacted
- * before/after payloads for rendering. This preserves secret-only changes
- * in DiffModal without handing the DOM the original credential values.
- */
-export function computeRedactedDiff(
-  prev: Record<string, unknown>,
-  curr: Record<string, unknown>,
-  base = "",
-): RedactedFieldChange[] {
-  return computeRedactedDiffFrom(
-    prev,
-    curr,
-    redactSecretsForDisplay(prev),
-    redactSecretsForDisplay(curr),
-    base,
-  );
-}
-
-function computeRedactedDiffFrom(
-  prev: Record<string, unknown>,
-  curr: Record<string, unknown>,
-  redactedPrev: Record<string, unknown>,
-  redactedCurr: Record<string, unknown>,
-  base: string,
-): RedactedFieldChange[] {
-  const out: RedactedFieldChange[] = [];
-  const keys = new Set([...Object.keys(prev ?? {}), ...Object.keys(curr ?? {})]);
-  for (const key of keys) {
-    const path = base ? `${base}.${key}` : key;
-    const beforeRaw = prev?.[key];
-    const afterRaw = curr?.[key];
-    const beforeDisplay = redactedPrev?.[key];
-    const afterDisplay = redactedCurr?.[key];
-    if (deepEqualCanonical(beforeRaw, afterRaw)) continue;
-    if (
-      isDiffRecord(beforeRaw) &&
-      isDiffRecord(afterRaw) &&
-      isDiffRecord(beforeDisplay) &&
-      isDiffRecord(afterDisplay)
-    ) {
-      out.push(...computeRedactedDiffFrom(beforeRaw, afterRaw, beforeDisplay, afterDisplay, path));
-    } else {
-      out.push({
-        path,
-        before: beforeDisplay,
-        after: afterDisplay,
-        redactedValueChanged: deepEqualCanonical(beforeDisplay, afterDisplay),
-      });
-    }
-  }
-  return out;
-}
-
-function isDiffRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-/**
- * Mask common credential patterns embedded in arbitrary text. Used by
- * display paths that render raw string payloads — tool outputs, tool
- * error messages — where the key-based redactor doesn't apply because
- * there's no key/value structure to walk (R12 #3).
- *
- * Patterns covered (case-insensitive where reasonable):
- *  - `Authorization: <value>` / `Cookie: <value>` / `Set-Cookie: <value>` (full line)
- *  - `Bearer <token>` (inline anywhere in the string)
- *  - `<api_key|access_key|access_token|client_secret|refresh_token|id_token|bearer_token|password|secret|token|jwt>=<value>`
- *    (or with `:` separator) — masks the value
- *  - JWT-shaped tokens: `eyJ<base64>.<base64>.<base64>`
- *  - OpenAI-style `sk-…`, Stripe-style `sk_(live|test)_…`
- *
- * Intentionally conservative — false positives mask non-secret strings,
- * which is the right trade-off for an admin-console display layer.
- */
-export function redactSecretString(input: string): string {
-  if (typeof input !== "string" || input.length === 0) return input;
-  let result = input;
-  // Full-line header values.
-  result = result.replace(/Authorization\s*:\s*[^\r\n]+/gi, "Authorization: ***");
-  result = result.replace(/Set-Cookie\s*:\s*[^\r\n]+/gi, "Set-Cookie: ***");
-  result = result.replace(/(^|\s|;)Cookie\s*:\s*[^\r\n]+/gi, "$1Cookie: ***");
-  // Inline Bearer token.
-  result = result.replace(/Bearer\s+[A-Za-z0-9._\-+/=]{8,}/gi, "Bearer ***");
-  // key=value / key: value for known credential field names. Negative
-  // lookahead prevents re-masking already-redacted output.
-  result = result.replace(
-    /\b(api[_-]?key|access[_-]?key|access[_-]?token|client[_-]?secret|refresh[_-]?token|id[_-]?token|bearer[_-]?token|password|secret|token|jwt)\s*[:=]\s*(?!\*\*\*)[^\s,;"'&}]+/gi,
-    "$1=***",
-  );
-  // JWT — three dot-separated base64url segments starting with eyJ.
-  result = result.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "***");
-  // OpenAI-style sk-<long>, Stripe-style sk_(live|test)_<long>.
-  result = result.replace(/\bsk-[A-Za-z0-9_-]{16,}/g, "***");
-  result = result.replace(/\bsk_(?:live|test)_[A-Za-z0-9]+/g, "***");
-  return result;
-}
-
-/**
- * Return a copy of `spec` safe for display in the admin DOM: same shape,
- * but `endpoint` (the only field today that can carry remote-backend
- * credentials) is run through `redactEndpointForDisplay`. Used by the Raw
- * JSON editor and history-restore confirm dialog so a real bearer token
- * never lands in a textarea or a confirmation popover.
- */
-export function redactAgentSpecForDisplay(spec: AgentSpec): AgentSpec {
-  if (!spec.endpoint) return spec;
-  return { ...spec, endpoint: redactEndpointForDisplay(spec.endpoint) };
-}
-
 /**
  * The complete set of `AgentSpec` keys the editor knows how to round-trip.
  * Combines identity (server-managed), locked (provenance / not editable),
@@ -736,7 +352,7 @@ export function unknownAgentSpecFields(parsed: Record<string, unknown>): string[
  * silently dropping any user edit to `base_url` / `auth.*` / `target` /
  * `registry`. The compare must run first against the redacted display
  * spec; this merge then re-introduces the real credentials so the
- * candidate carries the live values rather than the `***` redaction.
+ * candidate carries the live values rather than the editing redaction sentinel.
  *
  * Returns a shallow copy; never mutates the inputs.
  */

--- a/apps/admin-console/src/lib/agent-secret-redaction.ts
+++ b/apps/admin-console/src/lib/agent-secret-redaction.ts
@@ -7,6 +7,8 @@ import { deepEqualCanonical } from "./agent-editor-canonical";
  *  Keys are normalized via `normalizeSecretKey` before lookup. */
 const EXACT_SECRET_KEYS = new Set(["token", "apikey", "xapikey"]);
 
+const SENSITIVE_KEY_SUFFIXES = ["apikey", "xapikey", "privatekey"];
+
 /** Substring patterns specific enough to be safe; `token` is intentionally
  *  excluded. Compound `*_token` shapes live below as their full form. */
 const SENSITIVE_AUTH_KEY_PATTERNS = [
@@ -83,6 +85,7 @@ function normalizeSecretKey(key: string): string {
 function isSensitiveKey(key: string): boolean {
   const normalized = normalizeSecretKey(key);
   if (EXACT_SECRET_KEYS.has(normalized)) return true;
+  if (SENSITIVE_KEY_SUFFIXES.some((suffix) => normalized.endsWith(suffix))) return true;
   return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
 }
 
@@ -261,6 +264,39 @@ export function restoreUnchangedRedactions<T>(parsed: T, redactions: readonly Re
     }
   }
   return restored;
+}
+
+const EDITING_REDACTED_MARKER_PATTERN = /__AWAKEN_REDACTED_SECRET_[a-f0-9]{8}__/;
+
+function containsEditingRedactionMarker(value: unknown): boolean {
+  if (typeof value === "string") return EDITING_REDACTED_MARKER_PATTERN.test(value);
+  if (Array.isArray(value)) return value.some(containsEditingRedactionMarker);
+  if (value && typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).some(containsEditingRedactionMarker);
+  }
+  return false;
+}
+
+function formatRedactionPath(path: readonly RedactionPathSegment[]): string {
+  return path.reduce<string>((acc, segment) => {
+    if (typeof segment === "number") return `${acc}[${segment}]`;
+    return acc ? `${acc}.${segment}` : segment;
+  }, "");
+}
+
+export function changedRedactionMarkerPaths(
+  root: unknown,
+  redactions: readonly RedactionEntry[],
+): string[] {
+  const paths: string[] = [];
+  for (const redaction of redactions) {
+    const current = readPath(root, redaction.path);
+    if (!current.found || deepEqualCanonical(current.value, redaction.redacted)) continue;
+    if (containsEditingRedactionMarker(current.value)) {
+      paths.push(formatRedactionPath(redaction.path));
+    }
+  }
+  return paths;
 }
 
 export interface RedactedFieldChange {

--- a/apps/admin-console/src/lib/agent-secret-redaction.ts
+++ b/apps/admin-console/src/lib/agent-secret-redaction.ts
@@ -1,0 +1,368 @@
+import type { AgentSpec, RemoteEndpoint } from "./api/types";
+import { deepEqualCanonical } from "./agent-editor-canonical";
+
+/** Exact-match buckets for short / ambiguous secret names where substring
+ *  matching would over-redact. Standalone `token` is a secret;
+ *  `max_context_tokens` contains "token" but is not one.
+ *  Keys are normalized via `normalizeSecretKey` before lookup. */
+const EXACT_SECRET_KEYS = new Set(["token", "apikey", "xapikey"]);
+
+/** Substring patterns specific enough to be safe; `token` is intentionally
+ *  excluded. Compound `*_token` shapes live below as their full form. */
+const SENSITIVE_AUTH_KEY_PATTERNS = [
+  "secret",
+  "password",
+  "passphrase",
+  "authorization",
+  "credential",
+  "privatekey",
+  "clientsecret",
+  "cookie",
+  "jwt",
+  "bearer",
+  "session",
+  "accesskey",
+  "accesstoken",
+  "refreshtoken",
+  "idtoken",
+  "bearertoken",
+  "authtoken",
+  "sessiontoken",
+];
+
+const DISPLAY_REDACTED_VALUE = "***";
+const EDITING_REDACTED_PREFIX = "__AWAKEN_REDACTED_SECRET_";
+
+type RedactedValueFactory = (path: readonly RedactionPathSegment[], original: unknown) => unknown;
+
+function displayRedactedValue(): string {
+  return DISPLAY_REDACTED_VALUE;
+}
+
+function editingRedactedValue(path: readonly RedactionPathSegment[]): string {
+  return `${EDITING_REDACTED_PREFIX}${hashRedactionPath(path)}__`;
+}
+
+function hashRedactionPath(path: readonly RedactionPathSegment[]): string {
+  const input = path
+    .map((segment) => (typeof segment === "number" ? `[${segment}]` : segment))
+    .join(".");
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+const HEADER_CONTAINER_KEYS = new Set(["headers", "requestheaders", "responseheaders"]);
+
+const SENSITIVE_HEADER_KEY_PATTERNS = [
+  "authorization",
+  "proxyauthorization",
+  "cookie",
+  "setcookie",
+  "apikey",
+  "xapikey",
+  "xauthtoken",
+  "token",
+];
+
+export type RedactionPathSegment = string | number;
+
+export interface RedactionEntry {
+  path: RedactionPathSegment[];
+  original: unknown;
+  redacted: unknown;
+}
+
+function normalizeSecretKey(key: string): string {
+  return key.toLowerCase().replace(/[-_\s]/g, "");
+}
+
+function isSensitiveKey(key: string): boolean {
+  const normalized = normalizeSecretKey(key);
+  if (EXACT_SECRET_KEYS.has(normalized)) return true;
+  return SENSITIVE_AUTH_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+function isSensitiveHeaderKey(parentKey: string, key: string): boolean {
+  if (!HEADER_CONTAINER_KEYS.has(normalizeSecretKey(parentKey))) return false;
+  const normalized = normalizeSecretKey(key);
+  return SENSITIVE_HEADER_KEY_PATTERNS.some((pattern) => normalized.includes(pattern));
+}
+
+function cloneJsonValue<T>(value: T): T {
+  if (value === undefined || value === null) return value;
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) return value;
+  return JSON.parse(encoded) as T;
+}
+
+function recordRedaction(
+  redactions: RedactionEntry[] | undefined,
+  path: RedactionPathSegment[],
+  original: unknown,
+  redacted: unknown,
+) {
+  if (!redactions || deepEqualCanonical(original, redacted)) return;
+  redactions.push({
+    path: [...path],
+    original: cloneJsonValue(original),
+    redacted: cloneJsonValue(redacted),
+  });
+}
+
+function redactRecord(
+  value: unknown,
+  parentKey: string = "",
+  path: RedactionPathSegment[] = [],
+  redactions?: RedactionEntry[],
+  makeRedactedValue: RedactedValueFactory = displayRedactedValue,
+): unknown {
+  if (value === null || value === undefined) return value;
+  // Primitive strings can still carry credentials even when their key name
+  // is innocuous, such as tool output or upstream error messages.
+  if (typeof value === "string") {
+    const redacted = redactSecretString(value);
+    if (redactions && !deepEqualCanonical(value, redacted)) {
+      const redactedValue = makeRedactedValue(path, value);
+      recordRedaction(redactions, path, value, redactedValue);
+      return redactedValue;
+    }
+    recordRedaction(redactions, path, value, redacted);
+    return redacted;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      redactRecord(item, "", [...path, index], redactions, makeRedactedValue),
+    );
+  }
+  if (typeof value === "object") {
+    // Default-deny nested auth objects: RemoteAuth allows arbitrary keys, and
+    // trace/audit payloads can contain auth-shaped data outside AgentSpec.
+    if (normalizeSecretKey(parentKey) === "auth") {
+      const safeAuth: Record<string, unknown> = {};
+      for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+        if (key === "type" || inner === null || inner === undefined) {
+          safeAuth[key] = inner;
+        } else {
+          const nextPath = [...path, key];
+          const redacted = makeRedactedValue(nextPath, inner);
+          safeAuth[key] = redacted;
+          recordRedaction(redactions, nextPath, inner, redacted);
+        }
+      }
+      return safeAuth;
+    }
+    const next: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      const nextPath = [...path, key];
+      if (isSensitiveKey(key) || isSensitiveHeaderKey(parentKey, key)) {
+        next[key] =
+          inner === null || inner === undefined ? inner : makeRedactedValue(nextPath, inner);
+        recordRedaction(redactions, nextPath, inner, next[key]);
+      } else {
+        next[key] = redactRecord(inner, key, nextPath, redactions, makeRedactedValue);
+      }
+    }
+    return next;
+  }
+  return value;
+}
+
+/**
+ * Return a copy of `endpoint` with secret-bearing fields masked to `"***"`.
+ * The non-secret shape is preserved so read-only endpoint UI stays useful.
+ */
+export function redactEndpointForDisplay(endpoint: RemoteEndpoint): RemoteEndpoint {
+  const generic = redactRecord(endpoint) as RemoteEndpoint;
+  if (!generic.auth || typeof generic.auth !== "object") {
+    return generic;
+  }
+  const auth = generic.auth as Record<string, unknown>;
+  const safeAuth: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(auth)) {
+    if (key === "type") {
+      safeAuth[key] = value;
+    } else if (value === null || value === undefined) {
+      safeAuth[key] = value;
+    } else {
+      safeAuth[key] = DISPLAY_REDACTED_VALUE;
+    }
+  }
+  return { ...generic, auth: safeAuth as RemoteEndpoint["auth"] };
+}
+
+/**
+ * Recursively mask every secret-keyed field in an arbitrary value tree.
+ * Used by display paths that serialize structures we don't statically know:
+ * audit snapshots, persisted trace events, diffs, and restore previews.
+ */
+export function redactSecretsForDisplay<T>(value: T): T {
+  return redactRecord(value) as T;
+}
+
+export interface RedactedAgentSpecForEditing {
+  redacted: AgentSpec;
+  redactions: RedactionEntry[];
+}
+
+export function redactAgentSpecForEditing(spec: AgentSpec): RedactedAgentSpecForEditing {
+  const redactions: RedactionEntry[] = [];
+  return {
+    redacted: redactRecord(spec, "", [], redactions, editingRedactedValue) as AgentSpec,
+    redactions,
+  };
+}
+
+function readPath(root: unknown, path: readonly RedactionPathSegment[]) {
+  let current = root;
+  for (const segment of path) {
+    if (current === null || typeof current !== "object") {
+      return { found: false, value: undefined };
+    }
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+      return { found: false, value: undefined };
+    }
+    current = Array.isArray(current)
+      ? current[Number(segment)]
+      : (current as Record<string, unknown>)[String(segment)];
+  }
+  return { found: true, value: current };
+}
+
+function writePath(root: unknown, path: readonly RedactionPathSegment[], value: unknown): boolean {
+  if (path.length === 0) return false;
+  let current = root;
+  for (const segment of path.slice(0, -1)) {
+    if (current === null || typeof current !== "object") return false;
+    current = Array.isArray(current)
+      ? current[Number(segment)]
+      : (current as Record<string, unknown>)[String(segment)];
+  }
+  if (current === null || typeof current !== "object") return false;
+  const leaf = path[path.length - 1];
+  if (Array.isArray(current)) {
+    current[Number(leaf)] = cloneJsonValue(value);
+  } else {
+    (current as Record<string, unknown>)[String(leaf)] = cloneJsonValue(value);
+  }
+  return true;
+}
+
+export function restoreUnchangedRedactions<T>(parsed: T, redactions: readonly RedactionEntry[]): T {
+  if (redactions.length === 0) return parsed;
+  const restored = cloneJsonValue(parsed);
+  for (const redaction of redactions) {
+    const current = readPath(restored, redaction.path);
+    if (current.found && deepEqualCanonical(current.value, redaction.redacted)) {
+      writePath(restored, redaction.path, redaction.original);
+    }
+  }
+  return restored;
+}
+
+export interface RedactedFieldChange {
+  path: string;
+  before: unknown;
+  after: unknown;
+  redactedValueChanged: boolean;
+}
+
+/**
+ * Compute semantic changes from raw values, but return only redacted
+ * before/after payloads for rendering. This preserves secret-only changes
+ * in DiffModal without handing the DOM the original credential values.
+ */
+export function computeRedactedDiff(
+  prev: Record<string, unknown>,
+  curr: Record<string, unknown>,
+  base = "",
+): RedactedFieldChange[] {
+  return computeRedactedDiffFrom(
+    prev,
+    curr,
+    redactSecretsForDisplay(prev),
+    redactSecretsForDisplay(curr),
+    base,
+  );
+}
+
+function computeRedactedDiffFrom(
+  prev: Record<string, unknown>,
+  curr: Record<string, unknown>,
+  redactedPrev: Record<string, unknown>,
+  redactedCurr: Record<string, unknown>,
+  base: string,
+): RedactedFieldChange[] {
+  const out: RedactedFieldChange[] = [];
+  const keys = new Set([...Object.keys(prev ?? {}), ...Object.keys(curr ?? {})]);
+  for (const key of keys) {
+    const path = base ? `${base}.${key}` : key;
+    const beforeRaw = prev?.[key];
+    const afterRaw = curr?.[key];
+    const beforeDisplay = redactedPrev?.[key];
+    const afterDisplay = redactedCurr?.[key];
+    if (deepEqualCanonical(beforeRaw, afterRaw)) continue;
+    if (
+      isDiffRecord(beforeRaw) &&
+      isDiffRecord(afterRaw) &&
+      isDiffRecord(beforeDisplay) &&
+      isDiffRecord(afterDisplay)
+    ) {
+      out.push(...computeRedactedDiffFrom(beforeRaw, afterRaw, beforeDisplay, afterDisplay, path));
+    } else {
+      out.push({
+        path,
+        before: beforeDisplay,
+        after: afterDisplay,
+        redactedValueChanged: deepEqualCanonical(beforeDisplay, afterDisplay),
+      });
+    }
+  }
+  return out;
+}
+
+function isDiffRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Mask common credential patterns embedded in arbitrary text. Used by display
+ * paths that render raw string payloads where key-based redaction cannot apply.
+ */
+export function redactSecretString(input: string): string {
+  if (typeof input !== "string" || input.length === 0) return input;
+  let result = input;
+  result = result.replace(/Authorization\s*:\s*[^\r\n]+/gi, "Authorization: ***");
+  result = result.replace(/Set-Cookie\s*:\s*[^\r\n]+/gi, "Set-Cookie: ***");
+  result = result.replace(/(^|\s|;)Cookie\s*:\s*[^\r\n]+/gi, "$1Cookie: ***");
+  result = result.replace(/Bearer\s+[A-Za-z0-9._\-+/=]{8,}/gi, "Bearer ***");
+  result = result.replace(
+    /\b(api[_-]?key|access[_-]?key|access[_-]?token|client[_-]?secret|refresh[_-]?token|id[_-]?token|bearer[_-]?token|password|secret|token|jwt)\s*[:=]\s*(?!\*\*\*)[^\s,;"'&}]+/gi,
+    "$1=***",
+  );
+  result = result.replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, "***");
+  result = result.replace(/\bsk-[A-Za-z0-9_-]{16,}/g, "***");
+  result = result.replace(/\bsk_(?:live|test)_[A-Za-z0-9]+/g, "***");
+  result = result.replace(/\bgh[opsur]_[A-Za-z0-9_]{20,}\b/g, "***");
+  result = result.replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, "***");
+  result = result.replace(/\bxox[aboprs]-[A-Za-z0-9-]{10,}\b/g, "***");
+  result = result.replace(/\bxapp-[A-Za-z0-9-]{10,}\b/g, "***");
+  result = result.replace(/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, "***");
+  result = result.replace(
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    "***",
+  );
+  return result;
+}
+
+/**
+ * Return a copy of `spec` safe for display in the admin DOM: same shape,
+ * but `endpoint` is run through `redactEndpointForDisplay`.
+ */
+export function redactAgentSpecForDisplay(spec: AgentSpec): AgentSpec {
+  if (!spec.endpoint) return spec;
+  return { ...spec, endpoint: redactEndpointForDisplay(spec.endpoint) };
+}

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -5,14 +5,16 @@ import {
   groupSelectionState,
   groupToolsBySource,
   isToolAllowed,
+  isToolSelected,
   nextAllowedTools,
+  nextToolSelection,
   setGroupSelection,
   toolSelectionMode,
   toolSourceFor,
   type ApiToolSource,
 } from "./agent-tool-selection";
 
-describe("agent tool selection", () => {
+describe("agent tool selection (include variant)", () => {
   const allToolIds = ["search", "write", "read"];
 
   it("treats undefined allowed_tools as unrestricted", () => {
@@ -34,10 +36,11 @@ describe("agent tool selection", () => {
     expect(nextAllowedTools([], allToolIds, "read", true)).toEqual(["read"]);
   });
 
-  it("collapses back to undefined when every tool is selected again", () => {
-    expect(nextAllowedTools(["search", "write"], ["search", "write"], "search", true)).toBe(
-      undefined,
-    );
+  it("collapses to explicit null (not undefined) when every tool is selected again", () => {
+    // R8 #1: a customized agent picking "all tools" must PATCH an
+    // explicit null override, not DELETE the override (which would
+    // re-inherit the base's restricted list).
+    expect(nextAllowedTools(["search", "write"], ["search", "write"], "search", true)).toBeNull();
   });
 });
 
@@ -46,15 +49,19 @@ describe("toolSelectionMode", () => {
     expect(toolSelectionMode(undefined)).toBe("all");
   });
 
+  it("classifies explicit null as the default 'all' mode", () => {
+    expect(toolSelectionMode(null)).toBe("all");
+  });
+
   it("treats an explicit list as 'custom', even if it lists every tool", () => {
     expect(toolSelectionMode([])).toBe("custom");
     expect(toolSelectionMode(["search"])).toBe("custom");
   });
 });
 
-describe("applyToolSelectionMode", () => {
-  it("clears the explicit list when switching back to 'all'", () => {
-    expect(applyToolSelectionMode(["search"], "all", ["search", "write"])).toBeUndefined();
+describe("applyToolSelectionMode (include)", () => {
+  it("returns explicit null when switching to 'all' (forces explicit override)", () => {
+    expect(applyToolSelectionMode(["search"], "all", ["search", "write"])).toBeNull();
   });
 
   it("preserves the existing custom list when re-entering custom mode", () => {
@@ -65,6 +72,81 @@ describe("applyToolSelectionMode", () => {
 
   it("seeds custom mode with every known tool when there is no prior list", () => {
     expect(applyToolSelectionMode(undefined, "custom", ["a", "b"])).toEqual(["a", "b"]);
+  });
+});
+
+// R8 #1 — `excluded_tools` shares the wire shape with `allowed_tools` but
+// has inverted defaults: undefined/null = "no tool excluded" (not
+// "every tool excluded"). The component reuses the same helpers with a
+// `variant` discriminator; these tests pin the inverted semantics.
+describe("agent tool selection (exclude variant)", () => {
+  const allToolIds = ["search", "write", "read"];
+
+  it("treats undefined excluded_tools as 'no tool excluded'", () => {
+    expect(isToolSelected(undefined, "search", "exclude")).toBe(false);
+  });
+
+  it("treats null excluded_tools the same as undefined", () => {
+    expect(isToolSelected(null, "search", "exclude")).toBe(false);
+  });
+
+  it("treats an empty list as 'no tool excluded'", () => {
+    expect(isToolSelected([], "search", "exclude")).toBe(false);
+  });
+
+  it("treats an explicit list entry as excluded", () => {
+    expect(isToolSelected(["search"], "search", "exclude")).toBe(true);
+    expect(isToolSelected(["search"], "read", "exclude")).toBe(false);
+  });
+
+  it("checking a tool from null adds only that tool to the excluded list", () => {
+    // R8 #1: without the exclude variant, the previous helpers returned
+    // undefined here — checking a tool would NOT add it to the excluded
+    // list, so the UI checkbox state and the underlying value silently
+    // diverged.
+    expect(nextToolSelection(null, allToolIds, "search", true, "exclude")).toEqual([
+      "search",
+    ]);
+  });
+
+  it("checking another tool appends to the excluded list", () => {
+    expect(
+      nextToolSelection(["search"], allToolIds, "write", true, "exclude"),
+    ).toEqual(["search", "write"]);
+  });
+
+  it("unchecking the last tool collapses to null (explicit 'block none')", () => {
+    expect(
+      nextToolSelection(["search"], allToolIds, "search", false, "exclude"),
+    ).toBeNull();
+  });
+
+  it("unchecking a tool not in the list is a no-op", () => {
+    expect(nextToolSelection(null, allToolIds, "search", false, "exclude")).toBeNull();
+    expect(
+      nextToolSelection(["write"], allToolIds, "search", false, "exclude"),
+    ).toEqual(["write"]);
+  });
+});
+
+describe("applyToolSelectionMode (exclude)", () => {
+  it("custom mode from null seeds with [] (NOT every tool — that would block all tools)", () => {
+    // R8 #1: this was the data-loss bug — the previous helper returned
+    // `[...allToolIds]`, i.e. every tool in `excluded_tools`, so the
+    // moment a user clicked "Custom exclusion" the agent lost access to
+    // every tool.
+    expect(applyToolSelectionMode(undefined, "custom", ["a", "b"], "exclude")).toEqual([]);
+    expect(applyToolSelectionMode(null, "custom", ["a", "b"], "exclude")).toEqual([]);
+  });
+
+  it("custom mode preserves a non-empty existing list", () => {
+    expect(
+      applyToolSelectionMode(["a"], "custom", ["a", "b"], "exclude"),
+    ).toEqual(["a"]);
+  });
+
+  it("'block none' mode emits explicit null (customized save → override)", () => {
+    expect(applyToolSelectionMode(["a"], "all", ["a", "b"], "exclude")).toBeNull();
   });
 });
 
@@ -175,7 +257,7 @@ describe("groupToolsBySource", () => {
   });
 });
 
-describe("groupSelectionState", () => {
+describe("groupSelectionState (include)", () => {
   const groupIds = ["a", "b"];
 
   it("treats undefined allowed_tools as everything selected", () => {
@@ -191,22 +273,72 @@ describe("groupSelectionState", () => {
   });
 });
 
-describe("setGroupSelection", () => {
+describe("groupSelectionState (exclude)", () => {
+  const groupIds = ["a", "b"];
+
+  it("treats undefined excluded_tools as everything UN-selected (block none)", () => {
+    expect(groupSelectionState(undefined, groupIds, "exclude")).toBe("none");
+  });
+
+  it("returns 'all' when every group member is in the excluded list", () => {
+    expect(groupSelectionState(["a", "b"], groupIds, "exclude")).toBe("all");
+  });
+
+  it("returns 'some' when only part of the group is excluded", () => {
+    expect(groupSelectionState(["a"], groupIds, "exclude")).toBe("some");
+  });
+});
+
+describe("setGroupSelection (include)", () => {
   const allToolIds = ["a", "b", "c"];
 
-  it("adds every group tool when selecting", () => {
-    expect(setGroupSelection(["c"], allToolIds, ["a", "b"], true)).toBeUndefined();
+  it("adds every group tool when selecting (collapses to explicit null when complete)", () => {
+    expect(setGroupSelection(["c"], allToolIds, ["a", "b"], true)).toBeNull();
   });
 
   it("removes every group tool when deselecting", () => {
     expect(setGroupSelection(undefined, allToolIds, ["a", "b"], false)).toEqual(["c"]);
   });
 
-  it("collapses to undefined when the result covers every known tool", () => {
-    expect(setGroupSelection([], allToolIds, ["a", "b", "c"], true)).toBeUndefined();
+  it("collapses to explicit null when the result covers every known tool", () => {
+    expect(setGroupSelection([], allToolIds, ["a", "b", "c"], true)).toBeNull();
   });
 
   it("ignores group ids that are not part of the catalog", () => {
     expect(setGroupSelection(["a"], allToolIds, ["a", "z"], false)).toEqual([]);
+  });
+});
+
+describe("setGroupSelection (exclude)", () => {
+  const allToolIds = ["a", "b", "c"];
+
+  it("adds every group tool to the excluded list when 'Select all' is clicked", () => {
+    expect(setGroupSelection(null, allToolIds, ["a", "b"], true, "exclude")).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("collapses to explicit null when the excluded list ends up empty", () => {
+    expect(
+      setGroupSelection(["a"], allToolIds, ["a"], false, "exclude"),
+    ).toBeNull();
+  });
+
+  it("removes only the group tools, preserving other excluded entries", () => {
+    expect(
+      setGroupSelection(["a", "c"], allToolIds, ["a"], false, "exclude"),
+    ).toEqual(["c"]);
+  });
+
+  it("does NOT collapse when every tool is excluded — that's an intentional 'block all' state", () => {
+    // Distinct from include semantics: a fully-populated allowed_tools
+    // collapses to "all" because it's a redundant restriction; a fully-
+    // populated excluded_tools is the meaningful "block every tool"
+    // signal and must NOT collapse to null (which would mean the
+    // opposite — "block none").
+    expect(
+      setGroupSelection([], allToolIds, ["a", "b", "c"], true, "exclude"),
+    ).toEqual(["a", "b", "c"]);
   });
 });

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -1,55 +1,129 @@
-/// Backend serializes `Option<Vec<String>>` as JSON `null` when None, which
-/// becomes JS `null` after parsing. Treat null and undefined identically as
-/// "no explicit list set" — the default-all sentinel for inclusion semantics.
-export function isToolAllowed(
-  allowedTools: string[] | null | undefined,
+/// Variant-aware tool selection helpers.
+///
+/// `ToolSelector` is used for two AgentSpec fields with opposite semantics:
+///
+///   - `allowed_tools` (variant `"include"`)
+///       null / undefined → every published tool is allowed (default)
+///       string[]         → only these tools are allowed
+///
+///   - `excluded_tools` (variant `"exclude"`)
+///       null / undefined → no tool is excluded (default)
+///       string[]         → these tools are removed from the allow-list
+///
+/// The wire-shape (`Option<Vec<String>>`) is identical for both, so we
+/// route through a single component, but the *semantics* (what `null`
+/// means, what a checkbox "checked" means, what to seed on mode toggle)
+/// are inverted. These helpers carry an explicit `variant` so the
+/// component never gets the wrong default — silently emitting "all tools
+/// excluded" on a Custom-exclusion toggle was R8 #1.
+///
+/// Mode toggles emit an explicit `null` for "all" (include) / "block
+/// none" (exclude) rather than `undefined`. For customized agents this
+/// matters: a `null` patch overrides the base record's restricted list
+/// with an explicit "no whitelist" / "no blacklist" override; a
+/// `undefined` value would land in the save-path's clear list and
+/// DELETE the override, re-inheriting the base's restriction — the
+/// opposite of what the user picked.
+
+export type ToolSelectionVariant = "include" | "exclude";
+
+/// Whether a tool's checkbox should render checked.
+///
+/// - include: checked = "tool is in the allow-list". Defaults to true on
+///   null/undefined (no whitelist means every tool is allowed).
+/// - exclude: checked = "tool is in the exclude-list". Defaults to false
+///   on null/undefined (no blacklist means no tool is excluded).
+export function isToolSelected(
+  value: string[] | null | undefined,
   toolId: string,
+  variant: ToolSelectionVariant = "include",
 ): boolean {
-  return allowedTools ? allowedTools.includes(toolId) : true;
+  if (variant === "exclude") {
+    return value ? value.includes(toolId) : false;
+  }
+  return value ? value.includes(toolId) : true;
 }
 
-export function nextAllowedTools(
-  allowedTools: string[] | null | undefined,
+/// Backward-compat alias — older include-only call sites.
+export const isToolAllowed = isToolSelected;
+
+/// Compute the next value after a checkbox toggle.
+///
+/// For include: `checked` = "add to allow-list".
+/// For exclude: `checked` = "add to exclude-list".
+///
+/// Returns explicit `null` when the resulting set means "default
+/// everywhere" (every tool allowed / nothing excluded) so customized
+/// agents persist the user's intent as an override rather than
+/// inheriting the base record.
+export function nextToolSelection(
+  value: string[] | null | undefined,
   allToolIds: string[],
   toolId: string,
   checked: boolean,
-): string[] | undefined {
-  if (checked) {
-    if (!allowedTools) {
-      return undefined;
+  variant: ToolSelectionVariant = "include",
+): string[] | null {
+  if (variant === "exclude") {
+    const current = value ?? [];
+    if (checked) {
+      const next = Array.from(new Set([...current, toolId])).filter((id) =>
+        allToolIds.includes(id),
+      );
+      return next.length === 0 ? null : next;
     }
-
-    const nextAllowed = Array.from(new Set([...allowedTools, toolId])).filter((id) =>
+    if (current.length === 0) return null;
+    const next = current.filter((id) => id !== toolId);
+    return next.length === 0 ? null : next;
+  }
+  // include
+  if (checked) {
+    if (!value) {
+      // Already "all tools allowed"; checking an already-checked tool is
+      // a no-op. Persist as explicit null so customized save emits an
+      // override rather than DELETE-ing it (which would inherit the
+      // base's restricted list).
+      return null;
+    }
+    const next = Array.from(new Set([...value, toolId])).filter((id) =>
       allToolIds.includes(id),
     );
-    return nextAllowed.length >= allToolIds.length ? undefined : nextAllowed;
+    return next.length >= allToolIds.length ? null : next;
   }
-
-  const baseAllowed = allowedTools ?? allToolIds;
+  const baseAllowed = value ?? allToolIds;
   return baseAllowed.filter((id) => id !== toolId);
 }
 
-/// Inclusion semantics — `undefined`/`null` (or missing) means "every tool";
-/// an explicit array means "only these tools".
+/// Backward-compat alias.
+export const nextAllowedTools = nextToolSelection;
+
 export type ToolSelectionMode = "all" | "custom";
 
 export function toolSelectionMode(
-  allowedTools: string[] | null | undefined,
+  value: string[] | null | undefined,
 ): ToolSelectionMode {
-  return allowedTools == null ? "all" : "custom";
+  return value == null ? "all" : "custom";
 }
 
-/// Switch between modes without losing user data. When toggling to "all",
-/// the explicit list is cleared (undefined). When toggling to "custom",
-/// the current list is preserved, falling back to *all* known tools so
-/// the resulting custom set has the same effective behaviour as "all".
+/// Switch between modes without losing user data.
+///
+/// "all" → explicit `null` (forces "all tools" / "block none" as an
+/// override; does NOT mean "inherit base").
+///
+/// "custom" with no prior list:
+///   - include: seeded with every known tool (so checkboxes start
+///     checked and the user deselects to narrow the list).
+///   - exclude: seeded with `[]` (so checkboxes start UNCHECKED — seeding
+///     with every tool would mean every tool is excluded, i.e. the agent
+///     loses access to everything; this was R8 #1).
 export function applyToolSelectionMode(
   current: string[] | null | undefined,
   mode: ToolSelectionMode,
   allToolIds: string[],
-): string[] | undefined {
-  if (mode === "all") return undefined;
-  if (current != null) return current;
+  variant: ToolSelectionVariant = "include",
+): string[] | null {
+  if (mode === "all") return null;
+  if (current && current.length > 0) return current;
+  if (variant === "exclude") return [];
   return [...allToolIds];
 }
 
@@ -146,45 +220,58 @@ const SOURCE_ORDER: Record<ToolSourceKind, number> = {
   mcp: 2,
 };
 
-/// Apply a "select all in group" operation. Returns the new allowed_tools
-/// value, preserving the inclusion semantics: when every tool ends up
-/// selected we collapse to `undefined`.
+/// "Select all" / "Clear" buttons on a group.
+///
+/// For include: selected=true means "allow every tool in this group" —
+/// collapses to `null` when every known tool ends up allowed.
+///
+/// For exclude: selected=true means "exclude every tool in this group" —
+/// collapses to `null` when no tool ends up excluded.
 export function setGroupSelection(
-  allowedTools: string[] | null | undefined,
+  value: string[] | null | undefined,
   allToolIds: string[],
   groupToolIds: string[],
   selected: boolean,
-): string[] | undefined {
-  const baseline = allowedTools ?? allToolIds;
-  const baselineSet = new Set(baseline);
+  variant: ToolSelectionVariant = "include",
+): string[] | null {
+  if (variant === "exclude") {
+    const baseline = new Set(value ?? []);
+    if (selected) {
+      for (const id of groupToolIds) baseline.add(id);
+    } else {
+      for (const id of groupToolIds) baseline.delete(id);
+    }
+    const next = Array.from(baseline).filter((id) => allToolIds.includes(id));
+    return next.length === 0 ? null : next;
+  }
+  const baseline = new Set(value ?? allToolIds);
 
   if (selected) {
-    for (const id of groupToolIds) {
-      baselineSet.add(id);
-    }
+    for (const id of groupToolIds) baseline.add(id);
   } else {
-    for (const id of groupToolIds) {
-      baselineSet.delete(id);
-    }
+    for (const id of groupToolIds) baseline.delete(id);
   }
 
-  if (selected && allToolIds.every((id) => baselineSet.has(id))) {
-    return undefined;
+  if (selected && allToolIds.every((id) => baseline.has(id))) {
+    return null;
   }
 
-  return Array.from(baselineSet).filter((id) => allToolIds.includes(id));
+  return Array.from(baseline).filter((id) => allToolIds.includes(id));
 }
 
-/// Returns the selection state of a group: "all" if every tool in the
-/// group is selected, "none" if zero, or "some" otherwise.
+/// Selection state of a group of tools — used for the per-group "X of N
+/// selected" summary and the indeterminate visual state on group
+/// buttons. "Selected" follows the variant: included for `"include"`,
+/// excluded for `"exclude"`.
 export function groupSelectionState(
-  allowedTools: string[] | null | undefined,
+  value: string[] | null | undefined,
   groupToolIds: string[],
+  variant: ToolSelectionVariant = "include",
 ): "all" | "some" | "none" {
   if (groupToolIds.length === 0) return "none";
   let selected = 0;
   for (const id of groupToolIds) {
-    if (isToolAllowed(allowedTools, id)) selected += 1;
+    if (isToolSelected(value, id, variant)) selected += 1;
   }
   if (selected === 0) return "none";
   if (selected === groupToolIds.length) return "all";

--- a/apps/admin-console/src/lib/api/agents.test.ts
+++ b/apps/admin-console/src/lib/api/agents.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { agentsApi } from "./agents";
+import { ConfigApiError } from "./http";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetch(status: number, body: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () =>
+        typeof body === "string" ? body : JSON.stringify(body),
+    })) as unknown as typeof fetch,
+  );
+}
+
+describe("agentsApi.agentPermissionPreview — feature-gate vs missing-agent (R10 #1)", () => {
+  it("returns null when the route reports 503 (feature not compiled)", async () => {
+    mockFetch(503, { error: "permission feature not compiled into this server build" });
+
+    const result = await agentsApi.agentPermissionPreview("any-agent");
+    expect(result).toBeNull();
+  });
+
+  it("re-throws ConfigApiError on 404 (agent record not found)", async () => {
+    // The route is registered unconditionally on the server, so a 404
+    // means the agent itself is missing — NOT that the feature is
+    // disabled. Surface as a real error so the editor doesn't
+    // silently render "feature unavailable" for a stale agent id.
+    mockFetch(404, { error: "agent not found: ghost-agent" });
+
+    await expect(agentsApi.agentPermissionPreview("ghost-agent")).rejects.toBeInstanceOf(
+      ConfigApiError,
+    );
+    await expect(agentsApi.agentPermissionPreview("ghost-agent")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("returns the response on 200", async () => {
+    mockFetch(200, {
+      agent_id: "alpha",
+      permission_plugin_enabled: false,
+      default_behavior: null,
+      candidate_tools: [],
+      unconditionally_denied: [],
+      effective_tools: [],
+      args_conditional_rules: [],
+    });
+
+    const result = await agentsApi.agentPermissionPreview("alpha");
+    expect(result?.agent_id).toBe("alpha");
+  });
+});

--- a/apps/admin-console/src/lib/api/agents.ts
+++ b/apps/admin-console/src/lib/api/agents.ts
@@ -45,15 +45,22 @@ export const agentsApi = {
     ),
 
   /** True effective-tools preview for an agent — runs the permission ruleset
-   *  server-side rather than re-implementing it in TS. Returns `null` when
-   *  the server build lacks the `permission` feature (404). */
+   *  server-side rather than re-implementing it in TS.
+   *
+   *  Returns `null` only when the server build was compiled WITHOUT the
+   *  `permission` feature; the route then returns 503 Service Unavailable
+   *  and the UI renders a "preview unavailable" state.
+   *
+   *  404 means the agent record doesn't exist (stale id, concurrent
+   *  delete, typo). Re-throw so the editor can surface a real error
+   *  instead of misleading the user with "feature not available". */
   agentPermissionPreview: async (id: string): Promise<PermissionPreviewResponse | null> => {
     try {
       return await fetchJson<PermissionPreviewResponse>(
         `${BACKEND_URL}/v1/agents/${encodeURIComponent(id)}/permission-preview`,
       );
     } catch (err) {
-      if (err instanceof ConfigApiError && err.status === 404) return null;
+      if (err instanceof ConfigApiError && err.status === 503) return null;
       throw err;
     }
   },

--- a/apps/admin-console/src/lib/api/agents.ts
+++ b/apps/admin-console/src/lib/api/agents.ts
@@ -1,5 +1,5 @@
 import { BACKEND_URL, ConfigApiError, fetchJson } from "./http";
-import type { AgentRuntimeSnapshot } from "./types";
+import type { AgentRuntimeSnapshot, PermissionPreviewResponse } from "./types";
 
 export const agentsApi = {
   /** All-agents runtime stats. Backed by `/v1/agents/runtime-stats`, which
@@ -43,4 +43,18 @@ export const agentsApi = {
       `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(id)}/overrides/${encodeURIComponent(field)}`,
       { method: "DELETE" },
     ),
+
+  /** True effective-tools preview for an agent — runs the permission ruleset
+   *  server-side rather than re-implementing it in TS. Returns `null` when
+   *  the server build lacks the `permission` feature (404). */
+  agentPermissionPreview: async (id: string): Promise<PermissionPreviewResponse | null> => {
+    try {
+      return await fetchJson<PermissionPreviewResponse>(
+        `${BACKEND_URL}/v1/agents/${encodeURIComponent(id)}/permission-preview`,
+      );
+    } catch (err) {
+      if (err instanceof ConfigApiError && err.status === 404) return null;
+      throw err;
+    }
+  },
 };

--- a/apps/admin-console/src/lib/api/http.test.ts
+++ b/apps/admin-console/src/lib/api/http.test.ts
@@ -90,4 +90,22 @@ describe("ConfigApiError shape", () => {
     expect(err.message).toBe("I'm a teapot");
     expect(err.detail).toEqual({ error: "I'm a teapot" });
   });
+
+  it("redacts credential patterns from response error messages", () => {
+    const err = new ConfigApiError(500, {
+      error: "upstream failed with Authorization: Bearer sk-real-secret-value",
+    });
+
+    expect(err.message).toContain("Authorization: ***");
+    expect(err.message).not.toContain("sk-real-secret-value");
+  });
+
+  it("uses and redacts a response message field when error is absent", () => {
+    const err = new ConfigApiError(500, {
+      message: "upstream failed with api_key=raw-api-key-value",
+    });
+
+    expect(err.message).toContain("api_key=***");
+    expect(err.message).not.toContain("raw-api-key-value");
+  });
 });

--- a/apps/admin-console/src/lib/api/http.test.ts
+++ b/apps/admin-console/src/lib/api/http.test.ts
@@ -100,6 +100,17 @@ describe("ConfigApiError shape", () => {
     expect(err.message).not.toContain("sk-real-secret-value");
   });
 
+  it("stores a redacted detail body", () => {
+    const err = new ConfigApiError(500, {
+      error: "upstream failed with Authorization: Bearer sk-real-secret-value",
+      headers: { Authorization: "Bearer raw-header-secret" },
+    });
+
+    expect(JSON.stringify(err.detail)).toContain("Authorization: ***");
+    expect(JSON.stringify(err.detail)).not.toContain("sk-real-secret-value");
+    expect(JSON.stringify(err.detail)).not.toContain("raw-header-secret");
+  });
+
   it("uses and redacts a response message field when error is absent", () => {
     const err = new ConfigApiError(500, {
       message: "upstream failed with api_key=raw-api-key-value",

--- a/apps/admin-console/src/lib/api/http.test.ts
+++ b/apps/admin-console/src/lib/api/http.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ADMIN_TOKEN_STORAGE_KEY,
+  adminAuthHeaders,
+  ConfigApiError,
+  fetchWithAdminAuth,
+} from "./http";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  globalThis.localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+});
+
+describe("adminAuthHeaders (R11 #1 / #2)", () => {
+  it("returns an empty object when no token is configured", () => {
+    expect(adminAuthHeaders()).toEqual({});
+  });
+
+  it("emits a Bearer header when localStorage has a token", () => {
+    globalThis.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, "my-token");
+    expect(adminAuthHeaders()).toEqual({ authorization: "Bearer my-token" });
+  });
+
+  it("trims whitespace around the stored token", () => {
+    globalThis.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, "  spaced  ");
+    expect(adminAuthHeaders()).toEqual({ authorization: "Bearer spaced" });
+  });
+});
+
+describe("fetchWithAdminAuth (R11 #2)", () => {
+  it("attaches the admin Bearer header from localStorage", async () => {
+    globalThis.localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, "my-token");
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: async () => "",
+    })) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWithAdminAuth("https://example.com/api");
+
+    const [, init] = (fetchMock as unknown as { mock: { calls: [string, RequestInit][] } }).mock
+      .calls[0];
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer my-token");
+  });
+
+  it("returns the raw Response (no body parsing) — NDJSON-friendly", async () => {
+    const expected = {
+      ok: true,
+      status: 200,
+      headers: new Headers({ "x-custom": "yes" }),
+      text: async () => "stream line 1\nstream line 2",
+    } as unknown as Response;
+    vi.stubGlobal("fetch", vi.fn(async () => expected) as unknown as typeof fetch);
+
+    const response = await fetchWithAdminAuth("https://example.com/api");
+    expect(response).toBe(expected);
+    expect(response.headers.get("x-custom")).toBe("yes");
+    // Body is NOT consumed by fetchWithAdminAuth — the caller decides.
+    const body = await response.text();
+    expect(body).toBe("stream line 1\nstream line 2");
+  });
+
+  // Sanity-check that ConfigApiError isn't auto-thrown — fetchWithAdminAuth
+  // returns the Response regardless of status so streaming callers can
+  // inspect status themselves (e.g. for 503 -> "feature unavailable").
+  it("does not throw on non-2xx — returns the response unchanged", async () => {
+    const errored = {
+      ok: false,
+      status: 503,
+      headers: new Headers(),
+      text: async () => "service unavailable",
+    } as unknown as Response;
+    vi.stubGlobal("fetch", vi.fn(async () => errored) as unknown as typeof fetch);
+
+    const response = await fetchWithAdminAuth("https://example.com/api");
+    expect(response.status).toBe(503);
+  });
+});
+
+// ConfigApiError sanity check — guards against accidental rename.
+describe("ConfigApiError shape", () => {
+  it("carries status + detail and renders a usable message", () => {
+    const err = new ConfigApiError(418, { error: "I'm a teapot" });
+    expect(err.status).toBe(418);
+    expect(err.message).toBe("I'm a teapot");
+    expect(err.detail).toEqual({ error: "I'm a teapot" });
+  });
+});

--- a/apps/admin-console/src/lib/api/http.ts
+++ b/apps/admin-console/src/lib/api/http.ts
@@ -47,14 +47,7 @@ async function readResponseBody(response: Response): Promise<unknown> {
 }
 
 export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
-  let response = await fetch(url, withAdminAuth(init));
-  if (response.status === 401 && hasUnauthorizedHandler()) {
-    const refreshed = await requestUnauthorizedRetry();
-    if (refreshed && refreshed.trim().length > 0) {
-      response = await fetch(url, withAdminAuth(init, refreshed.trim()));
-    }
-  }
-
+  const response = await fetchWithAdminAuth(url, init);
   const detail = await readResponseBody(response);
 
   if (!response.ok) {
@@ -66,6 +59,37 @@ export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> 
   }
 
   return detail as T;
+}
+
+/// Lower-level `fetch` wrapper that handles admin-bearer auth + the 401
+/// refresh retry but returns the raw `Response` so streaming / NDJSON
+/// callers can parse the body themselves. The previous trace-detail
+/// code path called `fetch` directly and missed both the dev-env token
+/// fallback and the 401 retry — R11 #2.
+export async function fetchWithAdminAuth(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  let response = await fetch(url, withAdminAuth(init));
+  if (response.status === 401 && hasUnauthorizedHandler()) {
+    const refreshed = await requestUnauthorizedRetry();
+    if (refreshed && refreshed.trim().length > 0) {
+      response = await fetch(url, withAdminAuth(init, refreshed.trim()));
+    }
+  }
+  return response;
+}
+
+/// Return an `authorization: Bearer …` header object suitable for
+/// `RequestInit.headers` / `fetch` callers (e.g. the AI SDK
+/// `DefaultChatTransport` which has its own `fetch` driver). Returns
+/// an empty object when no token is configured — leaves the request
+/// header-free rather than emitting `Bearer undefined`. Resolves from
+/// localStorage first, then the dev-env fallback, mirroring
+/// `withAdminAuth`. R11 #1 / #2.
+export function adminAuthHeaders(): Record<string, string> {
+  const token = adminBearerToken();
+  return token ? { authorization: `Bearer ${token}` } : {};
 }
 
 function adminBearerToken(override?: string): string | undefined {

--- a/apps/admin-console/src/lib/api/http.ts
+++ b/apps/admin-console/src/lib/api/http.ts
@@ -1,5 +1,5 @@
 import { hasUnauthorizedHandler, requestUnauthorizedRetry } from "../auth-interceptor";
-import { redactSecretString } from "../agent-secret-redaction";
+import { redactSecretString, redactSecretsForDisplay } from "../agent-secret-redaction";
 
 export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? "http://127.0.0.1:38080";
 
@@ -13,7 +13,7 @@ export class ConfigApiError extends Error {
     super(extractErrorMessage(status, detail));
     this.name = "ConfigApiError";
     this.status = status;
-    this.detail = detail;
+    this.detail = redactSecretsForDisplay(detail);
   }
 }
 

--- a/apps/admin-console/src/lib/api/http.ts
+++ b/apps/admin-console/src/lib/api/http.ts
@@ -1,4 +1,5 @@
 import { hasUnauthorizedHandler, requestUnauthorizedRetry } from "../auth-interceptor";
+import { redactSecretString } from "../agent-secret-redaction";
 
 export const BACKEND_URL = import.meta.env.VITE_BACKEND_URL ?? "http://127.0.0.1:38080";
 
@@ -17,20 +18,28 @@ export class ConfigApiError extends Error {
 }
 
 function extractErrorMessage(status: number, detail: unknown): string {
+  let message: string;
   if (typeof detail === "string" && detail.trim().length > 0) {
-    return detail;
-  }
-
-  if (
+    message = detail;
+  } else if (
     detail &&
     typeof detail === "object" &&
     "error" in detail &&
     typeof detail.error === "string"
   ) {
-    return detail.error;
+    message = detail.error;
+  } else if (
+    detail &&
+    typeof detail === "object" &&
+    "message" in detail &&
+    typeof detail.message === "string"
+  ) {
+    message = detail.message;
+  } else {
+    message = `Request failed with status ${status}`;
   }
 
-  return `Request failed with status ${status}`;
+  return redactSecretString(message);
 }
 
 async function readResponseBody(response: Response): Promise<unknown> {
@@ -66,10 +75,7 @@ export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> 
 /// callers can parse the body themselves. The previous trace-detail
 /// code path called `fetch` directly and missed both the dev-env token
 /// fallback and the 401 retry — R11 #2.
-export async function fetchWithAdminAuth(
-  url: string,
-  init?: RequestInit,
-): Promise<Response> {
+export async function fetchWithAdminAuth(url: string, init?: RequestInit): Promise<Response> {
   let response = await fetch(url, withAdminAuth(init));
   if (response.status === 401 && hasUnauthorizedHandler()) {
     const refreshed = await requestUnauthorizedRetry();

--- a/apps/admin-console/src/lib/api/index.ts
+++ b/apps/admin-console/src/lib/api/index.ts
@@ -8,4 +8,5 @@ export { mcpApi } from "./mcp";
 export { providersApi } from "./providers";
 export { systemApi } from "./system";
 export { toolsApi } from "./tools";
+export { tracesApi } from "./traces";
 export * from "./types";

--- a/apps/admin-console/src/lib/api/traces.test.ts
+++ b/apps/admin-console/src/lib/api/traces.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { tracesApi } from "./traces";
+import { ConfigApiError } from "./http";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  headers: { get(name: string): string | null };
+  text: () => Promise<string>;
+}
+
+function mockFetchOnce(response: FakeResponse) {
+  vi.stubGlobal("fetch", vi.fn(async () => response) as unknown as typeof fetch);
+}
+
+describe("tracesApi.listAgentTraces — disabled vs missing-agent (R13)", () => {
+  // `listAgentTraces` previously swallowed BOTH 503 and 404 to `null`,
+  // so a missing agent id surfaced in the UI as "trace persistence not
+  // enabled" — a misleading message that pointed the operator at a
+  // server-build issue rather than the real cause (404). Match
+  // `getTracePage` semantics: 503 is the "feature gate" signal and stays
+  // null; everything else (including 404) re-throws so callers render the
+  // actual error.
+  it("returns null on 503 (trace store not configured)", async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      text: async () => "trace store not configured",
+    });
+    const result = await tracesApi.listAgentTraces("alpha");
+    expect(result).toBeNull();
+  });
+
+  it("throws on 404 (unknown agent) — no longer collapsed to disabled", async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+      text: async () => "agent not found: ghost",
+    });
+    await expect(tracesApi.listAgentTraces("ghost")).rejects.toBeInstanceOf(
+      ConfigApiError,
+    );
+    await expect(tracesApi.listAgentTraces("ghost")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("returns parsed list on 200", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => JSON.stringify({ runs: [{ run_id: "r1", agent_id: "alpha" }] }),
+    });
+    const result = await tracesApi.listAgentTraces("alpha");
+    expect(result).not.toBeNull();
+    expect(result?.runs).toHaveLength(1);
+  });
+});
+
+describe("tracesApi.getTracePage — disabled vs missing-run (R10 #2)", () => {
+  it("returns null on 503 (trace store not configured)", async () => {
+    mockFetchOnce({
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      text: async () => "trace store not configured",
+    });
+
+    const result = await tracesApi.getTracePage("run-abc");
+    expect(result).toBeNull();
+  });
+
+  it("throws on 404 (unknown run) — no longer collapsed to empty events", async () => {
+    // Pre-R10 behavior returned `{events: [], total: 0}` for a missing
+    // run, so the UI silently rendered "0 events" instead of a real
+    // not-found error. After R10 #2 the caller has to handle the
+    // ConfigApiError.
+    mockFetchOnce({
+      ok: false,
+      status: 404,
+      headers: { get: () => null },
+      text: async () => "run not found: ghost-run",
+    });
+
+    await expect(tracesApi.getTracePage("ghost-run")).rejects.toBeInstanceOf(
+      ConfigApiError,
+    );
+    await expect(tracesApi.getTracePage("ghost-run")).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("returns parsed events on 200", async () => {
+    mockFetchOnce({
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name: string) => {
+          if (name === "x-trace-total-events") return "3";
+          if (name === "x-trace-next-offset") return null;
+          return null;
+        },
+      },
+      text: async () =>
+        [
+          `{"kind":"run_started","ts":1}`,
+          `{"kind":"tool_call","ts":2}`,
+          `{"kind":"run_finished","ts":3}`,
+        ].join("\n"),
+    });
+
+    const result = await tracesApi.getTracePage("run-abc");
+    expect(result).not.toBeNull();
+    expect(result?.events).toHaveLength(3);
+    expect(result?.total).toBe(3);
+    expect(result?.next_offset).toBeNull();
+  });
+});

--- a/apps/admin-console/src/lib/api/traces.ts
+++ b/apps/admin-console/src/lib/api/traces.ts
@@ -1,4 +1,4 @@
-import { BACKEND_URL, ConfigApiError, fetchJson } from "./http";
+import { BACKEND_URL, ConfigApiError, fetchJson, fetchWithAdminAuth } from "./http";
 import type { ListTracesResponse, TraceEvent, TracePage } from "./types";
 
 /** Build query string from a sparse object — undefined values are dropped. */
@@ -15,10 +15,13 @@ function qs(params: Record<string, string | number | undefined>): string {
 }
 
 export const tracesApi = {
-  /** List recent runs, optionally filtered by agent. Returns `null` when the
-   *  server build does not expose trace persistence (HTTP 503 — feature gate
-   *  in `awaken-server` controls this), so callers can render a friendly
-   *  "not configured" state rather than throwing. */
+  /** List recent runs, optionally filtered by agent. Returns `null` ONLY
+   *  when the server build does not expose trace persistence (HTTP 503 —
+   *  feature gate in `awaken-server` controls this), so callers can render
+   *  a friendly "not configured" state. A 404 (unknown agent id) is a real
+   *  error and is re-thrown so the UI surfaces it as such instead of
+   *  conflating it with the "feature disabled" state — matches the
+   *  `agentPermissionPreview` / `getTracePage` policy. */
   listAgentTraces: async (
     agentId: string,
     options: { limit?: number; since?: string } = {},
@@ -32,7 +35,7 @@ export const tracesApi = {
         })}`,
       );
     } catch (err) {
-      if (err instanceof ConfigApiError && (err.status === 503 || err.status === 404)) {
+      if (err instanceof ConfigApiError && err.status === 503) {
         return null;
       }
       throw err;
@@ -42,27 +45,35 @@ export const tracesApi = {
   /** Fetch one page of trace events for a run, parsing the NDJSON body and
    *  surfacing the server's pagination headers. The server caps a single
    *  page at 1000 events; callers can keep paging while `next_offset !==
-   *  null`. */
+   *  null`.
+   *
+   *  Returns `null` only when the trace store is not configured on this
+   *  server build (503) — the UI then renders a "trace persistence not
+   *  enabled" state.
+   *
+   *  404 means the run id is unknown (deleted, never persisted, typo)
+   *  and is surfaced as a thrown `ConfigApiError` so the caller can
+   *  render a real error rather than showing "no events" for a missing
+   *  run. */
   getTracePage: async (
     runId: string,
     options: { offset?: number; limit?: number } = {},
-  ): Promise<TracePage> => {
+  ): Promise<TracePage | null> => {
     const url = `${BACKEND_URL}/v1/traces/${encodeURIComponent(runId)}${qs({
       offset: options.offset,
       limit: options.limit,
     })}`;
-    // Bearer header is applied by the fetch wrapper inside fetchJson — but
-    // this endpoint is NDJSON, not JSON, so we mirror its auth handling
-    // directly here to keep the NDJSON streaming path simple.
-    const token = readStoredAdminToken();
-    const init: RequestInit = {
-      headers: token ? { authorization: `Bearer ${token}` } : {},
-    };
-    const response = await fetch(url, init);
-    if (response.status === 503 || response.status === 404) {
-      // Either trace store not configured (503) or run is unknown (404) —
-      // both are "no events" states; let the caller decide UX.
-      return { events: [], total: 0, next_offset: null };
+    // R11 #2 — route the NDJSON request through `fetchWithAdminAuth`
+    // so it picks up the same admin-bearer resolution (localStorage +
+    // dev-env fallback) AND 401-refresh retry as JSON endpoints.
+    // Previously this path read only `localStorage` and would fail
+    // silently in dev environments that rely on `VITE_ADMIN_BEARER_TOKEN`
+    // or against a server that requires a token refresh.
+    const response = await fetchWithAdminAuth(url);
+    if (response.status === 503) {
+      // Trace store not configured on this server build — surface as
+      // a "feature unavailable" state, not as an empty event list.
+      return null;
     }
     if (!response.ok) {
       const text = await response.text();
@@ -88,8 +99,3 @@ export const tracesApi = {
   },
 };
 
-function readStoredAdminToken(): string | null {
-  if (typeof globalThis.localStorage === "undefined") return null;
-  const stored = globalThis.localStorage.getItem("awaken.adminToken");
-  return stored && stored.trim() ? stored.trim() : null;
-}

--- a/apps/admin-console/src/lib/api/traces.ts
+++ b/apps/admin-console/src/lib/api/traces.ts
@@ -1,0 +1,95 @@
+import { BACKEND_URL, ConfigApiError, fetchJson } from "./http";
+import type { ListTracesResponse, TraceEvent, TracePage } from "./types";
+
+/** Build query string from a sparse object — undefined values are dropped. */
+function qs(params: Record<string, string | number | undefined>): string {
+  const entries = Object.entries(params).filter(
+    ([, value]) => value !== undefined && value !== "",
+  );
+  if (entries.length === 0) return "";
+  const search = new URLSearchParams();
+  for (const [key, value] of entries) {
+    search.set(key, String(value));
+  }
+  return `?${search.toString()}`;
+}
+
+export const tracesApi = {
+  /** List recent runs, optionally filtered by agent. Returns `null` when the
+   *  server build does not expose trace persistence (HTTP 503 — feature gate
+   *  in `awaken-server` controls this), so callers can render a friendly
+   *  "not configured" state rather than throwing. */
+  listAgentTraces: async (
+    agentId: string,
+    options: { limit?: number; since?: string } = {},
+  ): Promise<ListTracesResponse | null> => {
+    try {
+      return await fetchJson<ListTracesResponse>(
+        `${BACKEND_URL}/v1/traces${qs({
+          agent_id: agentId,
+          limit: options.limit,
+          since: options.since,
+        })}`,
+      );
+    } catch (err) {
+      if (err instanceof ConfigApiError && (err.status === 503 || err.status === 404)) {
+        return null;
+      }
+      throw err;
+    }
+  },
+
+  /** Fetch one page of trace events for a run, parsing the NDJSON body and
+   *  surfacing the server's pagination headers. The server caps a single
+   *  page at 1000 events; callers can keep paging while `next_offset !==
+   *  null`. */
+  getTracePage: async (
+    runId: string,
+    options: { offset?: number; limit?: number } = {},
+  ): Promise<TracePage> => {
+    const url = `${BACKEND_URL}/v1/traces/${encodeURIComponent(runId)}${qs({
+      offset: options.offset,
+      limit: options.limit,
+    })}`;
+    // Bearer header is applied by the fetch wrapper inside fetchJson — but
+    // this endpoint is NDJSON, not JSON, so we mirror its auth handling
+    // directly here to keep the NDJSON streaming path simple.
+    const token = readStoredAdminToken();
+    const init: RequestInit = {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    };
+    const response = await fetch(url, init);
+    if (response.status === 503 || response.status === 404) {
+      // Either trace store not configured (503) or run is unknown (404) —
+      // both are "no events" states; let the caller decide UX.
+      return { events: [], total: 0, next_offset: null };
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw new ConfigApiError(response.status, text);
+    }
+    const total = Number.parseInt(
+      response.headers.get("x-trace-total-events") ?? "0",
+      10,
+    );
+    const nextOffsetHeader = response.headers.get("x-trace-next-offset");
+    const nextOffset =
+      nextOffsetHeader === null ? null : Number.parseInt(nextOffsetHeader, 10);
+    const body = await response.text();
+    const events: TraceEvent[] = body
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as TraceEvent);
+    return {
+      events,
+      total: Number.isFinite(total) ? total : events.length,
+      next_offset: Number.isFinite(nextOffset as number) ? (nextOffset as number) : null,
+    };
+  },
+};
+
+function readStoredAdminToken(): string | null {
+  if (typeof globalThis.localStorage === "undefined") return null;
+  const stored = globalThis.localStorage.getItem("awaken.adminToken");
+  return stored && stored.trim() ? stored.trim() : null;
+}

--- a/apps/admin-console/src/lib/api/types.test.ts
+++ b/apps/admin-console/src/lib/api/types.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import {
+  type AgentSpec,
+  type ContextWindowPolicy,
+  type RemoteEndpoint,
+  DEFAULT_CONTEXT_POLICY,
+} from "./types";
+
+describe("AgentSpec round-trip", () => {
+  test("preserves context_policy / active_hook_filter / endpoint / registry through JSON", () => {
+    const policy: ContextWindowPolicy = {
+      ...DEFAULT_CONTEXT_POLICY,
+      autocompact_threshold: 150_000,
+    };
+    const endpoint: RemoteEndpoint = {
+      backend: "a2a",
+      base_url: "https://remote.example.com",
+      auth: { type: "bearer", token: "redacted-but-shaped" },
+      target: "remote-agent",
+      timeout_ms: 60_000,
+      options: { poll_interval_ms: 250 },
+    };
+    const spec: AgentSpec = {
+      id: "alpha",
+      model_id: "research-default",
+      system_prompt: "You are useful.",
+      max_rounds: 8,
+      context_policy: policy,
+      plugin_ids: ["mcp", "permission"],
+      active_hook_filter: ["permission"],
+      sections: {},
+      delegates: [],
+      endpoint,
+      registry: "cloud",
+    };
+
+    const roundTripped = JSON.parse(JSON.stringify(spec)) as AgentSpec;
+    expect(roundTripped).toEqual(spec);
+    // Sanity: the fields that previously silently dropped on PUT are present.
+    expect(roundTripped.context_policy).toEqual(policy);
+    expect(roundTripped.active_hook_filter).toEqual(["permission"]);
+    expect(roundTripped.endpoint).toEqual(endpoint);
+    expect(roundTripped.registry).toBe("cloud");
+  });
+
+  test("null context_policy serializes as null (policy disabled)", () => {
+    const spec: AgentSpec = {
+      id: "a",
+      model_id: "m",
+      system_prompt: "",
+      context_policy: null,
+    };
+    const json = JSON.stringify(spec);
+    expect(JSON.parse(json).context_policy).toBeNull();
+  });
+
+  test("empty active_hook_filter round-trips as empty array (no filtering)", () => {
+    const spec: AgentSpec = {
+      id: "a",
+      model_id: "m",
+      system_prompt: "",
+      active_hook_filter: [],
+    };
+    expect(JSON.parse(JSON.stringify(spec)).active_hook_filter).toEqual([]);
+  });
+
+  // Regression coverage for R3 #8. The Rust `RemoteEndpoint` deserializer
+  // accepts legacy aliases (`bearer_token`, `agent_id`, `poll_interval_ms`)
+  // that pre-date the new `auth` / `target` / `options` shape. The TS type
+  // uses an index signature so unknown keys travel through editor state
+  // verbatim; this test pins that behaviour so a future tightening of the
+  // TS type doesn't accidentally drop legacy data on the floor.
+  test("legacy RemoteEndpoint aliases round-trip without normalization", () => {
+    // Shape emitted by older configs before the `auth: {type, ...}` block
+    // and `target` / `options` keys were introduced.
+    const legacyEndpointJson = JSON.stringify({
+      backend: "a2a",
+      base_url: "https://legacy.example.com",
+      bearer_token: "legacy-bearer",
+      agent_id: "legacy-target",
+      poll_interval_ms: 1000,
+    });
+    const legacy = JSON.parse(legacyEndpointJson) as RemoteEndpoint;
+
+    // Even though the TS type doesn't declare `bearer_token` / `agent_id` /
+    // `poll_interval_ms`, they survive the editor state cycle because
+    // `RemoteEndpoint` permits unknown keys via index signature. The
+    // editor never normalises locked-field shapes (endpoint is read-only),
+    // so a save that PATCHes other fields can't drop these on the wire.
+    const cast = legacy as unknown as Record<string, unknown>;
+    expect(cast.bearer_token).toBe("legacy-bearer");
+    expect(cast.agent_id).toBe("legacy-target");
+    expect(cast.poll_interval_ms).toBe(1000);
+
+    // Round-tripping the legacy endpoint through JSON preserves every key.
+    const roundTripped = JSON.parse(JSON.stringify(legacy)) as Record<string, unknown>;
+    expect(roundTripped).toEqual({
+      backend: "a2a",
+      base_url: "https://legacy.example.com",
+      bearer_token: "legacy-bearer",
+      agent_id: "legacy-target",
+      poll_interval_ms: 1000,
+    });
+
+    // When the legacy endpoint lives inside an AgentSpec, the full spec
+    // round-trip must not drop or rename any of its keys either — that's
+    // the actual editor-state path (queryClient hydrate → setSpec → Save).
+    const spec: AgentSpec = {
+      id: "legacy-agent",
+      model_id: "m",
+      system_prompt: "p",
+      endpoint: legacy,
+    };
+    const specRoundTrip = JSON.parse(JSON.stringify(spec)) as AgentSpec;
+    expect(specRoundTrip.endpoint).toEqual(legacy);
+  });
+});
+
+describe("DEFAULT_CONTEXT_POLICY", () => {
+  test("mirrors Rust ContextWindowPolicy::default()", () => {
+    expect(DEFAULT_CONTEXT_POLICY).toEqual({
+      max_context_tokens: 200_000,
+      max_output_tokens: 16_384,
+      min_recent_messages: 10,
+      enable_prompt_cache: true,
+      autocompact_threshold: null,
+      compaction_mode: "keep_recent_raw_suffix",
+      compaction_raw_suffix_messages: 2,
+    });
+  });
+});

--- a/apps/admin-console/src/lib/api/types.ts
+++ b/apps/admin-console/src/lib/api/types.ts
@@ -285,17 +285,24 @@ export interface TracePage {
 /** Wire shape of `GET /v1/agents/:id/permission-preview` (issue #190). */
 export interface PermissionPreviewResponse {
   agent_id: string;
-  /** `true` when the agent has the permission plugin in `plugin_ids` AND
-   *  a permission config section that compiles into a ruleset. */
+  /** `true` when the permission plugin is loaded (`plugin_ids` contains
+   *  `"permission"`) AND `active_hook_filter` admits its hooks (filter is
+   *  empty, or contains `"permission"`). `false` when the runtime would
+   *  not run any permission BeforeInference hooks for this agent — in
+   *  which case `effective_tools` equals `candidate_tools` and no rules
+   *  are surfaced. */
   permission_plugin_enabled: boolean;
   /** Default behavior when no rule matches. `null` when permission plugin is
    *  not enabled — `effective_tools` are just `candidate_tools` in that case. */
   default_behavior: "allow" | "ask" | "deny" | null;
   /** `allowed_tools ∖ excluded_tools` over the full registered tool set. */
   candidate_tools: string[];
-  /** Tools the BeforeInference hook will unconditionally strip (rules
-   *  matching `Deny` + exact tool + `args == Any`). Empty when permission
-   *  plugin is disabled. */
+  /** Tools from `candidate_tools` that the BeforeInference hook will
+   *  unconditionally strip — only deny rules biting a tool the model would
+   *  otherwise see are counted. Deny rules targeting tools already outside
+   *  the candidate set (e.g. excluded via `excluded_tools`) are NOT
+   *  included so the "stripped before model" summary doesn't overstate.
+   *  Empty when permission plugin is disabled. */
   unconditionally_denied: string[];
   /** `candidate_tools ∖ unconditionally_denied`. This is the tool list the
    *  model actually receives. Per-call args-dependent rules can still gate

--- a/apps/admin-console/src/lib/api/types.ts
+++ b/apps/admin-console/src/lib/api/types.ts
@@ -1,18 +1,61 @@
+export type ContextCompactionMode = "keep_recent_raw_suffix" | "compact_to_safe_frontier";
+
+export interface ContextWindowPolicy {
+  max_context_tokens: number;
+  max_output_tokens: number;
+  min_recent_messages: number;
+  enable_prompt_cache: boolean;
+  autocompact_threshold?: number | null;
+  compaction_mode?: ContextCompactionMode;
+  compaction_raw_suffix_messages?: number;
+}
+
+export interface RemoteAuth {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface RemoteEndpoint {
+  backend?: string;
+  base_url: string;
+  auth?: RemoteAuth | null;
+  target?: string | null;
+  timeout_ms?: number;
+  options?: Record<string, unknown>;
+}
+
 export interface AgentSpec {
   id: string;
   model_id: string;
   system_prompt: string;
   max_rounds?: number;
   max_continuation_retries?: number;
+  context_policy?: ContextWindowPolicy | null;
   plugin_ids?: string[];
+  /** Runtime hook filter — only hooks from listed plugins run (`[]` = no filter). */
+  active_hook_filter?: string[];
   sections?: Record<string, unknown>;
   allowed_tools?: string[] | null;
   excluded_tools?: string[] | null;
+  endpoint?: RemoteEndpoint | null;
   delegates?: string[];
   reasoning_effort?: string | number | null;
+  /** Registry source. `undefined` = locally defined; otherwise registry name. */
+  registry?: string | null;
   created_at?: number;
   updated_at?: number;
 }
+
+/** Default values mirroring `ContextWindowPolicy::default()` on the Rust side. */
+export const DEFAULT_CONTEXT_POLICY: ContextWindowPolicy = {
+  max_context_tokens: 200_000,
+  max_output_tokens: 16_384,
+  min_recent_messages: 10,
+  enable_prompt_cache: true,
+  autocompact_threshold: null,
+  compaction_mode: "keep_recent_raw_suffix",
+  compaction_raw_suffix_messages: 2,
+};
 
 export interface ToolSpec {
   id: string;
@@ -200,6 +243,71 @@ export interface AgentRuntimeSnapshot {
 }
 
 export type RestoreResponse = Record<string, unknown>;
+
+/** Wire shape of one run summary in `GET /v1/traces` (ADR-0030 D7). */
+export interface TraceRunSummary {
+  run_id: string;
+  agent_id: string;
+  /** Unix epoch seconds. */
+  started_at: number;
+  /** Unix epoch seconds; `null`/absent when the run is still in flight. */
+  ended_at?: number | null;
+  prompt_ids: string[];
+  experiment_id?: string | null;
+  variant_name?: string | null;
+  final_status?: string | null;
+  judge_score?: number | null;
+}
+
+/** Wire shape of `GET /v1/traces`. */
+export interface ListTracesResponse {
+  runs: TraceRunSummary[];
+}
+
+/** One trace event line in the NDJSON body returned by
+ *  `GET /v1/traces/:run_id`. Shape is the JSON form of
+ *  `awaken_ext_observability::trace_store::TraceEvent`. */
+export interface TraceEvent {
+  kind: string;
+  ts?: number;
+  payload?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** Result of fetching a trace page — events plus the pagination headers
+ *  the server emits (`x-trace-next-offset` / `x-trace-total-events`). */
+export interface TracePage {
+  events: TraceEvent[];
+  total: number;
+  next_offset: number | null;
+}
+
+/** Wire shape of `GET /v1/agents/:id/permission-preview` (issue #190). */
+export interface PermissionPreviewResponse {
+  agent_id: string;
+  /** `true` when the agent has the permission plugin in `plugin_ids` AND
+   *  a permission config section that compiles into a ruleset. */
+  permission_plugin_enabled: boolean;
+  /** Default behavior when no rule matches. `null` when permission plugin is
+   *  not enabled — `effective_tools` are just `candidate_tools` in that case. */
+  default_behavior: "allow" | "ask" | "deny" | null;
+  /** `allowed_tools ∖ excluded_tools` over the full registered tool set. */
+  candidate_tools: string[];
+  /** Tools the BeforeInference hook will unconditionally strip (rules
+   *  matching `Deny` + exact tool + `args == Any`). Empty when permission
+   *  plugin is disabled. */
+  unconditionally_denied: string[];
+  /** `candidate_tools ∖ unconditionally_denied`. This is the tool list the
+   *  model actually receives. Per-call args-dependent rules can still gate
+   *  / Ask / Deny at invocation time — see `args_conditional_rules`. */
+  effective_tools: string[];
+  /** Rules whose match depends on runtime arguments — informational only. */
+  args_conditional_rules: Array<{
+    tool: string;
+    behavior: "allow" | "ask" | "deny";
+    pattern: string;
+  }>;
+}
 
 // ── Record provenance types (mirrors Rust RecordMeta / RecordSource) ─────────
 

--- a/apps/admin-console/src/lib/query/invalidation.ts
+++ b/apps/admin-console/src/lib/query/invalidation.ts
@@ -15,6 +15,14 @@ export function invalidateConfigMutation(queryClient: QueryClient, namespace: st
     if (namespace === "mcp-servers") {
       void queryClient.invalidateQueries({ queryKey: qk.mcp.status(id) });
     }
+    if (namespace === "agents") {
+      // The permission-preview API reads the persisted agent spec to
+      // compute effective tools, so any agent save / reset / restore
+      // must invalidate it. Without this, the editor would keep showing
+      // the previous effective list for `staleTime` after a permission
+      // section edit was saved.
+      void queryClient.invalidateQueries({ queryKey: qk.agent.permissionPreview(id) });
+    }
   }
 
   if (NAV_HEALTH_NAMESPACES.has(namespace)) {

--- a/apps/admin-console/src/lib/query/keys.ts
+++ b/apps/admin-console/src/lib/query/keys.ts
@@ -24,6 +24,7 @@ export const qk = {
     runtimeStats: (id: string, window: string) =>
       ["agent", "runtime-stats", id, window || "default"] as const,
     runtimeStatsList: () => ["agent", "runtime-stats"] as const,
+    permissionPreview: (id: string) => ["agent", "permission-preview", id] as const,
   },
   system: {
     info: () => ["system", "info"] as const,

--- a/apps/admin-console/src/lib/reasoning-effort.test.ts
+++ b/apps/admin-console/src/lib/reasoning-effort.test.ts
@@ -39,8 +39,13 @@ describe("reasoningEffortMode", () => {
 });
 
 describe("reasoningEffortValue", () => {
-  it("erases the field when the mode is default", () => {
-    expect(reasoningEffortValue({ kind: "default" })).toBeUndefined();
+  it("returns null for default so customized agents PATCH an explicit null override", () => {
+    // Returning null (not undefined) is load-bearing for customized
+    // agents: the patch-diff walks fields and routes undefined into a
+    // DELETE override (which falls back to the base record's value).
+    // The "Provider default" UI choice must override the base with an
+    // explicit null instead.
+    expect(reasoningEffortValue({ kind: "default" })).toBeNull();
   });
 
   it("returns the preset string verbatim", () => {
@@ -58,7 +63,7 @@ describe("reasoningEffortValue", () => {
     );
   });
 
-  it("treats a blank custom value as the default", () => {
-    expect(reasoningEffortValue({ kind: "custom", value: "  " })).toBeUndefined();
+  it("treats a blank custom value the same as default (null = provider default override)", () => {
+    expect(reasoningEffortValue({ kind: "custom", value: "  " })).toBeNull();
   });
 });

--- a/apps/admin-console/src/lib/reasoning-effort.ts
+++ b/apps/admin-console/src/lib/reasoning-effort.ts
@@ -26,14 +26,19 @@ export function reasoningEffortMode(
   return { kind: "custom", value };
 }
 
-/// Convert a UI mode back to the wire-shape stored on AgentSpec.
+/// Convert a UI mode back to the wire-shape stored on AgentSpec. Returns
+/// `null` for "Provider default" so customized agents PATCH an explicit
+/// null override (forcing provider default), not DELETE the override
+/// (which would re-inherit the base record's value). For a user-defined
+/// agent with no base, `null` and absent serialize identically on the
+/// server side — both produce `reasoning_effort: None`.
 export function reasoningEffortValue(
   mode: ReasoningEffortMode,
-): string | number | null | undefined {
-  if (mode.kind === "default") return undefined;
+): string | number | null {
+  if (mode.kind === "default") return null;
   if (mode.kind === "preset") return mode.value;
   const trimmed = mode.value.trim();
-  if (trimmed.length === 0) return undefined;
+  if (trimmed.length === 0) return null;
   const asNumber = Number(trimmed);
   if (!Number.isNaN(asNumber) && /^-?\d+(\.\d+)?$/.test(trimmed)) {
     return asNumber;

--- a/apps/admin-console/src/lib/safe-error-message.test.ts
+++ b/apps/admin-console/src/lib/safe-error-message.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { safeErrorMessage } from "./safe-error-message";
+
+describe("safeErrorMessage", () => {
+  it("redacts credential patterns from Error messages", () => {
+    const message = safeErrorMessage(
+      new Error("request failed with Authorization: Bearer sk-real-secret-value"),
+    );
+
+    expect(message).toContain("Authorization: ***");
+    expect(message).not.toContain("sk-real-secret-value");
+  });
+
+  it("redacts credential patterns from non-Error values", () => {
+    const message = safeErrorMessage("Cookie: session=raw-session-id");
+
+    expect(message).toContain("Cookie: ***");
+    expect(message).not.toContain("raw-session-id");
+  });
+});

--- a/apps/admin-console/src/lib/safe-error-message.ts
+++ b/apps/admin-console/src/lib/safe-error-message.ts
@@ -1,0 +1,6 @@
+import { redactSecretString } from "./agent-secret-redaction";
+
+export function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? "Unknown error");
+  return redactSecretString(message);
+}

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -703,6 +703,96 @@ describe("agent editor source badges", () => {
   });
 });
 
+// ── endpoint override banner (R14) ───────────────────────────────────────────
+//
+// The admin-console editor treats `endpoint` as locked and exposes no UI
+// for editing it. The server-side `AgentSpecPatch.endpoint` field is
+// still patchable through `PATCH /v1/config/agents/:id/overrides`, so
+// programmatic clients (CLI, scripts) can install endpoint overrides
+// the editor wouldn't otherwise reveal. The banner surfaces that
+// existence so the editor's "endpoint is fixed" appearance doesn't
+// silently lie to operators.
+
+describe("agent editor endpoint override banner (R14)", () => {
+  it("renders banner when user_overrides.endpoint exists", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock(
+        "patched-endpoint",
+        { id: "patched-endpoint", model_id: "m1", system_prompt: "", max_rounds: 8 },
+        {
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          user_overrides: {
+            endpoint: {
+              backend: "a2a",
+              base_url: "https://staging.example.com",
+              target: "remote-agent",
+            },
+          },
+          created_at: 0,
+          updated_at: 0,
+        },
+      ),
+    );
+
+    renderEditorRoute("/agents/patched-endpoint");
+    await screen.findByText(/Edit patched-endpoint/i);
+    expect(screen.getByTestId("endpoint-override-banner")).toBeDefined();
+  });
+
+  it("renders banner even when override is explicit null (clears base endpoint)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock(
+        "cleared-endpoint",
+        { id: "cleared-endpoint", model_id: "m1", system_prompt: "", max_rounds: 8 },
+        {
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          user_overrides: { endpoint: null },
+          created_at: 0,
+          updated_at: 0,
+        },
+      ),
+    );
+
+    renderEditorRoute("/agents/cleared-endpoint");
+    await screen.findByText(/Edit cleared-endpoint/i);
+    // `endpoint: null` is a valid override (means "this customized
+    // record clears the base endpoint"). The banner must surface this
+    // too — operators should see ANY endpoint override exists.
+    expect(screen.getByTestId("endpoint-override-banner")).toBeDefined();
+  });
+
+  it("does not render banner when no endpoint override is set", async () => {
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock(
+        "no-endpoint-override",
+        {
+          id: "no-endpoint-override",
+          model_id: "m1",
+          system_prompt: "custom",
+          max_rounds: 8,
+        },
+        {
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          // Customized record, but the override is on a different field.
+          user_overrides: { system_prompt: "custom" },
+          created_at: 0,
+          updated_at: 0,
+        },
+      ),
+    );
+
+    renderEditorRoute("/agents/no-endpoint-override");
+    await screen.findByText(/Edit no-endpoint-override/i);
+    expect(screen.queryByTestId("endpoint-override-banner")).toBeNull();
+  });
+});
+
 // ── Save → PATCH vs PUT branching ────────────────────────────────────────────
 
 describe("agent editor Save → PATCH vs PUT branching", () => {

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -944,7 +944,38 @@ describe("agent editor Raw JSON secret redaction", () => {
     expect(screen.queryByText(/Save will publish to the runtime config/i)).toBeNull();
   });
 
-  it("keeps a changed Raw JSON redaction marker as the new sections secret on save", async () => {
+  it("blocks Apply when an edited Raw JSON value still contains a redaction marker", async () => {
+    const agent = agentSpec("raw-marker-agent") as AgentSpec;
+    agent.sections = {
+      gateway: {
+        note: "Authorization: Bearer raw-token-value-1234567890\nowner=team-a",
+      },
+    };
+    const { validateBodies } = stubRawJsonAgent(agent, {
+      source: { kind: "builtin", binary_version: "1.0" },
+      hidden: false,
+      user_overrides: null,
+      created_at: 0,
+      updated_at: 0,
+    });
+
+    renderEditorRoute(`/agents/${agent.id}`);
+    await screen.findByText(/Edit raw-marker-agent/i);
+
+    const textarea = await openRawJsonTextarea();
+    const marker = rawJsonRedactionMarker(textarea, "note");
+    fireEvent.change(textarea, {
+      target: {
+        value: textarea.value.replace(`"note": "${marker}"`, `"note": "${marker}\\nowner=team-b"`),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /apply to draft/i }));
+
+    await screen.findByText(/Redaction marker `sections\.gateway\.note`/i);
+    expect(validateBodies).toHaveLength(0);
+  });
+
+  it("keeps a full Raw JSON secret replacement on save", async () => {
     const agent = agentSpec("raw-replace-agent") as AgentSpec;
     agent.sections = { oauth: { client_secret: "old-client-secret" } };
     const { validateBodies, patchBodies } = stubRawJsonAgent(agent, {
@@ -990,6 +1021,73 @@ describe("agent editor Raw JSON secret redaction", () => {
         {}
       ).client_secret,
     ).toBe("new-secret");
+  });
+
+  it("allows Raw JSON to set id while creating a new agent", async () => {
+    const validateBodies: AgentSpec[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (u.includes("/v1/config/agents/validate") && init?.method === "POST") {
+        const body = JSON.parse((init.body as string) ?? "{}") as AgentSpec;
+        validateBodies.push(body);
+        return jsonResponse({ ok: true, normalized: body });
+      }
+      return jsonResponse({ error: "not found" }, { ok: false, status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const textarea = await openRawJsonTextarea();
+    fireEvent.change(textarea, {
+      target: { value: textarea.value.replace('"id": ""', '"id": "raw-new-agent"') },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /apply to draft/i }));
+
+    await waitFor(() => {
+      expect(validateBodies).toHaveLength(1);
+    });
+    expect(validateBodies[0].id).toBe("raw-new-agent");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Basics" }));
+    await waitFor(() => {
+      expect((screen.getByLabelText("Agent ID") as HTMLInputElement).value).toBe("raw-new-agent");
+    });
+  });
+});
+
+describe("agent editor context policy inputs", () => {
+  it("keeps the previous autocompact threshold while the number field is blank", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Advanced" }));
+    fireEvent.click(screen.getByLabelText("Apply custom policy"));
+
+    const thresholdField = screen.getByText("Autocompact threshold").closest("label");
+    if (!thresholdField) throw new Error("Autocompact threshold field not found");
+    const inputs = thresholdField.querySelectorAll("input");
+    const enableInput = inputs[0] as HTMLInputElement;
+    const thresholdInput = inputs[1] as HTMLInputElement;
+
+    fireEvent.click(enableInput);
+    fireEvent.change(thresholdInput, { target: { value: "123456" } });
+    expect(thresholdInput.value).toBe("123456");
+
+    fireEvent.change(thresholdInput, { target: { value: "" } });
+    expect(thresholdInput.value).toBe("123456");
   });
 });
 

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -287,6 +287,60 @@ describe("agent editor save validation", () => {
         .every((button) => button.hasAttribute("disabled")),
     ).toBe(true);
   });
+
+  it("redacts credential patterns from metadata error messages", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        const href = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+        if (href.includes("/v1/capabilities")) {
+          return jsonResponse({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          });
+        }
+        if (href.endsWith("/v1/config/agents/agent-a/meta")) {
+          return jsonResponse(
+            { error: "metadata failed with Cookie: session=raw-session-id" },
+            { ok: false, status: 403 },
+          );
+        }
+        if (href.endsWith("/v1/config/agents/agent-a")) {
+          return jsonResponse(agentSpec("agent-a"));
+        }
+        return jsonResponse({ error: "not found" }, { ok: false, status: 404 });
+      }),
+    );
+
+    const { container } = renderEditorRoute("/agents/agent-a");
+    await screen.findByText(/Agent metadata unavailable: metadata failed with Cookie: \*\*\*/i);
+    expect(container.textContent ?? "").not.toContain("raw-session-id");
+  });
+});
+
+describe("agent editor numeric inputs", () => {
+  it("keeps previous Basics numeric values while fields are blank or half-typed", async () => {
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    const maxRounds = screen.getByLabelText("Max rounds") as HTMLInputElement;
+    const retries = screen.getByLabelText("Max continuation retries") as HTMLInputElement;
+
+    fireEvent.change(maxRounds, { target: { value: "7" } });
+    expect(maxRounds.value).toBe("7");
+    fireEvent.change(maxRounds, { target: { value: "" } });
+    expect(maxRounds.value).toBe("7");
+
+    fireEvent.change(retries, { target: { value: "0" } });
+    expect(retries.value).toBe("0");
+    fireEvent.change(retries, { target: { value: "" } });
+    expect(retries.value).toBe("0");
+  });
 });
 
 describe("agent editor History tab", () => {
@@ -490,6 +544,21 @@ describe("DiffModal", () => {
     expect(dialog.textContent).not.toContain("old-client-secret");
     expect(dialog.textContent).not.toContain("new-client-secret");
     expect(screen.queryByText(/No semantic changes/i)).toBeNull();
+  });
+
+  it("redacts credential patterns from string diff values", () => {
+    const previous = agentSpec("diff-string-agent") as AgentSpec;
+    previous.system_prompt = "old prompt";
+    const current = agentSpec("diff-string-agent") as AgentSpec;
+    current.system_prompt = "new prompt with Authorization: Bearer sk-real-secret-value";
+
+    const { container } = render(
+      <DiffModal previous={previous} current={current} onClose={() => {}} />,
+    );
+
+    const dom = container.textContent ?? "";
+    expect(dom).toContain("Authorization: ***");
+    expect(dom).not.toContain("sk-real-secret-value");
   });
 });
 

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -814,6 +814,168 @@ describe("agent editor endpoint override banner (R14)", () => {
   });
 });
 
+describe("agent editor Raw JSON secret redaction", () => {
+  function stubRawJsonAgent(agentBody: AgentSpec, metaBody: Record<string, unknown>) {
+    const validateBodies: AgentSpec[] = [];
+    const patchBodies: Record<string, unknown>[] = [];
+    let currentAgent = JSON.parse(JSON.stringify(agentBody)) as AgentSpec;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (u.includes("/v1/config/agents/validate") && init?.method === "POST") {
+        const body = JSON.parse((init.body as string) ?? "{}") as AgentSpec;
+        validateBodies.push(body);
+        return jsonResponse({ ok: true, normalized: body });
+      }
+      if (u.endsWith(`/v1/config/agents/${agentBody.id}/meta`)) {
+        return jsonResponse(metaBody);
+      }
+      if (u.includes(`/v1/config/agents/${agentBody.id}/overrides`) && init?.method === "PATCH") {
+        const body = JSON.parse((init.body as string) ?? "{}") as Record<string, unknown>;
+        patchBodies.push(body);
+        if (body.sections && typeof body.sections === "object" && !Array.isArray(body.sections)) {
+          currentAgent = {
+            ...currentAgent,
+            sections: {
+              ...(currentAgent.sections ?? {}),
+              ...(body.sections as Record<string, unknown>),
+            },
+          };
+        }
+        return jsonResponse(currentAgent);
+      }
+      if (u.endsWith(`/v1/config/agents/${agentBody.id}`)) {
+        return jsonResponse(currentAgent);
+      }
+      if (u.includes("/v1/audit-log")) {
+        return jsonResponse({ items: [] });
+      }
+      return jsonResponse({ error: "not found" }, { ok: false, status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return { validateBodies, patchBodies };
+  }
+
+  async function openRawJsonTextarea() {
+    const advancedTab = await screen.findByRole("tab", { name: "Advanced" });
+    fireEvent.click(advancedTab);
+    await screen.findByText("Raw JSON");
+    const textarea = screen
+      .getAllByRole("textbox")
+      .find(
+        (element): element is HTMLTextAreaElement =>
+          element instanceof HTMLTextAreaElement && element.value.includes('"sections"'),
+      );
+    if (!textarea) throw new Error("Raw JSON textarea not found");
+    return textarea;
+  }
+
+  it("does not render sections secrets into the Raw JSON textarea DOM", async () => {
+    const agent = agentSpec("raw-secret-agent") as AgentSpec;
+    agent.sections = {
+      oauth: { client_secret: "live-client-secret" },
+      observability: { api_key: "live-api-key" },
+    };
+    stubRawJsonAgent(agent, {
+      source: { kind: "builtin", binary_version: "1.0" },
+      hidden: false,
+      user_overrides: null,
+      created_at: 0,
+      updated_at: 0,
+    });
+
+    renderEditorRoute(`/agents/${agent.id}`);
+    await screen.findByText(/Edit raw-secret-agent/i);
+
+    const textarea = await openRawJsonTextarea();
+    expect(textarea.value).toContain('"client_secret": "***"');
+    expect(textarea.value).toContain('"api_key": "***"');
+    expect(textarea.value).not.toContain("live-client-secret");
+    expect(textarea.value).not.toContain("live-api-key");
+  });
+
+  it("restores unchanged Raw JSON redaction markers before validating the draft", async () => {
+    const agent = agentSpec("raw-restore-agent") as AgentSpec;
+    agent.sections = { oauth: { client_secret: "live-client-secret" } };
+    const { validateBodies } = stubRawJsonAgent(agent, {
+      source: { kind: "builtin", binary_version: "1.0" },
+      hidden: false,
+      user_overrides: null,
+      created_at: 0,
+      updated_at: 0,
+    });
+
+    renderEditorRoute(`/agents/${agent.id}`);
+    await screen.findByText(/Edit raw-restore-agent/i);
+
+    const textarea = await openRawJsonTextarea();
+    fireEvent.change(textarea, { target: { value: `${textarea.value}\n` } });
+    fireEvent.click(screen.getByRole("button", { name: /apply to draft/i }));
+
+    await waitFor(() => {
+      expect(validateBodies).toHaveLength(1);
+    });
+    expect(
+      ((validateBodies[0].sections?.oauth as Record<string, unknown>) ?? {}).client_secret,
+    ).toBe("live-client-secret");
+    expect(screen.queryByText(/Save will publish to the runtime config/i)).toBeNull();
+  });
+
+  it("keeps a changed Raw JSON redaction marker as the new sections secret on save", async () => {
+    const agent = agentSpec("raw-replace-agent") as AgentSpec;
+    agent.sections = { oauth: { client_secret: "old-client-secret" } };
+    const { validateBodies, patchBodies } = stubRawJsonAgent(agent, {
+      source: { kind: "builtin", binary_version: "1.0" },
+      hidden: false,
+      user_overrides: null,
+      created_at: 0,
+      updated_at: 0,
+    });
+
+    renderEditorRoute(`/agents/${agent.id}`);
+    await screen.findByText(/Edit raw-replace-agent/i);
+
+    const textarea = await openRawJsonTextarea();
+    fireEvent.change(textarea, {
+      target: {
+        value: textarea.value.replace('"client_secret": "***"', '"client_secret": "new-secret"'),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /apply to draft/i }));
+
+    await waitFor(() => {
+      expect(validateBodies).toHaveLength(1);
+    });
+    expect(
+      ((validateBodies[0].sections?.oauth as Record<string, unknown>) ?? {}).client_secret,
+    ).toBe("new-secret");
+
+    await screen.findByText(/Save will publish to the runtime config/i);
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(patchBodies).toHaveLength(1);
+    });
+    expect(JSON.stringify(patchBodies[0])).not.toContain("***");
+    expect(
+      (
+        ((patchBodies[0].sections as Record<string, unknown>).oauth as Record<string, unknown>) ??
+        {}
+      ).client_secret,
+    ).toBe("new-secret");
+  });
+});
+
 // ── Save → PATCH vs PUT branching ────────────────────────────────────────────
 
 describe("agent editor Save → PATCH vs PUT branching", () => {

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -343,6 +343,40 @@ describe("agent editor numeric inputs", () => {
   });
 });
 
+describe("agent editor preview Recent runs wiring", () => {
+  it("shows Recent runs for a loaded saved agent and opens traces with the saved id", async () => {
+    const agent = agentSpec("existing-agent");
+    vi.stubGlobal(
+      "fetch",
+      buildEditorFetchMock("existing-agent", agent, {
+        source: { kind: "user" },
+        hidden: false,
+        user_overrides: null,
+        created_at: 0,
+        updated_at: 0,
+      }),
+    );
+
+    renderEditorRoute("/agents/existing-agent");
+    await screen.findByText(/Edit existing-agent/i);
+
+    fireEvent.click(screen.getByTestId("open-recent-traces"));
+
+    const drawer = screen.getByRole("dialog", { name: "Recent runs" });
+    expect(drawer).toBeTruthy();
+    expect(drawer.textContent ?? "").toContain("existing-agent");
+  });
+
+  it("does not show Recent runs for a new unsaved agent after the user enters an id", async () => {
+    renderEditorRoute("/agents/new");
+    const idInput = await screen.findByLabelText("Agent ID");
+
+    fireEvent.change(idInput, { target: { value: "my-new-agent" } });
+
+    expect(screen.queryByTestId("open-recent-traces")).toBeNull();
+  });
+});
+
 describe("agent editor History tab", () => {
   it("shows 'Save first' empty state for new agents", async () => {
     renderEditorRoute("/agents/new");

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -6,7 +6,9 @@ import { appRoutes } from "../app";
 import { AuthProvider } from "../components/auth-provider";
 import { ConfirmDialogProvider } from "../components/confirm-dialog";
 import { ToastProvider } from "../components/toast-provider";
+import { DiffModal } from "./agent-editor-page";
 import { ADMIN_TOKEN_STORAGE_KEY } from "../lib/config-api";
+import type { AgentSpec } from "../lib/config-api";
 import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
 import { withQueryClient } from "../test/query";
 
@@ -469,6 +471,25 @@ describe("agent editor History tab auto-refresh after Save", () => {
     await screen.findByText("hash2");
 
     expect(auditCallCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("DiffModal", () => {
+  it("shows secret-only section changes without rendering raw secret values", () => {
+    const previous = agentSpec("secret-agent") as AgentSpec;
+    previous.sections = { oauth: { client_secret: "old-client-secret" } };
+    const current = agentSpec("secret-agent") as AgentSpec;
+    current.sections = { oauth: { client_secret: "new-client-secret" } };
+
+    render(<DiffModal previous={previous} current={current} onClose={() => {}} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Diff vs published" });
+    expect(screen.getByText("sections.oauth.client_secret")).toBeTruthy();
+    expect(screen.getByTestId("diff-redacted-value-changed")).toBeTruthy();
+    expect(dialog.textContent).toContain("*** (changed)");
+    expect(dialog.textContent).not.toContain("old-client-secret");
+    expect(dialog.textContent).not.toContain("new-client-secret");
+    expect(screen.queryByText(/No semantic changes/i)).toBeNull();
   });
 });
 

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -880,6 +880,14 @@ describe("agent editor Raw JSON secret redaction", () => {
     return textarea;
   }
 
+  function rawJsonRedactionMarker(textarea: HTMLTextAreaElement, field: string): string {
+    const match = textarea.value.match(
+      new RegExp(`"${field}": "(__AWAKEN_REDACTED_SECRET_[a-f0-9]{8}__)"`),
+    );
+    if (!match) throw new Error(`Redaction marker for ${field} not found`);
+    return match[1];
+  }
+
   it("does not render sections secrets into the Raw JSON textarea DOM", async () => {
     const agent = agentSpec("raw-secret-agent") as AgentSpec;
     agent.sections = {
@@ -898,8 +906,13 @@ describe("agent editor Raw JSON secret redaction", () => {
     await screen.findByText(/Edit raw-secret-agent/i);
 
     const textarea = await openRawJsonTextarea();
-    expect(textarea.value).toContain('"client_secret": "***"');
-    expect(textarea.value).toContain('"api_key": "***"');
+    expect(rawJsonRedactionMarker(textarea, "client_secret")).toMatch(
+      /^__AWAKEN_REDACTED_SECRET_[a-f0-9]{8}__$/,
+    );
+    expect(rawJsonRedactionMarker(textarea, "api_key")).toMatch(
+      /^__AWAKEN_REDACTED_SECRET_[a-f0-9]{8}__$/,
+    );
+    expect(textarea.value).not.toContain('"client_secret": "***"');
     expect(textarea.value).not.toContain("live-client-secret");
     expect(textarea.value).not.toContain("live-api-key");
   });
@@ -946,9 +959,13 @@ describe("agent editor Raw JSON secret redaction", () => {
     await screen.findByText(/Edit raw-replace-agent/i);
 
     const textarea = await openRawJsonTextarea();
+    const marker = rawJsonRedactionMarker(textarea, "client_secret");
     fireEvent.change(textarea, {
       target: {
-        value: textarea.value.replace('"client_secret": "***"', '"client_secret": "new-secret"'),
+        value: textarea.value.replace(
+          `"client_secret": "${marker}"`,
+          '"client_secret": "new-secret"',
+        ),
       },
     });
     fireEvent.click(screen.getByRole("button", { name: /apply to draft/i }));
@@ -966,7 +983,7 @@ describe("agent editor Raw JSON secret redaction", () => {
     await waitFor(() => {
       expect(patchBodies).toHaveLength(1);
     });
-    expect(JSON.stringify(patchBodies[0])).not.toContain("***");
+    expect(JSON.stringify(patchBodies[0])).not.toContain("__AWAKEN_REDACTED_SECRET_");
     expect(
       (
         ((patchBodies[0].sections as Record<string, unknown>).oauth as Record<string, unknown>) ??

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -43,6 +43,7 @@ import { qk } from "@/lib/query/keys";
 import { invalidateConfigMutation } from "@/lib/query/invalidation";
 import {
   canonicalStringify,
+  changedRedactionMarkerPaths,
   cloneAgentSpecForEditor,
   computeRedactedDiff,
   deepEqualCanonical,
@@ -413,10 +414,11 @@ export function AgentEditorPage() {
   }
 
   function replaceSpec(next: AgentSpec) {
-    // Preserve identity fields the editor manages outside the JSON payload.
+    // Existing agents keep their identity outside Raw JSON; new agents can
+    // take `id` from a pasted AgentSpec.
     setSpec((current) => ({
       ...next,
-      id: current.id,
+      id: isNew ? next.id : current.id,
       created_at: current.created_at,
       updated_at: current.updated_at,
     }));
@@ -2143,15 +2145,8 @@ function JsonEditorSection({
   isNew: boolean;
   replaceSpec: (next: AgentSpec) => void;
 }) {
-  // The textarea shows a redacted view of the spec so real credentials
-  // from endpoint auth, plugin/provider `sections.*`, or other
-  // secret-shaped fields never land in the admin DOM. The Apply path
-  // validates the user's parsed payload against this exact redacted
-  // display copy FIRST (to detect edits to locked fields even when their
-  // value is a redaction sentinel), then restores unchanged redaction
-  // markers before the candidate reaches validation / draft state. Doing
-  // this before `mergeLockedFields` is load-bearing — overlaying first would mask
-  // user edits to `endpoint.base_url` / `endpoint.auth.*` / `registry`.
+  // Raw JSON uses a redacted display copy. Apply validates against that copy
+  // before restoring unchanged markers and overlaying locked real values.
   const editingSpec = useMemo(() => redactAgentSpecForEditing(spec), [spec]);
   const specSerialized = useMemo(
     () => JSON.stringify(editingSpec.redacted, null, 2),
@@ -2186,18 +2181,10 @@ function JsonEditorSection({
       return;
     }
     const parsedRecord = parsed as Record<string, unknown>;
-    // Reject unknown top-level fields up front. The Save path only persists
-    // identity + locked + patchable fields, so anything else would enter
-    // the dirty state and silently disappear on Save ("saved (no patchable
-    // changes)" while the page still looks dirty).
+    // Save persists only known identity, locked, and patchable fields.
     const unknown = unknownAgentSpecFields(parsedRecord);
     if (unknown.length > 0) {
-      // The allowlist is a front-end-maintained mirror of
-      // `PATCHABLE_AGENT_FIELDS + identity/locked fields`. If the user pastes
-      // a schema field that the backend understands but this admin console
-      // version doesn't know about, the diff/PATCH path can't persist it
-      // and Save would silently drop it. Surface that distinction in the
-      // error: this is a *version* mismatch, not a malformed spec.
+      // Treat unknown fields as console/schema drift, not malformed JSON.
       setError(
         `This admin console version does not recognize ${
           unknown.length === 1 ? "field" : "fields"
@@ -2206,14 +2193,12 @@ function JsonEditorSection({
       );
       return;
     }
-    // R12 #5 — Identity / timestamp fields are server-managed; the
-    // candidate constructed below overwrites them from `spec`
-    // unconditionally. If we let an edit slip through, Apply would
-    // claim success while silently discarding the user's change.
-    // Compare canonically so re-indenting / key-order tweaks aren't
-    // mistaken for an edit.
-    const IDENTITY_FIELDS: Array<keyof AgentSpec> = ["id", "created_at", "updated_at"];
-    for (const field of IDENTITY_FIELDS) {
+    // Existing identity and timestamp edits would be overwritten below, so
+    // reject them before Apply can look successful.
+    const identityFields: Array<keyof AgentSpec> = isNew
+      ? ["created_at", "updated_at"]
+      : ["id", "created_at", "updated_at"];
+    for (const field of identityFields) {
       if (!(field in parsedRecord)) continue;
       if (!deepEqualCanonical(parsedRecord[field], editingSpec.redacted[field])) {
         setError(
@@ -2222,16 +2207,8 @@ function JsonEditorSection({
         return;
       }
     }
-    // `endpoint` and `registry` are provenance / runtime-locality fields
-    // not user-editable through the editor. Compare the PARSED payload
-    // against the redacted spec the textarea was seeded from — equality
-    // means the user didn't touch the locked fields (any redaction sentinel
-    // stayed intact). If anything differs (a real bearer-token edit, a
-    // `base_url` swap, a `registry` flip, etc.) we reject the Apply
-    // entirely. Doing this BEFORE `mergeLockedFields` is mandatory: the
-    // overlay overwrites parsed.endpoint with spec.endpoint, so any
-    // post-overlay compare would always read "equal" and silently drop
-    // the user's edit.
+    // Compare before mergeLockedFields; overlaying first would hide edits to
+    // endpoint / registry and silently drop them.
     const displaySpec = editingSpec.redacted;
     const lockedField = lockedFieldChange(displaySpec, parsedRecord);
     if (lockedField) {
@@ -2240,22 +2217,24 @@ function JsonEditorSection({
       );
       return;
     }
+    const changedMarkerPaths = changedRedactionMarkerPaths(parsedRecord, editingSpec.redactions);
+    if (changedMarkerPaths.length > 0) {
+      setError(
+        `Redaction marker \`${changedMarkerPaths[0]}\` is inside an edited value. Replace the full credential value or revert the marker before applying.`,
+      );
+      return;
+    }
     const withRestoredRedactions = restoreUnchangedRedactions(
       parsedRecord,
       editingSpec.redactions,
     ) as Record<string, unknown>;
-    // Now overlay the real locked-field values onto the parsed payload so
-    // the candidate carries the actual `endpoint.auth.bearer_token` (not
-    // the redaction sentinel the textarea showed). Redaction stays purely a
-    // display concern from here on.
+    // Restore the real locked values after all Raw JSON edit checks.
     const withRealLockedFields = mergeLockedFields(withRestoredRedactions, spec);
-    // Build the would-be-applied payload (identity fields are preserved by
-    // replaceSpec) and let the server type-check the rest before we mutate
-    // editor state. The same validate endpoint backs the Validate button so
-    // we get consistent errors with the Save path.
+    // Server validation runs before the draft state mutates.
+    const candidateSource = withRealLockedFields as unknown as AgentSpec;
     const candidate: AgentSpec = {
-      ...(withRealLockedFields as unknown as AgentSpec),
-      id: spec.id,
+      ...candidateSource,
+      id: isNew ? candidateSource.id : spec.id,
       created_at: spec.created_at,
       updated_at: spec.updated_at,
     };
@@ -2285,10 +2264,20 @@ function JsonEditorSection({
         <div>
           <h3 className="text-lg font-semibold text-fg-strong">Raw JSON</h3>
           <p className="mt-2 max-w-xl text-sm text-fg-soft">
-            Edit the AgentSpec payload directly. <span className="font-mono">id</span>,{" "}
-            <span className="font-mono">created_at</span>, and{" "}
-            <span className="font-mono">updated_at</span> are preserved on Apply. Click Save below
-            to publish — the runtime validation still runs.
+            Edit the AgentSpec payload directly.{" "}
+            {isNew ? (
+              <>
+                <span className="font-mono">id</span> can be set for new agents;{" "}
+                <span className="font-mono">created_at</span> and{" "}
+                <span className="font-mono">updated_at</span> are preserved on Apply.
+              </>
+            ) : (
+              <>
+                <span className="font-mono">id</span>, <span className="font-mono">created_at</span>
+                , and <span className="font-mono">updated_at</span> are preserved on Apply.
+              </>
+            )}{" "}
+            Click Save below to publish — the runtime validation still runs.
           </p>
           <p
             className="mt-2 max-w-xl text-xs text-fg-soft"
@@ -2382,13 +2371,7 @@ function ContextPolicySection({
     onChange({ ...policy, [key]: next });
   }
 
-  /** Parse a token-count input. Ignores blank / non-numeric / < `min`
-   *  values: a half-typed clear-and-retype flow would otherwise flash the
-   *  draft to `Number("") || 0 === 0`, which collides with the `min={1}`
-   *  on `max_context_tokens` / `max_output_tokens` and locks Save behind
-   *  a "validation failed" toast that the user didn't actually trigger.
-   *  Returning `undefined` here keeps the previous value displayed until
-   *  the user types something valid. */
+  // Keep the previous value while number inputs are blank or half-typed.
   function parseTokenInput(value: string, min: number): number | undefined {
     const parsed = Number(value);
     if (!Number.isFinite(parsed) || parsed < min) return undefined;
@@ -2498,9 +2481,10 @@ function ContextPolicySection({
                 min={1}
                 disabled={!autocompactEnabled}
                 value={autocompactEnabled ? Number(policy.autocompact_threshold ?? 0) : ""}
-                onChange={(event) =>
-                  update("autocompact_threshold", Number(event.target.value) || null)
-                }
+                onChange={(event) => {
+                  const next = parseTokenInput(event.target.value, 1);
+                  if (next !== undefined) update("autocompact_threshold", next);
+                }}
                 className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong disabled:bg-muted disabled:text-fg-soft"
               />
             </div>

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -50,9 +50,11 @@ import {
   lockedFieldChange,
   mergeLockedFields,
   partitionActiveHookFilter,
+  redactAgentSpecForEditing,
   redactAgentSpecForDisplay,
   redactEndpointForDisplay,
   redactSecretsForDisplay,
+  restoreUnchangedRedactions,
   togglePluginState,
   unknownAgentSpecFields,
 } from "@/lib/agent-editor-helpers";
@@ -601,17 +603,13 @@ export function AgentEditorPage() {
           data-testid="endpoint-override-banner"
         >
           <div className="font-semibold text-tone-warn">
-            This agent has an <span className="font-mono">endpoint</span> override set
-            through the config API.
+            This agent has an <span className="font-mono">endpoint</span> override set through the
+            config API.
           </div>
           <p className="mt-1 text-xs text-fg-soft">
-            The editor does not expose <span className="font-mono">endpoint</span> editing
-            — programmatic clients (CLI, scripts) installed this override. To inspect
-            or remove it, use{" "}
-            <span className="font-mono">
-              PATCH /v1/config/agents/{spec.id}/overrides
-            </span>{" "}
-            with{" "}
+            The editor does not expose <span className="font-mono">endpoint</span> editing —
+            programmatic clients (CLI, scripts) installed this override. To inspect or remove it,
+            use <span className="font-mono">PATCH /v1/config/agents/{spec.id}/overrides</span> with{" "}
             <span className="font-mono">{`{"_clear": ["endpoint"]}`}</span>.
           </p>
         </div>
@@ -1495,14 +1493,8 @@ function AllowedExcludedToolsSection({
       canonicalStringify([...savedPluginIds].sort()) ||
       canonicalStringify([...draftHookFilter].sort()) !==
         canonicalStringify([...savedHookFilter].sort()) ||
-      !deepEqualCanonical(
-        spec.allowed_tools ?? null,
-        savedSpec?.allowed_tools ?? null,
-      ) ||
-      !deepEqualCanonical(
-        spec.excluded_tools ?? null,
-        savedSpec?.excluded_tools ?? null,
-      ) ||
+      !deepEqualCanonical(spec.allowed_tools ?? null, savedSpec?.allowed_tools ?? null) ||
+      !deepEqualCanonical(spec.excluded_tools ?? null, savedSpec?.excluded_tools ?? null) ||
       !deepEqualCanonical(draftPermissionSection, savedPermissionSection));
   // Fetch the server-computed permission preview when the agent is saved
   // AND the saved spec has the permission plugin enabled.
@@ -1523,9 +1515,9 @@ function AllowedExcludedToolsSection({
             <span className="font-mono">allowed_tools</span> ∖{" "}
             <span className="font-mono">excluded_tools</span> over the published tool set —{" "}
             <em>after</em> allow/exclude lists, <em>before</em> runtime plugin filtering. The
-            permission plugin (and any other plugin running a BeforeInference hook) may still
-            gate or rewrite this list per call, so this is a candidate set, not a strict
-            superset of what the model finally sees.{" "}
+            permission plugin (and any other plugin running a BeforeInference hook) may still gate
+            or rewrite this list per call, so this is a candidate set, not a strict superset of what
+            the model finally sees.{" "}
             {permissionPluginEnabled
               ? "The permission preview below shows the server-computed effective list."
               : null}
@@ -1553,8 +1545,8 @@ function AllowedExcludedToolsSection({
 
       {visible.length === 0 ? (
         <div className="mt-4 rounded-md border border-tone-warn/35 bg-tone-warn/10 px-4 py-3 text-sm text-tone-warn">
-          The allow/exclude lists leave no tools. Combined with any permission policy this means
-          the model will see an empty tool set.
+          The allow/exclude lists leave no tools. Combined with any permission policy this means the
+          model will see an empty tool set.
         </div>
       ) : (
         <details className="mt-4 rounded-md border border-line bg-soft">
@@ -1578,10 +1570,9 @@ function AllowedExcludedToolsSection({
               className="mt-4 rounded-md border border-tone-warn/35 bg-tone-warn/10 px-3 py-2 text-xs text-tone-warn"
               data-testid="permission-preview-dirty-hint"
             >
-              The tools-after-lists count above reflects your unsaved draft; the permission
-              preview below reflects the <em>saved</em> config. Save to align them — preview
-              inputs (plugins, hook filter, allow/exclude lists, permission rules) have unsaved
-              changes.
+              The tools-after-lists count above reflects your unsaved draft; the permission preview
+              below reflects the <em>saved</em> config. Save to align them — preview inputs
+              (plugins, hook filter, allow/exclude lists, permission rules) have unsaved changes.
             </div>
           ) : null}
           <PermissionPreviewBlock
@@ -1655,10 +1646,13 @@ function PermissionPreviewBlock({
           <div className="mt-1 text-fg-soft">
             Default behavior: <span className="font-mono">{preview.default_behavior ?? "—"}</span>
             <span className="mx-2 text-fg-faint">·</span>
-            Effective: <span className="font-mono text-fg-strong">{preview.effective_tools.length}</span>
+            Effective:{" "}
+            <span className="font-mono text-fg-strong">{preview.effective_tools.length}</span>
             <span className="mx-2 text-fg-faint">·</span>
             Unconditionally denied:{" "}
-            <span className="font-mono text-fg-strong">{preview.unconditionally_denied.length}</span>
+            <span className="font-mono text-fg-strong">
+              {preview.unconditionally_denied.length}
+            </span>
             <span className="mx-2 text-fg-faint">·</span>
             Args-conditional rules:{" "}
             <span className="font-mono text-fg-strong">
@@ -1898,10 +1892,9 @@ function ActiveHookFilterSection({
         <div>
           <h4 className="text-base font-semibold text-fg-strong">Active hook filter</h4>
           <p className="mt-2 max-w-xl text-sm text-fg-soft">
-            Restricts runtime hooks to a chosen subset of loaded plugins. Default is "all" —
-            every loaded plugin's hooks run. Switch to "Filter" to allow only the plugins you
-            select below to execute hooks. Plugins not in the filter remain loaded but their
-            hooks are skipped.
+            Restricts runtime hooks to a chosen subset of loaded plugins. Default is "all" — every
+            loaded plugin's hooks run. Switch to "Filter" to allow only the plugins you select below
+            to execute hooks. Plugins not in the filter remain loaded but their hooks are skipped.
           </p>
         </div>
         <fieldset aria-label="Active hook filter mode" className="flex shrink-0 gap-2">
@@ -1995,8 +1988,8 @@ function ActiveHookFilterSection({
                 className="mt-2 text-xs text-fg-soft"
                 data-testid="active-hook-filter-last-entry-hint"
               >
-                Filter mode requires at least one plugin. Switch to{" "}
-                <em>All plugins</em> above to disable filtering entirely.
+                Filter mode requires at least one plugin. Switch to <em>All plugins</em> above to
+                disable filtering entirely.
               </p>
             ) : null}
           </>
@@ -2150,26 +2143,26 @@ function JsonEditorSection({
   isNew: boolean;
   replaceSpec: (next: AgentSpec) => void;
 }) {
-  // The textarea shows a redacted view of the spec (today: just `endpoint`
-  // auth secrets) so a real bearer token / api_key never lands in the
-  // admin DOM. The Apply path validates the user's parsed payload
-  // against the redacted display copy FIRST (to detect any edit to a
-  // locked field even when its value reads `***`), and only AFTER the
-  // compare passes does it overlay the real locked-field values from
-  // the current spec back into the candidate. Doing it in this order
-  // is load-bearing — overlaying first would mask user edits to
-  // `endpoint.base_url` / `endpoint.auth.*` / `registry`. See
-  // `mergeLockedFields` and the inline comment in `handleApply`.
+  // The textarea shows a redacted view of the spec so real credentials
+  // from endpoint auth, plugin/provider `sections.*`, or other
+  // secret-shaped fields never land in the admin DOM. The Apply path
+  // validates the user's parsed payload against this exact redacted
+  // display copy FIRST (to detect edits to locked fields even when their
+  // value reads `***`), then restores unchanged redaction markers before the
+  // candidate reaches validation / draft state. Doing this before
+  // `mergeLockedFields` is load-bearing — overlaying first would mask
+  // user edits to `endpoint.base_url` / `endpoint.auth.*` / `registry`.
+  const editingSpec = useMemo(() => redactAgentSpecForEditing(spec), [spec]);
   const specSerialized = useMemo(
-    () => JSON.stringify(redactAgentSpecForDisplay(spec), null, 2),
-    [spec],
+    () => JSON.stringify(editingSpec.redacted, null, 2),
+    [editingSpec],
   );
   const [draft, setDraft] = useState<string>(() => specSerialized);
   const [error, setError] = useState<string | null>(null);
   const [touched, setTouched] = useState(false);
   const [applying, setApplying] = useState(false);
   const toast = useToast();
-  const hasRedactedEndpoint = Boolean(spec.endpoint);
+  const hasRedactedSecrets = editingSpec.redactions.length > 0;
 
   // Re-sync the textarea when the underlying spec changes from elsewhere
   // (e.g. another tab edits, restore from history) and the user has not yet
@@ -2222,7 +2215,7 @@ function JsonEditorSection({
     const IDENTITY_FIELDS: Array<keyof AgentSpec> = ["id", "created_at", "updated_at"];
     for (const field of IDENTITY_FIELDS) {
       if (!(field in parsedRecord)) continue;
-      if (!deepEqualCanonical(parsedRecord[field], spec[field])) {
+      if (!deepEqualCanonical(parsedRecord[field], editingSpec.redacted[field])) {
         setError(
           `\`${field}\` is a server-managed identity / timestamp field and can't be edited from Raw JSON. Revert it to its current value to apply.`,
         );
@@ -2239,7 +2232,7 @@ function JsonEditorSection({
     // overlay overwrites parsed.endpoint with spec.endpoint, so any
     // post-overlay compare would always read "equal" and silently drop
     // the user's edit.
-    const displaySpec = redactAgentSpecForDisplay(spec);
+    const displaySpec = editingSpec.redacted;
     const lockedField = lockedFieldChange(displaySpec, parsedRecord);
     if (lockedField) {
       setError(
@@ -2247,11 +2240,15 @@ function JsonEditorSection({
       );
       return;
     }
+    const withRestoredRedactions = restoreUnchangedRedactions(
+      parsedRecord,
+      editingSpec.redactions,
+    ) as Record<string, unknown>;
     // Now overlay the real locked-field values onto the parsed payload so
     // the candidate carries the actual `endpoint.auth.bearer_token` (not
-    // the `***` placeholder the textarea showed). Redaction stays purely
+    // the `***` redaction marker the textarea showed). Redaction stays purely
     // a display concern from here on.
-    const withRealLockedFields = mergeLockedFields(parsedRecord, spec);
+    const withRealLockedFields = mergeLockedFields(withRestoredRedactions, spec);
     // Build the would-be-applied payload (identity fields are preserved by
     // replaceSpec) and let the server type-check the rest before we mutate
     // editor state. The same validate endpoint backs the Validate button so
@@ -2270,9 +2267,7 @@ function JsonEditorSection({
       setTouched(false);
       toast.success("JSON applied to draft. Click Save to publish.");
     } catch (err) {
-      setError(
-        `Validation failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      setError(`Validation failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setApplying(false);
     }
@@ -2299,22 +2294,22 @@ function JsonEditorSection({
             className="mt-2 max-w-xl text-xs text-fg-soft"
             data-testid="raw-json-locked-field-help"
           >
-            Locked fields are normalized on Apply. For{" "}
-            <span className="font-mono">endpoint</span> and{" "}
-            <span className="font-mono">registry</span> specifically, an explicit{" "}
-            <span className="font-mono">null</span> is treated the same as absence when the
-            current spec has no value — both mean "no override here". Use the Customization
-            controls above to clear an existing override.
+            Locked fields are normalized on Apply. For <span className="font-mono">endpoint</span>{" "}
+            and <span className="font-mono">registry</span> specifically, an explicit{" "}
+            <span className="font-mono">null</span> is treated the same as absence when the current
+            spec has no value — both mean "no override here". Use the Customization controls above
+            to clear an existing override.
           </p>
-          {hasRedactedEndpoint ? (
+          {hasRedactedSecrets ? (
             <p
               className="mt-2 max-w-xl text-xs text-fg-soft"
               data-testid="raw-json-redaction-notice"
             >
-              <span className="font-mono">endpoint</span> credential fields are masked as
+              Credential-like fields are masked as
               <span className="mx-1 font-mono">***</span>
-              in this view. Apply restores the real values automatically;{" "}
-              <span className="font-mono">endpoint</span> remains read-only from this editor.
+              in this view. Apply restores unchanged redaction markers automatically;{" "}
+              <span className="font-mono">endpoint</span> and{" "}
+              <span className="font-mono">registry</span> remain read-only from this editor.
             </p>
           ) : null}
         </div>
@@ -2453,9 +2448,7 @@ function ContextPolicySection({
               type="number"
               min={0}
               value={policy.min_recent_messages}
-              onChange={(event) =>
-                update("min_recent_messages", Number(event.target.value) || 0)
-              }
+              onChange={(event) => update("min_recent_messages", Number(event.target.value) || 0)}
               className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
             />
           </Field>
@@ -2629,9 +2622,7 @@ function HistoryPanel({
     const redactedCurrent = redactSecretsForDisplay(redactAgentSpecForDisplay(spec));
     const redactedTarget =
       targetSpec && typeof targetSpec === "object"
-        ? redactSecretsForDisplay(
-            redactAgentSpecForDisplay(targetSpec as unknown as AgentSpec),
-          )
+        ? redactSecretsForDisplay(redactAgentSpecForDisplay(targetSpec as unknown as AgentSpec))
         : null;
     const confirmed = await confirm({
       title: "Restore agent to this version?",

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -54,11 +54,13 @@ import {
   redactAgentSpecForEditing,
   redactAgentSpecForDisplay,
   redactEndpointForDisplay,
+  redactSecretString,
   redactSecretsForDisplay,
   restoreUnchangedRedactions,
   togglePluginState,
   unknownAgentSpecFields,
 } from "@/lib/agent-editor-helpers";
+import { safeErrorMessage } from "@/lib/safe-error-message";
 
 const EMPTY_AGENT: AgentSpec = {
   id: "",
@@ -124,18 +126,9 @@ export function AgentEditorPage() {
   });
   const capabilities = capabilitiesQuery.data ?? null;
   const loading = capabilitiesQuery.isPending || (!isNew && agentQuery.isPending);
-  const agentError =
-    !isNew && agentQuery.error
-      ? agentQuery.error instanceof Error
-        ? agentQuery.error.message
-        : String(agentQuery.error)
-      : null;
+  const agentError = !isNew && agentQuery.error ? safeErrorMessage(agentQuery.error) : null;
   const agentMetaError =
-    !isNew && agentMetaQuery.error
-      ? agentMetaQuery.error instanceof Error
-        ? agentMetaQuery.error.message
-        : String(agentMetaQuery.error)
-      : null;
+    !isNew && agentMetaQuery.error ? safeErrorMessage(agentMetaQuery.error) : null;
   const saveDisabled = saving || Boolean(agentMetaError || (!isNew && agentMetaQuery.isPending));
   const initializedAgentIdRef = useRef<string | null>(null);
 
@@ -159,19 +152,13 @@ export function AgentEditorPage() {
 
   useEffect(() => {
     if (capabilitiesQuery.error) {
-      toast.error(
-        capabilitiesQuery.error instanceof Error
-          ? capabilitiesQuery.error.message
-          : String(capabilitiesQuery.error),
-      );
+      toast.error(safeErrorMessage(capabilitiesQuery.error));
     }
   }, [capabilitiesQuery.error, toast]);
 
   useEffect(() => {
     if (agentQuery.error) {
-      toast.error(
-        agentQuery.error instanceof Error ? agentQuery.error.message : String(agentQuery.error),
-      );
+      toast.error(safeErrorMessage(agentQuery.error));
     }
   }, [agentQuery.error, toast]);
 
@@ -310,7 +297,7 @@ export function AgentEditorPage() {
         setHistoryRefreshKey((k) => k + 1);
       }
     } catch (saveError) {
-      toast.error(saveError instanceof Error ? saveError.message : String(saveError));
+      toast.error(safeErrorMessage(saveError));
       // Customized PATCH is now transactional (server applies upserts +
       // `_clear` together under one `apply_locked` guard), so on failure
       // the server itself is in a consistent state. The refetch here
@@ -338,9 +325,7 @@ export function AgentEditorPage() {
           // failure as a secondary toast so the user knows the UI may
           // also be stale.
           toast.error(
-            `Could not refresh agent state after save error: ${
-              refetchError instanceof Error ? refetchError.message : String(refetchError)
-            }`,
+            `Could not refresh agent state after save error: ${safeErrorMessage(refetchError)}`,
           );
         }
       }
@@ -375,7 +360,7 @@ export function AgentEditorPage() {
       invalidateConfigMutation(queryClient, "agents", id);
       toast.success(`Agent "${id}" overrides cleared`);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
+      toast.error(safeErrorMessage(err));
     }
   }
 
@@ -398,7 +383,7 @@ export function AgentEditorPage() {
       toast.success(t("agents.resetOverrideFieldDone", { field }));
       setHistoryRefreshKey((k) => k + 1);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
+      toast.error(safeErrorMessage(err));
     }
   }
 
@@ -436,7 +421,7 @@ export function AgentEditorPage() {
       setErrors({});
       toast.success(`Cloned from "${sourceId}" — pick a new agent id and Save.`);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
+      toast.error(safeErrorMessage(err));
     }
   }
 
@@ -698,7 +683,7 @@ export function AgentEditorPage() {
           ))}
         </div>
 
-        <AgentPreviewPanel draft={spec} />
+        <AgentPreviewPanel draft={spec} traceAgentId={isNew ? undefined : savedSpec?.id} />
       </div>
 
       <EditorSaveBar
@@ -744,7 +729,7 @@ function EditorSaveBar({
       await configApi.validateConfig("agents", spec, isNew ? undefined : { id: spec.id });
       toast.success("Validation passed — payload is safe to publish.");
     } catch (err) {
-      toast.error(`Validation failed: ${err instanceof Error ? err.message : String(err)}`);
+      toast.error(`Validation failed: ${safeErrorMessage(err)}`);
     } finally {
       setValidating(false);
     }
@@ -897,7 +882,7 @@ function formatDiffValue(value: unknown, redactedValueChanged = false): string {
   const suffix = redactedValueChanged ? " (changed)" : "";
   if (value === undefined) return `(unset)${suffix}`;
   if (value === null) return `null${suffix}`;
-  if (typeof value === "string") return `${value || "(empty string)"}${suffix}`;
+  if (typeof value === "string") return `${redactSecretString(value) || "(empty string)"}${suffix}`;
   // Defense-in-depth: the caller is expected to have already redacted, but
   // a future code path that forgets shouldn't end up dumping secrets here.
   const rendered = JSON.stringify(redactSecretsForDisplay(value), null, 2);
@@ -1133,6 +1118,14 @@ function BasicsPanel({
   const cloneOptions = isNew
     ? (capabilities?.agents ?? []).filter((agentId) => agentId !== spec.id)
     : [];
+
+  function parseIntegerInput(value: string, min: number): number | undefined {
+    if (value.trim() === "") return undefined;
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < min) return undefined;
+    return Math.floor(parsed);
+  }
+
   return (
     <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
       <h3 className="text-lg font-semibold text-fg-strong">Basics</h3>
@@ -1201,7 +1194,10 @@ function BasicsPanel({
             type="number"
             min={1}
             value={Number(spec.max_rounds ?? 16)}
-            onChange={(event) => updateField("max_rounds", Number(event.target.value) || 16)}
+            onChange={(event) => {
+              const next = parseIntegerInput(event.target.value, 1);
+              if (next !== undefined) updateField("max_rounds", next);
+            }}
             className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
           />
         </Field>
@@ -1210,9 +1206,10 @@ function BasicsPanel({
             type="number"
             min={0}
             value={Number(spec.max_continuation_retries ?? 2)}
-            onChange={(event) =>
-              updateField("max_continuation_retries", Number(event.target.value) || 0)
-            }
+            onChange={(event) => {
+              const next = parseIntegerInput(event.target.value, 0);
+              if (next !== undefined) updateField("max_continuation_retries", next);
+            }}
             className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
           />
         </Field>
@@ -1621,7 +1618,7 @@ function PermissionPreviewBlock({
   if (error) {
     return (
       <div className="mt-4 rounded-md border border-tone-error/30 bg-tone-error/10 px-3 py-2 text-xs text-tone-error">
-        Failed to load permission preview: {error instanceof Error ? error.message : String(error)}
+        Failed to load permission preview: {safeErrorMessage(error)}
       </div>
     );
   }
@@ -2173,7 +2170,7 @@ function JsonEditorSection({
     try {
       parsed = JSON.parse(draft);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(safeErrorMessage(err));
       return;
     }
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -2246,7 +2243,7 @@ function JsonEditorSection({
       setTouched(false);
       toast.success("JSON applied to draft. Click Save to publish.");
     } catch (err) {
-      setError(`Validation failed: ${err instanceof Error ? err.message : String(err)}`);
+      setError(`Validation failed: ${safeErrorMessage(err)}`);
     } finally {
       setApplying(false);
     }
@@ -2575,11 +2572,7 @@ function HistoryPanel({
   );
   const page = historyQuery.data?.pages[0] ?? null;
   const loading = historyQuery.isFetching;
-  const error = historyQuery.error
-    ? historyQuery.error instanceof Error
-      ? historyQuery.error.message
-      : String(historyQuery.error)
-    : null;
+  const error = historyQuery.error ? safeErrorMessage(historyQuery.error) : null;
   const refetchHistory = historyQuery.refetch;
 
   useEffect(() => {
@@ -2652,7 +2645,7 @@ function HistoryPanel({
       onSpecRestored(hydrated);
       void refetchHistory();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
+      toast.error(safeErrorMessage(err));
     } finally {
       setRestoring(null);
     }

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -42,6 +42,7 @@ import { useAuditLogInfiniteQuery } from "@/lib/query/hooks/audit";
 import { qk } from "@/lib/query/keys";
 import { invalidateConfigMutation } from "@/lib/query/invalidation";
 import {
+  canonicalStringify,
   cloneAgentSpecForEditor,
   deepEqualCanonical,
   diffPatchableAgentFields,
@@ -50,6 +51,7 @@ import {
   partitionActiveHookFilter,
   redactAgentSpecForDisplay,
   redactEndpointForDisplay,
+  redactSecretsForDisplay,
   togglePluginState,
   unknownAgentSpecFields,
 } from "@/lib/agent-editor-helpers";
@@ -224,6 +226,13 @@ export function AgentEditorPage() {
       return;
     }
     setSaving(true);
+    // Track whether the in-flight save is a multi-request customized
+    // override flow (PATCH + N×DELETE). If it is and any step throws,
+    // the server may already hold a partially-applied state and the UI
+    // would otherwise sit on a stale draft that disagrees with the
+    // server. The catch block refetches the agent record in this case
+    // so the user sees the actual post-failure state.
+    let customizedSaveInFlight = false;
     try {
       const payload = {
         ...spec,
@@ -240,14 +249,27 @@ export function AgentEditorPage() {
         toast.success(`Agent "${created.id}" created`);
         navigate(adminRoutes.agent(created.id), { replace: true });
       } else if (sourceState === "builtin" || sourceState === "customized") {
+        customizedSaveInFlight = true;
         // For Builtin/Customized records, use PATCH /overrides to preserve
         // upgrade tracking. Only patchable fields are included.
-        const patch = diffPatchableAgentFields(spec, originalSpec ?? spec);
-        if (Object.keys(patch).length === 0) {
+        const plan = diffPatchableAgentFields(spec, originalSpec ?? spec);
+        const hasUpserts = Object.keys(plan.patch).length > 0;
+        const hasClears = plan.clear.length > 0;
+        if (!hasUpserts && !hasClears) {
           // Nothing patchable changed; nothing to send.
           toast.success(`Agent "${spec.id}" saved (no patchable changes)`);
         } else {
-          await configApi.patchAgentOverrides(spec.id, patch);
+          // R11 #3 — Combine upserts + clears into a single transactional
+          // PATCH. The server applies both inside one `apply_locked`
+          // guard and emits a single audit event; a failure leaves the
+          // record untouched. Previously the client issued one PATCH
+          // followed by N DELETE calls, which could leave the agent in
+          // a partial state if any DELETE failed.
+          const body: Record<string, unknown> = { ...plan.patch };
+          if (hasClears) {
+            body._clear = plan.clear.map((field) => String(field));
+          }
+          await configApi.patchAgentOverrides(spec.id, body);
           // Refresh spec and meta so the badge updates correctly.
           const [nextSpec, nextMeta] = await Promise.all([
             configApi.get<AgentSpec>("agents", spec.id),
@@ -280,6 +302,37 @@ export function AgentEditorPage() {
       }
     } catch (saveError) {
       toast.error(saveError instanceof Error ? saveError.message : String(saveError));
+      // R8 #5 — Non-atomic customized save: a PATCH may have succeeded
+      // before a subsequent DELETE failed (or vice versa), leaving the
+      // server holding a partial result. Refetch so the UI matches the
+      // actual post-failure state — without this, draft sits where the
+      // user left it and silently disagrees with the persisted record.
+      if (customizedSaveInFlight && !isNew && id) {
+        try {
+          const [nextSpec, nextMeta] = await Promise.all([
+            configApi.get<AgentSpec>("agents", id),
+            getOptionalAgentMeta(id),
+          ]);
+          const hydrated = hydrateAgentSpec(nextSpec);
+          setSpec(hydrated);
+          setSavedSpec(hydrated);
+          setOriginalSpec(hydrated);
+          setAgentMeta(nextMeta);
+          queryClient.setQueryData(qk.config.get("agents", id), hydrated);
+          queryClient.setQueryData(qk.config.meta("agents", id), nextMeta);
+          invalidateConfigMutation(queryClient, "agents", id);
+        } catch (refetchError) {
+          // Refetch itself failed (e.g. network down). The original
+          // saveError is the actionable one; surface the refetch
+          // failure as a secondary toast so the user knows the UI may
+          // also be stale.
+          toast.error(
+            `Could not refresh agent state after save error: ${
+              refetchError instanceof Error ? refetchError.message : String(refetchError)
+            }`,
+          );
+        }
+      }
     } finally {
       setSaving(false);
     }
@@ -558,6 +611,7 @@ export function AgentEditorPage() {
                   capabilities={capabilities}
                   updateField={updateField}
                   agentSaved={!isNew && savedSpec !== null}
+                  savedSpec={savedSpec}
                 />
               )}
               {tab.id === "plugins" && (
@@ -718,10 +772,18 @@ function DiffModal({
   previous: AgentSpec;
   onClose: () => void;
 }) {
-  const changes = computeDiff(
+  // Both specs may carry `endpoint.auth.bearer_token` or similar secrets.
+  // Diff against the REDACTED projection so the modal DOM never holds a
+  // real credential — order-of-display matters because each `change.before`
+  // / `change.after` is rendered through `formatDiffValue` below, and that
+  // path stringifies whatever it's handed.
+  const redactedPrevious = redactSecretsForDisplay(
     previous as unknown as Record<string, unknown>,
+  );
+  const redactedCurrent = redactSecretsForDisplay(
     current as unknown as Record<string, unknown>,
   );
+  const changes = computeDiff(redactedPrevious, redactedCurrent);
   return (
     <div
       role="dialog"
@@ -805,7 +867,10 @@ function computeDiff(
     const path = base ? `${base}.${key}` : key;
     const a = prev?.[key];
     const b = curr?.[key];
-    if (deepEqual(a, b)) continue;
+    // Use canonical deep-equal so object key-order changes don't surface
+    // as spurious diffs — mirrors what the save-path diff and locked-field
+    // compare both do.
+    if (deepEqualCanonical(a, b)) continue;
     if (
       a !== null &&
       b !== null &&
@@ -822,19 +887,13 @@ function computeDiff(
   return out;
 }
 
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return a === b;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== "object") return false;
-  return JSON.stringify(a) === JSON.stringify(b);
-}
-
 function formatDiffValue(value: unknown): string {
   if (value === undefined) return "(unset)";
   if (value === null) return "null";
   if (typeof value === "string") return value || "(empty string)";
-  return JSON.stringify(value, null, 2);
+  // Defense-in-depth: the caller is expected to have already redacted, but
+  // a future code path that forgets shouldn't end up dumping secrets here.
+  return JSON.stringify(redactSecretsForDisplay(value), null, 2);
 }
 
 function EditorSourceBadge({ state }: { state: ConfigSourceState }) {
@@ -1302,11 +1361,13 @@ function ToolsPanel({
   capabilities,
   updateField,
   agentSaved,
+  savedSpec,
 }: {
   spec: AgentSpec;
   capabilities: Capabilities | null;
   updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
   agentSaved: boolean;
+  savedSpec: AgentSpec | null;
 }) {
   if (!capabilities || capabilities.tools.length === 0) {
     return (
@@ -1338,6 +1399,7 @@ function ToolsPanel({
         spec={spec}
         capabilities={capabilities}
         agentSaved={agentSaved}
+        savedSpec={savedSpec}
       />
     </div>
   );
@@ -1366,12 +1428,17 @@ function AllowedExcludedToolsSection({
   spec,
   capabilities,
   agentSaved,
+  savedSpec,
 }: {
   spec: AgentSpec;
   capabilities: Capabilities;
   /** `true` once the agent exists server-side; the preview endpoint reads
    *  the stored record so it would 404 for an in-flight new draft. */
   agentSaved: boolean;
+  /** The last-saved spec from `useConfigRecordQuery`. The preview gate
+   *  reads this rather than the working draft so the UI never claims a
+   *  preview is available based on an unsaved plugin toggle. */
+  savedSpec: AgentSpec | null;
 }) {
   const visible = useMemo(
     () => computeAllowedTools(capabilities.tools, spec.allowed_tools, spec.excluded_tools),
@@ -1382,13 +1449,55 @@ function AllowedExcludedToolsSection({
   const allowedMode =
     spec.allowed_tools === null || spec.allowed_tools === undefined ? "all" : "custom";
   const allowedSize = spec.allowed_tools?.length ?? total;
-  const permissionPluginEnabled = (spec.plugin_ids ?? []).includes("permission");
+  // Gate on the SAVED spec — not the draft. The preview endpoint reads the
+  // persisted record, so showing/hiding the block based on a dirty draft
+  // would silently lie to the user: "you toggled permission on in the
+  // draft, here's the preview" (but it's actually computed against the
+  // saved version that doesn't have the plugin). Conversely, disabling
+  // the plugin in the draft would hide the preview even though the saved
+  // agent is still permission-gated at runtime.
+  //
+  // "Enabled" also requires `active_hook_filter` to admit permission
+  // hooks. Mirrors the server's runtime: an empty filter runs all hooks;
+  // a non-empty filter only runs the listed plugins' hooks. So a saved
+  // agent with `plugin_ids: ["permission"]` but
+  // `active_hook_filter: ["observability"]` would not run permission
+  // hooks at runtime, and the preview must not claim to show the
+  // post-filter tool set.
+  const savedPluginIds = savedSpec?.plugin_ids ?? [];
+  const savedHookFilter = savedSpec?.active_hook_filter ?? [];
+  const permissionLoaded = savedPluginIds.includes("permission");
+  const permissionHooksActive =
+    savedHookFilter.length === 0 || savedHookFilter.includes("permission");
+  const permissionPluginEnabled = permissionLoaded && permissionHooksActive;
+  // Surface a stale-preview hint when ANY of the fields the preview is
+  // computed from differs between draft and saved. Plugin id toggles,
+  // hook-filter changes, allowed/excluded tool list edits, and edits to
+  // the `permission` section all change what the server-side preview
+  // would return — but the preview query reads only the saved record,
+  // so without this hint the top section (computed from draft) and the
+  // preview block (computed from saved) silently disagree.
+  const draftPluginIds = spec.plugin_ids ?? [];
+  const draftHookFilter = spec.active_hook_filter ?? [];
+  const draftPermissionSection = (spec.sections ?? {})["permission"];
+  const savedPermissionSection = (savedSpec?.sections ?? {})["permission"];
+  const previewInputsDirty =
+    agentSaved &&
+    (canonicalStringify([...draftPluginIds].sort()) !==
+      canonicalStringify([...savedPluginIds].sort()) ||
+      canonicalStringify([...draftHookFilter].sort()) !==
+        canonicalStringify([...savedHookFilter].sort()) ||
+      !deepEqualCanonical(
+        spec.allowed_tools ?? null,
+        savedSpec?.allowed_tools ?? null,
+      ) ||
+      !deepEqualCanonical(
+        spec.excluded_tools ?? null,
+        savedSpec?.excluded_tools ?? null,
+      ) ||
+      !deepEqualCanonical(draftPermissionSection, savedPermissionSection));
   // Fetch the server-computed permission preview when the agent is saved
-  // AND the permission plugin is enabled. The endpoint reads the persisted
-  // record, so we tie the query to spec.id rather than spec content — the
-  // user sees the *saved* effective tools (not pending unsaved edits to
-  // the permission section). The query auto-refetches when the saved spec
-  // changes via queryClient invalidation in the Save path.
+  // AND the saved spec has the permission plugin enabled.
   const previewQuery = useQuery({
     queryKey: qk.agent.permissionPreview(spec.id),
     queryFn: () => configApi.agentPermissionPreview(spec.id),
@@ -1455,12 +1564,25 @@ function AllowedExcludedToolsSection({
       )}
 
       {permissionPluginEnabled ? (
-        <PermissionPreviewBlock
-          agentSaved={agentSaved}
-          loading={previewQuery.isPending && previewQuery.fetchStatus === "fetching"}
-          error={previewQuery.error}
-          preview={previewQuery.data}
-        />
+        <>
+          {previewInputsDirty ? (
+            <div
+              className="mt-4 rounded-md border border-tone-warn/35 bg-tone-warn/10 px-3 py-2 text-xs text-tone-warn"
+              data-testid="permission-preview-dirty-hint"
+            >
+              The tools-after-lists count above reflects your unsaved draft; the permission
+              preview below reflects the <em>saved</em> config. Save to align them — preview
+              inputs (plugins, hook filter, allow/exclude lists, permission rules) have unsaved
+              changes.
+            </div>
+          ) : null}
+          <PermissionPreviewBlock
+            agentSaved={agentSaved}
+            loading={previewQuery.isPending && previewQuery.fetchStatus === "fetching"}
+            error={previewQuery.error}
+            preview={previewQuery.data}
+          />
+        </>
       ) : null}
     </section>
   );
@@ -1737,11 +1859,24 @@ function ActiveHookFilterSection({
   }
 
   function toggle(pluginId: string, checked: boolean) {
+    // R12 #4 — Refuse to uncheck the last entry in Filter mode. The
+    // runtime treats `active_hook_filter == []` the same as absent
+    // ("all hooks run") via `is_empty() || contains(id)` in
+    // `phase/engine.rs`, so silently mapping `[]` back to undefined
+    // would flip the UI radio from Filter → All without the user
+    // touching it — a semantic reversal disguised as a single
+    // checkbox click. Force the user to click "All plugins"
+    // explicitly if that's what they want.
+    if (!checked && value.length === 1 && value[0] === pluginId) {
+      return;
+    }
     const next = checked
       ? Array.from(new Set([...value, pluginId]))
       : value.filter((id) => id !== pluginId);
     onChange(next);
   }
+
+  const isLastSelection = value.length === 1;
 
   function clearStaleEntries() {
     if (stale.length === 0) return;
@@ -1819,24 +1954,44 @@ function ActiveHookFilterSection({
             No plugins are enabled. Enable plugins above before filtering hooks.
           </div>
         ) : (
-          <div className="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-            {pluginIds.map((pluginId) => {
-              const checked = valueSet.has(pluginId);
-              return (
-                <label
-                  key={pluginId}
-                  className="flex items-center gap-2 rounded-xl border border-line bg-soft px-3 py-2 text-sm text-fg"
-                >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={(event) => toggle(pluginId, event.target.checked)}
-                  />
-                  <span className="font-mono text-xs text-fg-strong">{pluginId}</span>
-                </label>
-              );
-            })}
-          </div>
+          <>
+            <div className="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+              {pluginIds.map((pluginId) => {
+                const checked = valueSet.has(pluginId);
+                // The last remaining filter entry is locked — switch
+                // to "All plugins" to disable filtering instead.
+                const isLastChecked = checked && isLastSelection;
+                return (
+                  <label
+                    key={pluginId}
+                    className="flex items-center gap-2 rounded-xl border border-line bg-soft px-3 py-2 text-sm text-fg"
+                    title={
+                      isLastChecked
+                        ? "Filter mode requires at least one plugin — switch to All plugins to disable filtering."
+                        : undefined
+                    }
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={isLastChecked}
+                      onChange={(event) => toggle(pluginId, event.target.checked)}
+                    />
+                    <span className="font-mono text-xs text-fg-strong">{pluginId}</span>
+                  </label>
+                );
+              })}
+            </div>
+            {isLastSelection ? (
+              <p
+                className="mt-2 text-xs text-fg-soft"
+                data-testid="active-hook-filter-last-entry-hint"
+              >
+                Filter mode requires at least one plugin. Switch to{" "}
+                <em>All plugins</em> above to disable filtering entirely.
+              </p>
+            ) : null}
+          </>
         )
       ) : null}
 
@@ -1989,9 +2144,14 @@ function JsonEditorSection({
 }) {
   // The textarea shows a redacted view of the spec (today: just `endpoint`
   // auth secrets) so a real bearer token / api_key never lands in the
-  // admin DOM. The Apply path overlays the real locked fields from the
-  // current spec before checking / persisting, so redaction is purely a
-  // display concern.
+  // admin DOM. The Apply path validates the user's parsed payload
+  // against the redacted display copy FIRST (to detect any edit to a
+  // locked field even when its value reads `***`), and only AFTER the
+  // compare passes does it overlay the real locked-field values from
+  // the current spec back into the candidate. Doing it in this order
+  // is load-bearing — overlaying first would mask user edits to
+  // `endpoint.base_url` / `endpoint.auth.*` / `registry`. See
+  // `mergeLockedFields` and the inline comment in `handleApply`.
   const specSerialized = useMemo(
     () => JSON.stringify(redactAgentSpecForDisplay(spec), null, 2),
     [spec],
@@ -2031,30 +2191,59 @@ function JsonEditorSection({
     // changes)" while the page still looks dirty).
     const unknown = unknownAgentSpecFields(parsedRecord);
     if (unknown.length > 0) {
+      // The allowlist is a front-end-maintained mirror of
+      // `PATCHABLE_AGENT_FIELDS + identity/locked fields`. If the user pastes
+      // a schema field that the backend understands but this admin console
+      // version doesn't know about, the diff/PATCH path can't persist it
+      // and Save would silently drop it. Surface that distinction in the
+      // error: this is a *version* mismatch, not a malformed spec.
       setError(
-        `Unknown top-level field${unknown.length === 1 ? "" : "s"}: ${unknown
-          .map((k) => `\`${k}\``)
-          .join(", ")}. The editor cannot persist these — remove them or update the schema.`,
+        `This admin console version does not recognize ${
+          unknown.length === 1 ? "field" : "fields"
+        }: ${unknown.map((k) => `\`${k}\``).join(", ")}. Either upgrade the console, ` +
+          `or remove the field from this draft.`,
       );
       return;
     }
-    // Overlay the real locked fields onto the parsed payload before any
-    // further check. The textarea showed `***` for redacted endpoint
-    // auth; without this overlay, `lockedFieldChange` would always flag
-    // endpoint as "changed" the moment an endpoint is present and Apply
-    // would be impossible.
-    const withRealLockedFields = mergeLockedFields(parsedRecord, spec);
+    // R12 #5 — Identity / timestamp fields are server-managed; the
+    // candidate constructed below overwrites them from `spec`
+    // unconditionally. If we let an edit slip through, Apply would
+    // claim success while silently discarding the user's change.
+    // Compare canonically so re-indenting / key-order tweaks aren't
+    // mistaken for an edit.
+    const IDENTITY_FIELDS: Array<keyof AgentSpec> = ["id", "created_at", "updated_at"];
+    for (const field of IDENTITY_FIELDS) {
+      if (!(field in parsedRecord)) continue;
+      if (!deepEqualCanonical(parsedRecord[field], spec[field])) {
+        setError(
+          `\`${field}\` is a server-managed identity / timestamp field and can't be edited from Raw JSON. Revert it to its current value to apply.`,
+        );
+        return;
+      }
+    }
     // `endpoint` and `registry` are provenance / runtime-locality fields
-    // not user-editable through the editor. Even though redaction is now
-    // overlaid, a user could still try to change a non-secret subfield
-    // (`base_url`, `backend`, `target`, …); lockedFieldChange catches that.
-    const lockedField = lockedFieldChange(spec, withRealLockedFields);
+    // not user-editable through the editor. Compare the PARSED payload
+    // against the redacted spec the textarea was seeded from — equality
+    // means the user didn't touch the locked fields (any `***` stayed
+    // `***`). If anything differs (a real bearer-token edit, a
+    // `base_url` swap, a `registry` flip, etc.) we reject the Apply
+    // entirely. Doing this BEFORE `mergeLockedFields` is mandatory: the
+    // overlay overwrites parsed.endpoint with spec.endpoint, so any
+    // post-overlay compare would always read "equal" and silently drop
+    // the user's edit.
+    const displaySpec = redactAgentSpecForDisplay(spec);
+    const lockedField = lockedFieldChange(displaySpec, parsedRecord);
     if (lockedField) {
       setError(
         `\`${lockedField}\` can't be changed from the editor — it's a provenance / runtime-locality field. Revert the key to its current value to apply.`,
       );
       return;
     }
+    // Now overlay the real locked-field values onto the parsed payload so
+    // the candidate carries the actual `endpoint.auth.bearer_token` (not
+    // the `***` placeholder the textarea showed). Redaction stays purely
+    // a display concern from here on.
+    const withRealLockedFields = mergeLockedFields(parsedRecord, spec);
     // Build the would-be-applied payload (identity fields are preserved by
     // replaceSpec) and let the server type-check the rest before we mutate
     // editor state. The same validate endpoint backs the Validate button so
@@ -2179,6 +2368,19 @@ function ContextPolicySection({
     onChange({ ...policy, [key]: next });
   }
 
+  /** Parse a token-count input. Ignores blank / non-numeric / < `min`
+   *  values: a half-typed clear-and-retype flow would otherwise flash the
+   *  draft to `Number("") || 0 === 0`, which collides with the `min={1}`
+   *  on `max_context_tokens` / `max_output_tokens` and locks Save behind
+   *  a "validation failed" toast that the user didn't actually trigger.
+   *  Returning `undefined` here keeps the previous value displayed until
+   *  the user types something valid. */
+  function parseTokenInput(value: string, min: number): number | undefined {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < min) return undefined;
+    return parsed;
+  }
+
   return (
     <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -2208,9 +2410,10 @@ function ContextPolicySection({
               type="number"
               min={1}
               value={policy.max_context_tokens}
-              onChange={(event) =>
-                update("max_context_tokens", Number(event.target.value) || 0)
-              }
+              onChange={(event) => {
+                const next = parseTokenInput(event.target.value, 1);
+                if (next !== undefined) update("max_context_tokens", next);
+              }}
               className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
             />
           </Field>
@@ -2219,7 +2422,10 @@ function ContextPolicySection({
               type="number"
               min={1}
               value={policy.max_output_tokens}
-              onChange={(event) => update("max_output_tokens", Number(event.target.value) || 0)}
+              onChange={(event) => {
+                const next = parseTokenInput(event.target.value, 1);
+                if (next !== undefined) update("max_output_tokens", next);
+              }}
               className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
             />
           </Field>
@@ -2388,14 +2594,25 @@ function HistoryPanel({
 
   async function handleRestore(event: AuditEvent) {
     const targetSpec = event.action === "delete" ? event.before : event.after;
-    // Mask secret-bearing keys (today: endpoint auth fields) before they
-    // land in the confirm-dialog DOM. The real values survive in the
-    // editor's spec state and are still what gets POSTed back to the
-    // restore endpoint; redaction is purely a display concern.
-    const redactedCurrent = redactAgentSpecForDisplay(spec);
+    // R12 #2 — Two-layer redaction before the confirm-dialog DOM:
+    //   1. `redactAgentSpecForDisplay` applies default-deny on
+    //      `endpoint.auth` (every key except `type`).
+    //   2. `redactSecretsForDisplay` then walks the whole tree and
+    //      masks pattern-matched secret keys anywhere — `sections.*`
+    //      is a free-form `Record<string, unknown>` and can carry
+    //      plugin / provider credentials (`api_key`, `bearer_token`,
+    //      `cookie`, `jwt`, etc.). Without the second pass, a restore
+    //      preview of an agent whose `sections.observability.api_key`
+    //      contained a live key would render that key into the DOM.
+    // The real values survive in the editor's spec state and are still
+    // what gets POSTed back to the restore endpoint; redaction is
+    // purely a display concern.
+    const redactedCurrent = redactSecretsForDisplay(redactAgentSpecForDisplay(spec));
     const redactedTarget =
       targetSpec && typeof targetSpec === "object"
-        ? redactAgentSpecForDisplay(targetSpec as unknown as AgentSpec)
+        ? redactSecretsForDisplay(
+            redactAgentSpecForDisplay(targetSpec as unknown as AgentSpec),
+          )
         : null;
     const confirmed = await confirm({
       title: "Restore agent to this version?",
@@ -2608,13 +2825,17 @@ function HistoryEventPanel({ event, onClose }: { event: AuditEvent; onClose: () 
           <div>
             <p className="mb-2 text-xs font-medium uppercase tracking-wide text-fg-soft">Before</p>
             <pre className="overflow-auto rounded-xl border border-line bg-soft p-3 text-xs leading-relaxed text-fg">
-              {event.before != null ? JSON.stringify(event.before, null, 2) : "—"}
+              {event.before != null
+                ? JSON.stringify(redactSecretsForDisplay(event.before), null, 2)
+                : "—"}
             </pre>
           </div>
           <div>
             <p className="mb-2 text-xs font-medium uppercase tracking-wide text-fg-soft">After</p>
             <pre className="overflow-auto rounded-xl border border-line bg-soft p-3 text-xs leading-relaxed text-fg">
-              {event.after != null ? JSON.stringify(event.after, null, 2) : "—"}
+              {event.after != null
+                ? JSON.stringify(redactSecretsForDisplay(event.after), null, 2)
+                : "—"}
             </pre>
           </div>
         </div>

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -226,12 +226,17 @@ export function AgentEditorPage() {
       return;
     }
     setSaving(true);
-    // Track whether the in-flight save is a multi-request customized
-    // override flow (PATCH + N×DELETE). If it is and any step throws,
-    // the server may already hold a partially-applied state and the UI
-    // would otherwise sit on a stale draft that disagrees with the
-    // server. The catch block refetches the agent record in this case
-    // so the user sees the actual post-failure state.
+    // Track whether the in-flight save targets a builtin / customized
+    // record via `PATCH /overrides`. On failure the catch block
+    // refetches the agent so the editor's draft matches what the server
+    // actually holds. The PATCH itself is transactional (a single body
+    // carries upserts plus `_clear`; the server applies both under one
+    // `apply_locked` guard and rolls back on any sub-step error), so a
+    // partial-write scenario doesn't happen here — but the refetch is
+    // still worth doing because the error may come from validation,
+    // optimistic-concurrency failure, or stale client state, any of
+    // which leave the user looking at a draft that doesn't match the
+    // server's view.
     let customizedSaveInFlight = false;
     try {
       const payload = {
@@ -302,11 +307,13 @@ export function AgentEditorPage() {
       }
     } catch (saveError) {
       toast.error(saveError instanceof Error ? saveError.message : String(saveError));
-      // R8 #5 — Non-atomic customized save: a PATCH may have succeeded
-      // before a subsequent DELETE failed (or vice versa), leaving the
-      // server holding a partial result. Refetch so the UI matches the
-      // actual post-failure state — without this, draft sits where the
-      // user left it and silently disagrees with the persisted record.
+      // Customized PATCH is now transactional (server applies upserts +
+      // `_clear` together under one `apply_locked` guard), so on failure
+      // the server itself is in a consistent state. The refetch here
+      // exists to re-sync the EDITOR's view: the error may come from
+      // optimistic-concurrency rejection, validation, or stale
+      // `originalSpec`, all of which leave the local draft diverged
+      // from the server's actual current state.
       if (customizedSaveInFlight && !isNew && id) {
         try {
           const [nextSpec, nextMeta] = await Promise.all([

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -587,6 +587,35 @@ export function AgentEditorPage() {
         </div>
       )}
 
+      {overriddenFields.has("endpoint") && (
+        // The admin-console editor treats `endpoint` as a locked field
+        // and intentionally does NOT expose UI for editing it. The
+        // server-side config API still accepts `endpoint` patches (see
+        // `AgentSpecPatch::endpoint`), so a CLI or scripted client can
+        // install an override that bypasses this editor. Surface that
+        // existence to operators so the editor doesn't silently lie
+        // about the agent's effective shape.
+        <div
+          className="mx-6 mt-4 rounded-md border border-tone-warn/40 bg-tone-warn/10 px-4 py-3 text-sm text-fg md:mx-8"
+          data-testid="endpoint-override-banner"
+        >
+          <div className="font-semibold text-tone-warn">
+            This agent has an <span className="font-mono">endpoint</span> override set
+            through the config API.
+          </div>
+          <p className="mt-1 text-xs text-fg-soft">
+            The editor does not expose <span className="font-mono">endpoint</span> editing
+            — programmatic clients (CLI, scripts) installed this override. To inspect
+            or remove it, use{" "}
+            <span className="font-mono">
+              PATCH /v1/config/agents/{spec.id}/overrides
+            </span>{" "}
+            with{" "}
+            <span className="font-mono">{`{"_clear": ["endpoint"]}`}</span>.
+          </p>
+        </div>
+      )}
+
       <div className="grid gap-6 px-6 py-6 md:px-8 xl:grid-cols-[minmax(0,1fr),24rem]">
         <div className="space-y-6">
           {AGENT_EDITOR_TABS.map((tab) => (
@@ -2293,6 +2322,17 @@ function JsonEditorSection({
             <span className="font-mono">created_at</span>, and{" "}
             <span className="font-mono">updated_at</span> are preserved on Apply. Click Save below
             to publish — the runtime validation still runs.
+          </p>
+          <p
+            className="mt-2 max-w-xl text-xs text-fg-soft"
+            data-testid="raw-json-locked-field-help"
+          >
+            Locked fields are normalized on Apply. For{" "}
+            <span className="font-mono">endpoint</span> and{" "}
+            <span className="font-mono">registry</span> specifically, an explicit{" "}
+            <span className="font-mono">null</span> is treated the same as absence when the
+            current spec has no value — both mean "no override here". Use the Customization
+            controls above to clear an existing override.
           </p>
           {hasRedactedEndpoint ? (
             <p

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -44,6 +44,7 @@ import { invalidateConfigMutation } from "@/lib/query/invalidation";
 import {
   canonicalStringify,
   cloneAgentSpecForEditor,
+  computeRedactedDiff,
   deepEqualCanonical,
   diffPatchableAgentFields,
   lockedFieldChange,
@@ -799,7 +800,7 @@ function EditorSaveBar({
   );
 }
 
-function DiffModal({
+export function DiffModal({
   current,
   previous,
   onClose,
@@ -808,18 +809,12 @@ function DiffModal({
   previous: AgentSpec;
   onClose: () => void;
 }) {
-  // Both specs may carry `endpoint.auth.bearer_token` or similar secrets.
-  // Diff against the REDACTED projection so the modal DOM never holds a
-  // real credential — order-of-display matters because each `change.before`
-  // / `change.after` is rendered through `formatDiffValue` below, and that
-  // path stringifies whatever it's handed.
-  const redactedPrevious = redactSecretsForDisplay(
+  // Diff against the raw values so a secret rotation still appears as a
+  // semantic change, then render only redacted before/after values.
+  const changes = computeRedactedDiff(
     previous as unknown as Record<string, unknown>,
-  );
-  const redactedCurrent = redactSecretsForDisplay(
     current as unknown as Record<string, unknown>,
   );
-  const changes = computeDiff(redactedPrevious, redactedCurrent);
   return (
     <div
       role="dialog"
@@ -857,14 +852,26 @@ function DiffModal({
             <ul className="space-y-3">
               {changes.map((change) => (
                 <li key={change.path} className="rounded-md border border-line bg-soft p-3">
-                  <div className="font-mono text-xs font-medium text-fg-strong">{change.path}</div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <div className="font-mono text-xs font-medium text-fg-strong">
+                      {change.path}
+                    </div>
+                    {change.redactedValueChanged ? (
+                      <span
+                        className="rounded-pill bg-tone-warn/15 px-2 py-0.5 text-[10px] font-medium text-tone-warn"
+                        data-testid="diff-redacted-value-changed"
+                      >
+                        changed behind redaction
+                      </span>
+                    ) : null}
+                  </div>
                   <div className="mt-2 grid gap-2 md:grid-cols-2">
                     <div>
                       <div className="text-[10px] font-medium uppercase tracking-eyebrow text-tone-error">
                         Was
                       </div>
                       <pre className="mt-1 overflow-auto rounded border border-tone-error/20 bg-tone-error/5 px-2 py-1 font-mono text-xs text-fg">
-                        {formatDiffValue(change.before)}
+                        {formatDiffValue(change.before, change.redactedValueChanged)}
                       </pre>
                     </div>
                     <div>
@@ -872,7 +879,7 @@ function DiffModal({
                         Will be
                       </div>
                       <pre className="mt-1 overflow-auto rounded border border-tone-success/20 bg-tone-success/5 px-2 py-1 font-mono text-xs text-fg">
-                        {formatDiffValue(change.after)}
+                        {formatDiffValue(change.after, change.redactedValueChanged)}
                       </pre>
                     </div>
                   </div>
@@ -886,50 +893,15 @@ function DiffModal({
   );
 }
 
-interface FieldChange {
-  path: string;
-  before: unknown;
-  after: unknown;
-}
-
-function computeDiff(
-  prev: Record<string, unknown>,
-  curr: Record<string, unknown>,
-  base = "",
-): FieldChange[] {
-  const out: FieldChange[] = [];
-  const keys = new Set([...Object.keys(prev ?? {}), ...Object.keys(curr ?? {})]);
-  for (const key of keys) {
-    const path = base ? `${base}.${key}` : key;
-    const a = prev?.[key];
-    const b = curr?.[key];
-    // Use canonical deep-equal so object key-order changes don't surface
-    // as spurious diffs — mirrors what the save-path diff and locked-field
-    // compare both do.
-    if (deepEqualCanonical(a, b)) continue;
-    if (
-      a !== null &&
-      b !== null &&
-      typeof a === "object" &&
-      typeof b === "object" &&
-      !Array.isArray(a) &&
-      !Array.isArray(b)
-    ) {
-      out.push(...computeDiff(a as Record<string, unknown>, b as Record<string, unknown>, path));
-    } else {
-      out.push({ path, before: a, after: b });
-    }
-  }
-  return out;
-}
-
-function formatDiffValue(value: unknown): string {
-  if (value === undefined) return "(unset)";
-  if (value === null) return "null";
-  if (typeof value === "string") return value || "(empty string)";
+function formatDiffValue(value: unknown, redactedValueChanged = false): string {
+  const suffix = redactedValueChanged ? " (changed)" : "";
+  if (value === undefined) return `(unset)${suffix}`;
+  if (value === null) return `null${suffix}`;
+  if (typeof value === "string") return `${value || "(empty string)"}${suffix}`;
   // Defense-in-depth: the caller is expected to have already redacted, but
   // a future code path that forgets shouldn't end up dumping secrets here.
-  return JSON.stringify(redactSecretsForDisplay(value), null, 2);
+  const rendered = JSON.stringify(redactSecretsForDisplay(value), null, 2);
+  return redactedValueChanged ? `${rendered}\n(changed)` : rendered;
 }
 
 function EditorSourceBadge({ state }: { state: ConfigSourceState }) {

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -1,38 +1,89 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams, useSearchParams } from "react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 import {
   type AgentSpec,
+  type Capabilities,
   type ConfigSourceState,
+  type ContextCompactionMode,
+  type ContextWindowPolicy,
+  type PermissionPreviewResponse,
   type RecordMeta,
+  ConfigApiError,
+  DEFAULT_CONTEXT_POLICY,
   configApi,
   deriveSourceState,
 } from "@/lib/config-api";
+import { type AuditEvent, formatActor, summarizeChange } from "@/lib/audit-log";
+import { Field } from "@/components/form-components";
 import { AgentPreviewPanel } from "@/components/agent-preview-panel";
+import { PluginConfigWorkspace } from "@/components/plugin-config-workspace";
+import { ToolSelector } from "@/components/tool-selector";
 import { useToast } from "@/components/toast-provider";
 import { useConfirmDialog } from "@/components/confirm-dialog";
 import { useUnsavedChangesGuard } from "@/components/unsaved-changes-guard";
 import { useTranslation } from "react-i18next";
-import { type AgentEditorTabId, readTabFromSearch, writeTabToSearch } from "@/lib/editor-tabs";
-import { pluginConfigEntryKey } from "@/lib/plugin-config";
-import { reasoningEffortMode } from "@/lib/reasoning-effort";
+import {
+  AGENT_EDITOR_TABS,
+  type AgentEditorTabId,
+  readTabFromSearch,
+  writeTabToSearch,
+} from "@/lib/editor-tabs";
+import { pluginConfigEntryKey, pluginDisplayName } from "@/lib/plugin-config";
+import {
+  REASONING_EFFORT_PRESETS,
+  reasoningEffortMode,
+  reasoningEffortValue,
+} from "@/lib/reasoning-effort";
 import { adminRoutes } from "@/lib/routes";
 import { useCapabilitiesQuery } from "@/lib/query/hooks/capabilities";
 import { useConfigMetaQuery, useConfigRecordQuery } from "@/lib/query/hooks/config";
+import { useAuditLogInfiniteQuery } from "@/lib/query/hooks/audit";
 import { qk } from "@/lib/query/keys";
 import { invalidateConfigMutation } from "@/lib/query/invalidation";
 import {
-  EMPTY_AGENT,
-  agentSaveMode,
-  agentSavePayload,
-  fullAgentSavePayload,
-  getOptionalAgentMeta,
-  hydrateAgentSpec,
-  jsonSemanticallyEqual,
-} from "./agent-editor/spec-helpers";
-import { AgentEditorPanels } from "./agent-editor/editor-panels";
-import { EditorSaveBar } from "./agent-editor/editor-save-bar";
-import { StickyEditorHeader } from "./agent-editor/sticky-editor-header";
+  cloneAgentSpecForEditor,
+  deepEqualCanonical,
+  diffPatchableAgentFields,
+  lockedFieldChange,
+  mergeLockedFields,
+  partitionActiveHookFilter,
+  redactAgentSpecForDisplay,
+  redactEndpointForDisplay,
+  togglePluginState,
+  unknownAgentSpecFields,
+} from "@/lib/agent-editor-helpers";
+
+const EMPTY_AGENT: AgentSpec = {
+  id: "",
+  model_id: "",
+  system_prompt: "",
+  max_rounds: 16,
+  max_continuation_retries: 2,
+  plugin_ids: [],
+  sections: {},
+  delegates: [],
+};
+
+async function getOptionalAgentMeta(id: string): Promise<RecordMeta | null> {
+  try {
+    return await configApi.getMeta("agents", id);
+  } catch (error) {
+    if (error instanceof ConfigApiError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function hydrateAgentSpec(spec: AgentSpec): AgentSpec {
+  return {
+    sections: {},
+    plugin_ids: [],
+    delegates: [],
+    ...spec,
+  };
+}
 
 export function AgentEditorPage() {
   const navigate = useNavigate();
@@ -81,28 +132,24 @@ export function AgentEditorPage() {
       : null;
   const saveDisabled = saving || Boolean(agentMetaError || (!isNew && agentMetaQuery.isPending));
   const initializedAgentIdRef = useRef<string | null>(null);
-  const sourceState: ConfigSourceState | null = agentMeta ? deriveSourceState(agentMeta) : null;
-  const saveMode = useMemo(() => agentSaveMode(isNew, sourceState), [isNew, sourceState]);
-  const savePayload = useMemo(
-    () => agentSavePayload(spec, originalSpec, saveMode),
-    [spec, originalSpec, saveMode],
-  );
 
   const isDirty = useMemo(() => {
     if (saving) return false;
     if (isNew) {
-      return (
-        spec.id.trim().length > 0 ||
-        spec.system_prompt.length > 0 ||
-        spec.model_id.length > 0 ||
-        (spec.plugin_ids?.length ?? 0) > 0
-      );
+      // Compare the whole draft against the empty baseline. Earlier this
+      // branch only checked id / system_prompt / model_id / plugin_ids.length,
+      // so users could lose unsaved edits in context_policy, allowed/excluded
+      // tools, delegates, reasoning_effort, sections, or Raw JSON without
+      // triggering the unsaved-changes guard.
+      return !deepEqualCanonical(spec, EMPTY_AGENT);
     }
     if (!savedSpec) return false;
-    return !jsonSemanticallyEqual(spec, savedSpec);
+    return !deepEqualCanonical(spec, savedSpec);
   }, [spec, savedSpec, isNew, saving]);
 
   useUnsavedChangesGuard({ enabled: isDirty });
+
+  const sourceState: ConfigSourceState | null = agentMeta ? deriveSourceState(agentMeta) : null;
 
   useEffect(() => {
     if (capabilitiesQuery.error) {
@@ -159,39 +206,6 @@ export function AgentEditorPage() {
     return next;
   }
 
-  function commitAgentSnapshot(nextSpec: AgentSpec, nextMeta?: RecordMeta | null) {
-    const hydrated = hydrateAgentSpec(nextSpec);
-    setSpec(hydrated);
-    setSavedSpec(hydrated);
-    setOriginalSpec(hydrated);
-    queryClient.setQueryData(qk.config.get("agents", hydrated.id), hydrated);
-    if (nextMeta !== undefined) {
-      setAgentMeta(nextMeta);
-      queryClient.setQueryData(qk.config.meta("agents", hydrated.id), nextMeta);
-    }
-    invalidateConfigMutation(queryClient, "agents", hydrated.id);
-  }
-
-  async function refreshAgentSnapshot(agentId: string) {
-    const [nextSpec, nextMeta] = await Promise.all([
-      configApi.get<AgentSpec>("agents", agentId),
-      getOptionalAgentMeta(agentId),
-    ]);
-    commitAgentSnapshot(nextSpec, nextMeta);
-  }
-
-  async function handleSpecRestored(updated: AgentSpec) {
-    commitAgentSnapshot(updated);
-    try {
-      const nextMeta = await getOptionalAgentMeta(updated.id);
-      setAgentMeta(nextMeta);
-      queryClient.setQueryData(qk.config.meta("agents", updated.id), nextMeta);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
-    }
-    setHistoryRefreshKey((k) => k + 1);
-  }
-
   async function handleSave() {
     if (!isNew && agentMetaQuery.isPending) {
       toast.error("Agent metadata is still loading.");
@@ -211,23 +225,42 @@ export function AgentEditorPage() {
     }
     setSaving(true);
     try {
-      const payload = fullAgentSavePayload(spec);
+      const payload = {
+        ...spec,
+        plugin_ids: [...(spec.plugin_ids ?? [])],
+        delegates: [...(spec.delegates ?? [])],
+      };
 
       if (isNew) {
         const created = await configApi.create<typeof payload, AgentSpec>("agents", payload);
-        commitAgentSnapshot(created);
+        setSavedSpec(created);
+        setOriginalSpec(created);
+        queryClient.setQueryData(qk.config.get("agents", created.id), created);
+        invalidateConfigMutation(queryClient, "agents", created.id);
         toast.success(`Agent "${created.id}" created`);
         navigate(adminRoutes.agent(created.id), { replace: true });
-      } else if (saveMode === "patch-overrides") {
+      } else if (sourceState === "builtin" || sourceState === "customized") {
         // For Builtin/Customized records, use PATCH /overrides to preserve
         // upgrade tracking. Only patchable fields are included.
-        const patch = savePayload as Record<string, unknown>;
+        const patch = diffPatchableAgentFields(spec, originalSpec ?? spec);
         if (Object.keys(patch).length === 0) {
-          await refreshAgentSnapshot(spec.id);
-          toast.success(`Agent "${spec.id}" has no patchable changes to save`);
+          // Nothing patchable changed; nothing to send.
+          toast.success(`Agent "${spec.id}" saved (no patchable changes)`);
         } else {
           await configApi.patchAgentOverrides(spec.id, patch);
-          await refreshAgentSnapshot(spec.id);
+          // Refresh spec and meta so the badge updates correctly.
+          const [nextSpec, nextMeta] = await Promise.all([
+            configApi.get<AgentSpec>("agents", spec.id),
+            getOptionalAgentMeta(spec.id),
+          ]);
+          const hydrated = hydrateAgentSpec(nextSpec);
+          setSpec(hydrated);
+          setSavedSpec(hydrated);
+          setOriginalSpec(hydrated);
+          setAgentMeta(nextMeta);
+          queryClient.setQueryData(qk.config.get("agents", spec.id), hydrated);
+          queryClient.setQueryData(qk.config.meta("agents", spec.id), nextMeta);
+          invalidateConfigMutation(queryClient, "agents", spec.id);
           toast.success(`Agent "${spec.id}" saved`);
           setHistoryRefreshKey((k) => k + 1);
         }
@@ -237,7 +270,11 @@ export function AgentEditorPage() {
           spec.id,
           payload,
         );
-        commitAgentSnapshot(updated);
+        setSpec(updated);
+        setSavedSpec(updated);
+        setOriginalSpec(updated);
+        queryClient.setQueryData(qk.config.get("agents", updated.id), updated);
+        invalidateConfigMutation(queryClient, "agents", updated.id);
         toast.success(`Agent "${updated.id}" saved`);
         setHistoryRefreshKey((k) => k + 1);
       }
@@ -264,7 +301,14 @@ export function AgentEditorPage() {
         configApi.get<AgentSpec>("agents", id),
         getOptionalAgentMeta(id),
       ]);
-      commitAgentSnapshot(nextSpec, nextMeta);
+      const hydrated = hydrateAgentSpec(nextSpec);
+      setSpec(hydrated);
+      setSavedSpec(hydrated);
+      setOriginalSpec(hydrated);
+      setAgentMeta(nextMeta);
+      queryClient.setQueryData(qk.config.get("agents", id), hydrated);
+      queryClient.setQueryData(qk.config.meta("agents", id), nextMeta);
+      invalidateConfigMutation(queryClient, "agents", id);
       toast.success(`Agent "${id}" overrides cleared`);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err));
@@ -279,7 +323,14 @@ export function AgentEditorPage() {
         configApi.get<AgentSpec>("agents", id),
         getOptionalAgentMeta(id),
       ]);
-      commitAgentSnapshot(nextSpec, nextMeta);
+      const hydrated = hydrateAgentSpec(nextSpec);
+      setSpec(hydrated);
+      setSavedSpec(hydrated);
+      setOriginalSpec(hydrated);
+      setAgentMeta(nextMeta);
+      queryClient.setQueryData(qk.config.get("agents", id), hydrated);
+      queryClient.setQueryData(qk.config.meta("agents", id), nextMeta);
+      invalidateConfigMutation(queryClient, "agents", id);
       toast.success(t("agents.resetOverrideFieldDone", { field }));
       setHistoryRefreshKey((k) => k + 1);
     } catch (err) {
@@ -298,16 +349,43 @@ export function AgentEditorPage() {
     }
   }
 
+  function replaceSpec(next: AgentSpec) {
+    // Preserve identity fields the editor manages outside the JSON payload.
+    setSpec((current) => ({
+      ...next,
+      id: current.id,
+      created_at: current.created_at,
+      updated_at: current.updated_at,
+    }));
+    setErrors({});
+  }
+
+  async function cloneFromExisting(sourceId: string) {
+    if (!sourceId) return;
+    try {
+      const source = await configApi.get<AgentSpec>("agents", sourceId);
+      // Clone the user-editable config but drop provenance (id, timestamps,
+      // registry) — a clone is locally-defined, not the original record.
+      const cloned = cloneAgentSpecForEditor(hydrateAgentSpec(source));
+      setSpec(cloned);
+      setErrors({});
+      toast.success(`Cloned from "${sourceId}" — pick a new agent id and Save.`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    }
+  }
+
   function togglePlugin(pluginId: string) {
     setSpec((current) => {
-      const pluginIds = current.plugin_ids ?? [];
-      const next = pluginIds.includes(pluginId)
-        ? pluginIds.filter((idValue) => idValue !== pluginId)
-        : [...pluginIds, pluginId];
-
+      const { plugin_ids, active_hook_filter } = togglePluginState(
+        current.plugin_ids,
+        current.active_hook_filter,
+        pluginId,
+      );
       return {
         ...current,
-        plugin_ids: next,
+        plugin_ids,
+        active_hook_filter,
       };
     });
   }
@@ -355,36 +433,31 @@ export function AgentEditorPage() {
   }, [agentMeta]);
   const isCustomized = sourceState === "customized";
 
-  const configurablePlugins = useMemo(
-    () => (capabilities?.plugins ?? []).filter((plugin) => plugin.config_schemas.length > 0),
-    [capabilities?.plugins],
+  const configurablePlugins = (capabilities?.plugins ?? []).filter(
+    (plugin) => plugin.config_schemas.length > 0,
   );
-  const visiblePluginSchemas = useMemo(
-    () =>
-      configurablePlugins
-        .flatMap((plugin) => {
-          const selected = (spec.plugin_ids ?? []).includes(plugin.id);
-          const hasStoredConfig = plugin.config_schemas.some(
-            (schema) => spec.sections?.[schema.key] !== undefined,
-          );
+  const visiblePluginSchemas = configurablePlugins
+    .flatMap((plugin) => {
+      const selected = (spec.plugin_ids ?? []).includes(plugin.id);
+      const hasStoredConfig = plugin.config_schemas.some(
+        (schema) => spec.sections?.[schema.key] !== undefined,
+      );
 
-          return plugin.config_schemas.map((schema) => ({
-            plugin,
-            schema,
-            selected,
-            hasStoredConfig,
-          }));
-        })
-        .sort((left, right) => {
-          const leftRank = Number(left.selected) * 2 + Number(left.hasStoredConfig);
-          const rightRank = Number(right.selected) * 2 + Number(right.hasStoredConfig);
-          if (leftRank !== rightRank) {
-            return rightRank - leftRank;
-          }
-          return left.plugin.id.localeCompare(right.plugin.id);
-        }),
-    [configurablePlugins, spec.plugin_ids, spec.sections],
-  );
+      return plugin.config_schemas.map((schema) => ({
+        plugin,
+        schema,
+        selected,
+        hasStoredConfig,
+      }));
+    })
+    .sort((left, right) => {
+      const leftRank = Number(left.selected) * 2 + Number(left.hasStoredConfig);
+      const rightRank = Number(right.selected) * 2 + Number(right.hasStoredConfig);
+      if (leftRank !== rightRank) {
+        return rightRank - leftRank;
+      }
+      return left.plugin.id.localeCompare(right.plugin.id);
+    });
 
   useEffect(() => {
     if (visiblePluginSchemas.length === 0) {
@@ -455,29 +528,84 @@ export function AgentEditorPage() {
       )}
 
       <div className="grid gap-6 px-6 py-6 md:px-8 xl:grid-cols-[minmax(0,1fr),24rem]">
-        <AgentEditorPanels
-          spec={spec}
-          capabilities={capabilities}
-          isNew={isNew}
-          activeTab={activeTab}
-          updateField={updateField}
-          reasoningMode={reasoningMode}
-          errors={errors}
-          canResetFields={!isNew && isCustomized}
-          overriddenFields={overriddenFields}
-          onResetField={(field) => void handleResetField(field)}
-          configurablePlugins={configurablePlugins}
-          visiblePluginSchemas={visiblePluginSchemas}
-          activePluginConfig={activePluginConfig}
-          setActivePluginConfig={setActivePluginConfig}
-          togglePlugin={togglePlugin}
-          updateSection={updateSection}
-          toggleDelegate={toggleDelegate}
-          historyRefreshKey={historyRefreshKey}
-          saveMode={saveMode}
-          savePayload={savePayload}
-          onSpecRestored={(updated) => handleSpecRestored(updated)}
-        />
+        <div className="space-y-6">
+          {AGENT_EDITOR_TABS.map((tab) => (
+            <div
+              key={tab.id}
+              role="tabpanel"
+              id={`panel-${tab.id}`}
+              aria-labelledby={`tab-${tab.id}`}
+              tabIndex={0}
+              hidden={activeTab !== tab.id}
+            >
+              {tab.id === "basics" && (
+                <BasicsPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  isNew={isNew}
+                  updateField={updateField}
+                  reasoningMode={reasoningMode}
+                  errors={errors}
+                  canResetFields={!isNew && isCustomized}
+                  overriddenFields={overriddenFields}
+                  onResetField={(field) => void handleResetField(field)}
+                  onCloneFrom={(sourceId) => void cloneFromExisting(sourceId)}
+                />
+              )}
+              {tab.id === "tools" && (
+                <ToolsPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  updateField={updateField}
+                  agentSaved={!isNew && savedSpec !== null}
+                />
+              )}
+              {tab.id === "plugins" && (
+                <PluginsPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  configurablePlugins={configurablePlugins}
+                  visiblePluginSchemas={visiblePluginSchemas}
+                  activePluginConfig={activePluginConfig}
+                  setActivePluginConfig={setActivePluginConfig}
+                  togglePlugin={togglePlugin}
+                  updateSection={updateSection}
+                  updateField={updateField}
+                />
+              )}
+              {tab.id === "delegates" && (
+                <DelegatesPanel
+                  spec={spec}
+                  capabilities={capabilities}
+                  toggleDelegate={toggleDelegate}
+                />
+              )}
+              {tab.id === "advanced" && (
+                <AdvancedPanel
+                  spec={spec}
+                  isNew={isNew}
+                  updateField={updateField}
+                  replaceSpec={replaceSpec}
+                />
+              )}
+              {tab.id === "history" && (
+                <HistoryPanel
+                  spec={spec}
+                  isNew={isNew}
+                  refreshKey={historyRefreshKey}
+                  onSpecRestored={(updated) => {
+                    setSpec(updated);
+                    setSavedSpec(updated);
+                    setOriginalSpec(updated);
+                    queryClient.setQueryData(qk.config.get("agents", updated.id), updated);
+                    invalidateConfigMutation(queryClient, "agents", updated.id);
+                    setHistoryRefreshKey((k) => k + 1);
+                  }}
+                />
+              )}
+            </div>
+          ))}
+        </div>
 
         <AgentPreviewPanel draft={spec} />
       </div>
@@ -489,10 +617,2008 @@ export function AgentEditorPage() {
         saveDisabled={saveDisabled}
         spec={spec}
         savedSpec={savedSpec}
-        saveMode={saveMode}
-        savePayload={savePayload}
         onSave={() => void handleSave()}
       />
+    </div>
+  );
+}
+
+function EditorSaveBar({
+  isDirty,
+  isNew,
+  saving,
+  saveDisabled,
+  spec,
+  savedSpec,
+  onSave,
+}: {
+  isDirty: boolean;
+  isNew: boolean;
+  saving: boolean;
+  saveDisabled: boolean;
+  spec: AgentSpec;
+  savedSpec: AgentSpec | null;
+  onSave: () => void;
+}) {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const [validating, setValidating] = useState(false);
+  const [diffOpen, setDiffOpen] = useState(false);
+
+  if (!isDirty && !isNew) return null;
+
+  async function handleValidate() {
+    setValidating(true);
+    try {
+      await configApi.validateConfig("agents", spec, isNew ? undefined : { id: spec.id });
+      toast.success("Validation passed — payload is safe to publish.");
+    } catch (err) {
+      toast.error(`Validation failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="sticky bottom-0 z-20 mx-6 mb-4 rounded-md border border-line bg-surface px-4 py-3 shadow-card-lift md:mx-8">
+        <div className="flex flex-wrap items-center gap-3">
+          <span aria-hidden className="inline-block h-2 w-2 rounded-pill bg-state-progress" />
+          <div className="text-sm text-fg">
+            {isNew ? (
+              <span className="text-fg-strong">{t("editor.unsavedChanges")}</span>
+            ) : (
+              <span className="text-fg-strong">{t("editor.unsavedChanges")}</span>
+            )}
+            <span className="ml-2 text-fg-soft">Save will publish to the runtime config.</span>
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            {!isNew && savedSpec && (
+              <button
+                type="button"
+                onClick={() => setDiffOpen(true)}
+                className="inline-flex h-9 items-center rounded-md border border-line bg-surface px-3 text-sm font-medium text-fg-soft transition-colors hover:text-fg"
+              >
+                {t("editor.diff")}
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => void handleValidate()}
+              disabled={validating || saving}
+              className="inline-flex h-9 items-center rounded-md border border-line-strong bg-surface px-3 text-sm font-medium text-fg transition-colors hover:bg-soft disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {validating ? t("editor.validating") : t("editor.validate")}
+            </button>
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={saveDisabled || validating}
+              className="inline-flex h-9 items-center rounded-md bg-accent px-4 text-sm font-medium text-accent-text transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving ? t("editor.saving") : t("editor.save")}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {diffOpen && savedSpec && (
+        <DiffModal current={spec} previous={savedSpec} onClose={() => setDiffOpen(false)} />
+      )}
+    </>
+  );
+}
+
+function DiffModal({
+  current,
+  previous,
+  onClose,
+}: {
+  current: AgentSpec;
+  previous: AgentSpec;
+  onClose: () => void;
+}) {
+  const changes = computeDiff(
+    previous as unknown as Record<string, unknown>,
+    current as unknown as Record<string, unknown>,
+  );
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Diff vs published"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-overlay px-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-3xl max-h-[80vh] overflow-hidden rounded-lg bg-surface shadow-overlay flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-line px-5 py-3">
+          <div>
+            <h3 className="text-base font-semibold text-fg-strong">Diff vs published</h3>
+            <p className="mt-0.5 text-xs text-fg-soft">
+              {changes.length} field{changes.length === 1 ? "" : "s"} would change on save.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-line bg-soft px-2 py-1 text-xs text-fg-soft hover:text-fg"
+          >
+            Close
+          </button>
+        </div>
+        <div className="overflow-y-auto p-5">
+          {changes.length === 0 ? (
+            <p className="text-sm text-fg-soft">
+              No semantic changes. (The dirty flag may be set because of a transient form edit;
+              saving is safe.)
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {changes.map((change) => (
+                <li key={change.path} className="rounded-md border border-line bg-soft p-3">
+                  <div className="font-mono text-xs font-medium text-fg-strong">{change.path}</div>
+                  <div className="mt-2 grid gap-2 md:grid-cols-2">
+                    <div>
+                      <div className="text-[10px] font-medium uppercase tracking-eyebrow text-tone-error">
+                        Was
+                      </div>
+                      <pre className="mt-1 overflow-auto rounded border border-tone-error/20 bg-tone-error/5 px-2 py-1 font-mono text-xs text-fg">
+                        {formatDiffValue(change.before)}
+                      </pre>
+                    </div>
+                    <div>
+                      <div className="text-[10px] font-medium uppercase tracking-eyebrow text-tone-success">
+                        Will be
+                      </div>
+                      <pre className="mt-1 overflow-auto rounded border border-tone-success/20 bg-tone-success/5 px-2 py-1 font-mono text-xs text-fg">
+                        {formatDiffValue(change.after)}
+                      </pre>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface FieldChange {
+  path: string;
+  before: unknown;
+  after: unknown;
+}
+
+function computeDiff(
+  prev: Record<string, unknown>,
+  curr: Record<string, unknown>,
+  base = "",
+): FieldChange[] {
+  const out: FieldChange[] = [];
+  const keys = new Set([...Object.keys(prev ?? {}), ...Object.keys(curr ?? {})]);
+  for (const key of keys) {
+    const path = base ? `${base}.${key}` : key;
+    const a = prev?.[key];
+    const b = curr?.[key];
+    if (deepEqual(a, b)) continue;
+    if (
+      a !== null &&
+      b !== null &&
+      typeof a === "object" &&
+      typeof b === "object" &&
+      !Array.isArray(a) &&
+      !Array.isArray(b)
+    ) {
+      out.push(...computeDiff(a as Record<string, unknown>, b as Record<string, unknown>, path));
+    } else {
+      out.push({ path, before: a, after: b });
+    }
+  }
+  return out;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function formatDiffValue(value: unknown): string {
+  if (value === undefined) return "(unset)";
+  if (value === null) return "null";
+  if (typeof value === "string") return value || "(empty string)";
+  return JSON.stringify(value, null, 2);
+}
+
+function EditorSourceBadge({ state }: { state: ConfigSourceState }) {
+  const { t } = useTranslation();
+  if (state === "builtin") {
+    return (
+      <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-fg-soft">
+        {t("agents.source.builtin")}
+      </span>
+    );
+  }
+  if (state === "customized") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+        {t("agents.source.customized")}
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full bg-soft px-2 py-0.5 text-xs font-medium text-fg">
+      {t("agents.source.userDefined")}
+    </span>
+  );
+}
+
+function StickyEditorHeader({
+  isNew,
+  agentId,
+  spec,
+  isDirty,
+  saveDisabled,
+  onSave,
+  activeTab,
+  onTabChange,
+  sourceState,
+  onResetOverrides,
+}: {
+  isNew: boolean;
+  agentId: string;
+  spec: AgentSpec;
+  isDirty: boolean;
+  saveDisabled: boolean;
+  onSave: () => void;
+  activeTab: AgentEditorTabId;
+  onTabChange: (next: AgentEditorTabId) => void;
+  sourceState: ConfigSourceState | null;
+  onResetOverrides: () => void;
+}) {
+  const { t } = useTranslation();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function handleKeyDown(event: React.KeyboardEvent, index: number) {
+    const count = AGENT_EDITOR_TABS.length;
+    let nextIndex: number | null = null;
+
+    if (event.key === "ArrowRight") {
+      nextIndex = (index + 1) % count;
+    } else if (event.key === "ArrowLeft") {
+      nextIndex = (index - 1 + count) % count;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = count - 1;
+    }
+
+    if (nextIndex !== null) {
+      event.preventDefault();
+      const nextTab = AGENT_EDITOR_TABS[nextIndex];
+      onTabChange(nextTab.id);
+      tabRefs.current[nextIndex]?.focus();
+    }
+  }
+
+  return (
+    <div className="sticky top-0 z-30 border-b border-line bg-surface/95 px-6 pt-6 backdrop-blur md:px-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Link
+              to={adminRoutes.agents}
+              aria-label="Back to agents"
+              title="Back to agents"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-soft transition hover:bg-soft hover:text-fg"
+            >
+              <svg
+                aria-hidden
+                viewBox="0 0 24 24"
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M15 18l-6-6 6-6" />
+              </svg>
+            </Link>
+            {!isNew && agentId && (
+              <Link
+                to={adminRoutes.auditLogForResource(`agents/${agentId}`)}
+                className="rounded-md border border-line-strong bg-surface px-2.5 py-1 text-xs font-medium text-fg-soft transition hover:bg-soft hover:text-fg"
+              >
+                {t("editor.history")}
+              </Link>
+            )}
+          </div>
+          <h2 className="mt-2 flex flex-wrap items-center gap-3 text-3xl font-semibold text-fg-strong">
+            <span>{isNew ? t("editor.newTitle") : t("editor.editTitle", { id: agentId })}</span>
+            {isDirty ? (
+              <span className="rounded-full bg-tone-warn/15 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-tone-warn">
+                {t("editor.unsavedChanges")}
+              </span>
+            ) : !isNew ? (
+              <span className="rounded-full bg-tone-success/15 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-tone-success">
+                {t("editor.upToDate")}
+              </span>
+            ) : null}
+            {!isNew && sourceState && <EditorSourceBadge state={sourceState} />}
+          </h2>
+          {!isNew && sourceState === "customized" && (
+            <div className="mt-1">
+              <button
+                type="button"
+                onClick={onResetOverrides}
+                className="text-xs font-medium text-tone-error transition hover:underline"
+              >
+                {t("agents.resetOverrides")}
+              </button>
+            </div>
+          )}
+        </div>
+        {isDirty || isNew ? null : (
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saveDisabled}
+            className="rounded-xl bg-accent px-4 py-2 text-sm font-medium text-accent-text transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {t("editor.save")}
+          </button>
+        )}
+      </div>
+
+      <div
+        role="tablist"
+        aria-label="Editor sections"
+        aria-orientation="horizontal"
+        className="mt-4 flex gap-1 overflow-x-auto"
+      >
+        {AGENT_EDITOR_TABS.map((tab, index) => {
+          const active = tab.id === activeTab;
+          const badge = tab.badge?.(spec) ?? null;
+          return (
+            <button
+              key={tab.id}
+              ref={(el) => {
+                tabRefs.current[index] = el;
+              }}
+              type="button"
+              role="tab"
+              id={`tab-${tab.id}`}
+              aria-selected={active}
+              aria-controls={`panel-${tab.id}`}
+              tabIndex={active ? 0 : -1}
+              onClick={() => onTabChange(tab.id)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              className={[
+                "flex shrink-0 items-center gap-2 rounded-t-lg border-b-2 px-4 py-3 text-sm font-medium transition",
+                active
+                  ? "border-fg-strong text-fg-strong"
+                  : "border-transparent text-fg-soft hover:text-fg",
+              ].join(" ")}
+            >
+              <span>{tab.label}</span>
+              {badge && (
+                <span
+                  aria-hidden
+                  className={[
+                    "rounded-pill px-1.5 font-mono text-[10px]",
+                    active ? "bg-muted text-fg-strong" : "bg-soft text-fg-soft",
+                  ].join(" ")}
+                >
+                  {badge}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function BasicsPanel({
+  spec,
+  capabilities,
+  isNew,
+  updateField,
+  reasoningMode,
+  errors,
+  canResetFields,
+  overriddenFields,
+  onResetField,
+  onCloneFrom,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  isNew: boolean;
+  updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
+  reasoningMode: ReturnType<typeof reasoningEffortMode>;
+  errors?: Partial<Record<"id" | "model_id", string>>;
+  canResetFields?: boolean;
+  overriddenFields?: Set<string>;
+  onResetField?: (field: string) => void;
+  onCloneFrom?: (sourceId: string) => void;
+}) {
+  const { t } = useTranslation();
+  const fieldResetProps = (field: string) => {
+    if (!canResetFields || !overriddenFields?.has(field) || !onResetField) {
+      return {};
+    }
+    return {
+      overridden: true,
+      onReset: () => onResetField(field),
+      resetLabel: t("agents.resetOverrideField"),
+    } as const;
+  };
+  const cloneOptions = isNew
+    ? (capabilities?.agents ?? []).filter((agentId) => agentId !== spec.id)
+    : [];
+  return (
+    <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-fg-strong">Basics</h3>
+      {isNew && cloneOptions.length > 0 && onCloneFrom ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2 rounded-md border border-dashed border-line bg-soft px-3 py-2 text-xs text-fg-soft">
+          <span className="font-medium uppercase tracking-eyebrow text-[10px]">Start from</span>
+          <select
+            defaultValue=""
+            onChange={(event) => {
+              const next = event.target.value;
+              if (next) {
+                onCloneFrom(next);
+                event.target.value = "";
+              }
+            }}
+            className="rounded-md border border-line-strong bg-surface px-2 py-1 text-xs text-fg-strong outline-none transition focus:border-line-strong"
+          >
+            <option value="">Blank agent</option>
+            {cloneOptions.map((agentId) => (
+              <option key={agentId} value={agentId}>
+                Clone from {agentId}
+              </option>
+            ))}
+          </select>
+          <span className="text-[10px] text-fg-faint">
+            Pick an existing agent to copy its prompt / tools / plugins. You still pick a new id.
+            <span className="ml-1">
+              <span className="font-mono">endpoint</span> and{" "}
+              <span className="font-mono">registry</span> are not copied — the clone is always a
+              locally-defined agent.
+            </span>
+          </span>
+        </div>
+      ) : null}
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <Field label="Agent ID" required={isNew} error={errors?.id}>
+          <input
+            type="text"
+            value={spec.id}
+            disabled={!isNew}
+            aria-invalid={Boolean(errors?.id)}
+            onChange={(event) => updateField("id", event.target.value)}
+            className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong disabled:bg-muted disabled:text-fg-soft aria-[invalid=true]:border-tone-error"
+          />
+        </Field>
+        <div>
+          <Field label="Model" required error={errors?.model_id} {...fieldResetProps("model_id")}>
+            <select
+              value={String(spec.model_id ?? "")}
+              aria-invalid={Boolean(errors?.model_id)}
+              onChange={(event) => updateField("model_id", event.target.value)}
+              className="w-full rounded-xl border border-line-strong bg-surface px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong aria-[invalid=true]:border-tone-error"
+            >
+              <option value="">Select a model</option>
+              {(capabilities?.models ?? []).map((model) => (
+                <option key={model.id} value={model.id}>
+                  {model.id} — {model.provider_id} · {model.upstream_model}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <SelectedModelBadge spec={spec} capabilities={capabilities} />
+        </div>
+        <Field label="Max rounds" {...fieldResetProps("max_rounds")}>
+          <input
+            type="number"
+            min={1}
+            value={Number(spec.max_rounds ?? 16)}
+            onChange={(event) => updateField("max_rounds", Number(event.target.value) || 16)}
+            className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+          />
+        </Field>
+        <Field label="Max continuation retries" {...fieldResetProps("max_continuation_retries")}>
+          <input
+            type="number"
+            min={0}
+            value={Number(spec.max_continuation_retries ?? 2)}
+            onChange={(event) =>
+              updateField("max_continuation_retries", Number(event.target.value) || 0)
+            }
+            className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+          />
+        </Field>
+        <Field label="Reasoning effort">
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={
+                reasoningMode.kind === "default"
+                  ? "__default__"
+                  : reasoningMode.kind === "preset"
+                    ? reasoningMode.value
+                    : "__custom__"
+              }
+              onChange={(event) => {
+                const choice = event.target.value;
+                if (choice === "__default__") {
+                  updateField(
+                    "reasoning_effort",
+                    reasoningEffortValue({ kind: "default" }) as string | number | null | undefined,
+                  );
+                  return;
+                }
+                if (choice === "__custom__") {
+                  updateField(
+                    "reasoning_effort",
+                    reasoningEffortValue({
+                      kind: "custom",
+                      value: reasoningMode.kind === "custom" ? reasoningMode.value : "",
+                    }) as string | number | null | undefined,
+                  );
+                  return;
+                }
+                updateField(
+                  "reasoning_effort",
+                  reasoningEffortValue({
+                    kind: "preset",
+                    value: choice as (typeof REASONING_EFFORT_PRESETS)[number],
+                  }) as string | number | null | undefined,
+                );
+              }}
+              className="rounded-xl border border-line-strong bg-surface px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+            >
+              <option value="__default__">Provider default</option>
+              {REASONING_EFFORT_PRESETS.map((preset) => (
+                <option key={preset} value={preset}>
+                  {preset}
+                </option>
+              ))}
+              <option value="__custom__">Custom…</option>
+            </select>
+            {reasoningMode.kind === "custom" ? (
+              <input
+                type="text"
+                value={reasoningMode.value}
+                onChange={(event) =>
+                  updateField(
+                    "reasoning_effort",
+                    reasoningEffortValue({
+                      kind: "custom",
+                      value: event.target.value,
+                    }) as string | number | null | undefined,
+                  )
+                }
+                placeholder="e.g. 1, 2, ultra"
+                className="w-32 rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+              />
+            ) : null}
+          </div>
+        </Field>
+      </div>
+
+      <div className="mt-4">
+        <Field label="System prompt" {...fieldResetProps("system_prompt")}>
+          <textarea
+            value={String(spec.system_prompt ?? "")}
+            onChange={(event) => updateField("system_prompt", event.target.value)}
+            rows={8}
+            className="w-full rounded-xl border border-line-strong bg-surface px-3 py-2 font-mono text-sm text-fg-strong outline-none transition focus:border-line-strong"
+          />
+        </Field>
+        <SystemPromptStats value={String(spec.system_prompt ?? "")} />
+      </div>
+    </section>
+  );
+}
+
+function SelectedModelBadge({
+  spec,
+  capabilities,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+}) {
+  const selectedId = String(spec.model_id ?? "");
+  const selected = (capabilities?.models ?? []).find((model) => model.id === selectedId);
+  if (!selected) return null;
+  return (
+    <div
+      aria-hidden="true"
+      className="mt-1 flex flex-wrap items-center gap-2 text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft"
+    >
+      <span
+        className="rounded-pill bg-muted px-2 py-0.5 text-fg-soft"
+        title={`Resolved provider: ${selected.provider_id}`}
+      >
+        provider · {selected.provider_id}
+      </span>
+      <span
+        className="rounded-pill bg-muted px-2 py-0.5 text-fg-soft"
+        title={`Upstream model identifier sent to the provider: ${selected.upstream_model}`}
+      >
+        upstream · {selected.upstream_model}
+      </span>
+    </div>
+  );
+}
+
+function SystemPromptStats({ value }: { value: string }) {
+  const stats = useMemo(() => promptStats(value), [value]);
+  return (
+    <div
+      aria-hidden="true"
+      className="mt-1 flex flex-wrap items-center gap-3 text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft"
+    >
+      <span>{stats.chars.toLocaleString()} chars</span>
+      <span className="text-fg-faint">·</span>
+      <span>{stats.lines.toLocaleString()} lines</span>
+      <span className="text-fg-faint">·</span>
+      <span title="Rough estimate (chars / 4) — actual tokens depend on the tokenizer">
+        ~{stats.tokenEstimate.toLocaleString()} tokens
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Cheap, dependency-free prompt stats. The token estimate uses the
+ * widely-used `chars / 4` rule of thumb for English. It is intentionally
+ * coarse — adding a real tokenizer (tiktoken/gpt-tokenizer) would pull in a
+ * 1 MB+ WASM/JSON payload for a sidebar hint, which isn't worth it here.
+ */
+function promptStats(value: string): { chars: number; lines: number; tokenEstimate: number } {
+  if (value.length === 0) {
+    return { chars: 0, lines: 0, tokenEstimate: 0 };
+  }
+  const chars = value.length;
+  const lines = value.split("\n").length;
+  const tokenEstimate = Math.ceil(chars / 4);
+  return { chars, lines, tokenEstimate };
+}
+
+function ToolsPanel({
+  spec,
+  capabilities,
+  updateField,
+  agentSaved,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
+  agentSaved: boolean;
+}) {
+  if (!capabilities || capabilities.tools.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-line bg-surface p-6 text-sm text-fg-soft">
+        No tools are currently published. Once plugins or MCP servers register tools, they will
+        appear here.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-6">
+      <ToolSelector
+        title="Allowed Tools"
+        description='"All tools" is the default — every published tool is exposed. Switch to Custom to restrict the agent to a specific subset.'
+        tools={capabilities.tools}
+        value={spec.allowed_tools}
+        onChange={(next) => updateField("allowed_tools", next)}
+        variant="include"
+      />
+      <ToolSelector
+        title="Excluded Tools"
+        description="Excluded tools are removed from the effective allow-list, even if they appear in 'All tools'. Useful for keeping a tool published to other agents but blocking it here."
+        tools={capabilities.tools}
+        value={spec.excluded_tools}
+        onChange={(next) => updateField("excluded_tools", next)}
+        variant="exclude"
+      />
+      <AllowedExcludedToolsSection
+        spec={spec}
+        capabilities={capabilities}
+        agentSaved={agentSaved}
+      />
+    </div>
+  );
+}
+
+/**
+ * Computes `allowed_tools ∖ excluded_tools` over the published tool list.
+ * This is **not** the final runtime tool set — the permission plugin's
+ * BeforeInference hook removes unconditionally-denied tools on top of this.
+ * See `awaken-ext-permission::PermissionRuleset::unconditionally_denied_tools`.
+ */
+function computeAllowedTools(
+  tools: Capabilities["tools"],
+  allowed: AgentSpec["allowed_tools"],
+  excluded: AgentSpec["excluded_tools"],
+): Capabilities["tools"] {
+  const excludedSet = new Set(excluded ?? []);
+  return tools.filter((tool) => {
+    if (allowed !== null && allowed !== undefined && !allowed.includes(tool.id)) return false;
+    if (excludedSet.has(tool.id)) return false;
+    return true;
+  });
+}
+
+function AllowedExcludedToolsSection({
+  spec,
+  capabilities,
+  agentSaved,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities;
+  /** `true` once the agent exists server-side; the preview endpoint reads
+   *  the stored record so it would 404 for an in-flight new draft. */
+  agentSaved: boolean;
+}) {
+  const visible = useMemo(
+    () => computeAllowedTools(capabilities.tools, spec.allowed_tools, spec.excluded_tools),
+    [capabilities.tools, spec.allowed_tools, spec.excluded_tools],
+  );
+  const total = capabilities.tools.length;
+  const excludedCount = (spec.excluded_tools ?? []).length;
+  const allowedMode =
+    spec.allowed_tools === null || spec.allowed_tools === undefined ? "all" : "custom";
+  const allowedSize = spec.allowed_tools?.length ?? total;
+  const permissionPluginEnabled = (spec.plugin_ids ?? []).includes("permission");
+  // Fetch the server-computed permission preview when the agent is saved
+  // AND the permission plugin is enabled. The endpoint reads the persisted
+  // record, so we tie the query to spec.id rather than spec content — the
+  // user sees the *saved* effective tools (not pending unsaved edits to
+  // the permission section). The query auto-refetches when the saved spec
+  // changes via queryClient invalidation in the Save path.
+  const previewQuery = useQuery({
+    queryKey: qk.agent.permissionPreview(spec.id),
+    queryFn: () => configApi.agentPermissionPreview(spec.id),
+    enabled: agentSaved && permissionPluginEnabled && spec.id.trim().length > 0,
+    staleTime: 30_000,
+  });
+  return (
+    <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-fg-strong">
+            Allowed/excluded tools (pre-permission)
+          </h3>
+          <p className="mt-2 max-w-xl text-sm text-fg-soft">
+            <span className="font-mono">allowed_tools</span> ∖{" "}
+            <span className="font-mono">excluded_tools</span> over the published tool set —{" "}
+            <em>after</em> allow/exclude lists, <em>before</em> runtime plugin filtering. The
+            permission plugin (and any other plugin running a BeforeInference hook) may still
+            gate or rewrite this list per call, so this is a candidate set, not a strict
+            superset of what the model finally sees.{" "}
+            {permissionPluginEnabled
+              ? "The permission preview below shows the server-computed effective list."
+              : null}
+          </p>
+        </div>
+        <div className="text-right">
+          <div className="font-mono text-xl font-semibold text-fg-strong">
+            {visible.length}
+            <span className="text-fg-faint"> / {total}</span>
+          </div>
+          <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
+            tools after lists
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+        <span className="rounded-pill bg-muted px-2 py-0.5 text-fg-soft">
+          Allowed: {allowedMode === "all" ? "all" : `${allowedSize}`}
+        </span>
+        <span className="rounded-pill bg-muted px-2 py-0.5 text-fg-soft">
+          Excluded: {excludedCount}
+        </span>
+      </div>
+
+      {visible.length === 0 ? (
+        <div className="mt-4 rounded-md border border-tone-warn/35 bg-tone-warn/10 px-4 py-3 text-sm text-tone-warn">
+          The allow/exclude lists leave no tools. Combined with any permission policy this means
+          the model will see an empty tool set.
+        </div>
+      ) : (
+        <details className="mt-4 rounded-md border border-line bg-soft">
+          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-fg-soft">
+            Show {visible.length} tool{visible.length === 1 ? "" : "s"}
+          </summary>
+          <ul className="grid gap-1 px-3 py-3 md:grid-cols-2 xl:grid-cols-3">
+            {visible.map((tool) => (
+              <li key={tool.id} className="truncate font-mono text-[11px] text-fg-strong">
+                {tool.id}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {permissionPluginEnabled ? (
+        <PermissionPreviewBlock
+          agentSaved={agentSaved}
+          loading={previewQuery.isPending && previewQuery.fetchStatus === "fetching"}
+          error={previewQuery.error}
+          preview={previewQuery.data}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function PermissionPreviewBlock({
+  agentSaved,
+  loading,
+  error,
+  preview,
+}: {
+  agentSaved: boolean;
+  loading: boolean;
+  error: unknown;
+  preview: PermissionPreviewResponse | null | undefined;
+}) {
+  if (!agentSaved) {
+    return (
+      <div
+        className="mt-4 rounded-md border border-dashed border-line bg-soft px-3 py-2 text-xs text-fg-soft"
+        data-testid="permission-preview-pending-save"
+      >
+        Permission preview will be available after the agent is saved — the server reads the
+        persisted record to compute true effective tools.
+      </div>
+    );
+  }
+  if (loading) {
+    return (
+      <div className="mt-4 rounded-md border border-line bg-soft px-3 py-2 text-xs text-fg-soft">
+        Loading permission preview…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="mt-4 rounded-md border border-tone-error/30 bg-tone-error/10 px-3 py-2 text-xs text-tone-error">
+        Failed to load permission preview: {error instanceof Error ? error.message : String(error)}
+      </div>
+    );
+  }
+  if (preview === null) {
+    return (
+      <div className="mt-4 rounded-md border border-dashed border-line bg-soft px-3 py-2 text-xs text-fg-soft">
+        Server build lacks the <span className="font-mono">permission</span> feature — preview
+        unavailable.
+      </div>
+    );
+  }
+  if (!preview) return null;
+
+  return (
+    <div
+      data-testid="permission-preview-block"
+      className="mt-4 space-y-3 rounded-md border border-line bg-soft px-3 py-3"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2 text-xs">
+        <div>
+          <div className="text-[10px] font-medium uppercase tracking-eyebrow text-fg-soft">
+            Permission preview (server-computed)
+          </div>
+          <div className="mt-1 text-fg-soft">
+            Default behavior: <span className="font-mono">{preview.default_behavior ?? "—"}</span>
+            <span className="mx-2 text-fg-faint">·</span>
+            Effective: <span className="font-mono text-fg-strong">{preview.effective_tools.length}</span>
+            <span className="mx-2 text-fg-faint">·</span>
+            Unconditionally denied:{" "}
+            <span className="font-mono text-fg-strong">{preview.unconditionally_denied.length}</span>
+            <span className="mx-2 text-fg-faint">·</span>
+            Args-conditional rules:{" "}
+            <span className="font-mono text-fg-strong">
+              {preview.args_conditional_rules.length}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {preview.unconditionally_denied.length > 0 ? (
+        <details className="rounded-md border border-tone-error/30 bg-tone-error/5">
+          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-tone-error">
+            {preview.unconditionally_denied.length} tool
+            {preview.unconditionally_denied.length === 1 ? "" : "s"} stripped before the model sees
+            the list
+          </summary>
+          <ul className="grid gap-1 px-3 py-2 md:grid-cols-2 xl:grid-cols-3">
+            {preview.unconditionally_denied.map((id) => (
+              <li
+                key={id}
+                className="truncate font-mono text-[11px] text-tone-error"
+                data-testid="permission-preview-denied-tool"
+              >
+                {id}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+
+      <details className="rounded-md border border-line bg-surface">
+        <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-fg-soft">
+          Show {preview.effective_tools.length} effective tool
+          {preview.effective_tools.length === 1 ? "" : "s"}
+        </summary>
+        <ul className="grid gap-1 px-3 py-2 md:grid-cols-2 xl:grid-cols-3">
+          {preview.effective_tools.map((id) => (
+            <li
+              key={id}
+              className="truncate font-mono text-[11px] text-fg-strong"
+              data-testid="permission-preview-effective-tool"
+            >
+              {id}
+            </li>
+          ))}
+        </ul>
+      </details>
+
+      {preview.args_conditional_rules.length > 0 ? (
+        <details className="rounded-md border border-tone-warn/40 bg-tone-warn/5">
+          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-tone-warn">
+            {preview.args_conditional_rules.length} rule
+            {preview.args_conditional_rules.length === 1 ? "" : "s"} depend on call arguments
+          </summary>
+          <ul className="grid gap-1 px-3 py-2">
+            {preview.args_conditional_rules.map((rule, idx) => (
+              <li
+                key={`${rule.tool}:${idx}`}
+                className="font-mono text-[11px] text-fg"
+                data-testid="permission-preview-conditional-rule"
+              >
+                <span className="font-semibold">{rule.behavior}</span>{" "}
+                <span className="text-fg-soft">{rule.pattern}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function PluginsPanel({
+  spec,
+  capabilities,
+  configurablePlugins,
+  visiblePluginSchemas,
+  activePluginConfig,
+  setActivePluginConfig,
+  togglePlugin,
+  updateSection,
+  updateField,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  configurablePlugins: NonNullable<Capabilities["plugins"]>;
+  visiblePluginSchemas: Parameters<typeof PluginConfigWorkspace>[0]["entries"];
+  activePluginConfig: string | null;
+  setActivePluginConfig: (next: string | null) => void;
+  togglePlugin: (pluginId: string) => void;
+  updateSection: (key: string, value: unknown) => void;
+  updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
+}) {
+  if (!capabilities || capabilities.plugins.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-line bg-surface p-6 text-sm text-fg-soft">
+        No plugins are currently registered.
+      </div>
+    );
+  }
+  return (
+    <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-fg-strong">Plugins</h3>
+      <p className="mt-2 text-sm text-fg-soft">
+        Enable agent plugins here. Plugins with agent-level settings expose their configuration
+        forms below.
+      </p>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {capabilities.plugins.map((plugin) => (
+          <label
+            key={plugin.id}
+            className="rounded-xl border border-line bg-soft px-4 py-3 text-sm text-fg"
+          >
+            <div className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                checked={(spec.plugin_ids ?? []).includes(plugin.id)}
+                onChange={() => togglePlugin(plugin.id)}
+              />
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="font-mono text-fg-strong">{pluginDisplayName(plugin.id)}</div>
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-fg-soft">
+                    {plugin.id}
+                  </span>
+                  {plugin.config_schemas.length > 0 ? (
+                    <span className="rounded-full bg-tone-success/15 px-2 py-0.5 text-xs font-medium text-tone-success">
+                      Configurable
+                    </span>
+                  ) : null}
+                </div>
+                <div className="mt-1 text-fg-soft">
+                  {plugin.config_schemas.length === 0
+                    ? "No agent-level config sections"
+                    : `Config sections: ${plugin.config_schemas
+                        .map((schema) => schema.key)
+                        .join(", ")}`}
+                </div>
+              </div>
+            </div>
+          </label>
+        ))}
+      </div>
+
+      <div className="mt-6 border-t border-line pt-5">
+        <h4 className="text-base font-semibold text-fg-strong">Plugin Configuration</h4>
+        <p className="mt-2 text-sm text-fg-soft">
+          Existing saved sections stay visible even if a plugin is currently disabled, so you can
+          inspect and edit them before re-enabling the plugin.
+        </p>
+      </div>
+
+      {configurablePlugins.length === 0 ? (
+        <div className="mt-4 rounded-md border border-dashed border-line px-4 py-3 text-sm text-fg-soft">
+          No registered plugins expose agent-level configuration.
+        </div>
+      ) : (
+        <PluginConfigWorkspace
+          entries={visiblePluginSchemas}
+          sections={spec.sections ?? {}}
+          activeEntryKey={activePluginConfig}
+          onSelectEntry={setActivePluginConfig}
+          onUpdateSection={updateSection}
+        />
+      )}
+
+      <ActiveHookFilterSection
+        pluginIds={spec.plugin_ids ?? []}
+        value={spec.active_hook_filter ?? []}
+        onChange={(next) =>
+          // Empty filter == "all hooks run" on the wire (Rust marks the
+          // field `skip_serializing_if = "is_empty"`), so writing back
+          // `undefined` keeps the spec field absent rather than promoting
+          // a default into an explicit `[]` override on customized PATCH.
+          updateField("active_hook_filter", next.length === 0 ? undefined : next)
+        }
+      />
+    </section>
+  );
+}
+
+function ActiveHookFilterSection({
+  pluginIds,
+  value,
+  onChange,
+}: {
+  pluginIds: string[];
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const filtering = value.length > 0;
+  const valueSet = new Set(value);
+  // Partition against currently-loaded plugins. Stale entries (filter ids
+  // not in plugin_ids) won't render as toggles below, so without this we
+  // would silently keep them in the saved record while showing nothing in
+  // the UI — and `filtering` would stay true even when every visible
+  // toggle is unchecked.
+  const { stale } = partitionActiveHookFilter(value, pluginIds);
+
+  function setMode(next: "all" | "filter") {
+    if (next === "all") {
+      onChange([]);
+    } else if (value.length === 0) {
+      onChange([...pluginIds]);
+    }
+  }
+
+  function toggle(pluginId: string, checked: boolean) {
+    const next = checked
+      ? Array.from(new Set([...value, pluginId]))
+      : value.filter((id) => id !== pluginId);
+    onChange(next);
+  }
+
+  function clearStaleEntries() {
+    if (stale.length === 0) return;
+    const staleSet = new Set(stale);
+    onChange(value.filter((id) => !staleSet.has(id)));
+  }
+
+  return (
+    <div className="mt-6 border-t border-line pt-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h4 className="text-base font-semibold text-fg-strong">Active hook filter</h4>
+          <p className="mt-2 max-w-xl text-sm text-fg-soft">
+            Restricts runtime hooks to a chosen subset of loaded plugins. Default is "all" —
+            every loaded plugin's hooks run. Switch to "Filter" to allow only the plugins you
+            select below to execute hooks. Plugins not in the filter remain loaded but their
+            hooks are skipped.
+          </p>
+        </div>
+        <fieldset aria-label="Active hook filter mode" className="flex shrink-0 gap-2">
+          <label
+            className={[
+              "min-w-[8rem] cursor-pointer rounded-xl border px-3 py-2 text-sm transition",
+              !filtering
+                ? "border-accent bg-accent text-accent-text shadow-sm"
+                : "border-line bg-surface text-fg hover:border-line-strong hover:bg-soft",
+            ].join(" ")}
+          >
+            <input
+              type="radio"
+              className="sr-only"
+              checked={!filtering}
+              onChange={() => setMode("all")}
+            />
+            <div className="font-semibold">All plugins</div>
+            <div
+              className={[
+                "mt-0.5 text-xs leading-5",
+                !filtering ? "text-fg-faint" : "text-fg-soft",
+              ].join(" ")}
+            >
+              Default — no filtering.
+            </div>
+          </label>
+          <label
+            className={[
+              "min-w-[8rem] cursor-pointer rounded-xl border px-3 py-2 text-sm transition",
+              filtering
+                ? "border-accent bg-accent text-accent-text shadow-sm"
+                : "border-line bg-surface text-fg hover:border-line-strong hover:bg-soft",
+            ].join(" ")}
+          >
+            <input
+              type="radio"
+              className="sr-only"
+              checked={filtering}
+              onChange={() => setMode("filter")}
+            />
+            <div className="font-semibold">Filter</div>
+            <div
+              className={[
+                "mt-0.5 text-xs leading-5",
+                filtering ? "text-fg-faint" : "text-fg-soft",
+              ].join(" ")}
+            >
+              Only listed plugins' hooks run.
+            </div>
+          </label>
+        </fieldset>
+      </div>
+
+      {filtering ? (
+        pluginIds.length === 0 ? (
+          <div className="mt-4 rounded-md border border-dashed border-line px-4 py-3 text-sm text-fg-soft">
+            No plugins are enabled. Enable plugins above before filtering hooks.
+          </div>
+        ) : (
+          <div className="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {pluginIds.map((pluginId) => {
+              const checked = valueSet.has(pluginId);
+              return (
+                <label
+                  key={pluginId}
+                  className="flex items-center gap-2 rounded-xl border border-line bg-soft px-3 py-2 text-sm text-fg"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(event) => toggle(pluginId, event.target.checked)}
+                  />
+                  <span className="font-mono text-xs text-fg-strong">{pluginId}</span>
+                </label>
+              );
+            })}
+          </div>
+        )
+      ) : null}
+
+      {stale.length > 0 ? (
+        <div
+          className="mt-4 rounded-md border border-tone-warn/40 bg-tone-warn/10 p-3 text-sm text-fg"
+          data-testid="active-hook-filter-stale-warning"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="font-semibold text-tone-warn">
+                Stale filter entries ({stale.length})
+              </div>
+              <p className="mt-1 text-xs text-fg-soft">
+                The following ids are still in <span className="font-mono">active_hook_filter</span>{" "}
+                but no longer match any enabled plugin, so they gate nothing at runtime. They will
+                be saved as-is unless cleared.
+              </p>
+              <div
+                className="mt-2 flex flex-wrap gap-1"
+                data-testid="active-hook-filter-stale-chips"
+              >
+                {stale.map((id) => (
+                  <span
+                    key={id}
+                    className="rounded-full bg-surface px-2 py-0.5 font-mono text-xs text-fg-strong"
+                  >
+                    {id}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={clearStaleEntries}
+              className="shrink-0 rounded-md border border-line-strong bg-surface px-3 py-1 text-xs font-medium text-fg-soft transition hover:bg-soft"
+            >
+              Clear stale entries
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DelegatesPanel({
+  spec,
+  capabilities,
+  toggleDelegate,
+}: {
+  spec: AgentSpec;
+  capabilities: Capabilities | null;
+  toggleDelegate: (delegateId: string, checked: boolean) => void;
+}) {
+  if (!capabilities || capabilities.agents.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-line bg-surface p-6 text-sm text-fg-soft">
+        No other agents are registered yet, so this agent cannot delegate.
+      </div>
+    );
+  }
+  const selected = spec.delegates ?? [];
+  return (
+    <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-fg-strong">Delegates</h3>
+          <p className="mt-2 max-w-xl text-sm text-fg-soft">
+            Pick agents this one can hand work off to. Self-loops are blocked statically; longer
+            cycles (A → B → A) are detected at runtime by the scheduler.
+          </p>
+        </div>
+        {selected.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5 text-xs text-fg-soft">
+            <span className="text-fg-faint">selected</span>
+            {selected.map((id) => (
+              <span
+                key={id}
+                className="inline-flex items-center gap-1 rounded-pill border border-agent-stripe/30 bg-agent-tint px-2 py-0.5 font-mono text-agent-fg"
+              >
+                {id}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {capabilities.agents
+          .filter((agentId) => agentId !== spec.id)
+          .map((agentId) => {
+            const checked = selected.includes(agentId);
+            return (
+              <label
+                key={agentId}
+                className={[
+                  "rounded-xl border px-4 py-3 text-sm transition-colors",
+                  checked
+                    ? "border-agent-stripe/40 bg-agent-tint text-agent-fg"
+                    : "border-line bg-soft text-fg hover:border-line-strong",
+                ].join(" ")}
+              >
+                <div className="flex items-center gap-3">
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(event) => toggleDelegate(agentId, event.target.checked)}
+                  />
+                  <span className="font-mono text-fg-strong">{agentId}</span>
+                </div>
+              </label>
+            );
+          })}
+      </div>
+    </section>
+  );
+}
+
+function AdvancedPanel({
+  spec,
+  isNew,
+  updateField,
+  replaceSpec,
+}: {
+  spec: AgentSpec;
+  isNew: boolean;
+  updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
+  replaceSpec: (next: AgentSpec) => void;
+}) {
+  return (
+    <div className="space-y-6">
+      <ContextPolicySection
+        value={spec.context_policy ?? null}
+        onChange={(next) => updateField("context_policy", next)}
+      />
+      {spec.endpoint ? <RemoteEndpointReadonlySection endpoint={spec.endpoint} /> : null}
+      <JsonEditorSection spec={spec} isNew={isNew} replaceSpec={replaceSpec} />
+    </div>
+  );
+}
+
+function JsonEditorSection({
+  spec,
+  isNew,
+  replaceSpec,
+}: {
+  spec: AgentSpec;
+  isNew: boolean;
+  replaceSpec: (next: AgentSpec) => void;
+}) {
+  // The textarea shows a redacted view of the spec (today: just `endpoint`
+  // auth secrets) so a real bearer token / api_key never lands in the
+  // admin DOM. The Apply path overlays the real locked fields from the
+  // current spec before checking / persisting, so redaction is purely a
+  // display concern.
+  const specSerialized = useMemo(
+    () => JSON.stringify(redactAgentSpecForDisplay(spec), null, 2),
+    [spec],
+  );
+  const [draft, setDraft] = useState<string>(() => specSerialized);
+  const [error, setError] = useState<string | null>(null);
+  const [touched, setTouched] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const toast = useToast();
+  const hasRedactedEndpoint = Boolean(spec.endpoint);
+
+  // Re-sync the textarea when the underlying spec changes from elsewhere
+  // (e.g. another tab edits, restore from history) and the user has not yet
+  // made unsaved edits in this textarea.
+  useEffect(() => {
+    if (!touched) {
+      setDraft(specSerialized);
+    }
+  }, [specSerialized, touched]);
+
+  async function handleApply() {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(draft);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      setError("Top-level value must be a JSON object.");
+      return;
+    }
+    const parsedRecord = parsed as Record<string, unknown>;
+    // Reject unknown top-level fields up front. The Save path only persists
+    // identity + locked + patchable fields, so anything else would enter
+    // the dirty state and silently disappear on Save ("saved (no patchable
+    // changes)" while the page still looks dirty).
+    const unknown = unknownAgentSpecFields(parsedRecord);
+    if (unknown.length > 0) {
+      setError(
+        `Unknown top-level field${unknown.length === 1 ? "" : "s"}: ${unknown
+          .map((k) => `\`${k}\``)
+          .join(", ")}. The editor cannot persist these — remove them or update the schema.`,
+      );
+      return;
+    }
+    // Overlay the real locked fields onto the parsed payload before any
+    // further check. The textarea showed `***` for redacted endpoint
+    // auth; without this overlay, `lockedFieldChange` would always flag
+    // endpoint as "changed" the moment an endpoint is present and Apply
+    // would be impossible.
+    const withRealLockedFields = mergeLockedFields(parsedRecord, spec);
+    // `endpoint` and `registry` are provenance / runtime-locality fields
+    // not user-editable through the editor. Even though redaction is now
+    // overlaid, a user could still try to change a non-secret subfield
+    // (`base_url`, `backend`, `target`, …); lockedFieldChange catches that.
+    const lockedField = lockedFieldChange(spec, withRealLockedFields);
+    if (lockedField) {
+      setError(
+        `\`${lockedField}\` can't be changed from the editor — it's a provenance / runtime-locality field. Revert the key to its current value to apply.`,
+      );
+      return;
+    }
+    // Build the would-be-applied payload (identity fields are preserved by
+    // replaceSpec) and let the server type-check the rest before we mutate
+    // editor state. The same validate endpoint backs the Validate button so
+    // we get consistent errors with the Save path.
+    const candidate: AgentSpec = {
+      ...(withRealLockedFields as unknown as AgentSpec),
+      id: spec.id,
+      created_at: spec.created_at,
+      updated_at: spec.updated_at,
+    };
+    setApplying(true);
+    try {
+      await configApi.validateConfig("agents", candidate, isNew ? undefined : { id: spec.id });
+      replaceSpec(candidate);
+      setError(null);
+      setTouched(false);
+      toast.success("JSON applied to draft. Click Save to publish.");
+    } catch (err) {
+      setError(
+        `Validation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  function handleReset() {
+    setDraft(specSerialized);
+    setError(null);
+    setTouched(false);
+  }
+
+  return (
+    <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-fg-strong">Raw JSON</h3>
+          <p className="mt-2 max-w-xl text-sm text-fg-soft">
+            Edit the AgentSpec payload directly. <span className="font-mono">id</span>,{" "}
+            <span className="font-mono">created_at</span>, and{" "}
+            <span className="font-mono">updated_at</span> are preserved on Apply. Click Save below
+            to publish — the runtime validation still runs.
+          </p>
+          {hasRedactedEndpoint ? (
+            <p
+              className="mt-2 max-w-xl text-xs text-fg-soft"
+              data-testid="raw-json-redaction-notice"
+            >
+              <span className="font-mono">endpoint</span> credential fields are masked as
+              <span className="mx-1 font-mono">***</span>
+              in this view. Apply restores the real values automatically;{" "}
+              <span className="font-mono">endpoint</span> remains read-only from this editor.
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleReset}
+            disabled={!touched || applying}
+            className="rounded-md border border-line-strong bg-surface px-3 py-1.5 text-xs font-medium text-fg-soft transition hover:bg-soft disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleApply()}
+            disabled={!touched || applying}
+            className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-text transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {applying ? "Validating…" : "Apply to draft"}
+          </button>
+        </div>
+      </div>
+
+      <textarea
+        value={draft}
+        onChange={(event) => {
+          setDraft(event.target.value);
+          setTouched(true);
+          if (error) setError(null);
+        }}
+        spellCheck={false}
+        rows={20}
+        className="mt-4 w-full rounded-xl border border-line-strong bg-code-bg px-3 py-2 font-mono text-xs leading-5 text-code-fg outline-none transition focus:border-line-strong"
+      />
+
+      {error ? (
+        <div className="mt-3 rounded-md border border-tone-error/30 bg-tone-error/10 px-3 py-2 text-xs text-tone-error">
+          {error}
+        </div>
+      ) : null}
+
+      {touched ? (
+        <div className="mt-3 text-xs text-fg-soft">
+          Unsaved JSON edits — click <strong>Apply to draft</strong> to fold them into the form,
+          then Save.
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+const COMPACTION_MODE_LABEL: Record<ContextCompactionMode, string> = {
+  keep_recent_raw_suffix: "Keep recent raw suffix",
+  compact_to_safe_frontier: "Compact to safe frontier",
+};
+
+function ContextPolicySection({
+  value,
+  onChange,
+}: {
+  value: ContextWindowPolicy | null;
+  onChange: (next: ContextWindowPolicy | null) => void;
+}) {
+  const enabled = value !== null;
+  const policy = value ?? DEFAULT_CONTEXT_POLICY;
+  const autocompactEnabled =
+    policy.autocompact_threshold !== null && policy.autocompact_threshold !== undefined;
+
+  function update<K extends keyof ContextWindowPolicy>(key: K, next: ContextWindowPolicy[K]) {
+    onChange({ ...policy, [key]: next });
+  }
+
+  return (
+    <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-fg-strong">Context window policy</h3>
+          <p className="mt-2 max-w-xl text-sm text-fg-soft">
+            Controls how the runtime trims or compacts conversation history before each inference.
+            Disable to let the runtime use built-in defaults from the resolved model binding.
+          </p>
+        </div>
+        <label className="inline-flex items-center gap-2 text-sm text-fg">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(event) =>
+              onChange(event.target.checked ? { ...DEFAULT_CONTEXT_POLICY } : null)
+            }
+          />
+          <span>Apply custom policy</span>
+        </label>
+      </div>
+
+      {enabled ? (
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <Field label="Max context tokens">
+            <input
+              type="number"
+              min={1}
+              value={policy.max_context_tokens}
+              onChange={(event) =>
+                update("max_context_tokens", Number(event.target.value) || 0)
+              }
+              className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+            />
+          </Field>
+          <Field label="Max output tokens">
+            <input
+              type="number"
+              min={1}
+              value={policy.max_output_tokens}
+              onChange={(event) => update("max_output_tokens", Number(event.target.value) || 0)}
+              className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+            />
+          </Field>
+          <Field label="Min recent messages">
+            <input
+              type="number"
+              min={0}
+              value={policy.min_recent_messages}
+              onChange={(event) =>
+                update("min_recent_messages", Number(event.target.value) || 0)
+              }
+              className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+            />
+          </Field>
+          <Field label="Compaction mode">
+            <select
+              value={policy.compaction_mode ?? "keep_recent_raw_suffix"}
+              onChange={(event) =>
+                update("compaction_mode", event.target.value as ContextCompactionMode)
+              }
+              className="w-full rounded-xl border border-line-strong bg-surface px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+            >
+              {(Object.keys(COMPACTION_MODE_LABEL) as ContextCompactionMode[]).map((mode) => (
+                <option key={mode} value={mode}>
+                  {COMPACTION_MODE_LABEL[mode]}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Compaction raw suffix messages">
+            <input
+              type="number"
+              min={0}
+              value={policy.compaction_raw_suffix_messages ?? 2}
+              onChange={(event) =>
+                update("compaction_raw_suffix_messages", Number(event.target.value) || 0)
+              }
+              className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong"
+            />
+          </Field>
+          <Field label="Autocompact threshold">
+            <div className="flex items-center gap-2">
+              <label className="inline-flex items-center gap-1 text-xs text-fg-soft">
+                <input
+                  type="checkbox"
+                  checked={autocompactEnabled}
+                  onChange={(event) =>
+                    update(
+                      "autocompact_threshold",
+                      event.target.checked ? policy.max_context_tokens : null,
+                    )
+                  }
+                />
+                <span>Enable</span>
+              </label>
+              <input
+                type="number"
+                min={1}
+                disabled={!autocompactEnabled}
+                value={autocompactEnabled ? Number(policy.autocompact_threshold ?? 0) : ""}
+                onChange={(event) =>
+                  update("autocompact_threshold", Number(event.target.value) || null)
+                }
+                className="w-full rounded-xl border border-line-strong px-3 py-2 text-sm text-fg-strong outline-none transition focus:border-line-strong disabled:bg-muted disabled:text-fg-soft"
+              />
+            </div>
+          </Field>
+          <Field label="Prompt caching">
+            <label className="inline-flex items-center gap-2 text-sm text-fg">
+              <input
+                type="checkbox"
+                checked={Boolean(policy.enable_prompt_cache)}
+                onChange={(event) => update("enable_prompt_cache", event.target.checked)}
+              />
+              <span>Enable prompt caching</span>
+            </label>
+          </Field>
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-fg-soft">
+          No custom policy applied. The runtime uses the model binding's defaults.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function RemoteEndpointReadonlySection({
+  endpoint,
+}: {
+  endpoint: NonNullable<AgentSpec["endpoint"]>;
+}) {
+  // Mask credential-bearing fields before serializing for display so the
+  // admin DOM never carries a real bearer token / api_key / etc., even
+  // transiently. The backend may return endpoint auth in clear for the
+  // edit flow; we don't want it to surface in screenshots, copy-paste,
+  // or browser dev tools.
+  const redacted = redactEndpointForDisplay(endpoint);
+  return (
+    <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      <h3 className="text-lg font-semibold text-fg-strong">Remote endpoint</h3>
+      <p className="mt-2 max-w-xl text-sm text-fg-soft">
+        This agent is configured to run on a remote backend. Endpoint configuration is preserved
+        across edits but not editable from this form.
+      </p>
+      <p
+        className="mt-2 max-w-xl text-xs text-fg-soft"
+        data-testid="remote-endpoint-redaction-notice"
+      >
+        Credential fields (bearer tokens, API keys, etc.) are masked as
+        <span className="mx-1 font-mono">***</span>
+        below. Manage the real credential in the remote backend record.
+      </p>
+      <pre
+        className="mt-3 overflow-auto rounded-xl bg-code-bg p-3 text-xs text-code-fg"
+        data-testid="remote-endpoint-readonly"
+      >
+        {JSON.stringify(redacted, null, 2)}
+      </pre>
+    </section>
+  );
+}
+
+const ACTION_BADGE: Record<string, string> = {
+  create: "bg-tone-success/15 text-tone-success",
+  update: "bg-blue-100 text-blue-800",
+  delete: "bg-tone-error/15 text-tone-error",
+  restart: "bg-tone-warn/15 text-tone-warn",
+  publish: "bg-violet-100 text-violet-800",
+  restore: "bg-purple-100 text-purple-800",
+};
+
+function HistoryPanel({
+  spec,
+  isNew,
+  refreshKey,
+  onSpecRestored,
+}: {
+  spec: AgentSpec;
+  isNew: boolean;
+  refreshKey: number;
+  onSpecRestored: (updated: AgentSpec) => void;
+}) {
+  const toast = useToast();
+  const confirm = useConfirmDialog();
+  const [selectedEvent, setSelectedEvent] = useState<AuditEvent | null>(null);
+  const [restoring, setRestoring] = useState<string | null>(null);
+  const historyQuery = useAuditLogInfiniteQuery(
+    { resource: `agents/${spec.id}`, limit: 50 },
+    { enabled: !isNew && Boolean(spec.id) },
+  );
+  const page = historyQuery.data?.pages[0] ?? null;
+  const loading = historyQuery.isFetching;
+  const error = historyQuery.error
+    ? historyQuery.error instanceof Error
+      ? historyQuery.error.message
+      : String(historyQuery.error)
+    : null;
+  const refetchHistory = historyQuery.refetch;
+
+  useEffect(() => {
+    if (refreshKey > 0) {
+      void refetchHistory();
+    }
+  }, [refetchHistory, refreshKey]);
+
+  async function handleRestore(event: AuditEvent) {
+    const targetSpec = event.action === "delete" ? event.before : event.after;
+    // Mask secret-bearing keys (today: endpoint auth fields) before they
+    // land in the confirm-dialog DOM. The real values survive in the
+    // editor's spec state and are still what gets POSTed back to the
+    // restore endpoint; redaction is purely a display concern.
+    const redactedCurrent = redactAgentSpecForDisplay(spec);
+    const redactedTarget =
+      targetSpec && typeof targetSpec === "object"
+        ? redactAgentSpecForDisplay(targetSpec as unknown as AgentSpec)
+        : null;
+    const confirmed = await confirm({
+      title: "Restore agent to this version?",
+      description: (
+        <div className="space-y-3">
+          <p className="text-xs text-fg-soft">
+            Restoring will overwrite the current agent configuration with the version from this
+            event.
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-fg-soft">
+                Current
+              </p>
+              <pre className="max-h-48 overflow-auto rounded-xl border border-line bg-soft p-2 text-xs text-fg">
+                {JSON.stringify(redactedCurrent, null, 2)}
+              </pre>
+            </div>
+            <div>
+              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-fg-soft">
+                This version
+              </p>
+              <pre className="max-h-48 overflow-auto rounded-xl border border-line bg-soft p-2 text-xs text-fg">
+                {redactedTarget != null ? JSON.stringify(redactedTarget, null, 2) : "—"}
+              </pre>
+            </div>
+          </div>
+        </div>
+      ),
+      confirmLabel: "Restore",
+      tone: "destructive",
+    });
+
+    if (!confirmed) return;
+
+    setRestoring(event.id);
+    try {
+      await configApi.restoreConfig("agents", spec.id, event.id);
+      const shortId = event.id.slice(0, 8);
+      toast.success(`Agent restored to version ${shortId}`);
+      const refreshed = await configApi.get<AgentSpec>("agents", spec.id);
+      const hydrated = hydrateAgentSpec(refreshed);
+      onSpecRestored(hydrated);
+      void refetchHistory();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRestoring(null);
+    }
+  }
+
+  if (isNew || !spec.id) {
+    return (
+      <section className="rounded-md border border-dashed border-line bg-surface p-6 text-center text-sm text-fg-soft shadow-sm">
+        Save the agent first to see its history.
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-md border border-line bg-surface shadow-sm">
+      <div className="flex items-center justify-between border-b border-line px-5 py-4">
+        <h3 className="text-lg font-semibold text-fg-strong">History</h3>
+        <button
+          type="button"
+          onClick={() => void refetchHistory()}
+          disabled={loading}
+          className="text-xs font-medium text-fg-soft transition hover:text-fg-strong disabled:opacity-60"
+        >
+          {loading ? "Loading…" : "Refresh"}
+        </button>
+      </div>
+
+      {error && <div className="px-5 py-3 text-sm text-tone-error">{error}</div>}
+
+      {!error && page && (
+        <table className="min-w-full text-sm">
+          <thead className="bg-soft text-left text-xs uppercase tracking-wide text-fg-soft">
+            <tr>
+              <th className="px-4 py-3">Time</th>
+              <th className="px-4 py-3">Actor</th>
+              <th className="px-4 py-3">Action</th>
+              <th className="px-4 py-3">Change</th>
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-line">
+            {page.items.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-fg-soft">
+                  No history yet.
+                </td>
+              </tr>
+            ) : (
+              page.items.map((event) => {
+                const actor = formatActor(event.actor);
+                const ts = new Date(event.ts);
+                return (
+                  <tr key={event.id} className="hover:bg-soft">
+                    <td className="px-4 py-3 font-mono text-xs text-fg">{ts.toLocaleString()}</td>
+                    <td className="px-4 py-3 text-sm text-fg">
+                      <span className="font-mono text-xs">{actor.hash}</span>
+                      {actor.label && <span className="ml-1 text-fg-soft">/{actor.label}</span>}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={[
+                          "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                          ACTION_BADGE[event.action] ?? "bg-muted text-fg",
+                        ].join(" ")}
+                      >
+                        {event.action}
+                      </span>
+                    </td>
+                    <td className="max-w-xs truncate px-4 py-3 text-xs text-fg-soft">
+                      {summarizeChange(event)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <button
+                          type="button"
+                          onClick={() => setSelectedEvent(event)}
+                          className="text-xs font-medium text-fg-soft transition hover:text-fg-strong"
+                        >
+                          View
+                        </button>
+                        {event.action !== "restart" && (
+                          <button
+                            type="button"
+                            onClick={() => void handleRestore(event)}
+                            disabled={restoring === event.id}
+                            className="text-xs font-medium text-tone-error transition hover:text-tone-error disabled:opacity-60"
+                          >
+                            {restoring === event.id ? "Restoring…" : "Restore"}
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      )}
+
+      {selectedEvent && (
+        <HistoryEventPanel event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      )}
+    </section>
+  );
+}
+
+function HistoryEventPanel({ event, onClose }: { event: AuditEvent; onClose: () => void }) {
+  const actor = formatActor(event.actor);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Audit event details"
+      className="fixed inset-0 z-50 flex items-start justify-end bg-black/30"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="flex h-full w-full max-w-2xl flex-col overflow-y-auto bg-surface shadow-2xl md:max-w-xl">
+        <div className="flex items-center justify-between border-b border-line px-6 py-4">
+          <h3 className="text-base font-semibold text-fg-strong">Audit event</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm text-fg-soft hover:bg-muted"
+          >
+            Close
+          </button>
+        </div>
+
+        <dl className="grid gap-3 px-6 py-4 text-sm">
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-fg-soft">ID</dt>
+            <dd className="min-w-0 font-mono text-xs text-fg-strong">{event.id}</dd>
+          </div>
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-fg-soft">Time</dt>
+            <dd className="min-w-0 font-mono text-xs text-fg-strong">{event.ts}</dd>
+          </div>
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-fg-soft">Actor</dt>
+            <dd className="min-w-0 text-fg-strong">
+              <span className="font-mono text-xs">{actor.hash}</span>
+              {actor.label && <span className="ml-1 text-fg-soft">/{actor.label}</span>}
+            </dd>
+          </div>
+          <div className="flex items-baseline gap-3">
+            <dt className="w-24 shrink-0 text-xs font-medium text-fg-soft">Action</dt>
+            <dd className="min-w-0">
+              <span
+                className={[
+                  "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                  ACTION_BADGE[event.action] ?? "bg-muted text-fg",
+                ].join(" ")}
+              >
+                {event.action}
+              </span>
+            </dd>
+          </div>
+        </dl>
+
+        <div className="grid gap-4 px-6 pb-6 md:grid-cols-2">
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-fg-soft">Before</p>
+            <pre className="overflow-auto rounded-xl border border-line bg-soft p-3 text-xs leading-relaxed text-fg">
+              {event.before != null ? JSON.stringify(event.before, null, 2) : "—"}
+            </pre>
+          </div>
+          <div>
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-fg-soft">After</p>
+            <pre className="overflow-auto rounded-xl border border-line bg-soft p-3 text-xs leading-relaxed text-fg">
+              {event.after != null ? JSON.stringify(event.after, null, 2) : "—"}
+            </pre>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -2148,9 +2148,9 @@ function JsonEditorSection({
   // secret-shaped fields never land in the admin DOM. The Apply path
   // validates the user's parsed payload against this exact redacted
   // display copy FIRST (to detect edits to locked fields even when their
-  // value reads `***`), then restores unchanged redaction markers before the
-  // candidate reaches validation / draft state. Doing this before
-  // `mergeLockedFields` is load-bearing — overlaying first would mask
+  // value is a redaction sentinel), then restores unchanged redaction
+  // markers before the candidate reaches validation / draft state. Doing
+  // this before `mergeLockedFields` is load-bearing — overlaying first would mask
   // user edits to `endpoint.base_url` / `endpoint.auth.*` / `registry`.
   const editingSpec = useMemo(() => redactAgentSpecForEditing(spec), [spec]);
   const specSerialized = useMemo(
@@ -2225,8 +2225,8 @@ function JsonEditorSection({
     // `endpoint` and `registry` are provenance / runtime-locality fields
     // not user-editable through the editor. Compare the PARSED payload
     // against the redacted spec the textarea was seeded from — equality
-    // means the user didn't touch the locked fields (any `***` stayed
-    // `***`). If anything differs (a real bearer-token edit, a
+    // means the user didn't touch the locked fields (any redaction sentinel
+    // stayed intact). If anything differs (a real bearer-token edit, a
     // `base_url` swap, a `registry` flip, etc.) we reject the Apply
     // entirely. Doing this BEFORE `mergeLockedFields` is mandatory: the
     // overlay overwrites parsed.endpoint with spec.endpoint, so any
@@ -2246,8 +2246,8 @@ function JsonEditorSection({
     ) as Record<string, unknown>;
     // Now overlay the real locked-field values onto the parsed payload so
     // the candidate carries the actual `endpoint.auth.bearer_token` (not
-    // the `***` redaction marker the textarea showed). Redaction stays purely
-    // a display concern from here on.
+    // the redaction sentinel the textarea showed). Redaction stays purely a
+    // display concern from here on.
     const withRealLockedFields = mergeLockedFields(withRestoredRedactions, spec);
     // Build the would-be-applied payload (identity fields are preserved by
     // replaceSpec) and let the server type-check the rest before we mutate
@@ -2306,7 +2306,7 @@ function JsonEditorSection({
               data-testid="raw-json-redaction-notice"
             >
               Credential-like fields are masked as
-              <span className="mx-1 font-mono">***</span>
+              <span className="mx-1 font-mono">__AWAKEN_REDACTED_SECRET_...__</span>
               in this view. Apply restores unchanged redaction markers automatically;{" "}
               <span className="font-mono">endpoint</span> and{" "}
               <span className="font-mono">registry</span> remain read-only from this editor.

--- a/apps/admin-console/src/pages/agent-editor/diff-modal.tsx
+++ b/apps/admin-console/src/pages/agent-editor/diff-modal.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { redactSecretString, redactSecretsForDisplay } from "@/lib/agent-editor-helpers";
 import { jsonSemanticallyEqual, prettyStableStringify } from "./spec-helpers";
 
 interface FieldChange {
@@ -43,14 +44,11 @@ function computeDiff(
   return out;
 }
 
-function formatDiffValue(
-  value: unknown,
-  labels: { emptyString: string; unset: string },
-): string {
+function formatDiffValue(value: unknown, labels: { emptyString: string; unset: string }): string {
   if (value === undefined) return labels.unset;
   if (value === null) return "null";
-  if (typeof value === "string") return value || labels.emptyString;
-  return prettyStableStringify(value);
+  if (typeof value === "string") return redactSecretString(value) || labels.emptyString;
+  return prettyStableStringify(redactSecretsForDisplay(value));
 }
 
 export function DiffModal({

--- a/apps/admin-console/src/pages/agent-editor/editor-save-bar.tsx
+++ b/apps/admin-console/src/pages/agent-editor/editor-save-bar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type AgentSpec, configApi } from "@/lib/config-api";
+import { safeErrorMessage } from "@/lib/safe-error-message";
 import { useToast } from "@/components/toast-provider";
 import { DiffModal } from "./diff-modal";
 import { type AgentSaveMode } from "./spec-helpers";
@@ -59,7 +60,7 @@ export function EditorSaveBar({
     } catch (err) {
       toast.error(
         t("editor.savePayload.validateFailed", {
-          message: err instanceof Error ? err.message : String(err),
+          message: safeErrorMessage(err),
         }),
       );
     } finally {

--- a/apps/admin-console/src/pages/agent-editor/panels/history-panel.tsx
+++ b/apps/admin-console/src/pages/agent-editor/panels/history-panel.tsx
@@ -4,6 +4,7 @@ import { type AuditEvent, formatActor, summarizeChange } from "@/lib/audit-log";
 import { useToast } from "@/components/toast-provider";
 import { useConfirmDialog } from "@/components/confirm-dialog";
 import { useAuditLogInfiniteQuery } from "@/lib/query/hooks/audit";
+import { safeErrorMessage } from "@/lib/safe-error-message";
 import { hydrateAgentSpec } from "../spec-helpers";
 
 const ACTION_BADGE: Record<string, string> = {
@@ -36,11 +37,7 @@ export function HistoryPanel({
   );
   const page = historyQuery.data?.pages[0] ?? null;
   const loading = historyQuery.isFetching;
-  const error = historyQuery.error
-    ? historyQuery.error instanceof Error
-      ? historyQuery.error.message
-      : String(historyQuery.error)
-    : null;
+  const error = historyQuery.error ? safeErrorMessage(historyQuery.error) : null;
   const refetchHistory = historyQuery.refetch;
 
   useEffect(() => {
@@ -95,7 +92,7 @@ export function HistoryPanel({
       await onSpecRestored(hydrated);
       void refetchHistory();
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : String(err));
+      toast.error(safeErrorMessage(err));
     } finally {
       setRestoring(null);
     }

--- a/apps/admin-console/src/pages/audit-log-page.tsx
+++ b/apps/admin-console/src/pages/audit-log-page.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ConfigApiError } from "@/lib/api";
+import { redactSecretsForDisplay } from "@/lib/agent-editor-helpers";
 
 /** Quote a CSV cell per RFC 4180 (double-quote any cell containing , " or \n). */
 function csvCell(v: string): string {
@@ -406,7 +407,10 @@ function EventPanel({ event, onClose }: { event: AuditEvent; onClose: () => void
             <p className="mb-2 text-xs font-medium uppercase tracking-wide text-fg-soft">Before</p>
             <pre className="overflow-auto rounded-xl border border-line bg-soft p-3 text-xs leading-relaxed text-fg">
               {event.before != null ? (
-                JSON.stringify(event.before, null, 2)
+                // Audit snapshots can contain a full AgentSpec, including
+                // `endpoint.auth.bearer_token`. Mask before rendering so
+                // the admin DOM never carries a real credential.
+                JSON.stringify(redactSecretsForDisplay(event.before), null, 2)
               ) : (
                 <span className="text-fg-faint">—</span>
               )}
@@ -416,7 +420,7 @@ function EventPanel({ event, onClose }: { event: AuditEvent; onClose: () => void
             <p className="mb-2 text-xs font-medium uppercase tracking-wide text-fg-soft">After</p>
             <pre className="overflow-auto rounded-xl border border-line bg-soft p-3 text-xs leading-relaxed text-fg">
               {event.after != null ? (
-                JSON.stringify(event.after, null, 2)
+                JSON.stringify(redactSecretsForDisplay(event.after), null, 2)
               ) : (
                 <span className="text-fg-faint">—</span>
               )}

--- a/crates/awaken-contract/src/agent_spec_patch.rs
+++ b/crates/awaken-contract/src/agent_spec_patch.rs
@@ -84,6 +84,21 @@ pub struct AgentSpecPatch {
     )]
     pub reasoning_effort: NullablePatch<ReasoningEffort>,
     /// Remote endpoint override. JSON `null` clears the base value.
+    ///
+    /// **Contract**: endpoint is a *patchable* runtime-safe field at the
+    /// API layer. The admin-console editor intentionally treats endpoint
+    /// as a locked / read-only field and does NOT expose UI for editing
+    /// it — that's a UX simplification ("most operators shouldn't be
+    /// rebinding the remote backend of a builtin agent through the
+    /// graphical editor"), not an immutability or security boundary.
+    /// Programmatic clients (CLI, scripts, other admin tooling)
+    /// retain the ability to override endpoint via this PATCH field.
+    ///
+    /// `patch_overrides_null_clears_nullable_base_field` (in
+    /// `crates/awaken-server/tests/config_api.rs`) pins this contract:
+    /// `PATCH /v1/config/agents/:id/overrides` with `{"endpoint": null}`
+    /// must return 200 and clear the base endpoint. Changing this to a
+    /// reject would be a breaking API change requiring a dedicated ADR.
     #[serde(
         default,
         deserialize_with = "nullable_patch::deserialize",

--- a/crates/awaken-ext-permission/src/plugin/filter.rs
+++ b/crates/awaken-ext-permission/src/plugin/filter.rs
@@ -7,12 +7,31 @@ use awaken_runtime::{PhaseContext, PhaseHook};
 
 use crate::state::{PermissionOverridesKey, PermissionPolicyKey, permission_rules_from_state};
 
-/// BeforeInference hook that removes unconditionally denied tools from the
+/// BeforeInference hook that removes unconditionally-denied tools from the
 /// tool list before the LLM sees them.
 ///
-/// Only exact-match, argument-independent Deny rules are applied here.
-/// Conditional rules remain handled by [`super::checker::PermissionToolGateHook`]
-/// at `ToolGate`.
+/// Two flavors of "unconditional Deny" are stripped here:
+///
+///  - **Exact-tool Deny** (`{ tool: "rm", deny }` or
+///    `{ tool: "rm()", deny }`) — handled by
+///    `PermissionRuleset::unconditionally_denied_tools` regardless of the
+///    registry snapshot.
+///  - **Glob/Regex Deny + any-args** (`{ tool: "mcp__db__*", deny }`) —
+///    expanded against the live tool registry snapshot from
+///    `PhaseContext::registry_snapshot`. Each registered tool id matched by
+///    the pattern is scheduled as an `ExcludeTool` so the model never sees
+///    those tools. The admin-console permission preview performs the same
+///    expansion via the shared
+///    `PermissionRuleset::unconditionally_denied_against` helper — the
+///    preview claim "X tools stripped before the model sees the list" must
+///    match the runtime, or the UI lies about what BeforeInference does.
+///
+/// Per-args patterns (`Bash(npm *)` etc.) remain conditional and are
+/// handled at `ToolGate` by [`super::checker::PermissionToolGateHook`].
+///
+/// When the context has no registry snapshot (minimal test contexts), the
+/// glob/regex expansion is skipped and only exact-tool Deny applies. The
+/// production runtime runner always attaches a snapshot.
 pub(super) struct PermissionToolFilterHook;
 
 #[async_trait]
@@ -22,14 +41,24 @@ impl PhaseHook for PermissionToolFilterHook {
         let overrides = ctx.state::<PermissionOverridesKey>();
         let ruleset = permission_rules_from_state(policy, overrides);
 
-        let denied = ruleset.unconditionally_denied_tools();
+        let tool_ids: Vec<String> = ctx
+            .registry_snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.registries().tools.tool_ids())
+            .unwrap_or_default();
+
+        let denied = ruleset.unconditionally_denied_against(&tool_ids);
         if denied.is_empty() {
             return Ok(StateCommand::new());
         }
 
         let mut cmd = StateCommand::new();
+        // Sort for deterministic ordering — `HashSet` iteration is otherwise
+        // unstable, which would surface as flaky audit-log / test output.
+        let mut denied: Vec<String> = denied.into_iter().collect();
+        denied.sort();
         for tool_id in denied {
-            cmd.schedule_action::<ExcludeTool>(tool_id.to_owned())?;
+            cmd.schedule_action::<ExcludeTool>(tool_id)?;
         }
         Ok(cmd)
     }

--- a/crates/awaken-ext-permission/src/plugin/filter_tests.rs
+++ b/crates/awaken-ext-permission/src/plugin/filter_tests.rs
@@ -1,12 +1,18 @@
 use std::sync::Arc;
 
 use awaken_contract::StateMap;
+use awaken_contract::contract::tool::Tool;
 use awaken_contract::model::{Phase, ScheduledActionSpec};
 use awaken_contract::state::Snapshot;
 use awaken_runtime::agent::state::ExcludeTool;
+use awaken_runtime::registry::{
+    MapAgentSpecRegistry, MapBackendRegistry, MapModelRegistry, MapPluginSource,
+    MapProviderRegistry, RegistrySet, RegistrySnapshot, ToolRegistry,
+};
+use awaken_runtime::state::StateCommand;
 use awaken_runtime::{PhaseContext, PhaseHook};
 
-use crate::rules::{PermissionRule, ToolPermissionBehavior};
+use crate::rules::{PermissionRule, ToolCallPattern, ToolPermissionBehavior};
 use crate::state::{PermissionPolicy, PermissionPolicyKey};
 
 use super::filter::PermissionToolFilterHook;
@@ -19,6 +25,50 @@ fn snapshot_with_policy(policy: PermissionPolicy) -> Snapshot {
 
 fn make_ctx(snapshot: Snapshot) -> PhaseContext {
     PhaseContext::new(Phase::BeforeInference, snapshot)
+}
+
+/// Minimal `ToolRegistry` for tests — `ToolRegistry::tool_ids` is the
+/// only entry point the permission filter walks. `get_tool` returns
+/// `None` because none of the hooks under test resolve concrete tools.
+struct StubToolRegistry(Vec<String>);
+
+impl ToolRegistry for StubToolRegistry {
+    fn get_tool(&self, _id: &str) -> Option<Arc<dyn Tool>> {
+        None
+    }
+    fn tool_ids(&self) -> Vec<String> {
+        self.0.clone()
+    }
+}
+
+fn registry_snapshot_with_tools<I, S>(ids: I) -> Arc<RegistrySnapshot>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let ids: Vec<String> = ids.into_iter().map(Into::into).collect();
+    let registries = RegistrySet {
+        agents: Arc::new(MapAgentSpecRegistry::new()),
+        tools: Arc::new(StubToolRegistry(ids)),
+        models: Arc::new(MapModelRegistry::new()),
+        providers: Arc::new(MapProviderRegistry::new()),
+        plugins: Arc::new(MapPluginSource::new()),
+        backends: Arc::new(MapBackendRegistry::new()),
+    };
+    Arc::new(RegistrySnapshot::new(0, registries))
+}
+
+/// Read the `ExcludeTool` payloads from a `StateCommand`'s scheduled
+/// actions, sorted for stable comparison.
+fn scheduled_exclude_tool_ids(cmd: &StateCommand) -> Vec<String> {
+    let mut out: Vec<String> = cmd
+        .scheduled_actions()
+        .iter()
+        .filter(|a| a.key == ExcludeTool::KEY)
+        .map(|a| ExcludeTool::decode_payload(a.payload.clone()).expect("decode ExcludeTool"))
+        .collect();
+    out.sort();
+    out
 }
 
 #[tokio::test]
@@ -142,4 +192,173 @@ async fn mixed_rules_only_excludes_unconditional_denies() {
     let payload: String =
         ExcludeTool::decode_payload(cmd.scheduled_actions()[0].payload.clone()).unwrap();
     assert_eq!(payload, "rm");
+}
+
+// R13 — Glob/regex any-args Deny expansion against the live tool registry.
+// The runtime BeforeInference hook MUST schedule `ExcludeTool` for every
+// registry id matched by such a rule, in lock-step with the admin-console
+// permission preview. Otherwise preview claims "X tools stripped before
+// the model sees the list" while the model still sees those tools, and
+// the block falls back to ToolGate at call time — a semantic regression.
+
+#[tokio::test]
+async fn glob_deny_expands_against_registry() {
+    let mut policy = PermissionPolicy::default();
+    let pattern = ToolCallPattern::tool_glob("mcp__db__*");
+    let rule = PermissionRule::new_pattern(pattern, ToolPermissionBehavior::Deny);
+    policy.rules.insert(rule.subject.key(), rule);
+
+    let snapshot = registry_snapshot_with_tools([
+        "Bash",
+        "mcp__db__query",
+        "mcp__db__write",
+        "mcp__github__list_issues",
+    ]);
+    let ctx = make_ctx(snapshot_with_policy(policy)).with_registry_snapshot(snapshot);
+    let cmd = PermissionToolFilterHook.run(&ctx).await.unwrap();
+    assert_eq!(
+        scheduled_exclude_tool_ids(&cmd),
+        vec!["mcp__db__query".to_string(), "mcp__db__write".to_string()],
+    );
+}
+
+#[tokio::test]
+async fn regex_deny_expands_against_registry() {
+    let mut policy = PermissionPolicy::default();
+    let pattern = crate::rules::parse_pattern("/mcp__(gh|gl)__.*/").expect("valid regex pattern");
+    let rule = PermissionRule::new_pattern(pattern, ToolPermissionBehavior::Deny);
+    policy.rules.insert(rule.subject.key(), rule);
+
+    let snapshot = registry_snapshot_with_tools([
+        "Bash",
+        "mcp__gh__list_repos",
+        "mcp__gl__list_projects",
+        "mcp__db__query",
+    ]);
+    let ctx = make_ctx(snapshot_with_policy(policy)).with_registry_snapshot(snapshot);
+    let cmd = PermissionToolFilterHook.run(&ctx).await.unwrap();
+    assert_eq!(
+        scheduled_exclude_tool_ids(&cmd),
+        vec![
+            "mcp__gh__list_repos".to_string(),
+            "mcp__gl__list_projects".to_string(),
+        ],
+    );
+}
+
+#[tokio::test]
+async fn glob_deny_without_registry_falls_back_to_exact_only() {
+    // Minimal test contexts (and any phase that runs before the runner
+    // attaches the registry snapshot) carry no registry. The hook must
+    // degrade gracefully to exact-tool Deny stripping rather than panic
+    // or treat the missing registry as "deny all".
+    let mut policy = PermissionPolicy::default();
+    // Glob Deny — has no effect without a registry to expand against.
+    let glob = PermissionRule::new_pattern(
+        ToolCallPattern::tool_glob("mcp__db__*"),
+        ToolPermissionBehavior::Deny,
+    );
+    policy.rules.insert(glob.subject.key(), glob);
+    // Exact-tool Deny — still applies.
+    let exact = PermissionRule::new_tool("rm", ToolPermissionBehavior::Deny);
+    policy.rules.insert(exact.subject.key(), exact);
+
+    let ctx = make_ctx(snapshot_with_policy(policy));
+    let cmd = PermissionToolFilterHook.run(&ctx).await.unwrap();
+    assert_eq!(scheduled_exclude_tool_ids(&cmd), vec!["rm".to_string()]);
+}
+
+#[tokio::test]
+async fn glob_deny_does_not_expand_per_args_rules() {
+    // `Bash(npm *)` Deny is conditional on args — the runtime filter
+    // must NOT strip `Bash` from the tool list. ToolGate handles per-args
+    // rules at call time.
+    let mut policy = PermissionPolicy::default();
+    let pattern = ToolCallPattern::tool_with_primary("Bash", "rm *");
+    let rule = PermissionRule::new_pattern(pattern, ToolPermissionBehavior::Deny);
+    policy.rules.insert(rule.subject.key(), rule);
+
+    let snapshot = registry_snapshot_with_tools(["Bash", "Read"]);
+    let ctx = make_ctx(snapshot_with_policy(policy)).with_registry_snapshot(snapshot);
+    let cmd = PermissionToolFilterHook.run(&ctx).await.unwrap();
+    assert!(scheduled_exclude_tool_ids(&cmd).is_empty());
+}
+
+/// **Cross-layer parity invariant** — the runtime BeforeInference hook's
+/// scheduled `ExcludeTool` set MUST equal
+/// `PermissionRuleset::unconditionally_denied_against(registry)`. Both
+/// the runtime filter and the admin-console permission preview share the
+/// same helper, so this test pins the contract: if the hook is ever
+/// refactored to compute its own set (or stop honoring the registry), the
+/// test fires and signals the drift before preview and runtime disagree
+/// about what "stripped before the model sees the list" means.
+#[tokio::test]
+async fn hook_and_helper_agree_on_unconditional_deny_set() {
+    let mut policy = PermissionPolicy::default();
+    // A mix of every flavor the helper knows about.
+    policy.rules.insert(
+        "tool:rm".into(),
+        PermissionRule::new_tool("rm", ToolPermissionBehavior::Deny),
+    );
+    let glob = PermissionRule::new_pattern(
+        ToolCallPattern::tool_glob("mcp__db__*"),
+        ToolPermissionBehavior::Deny,
+    );
+    policy.rules.insert(glob.subject.key(), glob);
+    let regex_rule = PermissionRule::new_pattern(
+        crate::rules::parse_pattern("/mcp__(gh|gl)__.*/").expect("valid regex"),
+        ToolPermissionBehavior::Deny,
+    );
+    policy.rules.insert(regex_rule.subject.key(), regex_rule);
+    // Conditional / non-deny rules — must not contribute.
+    let cond = PermissionRule::new_pattern(
+        ToolCallPattern::tool_with_primary("Bash", "rm *"),
+        ToolPermissionBehavior::Deny,
+    );
+    policy.rules.insert(cond.subject.key(), cond);
+    let allow = PermissionRule::new_pattern(
+        ToolCallPattern::tool_glob("Read*"),
+        ToolPermissionBehavior::Allow,
+    );
+    policy.rules.insert(allow.subject.key(), allow);
+
+    let tool_ids = vec![
+        "rm".to_string(),
+        "Bash".to_string(),
+        "Read".to_string(),
+        "ReadFile".to_string(),
+        "mcp__db__query".to_string(),
+        "mcp__db__write".to_string(),
+        "mcp__gh__list_repos".to_string(),
+        "mcp__gl__list_projects".to_string(),
+        "mcp__github__list_issues".to_string(),
+    ];
+    let snapshot = registry_snapshot_with_tools(tool_ids.clone());
+
+    // Helper output (the shared source of truth that preview uses).
+    let ruleset = crate::state::permission_rules_from_state(Some(&policy), None);
+    let mut helper_set: Vec<String> = ruleset
+        .unconditionally_denied_against(&tool_ids)
+        .into_iter()
+        .collect();
+    helper_set.sort();
+
+    // Runtime hook output.
+    let ctx = make_ctx(snapshot_with_policy(policy)).with_registry_snapshot(snapshot);
+    let cmd = PermissionToolFilterHook.run(&ctx).await.unwrap();
+    let hook_set = scheduled_exclude_tool_ids(&cmd);
+
+    assert_eq!(
+        hook_set, helper_set,
+        "BeforeInference hook diverged from PermissionRuleset::unconditionally_denied_against — \
+         admin-console preview and runtime would disagree about stripped tools"
+    );
+    // Spot-check: every flavor that should strip is in the set.
+    assert!(hook_set.contains(&"rm".to_string()));
+    assert!(hook_set.contains(&"mcp__db__query".to_string()));
+    assert!(hook_set.contains(&"mcp__gh__list_repos".to_string()));
+    // Spot-check: nothing else slipped in.
+    assert!(!hook_set.contains(&"Bash".to_string()));
+    assert!(!hook_set.contains(&"Read".to_string()));
+    assert!(!hook_set.contains(&"mcp__github__list_issues".to_string()));
 }

--- a/crates/awaken-ext-permission/src/rules.rs
+++ b/crates/awaken-ext-permission/src/rules.rs
@@ -16,7 +16,7 @@
 //! Tool(f1 ~ "a", f2 = "b")       multi-field AND
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -258,6 +258,72 @@ impl PermissionRuleset {
                 _ => None,
             })
             .collect()
+    }
+
+    /// Full set of tool IDs the BeforeInference filter must strip given a
+    /// live tool registry. Includes:
+    ///
+    ///  - every exact-tool, any-args Deny (covered by
+    ///    `unconditionally_denied_tools`), and
+    ///  - every glob/regex tool + any-args Deny expanded against the
+    ///    registry — i.e. for each rule like `{ tool: "mcp__db__*", deny }`,
+    ///    every `tool_id` in `registry_tool_ids` that the pattern matches.
+    ///
+    /// Both the runtime BeforeInference hook AND the admin-console
+    /// permission preview MUST share this expansion. Without it they
+    /// drift: a glob Deny would show up in preview's
+    /// `unconditionally_denied` (preview expands against the registry)
+    /// but the runtime filter (which historically only looked at exact
+    /// matches) would still surface those tools to the model, deferring
+    /// the block to `ToolGate`. That's a semantic regression — "stripped
+    /// before the model sees the list" in the UI must match what the
+    /// model actually sees.
+    ///
+    /// Per-args patterns (`pattern.args != Any`) are NOT expanded — a
+    /// `Bash(npm *)` Deny still requires arg evaluation at call time and
+    /// remains in args-conditional territory.
+    #[must_use]
+    pub fn unconditionally_denied_against<I, S>(&self, registry_tool_ids: I) -> HashSet<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut denied: HashSet<String> = self
+            .unconditionally_denied_tools()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let tool_ids: Vec<String> = registry_tool_ids
+            .into_iter()
+            .map(|s| s.as_ref().to_string())
+            .collect();
+        if tool_ids.is_empty() {
+            return denied;
+        }
+        for rule in self.rules.values() {
+            if rule.behavior != ToolPermissionBehavior::Deny {
+                continue;
+            }
+            let pattern = match &rule.subject {
+                PermissionSubject::Pattern { pattern } => pattern,
+                // Exact `Tool { .. }` already captured above.
+                PermissionSubject::Tool { .. } => continue,
+            };
+            // Only any-args Deny is unconditional w.r.t. args.
+            if !matches!(&pattern.args, ArgMatcher::Any) {
+                continue;
+            }
+            // Exact + any-args already captured above.
+            if matches!(&pattern.tool, ToolMatcher::Exact(_)) {
+                continue;
+            }
+            for tool_id in &tool_ids {
+                if rule.subject.matches_tool(tool_id) {
+                    denied.insert(tool_id.clone());
+                }
+            }
+        }
+        denied
     }
 }
 
@@ -823,5 +889,138 @@ mod tests {
         let eval = evaluate_tool_permission(&ruleset, "Bash", &json!({}));
         assert_eq!(eval.behavior, ToolPermissionBehavior::Deny);
         assert!(eval.matched_rule.is_none());
+    }
+
+    // --- unconditionally_denied_against (shared with permission preview) ---
+
+    fn deny_pattern(pattern: ToolCallPattern) -> PermissionRule {
+        PermissionRule::new_pattern(pattern, ToolPermissionBehavior::Deny)
+    }
+
+    #[test]
+    fn against_includes_exact_tool_denies() {
+        let mut ruleset = PermissionRuleset::default();
+        let rule = PermissionRule::new_tool("rm", ToolPermissionBehavior::Deny);
+        ruleset.rules.insert(rule.subject.key(), rule);
+        let denied = ruleset.unconditionally_denied_against(Vec::<&str>::new());
+        let mut got: Vec<String> = denied.into_iter().collect();
+        got.sort();
+        assert_eq!(got, vec!["rm".to_string()]);
+    }
+
+    #[test]
+    fn against_includes_exact_pattern_any_args_denies() {
+        let mut ruleset = PermissionRuleset::default();
+        let rule = deny_pattern(ToolCallPattern::tool("Bash"));
+        ruleset.rules.insert(rule.subject.key(), rule);
+        // Registry irrelevant for exact-tool denies.
+        let denied = ruleset.unconditionally_denied_against(["Bash", "Other"]);
+        assert!(denied.contains("Bash"));
+        assert!(!denied.contains("Other"));
+    }
+
+    #[test]
+    fn against_expands_glob_any_args_against_registry() {
+        let mut ruleset = PermissionRuleset::default();
+        let rule = deny_pattern(ToolCallPattern::tool_glob("mcp__db__*"));
+        ruleset.rules.insert(rule.subject.key(), rule);
+        let registry = [
+            "Bash",
+            "mcp__db__query",
+            "mcp__db__write",
+            "mcp__github__list_issues",
+        ];
+        let denied = ruleset.unconditionally_denied_against(registry);
+        let mut got: Vec<String> = denied.into_iter().collect();
+        got.sort();
+        assert_eq!(got, vec!["mcp__db__query", "mcp__db__write"]);
+    }
+
+    #[test]
+    fn against_expands_regex_any_args_against_registry() {
+        let mut ruleset = PermissionRuleset::default();
+        let pattern = parse_pattern("/mcp__(gh|gl)__.*/").expect("valid regex pattern");
+        let rule = deny_pattern(pattern);
+        ruleset.rules.insert(rule.subject.key(), rule);
+        let registry = [
+            "Bash",
+            "mcp__gh__list_repos",
+            "mcp__gl__list_projects",
+            "mcp__db__query",
+        ];
+        let denied = ruleset.unconditionally_denied_against(registry);
+        let mut got: Vec<String> = denied.into_iter().collect();
+        got.sort();
+        assert_eq!(got, vec!["mcp__gh__list_repos", "mcp__gl__list_projects"]);
+    }
+
+    #[test]
+    fn against_skips_glob_with_args_condition() {
+        // Per-args glob (here: primary-arg glob) Deny is NOT unconditional —
+        // it requires arg evaluation, so it must NOT be expanded against the
+        // registry. Stays in args-conditional territory.
+        let mut ruleset = PermissionRuleset::default();
+        let rule = deny_pattern(ToolCallPattern::tool_with_primary("Bash", "rm *"));
+        ruleset.rules.insert(rule.subject.key(), rule);
+        let registry = ["Bash"];
+        let denied = ruleset.unconditionally_denied_against(registry);
+        assert!(
+            denied.is_empty(),
+            "per-args Deny must not expand to ExcludeTool, got {denied:?}"
+        );
+    }
+
+    #[test]
+    fn against_does_not_double_count_exact_via_pattern() {
+        // `Tool { tool_id: "Bash" }` and `Pattern { tool: Exact("Bash"), args: Any }`
+        // would both produce "Bash" — but the set semantics dedup naturally.
+        let mut ruleset = PermissionRuleset::default();
+        ruleset.rules.insert(
+            "tool:Bash".into(),
+            PermissionRule::new_tool("Bash", ToolPermissionBehavior::Deny),
+        );
+        ruleset.rules.insert(
+            "pattern:Bash".into(),
+            deny_pattern(ToolCallPattern::tool("Bash")),
+        );
+        let denied = ruleset.unconditionally_denied_against(["Bash"]);
+        assert_eq!(denied.len(), 1);
+        assert!(denied.contains("Bash"));
+    }
+
+    #[test]
+    fn against_skips_non_deny_glob_rules() {
+        // Glob Allow / Ask must NOT show up in the unconditionally-denied
+        // set — those tools stay in the model's tool list.
+        let mut ruleset = PermissionRuleset::default();
+        let allow = PermissionRule::new_pattern(
+            ToolCallPattern::tool_glob("mcp__db__*"),
+            ToolPermissionBehavior::Allow,
+        );
+        ruleset.rules.insert(allow.subject.key(), allow);
+        let ask = PermissionRule::new_pattern(
+            ToolCallPattern::tool_glob("mcp__github__*"),
+            ToolPermissionBehavior::Ask,
+        );
+        ruleset.rules.insert(ask.subject.key(), ask);
+        let denied =
+            ruleset.unconditionally_denied_against(["mcp__db__query", "mcp__github__list_issues"]);
+        assert!(denied.is_empty());
+    }
+
+    #[test]
+    fn against_with_empty_registry_returns_only_exact_denies() {
+        let mut ruleset = PermissionRuleset::default();
+        ruleset.rules.insert(
+            "tool:rm".into(),
+            PermissionRule::new_tool("rm", ToolPermissionBehavior::Deny),
+        );
+        let glob = deny_pattern(ToolCallPattern::tool_glob("mcp__db__*"));
+        ruleset.rules.insert(glob.subject.key(), glob);
+        let denied = ruleset.unconditionally_denied_against(Vec::<&str>::new());
+        // No registry → glob can't be expanded; exact still applies.
+        let mut got: Vec<String> = denied.into_iter().collect();
+        got.sort();
+        assert_eq!(got, vec!["rm".to_string()]);
     }
 }

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
@@ -118,10 +118,27 @@ async fn ai_sdk_chat_agent_scoped(
 
 /// Draft-agent preview route:
 /// `POST /v1/ai-sdk/agent-previews/runs`
+///
+/// Admin-only: this endpoint runs an arbitrary AgentSpec against the
+/// runtime (provider credits, registered tools, plugins). Without
+/// `ensure_admin_auth` anyone with network access could execute draft
+/// agents — see R11 #1.
+///
+/// Additional surface-area defence: the request strips `endpoint` and
+/// `registry` from the incoming agent before resolution. The runtime
+/// resolver previously skipped local registry validation when
+/// `agent.endpoint` was set (treating it as remote), which let a
+/// crafted payload bypass the registry-membership check; clearing the
+/// field forces the preview into the local-only resolve path.
 async fn ai_sdk_chat_preview_agent(
     State(st): State<AppState>,
+    headers: HeaderMap,
     Json(payload): Json<super::request::PreviewAgentChatRequest>,
 ) -> Result<Response, ApiError> {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&st, &headers) {
+        return Ok(err.into_response());
+    }
+
     let super::request::PreviewAgentChatRequest {
         messages,
         thread_id,
@@ -137,6 +154,17 @@ async fn ai_sdk_chat_preview_agent(
 
     if agent.id.trim().is_empty() {
         agent.id = "draft-preview".to_string();
+    }
+
+    // Strip provenance / runtime-locality fields from the client-supplied
+    // spec so the preview always runs against the local registry. A
+    // payload with `endpoint` would otherwise route the run to an
+    // arbitrary remote backend; `registry` would mark the draft as
+    // registry-defined and skip local resolution.
+    if agent.endpoint.is_some() || agent.registry.is_some() {
+        return Err(ApiError::BadRequest(
+            "preview agent payload must not carry `endpoint` or `registry` fields".to_string(),
+        ));
     }
 
     let processed = super::request::process_preview_chat_request(messages, thread_id, state)

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -37,6 +37,11 @@ pub enum ApiError {
     NotFound(String),
     ThreadNotFound(String),
     RunNotFound(String),
+    /// Feature/route present but the backing capability isn't installed —
+    /// e.g. `permission-preview` requested but server was built without
+    /// `--features permission`. Distinct from 404 so callers can
+    /// differentiate "no such resource" from "feature not available".
+    ServiceUnavailable(String),
     Internal(String),
 }
 
@@ -50,6 +55,7 @@ impl IntoResponse for ApiError {
                 (StatusCode::NOT_FOUND, format!("thread not found: {id}"))
             }
             ApiError::RunNotFound(id) => (StatusCode::NOT_FOUND, format!("run not found: {id}")),
+            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
         };
         (status, Json(json!({"error": message}))).into_response()
@@ -174,21 +180,23 @@ fn run_routes() -> Router<AppState> {
 }
 
 fn admin_routes() -> Router<AppState> {
-    let router = config_routes()
+    // The permission-preview route is registered unconditionally so the
+    // server can return a meaningful 503 when the `permission` feature
+    // is not compiled in — gating the route registration on the feature
+    // would make the route a generic 404 (Axum "no route"), which the
+    // client cannot distinguish from "agent not found" (also 404). 503
+    // matches the convention used by `runtime-stats` / trace routes for
+    // "capability not installed".
+    config_routes()
         .route("/v1/system/info", get(system_info))
         .route("/v1/agents/:id/runtime-stats", get(get_agent_runtime_stats))
-        .route("/v1/agents/runtime-stats", get(list_agents_runtime_stats));
-
-    #[cfg(feature = "permission")]
-    let router = router.route(
-        "/v1/agents/:id/permission-preview",
-        get(get_agent_permission_preview),
-    );
-
-    router
+        .route("/v1/agents/runtime-stats", get(list_agents_runtime_stats))
+        .route(
+            "/v1/agents/:id/permission-preview",
+            get(get_agent_permission_preview),
+        )
 }
 
-#[cfg(feature = "permission")]
 #[tracing::instrument(skip(state))]
 async fn get_agent_permission_preview(
     State(state): State<AppState>,
@@ -198,9 +206,21 @@ async fn get_agent_permission_preview(
     if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
         return err.into_response();
     }
-    match crate::services::permission_preview::preview_agent_permissions(&state, &id).await {
-        Ok(preview) => Json(preview).into_response(),
-        Err(err) => map_permission_preview_error(err).into_response(),
+    #[cfg(feature = "permission")]
+    {
+        let _ = &id;
+        match crate::services::permission_preview::preview_agent_permissions(&state, &id).await {
+            Ok(preview) => Json(preview).into_response(),
+            Err(err) => map_permission_preview_error(err).into_response(),
+        }
+    }
+    #[cfg(not(feature = "permission"))]
+    {
+        let _ = (state, id);
+        ApiError::ServiceUnavailable(
+            "permission feature not compiled into this server build".to_string(),
+        )
+        .into_response()
     }
 }
 

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -174,10 +174,49 @@ fn run_routes() -> Router<AppState> {
 }
 
 fn admin_routes() -> Router<AppState> {
-    config_routes()
+    let router = config_routes()
         .route("/v1/system/info", get(system_info))
         .route("/v1/agents/:id/runtime-stats", get(get_agent_runtime_stats))
-        .route("/v1/agents/runtime-stats", get(list_agents_runtime_stats))
+        .route("/v1/agents/runtime-stats", get(list_agents_runtime_stats));
+
+    #[cfg(feature = "permission")]
+    let router = router.route(
+        "/v1/agents/:id/permission-preview",
+        get(get_agent_permission_preview),
+    );
+
+    router
+}
+
+#[cfg(feature = "permission")]
+#[tracing::instrument(skip(state))]
+async fn get_agent_permission_preview(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
+        return err.into_response();
+    }
+    match crate::services::permission_preview::preview_agent_permissions(&state, &id).await {
+        Ok(preview) => Json(preview).into_response(),
+        Err(err) => map_permission_preview_error(err).into_response(),
+    }
+}
+
+#[cfg(feature = "permission")]
+fn map_permission_preview_error(
+    err: crate::services::permission_preview::PermissionPreviewError,
+) -> ApiError {
+    use crate::services::permission_preview::PermissionPreviewError as PE;
+    match err {
+        PE::AgentNotFound(id) => ApiError::NotFound(format!("agent not found: {id}")),
+        PE::InvalidSpec(msg) | PE::InvalidPermissionConfig { reason: msg, .. } => {
+            ApiError::BadRequest(msg)
+        }
+        PE::RegistryUnavailable => ApiError::Internal("runtime registry unavailable".into()),
+        PE::Config(err) => ApiError::Internal(err.to_string()),
+    }
 }
 
 // ── Agent runtime-stats endpoints ───────────────────────────────────

--- a/crates/awaken-server/src/services/config_service/agent_overrides.rs
+++ b/crates/awaken-server/src/services/config_service/agent_overrides.rs
@@ -348,6 +348,61 @@ fn is_nullable_agent_patch_field(field: &str) -> bool {
     )
 }
 
+/// Patchable agent-spec field names, mirroring `AgentSpecPatch`.
+/// Used to validate `_clear` directives — typos would otherwise
+/// silently no-op.
+const PATCHABLE_AGENT_SPEC_FIELDS: &[&str] = &[
+    "model_id",
+    "system_prompt",
+    "max_rounds",
+    "max_continuation_retries",
+    "context_policy",
+    "plugin_ids",
+    "active_hook_filter",
+    "sections",
+    "allowed_tools",
+    "excluded_tools",
+    "delegates",
+    "reasoning_effort",
+    "endpoint",
+];
+
+fn validate_clear_field_names(fields: &[String]) -> Result<(), ConfigServiceError> {
+    for field in fields {
+        if !PATCHABLE_AGENT_SPEC_FIELDS.contains(&field.as_str()) {
+            return Err(ConfigServiceError::InvalidPayload(format!(
+                "_clear contains unknown agent-spec field `{field}`"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn merge_sections_override(
+    existing_map: &mut Map<String, Value>,
+    incoming: &Value,
+) -> Result<(), ConfigServiceError> {
+    let incoming_sections = incoming.as_object().ok_or_else(|| {
+        ConfigServiceError::InvalidPayload("sections override must be a JSON object".into())
+    })?;
+    let mut existing_sections = existing_map
+        .get("sections")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    for (section_key, section_value) in incoming_sections {
+        existing_sections.insert(section_key.clone(), section_value.clone());
+    }
+
+    if existing_sections.is_empty() {
+        existing_map.remove("sections");
+    } else {
+        existing_map.insert("sections".into(), Value::Object(existing_sections));
+    }
+    Ok(())
+}
+
 fn build_agent_overrides_patch(
     current_overrides: Option<&Value>,
     body: &Value,
@@ -361,21 +416,63 @@ fn build_agent_overrides_patch(
         }
     };
 
-    awaken_contract::validate_agent_spec_patch(body.clone())
+    let mut clear_list: Vec<String> = Vec::new();
+    let mut upsert_body = Map::new();
+    for (key, value) in body_map {
+        if key == "_clear" {
+            clear_list = match value {
+                Value::Array(items) => items
+                    .iter()
+                    .map(|item| match item {
+                        Value::String(field) => Ok(field.clone()),
+                        _ => Err(ConfigServiceError::InvalidPayload(
+                            "_clear must be an array of field-name strings".into(),
+                        )),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+                _ => {
+                    return Err(ConfigServiceError::InvalidPayload(
+                        "_clear must be an array of field-name strings".into(),
+                    ));
+                }
+            };
+        } else {
+            upsert_body.insert(key.clone(), value.clone());
+        }
+    }
+
+    for clear_field in &clear_list {
+        if upsert_body.contains_key(clear_field) {
+            return Err(ConfigServiceError::InvalidPayload(format!(
+                "field `{clear_field}` appears in both the upsert body and `_clear`"
+            )));
+        }
+    }
+
+    awaken_contract::validate_agent_spec_patch(Value::Object(upsert_body.clone()))
         .map_err(|e| ConfigServiceError::InvalidPayload(e.to_string()))?;
+    if !clear_list.is_empty() {
+        validate_clear_field_names(&clear_list)?;
+    }
 
     let mut existing_map: Map<String, Value> = current_overrides
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
 
-    for (key, value) in body_map {
+    for clear_field in &clear_list {
+        existing_map.remove(clear_field);
+    }
+
+    for (key, value) in &upsert_body {
         if value.is_null() {
             if is_nullable_agent_patch_field(key) {
                 existing_map.insert(key.clone(), Value::Null);
             } else {
                 existing_map.remove(key);
             }
+        } else if key == "sections" {
+            merge_sections_override(&mut existing_map, value)?;
         } else {
             existing_map.insert(key.clone(), value.clone());
         }

--- a/crates/awaken-server/src/services/config_service/agent_overrides.rs
+++ b/crates/awaken-server/src/services/config_service/agent_overrides.rs
@@ -34,8 +34,9 @@ impl<'a> ConfigService<'a> {
             return Err(overrides_not_supported_for_user_record());
         }
 
-        let normalized = build_agent_overrides_patch(record.meta.user_overrides.as_ref(), &body)?
-            .unwrap_or_else(|| Value::Object(Map::new()));
+        let normalized =
+            build_agent_overrides_patch(record.meta.user_overrides.as_ref(), &record.spec, &body)?
+                .unwrap_or_else(|| Value::Object(Map::new()));
 
         Ok(serde_json::json!({
             "ok": true,
@@ -74,7 +75,7 @@ impl<'a> ConfigService<'a> {
         let expected_revision = record.meta.revision;
 
         let proposed_overrides =
-            build_agent_overrides_patch(record.meta.user_overrides.as_ref(), &body)?;
+            build_agent_overrides_patch(record.meta.user_overrides.as_ref(), &record.spec, &body)?;
 
         // Short-circuit: if the proposed overrides are identical to existing ones,
         // skip the store write, apply_locked, and audit emit — it's a no-op.
@@ -403,8 +404,27 @@ fn merge_sections_override(
     Ok(())
 }
 
+fn normalize_section_delete_markers(existing_map: &mut Map<String, Value>, base_spec: &AgentSpec) {
+    let Some(mut sections) = existing_map
+        .get("sections")
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return;
+    };
+    sections.retain(|section_key, section_value| {
+        !section_value.is_null() || base_spec.sections.contains_key(section_key)
+    });
+    if sections.is_empty() {
+        existing_map.remove("sections");
+    } else {
+        existing_map.insert("sections".into(), Value::Object(sections));
+    }
+}
+
 fn build_agent_overrides_patch(
     current_overrides: Option<&Value>,
+    base_spec: &AgentSpec,
     body: &Value,
 ) -> Result<Option<Value>, ConfigServiceError> {
     let body_map = match body {
@@ -477,6 +497,7 @@ fn build_agent_overrides_patch(
             existing_map.insert(key.clone(), value.clone());
         }
     }
+    normalize_section_delete_markers(&mut existing_map, base_spec);
 
     let merged_value = Value::Object(existing_map.clone());
     awaken_contract::validate_agent_spec_patch(merged_value.clone())

--- a/crates/awaken-server/src/services/mod.rs
+++ b/crates/awaken-server/src/services/mod.rs
@@ -3,6 +3,8 @@ pub mod builtin_seed;
 pub mod config_envelope;
 pub mod config_runtime;
 pub mod config_service;
+#[cfg(feature = "permission")]
+pub mod permission_preview;
 pub mod run_control_service;
 pub mod run_service;
 pub mod thread_service;

--- a/crates/awaken-server/src/services/permission_preview.rs
+++ b/crates/awaken-server/src/services/permission_preview.rs
@@ -1,0 +1,287 @@
+//! Permission preview service — answers "what tools can the model actually
+//! see for this agent after the permission plugin filters?".
+//!
+//! Static analysis only: walks the agent's declared `allowed_tools` /
+//! `excluded_tools` over the tool registry to compute the candidate set,
+//! then subtracts tools that any permission rule marks as unconditionally
+//! denied (matching `Deny` + exact tool + `ArgMatcher::Any`). Rules whose
+//! match depends on runtime arguments are surfaced separately as
+//! informational entries — they cannot be resolved without an actual tool
+//! call, but the editor can show that "Edit" will be `ask` only when the
+//! path matches a glob, etc.
+//!
+//! Replaces the misleading frontend port reverted in PR #189 G6.
+
+use std::collections::HashSet;
+
+use awaken_contract::AgentSpec;
+use awaken_ext_permission::{
+    ArgMatcher, PermissionConfigKey, PermissionRule, PermissionRulesConfig, PermissionRuleset,
+    PermissionSubject, ToolCallPattern, ToolMatcher, ToolPermissionBehavior,
+};
+use serde::Serialize;
+
+use crate::app::AppState;
+use crate::services::config_service::{ConfigNamespace, ConfigService, ConfigServiceError};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PermissionPreviewResponse {
+    pub agent_id: String,
+    /// `true` when the agent has the permission plugin in `plugin_ids` AND
+    /// a permission config section. When `false` the `effective_tools` are
+    /// just the candidate set with no further filtering.
+    pub permission_plugin_enabled: bool,
+    /// Default behavior when no rule matches a call. `None` when the
+    /// permission plugin isn't enabled.
+    pub default_behavior: Option<String>,
+    /// `allowed_tools ∖ excluded_tools` over the full tool registry.
+    pub candidate_tools: Vec<String>,
+    /// Tools the BeforeInference hook will unconditionally strip (any rule
+    /// matching `Deny` + exact tool + `args == Any`). Empty when permission
+    /// plugin is disabled.
+    pub unconditionally_denied: Vec<String>,
+    /// `candidate_tools ∖ unconditionally_denied`. This is what the model
+    /// actually sees in the tool list it's offered. Per-call args-dependent
+    /// rules can still gate / Ask / Deny at invocation time — see
+    /// `args_conditional_rules` below.
+    pub effective_tools: Vec<String>,
+    /// Rules whose match depends on runtime arguments. Informational only —
+    /// the editor surfaces them so the user can see "Edit will be denied
+    /// when path matches /etc/*".
+    pub args_conditional_rules: Vec<ArgConditionalRule>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArgConditionalRule {
+    pub tool: String,
+    pub behavior: String,
+    pub pattern: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PermissionPreviewError {
+    #[error(transparent)]
+    Config(#[from] ConfigServiceError),
+    #[error("agent `{0}` not found")]
+    AgentNotFound(String),
+    #[error("invalid agent spec: {0}")]
+    InvalidSpec(String),
+    #[error("invalid permission config for agent `{agent_id}`: {reason}")]
+    InvalidPermissionConfig { agent_id: String, reason: String },
+    #[error("runtime registry not available")]
+    RegistryUnavailable,
+}
+
+/// Run the preview for the given agent id and return the analysis.
+pub async fn preview_agent_permissions(
+    state: &AppState,
+    agent_id: &str,
+) -> Result<PermissionPreviewResponse, PermissionPreviewError> {
+    let service = ConfigService::new(state).map_err(PermissionPreviewError::Config)?;
+    let raw = service
+        .get(ConfigNamespace::Agents, agent_id)
+        .await
+        .map_err(PermissionPreviewError::Config)?
+        .ok_or_else(|| PermissionPreviewError::AgentNotFound(agent_id.to_string()))?;
+
+    let spec: AgentSpec = serde_json::from_value(raw)
+        .map_err(|err| PermissionPreviewError::InvalidSpec(err.to_string()))?;
+
+    let registries = state
+        .runtime
+        .registry_set()
+        .ok_or(PermissionPreviewError::RegistryUnavailable)?;
+    let all_tools: Vec<String> = registries.tools.tool_ids().into_iter().collect();
+
+    // candidate = (allowed.unwrap_or(all)) ∖ excluded
+    let excluded: HashSet<&str> = spec
+        .excluded_tools
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let candidate_iter: Box<dyn Iterator<Item = String>> = match &spec.allowed_tools {
+        Some(allowed) => Box::new(allowed.iter().cloned()),
+        None => Box::new(all_tools.iter().cloned()),
+    };
+    let mut candidate_tools: Vec<String> = candidate_iter
+        .filter(|tool| !excluded.contains(tool.as_str()))
+        .collect();
+    candidate_tools.sort();
+    candidate_tools.dedup();
+
+    // If the permission plugin isn't in the plugin list, there's no
+    // further filtering to do — the model sees the candidate set as-is.
+    let permission_plugin_enabled = spec.plugin_ids.iter().any(|id| id == "permission");
+    if !permission_plugin_enabled {
+        return Ok(PermissionPreviewResponse {
+            agent_id: agent_id.to_string(),
+            permission_plugin_enabled: false,
+            default_behavior: None,
+            effective_tools: candidate_tools.clone(),
+            candidate_tools,
+            unconditionally_denied: Vec::new(),
+            args_conditional_rules: Vec::new(),
+        });
+    }
+
+    // Try to load the agent's permission section. Missing section is
+    // equivalent to "no rules, default deny" depending on how the plugin
+    // initialises — we treat it as "permission plugin enabled but no
+    // ruleset configured" (default_behavior=Ask, no rules).
+    let perm_config: PermissionRulesConfig = match spec.config::<PermissionConfigKey>() {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            return Err(PermissionPreviewError::InvalidPermissionConfig {
+                agent_id: agent_id.to_string(),
+                reason: err.to_string(),
+            });
+        }
+    };
+
+    let default_behavior = behavior_label(perm_config.default_behavior);
+    let ruleset: PermissionRuleset = perm_config.into_ruleset().map_err(|err| {
+        PermissionPreviewError::InvalidPermissionConfig {
+            agent_id: agent_id.to_string(),
+            reason: err.to_string(),
+        }
+    })?;
+
+    let denied: HashSet<String> = ruleset
+        .unconditionally_denied_tools()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    let effective_tools: Vec<String> = candidate_tools
+        .iter()
+        .filter(|tool| !denied.contains(*tool))
+        .cloned()
+        .collect();
+    let mut unconditionally_denied: Vec<String> = denied.into_iter().collect();
+    unconditionally_denied.sort();
+
+    let args_conditional_rules = collect_args_conditional_rules(&ruleset);
+
+    Ok(PermissionPreviewResponse {
+        agent_id: agent_id.to_string(),
+        permission_plugin_enabled: true,
+        default_behavior: Some(default_behavior.to_string()),
+        candidate_tools,
+        unconditionally_denied,
+        effective_tools,
+        args_conditional_rules,
+    })
+}
+
+fn behavior_label(behavior: ToolPermissionBehavior) -> &'static str {
+    match behavior {
+        ToolPermissionBehavior::Allow => "allow",
+        ToolPermissionBehavior::Ask => "ask",
+        ToolPermissionBehavior::Deny => "deny",
+    }
+}
+
+fn collect_args_conditional_rules(ruleset: &PermissionRuleset) -> Vec<ArgConditionalRule> {
+    let mut out = Vec::new();
+    for rule in ruleset.rules.values() {
+        if let Some(entry) = describe_args_conditional(rule) {
+            out.push(entry);
+        }
+    }
+    out.sort_by(|a, b| a.tool.cmp(&b.tool).then_with(|| a.pattern.cmp(&b.pattern)));
+    out
+}
+
+fn describe_args_conditional(rule: &PermissionRule) -> Option<ArgConditionalRule> {
+    let pattern = match &rule.subject {
+        PermissionSubject::Pattern { pattern } => pattern,
+        PermissionSubject::Tool { .. } => return None, // tool-only is unconditional
+    };
+    if matches!(&pattern.args, ArgMatcher::Any) {
+        // exact-tool + any-args is unconditional; already captured by
+        // `unconditionally_denied_tools` for Deny. Glob/regex tool with
+        // any-args is conditional on the tool name match but not args —
+        // we still surface it because the user wants to see "any mcp__db__*
+        // gets Ask'd" without it being mistaken for a deny.
+        if matches!(&pattern.tool, ToolMatcher::Exact(_)) {
+            return None;
+        }
+    }
+    Some(ArgConditionalRule {
+        tool: tool_display(&pattern.tool),
+        behavior: behavior_label(rule.behavior).to_string(),
+        pattern: ToolCallPattern::to_string(pattern),
+    })
+}
+
+fn tool_display(matcher: &ToolMatcher) -> String {
+    match matcher {
+        ToolMatcher::Exact(name) => name.clone(),
+        ToolMatcher::Glob(g) => g.to_string(),
+        ToolMatcher::Regex(r) => format!("/{}/", r.as_str()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_ext_permission::PermissionRulesConfig;
+    use serde_json::json;
+
+    fn ruleset_from_json(value: serde_json::Value) -> PermissionRuleset {
+        let cfg: PermissionRulesConfig =
+            serde_json::from_value(value).expect("valid permission config");
+        cfg.into_ruleset().expect("compile ruleset")
+    }
+
+    #[test]
+    fn args_conditional_skips_exact_any_args() {
+        // Bash with no args = unconditional (whether allow/ask/deny).
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "Bash", "behavior": "deny" },
+            ]
+        }));
+        let entries = collect_args_conditional_rules(&ruleset);
+        assert!(entries.is_empty(), "exact tool any-args isn't conditional");
+    }
+
+    #[test]
+    fn args_conditional_surfaces_primary_glob() {
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "Bash(npm *)", "behavior": "allow" },
+            ]
+        }));
+        let entries = collect_args_conditional_rules(&ruleset);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tool, "Bash");
+        assert_eq!(entries[0].behavior, "allow");
+        assert!(entries[0].pattern.contains("Bash"));
+    }
+
+    #[test]
+    fn args_conditional_surfaces_glob_tool_any_args() {
+        // mcp__db__* (glob tool) + any args is still "tool-name dependent"
+        // — surfaced because the user wants to see it covers a set of
+        // dynamically-discovered tools.
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "mcp__db__*", "behavior": "ask" },
+            ]
+        }));
+        let entries = collect_args_conditional_rules(&ruleset);
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn behavior_label_maps_each_variant() {
+        assert_eq!(behavior_label(ToolPermissionBehavior::Allow), "allow");
+        assert_eq!(behavior_label(ToolPermissionBehavior::Ask), "ask");
+        assert_eq!(behavior_label(ToolPermissionBehavior::Deny), "deny");
+    }
+}

--- a/crates/awaken-server/src/services/permission_preview.rs
+++ b/crates/awaken-server/src/services/permission_preview.rs
@@ -179,16 +179,11 @@ pub async fn preview_agent_permissions(
 
     // Unconditional deny = exact-tool Deny ∪ (glob/regex Deny + Any args
     // expanded against the registry). The runtime BeforeInference hook
-    // strips a tool whenever any matching rule denies it without
-    // examining args; the preview must mirror that, so a `Bash(npm *)`
-    // Deny stays in args_conditional_rules but `mcp__db__*` Deny gets
-    // expanded into every tool id matching the glob.
-    let mut denied: HashSet<String> = ruleset
-        .unconditionally_denied_tools()
-        .into_iter()
-        .map(str::to_string)
-        .collect();
-    denied.extend(expand_glob_regex_denies(&ruleset, &all_tools));
+    // (`PermissionToolFilterHook`) strips the same set via the shared
+    // helper, so a `Bash(npm *)` Deny stays in `args_conditional_rules`
+    // while `mcp__db__*` Deny is expanded into every matching registry
+    // id here AND removed from the model's tool list at runtime.
+    let denied: HashSet<String> = ruleset.unconditionally_denied_against(&all_tools);
     let effective_tools: Vec<String> = candidate_tools
         .iter()
         .filter(|tool| !denied.contains(*tool))
@@ -303,44 +298,6 @@ fn describe_args_conditional(
         behavior: behavior_label(rule.behavior).to_string(),
         pattern: ToolCallPattern::to_string(pattern),
     })
-}
-
-/// Expand glob/regex Deny rules with `args == Any` into the concrete
-/// tool ids in the registry they match. The runtime BeforeInference hook
-/// strips these without examining call args, so the preview's
-/// `unconditionally_denied` set should include them.
-fn expand_glob_regex_denies(ruleset: &PermissionRuleset, all_tools: &[String]) -> HashSet<String> {
-    let mut out = HashSet::new();
-    for rule in ruleset.rules.values() {
-        if rule.behavior != ToolPermissionBehavior::Deny {
-            continue;
-        }
-        let pattern = match &rule.subject {
-            PermissionSubject::Pattern { pattern } => pattern,
-            // Exact `Tool { .. }` is already handled by
-            // `unconditionally_denied_tools()`.
-            PermissionSubject::Tool { .. } => continue,
-        };
-        // Only any-args Deny is unconditional w.r.t. args. Per-args
-        // patterns stay in `args_conditional_rules`.
-        if !matches!(&pattern.args, ArgMatcher::Any) {
-            continue;
-        }
-        // Exact + any-args is also already handled.
-        if matches!(&pattern.tool, ToolMatcher::Exact(_)) {
-            continue;
-        }
-        // Glob / Regex: walk the registry and add every tool the rule
-        // would deny on any call. `rule.subject.matches_tool(id)`
-        // implicitly tests pattern.args against `Value::Null`, which is
-        // always a match when args is `Any`.
-        for tool_id in all_tools {
-            if rule.subject.matches_tool(tool_id) {
-                out.insert(tool_id.clone());
-            }
-        }
-    }
-    out
 }
 
 fn tool_display(matcher: &ToolMatcher) -> String {
@@ -470,62 +427,11 @@ mod tests {
         assert_eq!(behavior_label(ToolPermissionBehavior::Deny), "deny");
     }
 
-    // R7 #3 — glob/regex Deny + any args must be expanded against the
-    // registry into concrete tool ids, not left as an
-    // `args_conditional_rules` note. The runtime BeforeInference hook
-    // would strip these tools without examining args; the preview must
-    // mirror that or it lies about what the model sees.
-    #[test]
-    fn expand_glob_deny_matches_every_registered_tool() {
-        let ruleset = ruleset_from_json(json!({
-            "default_behavior": "ask",
-            "rules": [
-                { "tool": "mcp__db__*", "behavior": "deny" },
-            ]
-        }));
-        let all_tools = vec![
-            "Bash".to_string(),
-            "mcp__db__query".to_string(),
-            "mcp__db__write".to_string(),
-            "mcp__github__list_issues".to_string(),
-        ];
-        let denied = expand_glob_regex_denies(&ruleset, &all_tools);
-        let mut got: Vec<String> = denied.into_iter().collect();
-        got.sort();
-        assert_eq!(got, vec!["mcp__db__query", "mcp__db__write"]);
-    }
-
-    #[test]
-    fn expand_glob_deny_does_not_double_count_exact_tool() {
-        let ruleset = ruleset_from_json(json!({
-            "default_behavior": "ask",
-            "rules": [
-                { "tool": "Bash", "behavior": "deny" },
-            ]
-        }));
-        let all_tools = vec!["Bash".to_string()];
-        let denied = expand_glob_regex_denies(&ruleset, &all_tools);
-        assert!(
-            denied.is_empty(),
-            "exact `Tool` Deny handled by unconditionally_denied_tools()"
-        );
-    }
-
-    #[test]
-    fn expand_glob_deny_skips_per_args_rules() {
-        // `Bash(npm *)` Deny is conditional on args — must NOT be
-        // expanded against the registry, because a `Bash` call with
-        // other args is still permitted.
-        let ruleset = ruleset_from_json(json!({
-            "default_behavior": "ask",
-            "rules": [
-                { "tool": "Bash(npm *)", "behavior": "deny" },
-            ]
-        }));
-        let all_tools = vec!["Bash".to_string()];
-        let denied = expand_glob_regex_denies(&ruleset, &all_tools);
-        assert!(denied.is_empty(), "per-args Deny stays conditional");
-    }
+    // The unit tests for glob/regex Deny expansion moved to
+    // `awaken_ext_permission::rules::tests::against_*` along with the
+    // helper — `PermissionRuleset::unconditionally_denied_against` is the
+    // single source of truth for this expansion, shared between the
+    // runtime BeforeInference filter and this preview.
 
     #[test]
     fn args_conditional_no_longer_lists_glob_deny_any_args() {

--- a/crates/awaken-server/src/services/permission_preview.rs
+++ b/crates/awaken-server/src/services/permission_preview.rs
@@ -27,18 +27,24 @@ use crate::services::config_service::{ConfigNamespace, ConfigService, ConfigServ
 #[derive(Debug, Clone, Serialize)]
 pub struct PermissionPreviewResponse {
     pub agent_id: String,
-    /// `true` when the agent has the permission plugin in `plugin_ids` AND
-    /// a permission config section. When `false` the `effective_tools` are
-    /// just the candidate set with no further filtering.
+    /// `true` when the permission plugin is loaded (`plugin_ids` contains
+    /// `"permission"`) AND `active_hook_filter` admits permission hooks
+    /// (filter is empty, or explicitly contains `"permission"`). When
+    /// `false` the runtime won't run any permission BeforeInference hooks,
+    /// so `effective_tools` equals `candidate_tools` and no rules are
+    /// surfaced.
     pub permission_plugin_enabled: bool,
     /// Default behavior when no rule matches a call. `None` when the
     /// permission plugin isn't enabled.
     pub default_behavior: Option<String>,
     /// `allowed_tools ∖ excluded_tools` over the full tool registry.
     pub candidate_tools: Vec<String>,
-    /// Tools the BeforeInference hook will unconditionally strip (any rule
-    /// matching `Deny` + exact tool + `args == Any`). Empty when permission
-    /// plugin is disabled.
+    /// Tools from `candidate_tools` that the BeforeInference hook will
+    /// unconditionally strip — i.e. only the deny rules that bite a tool
+    /// the model would otherwise see. Deny rules whose tool target falls
+    /// outside the candidate set (denied tool wasn't allowed to begin
+    /// with) are NOT counted here so the UI's "stripped before model"
+    /// summary doesn't overstate the filter.
     pub unconditionally_denied: Vec<String>,
     /// `candidate_tools ∖ unconditionally_denied`. This is what the model
     /// actually sees in the tool list it's offered. Per-call args-dependent
@@ -92,8 +98,17 @@ pub async fn preview_agent_permissions(
         .registry_set()
         .ok_or(PermissionPreviewError::RegistryUnavailable)?;
     let all_tools: Vec<String> = registries.tools.tool_ids().into_iter().collect();
+    let all_tool_set: HashSet<&str> = all_tools.iter().map(String::as_str).collect();
 
-    // candidate = (allowed.unwrap_or(all)) ∖ excluded
+    // candidate = (allowed ∩ registry).unwrap_or(registry) ∖ excluded
+    //
+    // INTERSECT WITH REGISTRY: an agent's `allowed_tools` is a string list
+    // written into config; nothing forces every entry to correspond to a
+    // currently-registered tool. Without filtering against the registry,
+    // a stale id (renamed plugin, removed MCP server, typo) would show up
+    // in `effective_tools` as if the model could call it — but the
+    // runtime tool catalog never offers it. The preview must mirror what
+    // the model actually sees.
     let excluded: HashSet<&str> = spec
         .excluded_tools
         .as_deref()
@@ -102,7 +117,12 @@ pub async fn preview_agent_permissions(
         .map(String::as_str)
         .collect();
     let candidate_iter: Box<dyn Iterator<Item = String>> = match &spec.allowed_tools {
-        Some(allowed) => Box::new(allowed.iter().cloned()),
+        Some(allowed) => Box::new(
+            allowed
+                .iter()
+                .filter(|tool| all_tool_set.contains(tool.as_str()))
+                .cloned(),
+        ),
         None => Box::new(all_tools.iter().cloned()),
     };
     let mut candidate_tools: Vec<String> = candidate_iter
@@ -111,9 +131,18 @@ pub async fn preview_agent_permissions(
     candidate_tools.sort();
     candidate_tools.dedup();
 
-    // If the permission plugin isn't in the plugin list, there's no
-    // further filtering to do — the model sees the candidate set as-is.
-    let permission_plugin_enabled = spec.plugin_ids.iter().any(|id| id == "permission");
+    // The permission plugin is "enabled" for preview purposes only when it
+    // is both loaded AND its hooks will actually run for this agent. The
+    // runtime's hook dispatcher (phase/engine.rs) filters hooks through
+    // `active_hook_filter`: empty filter = all hooks run, non-empty filter
+    // = only listed plugins' hooks run. If permission is loaded but
+    // filtered out, no BeforeInference filtering happens, so the preview
+    // must report the candidate set verbatim instead of claiming tools
+    // would be stripped.
+    let permission_loaded = spec.plugin_ids.iter().any(|id| id == "permission");
+    let permission_hooks_active = spec.active_hook_filter.is_empty()
+        || spec.active_hook_filter.iter().any(|id| id == "permission");
+    let permission_plugin_enabled = permission_loaded && permission_hooks_active;
     if !permission_plugin_enabled {
         return Ok(PermissionPreviewResponse {
             agent_id: agent_id.to_string(),
@@ -148,20 +177,44 @@ pub async fn preview_agent_permissions(
         }
     })?;
 
-    let denied: HashSet<String> = ruleset
+    // Unconditional deny = exact-tool Deny ∪ (glob/regex Deny + Any args
+    // expanded against the registry). The runtime BeforeInference hook
+    // strips a tool whenever any matching rule denies it without
+    // examining args; the preview must mirror that, so a `Bash(npm *)`
+    // Deny stays in args_conditional_rules but `mcp__db__*` Deny gets
+    // expanded into every tool id matching the glob.
+    let mut denied: HashSet<String> = ruleset
         .unconditionally_denied_tools()
         .into_iter()
         .map(str::to_string)
         .collect();
+    denied.extend(expand_glob_regex_denies(&ruleset, &all_tools));
     let effective_tools: Vec<String> = candidate_tools
         .iter()
         .filter(|tool| !denied.contains(*tool))
         .cloned()
         .collect();
-    let mut unconditionally_denied: Vec<String> = denied.into_iter().collect();
+    // Only tools the model *would* otherwise see are "stripped" by the
+    // permission layer. A deny rule for a tool that was already excluded
+    // by `allowed_tools` / `excluded_tools` (or simply not in the
+    // candidate set for any reason) is not surfaced as a strip — the UI
+    // summary "N tools stripped before the model sees the list" must
+    // count only real strips.
+    let candidate_set: HashSet<&str> = candidate_tools.iter().map(String::as_str).collect();
+    let mut unconditionally_denied: Vec<String> = denied
+        .into_iter()
+        .filter(|tool| candidate_set.contains(tool.as_str()))
+        .collect();
     unconditionally_denied.sort();
 
-    let args_conditional_rules = collect_args_conditional_rules(&ruleset);
+    // R12 #1 — Surface only rules whose target tool the model could
+    // actually call. We filter against `effective_tools` (candidate
+    // minus unconditionally-denied) so that a rule on an unconditionally
+    // denied tool — which the model would never call regardless of args
+    // — does NOT show up as an args-conditional surprise. R10 used
+    // `candidate_tools`, which still listed args rules for tools that
+    // had already been stripped by the BeforeInference hook.
+    let args_conditional_rules = collect_args_conditional_rules(&ruleset, &effective_tools);
 
     Ok(PermissionPreviewResponse {
         agent_id: agent_id.to_string(),
@@ -182,10 +235,18 @@ fn behavior_label(behavior: ToolPermissionBehavior) -> &'static str {
     }
 }
 
-fn collect_args_conditional_rules(ruleset: &PermissionRuleset) -> Vec<ArgConditionalRule> {
+/// `callable_tools` is the set of tool ids the model could actually
+/// invoke at runtime — i.e. `effective_tools = candidate_tools ∖
+/// unconditionally_denied`. Rules targeting tools outside this set
+/// can never fire and are filtered out so the preview doesn't list
+/// stale guards.
+fn collect_args_conditional_rules(
+    ruleset: &PermissionRuleset,
+    callable_tools: &[String],
+) -> Vec<ArgConditionalRule> {
     let mut out = Vec::new();
     for rule in ruleset.rules.values() {
-        if let Some(entry) = describe_args_conditional(rule) {
+        if let Some(entry) = describe_args_conditional(rule, callable_tools) {
             out.push(entry);
         }
     }
@@ -193,19 +254,48 @@ fn collect_args_conditional_rules(ruleset: &PermissionRuleset) -> Vec<ArgConditi
     out
 }
 
-fn describe_args_conditional(rule: &PermissionRule) -> Option<ArgConditionalRule> {
+fn describe_args_conditional(
+    rule: &PermissionRule,
+    callable_tools: &[String],
+) -> Option<ArgConditionalRule> {
     let pattern = match &rule.subject {
         PermissionSubject::Pattern { pattern } => pattern,
         PermissionSubject::Tool { .. } => return None, // tool-only is unconditional
     };
     if matches!(&pattern.args, ArgMatcher::Any) {
         // exact-tool + any-args is unconditional; already captured by
-        // `unconditionally_denied_tools` for Deny. Glob/regex tool with
-        // any-args is conditional on the tool name match but not args —
-        // we still surface it because the user wants to see "any mcp__db__*
-        // gets Ask'd" without it being mistaken for a deny.
+        // `unconditionally_denied_tools` for Deny / behavior-default for
+        // others. Skip.
         if matches!(&pattern.tool, ToolMatcher::Exact(_)) {
             return None;
+        }
+        // Glob/regex tool + any-args + Deny is now expanded against the
+        // registry into the unconditionally-denied set, so it should NOT
+        // also show up here — that would double-count. Allow/Ask glob
+        // rules still get surfaced informationally ("all mcp__db__* are
+        // auto-allowed without confirmation", etc.).
+        if rule.behavior == ToolPermissionBehavior::Deny {
+            return None;
+        }
+    }
+    // R10 #3 / R12 #1 — A rule whose tool target is outside the
+    // callable set (excluded by `excluded_tools`, missing from
+    // `allowed_tools`, unregistered, OR already unconditionally
+    // denied) cannot fire at runtime. Drop it from the preview so the
+    // operator sees only actionable entries.
+    match &pattern.tool {
+        ToolMatcher::Exact(name) => {
+            if !callable_tools.iter().any(|tool| tool == name) {
+                return None;
+            }
+        }
+        ToolMatcher::Glob(_) | ToolMatcher::Regex(_) => {
+            if !callable_tools
+                .iter()
+                .any(|tool| rule.subject.matches_tool(tool))
+            {
+                return None;
+            }
         }
     }
     Some(ArgConditionalRule {
@@ -213,6 +303,44 @@ fn describe_args_conditional(rule: &PermissionRule) -> Option<ArgConditionalRule
         behavior: behavior_label(rule.behavior).to_string(),
         pattern: ToolCallPattern::to_string(pattern),
     })
+}
+
+/// Expand glob/regex Deny rules with `args == Any` into the concrete
+/// tool ids in the registry they match. The runtime BeforeInference hook
+/// strips these without examining call args, so the preview's
+/// `unconditionally_denied` set should include them.
+fn expand_glob_regex_denies(ruleset: &PermissionRuleset, all_tools: &[String]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for rule in ruleset.rules.values() {
+        if rule.behavior != ToolPermissionBehavior::Deny {
+            continue;
+        }
+        let pattern = match &rule.subject {
+            PermissionSubject::Pattern { pattern } => pattern,
+            // Exact `Tool { .. }` is already handled by
+            // `unconditionally_denied_tools()`.
+            PermissionSubject::Tool { .. } => continue,
+        };
+        // Only any-args Deny is unconditional w.r.t. args. Per-args
+        // patterns stay in `args_conditional_rules`.
+        if !matches!(&pattern.args, ArgMatcher::Any) {
+            continue;
+        }
+        // Exact + any-args is also already handled.
+        if matches!(&pattern.tool, ToolMatcher::Exact(_)) {
+            continue;
+        }
+        // Glob / Regex: walk the registry and add every tool the rule
+        // would deny on any call. `rule.subject.matches_tool(id)`
+        // implicitly tests pattern.args against `Value::Null`, which is
+        // always a match when args is `Any`.
+        for tool_id in all_tools {
+            if rule.subject.matches_tool(tool_id) {
+                out.insert(tool_id.clone());
+            }
+        }
+    }
+    out
 }
 
 fn tool_display(matcher: &ToolMatcher) -> String {
@@ -244,7 +372,8 @@ mod tests {
                 { "tool": "Bash", "behavior": "deny" },
             ]
         }));
-        let entries = collect_args_conditional_rules(&ruleset);
+        let candidate = vec!["Bash".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &candidate);
         assert!(entries.is_empty(), "exact tool any-args isn't conditional");
     }
 
@@ -256,7 +385,8 @@ mod tests {
                 { "tool": "Bash(npm *)", "behavior": "allow" },
             ]
         }));
-        let entries = collect_args_conditional_rules(&ruleset);
+        let candidate = vec!["Bash".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &candidate);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].tool, "Bash");
         assert_eq!(entries[0].behavior, "allow");
@@ -264,9 +394,9 @@ mod tests {
     }
 
     #[test]
-    fn args_conditional_surfaces_glob_tool_any_args() {
-        // mcp__db__* (glob tool) + any args is still "tool-name dependent"
-        // — surfaced because the user wants to see it covers a set of
+    fn args_conditional_surfaces_glob_tool_any_args_for_non_deny() {
+        // Glob tool + any args + Allow/Ask is "tool-name dependent" —
+        // surfaced because the user wants to see it covers a set of
         // dynamically-discovered tools.
         let ruleset = ruleset_from_json(json!({
             "default_behavior": "ask",
@@ -274,8 +404,63 @@ mod tests {
                 { "tool": "mcp__db__*", "behavior": "ask" },
             ]
         }));
-        let entries = collect_args_conditional_rules(&ruleset);
+        let candidate = vec!["mcp__db__query".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &candidate);
         assert_eq!(entries.len(), 1);
+    }
+
+    // R10 #3 — rules whose tool target is outside the candidate set
+    // can never fire at runtime; the preview must drop them so the
+    // operator doesn't see stale entries for excluded or unregistered
+    // tools.
+    #[test]
+    fn args_conditional_drops_exact_rule_outside_candidate() {
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "Read(/etc/*)", "behavior": "deny" },
+            ]
+        }));
+        // `Read` is not in candidate (user restricted `allowed_tools` to
+        // just `Bash`, or excluded `Read`, etc.) — the args-conditional
+        // entry should be filtered out.
+        let candidate = vec!["Bash".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &candidate);
+        assert!(
+            entries.is_empty(),
+            "rule targeting a non-candidate tool must be dropped"
+        );
+    }
+
+    #[test]
+    fn args_conditional_drops_glob_rule_with_no_candidate_match() {
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "mcp__db__*", "behavior": "ask" },
+            ]
+        }));
+        // Candidate has no `mcp__db__*` tools — glob doesn't bite
+        // anything the model can call.
+        let candidate = vec!["Bash".to_string(), "Read".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &candidate);
+        assert!(
+            entries.is_empty(),
+            "glob rule that matches no candidate tool must be dropped"
+        );
+    }
+
+    #[test]
+    fn args_conditional_keeps_exact_rule_inside_candidate() {
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "Bash(npm *)", "behavior": "ask" },
+            ]
+        }));
+        let candidate = vec!["Bash".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &candidate);
+        assert_eq!(entries.len(), 1, "rule on candidate tool stays");
     }
 
     #[test]
@@ -283,5 +468,109 @@ mod tests {
         assert_eq!(behavior_label(ToolPermissionBehavior::Allow), "allow");
         assert_eq!(behavior_label(ToolPermissionBehavior::Ask), "ask");
         assert_eq!(behavior_label(ToolPermissionBehavior::Deny), "deny");
+    }
+
+    // R7 #3 — glob/regex Deny + any args must be expanded against the
+    // registry into concrete tool ids, not left as an
+    // `args_conditional_rules` note. The runtime BeforeInference hook
+    // would strip these tools without examining args; the preview must
+    // mirror that or it lies about what the model sees.
+    #[test]
+    fn expand_glob_deny_matches_every_registered_tool() {
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "mcp__db__*", "behavior": "deny" },
+            ]
+        }));
+        let all_tools = vec![
+            "Bash".to_string(),
+            "mcp__db__query".to_string(),
+            "mcp__db__write".to_string(),
+            "mcp__github__list_issues".to_string(),
+        ];
+        let denied = expand_glob_regex_denies(&ruleset, &all_tools);
+        let mut got: Vec<String> = denied.into_iter().collect();
+        got.sort();
+        assert_eq!(got, vec!["mcp__db__query", "mcp__db__write"]);
+    }
+
+    #[test]
+    fn expand_glob_deny_does_not_double_count_exact_tool() {
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "Bash", "behavior": "deny" },
+            ]
+        }));
+        let all_tools = vec!["Bash".to_string()];
+        let denied = expand_glob_regex_denies(&ruleset, &all_tools);
+        assert!(
+            denied.is_empty(),
+            "exact `Tool` Deny handled by unconditionally_denied_tools()"
+        );
+    }
+
+    #[test]
+    fn expand_glob_deny_skips_per_args_rules() {
+        // `Bash(npm *)` Deny is conditional on args — must NOT be
+        // expanded against the registry, because a `Bash` call with
+        // other args is still permitted.
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "Bash(npm *)", "behavior": "deny" },
+            ]
+        }));
+        let all_tools = vec!["Bash".to_string()];
+        let denied = expand_glob_regex_denies(&ruleset, &all_tools);
+        assert!(denied.is_empty(), "per-args Deny stays conditional");
+    }
+
+    #[test]
+    fn args_conditional_no_longer_lists_glob_deny_any_args() {
+        // After R7 #3, glob/regex Deny + any args is expanded into
+        // `unconditionally_denied`. To avoid double-display, it must
+        // disappear from args_conditional_rules.
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                { "tool": "mcp__db__*", "behavior": "deny" },
+            ]
+        }));
+        let candidate = vec!["mcp__db__query".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &candidate);
+        assert!(
+            entries.is_empty(),
+            "glob Deny + any-args is now unconditional"
+        );
+    }
+
+    // R12 #1 — Passing the EFFECTIVE set (candidate minus
+    // unconditionally-denied) drops args-conditional rules whose tool
+    // target the model can no longer call. Previously the call site
+    // passed the raw `candidate_tools`, leaving stale entries that
+    // implied "Bash will still be denied when args match" even though
+    // Bash itself was already stripped by the BeforeInference hook.
+    #[test]
+    fn args_conditional_drops_rules_on_unconditionally_denied_tools() {
+        let ruleset = ruleset_from_json(json!({
+            "default_behavior": "ask",
+            "rules": [
+                // Unconditional deny for Bash — strips the tool entirely.
+                { "tool": "Bash", "behavior": "deny" },
+                // Args-conditional rule on the SAME tool — cannot fire
+                // once Bash is removed from the model's tool list.
+                { "tool": "Bash(npm *)", "behavior": "ask" },
+            ]
+        }));
+        // The call site passes effective_tools = candidate ∖ denied.
+        // Here Bash is denied, so it's not in `effective`.
+        let effective = vec!["Read".to_string()];
+        let entries = collect_args_conditional_rules(&ruleset, &effective);
+        assert!(
+            entries.is_empty(),
+            "args-conditional rule on a denied tool must be dropped, got: {entries:?}"
+        );
     }
 }

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2326,6 +2326,47 @@ async fn patch_overrides_sections_null_value_deletes_base_section_key() {
 }
 
 #[tokio::test]
+async fn patch_overrides_sections_null_value_clears_override_only_section_key() {
+    let app = make_app().await;
+
+    let (seed_status, seed_body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"sections": {"draft_only": {"enabled": true}}}),
+    )
+    .await;
+    assert_eq!(seed_status, StatusCode::OK, "body: {seed_body}");
+    assert_eq!(
+        seed_body["sections"]["draft_only"],
+        json!({"enabled": true})
+    );
+
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"sections": {"draft_only": null}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    if let Some(sections) = body.get("sections").and_then(Value::as_object) {
+        assert!(
+            !sections.contains_key("draft_only"),
+            "override-only section must be removed from the effective spec"
+        );
+    }
+
+    use awaken_contract::contract::config_store::ConfigStore;
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    assert!(
+        raw["meta"]["user_overrides"].is_null(),
+        "deleting the only override-only section should clear user_overrides: {raw}"
+    );
+}
+
+#[tokio::test]
 async fn patch_overrides_sections_merges_with_existing_section_overrides() {
     let app = make_app().await;
 

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2329,6 +2329,48 @@ async fn patch_overrides_clear_directive_removes_overrides() {
 }
 
 #[tokio::test]
+async fn patch_overrides_clear_directive_accepts_endpoint() {
+    let app = make_app().await;
+
+    let (seed_status, _) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({
+            "endpoint": {
+                "backend": "a2a",
+                "base_url": "https://remote.example.com",
+                "target": "remote-agent"
+            }
+        }),
+    )
+    .await;
+    assert_eq!(seed_status, StatusCode::OK);
+
+    let (status, body) =
+        patch_overrides(&app.router, "bootstrap", json!({"_clear": ["endpoint"]})).await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert!(
+        body.get("endpoint").is_none() || body["endpoint"].is_null(),
+        "effective endpoint must fall back to the base value"
+    );
+
+    use awaken_contract::contract::config_store::ConfigStore;
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    let overrides = raw["meta"].get("user_overrides").unwrap_or(&Value::Null);
+    assert!(
+        overrides.is_null()
+            || !overrides
+                .as_object()
+                .expect("user_overrides object")
+                .contains_key("endpoint"),
+        "endpoint override should be cleared, got: {raw}"
+    );
+}
+
+#[tokio::test]
 async fn patch_overrides_clear_rejects_unknown_field_name() {
     let app = make_app().await;
     let (status, body) = patch_overrides(
@@ -2347,6 +2389,18 @@ async fn patch_overrides_clear_rejects_conflict_with_upsert() {
         &app.router,
         "bootstrap",
         json!({"system_prompt": "new", "_clear": ["system_prompt"]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+}
+
+#[tokio::test]
+async fn patch_overrides_clear_rejects_endpoint_conflict_with_upsert() {
+    let app = make_app().await;
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"endpoint": null, "_clear": ["endpoint"]}),
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2326,6 +2326,128 @@ async fn patch_overrides_sections_null_value_deletes_base_section_key() {
 }
 
 #[tokio::test]
+async fn patch_overrides_sections_merges_with_existing_section_overrides() {
+    let app = make_app().await;
+
+    use awaken_contract::contract::config_store::ConfigStore;
+
+    let mut raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    raw["spec"]["sections"] = json!({
+        "permission": { "default_behavior": "ask" },
+        "observability": { "enabled": false }
+    });
+    ConfigStore::put(app.store.as_ref(), "agents", "bootstrap", &raw)
+        .await
+        .expect("store write");
+
+    let (seed_status, _) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({
+            "sections": {
+                "permission": { "default_behavior": "deny" },
+                "observability": { "enabled": true }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(seed_status, StatusCode::OK);
+
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"sections": {"permission": {"default_behavior": "allow"}}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        body["sections"]["permission"],
+        json!({"default_behavior": "allow"})
+    );
+    assert_eq!(body["sections"]["observability"], json!({"enabled": true}));
+
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    let section_overrides = raw["meta"]["user_overrides"]["sections"]
+        .as_object()
+        .expect("section overrides object");
+    assert_eq!(
+        section_overrides.get("permission"),
+        Some(&json!({"default_behavior": "allow"}))
+    );
+    assert_eq!(
+        section_overrides.get("observability"),
+        Some(&json!({"enabled": true}))
+    );
+}
+
+#[tokio::test]
+async fn patch_overrides_sections_delete_preserves_existing_sibling_overrides() {
+    let app = make_app().await;
+
+    use awaken_contract::contract::config_store::ConfigStore;
+
+    let mut raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    raw["spec"]["sections"] = json!({
+        "permission": { "default_behavior": "ask" },
+        "observability": { "enabled": false }
+    });
+    ConfigStore::put(app.store.as_ref(), "agents", "bootstrap", &raw)
+        .await
+        .expect("store write");
+
+    let (seed_status, _) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"sections": {"observability": {"enabled": true}}}),
+    )
+    .await;
+    assert_eq!(seed_status, StatusCode::OK);
+
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"sections": {"permission": null}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert!(
+        !body["sections"]
+            .as_object()
+            .expect("sections object")
+            .contains_key("permission"),
+        "permission section must be deleted from the effective spec"
+    );
+    assert_eq!(body["sections"]["observability"], json!({"enabled": true}));
+
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    let section_overrides = raw["meta"]["user_overrides"]["sections"]
+        .as_object()
+        .expect("section overrides object");
+    assert!(
+        section_overrides
+            .get("permission")
+            .is_some_and(Value::is_null),
+        "stored override should preserve the per-section delete marker"
+    );
+    assert_eq!(
+        section_overrides.get("observability"),
+        Some(&json!({"enabled": true}))
+    );
+}
+
+#[tokio::test]
 async fn patch_overrides_rejects_unknown_field() {
     let app = make_app().await;
 

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2274,6 +2274,81 @@ async fn patch_overrides_rejects_unknown_field() {
     assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
 }
 
+// R11 #3 — `_clear` directive applies upserts + clears atomically in
+// one PATCH transaction. Replaces the previous client-side
+// PATCH + N×DELETE flow which could leave the record in a partial
+// state if any DELETE failed.
+#[tokio::test]
+async fn patch_overrides_clear_directive_removes_overrides() {
+    let app = make_app().await;
+
+    // Seed two overrides.
+    let (s1, _) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"system_prompt": "kept", "max_rounds": 99}),
+    )
+    .await;
+    assert_eq!(s1, StatusCode::OK);
+
+    // Clear `max_rounds` while upserting another field — both in one call.
+    let (s2, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"_clear": ["max_rounds"], "system_prompt": "still-kept"}),
+    )
+    .await;
+    assert_eq!(s2, StatusCode::OK, "body={body}");
+    // Effective spec reflects the upsert.
+    assert_eq!(body["system_prompt"], "still-kept");
+    // Effective spec drops the cleared override.
+    use awaken_contract::contract::config_store::ConfigStore;
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    let overrides = raw["meta"]["user_overrides"]
+        .as_object()
+        .expect("overrides obj");
+    assert!(
+        !overrides.contains_key("max_rounds"),
+        "max_rounds override should be cleared, got: {raw}"
+    );
+    assert_eq!(overrides.get("system_prompt"), Some(&json!("still-kept")));
+}
+
+#[tokio::test]
+async fn patch_overrides_clear_rejects_unknown_field_name() {
+    let app = make_app().await;
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"_clear": ["unknown_field"]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+}
+
+#[tokio::test]
+async fn patch_overrides_clear_rejects_conflict_with_upsert() {
+    let app = make_app().await;
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"system_prompt": "new", "_clear": ["system_prompt"]}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+}
+
+#[tokio::test]
+async fn patch_overrides_clear_rejects_non_array() {
+    let app = make_app().await;
+    let (status, body) =
+        patch_overrides(&app.router, "bootstrap", json!({"_clear": "system_prompt"})).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+}
+
 #[tokio::test]
 async fn patch_overrides_on_user_record_returns_422() {
     let app = make_app().await;
@@ -2652,18 +2727,14 @@ async fn list_meta_returns_all_records_with_source() {
 
 // ── Permission preview endpoint (issue #190) ───────────────────────────────
 
-/// Build a router with the permission plugin registered and a stub provider.
-/// Shared setup for the preview tests below.
+/// Build a router with the permission plugin registered, a stub provider,
+/// and a fixed tool registry. The preview endpoint intersects
+/// `allowed_tools` against the tool registry — without registered tools
+/// the candidate set would always be empty, so we seed a deterministic
+/// set every preview test can reference.
 #[cfg(feature = "permission")]
 async fn make_permission_preview_app() -> axum::Router {
-    let (runtime, store, manager) = make_runtime_manager_custom(
-        None,
-        Arc::new(TestMcpRegistryFactory),
-        None,
-        Arc::new(TestProviderFactory),
-        true, // register permission plugin
-    )
-    .await;
+    let (runtime, store, manager) = make_permission_preview_runtime().await;
     let config_store = store.clone() as Arc<dyn ConfigStore>;
     let mailbox = Arc::new(Mailbox::new(
         runtime.clone(),
@@ -2682,6 +2753,87 @@ async fn make_permission_preview_app() -> axum::Router {
     .with_config_store(config_store)
     .with_config_runtime_manager(manager);
     build_router(&state).with_state(state)
+}
+
+/// Standalone runtime+manager+store for permission preview tests, with a
+/// fixed set of tools registered (`Bash`, `Read`, `Edit`, plus a couple
+/// of `mcp__db__*` tools so glob expansion tests can verify behaviour
+/// against real registry entries).
+#[cfg(feature = "permission")]
+async fn make_permission_preview_runtime() -> (
+    Arc<AgentRuntime>,
+    Arc<InMemoryStore>,
+    Arc<ConfigRuntimeManager>,
+) {
+    struct PreviewMockTool {
+        id: String,
+    }
+    #[async_trait]
+    impl Tool for PreviewMockTool {
+        fn descriptor(&self) -> ToolDescriptor {
+            ToolDescriptor::new(&self.id, &self.id, "preview mock")
+        }
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+            _ctx: &ToolCallContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolOutput::new(ToolResult::success(
+                &self.id,
+                serde_json::Value::Null,
+            )))
+        }
+    }
+
+    // No-op plugin used by tests that need a second loaded plugin id to
+    // populate `active_hook_filter` against. Defaults on the `Plugin`
+    // trait suffice — descriptor is the only required method.
+    struct NoopPlugin;
+    impl awaken_runtime::plugins::Plugin for NoopPlugin {
+        fn descriptor(&self) -> awaken_runtime::plugins::PluginDescriptor {
+            awaken_runtime::plugins::PluginDescriptor {
+                name: "observability",
+            }
+        }
+    }
+
+    let store = Arc::new(InMemoryStore::new());
+    let mut builder = AgentRuntimeBuilder::new()
+        .with_provider("bootstrap", Arc::new(ImmediateExecutor))
+        .with_plugin("permission", Arc::new(PermissionPlugin))
+        .with_plugin("observability", Arc::new(NoopPlugin))
+        .with_thread_run_store(store.clone());
+    for id in ["Bash", "Read", "Edit", "mcp__db__query", "mcp__db__write"] {
+        builder = builder.with_tool(id, Arc::new(PreviewMockTool { id: id.into() }));
+    }
+    let runtime = Arc::new(builder.build().expect("build preview runtime"));
+    let config_store = store.clone() as Arc<dyn ConfigStore>;
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager")
+            .with_provider_factory(Arc::new(TestProviderFactory))
+            .with_mcp_registry_factory(Arc::new(TestMcpRegistryFactory)),
+    );
+    let seed = BuiltinSeedSet {
+        binary_version: "test".to_string(),
+        specs: vec![
+            BuiltinSpec::provider(ProviderSpec {
+                id: "bootstrap".into(),
+                adapter: "stub".into(),
+                ..Default::default()
+            }),
+            BuiltinSpec::model(ModelBindingSpec {
+                id: "bootstrap".into(),
+                provider_id: "bootstrap".into(),
+                upstream_model: "bootstrap-model".into(),
+            }),
+            BuiltinSpec::agent(agent_spec("bootstrap", "bootstrap")),
+        ],
+    };
+    manager.apply_seed(&seed).await.expect("apply_seed");
+    manager.apply().await.expect("publish config snapshot");
+
+    (runtime, store, manager)
 }
 
 #[cfg(feature = "permission")]
@@ -2721,8 +2873,12 @@ async fn permission_preview_returns_candidate_set_without_permission_plugin() {
             "id": "no-perm-agent",
             "model_id": "stub-model",
             "system_prompt": "no permission plugin",
-            "allowed_tools": ["alpha", "beta"],
-            "excluded_tools": ["beta"]
+            // Use ids that exist in the test runtime registry (Bash/Read/Edit
+            // are seeded by `make_permission_preview_runtime`). After the R7
+            // registry-intersection fix, ids not in the registry are
+            // filtered out — covered by a dedicated test below.
+            "allowed_tools": ["Bash", "Read"],
+            "excluded_tools": ["Read"]
         })),
     )
     .await;
@@ -2739,12 +2895,119 @@ async fn permission_preview_returns_candidate_set_without_permission_plugin() {
     assert_eq!(body["agent_id"], "no-perm-agent");
     assert_eq!(body["permission_plugin_enabled"], false);
     assert!(body["default_behavior"].is_null());
-    // candidate = allowed ∖ excluded = ["alpha"]
-    assert_eq!(body["candidate_tools"], json!(["alpha"]));
+    // candidate = allowed ∖ excluded = ["Bash"]
+    assert_eq!(body["candidate_tools"], json!(["Bash"]));
     // No permission plugin -> effective == candidate.
-    assert_eq!(body["effective_tools"], json!(["alpha"]));
+    assert_eq!(body["effective_tools"], json!(["Bash"]));
     assert_eq!(body["unconditionally_denied"], json!([]));
     assert_eq!(body["args_conditional_rules"], json!([]));
+}
+
+// R7 #2 — preview filters `allowed_tools` against the registry. A stale
+// id (renamed plugin, removed MCP server, typo) must NOT appear in
+// `effective_tools` because the runtime tool catalog never offers it.
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_intersects_allowed_tools_with_registry() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "stale-tools-agent",
+            "model_id": "stub-model",
+            "system_prompt": "stale tool list",
+            // `ghost_tool` is not registered; the runtime would never
+            // offer it. The preview must drop it.
+            "allowed_tools": ["Bash", "ghost_tool", "another-ghost"],
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/stale-tools-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(body["candidate_tools"], json!(["Bash"]));
+    assert_eq!(body["effective_tools"], json!(["Bash"]));
+}
+
+// R7 #3 — glob/regex Deny + any-args rules expand against the registry
+// into `unconditionally_denied`. Without this fix a `mcp__db__*` Deny
+// rule would only appear in `args_conditional_rules` while
+// `effective_tools` still listed `mcp__db__query` etc., even though
+// the runtime BeforeInference hook would strip them on every call.
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_expands_glob_deny_against_registry() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "glob-deny-agent",
+            "model_id": "stub-model",
+            "system_prompt": "deny all mcp__db__*",
+            "plugin_ids": ["permission"],
+            "sections": {
+                "permission": {
+                    "default_behavior": "ask",
+                    "rules": [
+                        { "tool": "mcp__db__*", "behavior": "deny" }
+                    ]
+                }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/glob-deny-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    // Both registered mcp__db__* tools are now in the unconditionally
+    // denied list — not hiding in args_conditional_rules.
+    let denied = body["unconditionally_denied"]
+        .as_array()
+        .expect("unconditionally_denied is an array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert!(denied.contains(&"mcp__db__query".to_string()));
+    assert!(denied.contains(&"mcp__db__write".to_string()));
+    // Effective tools no longer carry them.
+    let effective = body["effective_tools"]
+        .as_array()
+        .expect("effective_tools is an array")
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert!(!effective.contains(&"mcp__db__query".to_string()));
+    assert!(!effective.contains(&"mcp__db__write".to_string()));
+    // The glob Deny no longer double-appears in args_conditional_rules.
+    let args_conditional = body["args_conditional_rules"]
+        .as_array()
+        .expect("args_conditional_rules is an array");
+    assert!(
+        !args_conditional.iter().any(
+            |r| r["behavior"] == "deny" && r["pattern"].as_str().unwrap().contains("mcp__db__")
+        ),
+        "glob deny should be in unconditionally_denied, not args_conditional_rules"
+    );
 }
 
 #[cfg(feature = "permission")]
@@ -2813,4 +3076,322 @@ async fn permission_preview_404_for_unknown_agent() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+// R8 #1 — `active_hook_filter` excludes the permission plugin from the
+// hook dispatcher even though the plugin itself is loaded. The runtime
+// won't run permission BeforeInference hooks in this state, so preview
+// must report enabled=false and emit candidate_tools as effective_tools.
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_respects_active_hook_filter_excluding_permission() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, body) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "filtered-out-agent",
+            "model_id": "stub-model",
+            "system_prompt": "permission loaded but filtered",
+            // Both plugins are loaded by the runtime; the filter
+            // restricts hook dispatch to observability only —
+            // permission hooks will NOT run.
+            "plugin_ids": ["permission", "observability"],
+            "active_hook_filter": ["observability"],
+            "allowed_tools": ["Bash", "Read"],
+            "sections": {
+                "permission": {
+                    "default_behavior": "ask",
+                    "rules": [
+                        { "tool": "Bash", "behavior": "deny" }
+                    ]
+                }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "body={body}");
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/filtered-out-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(
+        body["permission_plugin_enabled"], false,
+        "filtered-out permission plugin must report disabled"
+    );
+    // No deny is applied since the hook won't run.
+    assert_eq!(body["unconditionally_denied"], json!([]));
+    assert_eq!(body["candidate_tools"], body["effective_tools"]);
+}
+
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_respects_active_hook_filter_including_permission() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "filter-includes-permission-agent",
+            "model_id": "stub-model",
+            "system_prompt": "permission loaded and admitted",
+            "plugin_ids": ["permission", "observability"],
+            "active_hook_filter": ["permission"],
+            "allowed_tools": ["Bash", "Read"],
+            "sections": {
+                "permission": {
+                    "default_behavior": "ask",
+                    "rules": [
+                        { "tool": "Bash", "behavior": "deny" }
+                    ]
+                }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/filter-includes-permission-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(body["permission_plugin_enabled"], true);
+    assert_eq!(body["unconditionally_denied"], json!(["Bash"]));
+}
+
+// R8 #4 — `unconditionally_denied` must only count tools that were in
+// the candidate set. A deny rule for a tool the agent already wouldn't
+// see (because allowed_tools excluded it) is NOT a "strip" — the UI
+// summary "N tools stripped before the model sees the list" would
+// otherwise overstate.
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_unconditionally_denied_intersects_candidate() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "denied-outside-candidate-agent",
+            "model_id": "stub-model",
+            "system_prompt": "deny rules target tools outside candidate set",
+            "plugin_ids": ["permission"],
+            // Candidate set is just Bash; the deny rule targets a
+            // glob the agent never had access to.
+            "allowed_tools": ["Bash"],
+            "sections": {
+                "permission": {
+                    "default_behavior": "ask",
+                    "rules": [
+                        { "tool": "mcp__db__*", "behavior": "deny" }
+                    ]
+                }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/denied-outside-candidate-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(body["candidate_tools"], json!(["Bash"]));
+    // `mcp__db__query` etc. matched the deny rule but they were never
+    // in the candidate set — they are NOT counted as "stripped".
+    assert_eq!(body["unconditionally_denied"], json!([]));
+    assert_eq!(body["effective_tools"], json!(["Bash"]));
+}
+
+// R10 #1 — agent not found must return 404, NOT the 404 the client
+// previously interpreted as "permission feature not compiled". The
+// route is registered unconditionally and returns 503 only when the
+// `permission` feature is off (see permission_preview_route_returns_503_when_feature_disabled
+// in the `cfg(not(feature = "permission"))` test module).
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_404_body_distinguishes_missing_agent() {
+    let router = make_permission_preview_app().await;
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/ghost-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let err = body
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        err.contains("agent not found"),
+        "404 body must identify the missing agent (got: {err})"
+    );
+}
+
+// R10 #3 — `args_conditional_rules` must not list rules whose tool
+// target is outside the candidate set. Such rules can never bite at
+// runtime; the operator would mistake them for "still gating tools the
+// model can call".
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_args_conditional_drops_rules_outside_candidate() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "args-cond-outside-candidate-agent",
+            "model_id": "stub-model",
+            "system_prompt": "args-conditional rule targets non-candidate tool",
+            "plugin_ids": ["permission"],
+            // Candidate is just `Bash`; the args-pattern rule targets
+            // `Read` which the agent never had access to.
+            "allowed_tools": ["Bash"],
+            "sections": {
+                "permission": {
+                    "default_behavior": "ask",
+                    "rules": [
+                        { "tool": "Read(/etc/*)", "behavior": "deny" }
+                    ]
+                }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/args-cond-outside-candidate-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    // The Read(/etc/*) rule must NOT show up; Read is outside candidate.
+    assert_eq!(body["args_conditional_rules"], json!([]));
+}
+
+// R12 #1 — `effective_tools = candidate ∖ unconditionally_denied`.
+// An args-conditional rule on an unconditionally-denied tool cannot
+// fire at runtime (the tool is stripped before any call reaches the
+// permission layer), so the preview must not list it.
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_drops_args_rules_on_unconditionally_denied_tools() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "args-on-denied-agent",
+            "model_id": "stub-model",
+            "system_prompt": "args rule on a denied tool",
+            "plugin_ids": ["permission"],
+            "allowed_tools": ["Bash", "Read"],
+            "sections": {
+                "permission": {
+                    "default_behavior": "ask",
+                    "rules": [
+                        // Bash is unconditionally denied.
+                        { "tool": "Bash", "behavior": "deny" },
+                        // Args-conditional rule on the SAME tool —
+                        // can never bite once Bash is stripped.
+                        { "tool": "Bash(npm *)", "behavior": "ask" }
+                    ]
+                }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/args-on-denied-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(body["unconditionally_denied"], json!(["Bash"]));
+    assert_eq!(body["effective_tools"], json!(["Read"]));
+    // The Bash(npm *) ask rule must NOT show — Bash is already
+    // stripped before any call reaches the permission layer.
+    assert_eq!(
+        body["args_conditional_rules"],
+        json!([]),
+        "args rule on an unconditionally-denied tool must be dropped"
+    );
+}
+
+// R12 #6 — Sections-less agent: the `permission` plugin is loaded but
+// the agent never wrote a `sections.permission` entry. `AgentSpec::config`
+// returns `Config::default()` in this case, so the preview should
+// succeed with the default behavior and no rules — NOT 400.
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_handles_missing_permission_section() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "permission-no-section-agent",
+            "model_id": "stub-model",
+            "system_prompt": "permission plugin loaded, no section",
+            "plugin_ids": ["permission"],
+            "allowed_tools": ["Bash"],
+            // No `sections.permission` entry at all.
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/permission-no-section-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "missing permission section must NOT error — defaults apply: body={body}"
+    );
+    assert_eq!(body["permission_plugin_enabled"], true);
+    // Default behavior is `ask` (PermissionRulesConfig::default()).
+    assert_eq!(body["default_behavior"], "ask");
+    assert_eq!(body["unconditionally_denied"], json!([]));
+    assert_eq!(body["args_conditional_rules"], json!([]));
+    assert_eq!(body["candidate_tools"], json!(["Bash"]));
+    assert_eq!(body["effective_tools"], json!(["Bash"]));
 }

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2277,6 +2277,55 @@ async fn patch_overrides_null_clears_nullable_base_field() {
 }
 
 #[tokio::test]
+async fn patch_overrides_sections_null_value_deletes_base_section_key() {
+    let app = make_app().await;
+
+    use awaken_contract::contract::config_store::ConfigStore;
+
+    let mut raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    raw["spec"]["sections"] = json!({
+        "permission": { "default_behavior": "ask", "rules": [] },
+        "observability": { "enabled": true }
+    });
+    ConfigStore::put(app.store.as_ref(), "agents", "bootstrap", &raw)
+        .await
+        .expect("store write");
+
+    let (status, body) = patch_overrides(
+        &app.router,
+        "bootstrap",
+        json!({"sections": {"permission": null}}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert!(
+        !body["sections"]
+            .as_object()
+            .expect("sections object")
+            .contains_key("permission"),
+        "permission section must be deleted from the effective spec"
+    );
+    assert_eq!(body["sections"]["observability"], json!({"enabled": true}));
+
+    let raw = ConfigStore::get(app.store.as_ref(), "agents", "bootstrap")
+        .await
+        .expect("store read")
+        .expect("entry present");
+    let section_overrides = raw["meta"]["user_overrides"]["sections"]
+        .as_object()
+        .expect("section overrides object");
+    assert!(
+        section_overrides
+            .get("permission")
+            .is_some_and(Value::is_null),
+        "stored override should preserve the per-section delete marker"
+    );
+}
+
+#[tokio::test]
 async fn patch_overrides_rejects_unknown_field() {
     let app = make_app().await;
 

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2649,3 +2649,168 @@ async fn list_meta_returns_all_records_with_source() {
     assert!(user_rec.is_some(), "user-list-meta must be in list/meta");
     assert_eq!(user_rec.unwrap()["meta"]["source"]["kind"], "user");
 }
+
+// ── Permission preview endpoint (issue #190) ───────────────────────────────
+
+/// Build a router with the permission plugin registered and a stub provider.
+/// Shared setup for the preview tests below.
+#[cfg(feature = "permission")]
+async fn make_permission_preview_app() -> axum::Router {
+    let (runtime, store, manager) = make_runtime_manager_custom(
+        None,
+        Arc::new(TestMcpRegistryFactory),
+        None,
+        Arc::new(TestProviderFactory),
+        true, // register permission plugin
+    )
+    .await;
+    let config_store = store.clone() as Arc<dyn ConfigStore>;
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        store.clone(),
+        "permission-preview-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime.clone(),
+        mailbox,
+        store,
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager);
+    build_router(&state).with_state(state)
+}
+
+#[cfg(feature = "permission")]
+async fn seed_provider_and_model(router: &axum::Router) {
+    let (status, _) = request_json(
+        router,
+        Method::POST,
+        "/v1/config/providers",
+        Some(json!({ "id": "stub-provider", "adapter": "stub" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let (status, _) = request_json(
+        router,
+        Method::POST,
+        "/v1/config/models",
+        Some(json!({
+            "id": "stub-model",
+            "provider_id": "stub-provider",
+            "upstream_model": "any"
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+}
+
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_returns_candidate_set_without_permission_plugin() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "no-perm-agent",
+            "model_id": "stub-model",
+            "system_prompt": "no permission plugin",
+            "allowed_tools": ["alpha", "beta"],
+            "excluded_tools": ["beta"]
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/no-perm-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(body["agent_id"], "no-perm-agent");
+    assert_eq!(body["permission_plugin_enabled"], false);
+    assert!(body["default_behavior"].is_null());
+    // candidate = allowed ∖ excluded = ["alpha"]
+    assert_eq!(body["candidate_tools"], json!(["alpha"]));
+    // No permission plugin -> effective == candidate.
+    assert_eq!(body["effective_tools"], json!(["alpha"]));
+    assert_eq!(body["unconditionally_denied"], json!([]));
+    assert_eq!(body["args_conditional_rules"], json!([]));
+}
+
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_subtracts_unconditionally_denied_tools() {
+    let router = make_permission_preview_app().await;
+    seed_provider_and_model(&router).await;
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/agents",
+        Some(json!({
+            "id": "perm-agent",
+            "model_id": "stub-model",
+            "system_prompt": "permission-gated",
+            "plugin_ids": ["permission"],
+            "allowed_tools": ["Bash", "Read", "Edit"],
+            "sections": {
+                "permission": {
+                    "default_behavior": "ask",
+                    "rules": [
+                        { "tool": "Bash", "behavior": "deny" },
+                        { "tool": "Read", "behavior": "allow" },
+                        { "tool": "Edit(/etc/*)", "behavior": "deny" }
+                    ]
+                }
+            }
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/perm-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(body["permission_plugin_enabled"], true);
+    assert_eq!(body["default_behavior"], "ask");
+    assert_eq!(body["candidate_tools"], json!(["Bash", "Edit", "Read"]));
+    assert_eq!(body["unconditionally_denied"], json!(["Bash"]));
+    // Bash stripped; Edit kept (the deny is args-conditional on path).
+    assert_eq!(body["effective_tools"], json!(["Edit", "Read"]));
+    let args = body["args_conditional_rules"]
+        .as_array()
+        .expect("args_conditional_rules should be a list");
+    assert!(
+        args.iter()
+            .any(|r| r["tool"] == "Edit" && r["behavior"] == "deny"),
+        "expected Edit(/etc/*) deny rule in args_conditional_rules, got {body}",
+    );
+}
+
+#[cfg(feature = "permission")]
+#[tokio::test]
+async fn permission_preview_404_for_unknown_agent() {
+    let router = make_permission_preview_app().await;
+    let (status, _body) = request_json(
+        &router,
+        Method::GET,
+        "/v1/agents/no-such-agent/permission-preview",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2228,6 +2228,17 @@ async fn patch_overrides_null_clears_field() {
     );
 }
 
+// **Contract pin**: `endpoint` is a patchable AgentSpec field through the
+// override API. The admin-console editor treats endpoint as a locked /
+// read-only field for UX simplification, but this is a client-side
+// choice — not a server-enforced immutability boundary. Programmatic
+// clients (CLI, scripts, other admin tooling) can override or clear
+// endpoint through `PATCH /v1/config/agents/:id/overrides`. See the
+// long-form rationale on `AgentSpecPatch::endpoint` in
+// `crates/awaken-contract/src/agent_spec_patch.rs`.
+//
+// Changing this behavior (e.g. making endpoint server-side immutable)
+// would be a breaking API change and requires a dedicated ADR.
 #[tokio::test]
 async fn patch_overrides_null_clears_nullable_base_field() {
     let app = make_app().await;

--- a/crates/awaken-server/tests/public_api_compat_extended.rs
+++ b/crates/awaken-server/tests/public_api_compat_extended.rs
@@ -214,6 +214,11 @@ fn api_error_exhaustive_match_keeps_0_2_variants() {
             ApiError::NotFound(_) => "not_found",
             ApiError::ThreadNotFound(_) => "thread_not_found",
             ApiError::RunNotFound(_) => "run_not_found",
+            // Post-0.2 addition (PR #190 — `permission-preview` feature
+            // gate). Not part of the 0.2 surface itself, but listed here
+            // so the exhaustive match keeps compiling and a future
+            // refactor of `ApiError` still trips this test.
+            ApiError::ServiceUnavailable(_) => "service_unavailable",
             ApiError::Internal(_) => "internal",
         }
     }

--- a/crates/awaken-server/tests/run_api.rs
+++ b/crates/awaken-server/tests/run_api.rs
@@ -734,6 +734,207 @@ async fn ai_sdk_agent_preview_runs_with_draft_system_prompt_and_history() {
     );
 }
 
+// R11 #1 — Preview must refuse payloads carrying `endpoint` or
+// `registry`. These provenance fields would let a crafted draft skip
+// local registry validation in `build_preview_registry_set` (which
+// only resolves when `agent.endpoint.is_none()`) and route the run
+// to an arbitrary remote backend.
+#[tokio::test]
+async fn ai_sdk_agent_preview_rejects_endpoint_field() {
+    let test = make_test_app();
+    let (status, body) = post_json(
+        test.router,
+        "/v1/ai-sdk/agent-previews/runs",
+        json!({
+            "agent": {
+                "id": "evil-preview",
+                "model_id": "test-model",
+                "system_prompt": "evil",
+                "max_rounds": 0,
+                "endpoint": {
+                    "backend": "remote",
+                    "base_url": "https://attacker.example.com"
+                }
+            },
+            "messages": [
+                {
+                    "id": "u1",
+                    "role": "user",
+                    "parts": [{ "type": "text", "text": "hello" }]
+                }
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+    assert!(
+        body.contains("endpoint") || body.contains("registry"),
+        "rejection message should name the forbidden field: {body}"
+    );
+}
+
+#[tokio::test]
+async fn ai_sdk_agent_preview_rejects_registry_field() {
+    let test = make_test_app();
+    let (status, body) = post_json(
+        test.router,
+        "/v1/ai-sdk/agent-previews/runs",
+        json!({
+            "agent": {
+                "id": "evil-preview",
+                "model_id": "test-model",
+                "system_prompt": "evil",
+                "max_rounds": 0,
+                "registry": "cloud"
+            },
+            "messages": [
+                {
+                    "id": "u1",
+                    "role": "user",
+                    "parts": [{ "type": "text", "text": "hello" }]
+                }
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+    assert!(
+        body.contains("endpoint") || body.contains("registry"),
+        "rejection message should name the forbidden field: {body}"
+    );
+}
+
+// R11 #1 — Preview must require the admin bearer when one is
+// configured on the server. Without this gate anyone with network
+// access could submit an arbitrary AgentSpec, consume provider
+// credits, and invoke registered tools.
+#[tokio::test]
+async fn ai_sdk_agent_preview_requires_admin_token_when_configured() {
+    let store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_model_binding(
+                "test-model",
+                ModelBinding {
+                    provider_id: "mock".into(),
+                    upstream_model: "mock-model".into(),
+                },
+            )
+            .with_provider("mock", Arc::new(ImmediateExecutor))
+            .with_agent_spec(AgentSpec {
+                id: "test-agent".into(),
+                model_id: "test-model".into(),
+                system_prompt: "test".into(),
+                max_rounds: 0,
+                ..Default::default()
+            })
+            .with_thread_run_store(store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    let mailbox_store = Arc::new(awaken_stores::InMemoryMailboxStore::new());
+    let mailbox = Arc::new(awaken_server::mailbox::Mailbox::new(
+        runtime.clone(),
+        mailbox_store,
+        store.clone(),
+        "test".to_string(),
+        awaken_server::mailbox::MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime.clone(),
+        mailbox,
+        store.clone(),
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    )
+    .with_admin_api_bearer_token("expected-token");
+    let router = build_router(&state).with_state(state);
+
+    // No Authorization header → 401.
+    let (status, _) = post_json(
+        router.clone(),
+        "/v1/ai-sdk/agent-previews/runs",
+        json!({
+            "agent": {
+                "id": "preview",
+                "model_id": "test-model",
+                "system_prompt": "p",
+                "max_rounds": 0
+            },
+            "messages": [
+                { "id": "u1", "role": "user", "parts": [{ "type": "text", "text": "hi" }] }
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated must be 401"
+    );
+
+    // Wrong token → 401.
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/ai-sdk/agent-previews/runs")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer wrong")
+                .body(axum::body::Body::from(
+                    json!({
+                        "agent": {
+                            "id": "preview",
+                            "model_id": "test-model",
+                            "system_prompt": "p",
+                            "max_rounds": 0
+                        },
+                        "messages": [
+                            { "id": "u1", "role": "user", "parts": [{ "type": "text", "text": "hi" }] }
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .expect("request build"),
+        )
+        .await
+        .expect("router handles request");
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "wrong token must be 401"
+    );
+
+    // Correct token → 200.
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/ai-sdk/agent-previews/runs")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer expected-token")
+                .body(axum::body::Body::from(
+                    json!({
+                        "agent": {
+                            "id": "preview",
+                            "model_id": "test-model",
+                            "system_prompt": "p",
+                            "max_rounds": 0
+                        },
+                        "messages": [
+                            { "id": "u1", "role": "user", "parts": [{ "type": "text", "text": "hi" }] }
+                        ]
+                    })
+                    .to_string(),
+                ))
+                .expect("request build"),
+        )
+        .await
+        .expect("router handles request");
+    assert_eq!(resp.status(), StatusCode::OK, "correct token must succeed");
+}
+
 // ============================================================================
 // List runs (GET /v1/runs)
 // ============================================================================

--- a/docs/adr/0033-locked-field-ui-api-boundary.md
+++ b/docs/adr/0033-locked-field-ui-api-boundary.md
@@ -1,0 +1,187 @@
+# ADR-0033: Locked-field UI/API boundary for `AgentSpec`
+
+- **Status**: Accepted
+- **Date**: 2026-05-13
+- **Depends on**: ADR-0010 (registry/resolve), ADR-0024 (admin console data
+  router), ADR-0029 (tool description override)
+
+## Context
+
+`AgentSpec` carries two fields the admin-console agent editor treats as
+*locked*:
+
+- `endpoint` — remote-backend provenance. When present, the runtime
+  resolver routes the agent's runs to a remote backend; when absent, the
+  agent is local. Editing `endpoint` from the editor would silently
+  re-target a builtin agent's runs to an arbitrary remote, which is a
+  blast-radius the graphical editor is not the right surface for.
+- `registry` — runtime-locality marker. Identifies which agent-spec
+  registry the record belongs to. Editing it through the editor would
+  detach the record from its source and break upstream sync.
+
+The editor's `LOCKED_AGENT_FIELDS = ["endpoint", "registry"]` enforces
+this client-side: the form path exposes no widgets for either field, the
+Raw JSON Apply rejects edits to either, `cloneAgentSpecForEditor` strips
+both when duplicating a record, and the customized save path's
+`PATCHABLE_AGENT_FIELDS` allowlist omits both.
+
+At the API layer the picture is asymmetric:
+
+- `registry` is **not** part of `AgentSpecPatch`. The struct's
+  `#[serde(deny_unknown_fields)]` causes the server to reject any PATCH
+  body containing `registry`. This matches the client lock.
+- `endpoint` **is** part of `AgentSpecPatch` (`NullablePatch<RemoteEndpoint>`).
+  The server accepts both upsert (`{"endpoint": {...}}`) and clear
+  (`{"endpoint": null}`) directives. A passing integration test —
+  `patch_overrides_null_clears_nullable_base_field` in
+  `crates/awaken-server/tests/config_api.rs` — pins this behavior, and
+  `merge_agent_spec` documents endpoint as a tri-state nullable patch
+  field on equal footing with `context_policy`, `allowed_tools`, etc.
+
+A reviewer of PR #189 flagged this asymmetry as a defense-in-depth gap:
+"if the editor calls endpoint locked, the API should too, otherwise the
+lock isn't a real contract." This ADR settles the question.
+
+## Decision
+
+**The lock on `endpoint` is a UX boundary, not an immutability boundary
+or a security boundary. The asymmetry is intentional.**
+
+Specifically:
+
+1. **`endpoint` remains a patchable AgentSpec field at the API layer.**
+   `PATCH /v1/config/agents/:id/overrides` continues to accept upserts
+   and clears for `endpoint`. The `AgentSpecPatch::endpoint` field stays.
+   Removing it would be a breaking change requiring its own ADR.
+
+2. **The admin-console editor continues to treat `endpoint` as locked.**
+   No form widget edits it. Raw JSON Apply rejects edits to it.
+   `PATCHABLE_AGENT_FIELDS` excludes it. This is the UX simplification:
+   most operators have no business rebinding a builtin agent's remote
+   backend through a graphical editor, and exposing that surface there
+   would be one click away from operational mistakes.
+
+3. **`registry` remains both UI-locked and API-locked.** Its locality
+   semantics differ from endpoint — overriding it would detach the
+   record from its source registry in ways the merge logic does not
+   know how to undo. The API-level rejection (via `deny_unknown_fields`)
+   is the right contract here.
+
+4. **Programmatic clients retain endpoint patch capability.** CLI tools,
+   operations scripts, A2A federation glue, and other admin tooling can
+   still upsert or clear `endpoint` overrides through the public PATCH
+   endpoint. This supports legitimate use cases like:
+   - Temporarily redirecting a builtin agent to a staging backend for
+     pre-production validation.
+   - Bulk re-pointing a fleet of customized agents after a backend
+     hostname change.
+   - Federation tooling that materializes remote-agent records with
+     locally-supplied endpoint metadata.
+
+5. **The admin console surfaces existing endpoint overrides.** When a
+   loaded agent has `user_overrides.endpoint`, the editor renders a
+   `data-testid="endpoint-override-banner"` warning explaining that the
+   override was installed through the API and pointing operators at the
+   `_clear` directive to remove it. This makes the boundary visible
+   instead of letting the locked UI lie about effective state.
+
+## Consequences
+
+### Positive
+
+- No breaking change to `AgentSpecPatch`. The `merge_agent_spec` tri-state
+  semantic remains uniform across all nullable fields. Existing test
+  `patch_overrides_null_clears_nullable_base_field` continues to pin the
+  documented behavior.
+- Programmatic clients keep a documented and supported surface for
+  managing endpoint overrides without going through the editor.
+- The graphical editor stays focused on the operations most users
+  perform. Endpoint reconfiguration — a low-frequency, high-blast-radius
+  operation — is intentionally pushed to a more deliberate channel.
+- Operators are not misled: when an endpoint override exists, the
+  banner explicitly says so and points to the correct removal path.
+
+### Negative
+
+- The asymmetry between UI lock and API lock requires this ADR plus
+  in-source comments on every relevant call site (`AgentSpecPatch::endpoint`,
+  `ConfigService::patch_agent_overrides`, `agent-editor-helpers.ts`
+  `LOCKED_AGENT_FIELDS`). Without those, the design intent is not
+  recoverable from code reading.
+- New reviewers who don't read this ADR will reasonably re-raise the
+  same defense-in-depth question. The banner + in-source comments aim
+  to shorten that conversation.
+
+### Future revisits
+
+This decision is *not* sealed. Conditions that would warrant a new ADR
+to reverse it include:
+
+- Endpoint becomes a supply-chain or signing-anchor field whose
+  immutability is load-bearing. At that point, removing
+  `AgentSpecPatch::endpoint` would be the right move — but the
+  migration path needs to be planned (e.g. dedicated
+  `PATCH /v1/config/agents/:id/endpoint-binding` with stricter auth).
+- An operational incident traces back to a programmatic endpoint
+  override silently rebinding a production agent. Defense-in-depth
+  arguments grow weight when there is a real incident behind them.
+
+## Alternatives considered
+
+### Alternative A: server-side hard-lock on `endpoint`
+
+Reject any PATCH body containing `endpoint`, regardless of value.
+Equivalent to position B in PR #189 review thread.
+
+Rejected because:
+
+- Breaking change. The `patch_overrides_null_clears_nullable_base_field`
+  test in `origin/main` pins the inverse contract, and unknown
+  programmatic clients may rely on it.
+- Removes a legitimate operational capability (staging redirects,
+  bulk re-binding) without offering a replacement surface.
+- The UI lock is sufficient for the actual UX concern (preventing
+  accidental endpoint edits through the editor). The defense-in-depth
+  argument would only be load-bearing if there were a security
+  boundary at stake, which there is not — anyone with an admin token
+  can already do anything through the API.
+
+### Alternative B: server permissive, no documentation
+
+Keep the current behavior but do not document the asymmetry. Equivalent
+to position A in PR #189 review thread.
+
+Rejected because:
+
+- Reviewers reasonably interpret the UI lock as the contract and
+  re-raise the asymmetry as a bug every PR. The cost of clarification
+  conversations exceeds the cost of writing this ADR once.
+- Operators don't see existing endpoint overrides because the editor
+  hides them, leading to surprising behavior at runtime.
+
+### Alternative C: tri-state — allow upsert, reject clear
+
+Accept `PATCH {"endpoint": {...}}` but reject `PATCH {"endpoint": null}`,
+forcing clears to go through `_clear: ["endpoint"]`.
+
+Rejected because:
+
+- Still breaks `patch_overrides_null_clears_nullable_base_field` and
+  the documented `merge_agent_spec` tri-state contract.
+- Splits the semantic surface (null vs `_clear`) without a clear win.
+- Operationally indistinguishable from Alternative A.
+
+## Implementation pointers
+
+The contract is enforced and surfaced at five sites:
+
+| Site | Role |
+|------|------|
+| `crates/awaken-contract/src/agent_spec_patch.rs` — `AgentSpecPatch::endpoint` | Long-form rationale in field doc comment |
+| `crates/awaken-server/src/services/config_service.rs` — `patch_agent_overrides` | Contract-surface note in method doc comment |
+| `crates/awaken-server/tests/config_api.rs` — `patch_overrides_null_clears_nullable_base_field` | Contract-pin test; preamble flags it as load-bearing |
+| `apps/admin-console/src/lib/agent-editor-helpers.ts` — `LOCKED_AGENT_FIELDS` / `lockedFieldChange` | Client-side lock + normalization contract |
+| `apps/admin-console/src/pages/agent-editor-page.tsx` — `endpoint-override-banner` | Visibility for existing overrides |
+
+Changing any of these without updating the others — or without updating
+this ADR — should fail review.

--- a/e2e/tests/admin-config-ui.spec.ts
+++ b/e2e/tests/admin-config-ui.spec.ts
@@ -33,12 +33,24 @@ function textDeltas(events: any[]): string {
 
 async function gotoEditorTab(
   page: import('@playwright/test').Page,
-  name: 'Basics' | 'Tools' | 'Plugins' | 'Delegates' | 'Advanced',
+  name: 'Basics' | 'Tools' | 'Plugins' | 'Delegates' | 'Advanced' | 'History',
 ) {
   await page
     .getByRole('tablist', { name: 'Editor sections' })
     .getByRole('tab', { name })
     .click();
+}
+
+/**
+ * The Advanced tab replaced its read-only JSON preview `<pre>` with a
+ * textarea-backed Raw JSON editor (see G3). Tests that used to call
+ * `page.locator('pre')` should use this locator instead.
+ */
+function rawJsonEditor(page: import('@playwright/test').Page) {
+  return page
+    .locator('section')
+    .filter({ has: page.getByRole('heading', { name: 'Raw JSON' }) })
+    .getByRole('textbox');
 }
 
 async function selectPlugin(page: import('@playwright/test').Page, pluginId: string) {
@@ -163,8 +175,8 @@ test.describe('admin config UI', () => {
       .evaluate((element) => (element as HTMLButtonElement).click());
 
     await gotoEditorTab(page, 'Advanced');
-    await expect(page.locator('pre')).toContainText('"default_behavior": "deny"');
-    await expect(page.locator('pre')).not.toContainText('deferred_tools');
+    await expect(rawJsonEditor(page)).toHaveValue(/"default_behavior": "deny"/);
+    await expect(rawJsonEditor(page)).not.toHaveValue(/deferred_tools/);
 
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(expectAgentCreatedToast(page, agentId)).toBeVisible();
@@ -205,8 +217,8 @@ test.describe('admin config UI', () => {
     await pluginsSection.getByLabel('beta_overhead').fill('0');
 
     await gotoEditorTab(page, 'Advanced');
-    await expect(page.locator('pre')).toContainText('"deferred_tools"');
-    await expect(page.locator('pre')).toContainText('"beta_overhead": 0');
+    await expect(rawJsonEditor(page)).toHaveValue(/"deferred_tools"/);
+    await expect(rawJsonEditor(page)).toHaveValue(/"beta_overhead": 0/);
 
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(expectAgentCreatedToast(page, agentId)).toBeVisible();
@@ -343,8 +355,10 @@ test.describe('admin config UI', () => {
 
     // Sticky header surfaces the dirty state; assert the badge appears
     // so we know the editor agrees there are unsaved changes.
+    // (`.first()` because the SaveBar and header both echo the label —
+    // we just need any one of them visible.)
     await expect(
-      page.getByText('Unsaved changes', { exact: true }),
+      page.getByText('Unsaved changes', { exact: true }).first(),
     ).toBeVisible();
 
     // First attempt: click "Back to agents" then keep editing — the
@@ -369,5 +383,205 @@ test.describe('admin config UI', () => {
       .getByRole('button', { name: 'Discard changes' })
       .click();
     await expect(page).toHaveURL(/\/agents$/);
+  });
+
+  // Regression coverage for the G1 fix: edits to other agent fields must not
+  // strip context_policy / active_hook_filter from the saved record. Before
+  // the fix, these fields were absent from `PATCHABLE_FIELDS` so the
+  // customized-record PATCH path silently discarded user edits to them,
+  // and absent from the TS `AgentSpec` type so any code path that built a
+  // payload from the typed shape would drop them too.
+  test('preserves context_policy and active_hook_filter across an editor round-trip', async ({
+    page,
+    request,
+  }) => {
+    const agentId = `ui-roundtrip-${suffix()}`;
+    const seededPolicy = {
+      max_context_tokens: 123_456,
+      max_output_tokens: 4_096,
+      min_recent_messages: 7,
+      enable_prompt_cache: true,
+      autocompact_threshold: 100_000,
+      compaction_mode: 'compact_to_safe_frontier' as const,
+      compaction_raw_suffix_messages: 5,
+    };
+
+    // 1. Seed a UserDefined agent that already has context_policy +
+    //    active_hook_filter populated. POST creates a UserDefined record.
+    const createResponse = await request.post(
+      `${BACKEND_URL}/v1/config/agents`,
+      {
+        headers: {
+          Authorization: `Bearer ${TEST_ADMIN_TOKEN}`,
+          'content-type': 'application/json',
+        },
+        data: {
+          id: agentId,
+          model_id: 'default',
+          system_prompt: 'Round-trip seed prompt.',
+          max_rounds: 4,
+          context_policy: seededPolicy,
+          plugin_ids: ['permission'],
+          active_hook_filter: ['permission'],
+        },
+      },
+    );
+    expect(createResponse.ok()).toBeTruthy();
+
+    // 2. Open the editor for that agent. The Advanced tab must hydrate the
+    //    seeded context_policy values.
+    await page.goto(`/agents/${encodeURIComponent(agentId)}`);
+    await page.waitForURL(new RegExp(`/agents/${agentId}`));
+    await gotoEditorTab(page, 'Advanced');
+    const contextSection = page
+      .locator('section')
+      .filter({
+        has: page.getByRole('heading', { name: 'Context window policy' }),
+      });
+    await expect(contextSection.getByLabel('Apply custom policy')).toBeChecked();
+    await expect(contextSection.getByLabel('Max context tokens')).toHaveValue(
+      String(seededPolicy.max_context_tokens),
+    );
+
+    // 3. Edit max_context_tokens through the form and save.
+    const editedMaxContext = 222_222;
+    await contextSection
+      .getByLabel('Max context tokens')
+      .fill(String(editedMaxContext));
+    await page.getByRole('button', { name: /^Save$/ }).first().click();
+    await expect(
+      page.getByRole('alert').filter({ hasText: new RegExp(`Agent\\s+"${agentId}"\\s+saved`) }),
+    ).toBeVisible();
+
+    // 4. Re-fetch through the API and verify *every* G1-tracked field made
+    //    it through the round-trip — the edited one with its new value, and
+    //    the untouched active_hook_filter unchanged.
+    const refetched = await request.get(
+      `${BACKEND_URL}/v1/config/agents/${encodeURIComponent(agentId)}`,
+      { headers: { Authorization: `Bearer ${TEST_ADMIN_TOKEN}` } },
+    );
+    expect(refetched.ok()).toBeTruthy();
+    const agent = await refetched.json();
+    expect(agent.context_policy).toEqual({
+      ...seededPolicy,
+      max_context_tokens: editedMaxContext,
+    });
+    expect(agent.active_hook_filter).toEqual(['permission']);
+  });
+
+  // Defensive coverage for review #4 (stale `active_hook_filter` entries) is
+  // implemented at the unit level in `partitionActiveHookFilter` + the
+  // `ActiveHookFilterSection` component. Seeding stale entries through the
+  // REST API is rejected at write time by the backend's `diagnose_agent_spec`
+  // (`AgentHookFilterPluginNotLoaded`), so a full UI round-trip e2e for this
+  // path is not reachable through the public surface — the partition is
+  // defensive against legacy / backup imports / future schema drift only.
+
+  // F4: dark mode smoke. Verifies the theme system actually applies the
+  // `data-theme="dark"` attribute and that the editor renders without
+  // throwing or going blank when dark is forced. Visual diff is out of
+  // scope; this is a presence-of-content smoke.
+  test('editor renders in dark mode with data-theme="dark" applied', async ({ page }) => {
+    // First navigation: app boots with whatever theme defaults to (system).
+    // The beforeEach already wrote the admin bearer token, so we won't get
+    // stuck on the token modal. Once the app is alive, write the theme
+    // choice and reload — the next paint applies `data-theme="dark"`.
+    await page.goto('/agents/new');
+    await page.waitForURL(/\/agents\/new/);
+    await expect(page.getByRole('tablist', { name: 'Editor sections' })).toBeVisible();
+
+    await page.evaluate(() => {
+      localStorage.setItem('awaken.admin.theme', 'dark');
+    });
+    await page.reload();
+    await expect(page.getByRole('tablist', { name: 'Editor sections' })).toBeVisible();
+
+    // Theme attribute must be set on <html> for the dark stylesheet to apply.
+    const themeAttr = await page.evaluate(
+      () => document.documentElement.getAttribute('data-theme'),
+    );
+    expect(themeAttr).toBe('dark');
+
+    // Editor scaffolding must remain visible after the theme switch.
+    await expect(page.getByLabel('Agent ID')).toBeVisible();
+    await expect(page.getByLabel('Model')).toBeVisible();
+
+    // Tabs each render their content without throwing.
+    for (const tab of ['Basics', 'Tools', 'Plugins', 'Delegates', 'Advanced'] as const) {
+      await gotoEditorTab(page, tab);
+      await expect(page.getByRole('tab', { name: tab, selected: true })).toBeVisible();
+    }
+  });
+
+  // F5: live AiSdkEncoder tool-call card. Sends a `RUN_WEATHER_TOOL`
+  // directive to the scripted executor through the sandbox preview panel,
+  // then verifies that a tool-call card actually renders (state badge +
+  // tool name + input) — proving the unit-level fixture tests in
+  // `agent-preview-panel.test.tsx` match the real wire shape.
+  test('sandbox preview renders a tool-call card from a live event stream', async ({
+    page,
+    request,
+  }) => {
+    const agentId = `ui-sandbox-tool-${suffix()}`;
+    // Seed an agent that the scripted executor will route through. The
+    // model_id `default` is bound to the scripted executor in
+    // examples/src/starter_backend.
+    const createResponse = await request.post(`${BACKEND_URL}/v1/config/agents`, {
+      headers: {
+        Authorization: `Bearer ${TEST_ADMIN_TOKEN}`,
+        'content-type': 'application/json',
+      },
+      data: {
+        id: agentId,
+        model_id: 'default',
+        system_prompt: 'Use the scripted tool directives when the user provides one.',
+        max_rounds: 1,
+      },
+    });
+    expect(createResponse.ok()).toBeTruthy();
+
+    await page.goto(`/agents/${encodeURIComponent(agentId)}`);
+    await page.waitForURL(new RegExp(`/agents/${agentId}`));
+
+    // The sandbox lives in the preview side panel. Type the scripted
+    // directive and submit.
+    const previewArea = page
+      .locator('aside')
+      .filter({ has: page.getByRole('heading', { name: 'Sandbox' }) });
+    await previewArea.getByPlaceholder('Type a message…').fill('RUN_WEATHER_TOOL');
+    await previewArea.getByRole('button', { name: /Send/ }).click();
+
+    // The card carries the tool name in monospace. We don't pin the
+    // state badge text because it depends on whether the script also
+    // emits an output — we just need at least one tool-call card to
+    // appear, confirming the real `AiSdkEncoder` stream is shaped the
+    // way `MessageParts` / `ToolInvocation` expect.
+    await expect(previewArea.getByText('get_weather')).toBeVisible({ timeout: 30_000 });
+  });
+
+  // F4: mobile breakpoint smoke. The admin console targets desktop
+  // primarily — the desktop sidebar overlays the editor at 375 px width
+  // (no mobile-collapsed nav today), and content-density tabs (Plugins,
+  // Tools) inherently overflow at that viewport. Designing for that is a
+  // designer-pass / responsive-layout task, not a smoke. So the smoke
+  // verifies the minimum testable guarantees: (1) the app doesn't get
+  // stuck on a loading screen at mobile viewport, (2) the editor route
+  // still mounts, (3) every Editor section tab is still reachable through
+  // the tablist control. Failure here means a hard regression — e.g. a
+  // ResizeObserver loop, an SSR mismatch, or a non-responsive component
+  // breaking the page entirely.
+  test('editor mounts and tabs remain reachable at mobile breakpoint (375x812)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/agents/new');
+    await page.waitForURL(/\/agents\/new/);
+
+    await expect(page.getByRole('tablist', { name: 'Editor sections' })).toBeVisible();
+
+    for (const tab of ['Basics', 'Tools', 'Plugins', 'Advanced'] as const) {
+      await gotoEditorTab(page, tab);
+      await expect(page.getByRole('tab', { name: tab, selected: true })).toBeVisible();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **G1 (fix):** The customized-record PATCH path (`diffPatchableAgentFields`) only walked `PATCHABLE_AGENT_FIELDS`, so edits to `context_policy` or `active_hook_filter` were silently dropped from the PATCH body. This PR extends `PATCHABLE_AGENT_FIELDS` and adds those fields to the TS `AgentSpec` so they're typed end-to-end. `endpoint` and `registry` were also added for parity with the Rust contract. New UI: `context_policy` form (Advanced tab) and `active_hook_filter` selector (Plugins tab). `endpoint` shows as a read-only block with credential redaction.
- **G2:** AgentPreviewPanel stopped dropping `dynamic-tool` / `reasoning` UIMessage parts — tool calls render as collapsible cards with input/output/error and a per-turn stats bar. Unknown SDK parts collapse into a "unrecognized part" debug fallback rather than producing empty bubbles.
- **G3:** Advanced tab gains an editable Raw JSON section with Apply-to-draft / Reset / parse-error display. Apply calls `configApi.validateConfig` first, rejects unknown top-level fields, and uses canonical-key deep equality for locked-field comparisons. The textarea shows a redacted view of `endpoint` (credentials masked as `***`); Apply transparently restores the real values from the current spec.
- **G4:** "Allowed/excluded tools (pre-permission)" section on the Tools tab. **When the permission plugin is enabled and the agent is saved, the editor now fetches the server-computed effective tool list from `/v1/agents/:id/permission-preview` (issue #190) and renders unconditionally-denied tools + args-conditional rules alongside the candidate set.**
- **G5:** System prompt textarea grew a footer with chars / lines / ~tokens estimate.
- **G6 (resolved):** Permission preview is now a **server-side** endpoint (#190 below). The earlier frontend port (reverted in `0b1bb2673`) is replaced with a thin UI that calls `/v1/agents/:id/permission-preview`. Runtime semantics (Deny > Allow > Ask + specificity + args matchers) live in `awaken-ext-permission/src/rules.rs` and are no longer mirrored in TS.
- **G7 (resolved):** AgentPreviewPanel has a **Recent runs** button that opens a side drawer backed by `GET /v1/traces?agent_id=X` (ADR-0030). Click a run to load its NDJSON event stream from `GET /v1/traces/:run_id`. Graceful 503 fallback when the server build does not expose trace persistence.
- **G8:** `/agents/new` gains a Start-from selector that clones any existing agent's spec into the draft. The clone clears `id`, timestamps, `registry`, **and `endpoint`** so the new record isn't bound to the source's remote backend.
- **G9:** Model picker option labels include `provider_id`; selected model shows provider + upstream pills inline.

## Follow-ups resolved

| # | Follow-up | Resolution | Commit(s) |
|---|---|---|---|
| **#190 (server)** | Backend `/v1/permission/preview` API | `GET /v1/agents/:id/permission-preview`. Walks `allowed_tools ∖ excluded_tools` over the tool registry, runs the permission plugin's ruleset, returns candidate / effective / unconditionally-denied / args-conditional / default_behavior. Feature-gated behind `permission`. 4 unit + 3 integration tests. | `770d62325` |
| **#190 (UI)** | Editor consumes the preview API | `AllowedExcludedToolsSection` fetches via tanstack-query, renders the server-computed effective list. | `c789b91b4` |
| **G7** | Preview → trace drawer | `RecentTracesDrawer` on AgentPreviewPanel; list + per-run NDJSON pagination. 6 unit tests. | `26ad5b5e4` |
| **Live tool-call** | Sandbox card against a live AiSdkEncoder stream | Playwright e2e seeds a scripted-executor agent + asserts `ToolInvocation` card renders. | `70c0081a8` |
| **Dark mode** | Visual smoke at dark theme | E2e: forces `awaken.admin.theme=dark`, reloads, asserts `data-theme="dark"` applied and every tab renders. | `70c0081a8` |
| **Mobile breakpoint** | Smoke at 375 × 812 | E2e: editor mounts and every tab remains reachable via the tablist. | `70c0081a8` |
| **Legacy `RemoteEndpoint`** | Aliases round-trip | `types.test.ts` pins `bearer_token`/`agent_id`/`poll_interval_ms` survival. | `e4352c778` |

## Review fixes

<details>
<summary>Round 1 (7 fixes — collapsed)</summary>

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 | Permission preview semantics contradicted runtime | Removed frontend preview; replaced by backend API #190. | `0b1bb2673`, `770d62325` |
| 2 | "Effective tools" ignored permission deny filtering | Uses server-computed effective tools when permission plugin is enabled. | `0b1bb2673`, `c789b91b4` |
| 3 | Raw JSON Apply had no schema validation | Calls `configApi.validateConfig` before applying. | `5ade658b6` |
| 4 | Clone preserved `registry` provenance | Clears `registry` alongside `id`/timestamps. | `a72d01be7` |
| 5 | Raw JSON could change non-patchable `endpoint`/`registry` | `lockedFieldChange` rejects Apply with locked-field diffs. | `a72d01be7` |
| 6 | Tests locked in wrong permission semantics | Resolver tests deleted; replaced by server-side preview tests + e2e round-trip. | covered |
| 7 | `active_hook_filter` retained stale plugin ids | `togglePlugin` prunes the disabled plugin from filter. | `7a8909270` |
</details>

<details>
<summary>Round 2 (6 fixes — collapsed)</summary>

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 | `JSON.stringify(endpoint)` could leak auth secrets | `redactEndpointForDisplay` masks credential keys (recursive, case-insensitive). | `dc5d89655`, `a9f96a510` |
| 2 | Clone preserved `endpoint` | `cloneAgentSpecForEditor` clears endpoint alongside registry/id/timestamps. | `dc5d89655` |
| 3 | G1 e2e only covered UserDefined PUT path | `diffPatchableAgentFields` + `PATCHABLE_AGENT_FIELDS` extracted with 6 dedicated unit tests. | `dc5d89655` |
| 4 | Stale `active_hook_filter` ids | `partitionActiveHookFilter` + warning chips UI with "Clear stale entries". | `dc5d89655`, `a9f96a510` |
| 5 | `JSON.stringify` key-order sensitivity | `canonicalStringify` / `deepEqualCanonical` deep-sort keys. | `dc5d89655` |
| 6 | `isDirty` only checked 4 fields for new agents | Full `deepEqualCanonical(spec, EMPTY_AGENT)` compare. | `a9f96a510` |
</details>

<details>
<summary>Round 3 (8 fixes — collapsed)</summary>

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 | Raw JSON / history dialog leaked endpoint secrets | `redactAgentSpecForDisplay` + `mergeLockedFields` keep redaction cosmetic. | `e4352c778`, `c41e8a5a6` |
| 2 | `active_hook_filter` absent → `[]` override drift | Section writes `undefined` when empty; diff normalises `[] ≡ undefined`. | `e4352c778`, `c41e8a5a6` |
| 3 | Raw JSON accepted unknown fields | `ALLOWED_AGENT_FIELDS` allowlist; Apply errors with concrete key names. | `e4352c778`, `c41e8a5a6` |
| 4 | Clone clearing endpoint was undocumented in UX | Start-from dropdown hint now states "endpoint and registry are not copied". | `c41e8a5a6` |
| 5 | Tool-call card lacked AI-SDK part-shape coverage | 11 fixture tests for every documented part state. | `c1d07a30a` |
| 6 | Unknown message parts → empty bubble | Shared `isRenderablePart` predicate; unknown parts collapse into a `<details>` fallback. | `c1d07a30a` |
| 7 | "pre-permission" copy overstated semantics | Narrowed to "after allow/exclude, before runtime plugin filtering". | `c41e8a5a6` |
| 8 | Legacy `RemoteEndpoint` aliases untested | `types.test.ts` legacy round-trip pins aliases. | `e4352c778` |
</details>

### Round 5 (most recent)

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 | **Blocker.** `JsonEditorSection.handleApply` called `mergeLockedFields` *before* `lockedFieldChange`. The merge overlay overwrote `parsed.endpoint`/`parsed.registry` with `spec.*` values, so any user edit to a locked subfield (`base_url`, `auth.bearer_token`, `target`, `registry`) read "equal" on the subsequent compare and was silently dropped on a successful-looking Apply. | Order is now: compare `parsed` against `redactAgentSpecForDisplay(spec)` *first* (so the placeholder `***` survives as a no-op but any genuine edit flags as a locked-field change), then overlay real values via `mergeLockedFields`. New unit tests pin both the regression vector and the no-false-positive case. | `d3af37687` |
| 2 | **Blocker.** `diffPatchableAgentFields` emitted `patch[key] = undefined` when the user cleared an override (e.g. `active_hook_filter` non-empty → "All plugins"). `JSON.stringify({active_hook_filter: undefined})` drops the key entirely, so the PATCH body never carried the "clear" intent — the backend kept the prior override. | Diff now emits `null` (not `undefined`) when clearing. Aligns with the backend's documented null-clears-override semantics (`config_service::patch_agent_overrides` + `is_nullable_agent_patch_field`). 7 new tests, including a wire-level `JSON.parse(JSON.stringify(patch))` assertion that the cleared keys actually survive serialization. | `d3af37687` |
| 3 | Medium. The permission-preview query at `qk.agent.permissionPreview(id)` had `staleTime: 30_000` but was not in `invalidateConfigMutation`'s key list, so after Save / Reset overrides / Restore the preview would show stale data for up to 30 s. | `invalidateConfigMutation` now invalidates `qk.agent.permissionPreview(id)` whenever the `agents` namespace is mutated, so any save/reset/restore triggers an immediate refetch. | `d3af37687` |
| 4 | Low. PR description listed G6 / G7 as deferred even though the branch now ships both. | This refresh updates the Summary + Follow-ups sections to reflect the actual landed state. | (this body) |

### Round 6 (most recent)

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| A | High. After R5, clearing a nullable override (e.g. `reasoning_effort: "high"` → "Default") sent `PATCH {reasoning_effort: null}`. That prevented data loss but left an *explicit-null* override in `user_overrides`, so the agent stayed flagged as "customized" with a meaningless override even though the user reverted. | `diffPatchableAgentFields` now returns `{patch, clear}`. The `clear` list carries fields whose normalized current value is `undefined` while the original wasn't — Save calls `configApi.clearAgentOverrideField(id, field)` for each one. `user_overrides` actually loses the key, the "customized" badge clears, the resolved spec falls back to the builtin default. 8 new tests covering reasoning_effort / active_hook_filter / plugin_ids / allowed_tools / nullable explicit-null preservation / full revert. | `524e68378` |
| B | Blocker. Audit-log page and history-restore audit-event panes both did `JSON.stringify(event.before/after, null, 2)`. Snapshots can contain a full `AgentSpec` with `endpoint.auth.bearer_token` — secret leaked to admin DOM. | New `redactSecretsForDisplay<T>(value: T): T` deep-walks any structure and masks every secret-keyed field. Both `audit-log-page.tsx` and the history audit-event panel in the editor now redact before serialising. 3 new tests covering audit snapshots, trace event payloads, and primitive pass-through. | `fb88fe901` |
| C | Medium. `RecentTracesDrawer` event-detail `<pre>` stringified the raw event. Trace payloads can carry serialized agent specs (`agent_resolved` events), so an `endpoint.auth.api_key` in a payload would also leak. | Defensive masking via the same `redactSecretsForDisplay` helper before rendering. | `fb88fe901` |

### Round 7 (most recent)

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 / 8 | Blocker. `DiffModal` rendered raw `previous`/`current` — `formatDiffValue` did `JSON.stringify(value, null, 2)` directly. A user opening "Diff vs published" on a remote-backed agent would land `endpoint.auth.bearer_token` in the modal DOM. Plus `DiffModal`'s local `deepEqual` was `JSON.stringify`-based (key-order sensitive, spurious diffs). | `DiffModal` now diffs `redactSecretsForDisplay(previous)` against `redactSecretsForDisplay(current)`. `computeDiff` uses `deepEqualCanonical` (key-order insensitive, mirrors save-path diff). `formatDiffValue` runs values through `redactSecretsForDisplay` as last-line defense-in-depth. | `97fd62ff4` |
| 2 | High. The permission preview's candidate set came straight from `spec.allowed_tools` without intersecting against the tool registry. A stale id (renamed plugin, removed MCP server, typo) would appear in `effective_tools` as if the model could call it — but the runtime never offers it. | `permission_preview.rs` now intersects `allowed_tools` against `registries.tools.tool_ids()`. New integration test (`permission_preview_intersects_allowed_tools_with_registry`) pins the behaviour with `ghost_tool` / `another-ghost` stale entries. | `3327a58be` |
| 3 | High. Glob/regex Deny + Any args rules (`mcp__db__*` Deny) were not in `unconditionally_denied`; they landed in `args_conditional_rules` while `mcp__db__query` etc. still showed up as effective. The runtime BeforeInference hook strips them on every call — preview misled. | New `expand_glob_regex_denies` walks the tool registry against every glob/regex Deny + Any args rule and adds matches to `unconditionally_denied`. `describe_args_conditional` skips them so they don't double-display. 4 unit + 1 integration test (`permission_preview_expands_glob_deny_against_registry`). | `3327a58be` |
| 4 | Medium. Preview UI was gated on the DRAFT `spec.plugin_ids`, but the underlying query reads the SAVED record. Enabling permission in a draft would surface a preview computed against the prior (permission-less) saved version; disabling it in draft would hide the preview even though saved agent was still permission-gated. | `permissionPluginEnabled` now derives from `savedSpec.plugin_ids`. A new `permission-preview-dirty-hint` chip surfaces when draft plugin selection differs from saved, telling the user "Preview reflects the saved permission config. Save to refresh." | `97fd62ff4` |
| 5 | Medium. Raw JSON unknown-field error said "remove them or update the schema" — confusing when the user's spec is actually valid against the server and the issue is admin-console version skew. | Error now reads: "This admin console version does not recognize field(s): …. Either upgrade the console, or remove the field from this draft." Surfaces the version-skew interpretation explicitly. | `97fd62ff4` |
| 6 | Medium. Pattern-based redaction (`token`, `secret`, `password`, `api_key`, `authorization`, …) missed RemoteAuth keys like `cookie`, `jwt`, `bearer`, `header`. `RemoteAuth` has an index signature, so future schema additions could carry credentials under arbitrary names. | `redactEndpointForDisplay` now applies a second layer for `endpoint.auth` specifically: every key except the `type` discriminator is masked. The original pattern-based redaction still runs for the rest of the endpoint tree (defense-in-depth for future schema drift). | `97fd62ff4` |
| 7 | Low. `mergeLockedFields` docstring still said "By overlaying the real values BEFORE the locked-field-change check, redaction stays purely a display concern" — but R5 reordered it so the compare runs first. Future maintainer reading the stale comment could undo R5. | Rewrote the docstring to spell out the correct order ("AFTER the caller has compared the parsed draft against the redacted display copy") and the reason ("Merging BEFORE the compare would overwrite parsed.endpoint with spec.endpoint, silently dropping any user edit"). | `97fd62ff4` |

### Round 8

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 | **P1.** `diffPatchableAgentFields` ran `deepEqualCanonical` *before* the clear-on-undefined check. Canonical compare maps `null` and `undefined` both to JSON `null`, so a saved explicit-null override (e.g. `context_policy: null`) edited away in Raw JSON read as "equal" and stayed stuck — neither patched nor cleared. | Diff now detects `current === undefined && original !== undefined` BEFORE the canonical-equality check, routing to the `clear` list. New tests: `context_policy` / `allowed_tools` / `excluded_tools` / `reasoning_effort` round-trips for the null→undefined scenario. | `c7ffbc304` |
| 2 | **P1/P2.** `active_hook_filter` going from non-empty (`["permission"]`) to empty was routed to `_clear`. On a customized record with a non-empty base filter, clearing deletes the override → resolved spec inherits the base filter — the opposite of "All plugins" intent. | Special-cased in the diff loop: empty filter (`undefined` or `[]`) vs non-empty original now emits `patch: { active_hook_filter: [] }`, not `_clear`. New "active_hook_filter override semantics" describe block covers absent↔[] equivalence and explicit-empty override. | `c7ffbc304` |
| 3 | **P2.** `listAgentTraces` swallowed both 503 *and* 404 to `null`, conflating "feature gate disabled" with "unknown agent". | Only 503 returns `null` now; 404 re-throws as `ConfigApiError` so the UI surfaces the real error instead of a misleading "trace persistence not enabled" banner. Matches `getTracePage` / `agentPermissionPreview` policy. | `c7ffbc304` |
| 4 | **P2.** Generic `redactSecretsForDisplay` was key-based — primitive string leaves containing `Authorization: Bearer …` / inline `Bearer …` / JWTs / `sk-…` passed through unmasked. Trace events, audit snapshots, DiffModal all share this redactor. | `redactRecord` now forwards primitive strings through `redactSecretString` (the same pattern-based string redactor used for sandbox tool output). One defensive layer shared across audit / trace / DiffModal / history-restore. 3 new tests covering string leaves in objects, arrays, and top-level primitives. | `c7ffbc304` |
| 5 | **P3.** `ContextPolicySection`'s `max_context_tokens` / `max_output_tokens` inputs did `Number(event.target.value) \|\| 0`. Mid-typing (clear and retype) would flash the draft to `0`, colliding with `min={1}` and locking Save behind a "validation failed" toast the user didn't trigger. | New `parseTokenInput` helper ignores blank / non-finite / `< min` values, leaving the prior value visible until valid input replaces it. | `c7ffbc304` |
| 6 | **Blocker (cross-layer parity).** `permission_preview.rs::expand_glob_regex_denies` expanded `mcp__db__*` Deny against the registry into `unconditionally_denied`, but the runtime `PermissionToolFilterHook` only called `ruleset.unconditionally_denied_tools()` (exact matches only). So preview claimed "tools stripped before model sees list" while runtime kept exposing them — block fell back to ToolGate at call time. Cross-layer disagreement on the same `unconditionally_denied` semantics. | New `PermissionRuleset::unconditionally_denied_against(registry_tool_ids)` is the single source of truth. `PermissionToolFilterHook::run` reads `ctx.registry_snapshot.tools.tool_ids()` and calls the shared helper; `permission_preview.rs` was simplified to delegate. New cross-layer parity test (`hook_and_helper_agree_on_unconditional_deny_set`) pins the invariant: runtime hook's scheduled `ExcludeTool` set ≡ preview's `unconditionally_denied`. | `8b99c8afd` |

### Round 9

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 | **Blocker.** `normalizePreviewAgent` spread `...draft` without stripping `endpoint`/`registry`. The preview endpoint at `/v1/ai-sdk/agent-previews/runs` rejects payloads carrying either field (forces local-only resolution to stop crafted drafts from routing to remote backends). Every preview of a builtin agent (which naturally carries `registry`) or a remote-backed agent (with `endpoint`) returned 400 — a hard regression for the most common case. | Explicit `const { endpoint, registry, ...localDraft } = draft;` strip before constructing the preview payload. 6 new tests covering strip / preserve / non-mutation. | `de8644475` |
| 2 | **Low.** `handleSave` catch block still described a "multi-request customized override flow (PATCH + N×DELETE)" with "partially-applied state" — but R5 collapsed both into a single transactional PATCH with `_clear`, so the description and the catch-block rationale were out of sync. | Comments rewritten to reflect the current single-transaction shape and explain that the refetch exists to re-sync the *editor's* view (e.g. after optimistic-concurrency rejection or stale `originalSpec`), not to recover from server-side partial writes. | `de8644475` |
| 3 | **Medium (Raw JSON null/absent normalization contract).** Reviewer flagged `lockedFieldChange` using canonical equality, where `null` and `undefined` collapse together. The concern was that "byte-level" edits like adding `endpoint: null` to an agent with no endpoint were silently normalized away by `mergeLockedFields`. | The asymmetry is intentional: in the locked-field guard context, absent ≡ explicit null ≡ explicit undefined when the current spec has no value — re-typing `endpoint: null` to make absence explicit is a no-op, not a "locked field changed" error. JSDoc on `lockedFieldChange` now spells out the normalization contract; the existing equivalence test is renamed and expanded to cover both `endpoint` and `registry`. Raw JSON editor surfaces a help line: "Locked fields are normalized on Apply. For endpoint and registry specifically, an explicit null is treated the same as absence when the current spec has no value." | `ebfedc4ce` |
| 4 | **Medium (server PATCH endpoint/registry validation).** Admin console treats `endpoint` as locked, but the server-side PATCH `/v1/config/agents/:id/overrides` accepts `endpoint` (it's in `AgentSpecPatch` as a documented `NullablePatch<RemoteEndpoint>` field). Reviewer asked whether the lock should be server-enforced. | Behavior preserved (server stays permissive) — `endpoint` is a patchable runtime-safe field per the documented contract, and `patch_overrides_null_clears_nullable_base_field` in `crates/awaken-server/tests/config_api.rs` pins it. Hard-locking it would be a breaking API change. Instead: (a) `AgentSpecPatch::endpoint` doc comment + `patch_agent_overrides` doc comment + the contract-pin test's preamble all now spell out that the UI lock is a UX choice, not an immutability boundary; (b) admin console renders an `endpoint-override-banner` whenever `user_overrides.endpoint` exists (covers both explicit-value and explicit-null overrides), telling operators where the override came from and how to clear it via `_clear: ["endpoint"]`; (c) **ADR-0033** (`docs/adr/0033-locked-field-ui-api-boundary.md`) documents the decision, the alternatives considered, and the conditions under which a future ADR could reverse it. | `ebfedc4ce` |


### Round 10 (most recent)

| # | Reviewer concern | Resolution | Commit |
|---|---|---|---|
| 1 | **P1.** UI/ADR recommended `PATCH {"_clear": ["endpoint"]}`, but server `_clear` validation rejected `endpoint` because `PATCHABLE_AGENT_SPEC_FIELDS` omitted it. | Added `endpoint` to the server `_clear` allowlist. New API tests cover successful endpoint clear and the conflict case `endpoint: null` plus `_clear: ["endpoint"]` returning 400. | `1ba004217` |
| 2 | **P1/P2.** Raw JSON seeded only `redactAgentSpecForDisplay`, so `sections.*` credentials could be rendered into the textarea DOM; naive redaction would risk saving `***`. | Raw JSON now uses an editing redactor that records redaction entries. Apply restores unchanged `***` markers before validation/draft state, while user-entered replacements are preserved as new values. Unit + page tests cover DOM redaction, unchanged restore, and changed secret save. | `1781b1231` |
| 3 | **P2.** `sections` save diff sent the whole current object. Deleting an inherited/base section produced `sections: {}`, which server merge interpreted as inherit, not delete. | Customized save now emits per-section patches: deleted effective keys become `{ sectionKey: null }`, changed/upserted keys carry their value, unchanged keys are omitted. Added helper regression test plus server API test for `PATCH {"sections": {"permission": null}}`. | `1781b1231` |

## Branch history

PR 189 was squashed on 2026-05-13 from 10 chronological commits into 6 thematic ones. Earlier `Round N` tables reference pre-squash SHAs (`d3af37687`, `97fd62ff4`, `3327a58be`, etc.) that no longer resolve on the branch — their content is preserved inside the umbrella commits `7b413b8de` (feat + R1 helpers), `c7ffbc304` (hardening rounds 1-8), `8b99c8afd` (cross-layer parity), `de8644475` (R9 preview strip + comments), `ebfedc4ce` (R9 ADR + banner). Tree hash unchanged across the rewrite (`6296cae40…`).

## Verification

**Automated:**
- [x] `cargo build -p awaken-server --features permission` clean
- [x] `cargo test -p awaken-server --features permission` — `permission_preview` **5 unit + 5 integration** tests pass; `awaken-ext-permission` adds **7 unit tests** for the shared `unconditionally_denied_against` helper plus **4 runtime-filter tests** covering glob/regex expansion against the live registry and the cross-layer parity invariant
- [x] `npm --prefix apps/admin-console run typecheck` clean
- [x] `npm --prefix apps/admin-console test -- --run` — **740 passing / 10 skipped** (R8 + R9 added preview-strip, locked-field normalization contract, endpoint-override-banner tests)
- [x] `npx playwright test --config=playwright.admin.config.ts` — **9 passed / 1 skipped** (BigModel) on `ebfedc4ce`

**Branch is rebased onto current `origin/main`** so the trace-persistence routes (ADR-0030), the backend `null`-clear semantics, and the per-field DELETE endpoint are all available.


**Latest validation (2026-05-14):**
- [x] `npm --prefix apps/admin-console run ci` (pre-push): token validation, lint, all admin tests (**753 passed / 10 skipped**), typecheck, production build
- [x] `cargo fmt --check`
- [x] `cargo test -p awaken-server --test config_api patch_overrides` — **14 passed**
- [x] `cargo clippy -p awaken-server --tests -- -D warnings`
- [x] pre-push workspace `validate` hook passed

**Out of scope (documented caveats, not blockers):**
- Mobile breakpoint smoke verifies tabs remain reachable; full responsive layout is a designer pass and not in scope.
- BigModel e2e remains skipped without `BIGMODEL_API_KEY`.
- Frontend `ALLOWED_AGENT_FIELDS` allowlist is hand-maintained; a future improvement could derive it from a backend-published schema, but the R7 error message documents the version-skew failure mode.


