### PR TITLE
MCP: spec compliance + sampling routing infra + reliability + e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,18 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --locked
 
+  mcp-reference-e2e:
+    name: MCP Reference E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cargo test --locked -p awaken-ext-mcp --test e2e_server_everything -- --ignored --test-threads=1
+
   book-doctests:
     name: Book Doctests
     runs-on: ubuntu-latest

--- a/apps/admin-console/src/lib/api/types.ts
+++ b/apps/admin-console/src/lib/api/types.ts
@@ -151,6 +151,12 @@ export interface McpServerStatusResponse {
   last_success_at?: number | null;
   reconnecting: boolean;
   permanently_failed: boolean;
+  /** Redacted stable digest of the live HTTP session id. `null` for stdio transports. */
+  session_id?: string | null;
+  /** Count of successful runtime re-creations since the server was first enabled. */
+  reconnect_count?: number;
+  /** Unix seconds, omitted before first successful initialize. */
+  last_init_at?: number | null;
 }
 
 /** Wire-format mirror of `GET /v1/system/info` response. */

--- a/apps/admin-console/src/lib/api/types.ts
+++ b/apps/admin-console/src/lib/api/types.ts
@@ -151,10 +151,10 @@ export interface McpServerStatusResponse {
   last_success_at?: number | null;
   reconnecting: boolean;
   permanently_failed: boolean;
-  /** Redacted stable digest of the live HTTP session id. `null` for stdio transports. */
-  session_id?: string | null;
+  /** HTTP session generation, incremented on session reset/reinitialize cycles. */
+  session_generation?: number | null;
   /** Count of successful runtime re-creations since the server was first enabled. */
-  reconnect_count?: number;
+  transport_reconnect_count?: number;
   /** Unix seconds, omitted before first successful initialize. */
   last_init_at?: number | null;
 }

--- a/crates/awaken-contract/src/contract/tool.rs
+++ b/crates/awaken-contract/src/contract/tool.rs
@@ -259,6 +259,8 @@ pub enum ToolError {
     InvalidArguments(String),
     #[error("Execution failed: {0}")]
     ExecutionFailed(String),
+    #[error("Cancelled: {0}")]
+    Cancelled(String),
     #[error("Denied: {0}")]
     Denied(String),
     #[error("Not found: {0}")]
@@ -765,6 +767,10 @@ mod tests {
         assert_eq!(
             ToolError::ExecutionFailed("boom".into()).to_string(),
             "Execution failed: boom"
+        );
+        assert_eq!(
+            ToolError::Cancelled("by user".into()).to_string(),
+            "Cancelled: by user"
         );
         assert_eq!(ToolError::Denied("nope".into()).to_string(), "Denied: nope");
         assert_eq!(

--- a/crates/awaken-contract/tests/contract_integration.rs
+++ b/crates/awaken-contract/tests/contract_integration.rs
@@ -347,6 +347,7 @@ fn tool_error_variants_display() {
             ToolError::ExecutionFailed("crash".into()),
             "Execution failed: crash",
         ),
+        (ToolError::Cancelled("by user".into()), "Cancelled: by user"),
         (ToolError::Denied("blocked".into()), "Denied: blocked"),
         (
             ToolError::NotFound("missing tool".into()),

--- a/crates/awaken-ext-mcp/src/lib.rs
+++ b/crates/awaken-ext-mcp/src/lib.rs
@@ -22,6 +22,6 @@ pub use plugin::McpPlugin;
 pub use progress::McpProgressUpdate;
 pub use sampling::{DefaultSamplingHandler, SamplingHandler};
 pub use transport::{
-    McpPromptArgument, McpPromptDefinition, McpPromptMessage, McpPromptResult,
+    McpCallMetadata, McpPromptArgument, McpPromptDefinition, McpPromptMessage, McpPromptResult,
     McpResourceDefinition, McpToolTransport,
 };

--- a/crates/awaken-ext-mcp/src/lib.rs
+++ b/crates/awaken-ext-mcp/src/lib.rs
@@ -24,6 +24,7 @@ pub use sampling::{
     DefaultSamplingHandler, FixedSamplingHandlerFactory, SamplingHandler, SamplingHandlerFactory,
 };
 pub use transport::{
-    McpCallContext, McpCallMetadata, McpCallSampling, McpPromptArgument, McpPromptDefinition,
-    McpPromptMessage, McpPromptResult, McpResourceDefinition, McpToolTransport,
+    ListChangedKind, McpCallContext, McpCallMetadata, McpCallSampling, McpPromptArgument,
+    McpPromptDefinition, McpPromptMessage, McpPromptResult, McpResourceDefinition,
+    McpToolTransport,
 };

--- a/crates/awaken-ext-mcp/src/lib.rs
+++ b/crates/awaken-ext-mcp/src/lib.rs
@@ -16,7 +16,7 @@ pub use config::{McpServerConnectionConfig, TransportTypeId};
 pub use error::McpError;
 pub use manager::{
     McpPromptEntry, McpRefreshHealth, McpResourceEntry, McpServerStatusSnapshot,
-    McpServerToolEntry, McpToolRegistry, McpToolRegistryManager,
+    McpServerToolEntry, McpToolRegistry, McpToolRegistryManager, ResourceUpdated,
 };
 pub use plugin::McpPlugin;
 pub use progress::McpProgressUpdate;

--- a/crates/awaken-ext-mcp/src/lib.rs
+++ b/crates/awaken-ext-mcp/src/lib.rs
@@ -20,8 +20,10 @@ pub use manager::{
 };
 pub use plugin::McpPlugin;
 pub use progress::McpProgressUpdate;
-pub use sampling::{DefaultSamplingHandler, SamplingHandler};
+pub use sampling::{
+    DefaultSamplingHandler, FixedSamplingHandlerFactory, SamplingHandler, SamplingHandlerFactory,
+};
 pub use transport::{
-    McpCallMetadata, McpPromptArgument, McpPromptDefinition, McpPromptMessage, McpPromptResult,
-    McpResourceDefinition, McpToolTransport,
+    McpCallContext, McpCallMetadata, McpCallSampling, McpPromptArgument, McpPromptDefinition,
+    McpPromptMessage, McpPromptResult, McpResourceDefinition, McpToolTransport,
 };

--- a/crates/awaken-ext-mcp/src/manager.rs
+++ b/crates/awaken-ext-mcp/src/manager.rs
@@ -23,7 +23,7 @@ use crate::id_mapping::to_tool_id;
 use crate::progress::{
     McpProgressUpdate, ProgressEmitGate, normalize_progress, should_emit_progress,
 };
-use crate::sampling::SamplingHandler;
+use crate::sampling::{SamplingHandler, SamplingHandlerFactory};
 use crate::transport::{
     McpPromptDefinition, McpPromptResult, McpResourceDefinition, McpToolTransport,
     call_result_to_tool_data, connect_transport,
@@ -87,6 +87,24 @@ pub struct McpServerStatusSnapshot {
     /// True after the manager has given up reconnecting. The server is
     /// staying offline until manual restart.
     pub permanently_failed: bool,
+    /// Server-assigned MCP session id (Streamable HTTP transport only).
+    /// `None` for stdio transports (the protocol does not define a
+    /// session id concept there) and for HTTP servers that don't issue
+    /// one. Surfaced for diagnostics — admins debugging "is the server
+    /// invalidating our session?" want to see this value change after
+    /// a 404 → reinit cycle.
+    pub session_id: Option<String>,
+    /// Number of times the transport has been torn down and rebuilt since
+    /// the server was first enabled. Increments after every successful
+    /// reconnect (`finish_reconnect_success`). Operators use this to
+    /// spot flapping servers without trawling logs.
+    pub reconnect_count: u64,
+    /// Wall-clock time of the most recent successful MCP `initialize`
+    /// response (i.e. when this session was opened). `None` until the
+    /// first connect succeeds. Distinct from `last_success_at`, which
+    /// tracks the most recent RPC — useful when the server is up but
+    /// `initialize` hasn't been re-run after a 404.
+    pub last_init_at: Option<SystemTime>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -216,6 +234,29 @@ impl Tool for McpTool {
         // `notifications/cancelled` (spec 2025-06-18 §Cancellation) and
         // free server-side resources when the agent run is torn down.
         let cancellation = ctx.cancellation_token.clone();
+        // Resolve per-agent sampling routing. Three states:
+        //   - No factory wired → Inherit: legacy behaviour, transport
+        //     falls back to its fixed (or absent) handler.
+        //   - Factory consulted and returned Some(h) → Bound: this
+        //     call's server-initiated sampling/createMessage routes to
+        //     THIS agent's executor.
+        //   - Factory consulted and returned None → Denied: the factory
+        //     refused to bind (agent model unresolved, opted out, etc.).
+        //     The transport will reject sampling/createMessage for this
+        //     call rather than falling through — falling through would
+        //     leak across agents.
+        let sampling = match state.sampling_handler_factory.as_ref() {
+            Some(factory) => match factory.for_agent(&ctx.agent_spec).await {
+                Some(h) => crate::transport::McpCallSampling::Bound(h),
+                None => crate::transport::McpCallSampling::Denied,
+            },
+            None => crate::transport::McpCallSampling::Inherit,
+        };
+        let call_context = crate::transport::McpCallContext {
+            metadata,
+            cancellation,
+            sampling,
+        };
         let res = match with_runtime_lease(
             &state,
             &self.server_name,
@@ -227,8 +268,7 @@ impl Tool for McpTool {
                     &tool_name,
                     args,
                     Some(progress_tx),
-                    metadata,
-                    cancellation,
+                    call_context,
                 ));
                 let mut gate = ProgressEmitGate::default();
 
@@ -484,6 +524,23 @@ struct McpServerSlot {
     next_generation: u64,
     published_snapshot: Option<McpPublishedSnapshot>,
     lifecycle_lock: Arc<AsyncMutex<()>>,
+    /// Number of times the runtime has been re-created since the server
+    /// was first enabled. Counts only SUCCESSFUL reconnects (a 404 →
+    /// reset cycle on HTTP transport doesn't tear down the runtime, so
+    /// doesn't bump this). Reset only by `toggle(disable)` →
+    /// `toggle(enable)`.
+    reconnect_count: u64,
+    /// Wall-clock time of the most recent successful MCP `initialize`
+    /// response. Set when `connect_runtime` succeeds; remains until the
+    /// next successful reconnect / re-enable.
+    last_init_at: Option<SystemTime>,
+    /// Last session id captured at connect/reconnect. Kept as a
+    /// fallback for `server_status_snapshot` — the snapshot prefers
+    /// the **live** value read from the transport (via
+    /// `current_session_id().await`), but falls back to this cache
+    /// when the runtime has been torn down (no transport available).
+    /// HTTP transport only; stdio leaves this `None`.
+    last_known_session_id: Option<String>,
 }
 
 // ── Registry snapshot ──
@@ -498,7 +555,17 @@ struct McpRegistryState {
     servers: RwLock<Vec<McpServerSlot>>,
     snapshot: RwLock<McpRegistrySnapshot>,
     periodic_refresh: PeriodicRefresher,
+    /// Transport-level fallback handler for server-initiated
+    /// `sampling/createMessage`. Set once at registry assembly; used
+    /// when there's no per-call handler in flight (or when multiple
+    /// calls are in flight and routing is ambiguous).
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
+    /// Factory that resolves a per-call sampling handler based on the
+    /// calling agent's spec. Optional — when `None`, all sampling
+    /// flows through the transport-level fallback above. Wiring this
+    /// up is what fixes the "all agents share one LLM for sampling"
+    /// leak documented in the audit.
+    sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
 }
 
 fn read_lock<T>(lock: &RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
@@ -1016,6 +1083,7 @@ fn finish_reconnect_success(
     runtime: McpServerRuntime,
     catalog: McpPublishedCatalog,
     attempted_at: SystemTime,
+    session_id: Option<String>,
 ) -> Result<(), McpError> {
     let mut servers = write_lock(&state.servers);
     let index = find_server_index(&servers, server_name)?;
@@ -1026,6 +1094,13 @@ fn finish_reconnect_success(
         generation,
         catalog,
     });
+    // Successful reconnect: bump the diagnostic counter + mark the
+    // freshly-issued init timestamp. Operators reading the status snapshot
+    // can distinguish "first connect" (reconnect_count=0) from "flapping"
+    // (reconnect_count rising) without trawling logs.
+    slot.reconnect_count = slot.reconnect_count.saturating_add(1);
+    slot.last_init_at = Some(attempted_at);
+    slot.last_known_session_id = session_id;
     reset_all_server_health_on_success(slot, attempted_at);
     Ok(())
 }
@@ -1128,12 +1203,16 @@ async fn reconnect_server_locked(
         }
     };
 
+    // Capture the freshly-issued session id (HTTP) before we hand the
+    // runtime back to the slot map. Stdio's transport returns None.
+    let session_id = runtime.transport.current_session_id().await;
     finish_reconnect_success(
         state.as_ref(),
         server_name,
         runtime,
         catalog,
         SystemTime::now(),
+        session_id,
     )?;
     Ok(())
 }
@@ -1425,13 +1504,28 @@ impl McpToolRegistryManager {
         configs: impl IntoIterator<Item = McpServerConnectionConfig>,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
     ) -> Result<Self, McpError> {
+        Self::connect_with_sampling_factory(configs, sampling_handler, None).await
+    }
+
+    /// Connect with both a transport-level fallback handler AND a
+    /// per-agent factory. When the factory is `Some`, `McpTool::execute`
+    /// consults it at each call to route server-initiated
+    /// `sampling/createMessage` to the calling agent's executor. The
+    /// fallback handler covers the cases the factory returns `None` for,
+    /// or the >1-in-flight ambiguous case at the transport layer.
+    pub async fn connect_with_sampling_factory(
+        configs: impl IntoIterator<Item = McpServerConnectionConfig>,
+        sampling_handler: Option<Arc<dyn SamplingHandler>>,
+        sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
+    ) -> Result<Self, McpError> {
         let mut entries: Vec<(McpServerConnectionConfig, Arc<dyn McpToolTransport>)> = Vec::new();
         for cfg in configs {
             validate_server_name(&cfg.name)?;
             let transport = connect_transport(&cfg, sampling_handler.clone()).await?;
             entries.push((cfg, transport));
         }
-        Self::from_tool_transports(entries, sampling_handler).await
+        Self::from_tool_transports_with_factory(entries, sampling_handler, sampling_handler_factory)
+            .await
     }
 
     pub async fn from_transports(
@@ -1444,12 +1538,28 @@ impl McpToolRegistryManager {
         entries: impl IntoIterator<Item = (McpServerConnectionConfig, Arc<dyn McpToolTransport>)>,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
     ) -> Result<Self, McpError> {
+        Self::from_tool_transports_with_factory(entries, sampling_handler, None).await
+    }
+
+    /// Variant of `from_tool_transports` that also accepts a
+    /// [`SamplingHandlerFactory`]. When set, the factory is consulted
+    /// at each `tools/call` to construct a per-agent
+    /// [`SamplingHandler`] — server-initiated `sampling/createMessage`
+    /// during that call then routes to the calling agent's LLM
+    /// executor. When `None`, sampling falls back to the fixed
+    /// `sampling_handler` (legacy behaviour).
+    pub async fn from_tool_transports_with_factory(
+        entries: impl IntoIterator<Item = (McpServerConnectionConfig, Arc<dyn McpToolTransport>)>,
+        sampling_handler: Option<Arc<dyn SamplingHandler>>,
+        sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
+    ) -> Result<Self, McpError> {
         let servers = Self::build_servers(entries).await?;
         let state = Arc::new(McpRegistryState {
             servers: RwLock::new(servers),
             snapshot: RwLock::new(McpRegistrySnapshot::default()),
             periodic_refresh: PeriodicRefresher::new(),
             sampling_handler,
+            sampling_handler_factory,
         });
 
         let server_names: Vec<String> = {
@@ -1485,6 +1595,10 @@ impl McpToolRegistryManager {
                 return Err(McpError::DuplicateServerName(cfg.name));
             }
             let capabilities = transport.server_capabilities().await?;
+            // Capture the session id (HTTP only; stdio returns None) for
+            // the diagnostic snapshot. Done here while we're still async
+            // so the snapshot accessor can stay synchronous.
+            let last_known_session_id = transport.current_session_id().await;
 
             servers.push(McpServerSlot {
                 meta: McpServerMetadata {
@@ -1517,6 +1631,9 @@ impl McpToolRegistryManager {
                 next_generation: 2,
                 published_snapshot: None,
                 lifecycle_lock: Arc::new(AsyncMutex::new(())),
+                reconnect_count: 0,
+                last_init_at: Some(connected_at),
+                last_known_session_id,
             });
         }
 
@@ -1576,39 +1693,84 @@ impl McpToolRegistryManager {
     /// Return a status snapshot for the named server, including connection state and
     /// the most recently discovered tool list.
     ///
+    /// Async because the HTTP session id is read **live** from the
+    /// transport (`current_session_id().await`). The slot keeps a cached
+    /// value at connect/reconnect time but `MCP session expired` triggers
+    /// a silent re-`initialize` that rotates the id without going through
+    /// the reconnect path — the cache would be stale until the next
+    /// reconnect. Reading live closes that window for admin/observability
+    /// consumers.
+    ///
     /// Returns [`McpError::UnknownServer`] when `server_name` is not registered.
-    pub fn server_status_snapshot(
+    pub async fn server_status_snapshot(
         &self,
         server_name: &str,
     ) -> Result<McpServerStatusSnapshot, McpError> {
-        let servers = read_lock(&self.state.servers);
-        let index = find_server_index(&servers, server_name)?;
-        let slot = &servers[index];
-        let connected = slot.lifecycle == McpServerLifecycle::Connected;
-        let last_error = slot.health.last_error.clone();
-        let tools = slot
-            .published_snapshot
-            .as_ref()
-            .map(|snap| {
-                snap.catalog
-                    .tool_defs
-                    .iter()
-                    .map(|def| McpServerToolEntry {
-                        name: def.name.clone(),
-                        description: def.description.clone(),
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+        // Collect everything we need under the sync read lock, then
+        // release it before awaiting the transport (which itself locks
+        // its session). Holding the registry-wide RwLock across an
+        // await would also defeat any concurrent snapshot/reconnect.
+        let (
+            connected,
+            last_error,
+            tools,
+            health,
+            cached_session_id,
+            reconnect_count,
+            last_init_at,
+            transport_for_session,
+        ) = {
+            let servers = read_lock(&self.state.servers);
+            let index = find_server_index(&servers, server_name)?;
+            let slot = &servers[index];
+            let connected = slot.lifecycle == McpServerLifecycle::Connected;
+            let last_error = slot.health.last_error.clone();
+            let tools = slot
+                .published_snapshot
+                .as_ref()
+                .map(|snap| {
+                    snap.catalog
+                        .tool_defs
+                        .iter()
+                        .map(|def| McpServerToolEntry {
+                            name: def.name.clone(),
+                            description: def.description.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            let transport_for_session = slot.runtime.as_ref().map(|rt| Arc::clone(&rt.transport));
+            (
+                connected,
+                last_error,
+                tools,
+                slot.health.clone(),
+                slot.last_known_session_id.clone(),
+                slot.reconnect_count,
+                slot.last_init_at,
+                transport_for_session,
+            )
+        };
+
+        // Prefer the live session id from the transport. Falls back to
+        // the cached value (e.g. transport dropped, race during teardown).
+        let session_id = match transport_for_session {
+            Some(transport) => transport.current_session_id().await.or(cached_session_id),
+            None => cached_session_id,
+        };
+
         Ok(McpServerStatusSnapshot {
             connected,
             last_error,
             tools,
-            consecutive_failures: slot.health.consecutive_failures,
-            last_attempt_at: slot.health.last_attempt_at,
-            last_success_at: slot.health.last_success_at,
-            reconnecting: slot.health.reconnecting,
-            permanently_failed: slot.health.permanently_failed,
+            consecutive_failures: health.consecutive_failures,
+            last_attempt_at: health.last_attempt_at,
+            last_success_at: health.last_success_at,
+            reconnecting: health.reconnecting,
+            permanently_failed: health.permanently_failed,
+            session_id,
+            reconnect_count,
+            last_init_at,
         })
     }
 
@@ -2020,8 +2182,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2050,8 +2211,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2086,8 +2246,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2122,8 +2281,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2172,8 +2330,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2220,8 +2377,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2271,8 +2427,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2337,8 +2492,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             self.calls.lock().unwrap().push(name.to_string());
             Ok(CallToolResult {
@@ -2383,8 +2537,7 @@ mod tests {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             if self.connection_closed {
                 Err(McpTransportError::ConnectionClosed)
@@ -2421,8 +2574,7 @@ mod tests {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             unreachable!()
         }
@@ -2443,8 +2595,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2535,6 +2686,9 @@ mod tests {
                 },
             }),
             lifecycle_lock: Arc::new(AsyncMutex::new(())),
+            reconnect_count: 0,
+            last_init_at: None,
+            last_known_session_id: None,
         }
     }
 
@@ -2665,8 +2819,7 @@ mod tests {
                 _name: &str,
                 _args: Value,
                 _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-                _metadata: crate::transport::McpCallMetadata,
-                _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+                _context: crate::transport::McpCallContext,
             ) -> Result<CallToolResult, McpTransportError> {
                 unreachable!()
             }

--- a/crates/awaken-ext-mcp/src/manager.rs
+++ b/crates/awaken-ext-mcp/src/manager.rs
@@ -25,8 +25,8 @@ use crate::progress::{
 };
 use crate::sampling::{SamplingHandler, SamplingHandlerFactory};
 use crate::transport::{
-    McpPromptDefinition, McpPromptResult, McpResourceDefinition, McpToolTransport,
-    call_result_to_tool_data, connect_transport,
+    CANCELLED_BY_CLIENT, McpPromptDefinition, McpPromptResult, McpResourceDefinition,
+    McpToolTransport, call_result_to_tool_data, connect_transport,
 };
 
 // ── Metadata constants ──
@@ -41,6 +41,7 @@ const MCP_META_RESULT_CONTENT: &str = "mcp.result.content";
 const MCP_META_RESULT_STRUCTURED_CONTENT: &str = "mcp.result.structuredContent";
 const FAILURE_THRESHOLD: u64 = 3;
 const MAX_RECONNECT_ATTEMPTS: u32 = 5;
+const RESOURCE_UPDATED_CHANNEL_CAPACITY: usize = 1024;
 
 // ── Helper types ──
 
@@ -87,18 +88,15 @@ pub struct McpServerStatusSnapshot {
     /// True after the manager has given up reconnecting. The server is
     /// staying offline until manual restart.
     pub permanently_failed: bool,
-    /// Server-assigned MCP session id (Streamable HTTP transport only).
-    /// `None` for stdio transports (the protocol does not define a
-    /// session id concept there) and for HTTP servers that don't issue
-    /// one. Surfaced for diagnostics — admins debugging "is the server
-    /// invalidating our session?" want to see this value change after
-    /// a 404 → reinit cycle.
-    pub session_id: Option<String>,
-    /// Number of times the transport has been torn down and rebuilt since
-    /// the server was first enabled. Increments after every successful
-    /// reconnect (`finish_reconnect_success`). Operators use this to
-    /// spot flapping servers without trawling logs.
-    pub reconnect_count: u64,
+    /// HTTP session generation observed by the transport. Increments on
+    /// local session reset/reinitialize cycles, including HTTP 404
+    /// session expiry that does not rebuild the whole runtime.
+    pub session_generation: Option<u64>,
+    /// Number of times the transport runtime has been torn down and
+    /// rebuilt since the server was first enabled. This is distinct from
+    /// HTTP session reinitialization; use `session_generation` for 404
+    /// session reset churn.
+    pub transport_reconnect_count: u64,
     /// Wall-clock time of the most recent successful MCP `initialize`
     /// response (i.e. when this session was opened). `None` until the
     /// first connect succeeds. Distinct from `last_success_at`, which
@@ -237,9 +235,9 @@ impl Tool for McpTool {
         // Resolve per-agent sampling routing. Three states:
         //   - No factory wired → Inherit: legacy behaviour, transport
         //     falls back to its fixed (or absent) handler.
-        //   - Factory consulted and returned Some(h) → Bound: this
-        //     call's server-initiated sampling/createMessage routes to
-        //     THIS agent's executor.
+        //   - Factory consulted and returned Some(h) → Bound: request-
+        //     bound HTTP SSE sampling/createMessage routes to THIS
+        //     agent's executor.
         //   - Factory consulted and returned None → Denied: the factory
         //     refused to bind (agent model unresolved, opted out, etc.).
         //     The transport will reject sampling/createMessage for this
@@ -398,6 +396,9 @@ fn map_mcp_error(e: McpTransportError) -> ToolError {
     match e {
         McpTransportError::UnknownTool(name) => ToolError::NotFound(name),
         McpTransportError::Timeout(msg) => ToolError::ExecutionFailed(format!("timeout: {}", msg)),
+        McpTransportError::TransportError(msg) if msg == CANCELLED_BY_CLIENT => {
+            ToolError::Cancelled("client cancelled the MCP request".to_string())
+        }
         other => ToolError::ExecutionFailed(other.to_string()),
     }
 }
@@ -485,7 +486,7 @@ fn should_track_transport_failure(err: &McpTransportError) -> bool {
     ) || matches!(
         err,
         McpTransportError::TransportError(message)
-            if !message.contains("not supported")
+            if message != CANCELLED_BY_CLIENT && !message.contains("not supported")
     )
 }
 
@@ -552,13 +553,9 @@ struct McpServerSlot {
     /// response. Cached at connect/reconnect and used as a fallback when
     /// the transport cannot report a live value.
     last_init_at: Option<SystemTime>,
-    /// Last session id captured at connect/reconnect. Kept as a
-    /// fallback for `server_status_snapshot` — the snapshot prefers
-    /// the **live** value read from the transport (via
-    /// `current_session_id().await`), but falls back to this cache
-    /// when the runtime has been torn down (no transport available).
-    /// HTTP transport only; stdio leaves this `None`.
-    last_known_session_id: Option<String>,
+    /// Last HTTP session generation captured at connect/reconnect.
+    /// Used as a fallback when the runtime has been torn down.
+    last_known_session_generation: Option<u64>,
 }
 
 // ── Registry snapshot ──
@@ -575,14 +572,16 @@ struct McpRegistryState {
     periodic_refresh: PeriodicRefresher,
     /// Transport-level fallback handler for server-initiated
     /// `sampling/createMessage`. Set once at registry assembly; used
-    /// when there's no per-call handler in flight (or when multiple
-    /// calls are in flight and routing is ambiguous).
+    /// for unattributed server requests (stdio and HTTP GET listener)
+    /// and as the only mode where the client can advertise global
+    /// `sampling` capability.
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
     /// Factory that resolves a per-call sampling handler based on the
-    /// calling agent's spec. Optional — when `None`, all sampling
-    /// flows through the transport-level fallback above. Wiring this
-    /// up is what fixes the "all agents share one LLM for sampling"
-    /// leak documented in the audit.
+    /// calling agent's spec. Optional — when `None`, request-bound
+    /// sampling flows through the transport-level fallback above.
+    /// Wiring this up fixes the "all agents share one LLM for
+    /// sampling" leak only for transports/events that carry a specific
+    /// client request attribution.
     sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
     /// Client-side roots advertised to every connected MCP server.
     /// `Arc` so all transports share the same backing list at zero
@@ -593,11 +592,12 @@ struct McpRegistryState {
     /// Sender half of the multiplexed `notifications/resources/updated`
     /// stream. Per-server forwarder tasks (one per active transport)
     /// pull from `take_resource_updated_receiver` and push
-    /// `ResourceUpdated { server, uri }` here. Receiver consumed once
+    /// `ResourceUpdated { server, uri }` here. Bounded to avoid a noisy
+    /// server exhausting process memory when the host is slow or not
+    /// subscribed; overflow events are dropped. Receiver consumed once
     /// via [`McpToolRegistryManager::take_resource_updated_receiver`].
-    resource_updated_tx: tokio::sync::mpsc::UnboundedSender<ResourceUpdated>,
-    resource_updated_rx:
-        tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<ResourceUpdated>>>,
+    resource_updated_tx: tokio::sync::mpsc::Sender<ResourceUpdated>,
+    resource_updated_rx: tokio::sync::Mutex<Option<tokio::sync::mpsc::Receiver<ResourceUpdated>>>,
 }
 
 /// Multiplexed `notifications/resources/updated` event surfaced from
@@ -1232,7 +1232,7 @@ fn finish_reconnect_success(
     runtime: McpServerRuntime,
     catalog: McpPublishedCatalog,
     attempted_at: SystemTime,
-    session_id: Option<String>,
+    session_generation: Option<u64>,
 ) -> Result<(), McpError> {
     let mut servers = write_lock(&state.servers);
     let index = find_server_index(&servers, server_name)?;
@@ -1243,13 +1243,12 @@ fn finish_reconnect_success(
         generation,
         catalog,
     });
-    // Successful reconnect: bump the diagnostic counter + mark the
-    // freshly-issued init timestamp. Operators reading the status snapshot
-    // can distinguish "first connect" (reconnect_count=0) from "flapping"
-    // (reconnect_count rising) without trawling logs.
+    // Successful runtime reconnect: bump the diagnostic counter + mark
+    // the freshly-issued init timestamp. HTTP session reset/reinit that
+    // keeps this runtime alive is exposed separately as session_generation.
     slot.reconnect_count = slot.reconnect_count.saturating_add(1);
     slot.last_init_at = Some(attempted_at);
-    slot.last_known_session_id = session_id;
+    slot.last_known_session_generation = session_generation;
     reset_all_server_health_on_success(slot, attempted_at);
     Ok(())
 }
@@ -1310,12 +1309,12 @@ fn finish_disable_transition(
     slot.health.last_attempt_at = Some(SystemTime::now());
     slot.health.last_error = close_error.map(ToString::to_string);
     // Clear the diagnostic fields that should reset on disable. The
-    // `last_known_session_id` doc says it's a fallback for when the
-    // runtime is torn down — once disabled, that fallback would
-    // surface stale info via `server_status_snapshot`. Similarly,
-    // `reconnect_count` is documented as reset by disable→enable,
+    // Clear diagnostic fields that should reset on disable. Once
+    // disabled, session generation would surface stale info via
+    // `server_status_snapshot`. Similarly,
+    // `transport_reconnect_count` is documented as reset by disable→enable,
     // and `last_init_at` belongs to the now-torn-down session.
-    slot.last_known_session_id = None;
+    slot.last_known_session_generation = None;
     slot.last_init_at = None;
     slot.reconnect_count = 0;
     Ok(())
@@ -1378,9 +1377,9 @@ async fn reconnect_server_locked(
         }
     };
 
-    // Capture the freshly-issued session id (HTTP) before we hand the
-    // runtime back to the slot map. Stdio's transport returns None.
-    let session_id = runtime.transport.current_session_id().await;
+    // Capture the freshly-issued session generation (HTTP) before we
+    // hand the runtime back to the slot map. Stdio returns None.
+    let session_generation = runtime.transport.current_session_generation().await;
     // Subscribe to the new transport's list_changed AND
     // resources/updated notifications BEFORE handing it back to the
     // slot map: once the runtime is owned by the slot we have no async
@@ -1395,7 +1394,7 @@ async fn reconnect_server_locked(
         runtime,
         catalog,
         SystemTime::now(),
-        session_id,
+        session_generation,
     )?;
     if let Some(rx) = resource_updated_rx {
         spawn_resource_updated_forwarder(resource_updated_tx, server_name.to_string(), rx);
@@ -1568,23 +1567,29 @@ where
 /// either the per-transport receiver closes (transport dropped) or the
 /// manager-wide sender errors (registry torn down).
 fn spawn_resource_updated_forwarder(
-    tx: tokio::sync::mpsc::UnboundedSender<ResourceUpdated>,
+    tx: tokio::sync::mpsc::Sender<ResourceUpdated>,
     server_name: String,
     mut rx: tokio::sync::mpsc::UnboundedReceiver<String>,
-) {
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(uri) = rx.recv().await {
-            if tx
-                .send(ResourceUpdated {
-                    server: server_name.clone(),
-                    uri,
-                })
-                .is_err()
-            {
-                break;
+            match tx.try_send(ResourceUpdated {
+                server: server_name.clone(),
+                uri,
+            }) {
+                Ok(()) => {}
+                Err(tokio::sync::mpsc::error::TrySendError::Full(event)) => {
+                    tracing::warn!(
+                        server = %event.server,
+                        uri = %event.uri,
+                        capacity = RESOURCE_UPDATED_CHANNEL_CAPACITY,
+                        "dropping MCP resource update because manager channel is full"
+                    );
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => break,
             }
         }
-    });
+    })
 }
 
 /// Consume `notifications/.../list_changed` events from `rx` and refresh
@@ -1807,8 +1812,9 @@ impl McpToolRegistryManager {
 
     /// Connect with both a transport-level fallback handler AND a
     /// per-agent factory. When the factory is `Some`, `McpTool::execute`
-    /// consults it at each call to route server-initiated
-    /// `sampling/createMessage` to the calling agent's executor.
+    /// consults it at each call so request-bound HTTP SSE
+    /// `sampling/createMessage` can route to the calling agent's
+    /// executor.
     /// Factory-only mode does not advertise global sampling capability;
     /// only a fixed transport-level fallback handler can safely answer
     /// sampling requests from streams without per-call attribution.
@@ -1822,8 +1828,8 @@ impl McpToolRegistryManager {
     ///   sampling for this call is REJECTED with method-not-supported.
     ///   It does NOT fall back to `sampling_handler` — that fallback
     ///   would re-introduce the cross-agent leak the factory exists
-    ///   to prevent. The fallback only covers the "no factory at all"
-    ///   and the ambiguous-cardinality cases at the transport layer.
+    ///   to prevent. The fallback only covers unattributed server
+    ///   requests or the "no factory at all" request-bound path.
     pub async fn connect_with_sampling_factory(
         configs: impl IntoIterator<Item = McpServerConnectionConfig>,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
@@ -1903,10 +1909,11 @@ impl McpToolRegistryManager {
     /// Variant of `from_tool_transports` that also accepts a
     /// [`SamplingHandlerFactory`]. When set, the factory is consulted
     /// at each `tools/call` to construct a per-agent
-    /// [`SamplingHandler`] — server-initiated `sampling/createMessage`
-    /// during that call then routes to the calling agent's LLM
-    /// executor. When `None`, sampling falls back to the fixed
-    /// `sampling_handler` (legacy behaviour).
+    /// [`SamplingHandler`] — request-bound HTTP SSE
+    /// `sampling/createMessage` during that call then routes to the
+    /// calling agent's LLM executor. When `None`, request-bound
+    /// sampling falls back to the fixed `sampling_handler` (legacy
+    /// behaviour).
     ///
     /// Delegates to [`Self::from_tool_transports_with_factory_and_roots`]
     /// with an empty roots list (the `roots` capability is not
@@ -1944,7 +1951,7 @@ impl McpToolRegistryManager {
         validate_server_configs(&configs)?;
         let servers = Self::build_servers(entries).await?;
         let (resource_updated_tx, resource_updated_rx) =
-            tokio::sync::mpsc::unbounded_channel::<ResourceUpdated>();
+            tokio::sync::mpsc::channel::<ResourceUpdated>(RESOURCE_UPDATED_CHANNEL_CAPACITY);
         let state = Arc::new(McpRegistryState {
             servers: RwLock::new(servers),
             snapshot: RwLock::new(McpRegistrySnapshot::default()),
@@ -2046,10 +2053,10 @@ impl McpToolRegistryManager {
                     return Err(error.into());
                 }
             };
-            // Capture the session id (HTTP only; stdio returns None) for
-            // the diagnostic snapshot. Done here while we're still async
-            // so the snapshot accessor can stay synchronous.
-            let last_known_session_id = transport.current_session_id().await;
+            // Capture HTTP session generation for the diagnostic
+            // snapshot. Done here while we're still async so the
+            // snapshot accessor can fall back after runtime teardown.
+            let last_known_session_generation = transport.current_session_generation().await;
 
             servers.push(McpServerSlot {
                 meta: McpServerMetadata {
@@ -2084,7 +2091,7 @@ impl McpToolRegistryManager {
                 lifecycle_lock: Arc::new(AsyncMutex::new(())),
                 reconnect_count: 0,
                 last_init_at: Some(connected_at),
-                last_known_session_id,
+                last_known_session_generation,
             });
         }
 
@@ -2131,7 +2138,7 @@ impl McpToolRegistryManager {
                 .filter_map(|slot| {
                     slot.lifecycle = McpServerLifecycle::Disabled;
                     slot.published_snapshot = None;
-                    slot.last_known_session_id = None;
+                    slot.last_known_session_generation = None;
                     slot.runtime.take()
                 })
                 .collect()
@@ -2181,12 +2188,14 @@ impl McpToolRegistryManager {
     /// the most recently discovered tool list.
     ///
     /// Async because HTTP session diagnostics are read **live** from the
-    /// transport (`current_session_id().await` and
+    /// transport (`current_session_generation().await` and
     /// `current_session_started_at().await`). The slot keeps cached
     /// connect/reconnect values, but `MCP session expired` triggers a
-    /// silent re-`initialize` that rotates the id and timestamp without
-    /// going through the reconnect path. Reading live closes that window
-    /// for admin/observability consumers.
+    /// silent re-`initialize` that rotates the id/generation/timestamp
+    /// without going through the reconnect path. Reading live closes
+    /// that window for admin/observability consumers. The returned
+    /// snapshot exposes the generation, not the raw `MCP-Session-Id`
+    /// header value.
     ///
     /// Returns [`McpError::UnknownServer`] when `server_name` is not registered.
     pub async fn server_status_snapshot(
@@ -2202,7 +2211,7 @@ impl McpToolRegistryManager {
             last_error,
             tools,
             health,
-            cached_session_id,
+            cached_session_generation,
             reconnect_count,
             cached_last_init_at,
             transport_for_session,
@@ -2232,7 +2241,7 @@ impl McpToolRegistryManager {
                 last_error,
                 tools,
                 slot.health.clone(),
-                slot.last_known_session_id.clone(),
+                slot.last_known_session_generation,
                 slot.reconnect_count,
                 slot.last_init_at,
                 transport_for_session,
@@ -2242,15 +2251,18 @@ impl McpToolRegistryManager {
         // Prefer live HTTP session diagnostics from the transport. Fall
         // back to cached values when there is no live runtime or when the
         // transport is stdio and has no HTTP session concept.
-        let (session_id, last_init_at) = match transport_for_session {
+        let (session_generation, last_init_at) = match transport_for_session {
             Some(transport) => (
-                transport.current_session_id().await.or(cached_session_id),
+                transport
+                    .current_session_generation()
+                    .await
+                    .or(cached_session_generation),
                 transport
                     .current_session_started_at()
                     .await
                     .or(cached_last_init_at),
             ),
-            None => (cached_session_id, cached_last_init_at),
+            None => (cached_session_generation, cached_last_init_at),
         };
 
         Ok(McpServerStatusSnapshot {
@@ -2262,8 +2274,8 @@ impl McpToolRegistryManager {
             last_success_at: health.last_success_at,
             reconnecting: health.reconnecting,
             permanently_failed: health.permanently_failed,
-            session_id,
-            reconnect_count,
+            session_generation,
+            transport_reconnect_count: reconnect_count,
             last_init_at,
         })
     }
@@ -2466,7 +2478,7 @@ impl McpToolRegistryManager {
     /// fresh per-server forwarder feeding into the same channel.
     pub async fn take_resource_updated_receiver(
         &self,
-    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<ResourceUpdated>> {
+    ) -> Option<tokio::sync::mpsc::Receiver<ResourceUpdated>> {
         self.state.resource_updated_rx.lock().await.take()
     }
 
@@ -3117,6 +3129,7 @@ mod tests {
     struct FailingCallTransport {
         tools: Vec<McpToolDefinition>,
         connection_closed: bool,
+        cancelled: bool,
     }
 
     impl FailingCallTransport {
@@ -3124,6 +3137,15 @@ mod tests {
             Self {
                 tools: vec![MockTransport::tool_def(tool_name)],
                 connection_closed: true,
+                cancelled: false,
+            }
+        }
+
+        fn cancelled(tool_name: &str) -> Self {
+            Self {
+                tools: vec![MockTransport::tool_def(tool_name)],
+                connection_closed: false,
+                cancelled: true,
             }
         }
     }
@@ -3143,6 +3165,10 @@ mod tests {
         ) -> Result<CallToolResult, McpTransportError> {
             if self.connection_closed {
                 Err(McpTransportError::ConnectionClosed)
+            } else if self.cancelled {
+                Err(McpTransportError::TransportError(
+                    CANCELLED_BY_CLIENT.to_string(),
+                ))
             } else {
                 Err(McpTransportError::TransportError(
                     "scripted tool call failure".to_string(),
@@ -3337,7 +3363,7 @@ mod tests {
             lifecycle_lock: Arc::new(AsyncMutex::new(())),
             reconnect_count: 0,
             last_init_at: None,
-            last_known_session_id: None,
+            last_known_session_generation: None,
         }
     }
 
@@ -4180,6 +4206,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_call_client_cancellation_does_not_update_health_or_reconnect() {
+        let transport =
+            Arc::new(FailingCallTransport::cancelled("echo")) as Arc<dyn McpToolTransport>;
+        let mgr = McpToolRegistryManager::from_transports(vec![(cfg("srv"), transport)])
+            .await
+            .unwrap();
+
+        let tool = mgr.registry().get("mcp__srv__echo").unwrap();
+        let ctx = awaken_contract::contract::tool::ToolCallContext::test_default();
+
+        for _ in 0..3 {
+            let err = tool.execute(json!({}), &ctx).await.unwrap_err();
+            assert!(matches!(err, ToolError::Cancelled(_)));
+        }
+
+        let health = mgr.server_health("srv").unwrap();
+        assert_eq!(health.consecutive_failures, 0);
+        assert_eq!(health.last_error, None);
+        let servers = read_lock(&mgr.state.servers);
+        assert_eq!(servers[0].rpc_health.consecutive_failures, 0);
+        assert_eq!(servers[0].lifecycle, McpServerLifecycle::Connected);
+        assert_eq!(servers[0].reconnect_attempts, 0);
+    }
+
+    #[tokio::test]
     async fn prompt_and_resource_failures_share_rpc_reconnect_budget() {
         let transport =
             Arc::new(FailingCatalogRpcTransport::new("echo")) as Arc<dyn McpToolTransport>;
@@ -4335,9 +4386,50 @@ mod tests {
     }
 
     #[test]
+    fn map_mcp_error_cancelled() {
+        let err = map_mcp_error(McpTransportError::TransportError(
+            CANCELLED_BY_CLIENT.to_string(),
+        ));
+        assert!(matches!(err, ToolError::Cancelled(msg) if msg.contains("cancelled")));
+    }
+
+    #[test]
     fn map_mcp_error_other() {
         let err = map_mcp_error(McpTransportError::TransportError("fail".to_string()));
         assert!(matches!(err, ToolError::ExecutionFailed(_)));
+    }
+
+    #[test]
+    fn client_cancellation_does_not_track_transport_failure() {
+        let err = McpTransportError::TransportError(CANCELLED_BY_CLIENT.to_string());
+        assert!(!should_track_transport_failure(&err));
+    }
+
+    #[tokio::test]
+    async fn resource_update_forwarder_drops_when_manager_channel_full() {
+        let (manager_tx, mut manager_rx) =
+            tokio::sync::mpsc::channel::<ResourceUpdated>(RESOURCE_UPDATED_CHANNEL_CAPACITY);
+        let (transport_tx, transport_rx) = mpsc::unbounded_channel::<String>();
+        let handle = spawn_resource_updated_forwarder(manager_tx, "srv".to_string(), transport_rx);
+
+        for idx in 0..(RESOURCE_UPDATED_CHANNEL_CAPACITY * 2) {
+            transport_tx
+                .send(format!("file:///resource-{idx}"))
+                .expect("transport receiver alive");
+        }
+        drop(transport_tx);
+        handle.await.expect("forwarder exits");
+
+        assert_eq!(
+            manager_rx.len(),
+            RESOURCE_UPDATED_CHANNEL_CAPACITY,
+            "bounded manager channel must not grow past capacity"
+        );
+        let mut drained = 0usize;
+        while manager_rx.try_recv().is_ok() {
+            drained += 1;
+        }
+        assert_eq!(drained, RESOURCE_UPDATED_CHANNEL_CAPACITY);
     }
 
     #[tokio::test]

--- a/crates/awaken-ext-mcp/src/manager.rs
+++ b/crates/awaken-ext-mcp/src/manager.rs
@@ -446,6 +446,24 @@ fn runtime_lease(slot: &McpServerSlot) -> Result<McpRuntimeLease, McpError> {
     })
 }
 
+fn update_runtime_capabilities(
+    state: &McpRegistryState,
+    server_name: &str,
+    generation: u64,
+    capabilities: Option<ServerCapabilities>,
+) {
+    let mut servers = write_lock(&state.servers);
+    let Ok(index) = find_server_index(&servers, server_name) else {
+        return;
+    };
+    let Some(runtime) = servers[index].runtime.as_mut() else {
+        return;
+    };
+    if runtime.generation == generation {
+        runtime.capabilities = capabilities;
+    }
+}
+
 fn resolve_live_runtime(
     state: &Weak<McpRegistryState>,
     server_name: &str,
@@ -531,8 +549,8 @@ struct McpServerSlot {
     /// `toggle(enable)`.
     reconnect_count: u64,
     /// Wall-clock time of the most recent successful MCP `initialize`
-    /// response. Set when `connect_runtime` succeeds; remains until the
-    /// next successful reconnect / re-enable.
+    /// response. Cached at connect/reconnect and used as a fallback when
+    /// the transport cannot report a live value.
     last_init_at: Option<SystemTime>,
     /// Last session id captured at connect/reconnect. Kept as a
     /// fallback for `server_status_snapshot` — the snapshot prefers
@@ -572,6 +590,24 @@ struct McpRegistryState {
     /// Per spec roots are a client-wide concept, not per-server, so
     /// this lives on the shared registry state.
     client_roots: Arc<Vec<mcp::Root>>,
+    /// Sender half of the multiplexed `notifications/resources/updated`
+    /// stream. Per-server forwarder tasks (one per active transport)
+    /// pull from `take_resource_updated_receiver` and push
+    /// `ResourceUpdated { server, uri }` here. Receiver consumed once
+    /// via [`McpToolRegistryManager::take_resource_updated_receiver`].
+    resource_updated_tx: tokio::sync::mpsc::UnboundedSender<ResourceUpdated>,
+    resource_updated_rx:
+        tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<ResourceUpdated>>>,
+}
+
+/// Multiplexed `notifications/resources/updated` event surfaced from
+/// any connected MCP server. The host normally cares which server
+/// owns the URI (mostly because authorization and read-back routing
+/// keyed by server-id), so we carry the server name alongside.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceUpdated {
+    pub server: String,
+    pub uri: String,
 }
 
 fn read_lock<T>(lock: &RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
@@ -661,6 +697,28 @@ fn server_supports_resources(capabilities: Option<&ServerCapabilities>) -> bool 
     capabilities.is_none_or(|capabilities| capabilities.resources.is_some())
 }
 
+/// Per spec §Resources / Subscriptions: server MUST advertise
+/// `resources.subscribe: true` before the client can subscribe. We
+/// fail closed — when capabilities are absent we don't pretend
+/// subscription works (unlike the more permissive `server_supports_*`
+/// helpers above, which optimistically allow the operation when
+/// capabilities haven't been observed yet).
+fn server_supports_resources_subscribe(capabilities: Option<&ServerCapabilities>) -> bool {
+    capabilities
+        .and_then(|c| c.resources.as_ref())
+        .and_then(|r| r.subscribe)
+        .unwrap_or(false)
+}
+
+/// Per spec §Utilities / Completion: server advertises `completions`
+/// as an empty object (`{}`) when supported. We require its presence;
+/// absence means the server doesn't accept `completion/complete`.
+fn server_supports_completions(capabilities: Option<&ServerCapabilities>) -> bool {
+    capabilities
+        .map(|c| c.completions.is_some())
+        .unwrap_or(false)
+}
+
 fn require_prompts(runtime: &McpRuntimeLease) -> Result<(), McpError> {
     if server_supports_prompts(runtime.capabilities.as_ref()) {
         return Ok(());
@@ -673,6 +731,23 @@ fn require_resources(runtime: &McpRuntimeLease) -> Result<(), McpError> {
         return Ok(());
     }
     Err(unsupported_capability(&runtime.server_name, "resources"))
+}
+
+fn require_resources_subscribe(runtime: &McpRuntimeLease) -> Result<(), McpError> {
+    if server_supports_resources_subscribe(runtime.capabilities.as_ref()) {
+        return Ok(());
+    }
+    Err(unsupported_capability(
+        &runtime.server_name,
+        "resources.subscribe",
+    ))
+}
+
+fn require_completions(runtime: &McpRuntimeLease) -> Result<(), McpError> {
+    if server_supports_completions(runtime.capabilities.as_ref()) {
+        return Ok(());
+    }
+    Err(unsupported_capability(&runtime.server_name, "completions"))
 }
 
 fn discover_tools(servers: &[McpServerSlot]) -> Result<HashMap<String, Arc<dyn Tool>>, McpError> {
@@ -737,6 +812,65 @@ fn build_published_tools(
 
 async fn close_runtime(runtime: McpServerRuntime) -> Result<(), McpError> {
     runtime.transport.close().await?;
+    Ok(())
+}
+
+async fn close_transport_best_effort(transport: Arc<dyn McpToolTransport>, context: &str) {
+    if let Err(error) = transport.close().await {
+        tracing::warn!(
+            error = %error,
+            context,
+            "failed to close MCP transport during cleanup"
+        );
+    }
+}
+
+async fn close_transport_entries_best_effort(
+    entries: Vec<(McpServerConnectionConfig, Arc<dyn McpToolTransport>)>,
+    context: &str,
+) {
+    let results = join_all(
+        entries
+            .into_iter()
+            .map(|(_, transport)| async move { transport.close().await }),
+    )
+    .await;
+    for result in results {
+        if let Err(error) = result {
+            tracing::warn!(
+                error = %error,
+                context,
+                "failed to close MCP transport during cleanup"
+            );
+        }
+    }
+}
+
+async fn close_servers_best_effort(servers: Vec<McpServerSlot>, context: &str) {
+    let runtimes = servers
+        .into_iter()
+        .filter_map(|slot| slot.runtime)
+        .collect::<Vec<_>>();
+    let results = join_all(runtimes.into_iter().map(close_runtime)).await;
+    for result in results {
+        if let Err(error) = result {
+            tracing::warn!(
+                error = %error,
+                context,
+                "failed to close MCP runtime during cleanup"
+            );
+        }
+    }
+}
+
+fn validate_server_configs(configs: &[McpServerConnectionConfig]) -> Result<(), McpError> {
+    let mut names = HashSet::new();
+    for config in configs {
+        validate_server_name(&config.name)?;
+        if !names.insert(config.name.clone()) {
+            return Err(McpError::DuplicateServerName(config.name.clone()));
+        }
+    }
     Ok(())
 }
 
@@ -965,11 +1099,19 @@ async fn connect_runtime(
     config: &McpServerConnectionConfig,
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
     client_roots: Arc<Vec<mcp::Root>>,
+    advertise_sampling: bool,
     generation: u64,
 ) -> Result<McpServerRuntime, McpError> {
-    let transport = connect_transport(config, sampling_handler, client_roots).await?;
+    let transport =
+        connect_transport(config, sampling_handler, client_roots, advertise_sampling).await?;
     let transport_type = transport.transport_type();
-    let capabilities = transport.server_capabilities().await?;
+    let capabilities = match transport.server_capabilities().await {
+        Ok(capabilities) => capabilities,
+        Err(error) => {
+            close_transport_best_effort(Arc::clone(&transport), "connect_runtime").await;
+            return Err(error.into());
+        }
+    };
     Ok(McpServerRuntime {
         generation,
         transport_type,
@@ -1167,6 +1309,15 @@ fn finish_disable_transition(
     clear_health_budgets(slot);
     slot.health.last_attempt_at = Some(SystemTime::now());
     slot.health.last_error = close_error.map(ToString::to_string);
+    // Clear the diagnostic fields that should reset on disable. The
+    // `last_known_session_id` doc says it's a fallback for when the
+    // runtime is torn down — once disabled, that fallback would
+    // surface stale info via `server_status_snapshot`. Similarly,
+    // `reconnect_count` is documented as reset by disable→enable,
+    // and `last_init_at` belongs to the now-torn-down session.
+    slot.last_known_session_id = None;
+    slot.last_init_at = None;
+    slot.reconnect_count = 0;
     Ok(())
 }
 
@@ -1176,6 +1327,7 @@ async fn reconnect_server_locked(
 ) -> Result<(), McpError> {
     let sampling_handler = state.sampling_handler.clone();
     let client_roots = Arc::clone(&state.client_roots);
+    let advertise_sampling = state.sampling_handler.is_some();
     let (config, generation, attempt, detached_runtime) =
         begin_reconnect_transition(state.as_ref(), server_name)?;
 
@@ -1188,7 +1340,15 @@ async fn reconnect_server_locked(
 
     tokio::time::sleep(reconnect_backoff(attempt)).await;
 
-    let runtime = match connect_runtime(&config, sampling_handler, client_roots, generation).await {
+    let runtime = match connect_runtime(
+        &config,
+        sampling_handler,
+        client_roots,
+        advertise_sampling,
+        generation,
+    )
+    .await
+    {
         Ok(runtime) => runtime,
         Err(err) => {
             finish_reconnect_error(state.as_ref(), server_name, &err)?;
@@ -1206,6 +1366,13 @@ async fn reconnect_server_locked(
     let catalog = match discover_catalog_from_lease(Arc::downgrade(state), &lease).await {
         Ok(catalog) => catalog,
         Err(err) => {
+            if let Err(close_err) = close_runtime(runtime).await {
+                tracing::warn!(
+                    error = %close_err,
+                    server = %server_name,
+                    "failed to close MCP runtime after reconnect discovery failure"
+                );
+            }
             finish_reconnect_error(state.as_ref(), server_name, &err)?;
             return Err(err);
         }
@@ -1214,11 +1381,14 @@ async fn reconnect_server_locked(
     // Capture the freshly-issued session id (HTTP) before we hand the
     // runtime back to the slot map. Stdio's transport returns None.
     let session_id = runtime.transport.current_session_id().await;
-    // Subscribe to the new transport's list_changed notifications
-    // BEFORE handing it back to the slot map: once the runtime is owned
-    // by the slot we have no async access to it. The receiver is
-    // one-shot per transport, so this is the only chance to claim it.
+    // Subscribe to the new transport's list_changed AND
+    // resources/updated notifications BEFORE handing it back to the
+    // slot map: once the runtime is owned by the slot we have no async
+    // access to it. The receivers are one-shot per transport, so this
+    // is the only chance to claim them.
     let list_changed_rx = runtime.transport.take_list_changed_receiver().await;
+    let resource_updated_rx = runtime.transport.take_resource_updated_receiver().await;
+    let resource_updated_tx = state.resource_updated_tx.clone();
     finish_reconnect_success(
         state.as_ref(),
         server_name,
@@ -1227,6 +1397,9 @@ async fn reconnect_server_locked(
         SystemTime::now(),
         session_id,
     )?;
+    if let Some(rx) = resource_updated_rx {
+        spawn_resource_updated_forwarder(resource_updated_tx, server_name.to_string(), rx);
+    }
     if let Some(rx) = list_changed_rx {
         spawn_list_changed_watcher(Arc::downgrade(state), server_name.to_string(), rx);
     }
@@ -1341,14 +1514,30 @@ where
     Fut: Future<Output = Result<T, McpTransportError>>,
     P: FnOnce(&McpRuntimeLease) -> Result<(), McpError>,
 {
-    let runtime = {
+    let mut runtime = {
         let servers = read_lock(&state.servers);
         let index = find_server_index(&servers, server_name).map_err(RuntimeOperationError::Mcp)?;
         runtime_lease(&servers[index]).map_err(RuntimeOperationError::Mcp)?
     };
+    let generation = runtime.generation;
+    let live_capabilities = match runtime.transport.server_capabilities().await {
+        Ok(capabilities) => capabilities,
+        Err(err) => {
+            record_runtime_operation_failure(
+                &Arc::downgrade(state),
+                server_name,
+                generation,
+                op_kind,
+                &err,
+            )
+            .await;
+            return Err(RuntimeOperationError::Transport(err));
+        }
+    };
+    runtime.capabilities = live_capabilities.clone();
+    update_runtime_capabilities(state.as_ref(), server_name, generation, live_capabilities);
     preflight(&runtime).map_err(RuntimeOperationError::Mcp)?;
 
-    let generation = runtime.generation;
     match operation(runtime).await {
         Ok(value) => {
             record_runtime_operation_success(
@@ -1374,6 +1563,30 @@ where
     }
 }
 
+/// Forward `notifications/resources/updated` URIs from one transport
+/// onto the manager-wide multiplexed channel. The task exits when
+/// either the per-transport receiver closes (transport dropped) or the
+/// manager-wide sender errors (registry torn down).
+fn spawn_resource_updated_forwarder(
+    tx: tokio::sync::mpsc::UnboundedSender<ResourceUpdated>,
+    server_name: String,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+) {
+    tokio::spawn(async move {
+        while let Some(uri) = rx.recv().await {
+            if tx
+                .send(ResourceUpdated {
+                    server: server_name.clone(),
+                    uri,
+                })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+}
+
 /// Consume `notifications/.../list_changed` events from `rx` and refresh
 /// the relevant catalogue for `server_name`.
 ///
@@ -1383,12 +1596,10 @@ where
 /// mutates, so polling can be supplemented (or replaced over time) by
 /// reactive refresh.
 ///
-/// Today the manager only caches the **tools** catalogue, so:
-///   - `Tools`  → drives a `refresh_server` (re-runs `tools/list`)
-///   - `Prompts` / `Resources` → log at debug level. List operations
-///     for those surfaces hit the server live on each agent call;
-///     there's nothing cached locally to invalidate yet. When a future
-///     PR caches them, this is the point to hook in.
+/// Today the manager only caches the **tools** catalogue, so `Tools`
+/// drives a `refresh_server` (re-running `tools/list`); `Prompts` and
+/// `Resources` are logged at debug level since list operations for
+/// those surfaces hit the server live on each agent call.
 fn spawn_list_changed_watcher(
     state_weak: Weak<McpRegistryState>,
     server_name: String,
@@ -1403,11 +1614,28 @@ fn spawn_list_changed_watcher(
                         // no one to receive subsequent notifications.
                         break;
                     };
-                    if let Err(err) = refresh_server(state, server_name.clone()).await {
+                    if let Err(err) = refresh_server(Arc::clone(&state), server_name.clone()).await
+                    {
                         tracing::warn!(
                             error = %err,
                             server = %server_name,
                             "list_changed-triggered tools refresh failed"
+                        );
+                        continue;
+                    }
+                    // refresh_server only writes the per-slot
+                    // `published_snapshot`. The manager-wide registry
+                    // snapshot (what `registry()` exposes) is rebuilt
+                    // separately — without this, callers keep seeing
+                    // the pre-list_changed tool catalog until the next
+                    // periodic refresh fires `refresh_state` (which
+                    // does both). Rebuild eagerly so the notification's
+                    // freshness actually propagates.
+                    if let Err(err) = rebuild_snapshot(state.as_ref()).await {
+                        tracing::warn!(
+                            error = %err,
+                            server = %server_name,
+                            "list_changed-triggered snapshot rebuild failed"
                         );
                     }
                 }
@@ -1580,9 +1808,22 @@ impl McpToolRegistryManager {
     /// Connect with both a transport-level fallback handler AND a
     /// per-agent factory. When the factory is `Some`, `McpTool::execute`
     /// consults it at each call to route server-initiated
-    /// `sampling/createMessage` to the calling agent's executor. The
-    /// fallback handler covers the cases the factory returns `None` for,
-    /// or the >1-in-flight ambiguous case at the transport layer.
+    /// `sampling/createMessage` to the calling agent's executor.
+    /// Factory-only mode does not advertise global sampling capability;
+    /// only a fixed transport-level fallback handler can safely answer
+    /// sampling requests from streams without per-call attribution.
+    ///
+    /// Three-state routing semantics (see `McpCallSampling`):
+    /// - **No factory configured** → `Inherit`: the transport falls
+    ///   back to `sampling_handler` if set, else method-not-supported.
+    /// - **Factory returns `Some(handler)`** → `Bound`: that handler
+    ///   serves sampling for this call.
+    /// - **Factory returns `None`** → `Denied`: server-initiated
+    ///   sampling for this call is REJECTED with method-not-supported.
+    ///   It does NOT fall back to `sampling_handler` — that fallback
+    ///   would re-introduce the cross-agent leak the factory exists
+    ///   to prevent. The fallback only covers the "no factory at all"
+    ///   and the ambiguous-cardinality cases at the transport layer.
     pub async fn connect_with_sampling_factory(
         configs: impl IntoIterator<Item = McpServerConnectionConfig>,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
@@ -1608,12 +1849,33 @@ impl McpToolRegistryManager {
         sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
         client_roots: Arc<Vec<mcp::Root>>,
     ) -> Result<Self, McpError> {
+        // Advertise sampling only when a transport-level fallback handler
+        // can answer global server-initiated sampling requests. A per-agent
+        // factory is only safe on per-request streams where request_id binds
+        // the server request to a specific tool call.
+        let advertise_sampling = sampling_handler.is_some();
+        let configs = configs.into_iter().collect::<Vec<_>>();
+        validate_server_configs(&configs)?;
         let mut entries: Vec<(McpServerConnectionConfig, Arc<dyn McpToolTransport>)> = Vec::new();
         for cfg in configs {
-            validate_server_name(&cfg.name)?;
-            let transport =
-                connect_transport(&cfg, sampling_handler.clone(), Arc::clone(&client_roots))
-                    .await?;
+            let transport = match connect_transport(
+                &cfg,
+                sampling_handler.clone(),
+                Arc::clone(&client_roots),
+                advertise_sampling,
+            )
+            .await
+            {
+                Ok(transport) => transport,
+                Err(error) => {
+                    close_transport_entries_best_effort(
+                        entries,
+                        "connect_with_sampling_factory_and_roots",
+                    )
+                    .await;
+                    return Err(error.into());
+                }
+            };
             entries.push((cfg, transport));
         }
         Self::from_tool_transports_with_factory_and_roots(
@@ -1674,7 +1936,15 @@ impl McpToolRegistryManager {
         sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
         client_roots: Arc<Vec<mcp::Root>>,
     ) -> Result<Self, McpError> {
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        let configs = entries
+            .iter()
+            .map(|(config, _)| config.clone())
+            .collect::<Vec<_>>();
+        validate_server_configs(&configs)?;
         let servers = Self::build_servers(entries).await?;
+        let (resource_updated_tx, resource_updated_rx) =
+            tokio::sync::mpsc::unbounded_channel::<ResourceUpdated>();
         let state = Arc::new(McpRegistryState {
             servers: RwLock::new(servers),
             snapshot: RwLock::new(McpRegistrySnapshot::default()),
@@ -1682,64 +1952,100 @@ impl McpToolRegistryManager {
             sampling_handler,
             sampling_handler_factory,
             client_roots,
+            resource_updated_tx,
+            resource_updated_rx: tokio::sync::Mutex::new(Some(resource_updated_rx)),
         });
+        let manager = Self { state };
 
         let server_names: Vec<String> = {
-            let servers = read_lock(&state.servers);
+            let servers = read_lock(&manager.state.servers);
             servers.iter().map(|slot| slot.meta.name.clone()).collect()
         };
         for server_name in &server_names {
             let attempted_at = SystemTime::now();
-            let runtime = resolve_live_runtime(&Arc::downgrade(&state), server_name)?;
-            let catalog = discover_catalog_from_lease(Arc::downgrade(&state), &runtime).await?;
-            let _ = apply_catalog_if_current(
-                state.as_ref(),
-                server_name,
-                runtime.generation,
-                attempted_at,
-                catalog,
-            )?;
+            let result = async {
+                let runtime = resolve_live_runtime(&Arc::downgrade(&manager.state), server_name)?;
+                let catalog =
+                    discover_catalog_from_lease(Arc::downgrade(&manager.state), &runtime).await?;
+                let _ = apply_catalog_if_current(
+                    manager.state.as_ref(),
+                    server_name,
+                    runtime.generation,
+                    attempted_at,
+                    catalog,
+                )?;
+                Ok::<(), McpError>(())
+            }
+            .await;
+            if let Err(error) = result {
+                let _ = manager.close_all().await;
+                return Err(error);
+            }
         }
-        rebuild_snapshot(state.as_ref()).await?;
+        if let Err(error) = rebuild_snapshot(manager.state.as_ref()).await {
+            let _ = manager.close_all().await;
+            return Err(error);
+        }
 
         // Subscribe to each transport's `notifications/.../list_changed`
-        // stream so we react to server-initiated catalogue mutations
-        // instead of waiting for the next periodic refresh tick. The
-        // receiver is one-shot per transport; this is the only place
-        // we claim it for the initial connect. (The reconnect path
-        // claims it at `finish_reconnect_success`.)
+        // and `notifications/resources/updated` streams so we react to
+        // server-initiated events instead of waiting for the next
+        // periodic refresh tick. Receivers are one-shot per transport;
+        // this is the only place we claim them for the initial connect.
+        // (The reconnect path claims them at `finish_reconnect_success`.)
         for server_name in &server_names {
-            let transport = {
-                let servers = read_lock(&state.servers);
-                let index = find_server_index(&servers, server_name)?;
-                servers[index]
-                    .runtime
-                    .as_ref()
-                    .map(|rt| Arc::clone(&rt.transport))
+            let transport_result = {
+                let servers = read_lock(&manager.state.servers);
+                find_server_index(&servers, server_name).map(|index| {
+                    servers[index]
+                        .runtime
+                        .as_ref()
+                        .map(|rt| Arc::clone(&rt.transport))
+                })
             };
-            if let Some(transport) = transport
-                && let Some(rx) = transport.take_list_changed_receiver().await
-            {
-                spawn_list_changed_watcher(Arc::downgrade(&state), server_name.clone(), rx);
+            let transport = match transport_result {
+                Ok(transport) => transport,
+                Err(error) => {
+                    let _ = manager.close_all().await;
+                    return Err(error);
+                }
+            };
+            if let Some(transport) = transport {
+                if let Some(rx) = transport.take_list_changed_receiver().await {
+                    spawn_list_changed_watcher(
+                        Arc::downgrade(&manager.state),
+                        server_name.clone(),
+                        rx,
+                    );
+                }
+                if let Some(rx) = transport.take_resource_updated_receiver().await {
+                    spawn_resource_updated_forwarder(
+                        manager.state.resource_updated_tx.clone(),
+                        server_name.clone(),
+                        rx,
+                    );
+                }
             }
         }
 
-        Ok(Self { state })
+        Ok(manager)
     }
 
     async fn build_servers(
-        entries: impl IntoIterator<Item = (McpServerConnectionConfig, Arc<dyn McpToolTransport>)>,
+        entries: Vec<(McpServerConnectionConfig, Arc<dyn McpToolTransport>)>,
     ) -> Result<Vec<McpServerSlot>, McpError> {
         let mut servers = Vec::new();
-        let mut names: HashSet<String> = HashSet::new();
         let connected_at = SystemTime::now();
 
         for (cfg, transport) in entries {
-            validate_server_name(&cfg.name)?;
-            if !names.insert(cfg.name.clone()) {
-                return Err(McpError::DuplicateServerName(cfg.name));
-            }
-            let capabilities = transport.server_capabilities().await?;
+            let capabilities = match transport.server_capabilities().await {
+                Ok(capabilities) => capabilities,
+                Err(error) => {
+                    close_transport_best_effort(Arc::clone(&transport), "build_servers").await;
+                    close_servers_best_effort(servers, "build_servers").await;
+                    return Err(error.into());
+                }
+            };
             // Capture the session id (HTTP only; stdio returns None) for
             // the diagnostic snapshot. Done here while we're still async
             // so the snapshot accessor can stay synchronous.
@@ -1816,6 +2122,42 @@ impl McpToolRegistryManager {
         self.state.periodic_refresh.stop().await
     }
 
+    pub async fn close_all(&self) -> Result<(), McpError> {
+        self.stop_periodic_refresh().await;
+        let runtimes: Vec<McpServerRuntime> = {
+            let mut servers = write_lock(&self.state.servers);
+            servers
+                .iter_mut()
+                .filter_map(|slot| {
+                    slot.lifecycle = McpServerLifecycle::Disabled;
+                    slot.published_snapshot = None;
+                    slot.last_known_session_id = None;
+                    slot.runtime.take()
+                })
+                .collect()
+        };
+
+        let mut first_error: Option<McpError> = None;
+        for result in join_all(runtimes.into_iter().map(close_runtime)).await {
+            if let Err(error) = result
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+        if let Err(error) = rebuild_snapshot(self.state.as_ref()).await
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+
+        if let Some(error) = first_error {
+            Err(error)
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn periodic_refresh_running(&self) -> bool {
         self.state.periodic_refresh.is_running()
     }
@@ -1838,13 +2180,13 @@ impl McpToolRegistryManager {
     /// Return a status snapshot for the named server, including connection state and
     /// the most recently discovered tool list.
     ///
-    /// Async because the HTTP session id is read **live** from the
-    /// transport (`current_session_id().await`). The slot keeps a cached
-    /// value at connect/reconnect time but `MCP session expired` triggers
-    /// a silent re-`initialize` that rotates the id without going through
-    /// the reconnect path — the cache would be stale until the next
-    /// reconnect. Reading live closes that window for admin/observability
-    /// consumers.
+    /// Async because HTTP session diagnostics are read **live** from the
+    /// transport (`current_session_id().await` and
+    /// `current_session_started_at().await`). The slot keeps cached
+    /// connect/reconnect values, but `MCP session expired` triggers a
+    /// silent re-`initialize` that rotates the id and timestamp without
+    /// going through the reconnect path. Reading live closes that window
+    /// for admin/observability consumers.
     ///
     /// Returns [`McpError::UnknownServer`] when `server_name` is not registered.
     pub async fn server_status_snapshot(
@@ -1862,7 +2204,7 @@ impl McpToolRegistryManager {
             health,
             cached_session_id,
             reconnect_count,
-            last_init_at,
+            cached_last_init_at,
             transport_for_session,
         ) = {
             let servers = read_lock(&self.state.servers);
@@ -1897,11 +2239,18 @@ impl McpToolRegistryManager {
             )
         };
 
-        // Prefer the live session id from the transport. Falls back to
-        // the cached value (e.g. transport dropped, race during teardown).
-        let session_id = match transport_for_session {
-            Some(transport) => transport.current_session_id().await.or(cached_session_id),
-            None => cached_session_id,
+        // Prefer live HTTP session diagnostics from the transport. Fall
+        // back to cached values when there is no live runtime or when the
+        // transport is stdio and has no HTTP session concept.
+        let (session_id, last_init_at) = match transport_for_session {
+            Some(transport) => (
+                transport.current_session_id().await.or(cached_session_id),
+                transport
+                    .current_session_started_at()
+                    .await
+                    .or(cached_last_init_at),
+            ),
+            None => (cached_session_id, cached_last_init_at),
         };
 
         Ok(McpServerStatusSnapshot {
@@ -2053,6 +2402,74 @@ impl McpToolRegistryManager {
             map_capability_operation_error(server_name, "resources", "read_resource", err)
         })
     }
+
+    /// Subscribe to updates for a single resource URI on `server_name`.
+    /// Requires the server to have advertised `resources.subscribe: true`
+    /// at initialize — otherwise the call returns `McpError::UnsupportedCapability`.
+    /// The host observes the resulting `notifications/resources/updated`
+    /// stream via [`Self::take_resource_updated_receiver`].
+    pub async fn subscribe_resource(&self, server_name: &str, uri: &str) -> Result<(), McpError> {
+        with_runtime_lease(
+            &self.state,
+            server_name,
+            McpRuntimeOpKind::Rpc,
+            require_resources_subscribe,
+            |runtime| async move { runtime.transport.subscribe_resource(uri).await },
+        )
+        .await
+        .map_err(|err| {
+            map_capability_operation_error(server_name, "resources", "subscribe_resource", err)
+        })
+    }
+
+    /// Cancel a prior subscription. Mirrors [`Self::subscribe_resource`].
+    pub async fn unsubscribe_resource(&self, server_name: &str, uri: &str) -> Result<(), McpError> {
+        with_runtime_lease(
+            &self.state,
+            server_name,
+            McpRuntimeOpKind::Rpc,
+            require_resources_subscribe,
+            |runtime| async move { runtime.transport.unsubscribe_resource(uri).await },
+        )
+        .await
+        .map_err(|err| {
+            map_capability_operation_error(server_name, "resources", "unsubscribe_resource", err)
+        })
+    }
+
+    /// Ask `server_name` for argument autocomplete via `completion/complete`.
+    /// Requires the server to have advertised `completions: {}` at
+    /// initialize.
+    pub async fn complete(
+        &self,
+        server_name: &str,
+        params: mcp::CompleteParams,
+    ) -> Result<mcp::CompleteResult, McpError> {
+        with_runtime_lease(
+            &self.state,
+            server_name,
+            McpRuntimeOpKind::Rpc,
+            require_completions,
+            |runtime| async move { runtime.transport.complete(params).await },
+        )
+        .await
+        .map_err(|err| map_capability_operation_error(server_name, "completions", "complete", err))
+    }
+
+    /// Take the multiplexed receiver for `notifications/resources/updated`
+    /// from every connected MCP server. Each event carries the
+    /// `(server, uri)` pair so the host can route reads back through
+    /// [`Self::read_resource`].
+    ///
+    /// One-shot: returns `None` if already taken. Surviving across
+    /// reconnects — when a server reconnects, the manager spawns a
+    /// fresh per-server forwarder feeding into the same channel.
+    pub async fn take_resource_updated_receiver(
+        &self,
+    ) -> Option<tokio::sync::mpsc::UnboundedReceiver<ResourceUpdated>> {
+        self.state.resource_updated_rx.lock().await.take()
+    }
+
     pub async fn reconnect(&self, server_name: &str) -> Result<(), McpError> {
         reconnect_server(&self.state, server_name).await?;
         rebuild_snapshot(self.state.as_ref()).await?;
@@ -2169,6 +2586,7 @@ mod tests {
     use mcp::{CallToolResult, McpToolDefinition};
     use serde_json::json;
     use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::{Notify, Semaphore, mpsc};
 
     // ── Mock transport ──
@@ -2200,6 +2618,45 @@ mod tests {
                 execution: None,
                 annotations: None,
             }
+        }
+    }
+
+    #[derive(Debug)]
+    struct LifecycleRecordingTransport {
+        tools: Vec<McpToolDefinition>,
+        capabilities_error: Option<&'static str>,
+        list_error: Option<&'static str>,
+        capabilities_count: Arc<AtomicUsize>,
+        close_count: Arc<AtomicUsize>,
+    }
+
+    impl LifecycleRecordingTransport {
+        fn new(tool_name: &str) -> Self {
+            Self {
+                tools: vec![MockTransport::tool_def(tool_name)],
+                capabilities_error: None,
+                list_error: None,
+                capabilities_count: Arc::new(AtomicUsize::new(0)),
+                close_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn with_capabilities_error(mut self, error: &'static str) -> Self {
+            self.capabilities_error = Some(error);
+            self
+        }
+
+        fn with_list_error(mut self, error: &'static str) -> Self {
+            self.list_error = Some(error);
+            self
+        }
+
+        fn capabilities_count(&self) -> usize {
+            self.capabilities_count.load(Ordering::SeqCst)
+        }
+
+        fn close_count(&self) -> usize {
+            self.close_count.load(Ordering::SeqCst)
         }
     }
 
@@ -2764,6 +3221,53 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl McpToolTransport for LifecycleRecordingTransport {
+        async fn list_tools(&self) -> Result<Vec<McpToolDefinition>, McpTransportError> {
+            if let Some(error) = self.list_error {
+                return Err(McpTransportError::TransportError(error.to_string()));
+            }
+            Ok(self.tools.clone())
+        }
+
+        async fn call_tool(
+            &self,
+            name: &str,
+            _args: Value,
+            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _context: crate::transport::McpCallContext,
+        ) -> Result<CallToolResult, McpTransportError> {
+            Ok(CallToolResult {
+                content: vec![mcp::ToolContent::Text {
+                    text: format!("called {name}"),
+                    annotations: None,
+                    meta: None,
+                }],
+                structured_content: None,
+                is_error: None,
+            })
+        }
+
+        fn transport_type(&self) -> TransportTypeId {
+            TransportTypeId::Stdio
+        }
+
+        async fn server_capabilities(
+            &self,
+        ) -> Result<Option<ServerCapabilities>, McpTransportError> {
+            self.capabilities_count.fetch_add(1, Ordering::SeqCst);
+            if let Some(error) = self.capabilities_error {
+                return Err(McpTransportError::TransportError(error.to_string()));
+            }
+            Ok(Some(ServerCapabilities::default()))
+        }
+
+        async fn close(&self) -> Result<(), McpTransportError> {
+            self.close_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
     fn cfg(name: &str) -> McpServerConnectionConfig {
         McpServerConnectionConfig::stdio(name, "echo", vec!["ok".to_string()])
     }
@@ -2925,20 +3429,77 @@ mod tests {
 
     #[tokio::test]
     async fn manager_rejects_duplicate_server_names() {
+        let first = Arc::new(LifecycleRecordingTransport::new("first"));
+        let second = Arc::new(LifecycleRecordingTransport::new("second"));
         let result = McpToolRegistryManager::from_transports(vec![
-            (
-                cfg("dup"),
-                Arc::new(MockTransport::default()) as Arc<dyn McpToolTransport>,
-            ),
-            (
-                cfg("dup"),
-                Arc::new(MockTransport::default()) as Arc<dyn McpToolTransport>,
-            ),
+            (cfg("dup"), first.clone() as Arc<dyn McpToolTransport>),
+            (cfg("dup"), second.clone() as Arc<dyn McpToolTransport>),
         ])
         .await;
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, McpError::DuplicateServerName(_)));
+        assert_eq!(
+            first.capabilities_count(),
+            0,
+            "duplicate names must be rejected before initializing transports"
+        );
+        assert_eq!(
+            second.capabilities_count(),
+            0,
+            "duplicate names must be rejected before initializing transports"
+        );
+    }
+
+    #[tokio::test]
+    async fn manager_closes_initialized_transports_when_capabilities_fail() {
+        let ok = Arc::new(LifecycleRecordingTransport::new("ok"));
+        let failing = Arc::new(
+            LifecycleRecordingTransport::new("bad")
+                .with_capabilities_error("scripted capabilities failure"),
+        );
+
+        let result = McpToolRegistryManager::from_transports(vec![
+            (cfg("ok"), ok.clone() as Arc<dyn McpToolTransport>),
+            (cfg("bad"), failing.clone() as Arc<dyn McpToolTransport>),
+        ])
+        .await;
+
+        let err = result.expect_err("capabilities failure should abort connect");
+        assert!(
+            err.to_string().contains("scripted capabilities failure"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(ok.close_count(), 1, "previous runtime must be closed");
+        assert_eq!(
+            failing.close_count(),
+            1,
+            "transport that failed initialization must be closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn manager_closes_runtimes_when_initial_discovery_fails() {
+        let failing = Arc::new(
+            LifecycleRecordingTransport::new("bad").with_list_error("scripted discovery failure"),
+        );
+
+        let result = McpToolRegistryManager::from_transports(vec![(
+            cfg("bad"),
+            failing.clone() as Arc<dyn McpToolTransport>,
+        )])
+        .await;
+
+        let err = result.expect_err("discovery failure should abort connect");
+        assert!(
+            err.to_string().contains("scripted discovery failure"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(
+            failing.close_count(),
+            1,
+            "runtime must be closed when manager construction fails after initialization"
+        );
     }
 
     #[tokio::test]

--- a/crates/awaken-ext-mcp/src/manager.rs
+++ b/crates/awaken-ext-mcp/src/manager.rs
@@ -566,6 +566,12 @@ struct McpRegistryState {
     /// up is what fixes the "all agents share one LLM for sampling"
     /// leak documented in the audit.
     sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
+    /// Client-side roots advertised to every connected MCP server.
+    /// `Arc` so all transports share the same backing list at zero
+    /// allocation cost; empty = `roots` capability not advertised.
+    /// Per spec roots are a client-wide concept, not per-server, so
+    /// this lives on the shared registry state.
+    client_roots: Arc<Vec<mcp::Root>>,
 }
 
 fn read_lock<T>(lock: &RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
@@ -958,9 +964,10 @@ fn reserve_generation(slot: &mut McpServerSlot) -> u64 {
 async fn connect_runtime(
     config: &McpServerConnectionConfig,
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
+    client_roots: Arc<Vec<mcp::Root>>,
     generation: u64,
 ) -> Result<McpServerRuntime, McpError> {
-    let transport = connect_transport(config, sampling_handler).await?;
+    let transport = connect_transport(config, sampling_handler, client_roots).await?;
     let transport_type = transport.transport_type();
     let capabilities = transport.server_capabilities().await?;
     Ok(McpServerRuntime {
@@ -1168,6 +1175,7 @@ async fn reconnect_server_locked(
     server_name: &str,
 ) -> Result<(), McpError> {
     let sampling_handler = state.sampling_handler.clone();
+    let client_roots = Arc::clone(&state.client_roots);
     let (config, generation, attempt, detached_runtime) =
         begin_reconnect_transition(state.as_ref(), server_name)?;
 
@@ -1180,7 +1188,7 @@ async fn reconnect_server_locked(
 
     tokio::time::sleep(reconnect_backoff(attempt)).await;
 
-    let runtime = match connect_runtime(&config, sampling_handler, generation).await {
+    let runtime = match connect_runtime(&config, sampling_handler, client_roots, generation).await {
         Ok(runtime) => runtime,
         Err(err) => {
             finish_reconnect_error(state.as_ref(), server_name, &err)?;
@@ -1206,6 +1214,11 @@ async fn reconnect_server_locked(
     // Capture the freshly-issued session id (HTTP) before we hand the
     // runtime back to the slot map. Stdio's transport returns None.
     let session_id = runtime.transport.current_session_id().await;
+    // Subscribe to the new transport's list_changed notifications
+    // BEFORE handing it back to the slot map: once the runtime is owned
+    // by the slot we have no async access to it. The receiver is
+    // one-shot per transport, so this is the only chance to claim it.
+    let list_changed_rx = runtime.transport.take_list_changed_receiver().await;
     finish_reconnect_success(
         state.as_ref(),
         server_name,
@@ -1214,6 +1227,9 @@ async fn reconnect_server_locked(
         SystemTime::now(),
         session_id,
     )?;
+    if let Some(rx) = list_changed_rx {
+        spawn_list_changed_watcher(Arc::downgrade(state), server_name.to_string(), rx);
+    }
     Ok(())
 }
 
@@ -1356,6 +1372,60 @@ where
             Err(RuntimeOperationError::Transport(err))
         }
     }
+}
+
+/// Consume `notifications/.../list_changed` events from `rx` and refresh
+/// the relevant catalogue for `server_name`.
+///
+/// Spawned per-runtime — the task exits naturally when the transport
+/// drops (channel closes). Per MCP 2025-06-18: a server SHOULD emit
+/// these notifications when its tool / prompt / resource catalogue
+/// mutates, so polling can be supplemented (or replaced over time) by
+/// reactive refresh.
+///
+/// Today the manager only caches the **tools** catalogue, so:
+///   - `Tools`  → drives a `refresh_server` (re-runs `tools/list`)
+///   - `Prompts` / `Resources` → log at debug level. List operations
+///     for those surfaces hit the server live on each agent call;
+///     there's nothing cached locally to invalidate yet. When a future
+///     PR caches them, this is the point to hook in.
+fn spawn_list_changed_watcher(
+    state_weak: Weak<McpRegistryState>,
+    server_name: String,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<crate::transport::ListChangedKind>,
+) {
+    tokio::spawn(async move {
+        while let Some(kind) = rx.recv().await {
+            match kind {
+                crate::transport::ListChangedKind::Tools => {
+                    let Some(state) = state_weak.upgrade() else {
+                        // Registry torn down — nothing to refresh, and
+                        // no one to receive subsequent notifications.
+                        break;
+                    };
+                    if let Err(err) = refresh_server(state, server_name.clone()).await {
+                        tracing::warn!(
+                            error = %err,
+                            server = %server_name,
+                            "list_changed-triggered tools refresh failed"
+                        );
+                    }
+                }
+                crate::transport::ListChangedKind::Prompts
+                | crate::transport::ListChangedKind::Resources => {
+                    tracing::debug!(
+                        server = %server_name,
+                        kind = ?kind,
+                        "list_changed event received; no client-side cache to invalidate today"
+                    );
+                }
+            }
+        }
+        tracing::debug!(
+            server = %server_name,
+            "list_changed watcher exiting (channel closed)"
+        );
+    });
 }
 
 async fn refresh_server(state: Arc<McpRegistryState>, server_name: String) -> Result<(), McpError> {
@@ -1518,14 +1588,41 @@ impl McpToolRegistryManager {
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
         sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
     ) -> Result<Self, McpError> {
+        Self::connect_with_sampling_factory_and_roots(
+            configs,
+            sampling_handler,
+            sampling_handler_factory,
+            Arc::new(Vec::new()),
+        )
+        .await
+    }
+
+    /// Variant of [`Self::connect_with_sampling_factory`] that also
+    /// accepts a client-wide roots list shared across all connected
+    /// servers. The same `Arc` is handed to every transport at
+    /// construction so the initialize-handshake `roots` capability and
+    /// the in-band `roots/list` response stay consistent.
+    pub async fn connect_with_sampling_factory_and_roots(
+        configs: impl IntoIterator<Item = McpServerConnectionConfig>,
+        sampling_handler: Option<Arc<dyn SamplingHandler>>,
+        sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
+        client_roots: Arc<Vec<mcp::Root>>,
+    ) -> Result<Self, McpError> {
         let mut entries: Vec<(McpServerConnectionConfig, Arc<dyn McpToolTransport>)> = Vec::new();
         for cfg in configs {
             validate_server_name(&cfg.name)?;
-            let transport = connect_transport(&cfg, sampling_handler.clone()).await?;
+            let transport =
+                connect_transport(&cfg, sampling_handler.clone(), Arc::clone(&client_roots))
+                    .await?;
             entries.push((cfg, transport));
         }
-        Self::from_tool_transports_with_factory(entries, sampling_handler, sampling_handler_factory)
-            .await
+        Self::from_tool_transports_with_factory_and_roots(
+            entries,
+            sampling_handler,
+            sampling_handler_factory,
+            client_roots,
+        )
+        .await
     }
 
     pub async fn from_transports(
@@ -1548,10 +1645,34 @@ impl McpToolRegistryManager {
     /// during that call then routes to the calling agent's LLM
     /// executor. When `None`, sampling falls back to the fixed
     /// `sampling_handler` (legacy behaviour).
+    ///
+    /// Delegates to [`Self::from_tool_transports_with_factory_and_roots`]
+    /// with an empty roots list (the `roots` capability is not
+    /// advertised; server-initiated `roots/list` returns
+    /// method-not-supported).
     pub async fn from_tool_transports_with_factory(
         entries: impl IntoIterator<Item = (McpServerConnectionConfig, Arc<dyn McpToolTransport>)>,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
         sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
+    ) -> Result<Self, McpError> {
+        Self::from_tool_transports_with_factory_and_roots(
+            entries,
+            sampling_handler,
+            sampling_handler_factory,
+            Arc::new(Vec::new()),
+        )
+        .await
+    }
+
+    /// Variant of [`Self::from_tool_transports_with_factory`] that
+    /// also accepts a client-wide roots list. When non-empty,
+    /// transports advertise the `roots` capability during `initialize`
+    /// and serve `roots/list` from this list.
+    pub async fn from_tool_transports_with_factory_and_roots(
+        entries: impl IntoIterator<Item = (McpServerConnectionConfig, Arc<dyn McpToolTransport>)>,
+        sampling_handler: Option<Arc<dyn SamplingHandler>>,
+        sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
+        client_roots: Arc<Vec<mcp::Root>>,
     ) -> Result<Self, McpError> {
         let servers = Self::build_servers(entries).await?;
         let state = Arc::new(McpRegistryState {
@@ -1560,25 +1681,49 @@ impl McpToolRegistryManager {
             periodic_refresh: PeriodicRefresher::new(),
             sampling_handler,
             sampling_handler_factory,
+            client_roots,
         });
 
         let server_names: Vec<String> = {
             let servers = read_lock(&state.servers);
             servers.iter().map(|slot| slot.meta.name.clone()).collect()
         };
-        for server_name in server_names {
+        for server_name in &server_names {
             let attempted_at = SystemTime::now();
-            let runtime = resolve_live_runtime(&Arc::downgrade(&state), &server_name)?;
+            let runtime = resolve_live_runtime(&Arc::downgrade(&state), server_name)?;
             let catalog = discover_catalog_from_lease(Arc::downgrade(&state), &runtime).await?;
             let _ = apply_catalog_if_current(
                 state.as_ref(),
-                &server_name,
+                server_name,
                 runtime.generation,
                 attempted_at,
                 catalog,
             )?;
         }
         rebuild_snapshot(state.as_ref()).await?;
+
+        // Subscribe to each transport's `notifications/.../list_changed`
+        // stream so we react to server-initiated catalogue mutations
+        // instead of waiting for the next periodic refresh tick. The
+        // receiver is one-shot per transport; this is the only place
+        // we claim it for the initial connect. (The reconnect path
+        // claims it at `finish_reconnect_success`.)
+        for server_name in &server_names {
+            let transport = {
+                let servers = read_lock(&state.servers);
+                let index = find_server_index(&servers, server_name)?;
+                servers[index]
+                    .runtime
+                    .as_ref()
+                    .map(|rt| Arc::clone(&rt.transport))
+            };
+            if let Some(transport) = transport
+                && let Some(rx) = transport.take_list_changed_receiver().await
+            {
+                spawn_list_changed_watcher(Arc::downgrade(&state), server_name.clone(), rx);
+            }
+        }
+
         Ok(Self { state })
     }
 

--- a/crates/awaken-ext-mcp/src/manager.rs
+++ b/crates/awaken-ext-mcp/src/manager.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use awaken_contract::PeriodicRefresher;
 use awaken_contract::contract::progress::ProgressStatus;
 use awaken_contract::contract::tool::{
-    Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
+    Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult, ToolStatus,
 };
 use futures::future::join_all;
 use mcp::McpToolDefinition;
@@ -25,8 +25,9 @@ use crate::progress::{
 };
 use crate::sampling::{SamplingHandler, SamplingHandlerFactory};
 use crate::transport::{
-    CANCELLED_BY_CLIENT, McpPromptDefinition, McpPromptResult, McpResourceDefinition,
-    McpToolTransport, call_result_to_tool_data, connect_transport,
+    CANCELLED_BY_CLIENT, ListChangedKind, MCP_PROGRESS_CHANNEL_CAPACITY, McpPromptDefinition,
+    McpPromptResult, McpResourceDefinition, McpToolTransport, call_result_to_tool_data,
+    connect_transport,
 };
 
 // ── Metadata constants ──
@@ -39,9 +40,14 @@ const MCP_META_UI_CONTENT: &str = "mcp.ui.content";
 const MCP_META_UI_MIME_TYPE: &str = "mcp.ui.mimeType";
 const MCP_META_RESULT_CONTENT: &str = "mcp.result.content";
 const MCP_META_RESULT_STRUCTURED_CONTENT: &str = "mcp.result.structuredContent";
+const MCP_META_RESULT_IS_ERROR: &str = "mcp.result.isError";
 const FAILURE_THRESHOLD: u64 = 3;
 const MAX_RECONNECT_ATTEMPTS: u32 = 5;
 const RESOURCE_UPDATED_CHANNEL_CAPACITY: usize = 1024;
+
+fn ui_resource_hydration_timeout() -> Duration {
+    Duration::from_millis(500)
+}
 
 // ── Helper types ──
 
@@ -261,7 +267,7 @@ impl Tool for McpTool {
             McpRuntimeOpKind::Rpc,
             |_| Ok(()),
             move |runtime| async move {
-                let (progress_tx, mut progress_rx) = mpsc::unbounded_channel();
+                let (progress_tx, mut progress_rx) = mpsc::channel(MCP_PROGRESS_CHANNEL_CAPACITY);
                 let mut call = Box::pin(runtime.transport.call_tool(
                     &tool_name,
                     args,
@@ -299,7 +305,18 @@ impl Tool for McpTool {
         };
 
         let data = call_result_to_tool_data(&res);
-        let mut result = ToolResult::success(self.descriptor.id.clone(), data);
+        let mut result = if res.is_error == Some(true) {
+            ToolResult {
+                tool_name: self.descriptor.id.clone(),
+                status: ToolStatus::Error,
+                data,
+                message: Some(crate::transport::tool_result_error_text(&res)),
+                suspension: None,
+                metadata: HashMap::new(),
+            }
+        } else {
+            ToolResult::success(self.descriptor.id.clone(), data)
+        };
 
         result.metadata.insert(
             MCP_META_SERVER.to_string(),
@@ -321,6 +338,11 @@ impl Tool for McpTool {
             result
                 .metadata
                 .insert(MCP_META_RESULT_STRUCTURED_CONTENT.to_string(), structured);
+        }
+        if res.is_error == Some(true) {
+            result
+                .metadata
+                .insert(MCP_META_RESULT_IS_ERROR.to_string(), Value::Bool(true));
         }
 
         if let Some(ref uri) = self.ui_resource_uri
@@ -353,15 +375,38 @@ async fn fetch_ui_resource(
     server_name: &str,
     uri: &str,
 ) -> Option<UiResourceContent> {
-    let value = with_runtime_lease(
-        state,
-        server_name,
-        McpRuntimeOpKind::Rpc,
-        |_| Ok(()),
-        |runtime| async move { runtime.transport.read_resource(uri).await },
+    tokio::time::timeout(
+        ui_resource_hydration_timeout(),
+        fetch_ui_resource_inner(state, server_name, uri),
     )
     .await
-    .ok()?;
+    .ok()
+    .flatten()
+}
+
+async fn fetch_ui_resource_inner(
+    state: &Arc<McpRegistryState>,
+    server_name: &str,
+    uri: &str,
+) -> Option<UiResourceContent> {
+    let mut runtime = {
+        let servers = read_lock(&state.servers);
+        let index = find_server_index(&servers, server_name).ok()?;
+        runtime_lease(&servers[index]).ok()?
+    };
+
+    if let Ok(live_capabilities) = runtime.transport.server_capabilities().await {
+        runtime.capabilities = live_capabilities.clone();
+        update_runtime_capabilities(
+            state.as_ref(),
+            server_name,
+            runtime.generation,
+            live_capabilities,
+        );
+    }
+
+    require_resources(&runtime).ok()?;
+    let value = runtime.transport.read_resource(uri).await.ok()?;
     let contents = value.get("contents")?.as_array()?;
     let first = contents.first()?;
     let text = first.get("text")?.as_str()?.to_string();
@@ -1569,7 +1614,7 @@ where
 fn spawn_resource_updated_forwarder(
     tx: tokio::sync::mpsc::Sender<ResourceUpdated>,
     server_name: String,
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+    mut rx: tokio::sync::mpsc::Receiver<String>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(uri) = rx.recv().await {
@@ -1592,32 +1637,40 @@ fn spawn_resource_updated_forwarder(
     })
 }
 
-/// Consume `notifications/.../list_changed` events from `rx` and refresh
-/// the relevant catalogue for `server_name`.
+/// Consume `notifications/tools/list_changed` events from `rx` and refresh
+/// the cached tools catalogue for `server_name`.
 ///
 /// Spawned per-runtime — the task exits naturally when the transport
 /// drops (channel closes). Per MCP 2025-06-18: a server SHOULD emit
-/// these notifications when its tool / prompt / resource catalogue
-/// mutates, so polling can be supplemented (or replaced over time) by
-/// reactive refresh.
+/// this notification when its tool catalogue mutates, so polling can be
+/// supplemented (or replaced over time) by reactive refresh.
 ///
 /// Today the manager only caches the **tools** catalogue, so `Tools`
-/// drives a `refresh_server` (re-running `tools/list`); `Prompts` and
-/// `Resources` are logged at debug level since list operations for
-/// those surfaces hit the server live on each agent call.
+/// drives a `refresh_server` (re-running `tools/list`). Prompt/resource
+/// list operations hit the server live on each agent call.
 fn spawn_list_changed_watcher(
     state_weak: Weak<McpRegistryState>,
     server_name: String,
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<crate::transport::ListChangedKind>,
+    mut rx: tokio::sync::mpsc::Receiver<ListChangedKind>,
 ) {
     tokio::spawn(async move {
+        let mut pending = HashSet::<ListChangedKind>::new();
         while let Some(kind) = rx.recv().await {
-            match kind {
-                crate::transport::ListChangedKind::Tools => {
+            pending.insert(kind);
+            while let Ok(kind) = rx.try_recv() {
+                pending.insert(kind);
+            }
+
+            loop {
+                let refresh_tools = pending.remove(&ListChangedKind::Tools);
+                let saw_prompts = pending.remove(&ListChangedKind::Prompts);
+                let saw_resources = pending.remove(&ListChangedKind::Resources);
+
+                if refresh_tools {
                     let Some(state) = state_weak.upgrade() else {
                         // Registry torn down — nothing to refresh, and
                         // no one to receive subsequent notifications.
-                        break;
+                        return;
                     };
                     if let Err(err) = refresh_server(Arc::clone(&state), server_name.clone()).await
                     {
@@ -1644,13 +1697,21 @@ fn spawn_list_changed_watcher(
                         );
                     }
                 }
-                crate::transport::ListChangedKind::Prompts
-                | crate::transport::ListChangedKind::Resources => {
+
+                if saw_prompts || saw_resources {
                     tracing::debug!(
                         server = %server_name,
-                        kind = ?kind,
+                        prompts = saw_prompts,
+                        resources = saw_resources,
                         "list_changed event received; no client-side cache to invalidate today"
                     );
+                }
+
+                while let Ok(kind) = rx.try_recv() {
+                    pending.insert(kind);
+                }
+                if pending.is_empty() {
+                    break;
                 }
             }
         }
@@ -2634,6 +2695,65 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct ListChangedTransport {
+        tools: Vec<McpToolDefinition>,
+        list_calls: Arc<AtomicUsize>,
+        list_changed_rx: tokio::sync::Mutex<Option<mpsc::Receiver<ListChangedKind>>>,
+    }
+
+    impl ListChangedTransport {
+        fn new(
+            tools: Vec<McpToolDefinition>,
+        ) -> (Self, mpsc::Sender<ListChangedKind>, Arc<AtomicUsize>) {
+            let (tx, rx) = mpsc::channel(crate::transport::LIST_CHANGED_CHANNEL_CAPACITY);
+            let list_calls = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    tools,
+                    list_calls: Arc::clone(&list_calls),
+                    list_changed_rx: tokio::sync::Mutex::new(Some(rx)),
+                },
+                tx,
+                list_calls,
+            )
+        }
+    }
+
+    #[async_trait]
+    impl McpToolTransport for ListChangedTransport {
+        async fn list_tools(&self) -> Result<Vec<McpToolDefinition>, McpTransportError> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.tools.clone())
+        }
+
+        async fn call_tool(
+            &self,
+            name: &str,
+            _args: Value,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
+            _context: crate::transport::McpCallContext,
+        ) -> Result<CallToolResult, McpTransportError> {
+            Ok(CallToolResult {
+                content: vec![mcp::ToolContent::Text {
+                    text: format!("called {name}"),
+                    annotations: None,
+                    meta: None,
+                }],
+                structured_content: None,
+                is_error: None,
+            })
+        }
+
+        fn transport_type(&self) -> TransportTypeId {
+            TransportTypeId::Stdio
+        }
+
+        async fn take_list_changed_receiver(&self) -> Option<mpsc::Receiver<ListChangedKind>> {
+            self.list_changed_rx.lock().await.take()
+        }
+    }
+
+    #[derive(Debug)]
     struct LifecycleRecordingTransport {
         tools: Vec<McpToolDefinition>,
         capabilities_error: Option<&'static str>,
@@ -2795,7 +2915,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -2824,7 +2944,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -2859,7 +2979,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -2894,7 +3014,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -2943,7 +3063,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -2990,7 +3110,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -3040,7 +3160,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -3105,7 +3225,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             self.calls.lock().unwrap().push(name.to_string());
@@ -3160,7 +3280,7 @@ mod tests {
             &self,
             _name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             if self.connection_closed {
@@ -3201,7 +3321,7 @@ mod tests {
             &self,
             _name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             unreachable!()
@@ -3222,7 +3342,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -3260,7 +3380,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -3550,7 +3670,7 @@ mod tests {
                 &self,
                 _name: &str,
                 _args: Value,
-                _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+                _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
                 _context: crate::transport::McpCallContext,
             ) -> Result<CallToolResult, McpTransportError> {
                 unreachable!()
@@ -4409,12 +4529,14 @@ mod tests {
     async fn resource_update_forwarder_drops_when_manager_channel_full() {
         let (manager_tx, mut manager_rx) =
             tokio::sync::mpsc::channel::<ResourceUpdated>(RESOURCE_UPDATED_CHANNEL_CAPACITY);
-        let (transport_tx, transport_rx) = mpsc::unbounded_channel::<String>();
+        let (transport_tx, transport_rx) =
+            mpsc::channel::<String>(RESOURCE_UPDATED_CHANNEL_CAPACITY);
         let handle = spawn_resource_updated_forwarder(manager_tx, "srv".to_string(), transport_rx);
 
         for idx in 0..(RESOURCE_UPDATED_CHANNEL_CAPACITY * 2) {
             transport_tx
                 .send(format!("file:///resource-{idx}"))
+                .await
                 .expect("transport receiver alive");
         }
         drop(transport_tx);
@@ -4430,6 +4552,44 @@ mod tests {
             drained += 1;
         }
         assert_eq!(drained, RESOURCE_UPDATED_CHANNEL_CAPACITY);
+    }
+
+    #[tokio::test]
+    async fn list_changed_watcher_coalesces_bursts() {
+        let (transport, tx, list_calls) =
+            ListChangedTransport::new(vec![MockTransport::tool_def("echo")]);
+        for _ in 0..crate::transport::LIST_CHANGED_CHANNEL_CAPACITY {
+            tx.try_send(ListChangedKind::Tools)
+                .expect("list_changed channel accepts bounded burst");
+        }
+        assert!(
+            tx.try_send(ListChangedKind::Tools).is_err(),
+            "list_changed ingress must be bounded"
+        );
+
+        let manager = McpToolRegistryManager::from_transports([(
+            cfg("srv"),
+            Arc::new(transport) as Arc<dyn McpToolTransport>,
+        )])
+        .await
+        .unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while list_calls.load(Ordering::SeqCst) < 2 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "coalesced list_changed refresh did not run"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            list_calls.load(Ordering::SeqCst),
+            2,
+            "initial discovery plus one coalesced refresh should handle the entire burst"
+        );
+        assert!(manager.registry().get("mcp__srv__echo").is_some());
     }
 
     #[tokio::test]

--- a/crates/awaken-ext-mcp/src/manager.rs
+++ b/crates/awaken-ext-mcp/src/manager.rs
@@ -200,6 +200,22 @@ impl Tool for McpTool {
             ));
         };
         let tool_name = self.tool_name.clone();
+        // Build vendor-attribution metadata from the calling agent/thread/run
+        // identity so the MCP server can correlate, rate-limit, or audit per
+        // tenant. Carried via JSON-RPC `params._meta.awaken/attribution` —
+        // see `McpCallMetadata` for the on-wire shape.
+        let metadata = crate::transport::McpCallMetadata {
+            agent_id: Some(ctx.run_identity.agent_id.clone()),
+            thread_id: Some(ctx.run_identity.thread_id.clone()),
+            run_id: Some(ctx.run_identity.run_id.clone()),
+            call_id: Some(ctx.call_id.clone()),
+            parent_run_id: ctx.run_identity.parent_run_id.clone(),
+            parent_call_id: ctx.run_identity.parent_tool_call_id.clone(),
+        };
+        // Propagate run cancellation to the MCP transport so it can emit
+        // `notifications/cancelled` (spec 2025-06-18 §Cancellation) and
+        // free server-side resources when the agent run is torn down.
+        let cancellation = ctx.cancellation_token.clone();
         let res = match with_runtime_lease(
             &state,
             &self.server_name,
@@ -211,6 +227,8 @@ impl Tool for McpTool {
                     &tool_name,
                     args,
                     Some(progress_tx),
+                    metadata,
+                    cancellation,
                 ));
                 let mut gate = ProgressEmitGate::default();
 
@@ -2002,6 +2020,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2030,6 +2050,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2064,6 +2086,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2098,6 +2122,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2146,6 +2172,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2192,6 +2220,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2241,6 +2271,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2305,6 +2337,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             self.calls.lock().unwrap().push(name.to_string());
             Ok(CallToolResult {
@@ -2349,6 +2383,8 @@ mod tests {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             if self.connection_closed {
                 Err(McpTransportError::ConnectionClosed)
@@ -2385,6 +2421,8 @@ mod tests {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             unreachable!()
         }
@@ -2405,6 +2443,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {
@@ -2625,6 +2665,8 @@ mod tests {
                 _name: &str,
                 _args: Value,
                 _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+                _metadata: crate::transport::McpCallMetadata,
+                _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
             ) -> Result<CallToolResult, McpTransportError> {
                 unreachable!()
             }

--- a/crates/awaken-ext-mcp/src/plugin.rs
+++ b/crates/awaken-ext-mcp/src/plugin.rs
@@ -10,9 +10,10 @@ use crate::manager::McpToolRegistry;
 /// Takes a snapshot of the [`McpToolRegistry`] at `register()` time and registers
 /// each discovered MCP tool through the [`PluginRegistrar`].
 ///
-/// **Known limitation**: tools are snapshotted once during `register()`. If MCP
-/// servers add or remove tools after registration (e.g. via periodic refresh),
-/// those changes will not be reflected until the next resolve cycle.
+/// **Known limitation**: tools are snapshotted once during `register()`. The
+/// underlying manager registry can refresh in response to periodic refresh or
+/// `notifications/tools/list_changed`, but an already-built awaken runtime
+/// keeps its registered tool set until the next resolve/register cycle.
 pub struct McpPlugin {
     registry: McpToolRegistry,
 }
@@ -49,7 +50,7 @@ mod tests {
     use mcp::transport::{McpTransportError, ServerCapabilities, TransportTypeId};
     use mcp::{CallToolResult, McpToolDefinition};
     use serde_json::{Value, json};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
 
     #[derive(Debug, Default)]
@@ -63,6 +64,23 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default)]
+    struct MutableMockTransport {
+        tools: Arc<Mutex<Vec<McpToolDefinition>>>,
+    }
+
+    impl MutableMockTransport {
+        fn with_tools(tools: Vec<McpToolDefinition>) -> Self {
+            Self {
+                tools: Arc::new(Mutex::new(tools)),
+            }
+        }
+
+        fn set_tools(&self, tools: Vec<McpToolDefinition>) {
+            *self.tools.lock().unwrap() = tools;
+        }
+    }
+
     #[async_trait]
     impl McpToolTransport for MockTransport {
         async fn list_tools(&self) -> Result<Vec<McpToolDefinition>, McpTransportError> {
@@ -73,7 +91,7 @@ mod tests {
             &self,
             name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
@@ -95,6 +113,35 @@ mod tests {
             &self,
         ) -> Result<Option<ServerCapabilities>, McpTransportError> {
             Ok(None)
+        }
+    }
+
+    #[async_trait]
+    impl McpToolTransport for MutableMockTransport {
+        async fn list_tools(&self) -> Result<Vec<McpToolDefinition>, McpTransportError> {
+            Ok(self.tools.lock().unwrap().clone())
+        }
+
+        async fn call_tool(
+            &self,
+            name: &str,
+            _args: Value,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
+            _context: crate::transport::McpCallContext,
+        ) -> Result<CallToolResult, McpTransportError> {
+            Ok(CallToolResult {
+                content: vec![mcp::ToolContent::Text {
+                    text: format!("called {name}"),
+                    annotations: None,
+                    meta: None,
+                }],
+                structured_content: None,
+                is_error: None,
+            })
+        }
+
+        fn transport_type(&self) -> TransportTypeId {
+            TransportTypeId::Stdio
         }
     }
 
@@ -185,5 +232,41 @@ mod tests {
 
         let tool_ids = registrar.tool_ids_for_test();
         assert_eq!(tool_ids.len(), 3, "expected 3 tools, got: {tool_ids:?}");
+    }
+
+    #[tokio::test]
+    async fn register_uses_current_registry_snapshot_per_resolve_cycle() {
+        let transport = Arc::new(MutableMockTransport::with_tools(vec![tool_def("alpha")]));
+        let manager = McpToolRegistryManager::from_transports([(
+            cfg("server_a"),
+            Arc::clone(&transport) as Arc<dyn McpToolTransport>,
+        )])
+        .await
+        .unwrap();
+        let plugin = McpPlugin::new(manager.registry());
+
+        let mut first_registrar = PluginRegistrar::new_for_test();
+        plugin.register(&mut first_registrar).unwrap();
+        assert_eq!(
+            first_registrar.tool_ids_for_test(),
+            vec!["mcp__server_a__alpha".to_string()]
+        );
+
+        transport.set_tools(vec![tool_def("beta")]);
+        manager.refresh().await.unwrap();
+
+        assert_eq!(
+            first_registrar.tool_ids_for_test(),
+            vec!["mcp__server_a__alpha".to_string()],
+            "an already-built runtime registrar is not mutated after MCP list_changed/refresh"
+        );
+
+        let mut second_registrar = PluginRegistrar::new_for_test();
+        plugin.register(&mut second_registrar).unwrap();
+        assert_eq!(
+            second_registrar.tool_ids_for_test(),
+            vec!["mcp__server_a__beta".to_string()],
+            "a new resolve/register cycle observes the refreshed MCP registry snapshot"
+        );
     }
 }

--- a/crates/awaken-ext-mcp/src/plugin.rs
+++ b/crates/awaken-ext-mcp/src/plugin.rs
@@ -74,8 +74,7 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: crate::transport::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: crate::transport::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {

--- a/crates/awaken-ext-mcp/src/plugin.rs
+++ b/crates/awaken-ext-mcp/src/plugin.rs
@@ -74,6 +74,8 @@ mod tests {
             name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: crate::transport::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(CallToolResult {
                 content: vec![mcp::ToolContent::Text {

--- a/crates/awaken-ext-mcp/src/sampling.rs
+++ b/crates/awaken-ext-mcp/src/sampling.rs
@@ -33,11 +33,24 @@ pub trait SamplingHandler: Send + Sync {
 /// at the registry level (the previous design leak documented in
 /// `awaken-ext-mcp` audit).
 ///
-/// Returns `None` when the agent shouldn't receive sampling (e.g.
-/// agent's `model_id` doesn't resolve, or the runtime explicitly opts
-/// out). The transport then falls back to its registry-level fixed
-/// handler — when even that is `None`, the server-initiated request is
-/// rejected with a JSON-RPC method-not-supported error.
+/// `for_agent` returns:
+/// - `Some(handler)` — bind this agent's call to that handler;
+///   `sampling/createMessage` during the call routes there.
+/// - `None` — the factory **explicitly refuses** to bind this agent
+///   (e.g. `agent.model_id` doesn't resolve, agent opted out, tenant
+///   has no sampling quota). The manager maps this to
+///   `McpCallSampling::Denied`; the transport then rejects the
+///   server-initiated `sampling/createMessage` with JSON-RPC
+///   method-not-supported. **It does NOT fall back to the registry-
+///   level fixed handler** — falling through would re-introduce the
+///   cross-agent leak this factory exists to prevent.
+///
+/// The "no factory configured at all" case is a separate state
+/// (`McpCallSampling::Inherit`) and is the only path that falls back
+/// to the transport-level fixed handler. See [`McpCallSampling`] in
+/// `awaken_ext_mcp::transport` for the full three-state semantics.
+///
+/// [`McpCallSampling`]: crate::transport::McpCallSampling
 #[async_trait]
 pub trait SamplingHandlerFactory: Send + Sync {
     async fn for_agent(&self, agent_spec: &AgentSpec) -> Option<Arc<dyn SamplingHandler>>;
@@ -99,13 +112,19 @@ impl DefaultSamplingHandler {
     /// error so the server learns its sampling request can't be
     /// serviced and can decide how to proceed (retry with text only,
     /// fall back to a different client, etc).
+    ///
+    /// Multiple text blocks within a single message are joined with a
+    /// blank line ("\n\n") so `"hello"` + `"world"` becomes
+    /// `"hello\n\nworld"`, not `"helloworld"`. The spec doesn't
+    /// prescribe a join; blank-line is the convention for prose
+    /// paragraphs and avoids accidentally fusing tokens.
     fn convert_messages(params: &CreateMessageParams) -> Result<Vec<Message>, McpTransportError> {
         let mut out = Vec::with_capacity(params.messages.len());
         for msg in &params.messages {
-            let mut text = String::new();
+            let mut text_parts: Vec<&str> = Vec::with_capacity(msg.content.len());
             for block in &msg.content {
                 match block {
-                    SamplingContent::Text { text: t, .. } => text.push_str(t),
+                    SamplingContent::Text { text: t, .. } => text_parts.push(t.as_str()),
                     other => {
                         return Err(McpTransportError::TransportError(format!(
                             "sampling request contains unsupported content kind: {} \
@@ -116,9 +135,10 @@ impl DefaultSamplingHandler {
                     }
                 }
             }
+            let joined = text_parts.join("\n\n");
             out.push(match msg.role {
-                mcp::Role::User => Message::user(text),
-                mcp::Role::Assistant => Message::assistant(text),
+                mcp::Role::User => Message::user(joined),
+                mcp::Role::Assistant => Message::assistant(joined),
             });
         }
         Ok(out)
@@ -176,12 +196,65 @@ fn sampling_content_kind(content: &SamplingContent) -> &'static str {
     }
 }
 
+/// Reject sampling requests whose presence would silently change LLM
+/// behaviour. The MCP spec lets the server specify model preferences,
+/// stop sequences, tool choice, etc.; awaken's handler currently maps
+/// only a small subset (system prompt, temperature, max_tokens), so
+/// honouring these would produce a different reply than the server
+/// asked for — a class of bug that's invisible until model output goes
+/// subtly wrong. Returning an error puts the burden back on the server
+/// to either retry without the unsupported field or fall over to a
+/// different client.
+///
+/// Returns `Err` with a human-readable description of the offending
+/// field. `Ok(())` means every behavioural field is either absent or
+/// in awaken's supported subset.
+fn reject_unsupported_sampling_fields(
+    params: &CreateMessageParams,
+) -> Result<(), McpTransportError> {
+    let mut unsupported: Vec<&'static str> = Vec::new();
+    if params
+        .stop_sequences
+        .as_ref()
+        .is_some_and(|s| !s.is_empty())
+    {
+        unsupported.push("stopSequences");
+    }
+    if params.include_context.is_some() {
+        unsupported.push("includeContext");
+    }
+    if params.model_preferences.is_some() {
+        unsupported.push("modelPreferences");
+    }
+    if params.tools.as_ref().is_some_and(|t| !t.is_empty()) {
+        unsupported.push("tools");
+    }
+    if params.tool_choice.is_some() {
+        unsupported.push("toolChoice");
+    }
+    if !unsupported.is_empty() {
+        return Err(McpTransportError::TransportError(format!(
+            "sampling request sets unsupported field(s): {} \
+             (awaken's DefaultSamplingHandler maps systemPrompt, \
+             temperature, maxTokens only; honouring others silently \
+             would change the LLM's reply away from what the server \
+             requested)",
+            unsupported.join(", ")
+        )));
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl SamplingHandler for DefaultSamplingHandler {
     async fn handle_create_message(
         &self,
         params: CreateMessageParams,
     ) -> Result<CreateMessageResult, McpTransportError> {
+        // Reject BEFORE message conversion so the server sees the
+        // field-level objection even when content happens to be valid.
+        reject_unsupported_sampling_fields(&params)?;
+
         let messages = Self::convert_messages(&params)?;
         if messages.is_empty() {
             return Err(McpTransportError::TransportError(
@@ -466,6 +539,102 @@ mod tests {
         assert_eq!(mcp_result.stop_reason.as_deref(), Some("endTurn"));
         assert!(matches!(mcp_result.role, mcp::Role::Assistant));
         assert_eq!(mcp_result.content.len(), 1);
+    }
+
+    #[test]
+    fn convert_messages_joins_multi_text_with_blank_line() {
+        // Prior version used push_str with no separator, so
+        // ["hello", "world"] became "helloworld". Blank-line join
+        // preserves the boundary so consumers can still see the
+        // paragraph structure the server sent.
+        let params = CreateMessageParams {
+            messages: vec![SamplingMessage {
+                role: mcp::Role::User,
+                content: vec![
+                    SamplingContent::Text {
+                        text: "hello".into(),
+                        annotations: None,
+                        meta: None,
+                    },
+                    SamplingContent::Text {
+                        text: "world".into(),
+                        annotations: None,
+                        meta: None,
+                    },
+                ],
+                meta: None,
+            }],
+            model_preferences: None,
+            system_prompt: None,
+            include_context: None,
+            temperature: None,
+            max_tokens: 1024,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+            task: None,
+            meta: None,
+        };
+        let msgs = DefaultSamplingHandler::convert_messages(&params).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].text(), "hello\n\nworld");
+    }
+
+    #[tokio::test]
+    async fn handle_create_message_rejects_stop_sequences() {
+        let executor = Arc::new(MockLlm {
+            response_text: "ignored".into(),
+        });
+        let handler = DefaultSamplingHandler::new(executor, "m");
+        let mut params = make_params("hi");
+        params.stop_sequences = Some(vec!["STOP".into()]);
+        let err = handler
+            .handle_create_message(params)
+            .await
+            .expect_err("stopSequences must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("stopSequences"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn handle_create_message_rejects_tool_choice() {
+        let executor = Arc::new(MockLlm {
+            response_text: "ignored".into(),
+        });
+        let handler = DefaultSamplingHandler::new(executor, "m");
+        let mut params = make_params("hi");
+        params.tool_choice = Some(mcp::ToolChoice {
+            mode: Some(mcp::ToolChoiceMode::Required),
+        });
+        let err = handler
+            .handle_create_message(params)
+            .await
+            .expect_err("toolChoice must be rejected");
+        assert!(format!("{err}").contains("toolChoice"));
+    }
+
+    #[tokio::test]
+    async fn handle_create_message_rejects_include_context_and_model_preferences() {
+        let executor = Arc::new(MockLlm {
+            response_text: "ignored".into(),
+        });
+        let handler = DefaultSamplingHandler::new(executor, "m");
+        let mut params = make_params("hi");
+        params.include_context = Some("thisServer".into());
+        params.model_preferences = Some(mcp::ModelPreferences {
+            hints: None,
+            cost_priority: None,
+            speed_priority: None,
+            intelligence_priority: None,
+        });
+        let err = handler
+            .handle_create_message(params)
+            .await
+            .expect_err("must reject");
+        let msg = format!("{err}");
+        assert!(msg.contains("includeContext"), "got: {msg}");
+        assert!(msg.contains("modelPreferences"), "got: {msg}");
     }
 
     #[tokio::test]

--- a/crates/awaken-ext-mcp/src/sampling.rs
+++ b/crates/awaken-ext-mcp/src/sampling.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use awaken_contract::AgentSpec;
 use awaken_contract::contract::content::ContentBlock;
 use awaken_contract::contract::executor::{InferenceRequest, LlmExecutor};
 use awaken_contract::contract::message::Message;
@@ -22,6 +23,47 @@ pub trait SamplingHandler: Send + Sync {
         &self,
         params: CreateMessageParams,
     ) -> Result<CreateMessageResult, McpTransportError>;
+}
+
+/// Factory that constructs a per-call [`SamplingHandler`] given the agent
+/// initiating an MCP tool call. Lets awaken route server-initiated
+/// `sampling/createMessage` requests to the **calling agent's** LLM
+/// executor — different agents using different models will see their own
+/// LLM respond to MCP sampling, instead of all sharing one fixed handler
+/// at the registry level (the previous design leak documented in
+/// `awaken-ext-mcp` audit).
+///
+/// Returns `None` when the agent shouldn't receive sampling (e.g.
+/// agent's `model_id` doesn't resolve, or the runtime explicitly opts
+/// out). The transport then falls back to its registry-level fixed
+/// handler — when even that is `None`, the server-initiated request is
+/// rejected with a JSON-RPC method-not-supported error.
+#[async_trait]
+pub trait SamplingHandlerFactory: Send + Sync {
+    async fn for_agent(&self, agent_spec: &AgentSpec) -> Option<Arc<dyn SamplingHandler>>;
+}
+
+/// Trivial factory that ignores the agent and always returns the same
+/// handler. Preserves the pre-R1 behaviour of "one fixed handler for all
+/// agents". New runtime wiring should provide a registry-driven factory
+/// that resolves the agent's `model_id` → provider → `LlmExecutor` and
+/// wraps it in [`DefaultSamplingHandler`] — that's the per-agent fix the
+/// MCP audit identified.
+pub struct FixedSamplingHandlerFactory {
+    handler: Arc<dyn SamplingHandler>,
+}
+
+impl FixedSamplingHandlerFactory {
+    pub fn new(handler: Arc<dyn SamplingHandler>) -> Self {
+        Self { handler }
+    }
+}
+
+#[async_trait]
+impl SamplingHandlerFactory for FixedSamplingHandlerFactory {
+    async fn for_agent(&self, _agent_spec: &AgentSpec) -> Option<Arc<dyn SamplingHandler>> {
+        Some(self.handler.clone())
+    }
 }
 
 /// Default [`SamplingHandler`] that converts MCP sampling requests to awaken
@@ -44,27 +86,42 @@ impl DefaultSamplingHandler {
     }
 
     /// Convert MCP sampling messages to awaken [`Message`] types.
-    fn convert_messages(params: &CreateMessageParams) -> Vec<Message> {
-        params
-            .messages
-            .iter()
-            .map(|msg| {
-                let text = msg
-                    .content
-                    .iter()
-                    .filter_map(|c| match c {
-                        SamplingContent::Text { text, .. } => Some(text.as_str()),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>()
-                    .join("");
-
-                match msg.role {
-                    mcp::Role::User => Message::user(text),
-                    mcp::Role::Assistant => Message::assistant(text),
+    ///
+    /// MCP `SamplingContent` is a union of `Text`, `Image`, `Audio`, …
+    /// awaken's [`Message`] today only carries text. Rather than
+    /// silently dropping non-text blocks (which would let the server's
+    /// "describe this image" prompt arrive at the LLM with the image
+    /// stripped — a correctness bug masked as an empty turn), we
+    /// surface the limitation as a typed error.
+    ///
+    /// Returns `Err(unsupported_content_kind)` on the first non-text
+    /// block encountered. Callers should map this to an MCP JSON-RPC
+    /// error so the server learns its sampling request can't be
+    /// serviced and can decide how to proceed (retry with text only,
+    /// fall back to a different client, etc).
+    fn convert_messages(params: &CreateMessageParams) -> Result<Vec<Message>, McpTransportError> {
+        let mut out = Vec::with_capacity(params.messages.len());
+        for msg in &params.messages {
+            let mut text = String::new();
+            for block in &msg.content {
+                match block {
+                    SamplingContent::Text { text: t, .. } => text.push_str(t),
+                    other => {
+                        return Err(McpTransportError::TransportError(format!(
+                            "sampling request contains unsupported content kind: {} \
+                             (awaken's sampling handler only supports text — server should \
+                             retry with a text-only message)",
+                            sampling_content_kind(other)
+                        )));
+                    }
                 }
-            })
-            .collect()
+            }
+            out.push(match msg.role {
+                mcp::Role::User => Message::user(text),
+                mcp::Role::Assistant => Message::assistant(text),
+            });
+        }
+        Ok(out)
     }
 
     /// Build the system prompt content blocks from the params.
@@ -106,13 +163,26 @@ impl DefaultSamplingHandler {
     }
 }
 
+/// Name the variant of [`SamplingContent`] for use in error messages.
+/// Kept as a private free function so it can be unit-tested independently
+/// of [`DefaultSamplingHandler`].
+fn sampling_content_kind(content: &SamplingContent) -> &'static str {
+    match content {
+        SamplingContent::Text { .. } => "text",
+        SamplingContent::Image { .. } => "image",
+        SamplingContent::Audio { .. } => "audio",
+        SamplingContent::ToolUse { .. } => "tool_use",
+        SamplingContent::ToolResult { .. } => "tool_result",
+    }
+}
+
 #[async_trait]
 impl SamplingHandler for DefaultSamplingHandler {
     async fn handle_create_message(
         &self,
         params: CreateMessageParams,
     ) -> Result<CreateMessageResult, McpTransportError> {
-        let messages = Self::convert_messages(&params);
+        let messages = Self::convert_messages(&params)?;
         if messages.is_empty() {
             return Err(McpTransportError::TransportError(
                 "sampling request contained no messages".to_string(),
@@ -249,12 +319,123 @@ mod tests {
             task: None,
             meta: None,
         };
-        let msgs = DefaultSamplingHandler::convert_messages(&params);
+        let msgs =
+            DefaultSamplingHandler::convert_messages(&params).expect("text-only converts cleanly");
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].role, Role::User);
         assert_eq!(msgs[0].text(), "hello");
         assert_eq!(msgs[1].role, Role::Assistant);
         assert_eq!(msgs[1].text(), "hi there");
+    }
+
+    #[test]
+    fn convert_messages_rejects_image_content() {
+        // Reviewer flagged the previous "silently filter non-text"
+        // behaviour: a server's "describe this image" sampling request
+        // would arrive at the LLM with the image stripped and only the
+        // prose text — producing nonsense answers and a baffling debug
+        // session. New behaviour: surface a typed error so the server
+        // sees method-supported-but-content-not-handled, not silent
+        // success with bogus output.
+        let params = CreateMessageParams {
+            messages: vec![SamplingMessage {
+                role: mcp::Role::User,
+                content: vec![
+                    SamplingContent::Text {
+                        text: "describe this:".into(),
+                        annotations: None,
+                        meta: None,
+                    },
+                    SamplingContent::Image {
+                        data: "base64-blob".into(),
+                        mime_type: "image/png".into(),
+                        annotations: None,
+                        meta: None,
+                    },
+                ],
+                meta: None,
+            }],
+            model_preferences: None,
+            system_prompt: None,
+            include_context: None,
+            temperature: None,
+            max_tokens: 1024,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+            task: None,
+            meta: None,
+        };
+        let err =
+            DefaultSamplingHandler::convert_messages(&params).expect_err("image must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("image"),
+            "error should identify the offending content kind, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn convert_messages_rejects_audio_content() {
+        let params = CreateMessageParams {
+            messages: vec![SamplingMessage {
+                role: mcp::Role::User,
+                content: vec![SamplingContent::Audio {
+                    data: "base64-blob".into(),
+                    mime_type: "audio/wav".into(),
+                    annotations: None,
+                    meta: None,
+                }],
+                meta: None,
+            }],
+            model_preferences: None,
+            system_prompt: None,
+            include_context: None,
+            temperature: None,
+            max_tokens: 1024,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+            task: None,
+            meta: None,
+        };
+        let err =
+            DefaultSamplingHandler::convert_messages(&params).expect_err("audio must be rejected");
+        assert!(format!("{err}").contains("audio"));
+    }
+
+    #[test]
+    fn sampling_content_kind_names_each_variant() {
+        // Lock in the strings used in error messages so a future
+        // refactor of the helper doesn't silently drop a variant.
+        assert_eq!(
+            sampling_content_kind(&SamplingContent::Text {
+                text: "x".into(),
+                annotations: None,
+                meta: None,
+            }),
+            "text"
+        );
+        assert_eq!(
+            sampling_content_kind(&SamplingContent::Image {
+                data: "x".into(),
+                mime_type: "image/png".into(),
+                annotations: None,
+                meta: None,
+            }),
+            "image"
+        );
+        assert_eq!(
+            sampling_content_kind(&SamplingContent::Audio {
+                data: "x".into(),
+                mime_type: "audio/wav".into(),
+                annotations: None,
+                meta: None,
+            }),
+            "audio"
+        );
     }
 
     #[test]
@@ -329,6 +510,38 @@ mod tests {
         };
         let err = handler.handle_create_message(params).await;
         assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn fixed_factory_returns_same_handler_regardless_of_agent() {
+        // The fixed factory preserves R0 behaviour: every agent gets the
+        // same handler. Per-agent routing only kicks in when callers wire
+        // a registry-driven factory.
+        let executor = Arc::new(MockLlm {
+            response_text: "shared".into(),
+        });
+        let handler: Arc<dyn SamplingHandler> =
+            Arc::new(DefaultSamplingHandler::new(executor, "shared-model"));
+        let factory = FixedSamplingHandlerFactory::new(Arc::clone(&handler));
+
+        let spec_a = AgentSpec {
+            id: "a".into(),
+            model_id: "claude-opus".into(),
+            system_prompt: "".into(),
+            ..Default::default()
+        };
+        let spec_b = AgentSpec {
+            id: "b".into(),
+            model_id: "gpt-5".into(),
+            system_prompt: "".into(),
+            ..Default::default()
+        };
+
+        let resolved_a = factory.for_agent(&spec_a).await.expect("Some handler");
+        let resolved_b = factory.for_agent(&spec_b).await.expect("Some handler");
+        // Same Arc identity regardless of agent.
+        assert!(Arc::ptr_eq(&resolved_a, &handler));
+        assert!(Arc::ptr_eq(&resolved_b, &handler));
     }
 
     #[tokio::test]

--- a/crates/awaken-ext-mcp/src/sampling.rs
+++ b/crates/awaken-ext-mcp/src/sampling.rs
@@ -197,14 +197,18 @@ fn sampling_content_kind(content: &SamplingContent) -> &'static str {
 }
 
 /// Reject sampling requests whose presence would silently change LLM
-/// behaviour. The MCP spec lets the server specify model preferences,
-/// stop sequences, tool choice, etc.; awaken's handler currently maps
+/// behaviour. The MCP spec lets the server specify stop sequences,
+/// context inclusion, tool choice, etc.; awaken's handler currently maps
 /// only a small subset (system prompt, temperature, max_tokens), so
 /// honouring these would produce a different reply than the server
 /// asked for — a class of bug that's invisible until model output goes
 /// subtly wrong. Returning an error puts the burden back on the server
 /// to either retry without the unsupported field or fall over to a
 /// different client.
+///
+/// `modelPreferences` is advisory in MCP sampling. The default handler
+/// uses the model already configured for the agent and ignores those
+/// hints instead of rejecting otherwise interoperable servers.
 ///
 /// Returns `Err` with a human-readable description of the offending
 /// field. `Ok(())` means every behavioural field is either absent or
@@ -222,9 +226,6 @@ fn reject_unsupported_sampling_fields(
     }
     if params.include_context.is_some() {
         unsupported.push("includeContext");
-    }
-    if params.model_preferences.is_some() {
-        unsupported.push("modelPreferences");
     }
     if params.tools.as_ref().is_some_and(|t| !t.is_empty()) {
         unsupported.push("tools");
@@ -615,26 +616,42 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_create_message_rejects_include_context_and_model_preferences() {
+    async fn handle_create_message_rejects_include_context() {
         let executor = Arc::new(MockLlm {
             response_text: "ignored".into(),
         });
         let handler = DefaultSamplingHandler::new(executor, "m");
         let mut params = make_params("hi");
         params.include_context = Some("thisServer".into());
-        params.model_preferences = Some(mcp::ModelPreferences {
-            hints: None,
-            cost_priority: None,
-            speed_priority: None,
-            intelligence_priority: None,
-        });
         let err = handler
             .handle_create_message(params)
             .await
             .expect_err("must reject");
         let msg = format!("{err}");
         assert!(msg.contains("includeContext"), "got: {msg}");
-        assert!(msg.contains("modelPreferences"), "got: {msg}");
+        assert!(!msg.contains("modelPreferences"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn default_sampling_handler_ignores_model_preferences() {
+        let executor = Arc::new(MockLlm {
+            response_text: "ok".into(),
+        });
+        let handler = DefaultSamplingHandler::new(executor, "configured-model");
+        let mut params = make_params("hi");
+        params.model_preferences = Some(mcp::ModelPreferences {
+            hints: None,
+            cost_priority: None,
+            speed_priority: None,
+            intelligence_priority: None,
+        });
+
+        let result = handler
+            .handle_create_message(params)
+            .await
+            .expect("modelPreferences are advisory and should not fail basic sampling");
+
+        assert_eq!(result.model, "configured-model");
     }
 
     #[tokio::test]

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -45,6 +45,9 @@ const MAX_SSE_EVENT_BYTES: usize = 1024 * 1024;
 const MAX_SSE_JSON_PAYLOAD_BYTES: usize = 1024 * 1024;
 const MAX_SSE_RETRY_DELAY_MS: u64 = 30_000;
 const MAX_SSE_RESUME_ATTEMPTS: u32 = 3;
+pub(crate) const LIST_CHANGED_CHANNEL_CAPACITY: usize = 128;
+pub(crate) const MCP_PROGRESS_CHANNEL_CAPACITY: usize = 128;
+pub(crate) const RESOURCE_UPDATED_INGRESS_CAPACITY: usize = 1024;
 
 /// Protocol versions awaken's transports know how to talk on the wire.
 ///
@@ -325,7 +328,7 @@ pub trait McpToolTransport: Send + Sync {
         &self,
         name: &str,
         args: Value,
-        progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         context: McpCallContext,
     ) -> Result<CallToolResult, McpTransportError>;
 
@@ -356,18 +359,18 @@ pub trait McpToolTransport: Send + Sync {
         None
     }
 
-    /// Take the receiver for `notifications/{tools,prompts,resources}/list_changed`
-    /// events. Each event names which catalogue changed so the host can
-    /// refresh only that surface. Per MCP 2025-11-25 §Server features,
-    /// servers that advertise `tools.listChanged` / `prompts.listChanged`
-    /// / `resources.listChanged` SHOULD emit these notifications when
-    /// the corresponding catalogue mutates — receiving one removes the
-    /// need for periodic polling.
+    /// Take the receiver for queued `notifications/tools/list_changed`
+    /// events. Per MCP 2025-11-25 §Server features, servers that
+    /// advertise `tools.listChanged` SHOULD emit this notification when
+    /// the tool catalogue mutates — receiving one removes the need for
+    /// periodic polling for that cached surface. Prompt/resource
+    /// list_changed notifications are parsed but not queued because
+    /// those catalogues are fetched live today.
     ///
     /// One-shot: callable at most once per transport instance. Returns
     /// `None` thereafter (and `None` for transports that don't emit
     /// these notifications, e.g. test stubs).
-    async fn take_list_changed_receiver(&self) -> Option<mpsc::UnboundedReceiver<ListChangedKind>> {
+    async fn take_list_changed_receiver(&self) -> Option<mpsc::Receiver<ListChangedKind>> {
         None
     }
 
@@ -394,7 +397,7 @@ pub trait McpToolTransport: Send + Sync {
     /// Each event carries the URI of the updated resource. The host
     /// can fetch the new contents via `read_resource` in response.
     /// One-shot like [`take_list_changed_receiver`].
-    async fn take_resource_updated_receiver(&self) -> Option<mpsc::UnboundedReceiver<String>> {
+    async fn take_resource_updated_receiver(&self) -> Option<mpsc::Receiver<String>> {
         None
     }
 
@@ -411,15 +414,19 @@ pub trait McpToolTransport: Send + Sync {
 }
 
 /// Which server-side catalogue the `notifications/.../list_changed`
-/// event refers to. The transport forwards one variant per notification;
-/// the manager dispatches a refresh against that catalogue.
+/// event refers to.
+///
+/// The manager currently caches only the tools catalogue, so transports
+/// forward `Tools` into the bounded refresh queue and ignore
+/// `Prompts`/`Resources` after parsing them. Prompt and resource lists
+/// are fetched live through the manager API today.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ListChangedKind {
     /// `notifications/tools/list_changed` — re-run `tools/list`.
     Tools,
-    /// `notifications/prompts/list_changed` — re-run `prompts/list`.
+    /// `notifications/prompts/list_changed` — parsed but not queued today.
     Prompts,
-    /// `notifications/resources/list_changed` — re-run `resources/list`.
+    /// `notifications/resources/list_changed` — parsed but not queued today.
     Resources,
 }
 
@@ -432,6 +439,29 @@ fn list_changed_method(method: &str) -> Option<ListChangedKind> {
         "notifications/prompts/list_changed" => Some(ListChangedKind::Prompts),
         "notifications/resources/list_changed" => Some(ListChangedKind::Resources),
         _ => None,
+    }
+}
+
+fn forward_list_changed(sender: &mpsc::Sender<ListChangedKind>, kind: ListChangedKind) {
+    match kind {
+        ListChangedKind::Tools => match sender.try_send(kind) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                tracing::debug!(
+                    capacity = LIST_CHANGED_CHANNEL_CAPACITY,
+                    "coalescing MCP tools/list_changed notification because refresh queue is full"
+                );
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::debug!("dropping MCP tools/list_changed notification; receiver is closed");
+            }
+        },
+        ListChangedKind::Prompts | ListChangedKind::Resources => {
+            tracing::debug!(
+                kind = ?kind,
+                "ignoring MCP list_changed notification for uncached catalogue"
+            );
+        }
     }
 }
 
@@ -771,9 +801,8 @@ impl Drop for PerCallSamplingGuard {
 pub(crate) struct ProgressAwareStdioTransport {
     write_tx: mpsc::Sender<WriteRequest>,
     pending: PendingRequests,
-    progress_subscribers: Arc<
-        tokio::sync::Mutex<HashMap<ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>>>,
-    >,
+    progress_subscribers:
+        Arc<tokio::sync::Mutex<HashMap<ProgressTokenKey, mpsc::Sender<McpProgressUpdate>>>>,
     next_id: AtomicI64,
     next_progress_token: AtomicI64,
     alive: Arc<AtomicBool>,
@@ -791,12 +820,12 @@ pub(crate) struct ProgressAwareStdioTransport {
     /// The reader task owns the cloned sender; when this transport (and
     /// thus the reader task) is dropped, the channel closes naturally.
     /// Taken at most once by [`take_list_changed_receiver`].
-    list_changed_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<ListChangedKind>>>,
+    list_changed_rx: tokio::sync::Mutex<Option<mpsc::Receiver<ListChangedKind>>>,
     /// Receiver half of the `notifications/resources/updated` channel.
     /// Each event is the URI of an updated resource. Mirrors the
     /// list_changed pattern — one-shot, taken via
     /// [`take_resource_updated_receiver`].
-    resource_updated_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<String>>>,
+    resource_updated_rx: tokio::sync::Mutex<Option<mpsc::Receiver<String>>>,
     /// Client-defined roots advertised to the server during `initialize`
     /// and served on subsequent `roots/list` requests. Empty = roots
     /// capability not advertised. Held as an `Arc` so the spawned
@@ -848,7 +877,7 @@ impl ProgressAwareStdioTransport {
         let alive = Arc::new(AtomicBool::new(true));
         let pending: PendingRequests = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
         let progress_subscribers: Arc<
-            tokio::sync::Mutex<HashMap<ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>>>,
+            tokio::sync::Mutex<HashMap<ProgressTokenKey, mpsc::Sender<McpProgressUpdate>>>,
         > = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
 
         let (write_tx, mut write_rx) = mpsc::channel::<WriteRequest>(256);
@@ -882,9 +911,11 @@ impl ProgressAwareStdioTransport {
         let sampling_handler_reader = sampling_handler.clone();
         let per_call_sampling: PerCallSamplingHandlers =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let (list_changed_tx, list_changed_rx) = mpsc::unbounded_channel::<ListChangedKind>();
+        let (list_changed_tx, list_changed_rx) =
+            mpsc::channel::<ListChangedKind>(LIST_CHANGED_CHANNEL_CAPACITY);
         let list_changed_tx_reader = list_changed_tx.clone();
-        let (resource_updated_tx, resource_updated_rx) = mpsc::unbounded_channel::<String>();
+        let (resource_updated_tx, resource_updated_rx) =
+            mpsc::channel::<String>(RESOURCE_UPDATED_INGRESS_CAPACITY);
         let resource_updated_tx_reader = resource_updated_tx.clone();
         let roots_reader = Arc::clone(&roots);
         let mut reader = BufReader::new(stdout);
@@ -913,9 +944,9 @@ impl ProgressAwareStdioTransport {
                                 // the receiver yet (or has dropped it),
                                 // a send error just means the host is
                                 // not interested — drop silently.
-                                let _ = list_changed_tx_reader.send(kind);
+                                forward_list_changed(&list_changed_tx_reader, kind);
                             } else if let Some(uri) = resource_updated_uri(&notification) {
-                                let _ = resource_updated_tx_reader.send(uri);
+                                let _ = resource_updated_tx_reader.try_send(uri);
                             } else {
                                 handle_progress_notification(&progress_reader, notification).await;
                             }
@@ -1077,7 +1108,7 @@ impl ProgressAwareStdioTransport {
         &self,
         method: &str,
         params: Option<Value>,
-        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         self.send_request_with_id(id, method, params, progress_registration, None)
@@ -1099,7 +1130,7 @@ impl ProgressAwareStdioTransport {
         id: i64,
         method: &str,
         params: Option<Value>,
-        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
         sent_flag: Option<Arc<AtomicBool>>,
     ) -> Result<Value, McpTransportError> {
         if !self.alive.load(Ordering::SeqCst) {
@@ -1244,7 +1275,7 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         &self,
         name: &str,
         args: Value,
-        progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         context: McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         let McpCallContext {
@@ -1367,15 +1398,7 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         handler_guard.unregister().await;
 
         let result = result?;
-        let call_result: CallToolResult = serde_json::from_value(result)?;
-
-        if call_result.is_error == Some(true) {
-            return Err(McpTransportError::ServerError(tool_result_error_text(
-                &call_result,
-            )));
-        }
-
-        Ok(call_result)
+        serde_json::from_value(result).map_err(Into::into)
     }
 
     fn transport_type(&self) -> TransportTypeId {
@@ -1386,11 +1409,11 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         Ok(self.capabilities.clone())
     }
 
-    async fn take_list_changed_receiver(&self) -> Option<mpsc::UnboundedReceiver<ListChangedKind>> {
+    async fn take_list_changed_receiver(&self) -> Option<mpsc::Receiver<ListChangedKind>> {
         self.list_changed_rx.lock().await.take()
     }
 
-    async fn take_resource_updated_receiver(&self) -> Option<mpsc::UnboundedReceiver<String>> {
+    async fn take_resource_updated_receiver(&self) -> Option<mpsc::Receiver<String>> {
         self.resource_updated_rx.lock().await.take()
     }
 
@@ -1473,16 +1496,16 @@ pub(crate) struct ProgressAwareHttpTransport {
     /// Cloned into the listening-stream task at the point we add one;
     /// for now, [`process_sse_event`] dispatches synchronously through
     /// this sender so per-request streams report list_changed too.
-    list_changed_tx: mpsc::UnboundedSender<ListChangedKind>,
+    list_changed_tx: mpsc::Sender<ListChangedKind>,
     /// One-shot receiver, taken at most once by
     /// [`take_list_changed_receiver`].
-    list_changed_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<ListChangedKind>>>,
+    list_changed_rx: tokio::sync::Mutex<Option<mpsc::Receiver<ListChangedKind>>>,
     /// Sender for `notifications/resources/updated` events; cloned by
     /// `process_sse_event` to forward each notification.
-    resource_updated_tx: mpsc::UnboundedSender<String>,
+    resource_updated_tx: mpsc::Sender<String>,
     /// One-shot receiver for resource-updated events; same pattern as
     /// `list_changed_rx`.
-    resource_updated_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<String>>>,
+    resource_updated_rx: tokio::sync::Mutex<Option<mpsc::Receiver<String>>>,
     /// Client-defined roots; same semantics as the stdio variant.
     /// Non-empty → roots capability advertised at initialize and
     /// `roots/list` is served from this list.
@@ -1600,8 +1623,10 @@ impl ProgressAwareHttpTransport {
                 ))
             })?;
 
-        let (list_changed_tx, list_changed_rx) = mpsc::unbounded_channel::<ListChangedKind>();
-        let (resource_updated_tx, resource_updated_rx) = mpsc::unbounded_channel::<String>();
+        let (list_changed_tx, list_changed_rx) =
+            mpsc::channel::<ListChangedKind>(LIST_CHANGED_CHANNEL_CAPACITY);
+        let (resource_updated_tx, resource_updated_rx) =
+            mpsc::channel::<String>(RESOURCE_UPDATED_INGRESS_CAPACITY);
         Ok(Self {
             endpoint: endpoint.clone(),
             client,
@@ -1809,7 +1834,7 @@ impl ProgressAwareHttpTransport {
         &self,
         method: &str,
         params: Option<Value>,
-        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         self.send_request_with_id(id, method, params, progress_registration, None, None)
@@ -1832,7 +1857,7 @@ impl ProgressAwareHttpTransport {
         id: i64,
         method: &str,
         params: Option<Value>,
-        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
         sent_flag: Option<Arc<AtomicBool>>,
         sent_session: Option<Arc<tokio::sync::Mutex<Option<HttpSessionSnapshot>>>>,
     ) -> Result<Value, McpTransportError> {
@@ -1869,7 +1894,7 @@ impl ProgressAwareHttpTransport {
         &self,
         method: &str,
         params: Option<Value>,
-        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
         self.initialize_if_needed().await?;
         match self
@@ -2339,7 +2364,7 @@ impl ProgressAwareHttpTransport {
         &self,
         response: reqwest::Response,
         request_id: i64,
-        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
         request_session: Option<HttpSessionSnapshot>,
     ) -> Result<Value, McpTransportError> {
         let content_type = response_content_type(&response);
@@ -2370,7 +2395,7 @@ impl ProgressAwareHttpTransport {
         &self,
         response: reqwest::Response,
         request_id: i64,
-        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
         request_session: HttpSessionSnapshot,
     ) -> Result<Value, McpTransportError> {
         let progress_key = progress_registration.as_ref().map(|(key, _)| key.clone());
@@ -2642,7 +2667,7 @@ impl ProgressAwareHttpTransport {
         lines: &[String],
         request_id: i64,
         progress_key: Option<&ProgressTokenKey>,
-        progress_tx: Option<&mpsc::UnboundedSender<McpProgressUpdate>>,
+        progress_tx: Option<&mpsc::Sender<McpProgressUpdate>>,
         request_session: &HttpSessionSnapshot,
     ) -> Result<Option<Result<Value, McpTransportError>>, McpTransportError> {
         let Some(payload) = sse_data_payload(lines, "HTTP SSE response")? else {
@@ -2671,14 +2696,14 @@ impl ProgressAwareHttpTransport {
                 if let Some(kind) = list_changed_method(&notification.method) {
                     // Forward to the host's `take_list_changed_receiver`
                     // consumer; best-effort if no one subscribed.
-                    let _ = self.list_changed_tx.send(kind);
+                    forward_list_changed(&self.list_changed_tx, kind);
                 } else if let Some(uri) = resource_updated_uri(&notification) {
-                    let _ = self.resource_updated_tx.send(uri);
+                    let _ = self.resource_updated_tx.try_send(uri);
                 } else if let (Some(expected_key), Some(sender)) = (progress_key, progress_tx)
                     && let Some((key, update)) = decode_progress_notification(notification)
                     && key == *expected_key
                 {
-                    let _ = sender.send(update);
+                    let _ = sender.try_send(update);
                 }
                 Ok(None)
             }
@@ -2785,8 +2810,8 @@ struct HttpListenerCtx {
     /// expiry would let subsequent calls send post_message() without
     /// a session id (spec violation — server returns 400/404 again).
     capabilities: Arc<tokio::sync::Mutex<Option<ServerCapabilities>>>,
-    list_changed_tx: mpsc::UnboundedSender<ListChangedKind>,
-    resource_updated_tx: mpsc::UnboundedSender<String>,
+    list_changed_tx: mpsc::Sender<ListChangedKind>,
+    resource_updated_tx: mpsc::Sender<String>,
     roots: Arc<Vec<Root>>,
     fallback_sampling: Option<Arc<dyn SamplingHandler>>,
     alive: Arc<AtomicBool>,
@@ -3060,9 +3085,9 @@ async fn process_listening_event(
     match message {
         JsonRpcMessage::Notification(notification) => {
             if let Some(kind) = list_changed_method(&notification.method) {
-                let _ = ctx.list_changed_tx.send(kind);
+                forward_list_changed(&ctx.list_changed_tx, kind);
             } else if let Some(uri) = resource_updated_uri(&notification) {
-                let _ = ctx.resource_updated_tx.send(uri);
+                let _ = ctx.resource_updated_tx.try_send(uri);
             }
             // progress notifications without a request_id can't be
             // routed; drop. The listening stream isn't tied to a
@@ -3214,7 +3239,7 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         &self,
         name: &str,
         args: Value,
-        progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         context: McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         let McpCallContext {
@@ -3421,15 +3446,7 @@ impl McpToolTransport for ProgressAwareHttpTransport {
             }
         };
 
-        let call_result: CallToolResult = serde_json::from_value(result_value)?;
-
-        if call_result.is_error == Some(true) {
-            return Err(McpTransportError::ServerError(tool_result_error_text(
-                &call_result,
-            )));
-        }
-
-        Ok(call_result)
+        serde_json::from_value(result_value).map_err(Into::into)
     }
 
     fn transport_type(&self) -> TransportTypeId {
@@ -3440,11 +3457,11 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         Ok(Some(self.initialize_if_needed().await?))
     }
 
-    async fn take_list_changed_receiver(&self) -> Option<mpsc::UnboundedReceiver<ListChangedKind>> {
+    async fn take_list_changed_receiver(&self) -> Option<mpsc::Receiver<ListChangedKind>> {
         self.list_changed_rx.lock().await.take()
     }
 
-    async fn take_resource_updated_receiver(&self) -> Option<mpsc::UnboundedReceiver<String>> {
+    async fn take_resource_updated_receiver(&self) -> Option<mpsc::Receiver<String>> {
         self.resource_updated_rx.lock().await.take()
     }
 
@@ -3652,7 +3669,7 @@ fn map_response_payload(payload: JsonRpcPayload) -> Result<Value, McpTransportEr
 
 async fn handle_progress_notification(
     subscribers: &Arc<
-        tokio::sync::Mutex<HashMap<ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>>>,
+        tokio::sync::Mutex<HashMap<ProgressTokenKey, mpsc::Sender<McpProgressUpdate>>>,
     >,
     notification: JsonRpcNotification,
 ) {
@@ -3660,10 +3677,14 @@ async fn handle_progress_notification(
         return;
     };
     let sender = subscribers.lock().await.get(&key).cloned();
-    if let Some(sender) = sender
-        && sender.send(update).is_err()
-    {
-        subscribers.lock().await.remove(&key);
+    if let Some(sender) = sender {
+        match sender.try_send(update) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {}
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                subscribers.lock().await.remove(&key);
+            }
+        }
     }
 }
 
@@ -3716,7 +3737,7 @@ fn parse_json_rpc_message(value: Value) -> Result<JsonRpcMessage, McpTransportEr
 pub(crate) fn decode_http_response_payload(
     body: Value,
     request_id: i64,
-    progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+    progress_registration: Option<(ProgressTokenKey, mpsc::Sender<McpProgressUpdate>)>,
 ) -> Result<Value, McpTransportError> {
     let progress_key = progress_registration.as_ref().map(|(key, _)| key.clone());
     let progress_tx = progress_registration
@@ -3741,7 +3762,7 @@ pub(crate) fn decode_http_response_payload(
                 return;
             };
             if key == *expected_key {
-                let _ = sender.send(update);
+                let _ = sender.try_send(update);
             }
         }
         JsonRpcMessage::Request(_) => {}
@@ -4155,6 +4176,34 @@ mod tests {
         assert_eq!(list_changed_method("tools/list_changed"), None); // missing prefix
     }
 
+    #[test]
+    fn list_changed_forwarder_prioritizes_cached_tools_catalogue() {
+        let (tx, mut rx) = mpsc::channel(LIST_CHANGED_CHANNEL_CAPACITY);
+        for _ in 0..(LIST_CHANGED_CHANNEL_CAPACITY * 2) {
+            forward_list_changed(&tx, ListChangedKind::Prompts);
+            forward_list_changed(&tx, ListChangedKind::Resources);
+        }
+        forward_list_changed(&tx, ListChangedKind::Tools);
+
+        assert_eq!(rx.try_recv(), Ok(ListChangedKind::Tools));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn list_changed_forwarder_bounds_duplicate_tools_notifications() {
+        let (tx, mut rx) = mpsc::channel(LIST_CHANGED_CHANNEL_CAPACITY);
+        for _ in 0..(LIST_CHANGED_CHANNEL_CAPACITY * 2) {
+            forward_list_changed(&tx, ListChangedKind::Tools);
+        }
+
+        assert_eq!(rx.len(), LIST_CHANGED_CHANNEL_CAPACITY);
+        let mut drained = 0usize;
+        while rx.try_recv().is_ok() {
+            drained += 1;
+        }
+        assert_eq!(drained, LIST_CHANGED_CHANNEL_CAPACITY);
+    }
+
     // ── protocol-version negotiation ──
 
     #[test]
@@ -4409,7 +4458,7 @@ mod tests {
 
     #[test]
     fn decode_http_batch_ignores_malformed_notifications() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel(MCP_PROGRESS_CHANNEL_CAPACITY);
         let body = json!([
             { "jsonrpc": "2.0", "method": "notifications/progress" },
             { "jsonrpc": "2.0", "method": "notifications/progress", "params": {"progressToken": {"bad": true}, "progress": "oops"} },
@@ -5715,7 +5764,7 @@ done
 
     #[test]
     fn decode_http_batch_emits_progress_before_and_after_response_in_order() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel(MCP_PROGRESS_CHANNEL_CAPACITY);
         let body = json!([
             {
                 "jsonrpc": "2.0",
@@ -6332,7 +6381,7 @@ done
 
     #[test]
     fn decode_http_response_progress_token_mismatch_not_emitted() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel(MCP_PROGRESS_CHANNEL_CAPACITY);
         let body = json!([
             {
                 "jsonrpc": "2.0",
@@ -6383,7 +6432,7 @@ done
 
     #[test]
     fn decode_http_response_progress_with_string_token() {
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel(MCP_PROGRESS_CHANNEL_CAPACITY);
         let body = json!([
             {
                 "jsonrpc": "2.0",

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -38,9 +38,17 @@ use crate::sampling::SamplingHandler;
 /// to surface the cancellation upward (e.g. as `ToolError::Cancelled`).
 pub const CANCELLED_BY_CLIENT: &str = "MCP request cancelled by client";
 
+const MCP_SESSION_EXPIRED: &str = "MCP session expired";
+const MCP_SESSION_EXPIRED_AFTER_ACCEPT: &str = "MCP session expired after request was accepted";
+const MAX_SSE_LINE_BYTES: usize = 64 * 1024;
+const MAX_SSE_EVENT_BYTES: usize = 1024 * 1024;
+const MAX_SSE_JSON_PAYLOAD_BYTES: usize = 1024 * 1024;
+const MAX_SSE_RETRY_DELAY_MS: u64 = 30_000;
+const MAX_SSE_RESUME_ATTEMPTS: u32 = 3;
+
 /// Protocol versions awaken's transports know how to talk on the wire.
 ///
-/// Per MCP 2025-06-18 §Lifecycle / Version Negotiation: "If the server
+/// Per MCP 2025-11-25 §Lifecycle / Version Negotiation: "If the server
 /// supports the requested protocol version, it MUST respond with the
 /// same version. Otherwise, the server MUST respond with another
 /// protocol version it supports." Our handshake sends
@@ -155,7 +163,7 @@ struct ListResourcesResult {
 /// thread / run / call initiated the request so it can do per-agent rate
 /// limiting, per-tenant OAuth, audit, or workflow correlation.
 ///
-/// Spec (2025-06-18 §JSON-RPC 2.0 + §Basic) reserves the `_meta` field on
+/// Spec (2025-11-25 §JSON-RPC 2.0 + §Basic) reserves the `_meta` field on
 /// request params for client-controlled metadata. By convention,
 /// vendor-specific keys are namespaced — we use `awaken/attribution` so
 /// our additions don't collide with future MCP spec fields (notably the
@@ -229,7 +237,7 @@ pub struct McpCallContext {
 /// transport can distinguish "no factory configured at all" from
 /// "factory consulted but declined to bind this agent" — these have
 /// different security semantics.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub enum McpCallSampling {
     /// No per-call decision was made. The transport falls through to
     /// its registry-level fixed handler (legacy behaviour, preserved
@@ -342,9 +350,16 @@ pub trait McpToolTransport: Send + Sync {
         None
     }
 
+    /// Wall-clock time of the current HTTP session's successful
+    /// `initialize`, if the transport can report it live. Stdio returns
+    /// `None`; manager snapshots fall back to their connect/reconnect cache.
+    async fn current_session_started_at(&self) -> Option<SystemTime> {
+        None
+    }
+
     /// Take the receiver for `notifications/{tools,prompts,resources}/list_changed`
     /// events. Each event names which catalogue changed so the host can
-    /// refresh only that surface. Per MCP 2025-06-18 §Server features,
+    /// refresh only that surface. Per MCP 2025-11-25 §Server features,
     /// servers that advertise `tools.listChanged` / `prompts.listChanged`
     /// / `resources.listChanged` SHOULD emit these notifications when
     /// the corresponding catalogue mutates — receiving one removes the
@@ -358,7 +373,7 @@ pub trait McpToolTransport: Send + Sync {
     }
 
     /// Subscribe to updates for a single resource URI. Per MCP
-    /// 2025-06-18 §Resources / Subscriptions: callable only when the
+    /// 2025-11-25 §Resources / Subscriptions: callable only when the
     /// server advertised `resources.subscribe: true` during initialize.
     /// The caller is responsible for that capability check; the
     /// transport just forwards the JSON-RPC request.
@@ -385,7 +400,7 @@ pub trait McpToolTransport: Send + Sync {
     }
 
     /// Ask the server for autocomplete suggestions for a prompt /
-    /// resource argument. Per MCP 2025-06-18 §Utilities / Completion:
+    /// resource argument. Per MCP 2025-11-25 §Utilities / Completion:
     /// only valid when the server advertised `completions: {}` in its
     /// initialize response — the caller is responsible for that
     /// capability check. The transport just forwards the request.
@@ -418,6 +433,194 @@ fn list_changed_method(method: &str) -> Option<ListChangedKind> {
         "notifications/prompts/list_changed" => Some(ListChangedKind::Prompts),
         "notifications/resources/list_changed" => Some(ListChangedKind::Resources),
         _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SseEventIdUpdate {
+    Absent,
+    Set(String),
+    Reset,
+}
+
+/// Extract the value of an `id:` field from the buffered SSE event lines.
+/// Per WHATWG SSE, an empty `id:` resets the last-event-id; that must be
+/// represented separately from an absent field so callers can clear stale
+/// resume cursors.
+fn extract_event_id(event_lines: &[String]) -> SseEventIdUpdate {
+    for line in event_lines.iter().rev() {
+        if let Some(rest) = line.strip_prefix("id:") {
+            let trimmed = rest.trim_start();
+            if trimmed.is_empty() {
+                return SseEventIdUpdate::Reset;
+            }
+            return SseEventIdUpdate::Set(trimmed.to_string());
+        }
+    }
+    SseEventIdUpdate::Absent
+}
+
+fn apply_event_id_update(last_event_id: &mut Option<String>, update: SseEventIdUpdate) {
+    match update {
+        SseEventIdUpdate::Absent => {}
+        SseEventIdUpdate::Set(id) => *last_event_id = Some(id),
+        SseEventIdUpdate::Reset => *last_event_id = None,
+    }
+}
+
+/// Extract an SSE `retry:` field as a reconnect delay. Malformed values are
+/// ignored, matching the EventSource processing model.
+fn extract_retry_delay(event_lines: &[String]) -> Option<Duration> {
+    let mut delay = None;
+    for line in event_lines {
+        if let Some(rest) = line.strip_prefix("retry:") {
+            let trimmed = rest.trim_start();
+            if let Ok(millis) = trimmed.parse::<u64>() {
+                delay = Some(Duration::from_millis(millis));
+            }
+        }
+    }
+    delay
+}
+
+fn bounded_sse_retry_delay(
+    event_lines: &[String],
+    context: &str,
+) -> Result<Option<Duration>, McpTransportError> {
+    let Some(delay) = extract_retry_delay(event_lines) else {
+        return Ok(None);
+    };
+    if delay > Duration::from_millis(MAX_SSE_RETRY_DELAY_MS) {
+        return Err(McpTransportError::ProtocolError(format!(
+            "{context} SSE retry delay exceeded {MAX_SSE_RETRY_DELAY_MS} ms"
+        )));
+    }
+    Ok(Some(delay))
+}
+
+fn response_content_type(response: &reqwest::Response) -> String {
+    response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn is_sse_content_type(content_type: &str) -> bool {
+    content_type.starts_with("text/event-stream")
+}
+
+fn validate_sse_response(
+    response: &reqwest::Response,
+    context: &str,
+) -> Result<(), McpTransportError> {
+    let content_type = response_content_type(response);
+    if is_sse_content_type(&content_type) {
+        Ok(())
+    } else {
+        Err(McpTransportError::ProtocolError(format!(
+            "{context} expected Content-Type text/event-stream, got {}",
+            if content_type.is_empty() {
+                "<missing>"
+            } else {
+                content_type.as_str()
+            }
+        )))
+    }
+}
+
+async fn decode_json_response_body(
+    response: reqwest::Response,
+    timeout: Duration,
+) -> Result<Value, McpTransportError> {
+    tokio::time::timeout(timeout, response.json())
+        .await
+        .map_err(|_| {
+            McpTransportError::Timeout(format!(
+                "HTTP JSON response body did not complete within {:?}",
+                timeout
+            ))
+        })?
+        .map_err(|e| {
+            McpTransportError::TransportError(format!("Failed to parse JSON response: {}", e))
+        })
+}
+
+fn push_sse_line_byte(
+    line_buf: &mut Vec<u8>,
+    byte: u8,
+    context: &str,
+) -> Result<(), McpTransportError> {
+    if line_buf.len() >= MAX_SSE_LINE_BYTES {
+        return Err(McpTransportError::ProtocolError(format!(
+            "{context} SSE line exceeded {MAX_SSE_LINE_BYTES} bytes"
+        )));
+    }
+    line_buf.push(byte);
+    Ok(())
+}
+
+fn push_sse_event_line(
+    event_lines: &mut Vec<String>,
+    event_bytes: &mut usize,
+    line: String,
+    context: &str,
+) -> Result<(), McpTransportError> {
+    *event_bytes = event_bytes
+        .checked_add(line.len().saturating_add(1))
+        .ok_or_else(|| {
+            McpTransportError::ProtocolError(format!(
+                "{context} SSE event exceeded {MAX_SSE_EVENT_BYTES} bytes"
+            ))
+        })?;
+    if *event_bytes > MAX_SSE_EVENT_BYTES {
+        return Err(McpTransportError::ProtocolError(format!(
+            "{context} SSE event exceeded {MAX_SSE_EVENT_BYTES} bytes"
+        )));
+    }
+    event_lines.push(line);
+    Ok(())
+}
+
+fn sse_data_payload(
+    event_lines: &[String],
+    context: &str,
+) -> Result<Option<String>, McpTransportError> {
+    let mut data_parts = Vec::new();
+    let mut payload_bytes = 0usize;
+    for line in event_lines {
+        if line.starts_with(':') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("data:") {
+            let part = rest.trim_start();
+            payload_bytes = payload_bytes
+                .checked_add(part.len())
+                .and_then(|bytes| bytes.checked_add(1))
+                .ok_or_else(|| {
+                    McpTransportError::ProtocolError(format!(
+                        "{context} SSE JSON payload exceeded {MAX_SSE_JSON_PAYLOAD_BYTES} bytes"
+                    ))
+                })?;
+            if payload_bytes > MAX_SSE_JSON_PAYLOAD_BYTES {
+                return Err(McpTransportError::ProtocolError(format!(
+                    "{context} SSE JSON payload exceeded {MAX_SSE_JSON_PAYLOAD_BYTES} bytes"
+                )));
+            }
+            data_parts.push(part.to_string());
+        }
+    }
+
+    if data_parts.is_empty() {
+        return Ok(None);
+    }
+    let payload = data_parts.join("\n");
+    if payload.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(payload))
     }
 }
 
@@ -526,17 +729,32 @@ impl PerCallSamplingGuard {
             }
         }
     }
+
+    /// Explicitly drop the per-call entry with an `.await`'d lock.
+    /// Call this on every exit path of `call_tool` so cardinality-
+    /// based routing in `select_sampling_handler` doesn't observe a
+    /// stale entry from a call that just returned. Marks the guard
+    /// inactive so the sync `Drop` impl becomes a no-op safety net.
+    async fn unregister(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.handlers.lock().await.remove(&self.id);
+        self.active = false;
+    }
 }
 
 impl Drop for PerCallSamplingGuard {
     fn drop(&mut self) {
+        // Reachable only if `unregister()` wasn't awaited (panic,
+        // early return on a path the future of call_tool aborts mid-
+        // way). Sync best-effort: try_lock first, spawn fallback for
+        // contended cases. The contended path is racy by design — we
+        // accept it as a backstop ONLY; correctness for the routing
+        // path comes from `unregister()` being called before return.
         if !self.active {
             return;
         }
-        // Drop is sync; we can only try to lock. The map is taken only
-        // briefly by the reader task or other guards, so try_lock should
-        // succeed in the common case. If contended, schedule removal so
-        // the entry doesn't outlive the call indefinitely.
         if let Ok(mut map) = self.handlers.try_lock() {
             map.remove(&self.id);
         } else {
@@ -594,6 +812,7 @@ impl ProgressAwareStdioTransport {
         config: &McpServerConnectionConfig,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
         roots: Arc<Vec<Root>>,
+        advertise_sampling: bool,
     ) -> Result<Self, McpTransportError> {
         let command = config.command.as_ref().ok_or_else(|| {
             McpTransportError::TransportError("Stdio transport requires command".to_string())
@@ -790,11 +1009,15 @@ impl ProgressAwareStdioTransport {
         };
 
         let mut capabilities = InitializeCapabilities::default();
-        if sampling_handler.is_some() {
+        // Advertise `sampling` only when this transport has a handler
+        // that can safely answer global server-initiated requests. A
+        // per-call factory is not global capability support; it is only
+        // safe when the stream binds the request to a specific call id.
+        if sampling_handler.is_some() || advertise_sampling {
             capabilities.sampling = Some(SamplingCapabilities::default());
         }
         if !transport.roots.is_empty() {
-            // Spec 2025-06-18 §Client features: clients advertising
+            // Spec 2025-11-25 §Client features: clients advertising
             // `roots` MUST be prepared to respond to `roots/list`. Our
             // roots are static post-construction (set via the
             // constructor arg, no runtime mutation today), so we
@@ -863,20 +1086,27 @@ impl ProgressAwareStdioTransport {
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
-        self.send_request_with_id(id, method, params, progress_registration)
+        self.send_request_with_id(id, method, params, progress_registration, None)
             .await
     }
 
-    /// Send a JSON-RPC request using a caller-supplied id. Extracted from
-    /// `send_request` so cancellable call paths can allocate the id up
-    /// front and reuse it when emitting `notifications/cancelled`
-    /// (which references the in-flight request by id per spec).
+    /// Send a JSON-RPC request using a caller-supplied id.
+    ///
+    /// `sent_flag`, when supplied, is set to `true` once the request
+    /// has been enqueued for transmission (channel push for stdio,
+    /// HTTP send returning OK for HTTP). The cancellable call path
+    /// reads it before emitting `notifications/cancelled`: if the
+    /// request never went out, the server hasn't allocated state for
+    /// the id, so the spec-mandated notification would reference a
+    /// requestId the peer never saw — confusing logs at best, an
+    /// "unknown requestId" rejection at worst.
     async fn send_request_with_id(
         &self,
         id: i64,
         method: &str,
         params: Option<Value>,
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        sent_flag: Option<Arc<AtomicBool>>,
     ) -> Result<Value, McpTransportError> {
         if !self.alive.load(Ordering::SeqCst) {
             return Err(McpTransportError::ConnectionClosed);
@@ -904,6 +1134,14 @@ impl ProgressAwareStdioTransport {
                 self.progress_subscribers.lock().await.remove(&key);
             }
             return Err(McpTransportError::ConnectionClosed);
+        }
+
+        // Channel push succeeded — the writer task will flush this
+        // line; ordering between the request and any subsequent
+        // notification (e.g. cancellation) is preserved via the
+        // single-consumer write channel.
+        if let Some(flag) = sent_flag.as_ref() {
+            flag.store(true, Ordering::SeqCst);
         }
 
         let response = tokio::time::timeout(self.timeout, rx).await;
@@ -1064,14 +1302,16 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         // required: if registration raced the server-initiated
         // sampling/createMessage we want to route to this entry, an
         // earlier try_lock-based scheme would silently miss it.
-        let _handler_guard =
+        let mut handler_guard =
             PerCallSamplingGuard::register(Arc::clone(&self.per_call_sampling), id, sampling).await;
 
+        let request_sent = Arc::new(AtomicBool::new(false));
         let request_fut = self.send_request_with_id(
             id,
             "tools/call",
             Some(serde_json::to_value(&params)?),
             progress_sender,
+            Some(Arc::clone(&request_sent)),
         );
 
         let result = match cancellation {
@@ -1081,7 +1321,7 @@ impl McpToolTransport for ProgressAwareStdioTransport {
                 tokio::select! {
                     biased;
                     _ = token.cancelled() => {
-                        // Per spec (2025-06-18 §Cancellation): the client
+                        // Per spec (2025-11-25 §Cancellation): the client
                         // SHOULD send `notifications/cancelled` with the
                         // in-flight requestId so the server can stop
                         // processing and free resources. We use the
@@ -1090,27 +1330,48 @@ impl McpToolTransport for ProgressAwareStdioTransport {
                         // returns; `kill_on_drop(true)` would race the
                         // notification write and the server might never
                         // see the cancellation.
-                        let _ = self
-                            .send_notification_flushed(
-                                "notifications/cancelled",
-                                Some(json!({
-                                    "requestId": id,
-                                    "reason": "client run cancelled",
-                                })),
-                            )
-                            .await;
+                        //
+                        // Only emit when the request actually went out.
+                        // If cancellation fired before `request_fut` had
+                        // a chance to push the request line onto the
+                        // write channel, the server never allocated
+                        // state for this requestId — emitting the
+                        // notification would reference an unknown id.
+                        if request_sent.load(Ordering::SeqCst) {
+                            let _ = self
+                                .send_notification_flushed(
+                                    "notifications/cancelled",
+                                    Some(json!({
+                                        "requestId": id,
+                                        "reason": "client run cancelled",
+                                    })),
+                                )
+                                .await;
+                        }
                         // Drop the pending entry so a late response is
                         // dropped on the reader floor rather than
                         // delivered to an orphaned channel.
                         self.forget_pending(id).await;
-                        Err(McpTransportError::TransportError(
+                        // Deterministic guard cleanup before return —
+                        // ensures cardinality-based routing doesn't
+                        // observe a stale entry from this just-returned
+                        // call. The sync Drop is a backstop only.
+                        handler_guard.unregister().await;
+                        return Err(McpTransportError::TransportError(
                             CANCELLED_BY_CLIENT.to_string(),
-                        ))
+                        ));
                     }
                     result = &mut request_fut => result,
                 }
             }
         };
+
+        // Deterministic guard cleanup on every non-cancel return path,
+        // before we transform `result` into the final value the caller
+        // sees. Without this, a fast follow-up call could observe a
+        // map entry from the just-returned call and route sampling to
+        // a stale handler.
+        handler_guard.unregister().await;
 
         let result = result?;
         let call_result: CallToolResult = serde_json::from_value(result)?;
@@ -1201,10 +1462,13 @@ impl McpToolTransport for ProgressAwareStdioTransport {
 pub(crate) struct ProgressAwareHttpTransport {
     endpoint: String,
     client: reqwest::Client,
+    streaming_client: reqwest::Client,
+    timeout: Duration,
     next_id: AtomicI64,
     next_progress_token: AtomicI64,
-    capabilities: tokio::sync::Mutex<Option<ServerCapabilities>>,
-    session: tokio::sync::RwLock<HttpSessionState>,
+    capabilities: Arc<tokio::sync::Mutex<Option<ServerCapabilities>>>,
+    initialize_lock: tokio::sync::Mutex<()>,
+    session: Arc<tokio::sync::RwLock<HttpSessionState>>,
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
     /// Per-call sampling handlers; same semantics as the stdio variant.
     /// Populated by `call_tool` while a request is in flight; consulted
@@ -1230,12 +1494,84 @@ pub(crate) struct ProgressAwareHttpTransport {
     /// Non-empty → roots capability advertised at initialize and
     /// `roots/list` is served from this list.
     roots: Arc<Vec<Root>>,
+    /// Whether to advertise `sampling` capability at initialize. This
+    /// is true only when the manager has a transport-level fallback
+    /// handler that can answer server requests without per-call
+    /// attribution; factory-only routing intentionally leaves it false.
+    advertise_sampling: bool,
+    /// Tracks whether we've spawned the background GET listening
+    /// stream task yet (spec 2025-11-25 §Streamable HTTP / Listening
+    /// for Messages from the Server). Start-once, never restart from
+    /// here — the task itself loops over connect / reconnect /
+    /// backoff. Set via `swap` so concurrent first-initialize callers
+    /// don't double-spawn.
+    listener_started: AtomicBool,
+    /// `AbortHandle` for the listener task. Held so `close()` (and
+    /// the Drop impl) can cancel the task immediately rather than
+    /// leaking it past the transport's lifetime. `None` before the
+    /// task is spawned; cleared on `close()`.
+    listener_abort: std::sync::Mutex<Option<tokio::task::AbortHandle>>,
+    /// Atomic kill switch the listener task polls between SSE chunks
+    /// so a clean `close()` shuts it down even if `AbortHandle::abort`
+    /// races a pending request.
+    listener_alive: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone, Default)]
 struct HttpSessionState {
     session_id: Option<String>,
     protocol_version: Option<String>,
+    started_at: Option<SystemTime>,
+    generation: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct HttpSessionSnapshot {
+    session_id: Option<String>,
+    protocol_version: Option<String>,
+    generation: u64,
+}
+
+impl HttpSessionState {
+    fn snapshot(&self) -> HttpSessionSnapshot {
+        HttpSessionSnapshot {
+            session_id: self.session_id.clone(),
+            protocol_version: self.protocol_version.clone(),
+            generation: self.generation,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HttpPostResponse {
+    response: reqwest::Response,
+    session: HttpSessionSnapshot,
+}
+
+async fn reset_http_session_state_if_current(
+    session: &Arc<tokio::sync::RwLock<HttpSessionState>>,
+    capabilities: &Arc<tokio::sync::Mutex<Option<ServerCapabilities>>>,
+    expected_session_id: Option<&str>,
+    expected_protocol_version: Option<&str>,
+    expected_generation: u64,
+) -> bool {
+    // Lock capabilities first to match initialize_if_needed's ordering.
+    // This keeps "clear caps + clear session" atomic from request paths
+    // that would otherwise see stale capabilities with an empty session.
+    let mut capabilities_guard = capabilities.lock().await;
+    let mut session_guard = session.write().await;
+    if session_guard.session_id.as_deref() != expected_session_id
+        || session_guard.protocol_version.as_deref() != expected_protocol_version
+        || session_guard.generation != expected_generation
+    {
+        return false;
+    }
+    *session_guard = HttpSessionState {
+        generation: session_guard.generation.saturating_add(1),
+        ..HttpSessionState::default()
+    };
+    *capabilities_guard = None;
+    true
 }
 
 impl ProgressAwareHttpTransport {
@@ -1243,6 +1579,7 @@ impl ProgressAwareHttpTransport {
         config: &McpServerConnectionConfig,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
         roots: Arc<Vec<Root>>,
+        advertise_sampling: bool,
     ) -> Result<Self, McpTransportError> {
         let endpoint = config.url.as_ref().ok_or_else(|| {
             McpTransportError::TransportError("HTTP transport requires URL".to_string())
@@ -1254,16 +1591,29 @@ impl ProgressAwareHttpTransport {
             .map_err(|e| {
                 McpTransportError::TransportError(format!("Failed to create HTTP client: {}", e))
             })?;
+        let streaming_client = reqwest::Client::builder()
+            .connect_timeout(timeout)
+            .read_timeout(timeout)
+            .build()
+            .map_err(|e| {
+                McpTransportError::TransportError(format!(
+                    "Failed to create HTTP streaming client: {}",
+                    e
+                ))
+            })?;
 
         let (list_changed_tx, list_changed_rx) = mpsc::unbounded_channel::<ListChangedKind>();
         let (resource_updated_tx, resource_updated_rx) = mpsc::unbounded_channel::<String>();
         Ok(Self {
             endpoint: endpoint.clone(),
             client,
+            streaming_client,
+            timeout,
             next_id: AtomicI64::new(1),
             next_progress_token: AtomicI64::new(1),
-            capabilities: tokio::sync::Mutex::new(None),
-            session: tokio::sync::RwLock::new(HttpSessionState::default()),
+            capabilities: Arc::new(tokio::sync::Mutex::new(None)),
+            initialize_lock: tokio::sync::Mutex::new(()),
+            session: Arc::new(tokio::sync::RwLock::new(HttpSessionState::default())),
             sampling_handler,
             per_call_sampling: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             list_changed_tx,
@@ -1271,28 +1621,48 @@ impl ProgressAwareHttpTransport {
             resource_updated_tx,
             resource_updated_rx: tokio::sync::Mutex::new(Some(resource_updated_rx)),
             roots,
+            advertise_sampling,
+            listener_started: AtomicBool::new(false),
+            listener_abort: std::sync::Mutex::new(None),
+            listener_alive: Arc::new(AtomicBool::new(true)),
         })
     }
 
     async fn initialize_if_needed(&self) -> Result<ServerCapabilities, McpTransportError> {
-        let mut guard = self.capabilities.lock().await;
-        if let Some(capabilities) = guard.clone() {
-            return Ok(capabilities);
+        {
+            let guard = self.capabilities.lock().await;
+            if let Some(capabilities) = guard.clone() {
+                self.spawn_listening_stream_once();
+                return Ok(capabilities);
+            }
+        }
+
+        let _initialize_guard = self.initialize_lock.lock().await;
+        {
+            let guard = self.capabilities.lock().await;
+            if let Some(capabilities) = guard.clone() {
+                self.spawn_listening_stream_once();
+                return Ok(capabilities);
+            }
         }
         let capabilities = self.initialize().await?;
+        let mut guard = self.capabilities.lock().await;
         *guard = Some(capabilities.clone());
+        drop(guard);
+        self.spawn_listening_stream_once();
         Ok(capabilities)
     }
 
     async fn initialize(&self) -> Result<ServerCapabilities, McpTransportError> {
         // Build advertised capabilities the same way the stdio path
-        // does: sampling iff a handler is configured, roots iff we
-        // have roots to serve. HTTP used to send empty capabilities
-        // (`{}`), which masked the sampling support — the server
-        // would refuse to call `sampling/createMessage` even though
-        // the client could handle it. Fix as part of the roots work.
+        // does: sampling iff this transport has a handler that can
+        // answer global server-initiated sampling requests, roots iff we
+        // have roots to serve. Per-call factories are intentionally not
+        // advertised as global sampling support; they are only safe on
+        // per-request SSE streams where request_id binds the sampling
+        // request to a specific agent call.
         let mut caps = InitializeCapabilities::default();
-        if self.sampling_handler.is_some() {
+        if self.sampling_handler.is_some() || self.advertise_sampling {
             caps.sampling = Some(SamplingCapabilities::default());
         }
         if !self.roots.is_empty() {
@@ -1302,48 +1672,130 @@ impl ProgressAwareHttpTransport {
         }
         let caps_value = serde_json::to_value(&caps).unwrap_or_else(|_| json!({}));
         let request_id = self.next_id.fetch_add(1, Ordering::SeqCst);
-        let response = self
+        let post_response = self
             .post_message(
                 JsonRpcMessage::Request(JsonRpcRequest::new(
                     JsonRpcId::Number(request_id),
                     "initialize".to_string(),
                     Some(initialize_params(caps_value, Value::Null)),
                 )),
-                false,
+                true,
             )
             .await?;
 
-        // Spec literal: `Mcp-Session-Id`. HeaderMap::get is
+        // Spec literal: `MCP-Session-Id`. HeaderMap::get is
         // case-insensitive so this works regardless of how the server
         // capitalises the response header.
-        let session_id = response
+        let session_id = post_response
+            .response
             .headers()
-            .get("Mcp-Session-Id")
+            .get("MCP-Session-Id")
             .and_then(|value| value.to_str().ok())
             .map(str::to_string);
 
-        let body = self
-            .decode_http_body(response, request_id, None)
+        let body = match self
+            .decode_initialize_body(post_response.response, request_id, session_id.as_deref())
             .await
-            .map_err(|e| McpTransportError::ProtocolError(format!("initialize failed: {e}")))?;
-        let result: InitializeResult = serde_json::from_value(body)?;
+        {
+            Ok(body) => body,
+            Err(err) => {
+                if let Some(session_id) = session_id.as_deref() {
+                    self.send_session_termination(session_id, None).await;
+                }
+                return Err(McpTransportError::ProtocolError(format!(
+                    "initialize failed: {err}"
+                )));
+            }
+        };
+        let result: InitializeResult = match serde_json::from_value(body) {
+            Ok(result) => result,
+            Err(err) => {
+                if let Some(session_id) = session_id.as_deref() {
+                    self.send_session_termination(session_id, None).await;
+                }
+                return Err(err.into());
+            }
+        };
 
         // Validate the server-echoed protocolVersion BEFORE accepting
         // the session id or emitting `notifications/initialized`. On
         // mismatch we leave session state empty so the next attempt
         // re-handshakes rather than half-living with an unusable session.
-        let negotiated = negotiate_protocol_version(&result.protocol_version)?;
+        let negotiated = match negotiate_protocol_version(&result.protocol_version) {
+            Ok(negotiated) => negotiated,
+            Err(err) => {
+                if let Some(session_id) = session_id.as_deref() {
+                    self.send_session_termination(session_id, None).await;
+                }
+                return Err(err);
+            }
+        };
 
-        {
+        let installed_generation = {
             let mut session = self.session.write().await;
-            session.session_id = session_id;
+            let installed_generation = session.generation.saturating_add(1);
+            session.session_id = session_id.clone();
             session.protocol_version = Some(negotiated.to_string());
+            session.started_at = Some(SystemTime::now());
+            session.generation = installed_generation;
+            installed_generation
+        };
+
+        if let Err(err) = self
+            .send_notification("notifications/initialized", Some(json!({})))
+            .await
+        {
+            reset_http_session_state_if_current(
+                &self.session,
+                &self.capabilities,
+                session_id.as_deref(),
+                Some(negotiated),
+                installed_generation,
+            )
+            .await;
+            if let Some(session_id) = session_id.as_deref() {
+                self.send_session_termination(session_id, Some(negotiated))
+                    .await;
+            }
+            return Err(err);
         }
 
-        self.send_notification("notifications/initialized", Some(json!({})))
-            .await?;
-
         Ok(result.capabilities)
+    }
+
+    /// Spawn the background GET listener task at most once per
+    /// transport instance. Idempotent: subsequent calls are no-ops.
+    fn spawn_listening_stream_once(&self) {
+        if self.listener_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let client = self.client.clone();
+        let streaming_client = self.streaming_client.clone();
+        let endpoint = self.endpoint.clone();
+        let session = Arc::clone(&self.session);
+        let capabilities = Arc::clone(&self.capabilities);
+        let list_changed_tx = self.list_changed_tx.clone();
+        let resource_updated_tx = self.resource_updated_tx.clone();
+        let roots = Arc::clone(&self.roots);
+        let fallback_sampling = self.sampling_handler.clone();
+        let alive = Arc::clone(&self.listener_alive);
+
+        let handle = tokio::spawn(run_http_listening_stream(HttpListenerCtx {
+            client,
+            streaming_client,
+            timeout: self.timeout,
+            endpoint,
+            session,
+            capabilities,
+            list_changed_tx,
+            resource_updated_tx,
+            roots,
+            fallback_sampling,
+            alive,
+        }));
+        if let Ok(mut slot) = self.listener_abort.lock() {
+            *slot = Some(handle.abort_handle());
+        }
     }
 
     async fn send_request(
@@ -1353,26 +1805,57 @@ impl ProgressAwareHttpTransport {
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
-        self.send_request_with_id(id, method, params, progress_registration)
+        self.send_request_with_id(id, method, params, progress_registration, None, None)
             .await
     }
 
     /// Variant of `send_request` that uses a caller-allocated id so the
     /// cancellable call path can emit `notifications/cancelled` against
     /// the same in-flight request id.
+    ///
+    /// `sent_flag` is an optimistic "believed in-progress" marker. It is
+    /// set after the HTTP session snapshot has been captured but before
+    /// awaiting response headers, because that wait can last for the
+    /// whole tool execution. `sent_session`, when supplied, receives the
+    /// exact session snapshot used for the POST so cancellation can send
+    /// `notifications/cancelled` to the original session instead of a
+    /// newer session installed by a concurrent reset/reinitialize.
     async fn send_request_with_id(
         &self,
         id: i64,
         method: &str,
         params: Option<Value>,
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        sent_flag: Option<Arc<AtomicBool>>,
+        sent_session: Option<Arc<tokio::sync::Mutex<Option<HttpSessionSnapshot>>>>,
     ) -> Result<Value, McpTransportError> {
         let request = JsonRpcRequest::new(JsonRpcId::Number(id), method.to_string(), params);
-        let response = self
-            .post_message(JsonRpcMessage::Request(request), true)
+        let session = self.session.read().await.snapshot();
+        if let Some(slot) = sent_session.as_ref() {
+            *slot.lock().await = Some(session.clone());
+        }
+        // Mark the request as "believed in-progress" BEFORE awaiting
+        // response headers. That await can last for the whole
+        // per-request SSE stream — many seconds for a long-running
+        // tool. Setting the flag only after that window would make the
+        // cancellation branch skip notifications/cancelled for the
+        // most-important case (slow tool call needs cancelling).
+        // Per MCP 2025-11-25 §Cancellation: unknown requestIds on
+        // `notifications/cancelled` SHOULD be ignored by the receiver,
+        // so being slightly optimistic here is safe.
+        if let Some(flag) = sent_flag.as_ref() {
+            flag.store(true, Ordering::SeqCst);
+        }
+        let post_response = self
+            .post_message_with_session_snapshot(JsonRpcMessage::Request(request), true, session)
             .await?;
-        self.decode_http_body(response, id, progress_registration)
-            .await
+        self.decode_http_body(
+            post_response.response,
+            id,
+            progress_registration,
+            Some(post_response.session),
+        )
+        .await
     }
 
     async fn send_initialized_request(
@@ -1387,8 +1870,7 @@ impl ProgressAwareHttpTransport {
             .await
         {
             Ok(value) => Ok(value),
-            Err(McpTransportError::ProtocolError(message)) if message == "MCP session expired" => {
-                self.reset_session().await;
+            Err(McpTransportError::ProtocolError(message)) if message == MCP_SESSION_EXPIRED => {
                 self.initialize_if_needed().await?;
                 self.send_request(method, params, progress_registration)
                     .await
@@ -1401,22 +1883,44 @@ impl ProgressAwareHttpTransport {
         &self,
         message: JsonRpcMessage,
         expect_response: bool,
-    ) -> Result<reqwest::Response, McpTransportError> {
-        let mut request = self.client.post(&self.endpoint).header(
+    ) -> Result<HttpPostResponse, McpTransportError> {
+        let session = self.session.read().await.snapshot();
+        self.post_message_with_session_snapshot(message, expect_response, session)
+            .await
+    }
+
+    async fn post_message_with_session_snapshot(
+        &self,
+        message: JsonRpcMessage,
+        expect_response: bool,
+        session: HttpSessionSnapshot,
+    ) -> Result<HttpPostResponse, McpTransportError> {
+        let is_initialize = matches!(
+            &message,
+            JsonRpcMessage::Request(request) if request.method == "initialize"
+        );
+        let client = if expect_response {
+            &self.streaming_client
+        } else {
+            &self.client
+        };
+        let mut request = client.post(&self.endpoint).header(
             reqwest::header::ACCEPT,
             "application/json, text/event-stream",
         );
 
-        let session = self.session.read().await.clone();
-        if let Some(protocol_version) = session.protocol_version {
-            request = request.header("MCP-Protocol-Version", protocol_version);
+        let sent_session_id = session.session_id.clone();
+        let sent_protocol_version = session.protocol_version.clone();
+        if !is_initialize && sent_protocol_version.is_none() {
+            return Err(McpTransportError::ProtocolError(
+                MCP_SESSION_EXPIRED.to_string(),
+            ));
         }
-        if let Some(session_id) = session.session_id {
-            // Spec literal is `Mcp-Session-Id` (title case), not `MCP-`.
-            // HTTP headers are case-insensitive per RFC 7230 so both work
-            // against compliant servers, but the spec writes it in title
-            // case and some intermediaries are pickier than they should be.
-            request = request.header("Mcp-Session-Id", session_id);
+        if let Some(ref protocol_version) = sent_protocol_version {
+            request = request.header("MCP-Protocol-Version", protocol_version.clone());
+        }
+        if let Some(ref session_id) = sent_session_id {
+            request = request.header("MCP-Session-Id", session_id.clone());
         }
 
         request = match message {
@@ -1425,21 +1929,39 @@ impl ProgressAwareHttpTransport {
             JsonRpcMessage::Response(response) => request.json(&response),
         };
 
-        let response = request.send().await.map_err(|e| {
-            McpTransportError::TransportError(format!("HTTP request failed: {}", e))
-        })?;
+        let response = tokio::time::timeout(self.timeout, request.send())
+            .await
+            .map_err(|_| {
+                McpTransportError::Timeout(format!(
+                    "HTTP request did not receive response headers within {:?}",
+                    self.timeout
+                ))
+            })?
+            .map_err(|e| {
+                McpTransportError::TransportError(format!("HTTP request failed: {}", e))
+            })?;
 
         let status = response.status();
         if !status.is_success() {
-            if status == reqwest::StatusCode::NOT_FOUND
-                && self.session.read().await.session_id.is_some()
-            {
+            if status == reqwest::StatusCode::NOT_FOUND && sent_session_id.is_some() {
+                reset_http_session_state_if_current(
+                    &self.session,
+                    &self.capabilities,
+                    sent_session_id.as_deref(),
+                    sent_protocol_version.as_deref(),
+                    session.generation,
+                )
+                .await;
                 return Err(McpTransportError::ProtocolError(
-                    "MCP session expired".to_string(),
+                    MCP_SESSION_EXPIRED.to_string(),
                 ));
             }
 
-            let body = response.text().await.unwrap_or_default();
+            let body = tokio::time::timeout(self.timeout, response.text())
+                .await
+                .ok()
+                .and_then(Result::ok)
+                .unwrap_or_default();
             return Err(McpTransportError::TransportError(format!(
                 "HTTP error: {} - {}",
                 status, body
@@ -1457,7 +1979,7 @@ impl ProgressAwareHttpTransport {
             )));
         }
 
-        Ok(response)
+        Ok(HttpPostResponse { response, session })
     }
 
     async fn send_notification(
@@ -1471,13 +1993,329 @@ impl ProgressAwareHttpTransport {
         Ok(())
     }
 
-    async fn send_response_message(
+    async fn send_notification_with_session(
+        &self,
+        method: &str,
+        params: Option<Value>,
+        request_session: &HttpSessionSnapshot,
+    ) -> Result<(), McpTransportError> {
+        let current_session = self.session.read().await.snapshot();
+        if current_session.generation != request_session.generation
+            || current_session.session_id != request_session.session_id
+            || current_session.protocol_version != request_session.protocol_version
+        {
+            tracing::debug!(
+                request_generation = request_session.generation,
+                current_generation = current_session.generation,
+                "sending MCP notification with captured HTTP session because current session changed"
+            );
+        }
+
+        let notification = JsonRpcNotification::new(method, params);
+        self.post_message_with_session_snapshot(
+            JsonRpcMessage::Notification(notification),
+            false,
+            request_session.clone(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn send_response_message_with_session(
         &self,
         response: JsonRpcResponse,
+        request_session: &HttpSessionSnapshot,
     ) -> Result<(), McpTransportError> {
-        self.post_message(JsonRpcMessage::Response(response), false)
-            .await?;
-        Ok(())
+        let current_session = self.session.read().await.snapshot();
+        if current_session.generation != request_session.generation
+            || current_session.session_id != request_session.session_id
+            || current_session.protocol_version != request_session.protocol_version
+        {
+            tracing::debug!(
+                stream_generation = request_session.generation,
+                current_generation = current_session.generation,
+                "dropping MCP per-request SSE response for stale HTTP session generation"
+            );
+            return Err(McpTransportError::ProtocolError(
+                MCP_SESSION_EXPIRED_AFTER_ACCEPT.to_string(),
+            ));
+        }
+
+        match self
+            .post_message_with_session_snapshot(
+                JsonRpcMessage::Response(response),
+                false,
+                request_session.clone(),
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(McpTransportError::ProtocolError(message)) if message == MCP_SESSION_EXPIRED => {
+                Err(McpTransportError::ProtocolError(
+                    MCP_SESSION_EXPIRED_AFTER_ACCEPT.to_string(),
+                ))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn decode_initialize_body(
+        &self,
+        response: reqwest::Response,
+        request_id: i64,
+        provisional_session_id: Option<&str>,
+    ) -> Result<Value, McpTransportError> {
+        let content_type = response_content_type(&response);
+
+        if content_type.starts_with("application/json") {
+            let body = decode_json_response_body(response, self.timeout).await?;
+            return decode_http_response_payload(body, request_id, None);
+        }
+
+        if content_type.starts_with("text/event-stream") {
+            return self
+                .decode_initialize_sse_response(response, request_id, provisional_session_id)
+                .await;
+        }
+
+        Err(McpTransportError::ProtocolError(format!(
+            "Unsupported HTTP content type: {}",
+            content_type
+        )))
+    }
+
+    async fn decode_initialize_sse_response(
+        &self,
+        response: reqwest::Response,
+        request_id: i64,
+        provisional_session_id: Option<&str>,
+    ) -> Result<Value, McpTransportError> {
+        let mut last_event_id: Option<String> = None;
+        let mut retry_delay: Option<Duration> = None;
+        let mut resume_attempts = 0u32;
+        let mut current_response = response;
+
+        loop {
+            let mut matched_response: Option<Result<Value, McpTransportError>> = None;
+            let mut event_lines: Vec<String> = Vec::new();
+            let mut event_bytes = 0usize;
+            let mut line_buf: Vec<u8> = Vec::new();
+            let mut stream_io_error: Option<reqwest::Error> = None;
+            let mut stream = current_response.bytes_stream();
+
+            while let Some(chunk) = stream.next().await {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(err) => {
+                        stream_io_error = Some(err);
+                        break;
+                    }
+                };
+
+                for byte in chunk {
+                    if byte == b'\n' {
+                        let mut line =
+                            String::from_utf8(std::mem::take(&mut line_buf)).map_err(|e| {
+                                McpTransportError::ProtocolError(format!(
+                                    "Invalid UTF-8 in initialize SSE response: {}",
+                                    e
+                                ))
+                            })?;
+                        if line.ends_with('\r') {
+                            line.pop();
+                        }
+
+                        if line.is_empty() {
+                            apply_event_id_update(
+                                &mut last_event_id,
+                                extract_event_id(&event_lines),
+                            );
+                            if let Some(result) =
+                                self.process_initialize_sse_event(&event_lines, request_id)?
+                            {
+                                matched_response = Some(result);
+                                break;
+                            }
+                            if let Some(delay) =
+                                bounded_sse_retry_delay(&event_lines, "initialize SSE response")?
+                            {
+                                retry_delay = Some(delay);
+                            }
+                            event_lines.clear();
+                            event_bytes = 0;
+                        } else {
+                            push_sse_event_line(
+                                &mut event_lines,
+                                &mut event_bytes,
+                                line,
+                                "initialize SSE response",
+                            )?;
+                        }
+                    } else {
+                        push_sse_line_byte(&mut line_buf, byte, "initialize SSE response")?;
+                    }
+                }
+
+                if matched_response.is_some() {
+                    break;
+                }
+            }
+
+            if !line_buf.is_empty() {
+                let mut line = String::from_utf8(std::mem::take(&mut line_buf)).map_err(|e| {
+                    McpTransportError::ProtocolError(format!(
+                        "Invalid UTF-8 in initialize SSE response: {}",
+                        e
+                    ))
+                })?;
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+                push_sse_event_line(
+                    &mut event_lines,
+                    &mut event_bytes,
+                    line,
+                    "initialize SSE response",
+                )?;
+            }
+
+            if matched_response.is_none() && !event_lines.is_empty() && stream_io_error.is_none() {
+                apply_event_id_update(&mut last_event_id, extract_event_id(&event_lines));
+                matched_response = self.process_initialize_sse_event(&event_lines, request_id)?;
+                if matched_response.is_none()
+                    && let Some(delay) =
+                        bounded_sse_retry_delay(&event_lines, "initialize SSE response")?
+                {
+                    retry_delay = Some(delay);
+                }
+            }
+
+            if let Some(result) = matched_response {
+                return result;
+            }
+
+            if resume_attempts < MAX_SSE_RESUME_ATTEMPTS
+                && let (Some(session_id), Some(id)) =
+                    (provisional_session_id, last_event_id.clone())
+            {
+                resume_attempts += 1;
+                if let Some(delay) = retry_delay {
+                    tokio::time::sleep(delay).await;
+                }
+                tracing::debug!(
+                    request_id,
+                    attempt = resume_attempts,
+                    last_event_id = %id,
+                    clean_eof = stream_io_error.is_none(),
+                    "initialize SSE stream ended before matched response; attempting Last-Event-ID resume"
+                );
+                match self.get_initialize_resume_stream(&id, session_id).await {
+                    Ok(resumed) => {
+                        current_response = resumed;
+                        continue;
+                    }
+                    Err(resume_err) => {
+                        if let Some(err) = stream_io_error {
+                            tracing::warn!(
+                                error = %resume_err,
+                                "initialize Last-Event-ID resume failed; surfacing original stream error"
+                            );
+                            return Err(McpTransportError::TransportError(format!(
+                                "Failed to read initialize SSE response body: {}",
+                                err
+                            )));
+                        }
+                        return Err(resume_err);
+                    }
+                }
+            }
+
+            if let Some(err) = stream_io_error {
+                return Err(McpTransportError::TransportError(format!(
+                    "Failed to read initialize SSE response body: {}",
+                    err
+                )));
+            }
+
+            return Err(McpTransportError::ProtocolError(format!(
+                "Missing initialize response for request id {}",
+                request_id
+            )));
+        }
+    }
+
+    fn process_initialize_sse_event(
+        &self,
+        lines: &[String],
+        request_id: i64,
+    ) -> Result<Option<Result<Value, McpTransportError>>, McpTransportError> {
+        let Some(payload) = sse_data_payload(lines, "initialize SSE response")? else {
+            return Ok(None);
+        };
+
+        let message =
+            parse_json_rpc_message(serde_json::from_str::<Value>(&payload).map_err(|e| {
+                McpTransportError::ProtocolError(format!(
+                    "Invalid JSON payload in initialize SSE response: {}",
+                    e
+                ))
+            })?)?;
+
+        match message {
+            JsonRpcMessage::Response(response) => {
+                if matches!(response.id, JsonRpcId::Number(id) if id == request_id) {
+                    Ok(Some(map_response_payload(response.payload)))
+                } else {
+                    Err(McpTransportError::ProtocolError(format!(
+                        "initialize SSE stream for request id {request_id} returned response for different id {:?}",
+                        response.id
+                    )))
+                }
+            }
+            JsonRpcMessage::Notification(_) => Ok(None),
+            JsonRpcMessage::Request(request) => Err(McpTransportError::ProtocolError(format!(
+                "initialize SSE stream returned server request before initialization completed: {}",
+                request.method
+            ))),
+        }
+    }
+
+    async fn get_initialize_resume_stream(
+        &self,
+        last_event_id: &str,
+        session_id: &str,
+    ) -> Result<reqwest::Response, McpTransportError> {
+        let request = self
+            .streaming_client
+            .get(&self.endpoint)
+            .header(reqwest::header::ACCEPT, "text/event-stream")
+            .header("MCP-Session-Id", session_id)
+            .header("MCP-Protocol-Version", MCP_PROTOCOL_VERSION)
+            .header("Last-Event-ID", last_event_id);
+
+        let response = tokio::time::timeout(self.timeout, request.send())
+            .await
+            .map_err(|_| {
+                McpTransportError::Timeout(format!(
+                    "initialize SSE resume GET did not receive response headers within {:?}",
+                    self.timeout
+                ))
+            })?
+            .map_err(|e| {
+                McpTransportError::TransportError(format!(
+                    "initialize SSE resume GET failed: {}",
+                    e
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            return Err(McpTransportError::TransportError(format!(
+                "initialize SSE resume GET returned {}",
+                response.status()
+            )));
+        }
+        validate_sse_response(&response, "initialize SSE resume GET")?;
+        Ok(response)
     }
 
     async fn decode_http_body(
@@ -1485,24 +2323,23 @@ impl ProgressAwareHttpTransport {
         response: reqwest::Response,
         request_id: i64,
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        request_session: Option<HttpSessionSnapshot>,
     ) -> Result<Value, McpTransportError> {
-        let content_type = response
-            .headers()
-            .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .unwrap_or_default()
-            .to_ascii_lowercase();
+        let content_type = response_content_type(&response);
 
         if content_type.starts_with("application/json") {
-            let body: Value = response.json().await.map_err(|e| {
-                McpTransportError::TransportError(format!("Failed to parse JSON response: {}", e))
-            })?;
+            let body = decode_json_response_body(response, self.timeout).await?;
             return decode_http_response_payload(body, request_id, progress_registration);
         }
 
         if content_type.starts_with("text/event-stream") {
+            let request_session = request_session.ok_or_else(|| {
+                McpTransportError::ProtocolError(
+                    "SSE response missing HTTP session snapshot".to_string(),
+                )
+            })?;
             return self
-                .decode_sse_response(response, request_id, progress_registration)
+                .decode_sse_response(response, request_id, progress_registration, request_session)
                 .await;
         }
 
@@ -1517,79 +2354,270 @@ impl ProgressAwareHttpTransport {
         response: reqwest::Response,
         request_id: i64,
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+        request_session: HttpSessionSnapshot,
     ) -> Result<Value, McpTransportError> {
         let progress_key = progress_registration.as_ref().map(|(key, _)| key.clone());
         let progress_tx = progress_registration.as_ref().map(|(_, tx)| tx.clone());
-        let mut matched_response: Option<Result<Value, McpTransportError>> = None;
-        let mut event_lines: Vec<String> = Vec::new();
-        let mut line_buf: Vec<u8> = Vec::new();
-        let mut stream = response.bytes_stream();
 
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| {
-                McpTransportError::TransportError(format!(
-                    "Failed to read SSE response body: {}",
-                    e
-                ))
-            })?;
+        // Per spec 2025-11-25 §Streamable HTTP / Resumability: track
+        // the highest `id:` field we've seen so a mid-stream drop or a
+        // clean server close before the final response can be resumed via
+        // `GET <endpoint>` + `Last-Event-ID`.
+        let mut last_event_id: Option<String> = None;
+        let mut retry_delay: Option<Duration> = None;
+        let mut resume_attempts = 0u32;
+        let mut current_response = response;
 
-            for byte in chunk {
-                if byte == b'\n' {
-                    let mut line =
-                        String::from_utf8(std::mem::take(&mut line_buf)).map_err(|e| {
-                            McpTransportError::ProtocolError(format!(
-                                "Invalid UTF-8 in SSE response: {}",
-                                e
-                            ))
-                        })?;
-                    if line.ends_with('\r') {
-                        line.pop();
+        loop {
+            let mut matched_response: Option<Result<Value, McpTransportError>> = None;
+            let mut event_lines: Vec<String> = Vec::new();
+            let mut event_bytes = 0usize;
+            let mut line_buf: Vec<u8> = Vec::new();
+            let mut stream_io_error: Option<reqwest::Error> = None;
+            let mut stream = current_response.bytes_stream();
+
+            while let Some(chunk) = stream.next().await {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(err) => {
+                        // Mid-stream IO error. If we have a
+                        // last_event_id and reconnect budget remains,
+                        // we'll attempt resume below.
+                        stream_io_error = Some(err);
+                        break;
                     }
+                };
 
-                    if line.is_empty() {
-                        if let Some(result) = self
-                            .process_sse_event(
-                                &event_lines,
-                                request_id,
-                                progress_key.as_ref(),
-                                progress_tx.as_ref(),
-                            )
-                            .await?
-                        {
-                            matched_response = Some(result);
-                            break;
+                for byte in chunk {
+                    if byte == b'\n' {
+                        let mut line =
+                            String::from_utf8(std::mem::take(&mut line_buf)).map_err(|e| {
+                                McpTransportError::ProtocolError(format!(
+                                    "Invalid UTF-8 in SSE response: {}",
+                                    e
+                                ))
+                            })?;
+                        if line.ends_with('\r') {
+                            line.pop();
                         }
-                        event_lines.clear();
+
+                        if line.is_empty() {
+                            apply_event_id_update(
+                                &mut last_event_id,
+                                extract_event_id(&event_lines),
+                            );
+                            if let Some(result) = self
+                                .process_sse_event(
+                                    &event_lines,
+                                    request_id,
+                                    progress_key.as_ref(),
+                                    progress_tx.as_ref(),
+                                    &request_session,
+                                )
+                                .await?
+                            {
+                                matched_response = Some(result);
+                                break;
+                            }
+                            if let Some(delay) =
+                                bounded_sse_retry_delay(&event_lines, "HTTP SSE response")?
+                            {
+                                retry_delay = Some(delay);
+                            }
+                            event_lines.clear();
+                            event_bytes = 0;
+                        } else {
+                            push_sse_event_line(
+                                &mut event_lines,
+                                &mut event_bytes,
+                                line,
+                                "HTTP SSE response",
+                            )?;
+                        }
                     } else {
-                        event_lines.push(line);
+                        push_sse_line_byte(&mut line_buf, byte, "HTTP SSE response")?;
                     }
-                } else {
-                    line_buf.push(byte);
+                }
+
+                if matched_response.is_some() {
+                    break;
                 }
             }
 
-            if matched_response.is_some() {
-                break;
+            // Final event without trailing blank-line terminator.
+            if !line_buf.is_empty() {
+                let mut line = String::from_utf8(std::mem::take(&mut line_buf)).map_err(|e| {
+                    McpTransportError::ProtocolError(format!(
+                        "Invalid UTF-8 in SSE response: {}",
+                        e
+                    ))
+                })?;
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+                push_sse_event_line(
+                    &mut event_lines,
+                    &mut event_bytes,
+                    line,
+                    "HTTP SSE response",
+                )?;
             }
-        }
+            if matched_response.is_none() && !event_lines.is_empty() && stream_io_error.is_none() {
+                apply_event_id_update(&mut last_event_id, extract_event_id(&event_lines));
+                matched_response = self
+                    .process_sse_event(
+                        &event_lines,
+                        request_id,
+                        progress_key.as_ref(),
+                        progress_tx.as_ref(),
+                        &request_session,
+                    )
+                    .await?;
+                if matched_response.is_none()
+                    && let Some(delay) = bounded_sse_retry_delay(&event_lines, "HTTP SSE response")?
+                {
+                    retry_delay = Some(delay);
+                }
+            }
 
-        if matched_response.is_none() && !event_lines.is_empty() {
-            matched_response = self
-                .process_sse_event(
-                    &event_lines,
+            if let Some(result) = matched_response {
+                return result;
+            }
+
+            // Stream ended without a matched response. MCP Streamable HTTP
+            // permits the server to close an SSE stream after sending an
+            // event id without terminating the logical stream; poll/resume
+            // through GET + Last-Event-ID for both broken streams and clean
+            // EOFs.
+            if resume_attempts < MAX_SSE_RESUME_ATTEMPTS
+                && let Some(id) = last_event_id.clone()
+            {
+                resume_attempts += 1;
+                if let Some(delay) = retry_delay {
+                    tokio::time::sleep(delay).await;
+                }
+                tracing::debug!(
                     request_id,
-                    progress_key.as_ref(),
-                    progress_tx.as_ref(),
-                )
-                .await?;
-        }
+                    attempt = resume_attempts,
+                    last_event_id = %id,
+                    clean_eof = stream_io_error.is_none(),
+                    "SSE stream ended before matched response; attempting Last-Event-ID resume"
+                );
+                match self
+                    .get_listening_stream(Some(&id), Some(request_session.generation))
+                    .await
+                {
+                    Ok(resumed) => {
+                        current_response = resumed;
+                        continue;
+                    }
+                    Err(resume_err) => {
+                        if matches!(
+                            &resume_err,
+                            McpTransportError::ProtocolError(message)
+                                if message == MCP_SESSION_EXPIRED
+                        ) {
+                            return Err(McpTransportError::ProtocolError(
+                                MCP_SESSION_EXPIRED_AFTER_ACCEPT.to_string(),
+                            ));
+                        }
+                        if let Some(err) = stream_io_error {
+                            tracing::warn!(
+                                error = %resume_err,
+                                "Last-Event-ID resume failed; surfacing original stream error"
+                            );
+                            return Err(McpTransportError::TransportError(format!(
+                                "Failed to read SSE response body: {}",
+                                err
+                            )));
+                        }
+                        return Err(resume_err);
+                    }
+                }
+            }
 
-        matched_response.unwrap_or_else(|| {
-            Err(McpTransportError::ProtocolError(format!(
+            if let Some(err) = stream_io_error {
+                return Err(McpTransportError::TransportError(format!(
+                    "Failed to read SSE response body: {}",
+                    err
+                )));
+            }
+
+            return Err(McpTransportError::ProtocolError(format!(
                 "Missing response for request id {}",
                 request_id
-            )))
-        })
+            )));
+        }
+    }
+
+    /// Issue a `GET <endpoint>` carrying the current session id and
+    /// the supplied `Last-Event-ID`. Used by [`decode_sse_response`] to
+    /// resume a broken per-request SSE stream. The server SHOULD reply
+    /// with an SSE stream containing only events strictly newer than
+    /// the supplied id (spec 2025-11-25 §Streamable HTTP / Resumability).
+    async fn get_listening_stream(
+        &self,
+        last_event_id: Option<&str>,
+        expected_generation: Option<u64>,
+    ) -> Result<reqwest::Response, McpTransportError> {
+        let mut request = self
+            .streaming_client
+            .get(&self.endpoint)
+            .header(reqwest::header::ACCEPT, "text/event-stream");
+        let session = self.session.read().await.snapshot();
+        let sent_session_id = session.session_id.clone();
+        let sent_protocol_version = session.protocol_version.clone();
+        if sent_protocol_version.is_none() {
+            return Err(McpTransportError::ProtocolError(
+                MCP_SESSION_EXPIRED.to_string(),
+            ));
+        }
+        if expected_generation.is_some_and(|generation| generation != session.generation) {
+            return Err(McpTransportError::ProtocolError(
+                MCP_SESSION_EXPIRED.to_string(),
+            ));
+        }
+        if let Some(ref session_id) = sent_session_id {
+            request = request.header("MCP-Session-Id", session_id.clone());
+        }
+        if let Some(ref protocol_version) = sent_protocol_version {
+            request = request.header("MCP-Protocol-Version", protocol_version.clone());
+        }
+        if let Some(id) = last_event_id {
+            request = request.header("Last-Event-ID", id);
+        }
+        let resp = tokio::time::timeout(self.timeout, request.send())
+            .await
+            .map_err(|_| {
+                McpTransportError::Timeout(format!(
+                    "SSE resume GET did not receive response headers within {:?}",
+                    self.timeout
+                ))
+            })?
+            .map_err(|e| {
+                McpTransportError::TransportError(format!("SSE resume GET failed: {}", e))
+            })?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND && sent_session_id.is_some() {
+            reset_http_session_state_if_current(
+                &self.session,
+                &self.capabilities,
+                sent_session_id.as_deref(),
+                sent_protocol_version.as_deref(),
+                session.generation,
+            )
+            .await;
+            return Err(McpTransportError::ProtocolError(
+                MCP_SESSION_EXPIRED.to_string(),
+            ));
+        }
+        if !resp.status().is_success() {
+            return Err(McpTransportError::TransportError(format!(
+                "SSE resume GET returned {}",
+                resp.status()
+            )));
+        }
+        validate_sse_response(&resp, "SSE resume GET")?;
+        Ok(resp)
     }
 
     async fn process_sse_event(
@@ -1598,25 +2626,11 @@ impl ProgressAwareHttpTransport {
         request_id: i64,
         progress_key: Option<&ProgressTokenKey>,
         progress_tx: Option<&mpsc::UnboundedSender<McpProgressUpdate>>,
+        request_session: &HttpSessionSnapshot,
     ) -> Result<Option<Result<Value, McpTransportError>>, McpTransportError> {
-        let mut data_parts = Vec::new();
-        for line in lines {
-            if line.starts_with(':') {
-                continue;
-            }
-            if let Some(rest) = line.strip_prefix("data:") {
-                data_parts.push(rest.trim_start().to_string());
-            }
-        }
-
-        if data_parts.is_empty() {
+        let Some(payload) = sse_data_payload(lines, "HTTP SSE response")? else {
             return Ok(None);
-        }
-
-        let payload = data_parts.join("\n");
-        if payload.is_empty() {
-            return Ok(None);
-        }
+        };
 
         let message =
             parse_json_rpc_message(serde_json::from_str::<Value>(&payload).map_err(|e| {
@@ -1631,7 +2645,10 @@ impl ProgressAwareHttpTransport {
                 if matches!(response.id, JsonRpcId::Number(id) if id == request_id) {
                     return Ok(Some(map_response_payload(response.payload)));
                 }
-                Ok(None)
+                Err(McpTransportError::ProtocolError(format!(
+                    "SSE stream for request id {request_id} returned response for different id {:?}",
+                    response.id
+                )))
             }
             JsonRpcMessage::Notification(notification) => {
                 if let Some(kind) = list_changed_method(&notification.method) {
@@ -1649,7 +2666,7 @@ impl ProgressAwareHttpTransport {
                 Ok(None)
             }
             JsonRpcMessage::Request(request) => {
-                // HTTP per-request SSE stream: per spec 2025-06-18
+                // HTTP per-request SSE stream: per spec 2025-11-25
                 // §Listening for Messages from the Server, messages on
                 // this stream "SHOULD relate to a single client request"
                 // — namely OUR `request_id`. So a server-initiated
@@ -1677,15 +2694,11 @@ impl ProgressAwareHttpTransport {
                 };
                 let response =
                     handle_server_request(chosen.as_deref(), self.roots.as_slice(), &request).await;
-                self.send_response_message(response).await?;
+                self.send_response_message_with_session(response, request_session)
+                    .await?;
                 Ok(None)
             }
         }
-    }
-
-    async fn reset_session(&self) {
-        *self.capabilities.lock().await = None;
-        *self.session.write().await = HttpSessionState::default();
     }
 }
 
@@ -1733,6 +2746,405 @@ fn send_signal(pid: u32, signal: Signal) -> Result<(), McpTransportError> {
 async fn terminate_child(child: &mut Child) -> Result<(), McpTransportError> {
     child.start_kill()?;
     let _ = child.wait().await;
+    Ok(())
+}
+
+// ── HTTP listening stream (spec 2025-11-25 §Streamable HTTP / Listening) ──
+
+/// State the listening-stream task needs. Held by value (each field
+/// is `Clone` or `Arc`'d) so the task is fully self-contained — it
+/// doesn't borrow from the transport, which lets the transport drop
+/// while the task is alive without lifetime headaches.
+struct HttpListenerCtx {
+    client: reqwest::Client,
+    streaming_client: reqwest::Client,
+    timeout: Duration,
+    endpoint: String,
+    session: Arc<tokio::sync::RwLock<HttpSessionState>>,
+    /// Same `Arc` the transport holds. Needed so the listener's 404
+    /// path can clear it: `initialize_if_needed` short-circuits when
+    /// `capabilities = Some`, so leaving it stale after a session
+    /// expiry would let subsequent calls send post_message() without
+    /// a session id (spec violation — server returns 400/404 again).
+    capabilities: Arc<tokio::sync::Mutex<Option<ServerCapabilities>>>,
+    list_changed_tx: mpsc::UnboundedSender<ListChangedKind>,
+    resource_updated_tx: mpsc::UnboundedSender<String>,
+    roots: Arc<Vec<Root>>,
+    fallback_sampling: Option<Arc<dyn SamplingHandler>>,
+    alive: Arc<AtomicBool>,
+}
+
+async fn run_http_listening_stream(ctx: HttpListenerCtx) {
+    const BACKOFF_BASE_MS: u64 = 500;
+    let mut backoff_ms: u64 = BACKOFF_BASE_MS;
+    let mut last_event_id: Option<String> = None;
+    let mut last_event_generation: Option<u64> = None;
+
+    while ctx.alive.load(Ordering::SeqCst) {
+        let session_snapshot = ctx.session.read().await.clone();
+        if last_event_generation != Some(session_snapshot.generation) {
+            // SSE event ids are scoped to the HTTP session/generation
+            // that produced them. Another request path can reset and
+            // re-initialize the session while this background listener
+            // is sleeping or consuming an old stream; never replay that
+            // old cursor against the fresh session.
+            last_event_id = None;
+            last_event_generation = Some(session_snapshot.generation);
+        }
+        if session_snapshot.protocol_version.is_none() {
+            // A prior 404 cleared the HTTP session. The request path
+            // owns re-initialize; the background listener must not send
+            // unauthenticated/unversioned GETs while waiting for that.
+            tokio::time::sleep(Duration::from_millis(BACKOFF_BASE_MS)).await;
+            continue;
+        }
+        let mut req = ctx
+            .streaming_client
+            .get(&ctx.endpoint)
+            .header(reqwest::header::ACCEPT, "text/event-stream");
+        if let Some(ref id) = session_snapshot.session_id {
+            req = req.header("MCP-Session-Id", id.clone());
+        }
+        if let Some(ref pv) = session_snapshot.protocol_version {
+            req = req.header("MCP-Protocol-Version", pv.clone());
+        }
+        if let Some(ref id) = last_event_id {
+            req = req.header("Last-Event-ID", id.clone());
+        }
+
+        let response = match tokio::time::timeout(ctx.timeout, req.send()).await {
+            Ok(Ok(resp)) => resp,
+            Ok(Err(err)) => {
+                tracing::debug!(error = %err, "MCP listening stream GET failed; backing off");
+                sleep_with_backoff(&mut backoff_ms).await;
+                continue;
+            }
+            Err(_) => {
+                tracing::debug!(
+                    timeout = ?ctx.timeout,
+                    "MCP listening stream GET timed out waiting for response headers; backing off"
+                );
+                sleep_with_backoff(&mut backoff_ms).await;
+                continue;
+            }
+        };
+
+        let status = response.status();
+        if status == reqwest::StatusCode::METHOD_NOT_ALLOWED {
+            tracing::debug!(
+                "MCP server does not support GET listening stream (405); stopping listener"
+            );
+            break;
+        }
+        if status == reqwest::StatusCode::NOT_FOUND && session_snapshot.session_id.is_some() {
+            // Session expired. Clear BOTH cached session AND cached
+            // capabilities — without the second, `initialize_if_needed`
+            // would short-circuit on next request-path call (capabilities
+            // = Some) and `post_message` would then run without a
+            // session id, getting another 404. Clearing capabilities
+            // forces the next request to walk the full handshake.
+            tracing::debug!(
+                "MCP listening stream got 404 — resetting session + capabilities to force re-handshake"
+            );
+            reset_http_session_state_if_current(
+                &ctx.session,
+                &ctx.capabilities,
+                session_snapshot.session_id.as_deref(),
+                session_snapshot.protocol_version.as_deref(),
+                session_snapshot.generation,
+            )
+            .await;
+            last_event_id = None;
+            sleep_with_backoff(&mut backoff_ms).await;
+            continue;
+        }
+        if !status.is_success() {
+            tracing::debug!(%status, "MCP listening stream non-success status; backing off");
+            sleep_with_backoff(&mut backoff_ms).await;
+            continue;
+        }
+        if let Err(error) = validate_sse_response(&response, "MCP listening stream GET") {
+            tracing::warn!(error = %error, "MCP listening stream returned non-SSE response; backing off");
+            sleep_with_backoff(&mut backoff_ms).await;
+            continue;
+        }
+
+        // Successful 200 with SSE body. Reset backoff and consume.
+        backoff_ms = BACKOFF_BASE_MS;
+        let stream_session = session_snapshot.snapshot();
+        let outcome =
+            consume_listening_stream(&ctx, response, &stream_session, &mut last_event_id).await;
+        if !ctx.alive.load(Ordering::SeqCst) {
+            break;
+        }
+        if let Some(delay) = outcome.retry_delay {
+            tokio::time::sleep(delay).await;
+        } else {
+            sleep_with_backoff(&mut backoff_ms).await;
+        }
+    }
+}
+
+async fn sleep_with_backoff(backoff_ms: &mut u64) {
+    tokio::time::sleep(Duration::from_millis(*backoff_ms)).await;
+    *backoff_ms = (*backoff_ms * 2).min(30_000);
+}
+
+/// Drain the SSE response body, forwarding each event to the
+/// appropriate channel. Returns when the stream ends (clean close or
+/// IO error). The caller loops to reconnect.
+#[derive(Debug, Default)]
+struct ListeningStreamOutcome {
+    retry_delay: Option<Duration>,
+}
+
+async fn consume_listening_stream(
+    ctx: &HttpListenerCtx,
+    response: reqwest::Response,
+    stream_session: &HttpSessionSnapshot,
+    last_event_id: &mut Option<String>,
+) -> ListeningStreamOutcome {
+    let mut outcome = ListeningStreamOutcome::default();
+    let mut event_lines: Vec<String> = Vec::new();
+    let mut event_bytes = 0usize;
+    let mut line_buf: Vec<u8> = Vec::new();
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream.next().await {
+        if !ctx.alive.load(Ordering::SeqCst) {
+            return outcome;
+        }
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(err) => {
+                tracing::debug!(error = %err, "MCP listening stream chunk error");
+                return outcome;
+            }
+        };
+        for byte in chunk {
+            if byte == b'\n' {
+                let mut line = match String::from_utf8(std::mem::take(&mut line_buf)) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        tracing::warn!(error = %err, "MCP listening stream invalid UTF-8");
+                        return outcome;
+                    }
+                };
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+                if line.is_empty() {
+                    apply_event_id_update(last_event_id, extract_event_id(&event_lines));
+                    match bounded_sse_retry_delay(&event_lines, "MCP listening stream") {
+                        Ok(Some(delay)) => outcome.retry_delay = Some(delay),
+                        Ok(None) => {}
+                        Err(err) => {
+                            tracing::warn!(error = %err, "MCP listening stream rejected SSE retry delay");
+                            return outcome;
+                        }
+                    }
+                    process_listening_event(ctx, stream_session, &event_lines).await;
+                    event_lines.clear();
+                    event_bytes = 0;
+                } else if let Err(err) = push_sse_event_line(
+                    &mut event_lines,
+                    &mut event_bytes,
+                    line,
+                    "MCP listening stream",
+                ) {
+                    tracing::warn!(error = %err, "MCP listening stream rejected oversized SSE event");
+                    return outcome;
+                }
+            } else if let Err(err) = push_sse_line_byte(&mut line_buf, byte, "MCP listening stream")
+            {
+                tracing::warn!(error = %err, "MCP listening stream rejected oversized SSE line");
+                return outcome;
+            }
+        }
+    }
+    // Final unterminated event (no trailing blank line).
+    if !line_buf.is_empty() {
+        let mut line = match String::from_utf8(std::mem::take(&mut line_buf)) {
+            Ok(line) => line,
+            Err(err) => {
+                tracing::warn!(error = %err, "MCP listening stream invalid UTF-8");
+                return outcome;
+            }
+        };
+        if line.ends_with('\r') {
+            line.pop();
+        }
+        if let Err(err) = push_sse_event_line(
+            &mut event_lines,
+            &mut event_bytes,
+            line,
+            "MCP listening stream",
+        ) {
+            tracing::warn!(error = %err, "MCP listening stream rejected oversized SSE event");
+            return outcome;
+        }
+    }
+    if !event_lines.is_empty() {
+        apply_event_id_update(last_event_id, extract_event_id(&event_lines));
+        match bounded_sse_retry_delay(&event_lines, "MCP listening stream") {
+            Ok(Some(delay)) => outcome.retry_delay = Some(delay),
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(error = %err, "MCP listening stream rejected SSE retry delay");
+                return outcome;
+            }
+        }
+        process_listening_event(ctx, stream_session, &event_lines).await;
+    }
+    outcome
+}
+
+async fn process_listening_event(
+    ctx: &HttpListenerCtx,
+    stream_session: &HttpSessionSnapshot,
+    event_lines: &[String],
+) {
+    if ctx.session.read().await.generation != stream_session.generation {
+        // This event belongs to a GET stream opened under an expired
+        // HTTP session. Do not apply stale notifications locally and,
+        // most importantly, do not answer server requests using a newer
+        // session id.
+        tracing::debug!(
+            stream_generation = stream_session.generation,
+            "dropping MCP listening event from stale HTTP session generation"
+        );
+        return;
+    }
+
+    let payload = match sse_data_payload(event_lines, "MCP listening stream") {
+        Ok(Some(payload)) => payload,
+        Ok(None) => return,
+        Err(err) => {
+            tracing::warn!(error = %err, "MCP listening stream rejected oversized SSE payload");
+            return;
+        }
+    };
+    let value = match serde_json::from_str::<Value>(&payload) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::warn!(error = %err, payload, "MCP listening stream invalid JSON");
+            return;
+        }
+    };
+    let message = match parse_json_rpc_message(value) {
+        Ok(m) => m,
+        Err(err) => {
+            tracing::warn!(error = %err, "MCP listening stream message parse failed");
+            return;
+        }
+    };
+
+    match message {
+        JsonRpcMessage::Notification(notification) => {
+            if let Some(kind) = list_changed_method(&notification.method) {
+                let _ = ctx.list_changed_tx.send(kind);
+            } else if let Some(uri) = resource_updated_uri(&notification) {
+                let _ = ctx.resource_updated_tx.send(uri);
+            }
+            // progress notifications without a request_id can't be
+            // routed; drop. The listening stream isn't tied to a
+            // single client request.
+        }
+        JsonRpcMessage::Request(request) => {
+            // Server-initiated request on the GET listening stream.
+            // Per spec 2025-11-25 §Streamable HTTP / Listening for
+            // Messages from the Server, these messages SHOULD be
+            // unrelated to concurrently-running client requests — so
+            // we MUST NOT use per-call-cardinality routing here.
+            // Doing so would let a sampling/createMessage on this
+            // stream be answered by an arbitrary in-flight agent's
+            // executor (the cross-agent leak the per-call factory
+            // exists to prevent).
+            //
+            // Resolution: use the registry-level fallback handler
+            // only. If no fallback is configured, the request is
+            // rejected with method-not-supported (-32601). Servers
+            // wanting per-agent sampling must initiate the request
+            // on the per-request SSE stream where request_id-based
+            // routing applies.
+            let chosen = ctx.fallback_sampling.clone();
+            let response =
+                handle_server_request(chosen.as_deref(), ctx.roots.as_slice(), &request).await;
+            // POST the response back to the server. See
+            // post_listener_response for status handling.
+            let _ = post_listener_response(ctx, stream_session, response).await;
+        }
+        JsonRpcMessage::Response(_) => {
+            // Responses on the listening stream are unexpected — the
+            // listening stream is for server-initiated traffic.
+            // Ignore.
+        }
+    }
+}
+
+async fn post_listener_response(
+    ctx: &HttpListenerCtx,
+    stream_session: &HttpSessionSnapshot,
+    response: JsonRpcResponse,
+) -> Result<(), McpTransportError> {
+    let mut req = ctx.client.post(&ctx.endpoint).header(
+        reqwest::header::ACCEPT,
+        "application/json, text/event-stream",
+    );
+    let current_session = ctx.session.read().await.snapshot();
+    if current_session.generation != stream_session.generation {
+        tracing::debug!(
+            stream_generation = stream_session.generation,
+            current_generation = current_session.generation,
+            "dropping MCP listening response for stale HTTP session generation"
+        );
+        return Err(McpTransportError::ProtocolError(
+            MCP_SESSION_EXPIRED.to_string(),
+        ));
+    }
+    let sent_session_id = stream_session.session_id.clone();
+    let sent_protocol_version = stream_session.protocol_version.clone();
+    if sent_protocol_version.is_none() {
+        return Err(McpTransportError::ProtocolError(
+            MCP_SESSION_EXPIRED.to_string(),
+        ));
+    }
+    if let Some(ref pv) = sent_protocol_version {
+        req = req.header("MCP-Protocol-Version", pv.clone());
+    }
+    if let Some(ref id) = sent_session_id {
+        req = req.header("MCP-Session-Id", id.clone());
+    }
+    let http_response = req.json(&response).send().await.map_err(|e| {
+        McpTransportError::TransportError(format!("listener response POST failed: {}", e))
+    })?;
+    // Per spec 2025-11-25 §Streamable HTTP: a client POSTing a
+    // JSON-RPC response/notification should expect 202 Accepted (or
+    // 200/204 for some servers). 4xx/5xx means the server rejected
+    // our response to its server-initiated request — silently
+    // dropping that would leave the server waiting indefinitely.
+    // Log at warn so oncall can see it; the listener task continues.
+    let status = http_response.status();
+    if status == reqwest::StatusCode::NOT_FOUND && sent_session_id.is_some() {
+        tracing::debug!(
+            "listener response POST got 404 — resetting session + capabilities to force re-handshake"
+        );
+        reset_http_session_state_if_current(
+            &ctx.session,
+            &ctx.capabilities,
+            sent_session_id.as_deref(),
+            sent_protocol_version.as_deref(),
+            stream_session.generation,
+        )
+        .await;
+        return Ok(());
+    }
+    if !status.is_success() && status != reqwest::StatusCode::NO_CONTENT {
+        tracing::warn!(
+            %status,
+            "listener response POST returned non-success status; server may treat its request as unanswered"
+        );
+    }
     Ok(())
 }
 
@@ -1824,6 +3236,7 @@ impl McpToolTransport for ProgressAwareHttpTransport {
             task: None,
             meta,
         };
+        let params_value = serde_json::to_value(&params)?;
 
         // Initialize runs UNINTERRUPTED — racing it with cancellation
         // can leave the session half-constructed: server assigns a
@@ -1845,57 +3258,152 @@ impl McpToolTransport for ProgressAwareHttpTransport {
             ));
         }
 
-        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        // Retry loop for the spec-defined `MCP session expired` case
+        // before the server accepted the request (the initial POST
+        // returned 404 against a request bearing our session id — see
+        // `post_message`). Once a per-request SSE body has begun, the
+        // tool may already be executing; resume failures are mapped to
+        // `MCP_SESSION_EXPIRED_AFTER_ACCEPT` and MUST NOT silently
+        // replay a potentially side-effectful `tools/call`.
+        // One pre-accept retry is enough: server told us the session is
+        // gone, so we reset, reinitialize, and resend with a fresh id.
+        // Anything beyond that is almost certainly a genuine
+        // server-side failure, not session staleness.
+        let mut session_retried = false;
+        let result_value = loop {
+            let id = self.next_id.fetch_add(1, Ordering::SeqCst);
 
-        // Register the per-call sampling decision deterministically
-        // BEFORE the request hits the wire. Awaiting the lock guarantees
-        // the reader sees this entry before it can receive a
-        // `sampling/createMessage` for our request id on the per-request
-        // SSE stream.
-        let _handler_guard =
-            PerCallSamplingGuard::register(Arc::clone(&self.per_call_sampling), id, sampling).await;
+            // Register the per-call sampling decision deterministically
+            // BEFORE the request hits the wire. Awaiting the lock guarantees
+            // the reader sees this entry before it can receive a
+            // `sampling/createMessage` for our request id on the per-request
+            // SSE stream.
+            let mut handler_guard = PerCallSamplingGuard::register(
+                Arc::clone(&self.per_call_sampling),
+                id,
+                sampling.clone(),
+            )
+            .await;
 
-        let request_fut = self.send_request_with_id(
-            id,
-            "tools/call",
-            Some(serde_json::to_value(&params)?),
-            progress_sender,
-        );
+            let request_sent = Arc::new(AtomicBool::new(false));
+            let request_session = Arc::new(tokio::sync::Mutex::new(None::<HttpSessionSnapshot>));
+            let request_fut = self.send_request_with_id(
+                id,
+                "tools/call",
+                Some(params_value.clone()),
+                progress_sender.clone(),
+                Some(Arc::clone(&request_sent)),
+                Some(Arc::clone(&request_session)),
+            );
 
-        let result = match cancellation {
-            None => request_fut.await,
-            Some(token) => {
-                tokio::pin!(request_fut);
-                tokio::select! {
-                    biased;
-                    _ = token.cancelled() => {
-                        // Per spec (2025-06-18 §Cancellation): SHOULD emit
-                        // notifications/cancelled with the in-flight
-                        // requestId so the server stops processing. The
-                        // in-flight HTTP request is dropped by virtue of
-                        // dropping `request_fut`; reqwest cancels the
-                        // socket. Then we issue a separate POST with the
-                        // cancellation notification.
-                        let _ = self
-                            .send_notification(
-                                "notifications/cancelled",
-                                Some(json!({
-                                    "requestId": id,
-                                    "reason": "client run cancelled",
-                                })),
-                            )
-                            .await;
+            let attempt_result = match cancellation.as_ref() {
+                None => request_fut.await,
+                Some(token) => {
+                    tokio::pin!(request_fut);
+                    tokio::select! {
+                        biased;
+                        _ = token.cancelled() => {
+                            // Per spec (2025-11-25 §Cancellation): SHOULD
+                            // emit notifications/cancelled with the
+                            // in-flight requestId so the server stops
+                            // processing. For HTTP this flag means the
+                            // request is believed issued/in-progress; the
+                            // POST may still be awaiting response headers.
+                            // Receivers should ignore unknown request ids.
+                            if request_sent.load(Ordering::SeqCst) {
+                                if let Some(session) = request_session.lock().await.clone() {
+                                    match self
+                                        .send_notification_with_session(
+                                            "notifications/cancelled",
+                                            Some(json!({
+                                                "requestId": id,
+                                                "reason": "client run cancelled",
+                                            })),
+                                            &session,
+                                        )
+                                        .await
+                                    {
+                                        Ok(()) => {}
+                                        // 404 here means the original
+                                        // session is already gone. The
+                                        // captured-session POST keeps
+                                        // this cancellation from leaking
+                                        // into a newer session; the
+                                        // in-flight old-session work may
+                                        // still run to completion server-side.
+                                        Err(McpTransportError::ProtocolError(ref msg))
+                                            if msg == MCP_SESSION_EXPIRED =>
+                                        {
+                                            tracing::warn!(
+                                                request_id = id,
+                                                "session expired while sending notifications/cancelled"
+                                            );
+                                        }
+                                        Err(err) => {
+                                            tracing::warn!(
+                                                error = %err,
+                                                request_id = id,
+                                                "notifications/cancelled send failed — server may continue executing the cancelled tool call"
+                                            );
+                                        }
+                                    }
+                                } else {
+                                    tracing::warn!(
+                                        request_id = id,
+                                        "notifications/cancelled skipped because no HTTP session snapshot was captured"
+                                    );
+                                }
+                            }
+                            // Deterministic guard cleanup before
+                            // returning — cardinality routing must
+                            // not see a stale entry from this call.
+                            handler_guard.unregister().await;
+                            return Err(McpTransportError::TransportError(
+                                CANCELLED_BY_CLIENT.to_string(),
+                            ));
+                        }
+                        result = &mut request_fut => result,
+                    }
+                }
+            };
+
+            match attempt_result {
+                Ok(value) => {
+                    // Success path — explicitly unregister so the
+                    // sampling map is consistent before we return.
+                    handler_guard.unregister().await;
+                    break value;
+                }
+                Err(McpTransportError::ProtocolError(ref message))
+                    if message == MCP_SESSION_EXPIRED && !session_retried =>
+                {
+                    // Drop the guard for the now-invalid id (await
+                    // the async cleanup, not the sync Drop), then
+                    // retry with the current session. The request path
+                    // that observed the 404 already performed a
+                    // compare-and-reset if it still owned the current
+                    // session; a stale 404 must not clobber a newer
+                    // session installed by another request.
+                    handler_guard.unregister().await;
+                    session_retried = true;
+                    self.initialize_if_needed().await?;
+                    if let Some(ref token) = cancellation
+                        && token.is_cancelled()
+                    {
                         return Err(McpTransportError::TransportError(
                             CANCELLED_BY_CLIENT.to_string(),
                         ));
                     }
-                    result = &mut request_fut => result,
+                    continue;
+                }
+                Err(err) => {
+                    handler_guard.unregister().await;
+                    return Err(err);
                 }
             }
         };
 
-        let result = result?;
-        let call_result: CallToolResult = serde_json::from_value(result)?;
+        let call_result: CallToolResult = serde_json::from_value(result_value)?;
 
         if call_result.is_error == Some(true) {
             return Err(McpTransportError::ServerError(tool_result_error_text(
@@ -1951,9 +3459,9 @@ impl McpToolTransport for ProgressAwareHttpTransport {
     }
 
     async fn close(&self) -> Result<(), McpTransportError> {
-        // Per spec (2025-06-18 §Streamable HTTP / Session Management):
+        // Per spec (2025-11-25 §Streamable HTTP / Session Management):
         // "Clients that no longer need a particular session SHOULD send an
-        //  HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header,
+        //  HTTP DELETE to the MCP endpoint with the MCP-Session-Id header,
         //  to explicitly terminate the session. The server MAY respond
         //  to this request with HTTP 405 Method Not Allowed."
         //
@@ -1964,15 +3472,34 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         // Errors are swallowed (best-effort): the server may legitimately
         // 405 to refuse termination, or the network may be down. Either
         // way we still tear down local state.
-        let session_id = self.session.read().await.session_id.clone();
-        if let Some(session_id) = session_id {
-            self.send_session_termination(&session_id).await;
+
+        // Stop the background GET listener BEFORE tearing down the
+        // session — otherwise the listener might race the DELETE and
+        // re-establish a new stream against the about-to-be-killed
+        // session. The atomic guards the consume loop's chunked
+        // wakeups; the abort handle short-circuits any in-flight
+        // request.
+        self.listener_alive.store(false, Ordering::SeqCst);
+        if let Ok(mut slot) = self.listener_abort.lock()
+            && let Some(handle) = slot.take()
+        {
+            handle.abort();
+        }
+
+        let session_snapshot = self.session.read().await.snapshot();
+        if let Some(session_id) = session_snapshot.session_id {
+            self.send_session_termination(
+                &session_id,
+                session_snapshot.protocol_version.as_deref(),
+            )
+            .await;
         }
 
         {
             let mut session = self.session.write().await;
             session.session_id = None;
             session.protocol_version = None;
+            session.started_at = None;
         }
 
         {
@@ -1986,6 +3513,26 @@ impl McpToolTransport for ProgressAwareHttpTransport {
     async fn current_session_id(&self) -> Option<String> {
         self.session.read().await.session_id.clone()
     }
+
+    async fn current_session_started_at(&self) -> Option<SystemTime> {
+        self.session.read().await.started_at
+    }
+}
+
+impl Drop for ProgressAwareHttpTransport {
+    fn drop(&mut self) {
+        // Cancel the background GET listener if it's still alive —
+        // without this, the task would keep retrying connections
+        // against an endpoint nobody is reading from. `close()`
+        // already does this on the happy path; Drop is the backstop
+        // for `Arc::drop` without an explicit close.
+        self.listener_alive.store(false, Ordering::SeqCst);
+        if let Ok(mut slot) = self.listener_abort.lock()
+            && let Some(handle) = slot.take()
+        {
+            handle.abort();
+        }
+    }
 }
 
 impl ProgressAwareHttpTransport {
@@ -1993,14 +3540,13 @@ impl ProgressAwareHttpTransport {
     /// server can immediately free session state. Swallows all errors —
     /// the client has already decided to terminate, so a server 405 / 5xx
     /// / network error doesn't change the outcome locally.
-    async fn send_session_termination(&self, session_id: &str) {
+    async fn send_session_termination(&self, session_id: &str, protocol_version: Option<&str>) {
         let mut request = self
             .client
             .delete(&self.endpoint)
-            .header("Mcp-Session-Id", session_id.to_string());
-        let protocol_version = self.session.read().await.protocol_version.clone();
+            .header("MCP-Session-Id", session_id.to_string());
         if let Some(protocol_version) = protocol_version {
-            request = request.header("MCP-Protocol-Version", protocol_version);
+            request = request.header("MCP-Protocol-Version", protocol_version.to_string());
         }
         match request.send().await {
             Ok(response) if response.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED => {
@@ -2034,15 +3580,26 @@ pub(crate) async fn connect_transport(
     config: &McpServerConnectionConfig,
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
     roots: Arc<Vec<Root>>,
+    advertise_sampling: bool,
 ) -> Result<Arc<dyn McpToolTransport>, McpTransportError> {
     match config.transport {
         TransportTypeId::Stdio => {
-            let transport =
-                ProgressAwareStdioTransport::connect(config, sampling_handler, roots).await?;
+            let transport = ProgressAwareStdioTransport::connect(
+                config,
+                sampling_handler,
+                roots,
+                advertise_sampling,
+            )
+            .await?;
             Ok(Arc::new(transport))
         }
         TransportTypeId::Http => {
-            let transport = ProgressAwareHttpTransport::connect(config, sampling_handler, roots)?;
+            let transport = ProgressAwareHttpTransport::connect(
+                config,
+                sampling_handler,
+                roots,
+                advertise_sampling,
+            )?;
             Ok(Arc::new(transport))
         }
     }
@@ -2269,7 +3826,7 @@ pub(crate) async fn handle_server_request(
                 Err(e) => JsonRpcResponse::error(request.id.clone(), -32000, e.to_string(), None),
             }
         }
-        // Spec 2025-06-18 §Client features / Roots: server may call
+        // Spec 2025-11-25 §Client features / Roots: server may call
         // `roots/list` only if the client advertised the `roots`
         // capability during initialize. We advertise based on whether
         // the roots vec was non-empty at construction, so an empty
@@ -2336,6 +3893,191 @@ mod tests {
 
     use super::*;
     use mcp::CreateMessageResult;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[derive(Clone, Debug)]
+    struct UnitHttpRequest {
+        method: String,
+        headers: HashMap<String, String>,
+        body: Value,
+    }
+
+    fn unit_header_end(buf: &[u8]) -> Option<usize> {
+        buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| i + 4)
+    }
+
+    fn unit_content_length(headers: &str) -> usize {
+        headers
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                key.trim()
+                    .eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0)
+    }
+
+    async fn read_unit_http_request(stream: &mut tokio::net::TcpStream) -> Option<UnitHttpRequest> {
+        let mut buf = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let (header_end_pos, body_len) = loop {
+            let n = stream.read(&mut chunk).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            let Some(end) = unit_header_end(&buf) else {
+                continue;
+            };
+            let headers = std::str::from_utf8(&buf[..end]).ok()?;
+            break (end, unit_content_length(headers));
+        };
+
+        while buf.len() < header_end_pos + body_len {
+            let n = stream.read(&mut chunk).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+        }
+
+        let headers_text = std::str::from_utf8(&buf[..header_end_pos]).ok()?;
+        let method = headers_text
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().next())
+            .unwrap_or_default()
+            .to_string();
+        let headers = headers_text
+            .lines()
+            .skip(1)
+            .filter_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                Some((key.trim().to_ascii_lowercase(), value.trim().to_string()))
+            })
+            .collect();
+        let body = if body_len == 0 {
+            Value::Null
+        } else {
+            serde_json::from_slice(&buf[header_end_pos..header_end_pos + body_len]).ok()?
+        };
+        Some(UnitHttpRequest {
+            method,
+            headers,
+            body,
+        })
+    }
+
+    async fn write_unit_http_response(
+        stream: &mut tokio::net::TcpStream,
+        status: u16,
+        content_type: &str,
+        body: String,
+        headers: &[(&str, String)],
+    ) {
+        let status_text = match status {
+            200 => "OK",
+            202 => "Accepted",
+            400 => "Bad Request",
+            _ => "OK",
+        };
+        let mut head = format!(
+            "HTTP/1.1 {status} {status_text}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n",
+            body.len()
+        );
+        for (key, value) in headers {
+            head.push_str(&format!("{key}: {value}\r\n"));
+        }
+        head.push_str("\r\n");
+        let _ = stream.write_all(head.as_bytes()).await;
+        let _ = stream.write_all(body.as_bytes()).await;
+        let _ = stream.shutdown().await;
+    }
+
+    // ── SSE event id extraction (R7 #6 Last-Event-ID resumability) ──
+
+    #[test]
+    fn extract_event_id_reads_id_line() {
+        let event = vec!["id: 42".to_string(), "data: {}".to_string()];
+        assert_eq!(extract_event_id(&event), SseEventIdUpdate::Set("42".into()));
+    }
+
+    #[test]
+    fn extract_event_id_tolerates_no_space_after_colon() {
+        // SSE spec permits `id:42` (no space).
+        let event = vec!["id:99".to_string(), "data: {}".to_string()];
+        assert_eq!(extract_event_id(&event), SseEventIdUpdate::Set("99".into()));
+    }
+
+    #[test]
+    fn extract_event_id_returns_none_when_absent() {
+        let event = vec!["data: {}".to_string(), "event: message".to_string()];
+        assert_eq!(extract_event_id(&event), SseEventIdUpdate::Absent);
+    }
+
+    #[test]
+    fn extract_event_id_treats_empty_value_as_reset() {
+        // Per spec: `id:\n` resets the last-event-id. This is distinct
+        // from an absent id so the reconnect path can clear stale state.
+        let event = vec!["id: ".to_string(), "data: {}".to_string()];
+        assert_eq!(extract_event_id(&event), SseEventIdUpdate::Reset);
+    }
+
+    #[test]
+    fn extract_event_id_takes_last_id_when_repeated() {
+        // SSE spec: the LAST id field in an event is authoritative.
+        // Our impl scans from the end and returns the first match.
+        let event = vec![
+            "id: 1".to_string(),
+            "data: ignored".to_string(),
+            "id: 2".to_string(),
+            "data: kept".to_string(),
+        ];
+        assert_eq!(extract_event_id(&event), SseEventIdUpdate::Set("2".into()));
+    }
+
+    #[test]
+    fn apply_event_id_update_clears_existing_id_on_reset() {
+        let mut last_event_id = Some("stale".to_string());
+        apply_event_id_update(&mut last_event_id, SseEventIdUpdate::Reset);
+        assert_eq!(last_event_id, None);
+    }
+
+    #[test]
+    fn extract_retry_delay_reads_milliseconds() {
+        let event = vec!["retry: 25".to_string(), "data: {}".to_string()];
+        assert_eq!(extract_retry_delay(&event), Some(Duration::from_millis(25)));
+    }
+
+    #[test]
+    fn extract_retry_delay_ignores_invalid_value() {
+        let event = vec!["retry: soon".to_string(), "data: {}".to_string()];
+        assert_eq!(extract_retry_delay(&event), None);
+    }
+
+    #[test]
+    fn extract_retry_delay_keeps_latest_valid_value() {
+        let event = vec![
+            "retry: 10".to_string(),
+            "retry: 20".to_string(),
+            "retry: soon".to_string(),
+            "data: {}".to_string(),
+        ];
+        assert_eq!(extract_retry_delay(&event), Some(Duration::from_millis(20)));
+    }
+
+    #[test]
+    fn bounded_sse_retry_delay_rejects_unbounded_sleep() {
+        let event = vec!["retry: 86400000".to_string(), "data:".to_string()];
+        let err = bounded_sse_retry_delay(&event, "test stream")
+            .expect_err("huge retry delay must be rejected");
+        assert!(
+            format!("{err}").contains("SSE retry delay exceeded"),
+            "unexpected error: {err}"
+        );
+    }
 
     // ── notifications/resources/updated parsing ──
 
@@ -2428,7 +4170,7 @@ mod tests {
         // Server replies with a version older than anything we know we
         // can wire-compat-talk on. Hard reject; the alternative is
         // sending `params._meta` (added in 2025-06-18) or
-        // `Mcp-Session-Id` semantics that older servers can't parse.
+        // `MCP-Session-Id` semantics that older servers can't parse.
         let err = negotiate_protocol_version("2000-01-01").unwrap_err();
         let msg = format!("{err}");
         assert!(
@@ -2688,15 +4430,389 @@ mod tests {
             "http://127.0.0.1:9".to_string(),
         );
         let transport =
-            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new())).unwrap();
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
 
         transport.close().await.unwrap();
         transport.close().await.unwrap();
     }
 
-    /// Spec (2025-06-18, §Streamable HTTP / Session Management):
+    #[tokio::test]
+    async fn http_non_initialize_post_without_protocol_returns_session_expired() {
+        let cfg = mcp::transport::McpServerConnectionConfig::http(
+            "http-no-protocol",
+            "http://127.0.0.1:9".to_string(),
+        );
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
+
+        let err = transport
+            .post_message(
+                JsonRpcMessage::Request(JsonRpcRequest::new(
+                    JsonRpcId::Number(1),
+                    "tools/call".to_string(),
+                    Some(json!({})),
+                )),
+                true,
+            )
+            .await
+            .expect_err("non-initialize POST without negotiated protocol must fail locally");
+
+        assert!(
+            matches!(&err, McpTransportError::ProtocolError(message) if message == MCP_SESSION_EXPIRED),
+            "expected local session-expired guard, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn per_request_sse_server_request_is_not_answered_on_new_session() {
+        let cfg = mcp::transport::McpServerConnectionConfig::http(
+            "http-stale-per-request-sse",
+            "http://127.0.0.1:9".to_string(),
+        );
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
+        {
+            let mut session = transport.session.write().await;
+            session.session_id = Some("session-new".to_string());
+            session.protocol_version = Some(MCP_PROTOCOL_VERSION.to_string());
+            session.generation = 2;
+        }
+
+        let stale_session = HttpSessionSnapshot {
+            session_id: Some("session-old".to_string()),
+            protocol_version: Some(MCP_PROTOCOL_VERSION.to_string()),
+            generation: 1,
+        };
+        let event = vec![format!(
+            "data: {}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "roots/list"
+            })
+        )];
+
+        let err = transport
+            .process_sse_event(&event, 1, None, None, &stale_session)
+            .await
+            .expect_err("stale per-request SSE server request must not use the new session");
+
+        assert!(
+            matches!(&err, McpTransportError::ProtocolError(message) if message == MCP_SESSION_EXPIRED_AFTER_ACCEPT),
+            "expected stale accepted-request session error before any response POST, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn http_send_initialized_request_reinitializes_if_session_clears_after_gate() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+        let observed = Arc::new(tokio::sync::Mutex::new(Vec::<UnitHttpRequest>::new()));
+        let observed_for_server = Arc::clone(&observed);
+
+        let server_task = tokio::spawn(async move {
+            let mut initialize_count = 0_usize;
+            let mut initialized_count = 0_usize;
+            loop {
+                let (mut stream, _) = listener.accept().await.expect("accept test request");
+                let request = read_unit_http_request(&mut stream)
+                    .await
+                    .expect("parse test request");
+                let wire_method = request.method.clone();
+                let rpc_method = request.body["method"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                observed_for_server.lock().await.push(request.clone());
+
+                if wire_method == "GET" {
+                    write_unit_http_response(
+                        &mut stream,
+                        405,
+                        "text/plain",
+                        "listener disabled".to_string(),
+                        &[],
+                    )
+                    .await;
+                    continue;
+                }
+
+                match rpc_method.as_str() {
+                    "initialize" => {
+                        initialize_count += 1;
+                        let body = json!({
+                            "jsonrpc": "2.0",
+                            "id": request.body["id"].clone(),
+                            "result": {
+                                "protocolVersion": MCP_PROTOCOL_VERSION,
+                                "capabilities": {},
+                                "serverInfo": {
+                                    "name": "test-server",
+                                    "version": "1.0.0"
+                                }
+                            }
+                        })
+                        .to_string();
+                        write_unit_http_response(
+                            &mut stream,
+                            200,
+                            "application/json",
+                            body,
+                            &[("MCP-Session-Id", format!("session-{initialize_count}"))],
+                        )
+                        .await;
+                    }
+                    "notifications/initialized" => {
+                        initialized_count += 1;
+                        write_unit_http_response(
+                            &mut stream,
+                            202,
+                            "text/plain",
+                            String::new(),
+                            &[],
+                        )
+                        .await;
+                    }
+                    "tools/call" => {
+                        let body = json!({
+                            "jsonrpc": "2.0",
+                            "id": request.body["id"].clone(),
+                            "result": {
+                                "content": [{"type": "text", "text": "ok"}]
+                            }
+                        })
+                        .to_string();
+                        write_unit_http_response(&mut stream, 200, "application/json", body, &[])
+                            .await;
+                        break;
+                    }
+                    other => panic!("unexpected method: {other}"),
+                }
+
+                assert!(
+                    initialize_count <= 2 && initialized_count <= 2,
+                    "test should not need extra handshakes"
+                );
+            }
+        });
+
+        let cfg = mcp::transport::McpServerConnectionConfig::http("http-race-retry", url);
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
+        let capabilities = transport.initialize().await.expect("initial initialize");
+        *transport.capabilities.lock().await = Some(capabilities);
+
+        let session = Arc::clone(&transport.session);
+        let capabilities = Arc::clone(&transport.capabilities);
+        let mut session_guard = session.write().await;
+        let request_fut =
+            transport.send_initialized_request("tools/call", Some(json!({"name": "echo"})), None);
+        tokio::pin!(request_fut);
+
+        assert!(
+            futures::poll!(&mut request_fut).is_pending(),
+            "request should be parked on the held session lock after passing the capability gate"
+        );
+
+        *capabilities.lock().await = None;
+        *session_guard = HttpSessionState::default();
+        drop(session_guard);
+
+        let result = request_fut
+            .await
+            .expect("session-expired guard should trigger reinitialize and retry");
+        assert_eq!(result["content"][0]["text"], json!("ok"));
+        tokio::time::timeout(Duration::from_secs(2), server_task)
+            .await
+            .expect("server task should finish")
+            .expect("server task should not panic");
+
+        let requests = observed.lock().await.clone();
+        let initialize_requests: Vec<_> = requests
+            .iter()
+            .filter(|request| request.body["method"] == "initialize")
+            .collect();
+        let tool_calls: Vec<_> = requests
+            .iter()
+            .filter(|request| request.body["method"] == "tools/call")
+            .collect();
+
+        assert_eq!(
+            initialize_requests.len(),
+            2,
+            "request retry should create a second session"
+        );
+        assert_eq!(
+            tool_calls.len(),
+            1,
+            "unversioned pre-retry call must not hit the server"
+        );
+        assert_eq!(
+            tool_calls[0].headers.get("mcp-session-id"),
+            Some(&"session-2".to_string())
+        );
+        assert_eq!(
+            tool_calls[0].headers.get("mcp-protocol-version"),
+            Some(&MCP_PROTOCOL_VERSION.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn http_initialize_failure_clears_partial_session_before_retry() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+        let observed = Arc::new(tokio::sync::Mutex::new(Vec::<UnitHttpRequest>::new()));
+        let observed_for_server = Arc::clone(&observed);
+
+        let server_task = tokio::spawn(async move {
+            let mut initialize_count = 0_usize;
+            let mut initialized_count = 0_usize;
+            for _ in 0..5 {
+                let (mut stream, _) = listener.accept().await.expect("accept test request");
+                let request = read_unit_http_request(&mut stream)
+                    .await
+                    .expect("parse test request");
+                observed_for_server.lock().await.push(request.clone());
+
+                if request.method == "DELETE" {
+                    write_unit_http_response(&mut stream, 200, "text/plain", String::new(), &[])
+                        .await;
+                    continue;
+                }
+
+                let method = request.body["method"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+
+                match method.as_str() {
+                    "initialize" => {
+                        initialize_count += 1;
+                        let body = json!({
+                            "jsonrpc": "2.0",
+                            "id": request.body["id"].clone(),
+                            "result": {
+                                "protocolVersion": MCP_PROTOCOL_VERSION,
+                                "capabilities": {},
+                                "serverInfo": {
+                                    "name": "test-server",
+                                    "version": "1.0.0"
+                                }
+                            }
+                        })
+                        .to_string();
+                        write_unit_http_response(
+                            &mut stream,
+                            200,
+                            "application/json",
+                            body,
+                            &[("MCP-Session-Id", format!("session-{initialize_count}"))],
+                        )
+                        .await;
+                    }
+                    "notifications/initialized" => {
+                        initialized_count += 1;
+                        if initialized_count == 1 {
+                            write_unit_http_response(
+                                &mut stream,
+                                400,
+                                "text/plain",
+                                "initialized rejected".to_string(),
+                                &[],
+                            )
+                            .await;
+                        } else {
+                            write_unit_http_response(
+                                &mut stream,
+                                202,
+                                "text/plain",
+                                String::new(),
+                                &[],
+                            )
+                            .await;
+                        }
+                    }
+                    other => panic!("unexpected method: {other}"),
+                }
+            }
+        });
+
+        let cfg = mcp::transport::McpServerConnectionConfig::http("http-init-cleanup", url);
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
+
+        let err = transport
+            .initialize()
+            .await
+            .expect_err("first initialized notification is rejected");
+        assert!(
+            format!("{err}").contains("400"),
+            "expected initialized rejection to surface, got: {err}"
+        );
+        let state_after_failure = transport.session.read().await.clone();
+        assert!(state_after_failure.session_id.is_none());
+        assert!(state_after_failure.protocol_version.is_none());
+
+        transport
+            .initialize()
+            .await
+            .expect("retry initialize should start from a clean session");
+        tokio::time::timeout(Duration::from_secs(2), server_task)
+            .await
+            .expect("server task should finish")
+            .expect("server task should not panic");
+
+        let requests = observed.lock().await.clone();
+        let initialize_requests: Vec<_> = requests
+            .iter()
+            .filter(|request| request.body["method"] == "initialize")
+            .collect();
+        let initialized_requests: Vec<_> = requests
+            .iter()
+            .filter(|request| request.body["method"] == "notifications/initialized")
+            .collect();
+        let delete_requests: Vec<_> = requests
+            .iter()
+            .filter(|request| request.method == "DELETE")
+            .collect();
+
+        assert_eq!(initialize_requests.len(), 2);
+        assert_eq!(initialized_requests.len(), 2);
+        assert_eq!(delete_requests.len(), 1);
+        assert_eq!(
+            delete_requests[0].headers.get("mcp-session-id"),
+            Some(&"session-1".to_string()),
+            "failed provisional session must be terminated"
+        );
+        assert_eq!(
+            delete_requests[0].headers.get("mcp-protocol-version"),
+            Some(&MCP_PROTOCOL_VERSION.to_string()),
+            "DELETE after initialized failure must carry the negotiated protocol version"
+        );
+        assert_eq!(
+            initialized_requests[0].headers.get("mcp-session-id"),
+            Some(&"session-1".to_string()),
+            "first initialized notification must exercise the partial session path"
+        );
+        assert!(
+            !initialize_requests[1]
+                .headers
+                .contains_key("mcp-session-id"),
+            "retry initialize must not carry the failed partial session"
+        );
+        assert!(
+            !initialize_requests[1]
+                .headers
+                .contains_key("mcp-protocol-version"),
+            "retry initialize must not carry the failed partial protocol"
+        );
+    }
+
+    /// Spec (2025-11-25, §Streamable HTTP / Session Management):
     /// "Clients that no longer need a particular session SHOULD send an
-    ///  HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header,
+    ///  HTTP DELETE to the MCP endpoint with the MCP-Session-Id header,
     ///  to explicitly terminate the session."
     ///
     /// Verifies that `ProgressAwareHttpTransport::close()` actually emits
@@ -2726,7 +4842,7 @@ mod tests {
 
         let cfg = mcp::transport::McpServerConnectionConfig::http("http-close-delete", url);
         let transport =
-            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new())).unwrap();
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
         // Pretend init already happened so close() has a session id to terminate.
         transport.session.write().await.session_id = Some("test-session-abc".into());
 
@@ -2747,14 +4863,14 @@ mod tests {
         );
 
         // Session id header (HTTP header names are case-insensitive but the
-        // spec literal is `Mcp-Session-Id`).
+        // spec literal is `MCP-Session-Id`).
         let has_session_header = request.lines().any(|line| {
             line.to_ascii_lowercase().starts_with("mcp-session-id:")
                 && line.contains("test-session-abc")
         });
         assert!(
             has_session_header,
-            "DELETE must carry the Mcp-Session-Id header. Request was:\n{request}"
+            "DELETE must carry the MCP-Session-Id header. Request was:\n{request}"
         );
 
         // Local state cleared after close().
@@ -2853,7 +4969,7 @@ mod tests {
         assert!(!obj.contains_key("awaken/attribution"));
     }
 
-    /// Spec (2025-06-18 §Cancellation): on a client-initiated cancel the
+    /// Spec (2025-11-25 §Cancellation): on a client-initiated cancel the
     /// client SHOULD send `notifications/cancelled` with the in-flight
     /// requestId. This test drives stdio `call_tool` against a reflective
     /// shell-script "MCP server" that:
@@ -2909,7 +5025,7 @@ done
         cfg.timeout_secs = 30;
 
         let transport = Arc::new(
-            ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()))
+            ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()), false)
                 .await
                 .expect("stdio transport connects"),
         );
@@ -2981,6 +5097,114 @@ done
         let _ = std::fs::remove_file(&scratch);
     }
 
+    /// R8 #6 regression: when the cancellation token is already
+    /// cancelled at the moment `call_tool` is entered, the early
+    /// pre-check returns the sentinel error WITHOUT ever attempting
+    /// to send `notifications/cancelled`. A notification here would
+    /// reference a requestId the server never saw (no `tools/call`
+    /// was issued), confusing oncall and possibly tripping strict
+    /// servers that validate requestId state.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stdio_call_tool_skips_cancel_notification_when_pre_cancelled() {
+        use serde_json::Value;
+
+        let scratch = std::env::temp_dir().join(format!(
+            "awaken-mcp-pre-cancel-{}-{}.log",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&scratch);
+        let scratch_str = scratch.to_string_lossy().to_string();
+
+        let script = format!(
+            r#"
+while IFS= read -r LINE; do
+    printf '%s\n' "$LINE" >> "{scratch}"
+    case "$LINE" in
+        *'"method":"initialize"'*)
+            ID=$(printf '%s' "$LINE" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+            printf '{{"jsonrpc":"2.0","id":%s,"result":{{"protocolVersion":"{version}","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"mock","version":"0"}}}}}}\n' "$ID"
+            ;;
+    esac
+done
+"#,
+            scratch = scratch_str,
+            version = MCP_PROTOCOL_VERSION,
+        );
+
+        let mut cfg = mcp::transport::McpServerConnectionConfig::stdio(
+            "stdio-pre-cancel",
+            "/bin/sh",
+            vec!["-c".to_string(), script],
+        );
+        cfg.timeout_secs = 30;
+
+        let transport =
+            ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()), false)
+                .await
+                .expect("stdio transport connects");
+
+        // Pre-cancel BEFORE the call starts. The pre-check at the top
+        // of call_tool must catch this and exit before allocating an
+        // id, registering the sampling guard, or writing anything.
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        let outcome = transport
+            .call_tool(
+                "test-tool",
+                json!({}),
+                None,
+                McpCallContext {
+                    cancellation: Some(cancel),
+                    ..McpCallContext::default()
+                },
+            )
+            .await;
+
+        match outcome {
+            Err(McpTransportError::TransportError(msg)) if msg == CANCELLED_BY_CLIENT => {}
+            other => panic!("expected CANCELLED_BY_CLIENT, got: {other:?}"),
+        }
+
+        // Give the writer task a beat to flush anything pending so the
+        // assertion isn't racy against in-flight writes. The intent is
+        // that NOTHING tools/call-related, and NO notifications/cancelled,
+        // was ever sent.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let contents = std::fs::read_to_string(&scratch).unwrap_or_default();
+        let saw_cancel_notification = contents
+            .lines()
+            .any(|l| l.contains("notifications/cancelled"));
+        let saw_tools_call = contents.lines().any(|l| l.contains("\"tools/call\""));
+        assert!(
+            !saw_cancel_notification,
+            "pre-cancel must NOT emit notifications/cancelled. Scratch contained:\n{contents}"
+        );
+        assert!(
+            !saw_tools_call,
+            "pre-cancel must NOT send tools/call. Scratch contained:\n{contents}"
+        );
+        // The initialize handshake DID happen (we needed it to construct
+        // the transport), so we expect to see at least one initialize.
+        let saw_initialize = contents
+            .lines()
+            .any(|l| l.contains("\"method\":\"initialize\""));
+        assert!(
+            saw_initialize,
+            "initialize handshake must still appear in scratch"
+        );
+
+        // Pacifier: avoid an unused-import warning when this test
+        // is the only consumer of `Value` in this scope.
+        let _: Option<Value> = None;
+        let _ = std::fs::remove_file(&scratch);
+    }
+
     /// End-to-end smoke test for R7 #2: the reflective stdio server
     /// emits `notifications/tools/list_changed` after `initialize`; the
     /// transport must forward the parsed `ListChangedKind::Tools` event
@@ -3014,9 +5238,10 @@ done
         );
         cfg.timeout_secs = 30;
 
-        let transport = ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()))
-            .await
-            .expect("stdio transport connects");
+        let transport =
+            ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()), false)
+                .await
+                .expect("stdio transport connects");
 
         let mut rx = transport
             .take_list_changed_receiver()
@@ -3035,6 +5260,84 @@ done
         // Receiver is one-shot — a second take returns None even when
         // the first call succeeded (and crucially does not panic).
         assert!(transport.take_list_changed_receiver().await.is_none());
+    }
+
+    /// Factory-only sampling is not a global capability: without a fixed
+    /// fallback handler, background server-initiated sampling has no safe
+    /// agent attribution. The manager must therefore leave `sampling`
+    /// unadvertised unless a transport-level handler exists.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stdio_does_not_advertise_sampling_without_fixed_handler() {
+        let scratch = std::env::temp_dir().join(format!(
+            "awaken-mcp-sampling-cap-{}-{}.log",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&scratch);
+        let scratch_str = scratch.to_string_lossy().to_string();
+
+        let script = format!(
+            r#"
+while IFS= read -r LINE; do
+    printf '%s\n' "$LINE" >> "{scratch}"
+    case "$LINE" in
+        *'"method":"initialize"'*)
+            ID=$(printf '%s' "$LINE" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+            printf '{{"jsonrpc":"2.0","id":%s,"result":{{"protocolVersion":"{version}","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"mock","version":"0"}}}}}}\n' "$ID"
+            ;;
+    esac
+done
+"#,
+            scratch = scratch_str,
+            version = MCP_PROTOCOL_VERSION,
+        );
+
+        let mut cfg = mcp::transport::McpServerConnectionConfig::stdio(
+            "stdio-sampling-cap",
+            "/bin/sh",
+            vec!["-c".to_string(), script],
+        );
+        cfg.timeout_secs = 30;
+
+        // sampling_handler = None (no fixed fallback), advertise_sampling = false.
+        let _ = ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()), false)
+            .await
+            .expect("stdio transport connects");
+
+        // Give the writer task a beat to land the initialize line on disk.
+        let started = Instant::now();
+        let init_line = loop {
+            let contents = std::fs::read_to_string(&scratch).unwrap_or_default();
+            if let Some(line) = contents
+                .lines()
+                .find(|l| l.contains("\"method\":\"initialize\""))
+            {
+                break line.to_string();
+            }
+            if started.elapsed() > Duration::from_secs(3) {
+                panic!(
+                    "did not observe initialize request. scratch contents:\n{}",
+                    contents
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        };
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&init_line).expect("initialize request must be valid JSON");
+        let caps = parsed["params"]["capabilities"]
+            .as_object()
+            .expect("capabilities object present");
+        assert!(
+            !caps.contains_key("sampling"),
+            "factory-only sampling must not advertise global `capabilities.sampling`; got: {init_line}"
+        );
+
+        let _ = std::fs::remove_file(&scratch);
     }
 
     // ── Per-call sampling routing tests (R1 #P1b) ──
@@ -3322,7 +5625,7 @@ done
 
         let cfg = mcp::transport::McpServerConnectionConfig::http("http-close-no-session", url);
         let transport =
-            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new())).unwrap();
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
         // No session id set.
         transport.close().await.unwrap();
 
@@ -3353,11 +5656,13 @@ done
         );
         cfg.timeout_secs = 1;
 
-        let err = match ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new())).await
-        {
-            Ok(_) => panic!("expected stdio initialization failure"),
-            Err(err) => err,
-        };
+        let err =
+            match ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()), false)
+                .await
+            {
+                Ok(_) => panic!("expected stdio initialization failure"),
+                Err(err) => err,
+            };
         assert!(matches!(err, McpTransportError::Timeout(_)));
 
         let started = Instant::now();

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -163,6 +163,60 @@ impl McpCallMetadata {
     }
 }
 
+/// Per-call bundle threading agent / thread / run identity, cancellation,
+/// and a sampling handler down to the MCP transport for a single
+/// `call_tool` invocation. Previously these were three separate
+/// parameters — combined here so adding a new dimension (logging
+/// override, deadline, etc.) doesn't churn every trait impl.
+///
+/// `Default` produces an empty context: no attribution, no cancellation,
+/// no per-call sampling handler. Transport behaviour then collapses to
+/// the legacy "registry-level fixed handler" path.
+#[derive(Default)]
+pub struct McpCallContext {
+    /// Vendor attribution surfaced to the server via `params._meta.awaken/attribution`.
+    pub metadata: McpCallMetadata,
+    /// Caller-supplied cancellation token. When fired during an in-flight
+    /// `tools/call`, the transport emits `notifications/cancelled` and
+    /// returns the [`CANCELLED_BY_CLIENT`] sentinel error.
+    pub cancellation: Option<CancellationToken>,
+    /// Decision about how server-initiated `sampling/createMessage`
+    /// during this call should be routed. See [`McpCallSampling`].
+    pub sampling: McpCallSampling,
+}
+
+/// Per-call sampling routing decision. Three explicit states so the
+/// transport can distinguish "no factory configured at all" from
+/// "factory consulted but declined to bind this agent" — these have
+/// different security semantics.
+#[derive(Default)]
+pub enum McpCallSampling {
+    /// No per-call decision was made. The transport falls through to
+    /// its registry-level fixed handler (legacy behaviour, preserved
+    /// for callers that don't wire a factory).
+    #[default]
+    Inherit,
+    /// Factory bound a specific handler to this call. Server-initiated
+    /// `sampling/createMessage` for this call's id routes here, not to
+    /// the transport's fallback. Mandatory for multi-agent correctness.
+    Bound(Arc<dyn SamplingHandler>),
+    /// Factory was consulted and explicitly refused to bind a handler
+    /// (e.g. agent's model_id doesn't resolve, agent opted out, tenant
+    /// has no sampling quota). The transport MUST reject
+    /// `sampling/createMessage` for this call with method-not-supported
+    /// — falling through to a global fallback would re-introduce the
+    /// cross-agent leak the factory exists to prevent.
+    Denied,
+}
+
+/// Internal map value mirroring [`McpCallSampling`] minus the `Inherit`
+/// variant (Inherit is represented by the absence of a map entry).
+#[derive(Clone)]
+enum PerCallSamplingEntry {
+    Bound(Arc<dyn SamplingHandler>),
+    Denied,
+}
+
 /// Build the `_meta` value for `tools/call` params. Combines the MCP
 /// `progressToken` (when progress is enabled) with optional vendor
 /// attribution from `McpCallMetadata`. Returns `None` when neither is
@@ -224,8 +278,7 @@ pub trait McpToolTransport: Send + Sync {
         name: &str,
         args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        metadata: McpCallMetadata,
-        cancellation: Option<CancellationToken>,
+        context: McpCallContext,
     ) -> Result<CallToolResult, McpTransportError>;
 
     fn transport_type(&self) -> TransportTypeId;
@@ -238,6 +291,15 @@ pub trait McpToolTransport: Send + Sync {
 
     async fn close(&self) -> Result<(), McpTransportError> {
         Ok(())
+    }
+
+    /// Current server-assigned session id, if any. Streamable HTTP
+    /// transports return the value cached after the most recent
+    /// successful `initialize`; stdio returns `None` (the protocol does
+    /// not define a session id for that transport). Display-only — do
+    /// not cache or persist outside the transport.
+    async fn current_session_id(&self) -> Option<String> {
+        None
     }
 }
 
@@ -270,6 +332,90 @@ struct WriteRequest {
     ack: Option<oneshot::Sender<()>>,
 }
 
+/// Type alias for the per-call sampling-handler map shared between
+/// `call_tool` (which inserts on entry, removes on exit) and the
+/// background reader/dispatcher (which looks up by in-flight call id when
+/// handling server-initiated `sampling/createMessage`).
+type PerCallSamplingHandlers = Arc<tokio::sync::Mutex<HashMap<i64, PerCallSamplingEntry>>>;
+
+/// RAII guard that inserts a per-call sampling entry at construction
+/// and removes it on drop. Registration is async/deterministic — the
+/// call_tool path awaits the lock so the entry is guaranteed visible
+/// before the request is sent on the wire. Without this guarantee the
+/// reader could observe a sampling/createMessage for our call before
+/// the entry exists and route to a stale fallback handler.
+struct PerCallSamplingGuard {
+    handlers: PerCallSamplingHandlers,
+    id: i64,
+    /// `false` when the call passed `McpCallSampling::Inherit` — no
+    /// entry was registered, so drop has nothing to remove.
+    active: bool,
+}
+
+impl PerCallSamplingGuard {
+    /// Register the per-call sampling decision for `id`. Awaits the
+    /// map lock — never silently skips registration. Callers MUST await
+    /// this before sending the request id on the wire, otherwise the
+    /// reader can race a server-initiated `sampling/createMessage` for
+    /// the call and miss the entry.
+    async fn register(
+        handlers: PerCallSamplingHandlers,
+        id: i64,
+        sampling: McpCallSampling,
+    ) -> Self {
+        match sampling {
+            McpCallSampling::Inherit => Self {
+                handlers,
+                id,
+                active: false,
+            },
+            McpCallSampling::Bound(h) => {
+                handlers
+                    .lock()
+                    .await
+                    .insert(id, PerCallSamplingEntry::Bound(h));
+                Self {
+                    handlers,
+                    id,
+                    active: true,
+                }
+            }
+            McpCallSampling::Denied => {
+                handlers
+                    .lock()
+                    .await
+                    .insert(id, PerCallSamplingEntry::Denied);
+                Self {
+                    handlers,
+                    id,
+                    active: true,
+                }
+            }
+        }
+    }
+}
+
+impl Drop for PerCallSamplingGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        // Drop is sync; we can only try to lock. The map is taken only
+        // briefly by the reader task or other guards, so try_lock should
+        // succeed in the common case. If contended, schedule removal so
+        // the entry doesn't outlive the call indefinitely.
+        if let Ok(mut map) = self.handlers.try_lock() {
+            map.remove(&self.id);
+        } else {
+            let handlers = Arc::clone(&self.handlers);
+            let id = self.id;
+            tokio::task::spawn(async move {
+                handlers.lock().await.remove(&id);
+            });
+        }
+    }
+}
+
 // ── Stdio transport ──
 
 pub(crate) struct ProgressAwareStdioTransport {
@@ -284,6 +430,15 @@ pub(crate) struct ProgressAwareStdioTransport {
     child: Arc<tokio::sync::Mutex<Option<Child>>>,
     timeout: Duration,
     capabilities: Option<ServerCapabilities>,
+    /// Map of in-flight tool-call JSON-RPC ids → per-call sampling
+    /// decision (Bound | Denied). Populated by `call_tool` whenever the
+    /// caller supplies a `McpCallSampling` other than `Inherit`; emptied
+    /// via the `PerCallSamplingGuard` on every exit path. Stdio cannot
+    /// correlate a server-initiated `sampling/createMessage` to a
+    /// specific in-flight `tools/call` (no spec-mandated id field), so
+    /// the reader uses cardinality heuristics over this map — see
+    /// [`select_sampling_handler`].
+    per_call_sampling: PerCallSamplingHandlers,
 }
 
 impl ProgressAwareStdioTransport {
@@ -360,6 +515,9 @@ impl ProgressAwareStdioTransport {
         let alive_reader = Arc::clone(&alive);
         let write_tx_reader = write_tx.clone();
         let sampling_handler_reader = sampling_handler.clone();
+        let per_call_sampling: PerCallSamplingHandlers =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let per_call_sampling_reader = Arc::clone(&per_call_sampling);
         let mut reader = BufReader::new(stdout);
         tokio::spawn(async move {
             let mut line = String::new();
@@ -384,11 +542,14 @@ impl ProgressAwareStdioTransport {
                             handle_progress_notification(&progress_reader, notification).await;
                         }
                         Ok(JsonRpcMessage::Request(request)) => {
-                            let handler = sampling_handler_reader.clone();
+                            let fallback = sampling_handler_reader.clone();
+                            let per_call = Arc::clone(&per_call_sampling_reader);
                             let wtx = write_tx_reader.clone();
                             tokio::spawn(async move {
+                                let chosen =
+                                    select_sampling_handler(&per_call, fallback.as_ref()).await;
                                 let response =
-                                    handle_server_request(handler.as_deref(), &request).await;
+                                    handle_server_request(chosen.as_deref(), &request).await;
                                 let line = format!(
                                     "{}\n",
                                     serde_json::to_string(&response).unwrap_or_default()
@@ -447,6 +608,7 @@ impl ProgressAwareStdioTransport {
             child: Arc::new(tokio::sync::Mutex::new(Some(child))),
             timeout: Duration::from_secs(config.timeout_secs),
             capabilities: None,
+            per_call_sampling,
         };
 
         let mut capabilities = InitializeCapabilities::default();
@@ -654,9 +816,27 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         name: &str,
         args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        metadata: McpCallMetadata,
-        cancellation: Option<CancellationToken>,
+        context: McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
+        let McpCallContext {
+            metadata,
+            cancellation,
+            sampling,
+        } = context;
+
+        // Pre-check cancellation BEFORE allocating the request id, the
+        // progress token, or the per-call sampling slot. Without this,
+        // an already-cancelled caller would still allocate a fresh id,
+        // emit `notifications/cancelled` for an id the server never
+        // saw, and pollute counters.
+        if let Some(ref token) = cancellation
+            && token.is_cancelled()
+        {
+            return Err(McpTransportError::TransportError(
+                CANCELLED_BY_CLIENT.to_string(),
+            ));
+        }
+
         let (progress_token, progress_sender) = match progress_tx {
             Some(sender) => {
                 let token =
@@ -681,6 +861,15 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         // inside `send_request` and there's no way to address the
         // in-flight call from outside.
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+
+        // Register the per-call sampling decision deterministically
+        // BEFORE the request hits the wire. Awaiting the lock here is
+        // required: if registration raced the server-initiated
+        // sampling/createMessage we want to route to this entry, an
+        // earlier try_lock-based scheme would silently miss it.
+        let _handler_guard =
+            PerCallSamplingGuard::register(Arc::clone(&self.per_call_sampling), id, sampling).await;
+
         let request_fut = self.send_request_with_id(
             id,
             "tools/call",
@@ -789,6 +978,11 @@ pub(crate) struct ProgressAwareHttpTransport {
     capabilities: tokio::sync::Mutex<Option<ServerCapabilities>>,
     session: tokio::sync::RwLock<HttpSessionState>,
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
+    /// Per-call sampling handlers; same semantics as the stdio variant.
+    /// Populated by `call_tool` while a request is in flight; consulted
+    /// by `handle_server_request` for `sampling/createMessage`. See
+    /// `select_sampling_handler` for the routing rule.
+    per_call_sampling: PerCallSamplingHandlers,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -821,6 +1015,7 @@ impl ProgressAwareHttpTransport {
             capabilities: tokio::sync::Mutex::new(None),
             session: tokio::sync::RwLock::new(HttpSessionState::default()),
             sampling_handler,
+            per_call_sampling: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         })
     }
 
@@ -1171,8 +1366,33 @@ impl ProgressAwareHttpTransport {
                 Ok(None)
             }
             JsonRpcMessage::Request(request) => {
-                let response =
-                    handle_server_request(self.sampling_handler.as_deref(), &request).await;
+                // HTTP per-request SSE stream: per spec 2025-06-18
+                // §Listening for Messages from the Server, messages on
+                // this stream "SHOULD relate to a single client request"
+                // — namely OUR `request_id`. So a server-initiated
+                // `sampling/createMessage` arriving here belongs to that
+                // call. Route directly by request_id rather than guessing
+                // via cardinality.
+                //
+                // Three states:
+                //   - Bound(h)  → use this call's bound handler
+                //   - Denied    → factory consulted, refused: reject
+                //                 (never silently fall through to a
+                //                 fallback that may belong to a
+                //                 different agent — that's the leak the
+                //                 per-call routing exists to prevent)
+                //   - no entry  → Inherit semantics: caller did not
+                //                 engage the factory, fall through to
+                //                 the transport-level fixed handler
+                let chosen: Option<Arc<dyn SamplingHandler>> = {
+                    let map = self.per_call_sampling.lock().await;
+                    match map.get(&request_id) {
+                        Some(PerCallSamplingEntry::Bound(h)) => Some(Arc::clone(h)),
+                        Some(PerCallSamplingEntry::Denied) => None,
+                        None => self.sampling_handler.clone(),
+                    }
+                };
+                let response = handle_server_request(chosen.as_deref(), &request).await;
                 self.send_response_message(response).await?;
                 Ok(None)
             }
@@ -1281,9 +1501,27 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         name: &str,
         args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        metadata: McpCallMetadata,
-        cancellation: Option<CancellationToken>,
+        context: McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
+        let McpCallContext {
+            metadata,
+            cancellation,
+            sampling,
+        } = context;
+
+        // Pre-check cancellation BEFORE anything observable: any side
+        // effect we trigger past this point (id allocation, sampling
+        // map insertion, HTTP initialize) costs the server some work
+        // we'd need to unwind. Caller already cancelled → error out
+        // immediately.
+        if let Some(ref token) = cancellation
+            && token.is_cancelled()
+        {
+            return Err(McpTransportError::TransportError(
+                CANCELLED_BY_CLIENT.to_string(),
+            ));
+        }
+
         let (progress_token, progress_sender) = match progress_tx {
             Some(sender) => {
                 let token =
@@ -1303,28 +1541,36 @@ impl McpToolTransport for ProgressAwareHttpTransport {
             meta,
         };
 
-        // Initialize (with cancellation race) before any tool call — the
-        // server might assign a fresh session id we need for the request.
-        match cancellation {
-            None => {
-                self.initialize_if_needed().await?;
-            }
-            Some(ref token) => {
-                let init_fut = self.initialize_if_needed();
-                tokio::pin!(init_fut);
-                tokio::select! {
-                    biased;
-                    _ = token.cancelled() => {
-                        return Err(McpTransportError::TransportError(
-                            CANCELLED_BY_CLIENT.to_string(),
-                        ));
-                    }
-                    result = &mut init_fut => { result?; }
-                }
-            }
+        // Initialize runs UNINTERRUPTED — racing it with cancellation
+        // can leave the session half-constructed: server assigns a
+        // session id, we drop the future before reading it, and the
+        // orphaned server-side session lingers. Initialize is shared
+        // across all callers of this transport (cached in
+        // `capabilities`) — local to this call, it's a setup step, not
+        // the cancellable work.
+        self.initialize_if_needed().await?;
+
+        // Re-check cancellation after initialize completed (it may
+        // have taken non-trivial time). Tools/call hasn't been
+        // allocated/sent yet, so this is still a clean exit.
+        if let Some(ref token) = cancellation
+            && token.is_cancelled()
+        {
+            return Err(McpTransportError::TransportError(
+                CANCELLED_BY_CLIENT.to_string(),
+            ));
         }
 
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+
+        // Register the per-call sampling decision deterministically
+        // BEFORE the request hits the wire. Awaiting the lock guarantees
+        // the reader sees this entry before it can receive a
+        // `sampling/createMessage` for our request id on the per-request
+        // SSE stream.
+        let _handler_guard =
+            PerCallSamplingGuard::register(Arc::clone(&self.per_call_sampling), id, sampling).await;
+
         let request_fut = self.send_request_with_id(
             id,
             "tools/call",
@@ -1420,6 +1666,10 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         }
 
         Ok(())
+    }
+
+    async fn current_session_id(&self) -> Option<String> {
+        self.session.read().await.session_id.clone()
     }
 }
 
@@ -1621,6 +1871,47 @@ pub(crate) fn decode_http_response_payload(
             request_id
         )))
     })
+}
+
+/// Resolve which sampling handler should service an incoming
+/// server-initiated request. Per-call handlers (registered by `call_tool`
+/// in flight) take precedence over the transport-level fallback when
+/// there is **exactly one** call in flight — that's the unambiguous
+/// case where we know which agent's executor should service the
+/// sampling request. With zero or multiple in-flight calls we cannot
+/// route safely (the MCP spec gives no correlation between
+/// `sampling/createMessage` and a specific `tools/call` id), so we fall
+/// back to the transport's fixed handler. Operators who need stricter
+/// per-call routing in the >1-in-flight case can serialize their tool
+/// calls or contribute server-side echoing of `params._meta.awaken/in_response_to_call_id`.
+/// Stdio routing: server-initiated `sampling/createMessage` from a
+/// stdio server has no spec-mandated correlation id back to a specific
+/// in-flight `tools/call`, so we use cardinality:
+///   - 0 entries: nothing per-call to honor → fall back to transport-level
+///     fixed handler (preserves legacy behaviour for callers that don't
+///     wire a per-call factory).
+///   - 1 entry: that entry's decision is authoritative — `Bound(h)` →
+///     use h; `Denied` → reject (None). Never fall through on Denied,
+///     since the factory was explicitly consulted for this call.
+///   - More than one entry: ambiguous. Conservative — reject (None).
+///     Operators who need sampling correctness with concurrent stdio
+///     tool calls must serialize the calls. Falling through to the
+///     transport fallback would leak across agents (the bug the
+///     factory exists to prevent).
+async fn select_sampling_handler(
+    per_call: &PerCallSamplingHandlers,
+    fallback: Option<&Arc<dyn SamplingHandler>>,
+) -> Option<Arc<dyn SamplingHandler>> {
+    let map = per_call.lock().await;
+    match map.len() {
+        0 => fallback.cloned(),
+        1 => match map.values().next() {
+            Some(PerCallSamplingEntry::Bound(h)) => Some(Arc::clone(h)),
+            Some(PerCallSamplingEntry::Denied) => None,
+            None => fallback.cloned(),
+        },
+        _ => None,
+    }
 }
 
 pub(crate) async fn handle_server_request(
@@ -2110,8 +2401,10 @@ done
                     "test-tool",
                     json!({}),
                     None,
-                    McpCallMetadata::default(),
-                    Some(cancel),
+                    McpCallContext {
+                        cancellation: Some(cancel),
+                        ..McpCallContext::default()
+                    },
                 )
                 .await
         });
@@ -2163,6 +2456,242 @@ done
         assert_eq!(parsed["params"]["reason"], "client run cancelled");
 
         let _ = std::fs::remove_file(&scratch);
+    }
+
+    // ── Per-call sampling routing tests (R1 #P1b) ──
+
+    /// Helper: a sampling handler that records which "agent" handled
+    /// the call by storing a tag in a shared slot. Lets tests verify
+    /// per-call routing picked the right one.
+    struct TaggedSamplingHandler {
+        tag: String,
+        last_caller: Arc<tokio::sync::Mutex<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl SamplingHandler for TaggedSamplingHandler {
+        async fn handle_create_message(
+            &self,
+            _params: CreateMessageParams,
+        ) -> Result<mcp::CreateMessageResult, McpTransportError> {
+            *self.last_caller.lock().await = Some(self.tag.clone());
+            use mcp::{Role, SamplingContent};
+            Ok(mcp::CreateMessageResult {
+                role: Role::Assistant,
+                content: vec![SamplingContent::Text {
+                    text: self.tag.clone(),
+                    annotations: None,
+                    meta: None,
+                }],
+                model: "stub".into(),
+                stop_reason: Some("endTurn".into()),
+                meta: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn select_sampling_routes_single_in_flight_to_per_call() {
+        let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let agent_handler: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "agent-A".into(),
+            last_caller: Arc::clone(&last_caller),
+        });
+        let fallback: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "fallback".into(),
+            last_caller: Arc::clone(&last_caller),
+        });
+        per_call
+            .lock()
+            .await
+            .insert(42, PerCallSamplingEntry::Bound(agent_handler));
+
+        let chosen = select_sampling_handler(&per_call, Some(&fallback)).await;
+        let chosen = chosen.expect("a handler was selected");
+
+        // Invoke and verify which one handled it.
+        let _ = chosen
+            .handle_create_message(make_minimal_sampling_params())
+            .await
+            .expect("handler succeeded");
+        assert_eq!(
+            *last_caller.lock().await,
+            Some("agent-A".to_string()),
+            "single in-flight call -> per-call handler wins"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_sampling_falls_back_when_zero_in_flight() {
+        let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let fallback: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "fallback".into(),
+            last_caller: Arc::clone(&last_caller),
+        });
+
+        let chosen = select_sampling_handler(&per_call, Some(&fallback))
+            .await
+            .expect("fallback returned");
+        let _ = chosen
+            .handle_create_message(make_minimal_sampling_params())
+            .await;
+        assert_eq!(*last_caller.lock().await, Some("fallback".to_string()));
+    }
+
+    #[tokio::test]
+    async fn select_sampling_returns_none_when_multiple_in_flight() {
+        // With >1 in-flight calls we can't unambiguously route — return
+        // None so the server gets method-not-supported. This is a
+        // SECURITY fix: previously we fell back to the transport-level
+        // fixed handler, which could be a different agent's executor.
+        // The factory exists precisely to prevent that cross-agent
+        // leak, so the conservative fix is to refuse rather than guess.
+        let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let agent_a: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "agent-A".into(),
+            last_caller: Arc::clone(&last_caller),
+        });
+        let agent_b: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "agent-B".into(),
+            last_caller: Arc::clone(&last_caller),
+        });
+        let fallback: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "fallback".into(),
+            last_caller: Arc::clone(&last_caller),
+        });
+        per_call
+            .lock()
+            .await
+            .insert(1, PerCallSamplingEntry::Bound(agent_a));
+        per_call
+            .lock()
+            .await
+            .insert(2, PerCallSamplingEntry::Bound(agent_b));
+
+        assert!(
+            select_sampling_handler(&per_call, Some(&fallback))
+                .await
+                .is_none(),
+            "multiple in-flight => refuse rather than guess (no fallback)"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_sampling_returns_none_on_denied_single_in_flight() {
+        // Factory was consulted and explicitly refused this call. The
+        // transport MUST NOT fall through to a transport-level fallback
+        // handler — that would re-introduce the cross-agent leak the
+        // factory exists to prevent.
+        let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let fallback: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "fallback".into(),
+            last_caller: Arc::clone(&last_caller),
+        });
+        per_call
+            .lock()
+            .await
+            .insert(7, PerCallSamplingEntry::Denied);
+        assert!(
+            select_sampling_handler(&per_call, Some(&fallback))
+                .await
+                .is_none(),
+            "Denied entry must NEVER fall through to fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_sampling_returns_none_when_no_handlers_anywhere() {
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        assert!(select_sampling_handler(&per_call, None).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn per_call_sampling_guard_inserts_and_removes_bound() {
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let handler: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
+            tag: "x".into(),
+            last_caller: Arc::new(tokio::sync::Mutex::new(None)),
+        });
+        {
+            let _guard = PerCallSamplingGuard::register(
+                Arc::clone(&per_call),
+                99,
+                McpCallSampling::Bound(handler),
+            )
+            .await;
+            assert!(per_call.lock().await.contains_key(&99));
+        }
+        // After guard drops the entry should be gone. Tolerate a brief
+        // yield for the spawned-removal path; in the happy path try_lock
+        // succeeds and removal is synchronous.
+        tokio::task::yield_now().await;
+        assert!(!per_call.lock().await.contains_key(&99));
+    }
+
+    #[tokio::test]
+    async fn per_call_sampling_guard_inserts_and_removes_denied() {
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        {
+            let _guard =
+                PerCallSamplingGuard::register(Arc::clone(&per_call), 7, McpCallSampling::Denied)
+                    .await;
+            assert!(matches!(
+                per_call.lock().await.get(&7),
+                Some(PerCallSamplingEntry::Denied)
+            ));
+        }
+        tokio::task::yield_now().await;
+        assert!(!per_call.lock().await.contains_key(&7));
+    }
+
+    #[tokio::test]
+    async fn per_call_sampling_guard_inherit_registers_nothing() {
+        // Inherit semantics: caller didn't engage the factory, so no
+        // per-call entry is registered. The transport's reader path
+        // sees an empty map and uses its fallback handler.
+        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        {
+            let _guard =
+                PerCallSamplingGuard::register(Arc::clone(&per_call), 3, McpCallSampling::Inherit)
+                    .await;
+            assert!(
+                per_call.lock().await.is_empty(),
+                "Inherit registers nothing"
+            );
+        }
+        // Drop is a no-op for Inherit — map remains empty.
+        tokio::task::yield_now().await;
+        assert!(per_call.lock().await.is_empty());
+    }
+
+    fn make_minimal_sampling_params() -> CreateMessageParams {
+        use mcp::SamplingMessage;
+        CreateMessageParams {
+            messages: vec![SamplingMessage {
+                role: mcp::Role::User,
+                content: vec![mcp::SamplingContent::Text {
+                    text: "hi".into(),
+                    annotations: None,
+                    meta: None,
+                }],
+                meta: None,
+            }],
+            model_preferences: None,
+            system_prompt: None,
+            include_context: None,
+            temperature: None,
+            max_tokens: 16,
+            stop_sequences: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+            task: None,
+            meta: None,
+        }
     }
 
     #[test]

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -26,8 +26,17 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, oneshot};
 
+use awaken_contract::cancellation::CancellationToken;
+
 use crate::progress::McpProgressUpdate;
 use crate::sampling::SamplingHandler;
+
+/// Sentinel error string used to distinguish a client-initiated
+/// cancellation from other transport errors at the call boundary. Kept
+/// as a string so the variant set in the upstream `McpTransportError`
+/// crate doesn't need extending — callers match on this exact message
+/// to surface the cancellation upward (e.g. as `ToolError::Cancelled`).
+pub const CANCELLED_BY_CLIENT: &str = "MCP request cancelled by client";
 
 #[cfg(unix)]
 use nix::sys::signal::{Signal, kill};
@@ -99,6 +108,81 @@ struct ListResourcesResult {
     resources: Vec<McpResourceDefinition>,
 }
 
+// ── McpCallMetadata ──
+
+/// Client-side attribution metadata attached to outgoing MCP tool calls
+/// via JSON-RPC `params._meta`. Lets the MCP server identify which agent /
+/// thread / run / call initiated the request so it can do per-agent rate
+/// limiting, per-tenant OAuth, audit, or workflow correlation.
+///
+/// Spec (2025-06-18 §JSON-RPC 2.0 + §Basic) reserves the `_meta` field on
+/// request params for client-controlled metadata. By convention,
+/// vendor-specific keys are namespaced — we use `awaken/attribution` so
+/// our additions don't collide with future MCP spec fields (notably the
+/// existing `progressToken` key, which we continue to set in the same
+/// `_meta` map).
+///
+/// All fields are optional. Empty `McpCallMetadata` is a no-op — no
+/// `awaken/attribution` key is added to `_meta`.
+#[derive(Debug, Clone, Default)]
+pub struct McpCallMetadata {
+    pub agent_id: Option<String>,
+    pub thread_id: Option<String>,
+    pub run_id: Option<String>,
+    pub call_id: Option<String>,
+    pub parent_run_id: Option<String>,
+    pub parent_call_id: Option<String>,
+}
+
+impl McpCallMetadata {
+    /// Serialize set fields into a `Map` under the `awaken/attribution`
+    /// key. No-op if every field is `None`.
+    fn write_into(&self, map: &mut Map<String, Value>) {
+        let mut bag = Map::new();
+        if let Some(v) = &self.agent_id {
+            bag.insert("agent_id".to_string(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.thread_id {
+            bag.insert("thread_id".to_string(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.run_id {
+            bag.insert("run_id".to_string(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.call_id {
+            bag.insert("call_id".to_string(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.parent_run_id {
+            bag.insert("parent_run_id".to_string(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.parent_call_id {
+            bag.insert("parent_call_id".to_string(), Value::String(v.clone()));
+        }
+        if !bag.is_empty() {
+            map.insert("awaken/attribution".to_string(), Value::Object(bag));
+        }
+    }
+}
+
+/// Build the `_meta` value for `tools/call` params. Combines the MCP
+/// `progressToken` (when progress is enabled) with optional vendor
+/// attribution from `McpCallMetadata`. Returns `None` when neither is
+/// present so the wire payload omits the `_meta` field entirely.
+fn build_call_tool_meta(
+    progress_token: Option<ProgressToken>,
+    metadata: &McpCallMetadata,
+) -> Result<Option<Value>, McpTransportError> {
+    let mut map = Map::new();
+    if let Some(token) = progress_token {
+        map.insert("progressToken".to_string(), serde_json::to_value(token)?);
+    }
+    metadata.write_into(&mut map);
+    if map.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Value::Object(map)))
+    }
+}
+
 // ── McpToolTransport trait ──
 
 /// Raw MCP client transport abstraction.
@@ -140,6 +224,8 @@ pub trait McpToolTransport: Send + Sync {
         name: &str,
         args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        metadata: McpCallMetadata,
+        cancellation: Option<CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError>;
 
     fn transport_type(&self) -> TransportTypeId;
@@ -176,6 +262,12 @@ impl From<&ProgressToken> for ProgressTokenKey {
 
 struct WriteRequest {
     line: String,
+    /// Optional ack channel: when present, the writer task signals after
+    /// the line has been written + flushed to the subprocess stdin. Used
+    /// by the cancellation path so `notifications/cancelled` is
+    /// guaranteed to reach the subprocess before the transport is
+    /// dropped (drop kills the subprocess via `kill_on_drop(true)`).
+    ack: Option<oneshot::Sender<()>>,
 }
 
 // ── Stdio transport ──
@@ -257,6 +349,9 @@ impl ProgressAwareStdioTransport {
                     alive_writer.store(false, Ordering::SeqCst);
                     break;
                 }
+                if let Some(ack) = req.ack {
+                    let _ = ack.send(());
+                }
             }
         });
 
@@ -298,7 +393,7 @@ impl ProgressAwareStdioTransport {
                                     "{}\n",
                                     serde_json::to_string(&response).unwrap_or_default()
                                 );
-                                let _ = wtx.send(WriteRequest { line }).await;
+                                let _ = wtx.send(WriteRequest { line, ack: None }).await;
                             });
                         }
                         Err(e) => {
@@ -396,7 +491,7 @@ impl ProgressAwareStdioTransport {
         let notification = JsonRpcNotification::new(method, params);
         let line = format!("{}\n", serde_json::to_string(&notification)?);
         self.write_tx
-            .send(WriteRequest { line })
+            .send(WriteRequest { line, ack: None })
             .await
             .map_err(|_| McpTransportError::ConnectionClosed)?;
         Ok(())
@@ -408,11 +503,26 @@ impl ProgressAwareStdioTransport {
         params: Option<Value>,
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        self.send_request_with_id(id, method, params, progress_registration)
+            .await
+    }
+
+    /// Send a JSON-RPC request using a caller-supplied id. Extracted from
+    /// `send_request` so cancellable call paths can allocate the id up
+    /// front and reuse it when emitting `notifications/cancelled`
+    /// (which references the in-flight request by id per spec).
+    async fn send_request_with_id(
+        &self,
+        id: i64,
+        method: &str,
+        params: Option<Value>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+    ) -> Result<Value, McpTransportError> {
         if !self.alive.load(Ordering::SeqCst) {
             return Err(McpTransportError::ConnectionClosed);
         }
 
-        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let request = JsonRpcRequest::new(JsonRpcId::Number(id), method.to_string(), params);
         let line = format!("{}\n", serde_json::to_string(&request)?);
 
@@ -424,7 +534,12 @@ impl ProgressAwareStdioTransport {
             self.progress_subscribers.lock().await.insert(key, sender);
         }
 
-        if self.write_tx.send(WriteRequest { line }).await.is_err() {
+        if self
+            .write_tx
+            .send(WriteRequest { line, ack: None })
+            .await
+            .is_err()
+        {
             self.pending.lock().await.remove(&id);
             if let Some(key) = progress_key {
                 self.progress_subscribers.lock().await.remove(&key);
@@ -451,6 +566,42 @@ impl ProgressAwareStdioTransport {
                 )))
             }
         }
+    }
+
+    /// Drop a pending request entry on cancellation so the reader task
+    /// doesn't keep the channel alive. The matching response (if it ever
+    /// arrives) will then be silently discarded.
+    async fn forget_pending(&self, id: i64) {
+        self.pending.lock().await.remove(&id);
+    }
+
+    /// Send a JSON-RPC notification and wait for the writer task to
+    /// confirm the line has been written + flushed to subprocess stdin.
+    /// Critical for the cancellation path: the transport is dropped
+    /// immediately after this returns, which triggers `kill_on_drop`
+    /// on the subprocess — without the ack we'd race the kill and the
+    /// `notifications/cancelled` might never reach the server.
+    async fn send_notification_flushed(
+        &self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Result<(), McpTransportError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(McpTransportError::ConnectionClosed);
+        }
+        let notification = JsonRpcNotification::new(method, params);
+        let line = format!("{}\n", serde_json::to_string(&notification)?);
+        let (ack_tx, ack_rx) = oneshot::channel();
+        self.write_tx
+            .send(WriteRequest {
+                line,
+                ack: Some(ack_tx),
+            })
+            .await
+            .map_err(|_| McpTransportError::ConnectionClosed)?;
+        // Bounded wait — if the writer task is gone the ack will drop.
+        let _ = tokio::time::timeout(Duration::from_secs(2), ack_rx).await;
+        Ok(())
     }
 }
 
@@ -503,21 +654,20 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         name: &str,
         args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        metadata: McpCallMetadata,
+        cancellation: Option<CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError> {
-        let progress_registration = progress_tx.map(|sender| {
-            let token =
-                ProgressToken::Number(self.next_progress_token.fetch_add(1, Ordering::SeqCst));
-            let key = ProgressTokenKey::from(&token);
-            (token, key, sender)
-        });
-
-        let (meta, progress_sender) = if let Some((token, key, sender)) = progress_registration {
-            let mut map = Map::new();
-            map.insert("progressToken".to_string(), serde_json::to_value(token)?);
-            (Some(Value::Object(map)), Some((key, sender)))
-        } else {
-            (None, None)
+        let (progress_token, progress_sender) = match progress_tx {
+            Some(sender) => {
+                let token =
+                    ProgressToken::Number(self.next_progress_token.fetch_add(1, Ordering::SeqCst));
+                let key = ProgressTokenKey::from(&token);
+                (Some(token), Some((key, sender)))
+            }
+            None => (None, None),
         };
+
+        let meta = build_call_tool_meta(progress_token, &metadata)?;
 
         let params = CallToolParams {
             name: name.to_string(),
@@ -526,13 +676,57 @@ impl McpToolTransport for ProgressAwareStdioTransport {
             meta,
         };
 
-        let result = self
-            .send_request(
-                "tools/call",
-                Some(serde_json::to_value(&params)?),
-                progress_sender,
-            )
-            .await?;
+        // Allocate the request id up front so notifications/cancelled can
+        // reference it on cancellation. Without this, the id is generated
+        // inside `send_request` and there's no way to address the
+        // in-flight call from outside.
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let request_fut = self.send_request_with_id(
+            id,
+            "tools/call",
+            Some(serde_json::to_value(&params)?),
+            progress_sender,
+        );
+
+        let result = match cancellation {
+            None => request_fut.await,
+            Some(token) => {
+                tokio::pin!(request_fut);
+                tokio::select! {
+                    biased;
+                    _ = token.cancelled() => {
+                        // Per spec (2025-06-18 §Cancellation): the client
+                        // SHOULD send `notifications/cancelled` with the
+                        // in-flight requestId so the server can stop
+                        // processing and free resources. We use the
+                        // flushed variant because the transport is
+                        // typically dropped immediately after this
+                        // returns; `kill_on_drop(true)` would race the
+                        // notification write and the server might never
+                        // see the cancellation.
+                        let _ = self
+                            .send_notification_flushed(
+                                "notifications/cancelled",
+                                Some(json!({
+                                    "requestId": id,
+                                    "reason": "client run cancelled",
+                                })),
+                            )
+                            .await;
+                        // Drop the pending entry so a late response is
+                        // dropped on the reader floor rather than
+                        // delivered to an orphaned channel.
+                        self.forget_pending(id).await;
+                        Err(McpTransportError::TransportError(
+                            CANCELLED_BY_CLIENT.to_string(),
+                        ))
+                    }
+                    result = &mut request_fut => result,
+                }
+            }
+        };
+
+        let result = result?;
         let call_result: CallToolResult = serde_json::from_value(result)?;
 
         if call_result.is_error == Some(true) {
@@ -653,9 +847,12 @@ impl ProgressAwareHttpTransport {
             )
             .await?;
 
+        // Spec literal: `Mcp-Session-Id`. HeaderMap::get is
+        // case-insensitive so this works regardless of how the server
+        // capitalises the response header.
         let session_id = response
             .headers()
-            .get("MCP-Session-Id")
+            .get("Mcp-Session-Id")
             .and_then(|value| value.to_str().ok())
             .map(str::to_string);
 
@@ -684,6 +881,20 @@ impl ProgressAwareHttpTransport {
         progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
     ) -> Result<Value, McpTransportError> {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        self.send_request_with_id(id, method, params, progress_registration)
+            .await
+    }
+
+    /// Variant of `send_request` that uses a caller-allocated id so the
+    /// cancellable call path can emit `notifications/cancelled` against
+    /// the same in-flight request id.
+    async fn send_request_with_id(
+        &self,
+        id: i64,
+        method: &str,
+        params: Option<Value>,
+        progress_registration: Option<(ProgressTokenKey, mpsc::UnboundedSender<McpProgressUpdate>)>,
+    ) -> Result<Value, McpTransportError> {
         let request = JsonRpcRequest::new(JsonRpcId::Number(id), method.to_string(), params);
         let response = self
             .post_message(JsonRpcMessage::Request(request), true)
@@ -729,7 +940,11 @@ impl ProgressAwareHttpTransport {
             request = request.header("MCP-Protocol-Version", protocol_version);
         }
         if let Some(session_id) = session.session_id {
-            request = request.header("MCP-Session-Id", session_id);
+            // Spec literal is `Mcp-Session-Id` (title case), not `MCP-`.
+            // HTTP headers are case-insensitive per RFC 7230 so both work
+            // against compliant servers, but the spec writes it in title
+            // case and some intermediaries are pickier than they should be.
+            request = request.header("Mcp-Session-Id", session_id);
         }
 
         request = match message {
@@ -1066,21 +1281,20 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         name: &str,
         args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        metadata: McpCallMetadata,
+        cancellation: Option<CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError> {
-        let progress_registration = progress_tx.map(|sender| {
-            let token =
-                ProgressToken::Number(self.next_progress_token.fetch_add(1, Ordering::SeqCst));
-            let key = ProgressTokenKey::from(&token);
-            (token, key, sender)
-        });
-
-        let (meta, progress_sender) = if let Some((token, key, sender)) = progress_registration {
-            let mut map = Map::new();
-            map.insert("progressToken".to_string(), serde_json::to_value(token)?);
-            (Some(Value::Object(map)), Some((key, sender)))
-        } else {
-            (None, None)
+        let (progress_token, progress_sender) = match progress_tx {
+            Some(sender) => {
+                let token =
+                    ProgressToken::Number(self.next_progress_token.fetch_add(1, Ordering::SeqCst));
+                let key = ProgressTokenKey::from(&token);
+                (Some(token), Some((key, sender)))
+            }
+            None => (None, None),
         };
+
+        let meta = build_call_tool_meta(progress_token, &metadata)?;
 
         let params = CallToolParams {
             name: name.to_string(),
@@ -1089,13 +1303,68 @@ impl McpToolTransport for ProgressAwareHttpTransport {
             meta,
         };
 
-        let result = self
-            .send_initialized_request(
-                "tools/call",
-                Some(serde_json::to_value(&params)?),
-                progress_sender,
-            )
-            .await?;
+        // Initialize (with cancellation race) before any tool call — the
+        // server might assign a fresh session id we need for the request.
+        match cancellation {
+            None => {
+                self.initialize_if_needed().await?;
+            }
+            Some(ref token) => {
+                let init_fut = self.initialize_if_needed();
+                tokio::pin!(init_fut);
+                tokio::select! {
+                    biased;
+                    _ = token.cancelled() => {
+                        return Err(McpTransportError::TransportError(
+                            CANCELLED_BY_CLIENT.to_string(),
+                        ));
+                    }
+                    result = &mut init_fut => { result?; }
+                }
+            }
+        }
+
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let request_fut = self.send_request_with_id(
+            id,
+            "tools/call",
+            Some(serde_json::to_value(&params)?),
+            progress_sender,
+        );
+
+        let result = match cancellation {
+            None => request_fut.await,
+            Some(token) => {
+                tokio::pin!(request_fut);
+                tokio::select! {
+                    biased;
+                    _ = token.cancelled() => {
+                        // Per spec (2025-06-18 §Cancellation): SHOULD emit
+                        // notifications/cancelled with the in-flight
+                        // requestId so the server stops processing. The
+                        // in-flight HTTP request is dropped by virtue of
+                        // dropping `request_fut`; reqwest cancels the
+                        // socket. Then we issue a separate POST with the
+                        // cancellation notification.
+                        let _ = self
+                            .send_notification(
+                                "notifications/cancelled",
+                                Some(json!({
+                                    "requestId": id,
+                                    "reason": "client run cancelled",
+                                })),
+                            )
+                            .await;
+                        return Err(McpTransportError::TransportError(
+                            CANCELLED_BY_CLIENT.to_string(),
+                        ));
+                    }
+                    result = &mut request_fut => result,
+                }
+            }
+        };
+
+        let result = result?;
         let call_result: CallToolResult = serde_json::from_value(result)?;
 
         if call_result.is_error == Some(true) {
@@ -1121,6 +1390,24 @@ impl McpToolTransport for ProgressAwareHttpTransport {
     }
 
     async fn close(&self) -> Result<(), McpTransportError> {
+        // Per spec (2025-06-18 §Streamable HTTP / Session Management):
+        // "Clients that no longer need a particular session SHOULD send an
+        //  HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header,
+        //  to explicitly terminate the session. The server MAY respond
+        //  to this request with HTTP 405 Method Not Allowed."
+        //
+        // Without this, the server-side session state lingers until its
+        // own TTL fires — for long-running awaken processes that toggle
+        // / reconnect MCP servers, this accumulates zombie sessions.
+        //
+        // Errors are swallowed (best-effort): the server may legitimately
+        // 405 to refuse termination, or the network may be down. Either
+        // way we still tear down local state.
+        let session_id = self.session.read().await.session_id.clone();
+        if let Some(session_id) = session_id {
+            self.send_session_termination(&session_id).await;
+        }
+
         {
             let mut session = self.session.write().await;
             session.session_id = None;
@@ -1133,6 +1420,46 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         }
 
         Ok(())
+    }
+}
+
+impl ProgressAwareHttpTransport {
+    /// Best-effort `DELETE <endpoint>` with the session id header so the
+    /// server can immediately free session state. Swallows all errors —
+    /// the client has already decided to terminate, so a server 405 / 5xx
+    /// / network error doesn't change the outcome locally.
+    async fn send_session_termination(&self, session_id: &str) {
+        let mut request = self
+            .client
+            .delete(&self.endpoint)
+            .header("Mcp-Session-Id", session_id.to_string());
+        let protocol_version = self.session.read().await.protocol_version.clone();
+        if let Some(protocol_version) = protocol_version {
+            request = request.header("MCP-Protocol-Version", protocol_version);
+        }
+        match request.send().await {
+            Ok(response) if response.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED => {
+                tracing::debug!(
+                    endpoint = %self.endpoint,
+                    "MCP server refused DELETE-session (405); session will expire on server TTL"
+                );
+            }
+            Ok(response) if !response.status().is_success() => {
+                tracing::debug!(
+                    endpoint = %self.endpoint,
+                    status = %response.status(),
+                    "MCP DELETE-session non-success; ignoring"
+                );
+            }
+            Ok(_) => {}
+            Err(err) => {
+                tracing::debug!(
+                    endpoint = %self.endpoint,
+                    error = %err,
+                    "MCP DELETE-session failed; ignoring"
+                );
+            }
+        }
     }
 }
 
@@ -1559,6 +1886,343 @@ mod tests {
 
         transport.close().await.unwrap();
         transport.close().await.unwrap();
+    }
+
+    /// Spec (2025-06-18, §Streamable HTTP / Session Management):
+    /// "Clients that no longer need a particular session SHOULD send an
+    ///  HTTP DELETE to the MCP endpoint with the Mcp-Session-Id header,
+    ///  to explicitly terminate the session."
+    ///
+    /// Verifies that `ProgressAwareHttpTransport::close()` actually emits
+    /// the DELETE with the right method, header name, and header value.
+    /// Uses an ephemeral TCP listener instead of pulling in a mock-server
+    /// dev-dep — the test owns its own one-shot server lifetime.
+    #[tokio::test]
+    async fn http_transport_close_sends_delete_with_session_id() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+
+        let recorded = Arc::new(tokio::sync::Mutex::new(None::<String>));
+        let recorded_clone = Arc::clone(&recorded);
+        let server_task = tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut buf = vec![0u8; 4096];
+                let n = stream.read(&mut buf).await.unwrap_or(0);
+                *recorded_clone.lock().await = Some(String::from_utf8_lossy(&buf[..n]).to_string());
+                let _ = stream
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                    .await;
+            }
+        });
+
+        let cfg = mcp::transport::McpServerConnectionConfig::http("http-close-delete", url);
+        let transport = ProgressAwareHttpTransport::connect(&cfg, None).unwrap();
+        // Pretend init already happened so close() has a session id to terminate.
+        transport.session.write().await.session_id = Some("test-session-abc".into());
+
+        transport.close().await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(2), server_task).await;
+
+        let request = recorded
+            .lock()
+            .await
+            .clone()
+            .expect("server must have observed a request from close()");
+
+        // Method line.
+        let first_line = request.lines().next().unwrap_or("");
+        assert!(
+            first_line.starts_with("DELETE "),
+            "close() must use HTTP DELETE; got first line: {first_line}"
+        );
+
+        // Session id header (HTTP header names are case-insensitive but the
+        // spec literal is `Mcp-Session-Id`).
+        let has_session_header = request.lines().any(|line| {
+            line.to_ascii_lowercase().starts_with("mcp-session-id:")
+                && line.contains("test-session-abc")
+        });
+        assert!(
+            has_session_header,
+            "DELETE must carry the Mcp-Session-Id header. Request was:\n{request}"
+        );
+
+        // Local state cleared after close().
+        let session_after = transport.session.read().await.clone();
+        assert!(session_after.session_id.is_none(), "session_id cleared");
+    }
+
+    // ── build_call_tool_meta tests ──
+
+    #[test]
+    fn build_meta_returns_none_when_no_progress_or_attribution() {
+        let meta = build_call_tool_meta(None, &McpCallMetadata::default()).unwrap();
+        assert!(
+            meta.is_none(),
+            "empty metadata + no progress => no _meta field"
+        );
+    }
+
+    #[test]
+    fn build_meta_includes_progress_token_alone() {
+        let meta =
+            build_call_tool_meta(Some(ProgressToken::Number(7)), &McpCallMetadata::default())
+                .unwrap()
+                .expect("Some(_meta) when progress is set");
+        let obj = meta.as_object().unwrap();
+        assert_eq!(obj.get("progressToken"), Some(&serde_json::json!(7)));
+        assert!(!obj.contains_key("awaken/attribution"));
+    }
+
+    #[test]
+    fn build_meta_namespaces_attribution_under_awaken_key() {
+        let metadata = McpCallMetadata {
+            agent_id: Some("research-assistant".into()),
+            thread_id: Some("thr-abc".into()),
+            run_id: Some("run-xyz".into()),
+            call_id: Some("call-1".into()),
+            parent_run_id: None,
+            parent_call_id: None,
+        };
+        let meta = build_call_tool_meta(None, &metadata)
+            .unwrap()
+            .expect("Some(_meta) when attribution is set");
+        let attribution = meta
+            .get("awaken/attribution")
+            .expect("attribution must be namespaced under awaken/attribution")
+            .as_object()
+            .unwrap();
+        assert_eq!(
+            attribution.get("agent_id"),
+            Some(&serde_json::json!("research-assistant"))
+        );
+        assert_eq!(
+            attribution.get("thread_id"),
+            Some(&serde_json::json!("thr-abc"))
+        );
+        assert_eq!(
+            attribution.get("run_id"),
+            Some(&serde_json::json!("run-xyz"))
+        );
+        assert_eq!(
+            attribution.get("call_id"),
+            Some(&serde_json::json!("call-1"))
+        );
+        // Absent fields don't pollute the bag.
+        assert!(!attribution.contains_key("parent_run_id"));
+        assert!(!attribution.contains_key("parent_call_id"));
+    }
+
+    #[test]
+    fn build_meta_combines_progress_token_and_attribution() {
+        let metadata = McpCallMetadata {
+            agent_id: Some("a1".into()),
+            ..Default::default()
+        };
+        let meta = build_call_tool_meta(Some(ProgressToken::String("tok-1".into())), &metadata)
+            .unwrap()
+            .expect("Some(_meta)");
+        let obj = meta.as_object().unwrap();
+        // Both progress and attribution coexist in the same _meta map.
+        assert!(obj.contains_key("progressToken"));
+        let attribution = obj.get("awaken/attribution").unwrap().as_object().unwrap();
+        assert_eq!(attribution.get("agent_id"), Some(&serde_json::json!("a1")));
+    }
+
+    #[test]
+    fn build_meta_omits_empty_attribution_bag() {
+        // Every attribution field set to None — the bag is empty so no
+        // `awaken/attribution` key is added even though metadata was
+        // technically "supplied" (Default::default()).
+        let meta =
+            build_call_tool_meta(Some(ProgressToken::Number(1)), &McpCallMetadata::default())
+                .unwrap()
+                .expect("Some(_meta)");
+        let obj = meta.as_object().unwrap();
+        assert!(obj.contains_key("progressToken"));
+        assert!(!obj.contains_key("awaken/attribution"));
+    }
+
+    /// Spec (2025-06-18 §Cancellation): on a client-initiated cancel the
+    /// client SHOULD send `notifications/cancelled` with the in-flight
+    /// requestId. This test drives stdio `call_tool` against a reflective
+    /// shell-script "MCP server" that:
+    ///   1. logs every stdin line to a scratch file,
+    ///   2. answers `initialize` so connect() succeeds,
+    ///   3. holds `tools/call` indefinitely (never responds),
+    /// then triggers `CancellationToken::cancel()` and asserts the
+    /// transport wrote a `notifications/cancelled` line with a matching
+    /// requestId and returned the cancellation sentinel error.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stdio_call_tool_cancellation_emits_notification() {
+        use serde_json::Value;
+
+        let scratch = std::env::temp_dir().join(format!(
+            "awaken-mcp-cancel-{}-{}.log",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&scratch);
+        let scratch_str = scratch.to_string_lossy().to_string();
+
+        let script = format!(
+            r#"
+while IFS= read -r LINE; do
+    printf '%s\n' "$LINE" >> "{scratch}"
+    case "$LINE" in
+        *'"method":"initialize"'*)
+            ID=$(printf '%s' "$LINE" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+            printf '{{"jsonrpc":"2.0","id":%s,"result":{{"protocolVersion":"2024-11-05","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"mock","version":"0"}}}}}}\n' "$ID"
+            ;;
+    esac
+done
+"#,
+            scratch = scratch_str
+        );
+
+        let mut cfg = mcp::transport::McpServerConnectionConfig::stdio(
+            "stdio-cancel",
+            "/bin/sh",
+            vec!["-c".to_string(), script],
+        );
+        cfg.timeout_secs = 30;
+
+        let transport = Arc::new(
+            ProgressAwareStdioTransport::connect(&cfg, None)
+                .await
+                .expect("stdio transport connects"),
+        );
+
+        let cancel = CancellationToken::new();
+        let cancel_trigger = cancel.clone();
+
+        let transport_for_call = Arc::clone(&transport);
+        let call_handle = tokio::spawn(async move {
+            transport_for_call
+                .call_tool(
+                    "test-tool",
+                    json!({}),
+                    None,
+                    McpCallMetadata::default(),
+                    Some(cancel),
+                )
+                .await
+        });
+
+        // Give the tools/call line time to land on subprocess stdin
+        // before triggering cancellation.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        cancel_trigger.cancel();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(5), call_handle)
+            .await
+            .expect("call did not return after cancellation")
+            .expect("call task joined");
+
+        match outcome {
+            Err(McpTransportError::TransportError(msg)) if msg == CANCELLED_BY_CLIENT => {}
+            other => panic!("expected CANCELLED_BY_CLIENT error, got: {other:?}"),
+        }
+
+        // Wait for the subprocess to flush the notification line.
+        let started = Instant::now();
+        let contents = loop {
+            let current = fs::read_to_string(&scratch).unwrap_or_default();
+            if current.contains("notifications/cancelled") {
+                break current;
+            }
+            if started.elapsed() > Duration::from_secs(3) {
+                panic!("did not observe notifications/cancelled. Got:\n{current}");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        };
+
+        let cancel_line = contents
+            .lines()
+            .find(|l| l.contains("notifications/cancelled"))
+            .expect("found cancellation line");
+        let parsed: Value = serde_json::from_str(cancel_line).expect("notification is valid JSON");
+        assert_eq!(parsed["method"], "notifications/cancelled");
+        // tools/call is the 2nd JSON-RPC request id (initialize was #1).
+        // The id allocator starts at 1 and increments; we tolerate any
+        // positive id since timing-dependent setup may shift it.
+        let request_id = parsed["params"]["requestId"]
+            .as_i64()
+            .expect("requestId must be a JSON-RPC integer id");
+        assert!(
+            request_id >= 1,
+            "requestId must reference an in-flight call"
+        );
+        assert_eq!(parsed["params"]["reason"], "client run cancelled");
+
+        let _ = std::fs::remove_file(&scratch);
+    }
+
+    #[test]
+    fn build_meta_includes_parent_when_present() {
+        let metadata = McpCallMetadata {
+            agent_id: Some("delegate".into()),
+            parent_run_id: Some("parent-run".into()),
+            parent_call_id: Some("parent-call".into()),
+            ..Default::default()
+        };
+        let attribution = build_call_tool_meta(None, &metadata)
+            .unwrap()
+            .unwrap()
+            .get("awaken/attribution")
+            .cloned()
+            .unwrap();
+        let obj = attribution.as_object().unwrap();
+        assert_eq!(
+            obj.get("parent_run_id"),
+            Some(&serde_json::json!("parent-run"))
+        );
+        assert_eq!(
+            obj.get("parent_call_id"),
+            Some(&serde_json::json!("parent-call"))
+        );
+    }
+
+    /// close() with no session id MUST NOT emit any HTTP request — there's
+    /// nothing to terminate. Pairs with the test above so a refactor that
+    /// accidentally always-DELETEs trips the empty-session case.
+    #[tokio::test]
+    async fn http_transport_close_without_session_emits_no_request() {
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+
+        let observed = Arc::new(tokio::sync::Mutex::new(false));
+        let observed_clone = Arc::clone(&observed);
+        let server_task = tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut buf = vec![0u8; 16];
+                if stream.read(&mut buf).await.unwrap_or(0) > 0 {
+                    *observed_clone.lock().await = true;
+                }
+            }
+        });
+
+        let cfg = mcp::transport::McpServerConnectionConfig::http("http-close-no-session", url);
+        let transport = ProgressAwareHttpTransport::connect(&cfg, None).unwrap();
+        // No session id set.
+        transport.close().await.unwrap();
+
+        // Give the listener a brief moment to observe a spurious request.
+        let _ = tokio::time::timeout(Duration::from_millis(150), server_task).await;
+        assert!(
+            !*observed.lock().await,
+            "close() with no session_id must not contact the server"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -341,19 +341,18 @@ pub trait McpToolTransport: Send + Sync {
         Ok(())
     }
 
-    /// Current server-assigned session id, if any. Streamable HTTP
-    /// transports return the value cached after the most recent
-    /// successful `initialize`; stdio returns `None` (the protocol does
-    /// not define a session id for that transport). Display-only — do
-    /// not cache or persist outside the transport.
-    async fn current_session_id(&self) -> Option<String> {
-        None
-    }
-
     /// Wall-clock time of the current HTTP session's successful
     /// `initialize`, if the transport can report it live. Stdio returns
     /// `None`; manager snapshots fall back to their connect/reconnect cache.
     async fn current_session_started_at(&self) -> Option<SystemTime> {
+        None
+    }
+
+    /// HTTP session generation, if the transport has session state.
+    /// Streamable HTTP increments this counter on local session reset
+    /// and reinitialize cycles, including 404 session expiry. Stdio has
+    /// no session concept and returns `None`.
+    async fn current_session_generation(&self) -> Option<u64> {
         None
     }
 
@@ -731,10 +730,10 @@ impl PerCallSamplingGuard {
     }
 
     /// Explicitly drop the per-call entry with an `.await`'d lock.
-    /// Call this on every exit path of `call_tool` so cardinality-
-    /// based routing in `select_sampling_handler` doesn't observe a
-    /// stale entry from a call that just returned. Marks the guard
-    /// inactive so the sync `Drop` impl becomes a no-op safety net.
+    /// Call this on every exit path of `call_tool` so request-bound
+    /// routing does not observe a stale entry from a call that just
+    /// returned. Marks the guard inactive so the sync `Drop` impl
+    /// becomes a no-op safety net.
     async fn unregister(&mut self) {
         if !self.active {
             return;
@@ -782,13 +781,11 @@ pub(crate) struct ProgressAwareStdioTransport {
     timeout: Duration,
     capabilities: Option<ServerCapabilities>,
     /// Map of in-flight tool-call JSON-RPC ids → per-call sampling
-    /// decision (Bound | Denied). Populated by `call_tool` whenever the
-    /// caller supplies a `McpCallSampling` other than `Inherit`; emptied
-    /// via the `PerCallSamplingGuard` on every exit path. Stdio cannot
-    /// correlate a server-initiated `sampling/createMessage` to a
-    /// specific in-flight `tools/call` (no spec-mandated id field), so
-    /// the reader uses cardinality heuristics over this map — see
-    /// [`select_sampling_handler`].
+    /// decision (Bound | Denied). HTTP request-bound SSE can correlate
+    /// server requests back to one client request; stdio cannot. The
+    /// stdio reader therefore never consults this map for server-
+    /// initiated sampling, but the call guard still owns cleanup for
+    /// shared helper code and future transports.
     per_call_sampling: PerCallSamplingHandlers,
     /// Receiver half of the `notifications/.../list_changed` channel.
     /// The reader task owns the cloned sender; when this transport (and
@@ -885,7 +882,6 @@ impl ProgressAwareStdioTransport {
         let sampling_handler_reader = sampling_handler.clone();
         let per_call_sampling: PerCallSamplingHandlers =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let per_call_sampling_reader = Arc::clone(&per_call_sampling);
         let (list_changed_tx, list_changed_rx) = mpsc::unbounded_channel::<ListChangedKind>();
         let list_changed_tx_reader = list_changed_tx.clone();
         let (resource_updated_tx, resource_updated_rx) = mpsc::unbounded_channel::<String>();
@@ -926,12 +922,10 @@ impl ProgressAwareStdioTransport {
                         }
                         Ok(JsonRpcMessage::Request(request)) => {
                             let fallback = sampling_handler_reader.clone();
-                            let per_call = Arc::clone(&per_call_sampling_reader);
                             let wtx = write_tx_reader.clone();
                             let roots = Arc::clone(&roots_reader);
                             tokio::spawn(async move {
-                                let chosen =
-                                    select_sampling_handler(&per_call, fallback.as_ref()).await;
+                                let chosen = select_stdio_sampling_handler(fallback.as_ref());
                                 let response = handle_server_request(
                                     chosen.as_deref(),
                                     roots.as_slice(),
@@ -1352,9 +1346,8 @@ impl McpToolTransport for ProgressAwareStdioTransport {
                         // dropped on the reader floor rather than
                         // delivered to an orphaned channel.
                         self.forget_pending(id).await;
-                        // Deterministic guard cleanup before return —
-                        // ensures cardinality-based routing doesn't
-                        // observe a stale entry from this just-returned
+                        // Deterministic guard cleanup before return so
+                        // no request-bound sampling entry survives this
                         // call. The sync Drop is a backstop only.
                         handler_guard.unregister().await;
                         return Err(McpTransportError::TransportError(
@@ -1470,10 +1463,10 @@ pub(crate) struct ProgressAwareHttpTransport {
     initialize_lock: tokio::sync::Mutex<()>,
     session: Arc<tokio::sync::RwLock<HttpSessionState>>,
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
-    /// Per-call sampling handlers; same semantics as the stdio variant.
+    /// Per-call sampling handlers for HTTP request-bound SSE streams.
     /// Populated by `call_tool` while a request is in flight; consulted
-    /// by `handle_server_request` for `sampling/createMessage`. See
-    /// `select_sampling_handler` for the routing rule.
+    /// by `process_sse_event` when `sampling/createMessage` arrives on
+    /// that same request stream.
     per_call_sampling: PerCallSamplingHandlers,
     /// Sender for `notifications/.../list_changed` events observed on
     /// the HTTP SSE listening stream (and on per-request SSE streams).
@@ -1515,6 +1508,11 @@ pub(crate) struct ProgressAwareHttpTransport {
     /// so a clean `close()` shuts it down even if `AbortHandle::abort`
     /// races a pending request.
     listener_alive: Arc<AtomicBool>,
+    /// `close()` is terminal for HTTP transports. Manager lifecycle
+    /// code drops closed runtimes and creates a fresh transport for
+    /// reconnect/re-enable, which avoids ambiguous listener restart
+    /// semantics after session teardown.
+    closed: AtomicBool,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1625,10 +1623,19 @@ impl ProgressAwareHttpTransport {
             listener_started: AtomicBool::new(false),
             listener_abort: std::sync::Mutex::new(None),
             listener_alive: Arc::new(AtomicBool::new(true)),
+            closed: AtomicBool::new(false),
         })
     }
 
+    fn ensure_open(&self) -> Result<(), McpTransportError> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(McpTransportError::ConnectionClosed);
+        }
+        Ok(())
+    }
+
     async fn initialize_if_needed(&self) -> Result<ServerCapabilities, McpTransportError> {
+        self.ensure_open()?;
         {
             let guard = self.capabilities.lock().await;
             if let Some(capabilities) = guard.clone() {
@@ -1895,6 +1902,7 @@ impl ProgressAwareHttpTransport {
         expect_response: bool,
         session: HttpSessionSnapshot,
     ) -> Result<HttpPostResponse, McpTransportError> {
+        self.ensure_open()?;
         let is_initialize = matches!(
             &message,
             JsonRpcMessage::Request(request) if request.method == "initialize"
@@ -2026,20 +2034,7 @@ impl ProgressAwareHttpTransport {
         response: JsonRpcResponse,
         request_session: &HttpSessionSnapshot,
     ) -> Result<(), McpTransportError> {
-        let current_session = self.session.read().await.snapshot();
-        if current_session.generation != request_session.generation
-            || current_session.session_id != request_session.session_id
-            || current_session.protocol_version != request_session.protocol_version
-        {
-            tracing::debug!(
-                stream_generation = request_session.generation,
-                current_generation = current_session.generation,
-                "dropping MCP per-request SSE response for stale HTTP session generation"
-            );
-            return Err(McpTransportError::ProtocolError(
-                MCP_SESSION_EXPIRED_AFTER_ACCEPT.to_string(),
-            ));
-        }
+        self.ensure_current_session_matches(request_session).await?;
 
         match self
             .post_message_with_session_snapshot(
@@ -2057,6 +2052,28 @@ impl ProgressAwareHttpTransport {
             }
             Err(err) => Err(err),
         }
+    }
+
+    async fn ensure_current_session_matches(
+        &self,
+        request_session: &HttpSessionSnapshot,
+    ) -> Result<(), McpTransportError> {
+        let current_session = self.session.read().await.snapshot();
+        if current_session.generation != request_session.generation
+            || current_session.session_id != request_session.session_id
+            || current_session.protocol_version != request_session.protocol_version
+        {
+            tracing::debug!(
+                stream_generation = request_session.generation,
+                current_generation = current_session.generation,
+                "dropping MCP per-request SSE response for stale HTTP session generation"
+            );
+            return Err(McpTransportError::ProtocolError(
+                MCP_SESSION_EXPIRED_AFTER_ACCEPT.to_string(),
+            ));
+        }
+
+        Ok(())
     }
 
     async fn decode_initialize_body(
@@ -2666,6 +2683,7 @@ impl ProgressAwareHttpTransport {
                 Ok(None)
             }
             JsonRpcMessage::Request(request) => {
+                self.ensure_current_session_matches(request_session).await?;
                 // HTTP per-request SSE stream: per spec 2025-11-25
                 // §Listening for Messages from the Server, messages on
                 // this stream "SHOULD relate to a single client request"
@@ -3355,8 +3373,8 @@ impl McpToolTransport for ProgressAwareHttpTransport {
                                 }
                             }
                             // Deterministic guard cleanup before
-                            // returning — cardinality routing must
-                            // not see a stale entry from this call.
+                            // returning so no request-bound sampling
+                            // entry survives this call.
                             handler_guard.unregister().await;
                             return Err(McpTransportError::TransportError(
                                 CANCELLED_BY_CLIENT.to_string(),
@@ -3459,6 +3477,9 @@ impl McpToolTransport for ProgressAwareHttpTransport {
     }
 
     async fn close(&self) -> Result<(), McpTransportError> {
+        if self.closed.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
         // Per spec (2025-11-25 §Streamable HTTP / Session Management):
         // "Clients that no longer need a particular session SHOULD send an
         //  HTTP DELETE to the MCP endpoint with the MCP-Session-Id header,
@@ -3510,12 +3531,12 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         Ok(())
     }
 
-    async fn current_session_id(&self) -> Option<String> {
-        self.session.read().await.session_id.clone()
-    }
-
     async fn current_session_started_at(&self) -> Option<SystemTime> {
         self.session.read().await.started_at
+    }
+
+    async fn current_session_generation(&self) -> Option<u64> {
+        Some(self.session.read().await.generation)
     }
 }
 
@@ -3760,32 +3781,13 @@ pub(crate) fn decode_http_response_payload(
 /// calls or contribute server-side echoing of `params._meta.awaken/in_response_to_call_id`.
 /// Stdio routing: server-initiated `sampling/createMessage` from a
 /// stdio server has no spec-mandated correlation id back to a specific
-/// in-flight `tools/call`, so we use cardinality:
-///   - 0 entries: nothing per-call to honor → fall back to transport-level
-///     fixed handler (preserves legacy behaviour for callers that don't
-///     wire a per-call factory).
-///   - 1 entry: that entry's decision is authoritative — `Bound(h)` →
-///     use h; `Denied` → reject (None). Never fall through on Denied,
-///     since the factory was explicitly consulted for this call.
-///   - More than one entry: ambiguous. Conservative — reject (None).
-///     Operators who need sampling correctness with concurrent stdio
-///     tool calls must serialize the calls. Falling through to the
-///     transport fallback would leak across agents (the bug the
-///     factory exists to prevent).
-async fn select_sampling_handler(
-    per_call: &PerCallSamplingHandlers,
+/// in-flight `tools/call`. We therefore never use per-call/per-agent
+/// handlers on stdio; only a transport-level fixed fallback can answer
+/// these requests.
+fn select_stdio_sampling_handler(
     fallback: Option<&Arc<dyn SamplingHandler>>,
 ) -> Option<Arc<dyn SamplingHandler>> {
-    let map = per_call.lock().await;
-    match map.len() {
-        0 => fallback.cloned(),
-        1 => match map.values().next() {
-            Some(PerCallSamplingEntry::Bound(h)) => Some(Arc::clone(h)),
-            Some(PerCallSamplingEntry::Denied) => None,
-            None => fallback.cloned(),
-        },
-        _ => None,
-    }
+    fallback.cloned()
 }
 
 pub(crate) async fn handle_server_request(
@@ -3889,6 +3891,7 @@ pub(crate) fn call_result_to_tool_data(call_result: &CallToolResult) -> Value {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::atomic::AtomicUsize;
     use std::time::Instant;
 
     use super::*;
@@ -4504,6 +4507,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_per_request_sse_sampling_request_does_not_invoke_handler() {
+        struct CountingSamplingHandler {
+            calls: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl SamplingHandler for CountingSamplingHandler {
+            async fn handle_create_message(
+                &self,
+                _params: CreateMessageParams,
+            ) -> Result<CreateMessageResult, McpTransportError> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                use mcp::{Role, SamplingContent};
+                Ok(CreateMessageResult {
+                    role: Role::Assistant,
+                    content: vec![SamplingContent::Text {
+                        text: "should not run".to_string(),
+                        annotations: None,
+                        meta: None,
+                    }],
+                    model: "mock-model".to_string(),
+                    stop_reason: None,
+                    meta: None,
+                })
+            }
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(CountingSamplingHandler {
+            calls: Arc::clone(&calls),
+        }) as Arc<dyn SamplingHandler>;
+        let cfg = mcp::transport::McpServerConnectionConfig::http(
+            "http-stale-sampling",
+            "http://127.0.0.1:9".to_string(),
+        );
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, Some(handler), Arc::new(Vec::new()), true)
+                .unwrap();
+        {
+            let mut session = transport.session.write().await;
+            session.session_id = Some("session-new".to_string());
+            session.protocol_version = Some(MCP_PROTOCOL_VERSION.to_string());
+            session.generation = 2;
+        }
+
+        let stale_session = HttpSessionSnapshot {
+            session_id: Some("session-old".to_string()),
+            protocol_version: Some(MCP_PROTOCOL_VERSION.to_string()),
+            generation: 1,
+        };
+        let event = vec![format!(
+            "data: {}",
+            json!({
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "sampling/createMessage",
+                "params": {
+                    "messages": [],
+                    "maxTokens": 1
+                }
+            })
+        )];
+
+        let err = transport
+            .process_sse_event(&event, 1, None, None, &stale_session)
+            .await
+            .expect_err("stale sampling request must be rejected before handler execution");
+
+        assert!(
+            matches!(&err, McpTransportError::ProtocolError(message) if message == MCP_SESSION_EXPIRED_AFTER_ACCEPT),
+            "expected stale accepted-request session error before handler execution, got: {err}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "stale per-request SSE sampling must not invoke local sampling handler"
+        );
+    }
+
+    #[tokio::test]
     async fn http_send_initialized_request_reinitializes_if_session_clears_after_gate() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -4876,6 +4959,25 @@ mod tests {
         // Local state cleared after close().
         let session_after = transport.session.read().await.clone();
         assert!(session_after.session_id.is_none(), "session_id cleared");
+    }
+
+    #[tokio::test]
+    async fn http_transport_close_is_terminal() {
+        let cfg = mcp::transport::McpServerConnectionConfig::http(
+            "http-close-terminal",
+            "http://127.0.0.1:9",
+        );
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new()), false).unwrap();
+
+        transport.close().await.unwrap();
+        transport.close().await.unwrap();
+
+        let err = transport
+            .server_capabilities()
+            .await
+            .expect_err("closed HTTP transport must not reinitialize");
+        assert!(matches!(err, McpTransportError::ConnectionClosed));
     }
 
     // ── build_call_tool_meta tests ──
@@ -5373,7 +5475,7 @@ done
     }
 
     #[tokio::test]
-    async fn select_sampling_routes_single_in_flight_to_per_call() {
+    async fn stdio_sampling_uses_only_fixed_fallback() {
         let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
         let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
         let agent_handler: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
@@ -5389,106 +5491,23 @@ done
             .await
             .insert(42, PerCallSamplingEntry::Bound(agent_handler));
 
-        let chosen = select_sampling_handler(&per_call, Some(&fallback)).await;
+        let chosen = select_stdio_sampling_handler(Some(&fallback));
         let chosen = chosen.expect("a handler was selected");
 
-        // Invoke and verify which one handled it.
         let _ = chosen
             .handle_create_message(make_minimal_sampling_params())
             .await
             .expect("handler succeeded");
         assert_eq!(
             *last_caller.lock().await,
-            Some("agent-A".to_string()),
-            "single in-flight call -> per-call handler wins"
+            Some("fallback".to_string()),
+            "stdio has no request correlation; it must not route sampling to the in-flight agent"
         );
     }
 
-    #[tokio::test]
-    async fn select_sampling_falls_back_when_zero_in_flight() {
-        let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
-        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let fallback: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
-            tag: "fallback".into(),
-            last_caller: Arc::clone(&last_caller),
-        });
-
-        let chosen = select_sampling_handler(&per_call, Some(&fallback))
-            .await
-            .expect("fallback returned");
-        let _ = chosen
-            .handle_create_message(make_minimal_sampling_params())
-            .await;
-        assert_eq!(*last_caller.lock().await, Some("fallback".to_string()));
-    }
-
-    #[tokio::test]
-    async fn select_sampling_returns_none_when_multiple_in_flight() {
-        // With >1 in-flight calls we can't unambiguously route — return
-        // None so the server gets method-not-supported. This is a
-        // SECURITY fix: previously we fell back to the transport-level
-        // fixed handler, which could be a different agent's executor.
-        // The factory exists precisely to prevent that cross-agent
-        // leak, so the conservative fix is to refuse rather than guess.
-        let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
-        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let agent_a: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
-            tag: "agent-A".into(),
-            last_caller: Arc::clone(&last_caller),
-        });
-        let agent_b: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
-            tag: "agent-B".into(),
-            last_caller: Arc::clone(&last_caller),
-        });
-        let fallback: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
-            tag: "fallback".into(),
-            last_caller: Arc::clone(&last_caller),
-        });
-        per_call
-            .lock()
-            .await
-            .insert(1, PerCallSamplingEntry::Bound(agent_a));
-        per_call
-            .lock()
-            .await
-            .insert(2, PerCallSamplingEntry::Bound(agent_b));
-
-        assert!(
-            select_sampling_handler(&per_call, Some(&fallback))
-                .await
-                .is_none(),
-            "multiple in-flight => refuse rather than guess (no fallback)"
-        );
-    }
-
-    #[tokio::test]
-    async fn select_sampling_returns_none_on_denied_single_in_flight() {
-        // Factory was consulted and explicitly refused this call. The
-        // transport MUST NOT fall through to a transport-level fallback
-        // handler — that would re-introduce the cross-agent leak the
-        // factory exists to prevent.
-        let last_caller = Arc::new(tokio::sync::Mutex::new(None::<String>));
-        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let fallback: Arc<dyn SamplingHandler> = Arc::new(TaggedSamplingHandler {
-            tag: "fallback".into(),
-            last_caller: Arc::clone(&last_caller),
-        });
-        per_call
-            .lock()
-            .await
-            .insert(7, PerCallSamplingEntry::Denied);
-        assert!(
-            select_sampling_handler(&per_call, Some(&fallback))
-                .await
-                .is_none(),
-            "Denied entry must NEVER fall through to fallback"
-        );
-    }
-
-    #[tokio::test]
-    async fn select_sampling_returns_none_when_no_handlers_anywhere() {
-        let per_call: PerCallSamplingHandlers = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        assert!(select_sampling_handler(&per_call, None).await.is_none());
+    #[test]
+    fn stdio_sampling_rejects_factory_only_without_fixed_fallback() {
+        assert!(select_stdio_sampling_handler(None).is_none());
     }
 
     #[tokio::test]

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -15,10 +15,10 @@ use mcp::transport::{
     McpTransportError, SamplingCapabilities, ServerCapabilities, TransportTypeId,
 };
 use mcp::{
-    CallToolParams, CallToolResult, CreateMessageParams, JsonRpcId, JsonRpcMessage,
-    JsonRpcNotification, JsonRpcPayload, JsonRpcRequest, JsonRpcResponse, ListToolsResult,
-    MCP_PROTOCOL_VERSION, McpToolDefinition, ProgressNotificationParams, ProgressToken,
-    ToolContent,
+    CallToolParams, CallToolResult, CompleteParams, CompleteResult, CreateMessageParams, JsonRpcId,
+    JsonRpcMessage, JsonRpcNotification, JsonRpcPayload, JsonRpcRequest, JsonRpcResponse,
+    ListRootsResult, ListToolsResult, MCP_PROTOCOL_VERSION, McpToolDefinition,
+    ProgressNotificationParams, ProgressToken, Root, ToolContent,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -37,6 +37,46 @@ use crate::sampling::SamplingHandler;
 /// crate doesn't need extending — callers match on this exact message
 /// to surface the cancellation upward (e.g. as `ToolError::Cancelled`).
 pub const CANCELLED_BY_CLIENT: &str = "MCP request cancelled by client";
+
+/// Protocol versions awaken's transports know how to talk on the wire.
+///
+/// Per MCP 2025-06-18 §Lifecycle / Version Negotiation: "If the server
+/// supports the requested protocol version, it MUST respond with the
+/// same version. Otherwise, the server MUST respond with another
+/// protocol version it supports." Our handshake sends
+/// [`MCP_PROTOCOL_VERSION`] (the version baked into the upstream `mcp`
+/// crate); we accept the server's response only if it appears in this
+/// list. Mismatch is a hard error rather than a silent downgrade —
+/// silent downgrade would mean we send wire shapes the server can't
+/// parse, with failures surfacing far from the cause.
+///
+/// Order is purely informational. The list intentionally stays narrow
+/// (one entry today); widen it only when wire-format compatibility for
+/// an older spec rev has been verified end-to-end.
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &[MCP_PROTOCOL_VERSION];
+
+/// Validate the `protocolVersion` echoed by the server in `InitializeResult`.
+///
+/// Returns the negotiated version (always one of [`SUPPORTED_PROTOCOL_VERSIONS`])
+/// or a [`McpTransportError::ProtocolError`] describing the mismatch.
+/// The error names both sides so operators don't have to dig through
+/// logs to see which way to upgrade.
+pub(crate) fn negotiate_protocol_version(
+    server_version: &str,
+) -> Result<&'static str, McpTransportError> {
+    if let Some(accepted) = SUPPORTED_PROTOCOL_VERSIONS
+        .iter()
+        .find(|v| **v == server_version)
+    {
+        Ok(*accepted)
+    } else {
+        Err(McpTransportError::ProtocolError(format!(
+            "MCP server replied with unsupported protocolVersion {server_version:?}; \
+             awaken supports {SUPPORTED_PROTOCOL_VERSIONS:?}. The server should respond \
+             with one of these or upgrade to {MCP_PROTOCOL_VERSION}."
+        )))
+    }
+}
 
 #[cfg(unix)]
 use nix::sys::signal::{Signal, kill};
@@ -301,6 +341,99 @@ pub trait McpToolTransport: Send + Sync {
     async fn current_session_id(&self) -> Option<String> {
         None
     }
+
+    /// Take the receiver for `notifications/{tools,prompts,resources}/list_changed`
+    /// events. Each event names which catalogue changed so the host can
+    /// refresh only that surface. Per MCP 2025-06-18 §Server features,
+    /// servers that advertise `tools.listChanged` / `prompts.listChanged`
+    /// / `resources.listChanged` SHOULD emit these notifications when
+    /// the corresponding catalogue mutates — receiving one removes the
+    /// need for periodic polling.
+    ///
+    /// One-shot: callable at most once per transport instance. Returns
+    /// `None` thereafter (and `None` for transports that don't emit
+    /// these notifications, e.g. test stubs).
+    async fn take_list_changed_receiver(&self) -> Option<mpsc::UnboundedReceiver<ListChangedKind>> {
+        None
+    }
+
+    /// Subscribe to updates for a single resource URI. Per MCP
+    /// 2025-06-18 §Resources / Subscriptions: callable only when the
+    /// server advertised `resources.subscribe: true` during initialize.
+    /// The caller is responsible for that capability check; the
+    /// transport just forwards the JSON-RPC request.
+    async fn subscribe_resource(&self, _uri: &str) -> Result<(), McpTransportError> {
+        Err(McpTransportError::TransportError(
+            "subscribe_resource not supported".to_string(),
+        ))
+    }
+
+    /// Cancel a prior subscription. Mirrors [`subscribe_resource`] —
+    /// caller is responsible for capability gating.
+    async fn unsubscribe_resource(&self, _uri: &str) -> Result<(), McpTransportError> {
+        Err(McpTransportError::TransportError(
+            "unsubscribe_resource not supported".to_string(),
+        ))
+    }
+
+    /// Take the receiver for `notifications/resources/updated` events.
+    /// Each event carries the URI of the updated resource. The host
+    /// can fetch the new contents via `read_resource` in response.
+    /// One-shot like [`take_list_changed_receiver`].
+    async fn take_resource_updated_receiver(&self) -> Option<mpsc::UnboundedReceiver<String>> {
+        None
+    }
+
+    /// Ask the server for autocomplete suggestions for a prompt /
+    /// resource argument. Per MCP 2025-06-18 §Utilities / Completion:
+    /// only valid when the server advertised `completions: {}` in its
+    /// initialize response — the caller is responsible for that
+    /// capability check. The transport just forwards the request.
+    async fn complete(&self, _params: CompleteParams) -> Result<CompleteResult, McpTransportError> {
+        Err(McpTransportError::TransportError(
+            "completion/complete not supported".to_string(),
+        ))
+    }
+}
+
+/// Which server-side catalogue the `notifications/.../list_changed`
+/// event refers to. The transport forwards one variant per notification;
+/// the manager dispatches a refresh against that catalogue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ListChangedKind {
+    /// `notifications/tools/list_changed` — re-run `tools/list`.
+    Tools,
+    /// `notifications/prompts/list_changed` — re-run `prompts/list`.
+    Prompts,
+    /// `notifications/resources/list_changed` — re-run `resources/list`.
+    Resources,
+}
+
+/// Parse a JSON-RPC method name into a recognised list-changed kind.
+/// Returns `None` for any method that isn't one of the three
+/// standard `notifications/.../list_changed` strings.
+fn list_changed_method(method: &str) -> Option<ListChangedKind> {
+    match method {
+        "notifications/tools/list_changed" => Some(ListChangedKind::Tools),
+        "notifications/prompts/list_changed" => Some(ListChangedKind::Prompts),
+        "notifications/resources/list_changed" => Some(ListChangedKind::Resources),
+        _ => None,
+    }
+}
+
+/// Parse a `notifications/resources/updated` notification's params into
+/// the affected resource URI. Returns `None` if the method doesn't
+/// match or the params don't carry a string `uri`.
+fn resource_updated_uri(notification: &JsonRpcNotification) -> Option<String> {
+    if notification.method != "notifications/resources/updated" {
+        return None;
+    }
+    notification
+        .params
+        .as_ref()?
+        .get("uri")?
+        .as_str()
+        .map(str::to_string)
 }
 
 // ── Progress token key ──
@@ -439,12 +572,28 @@ pub(crate) struct ProgressAwareStdioTransport {
     /// the reader uses cardinality heuristics over this map — see
     /// [`select_sampling_handler`].
     per_call_sampling: PerCallSamplingHandlers,
+    /// Receiver half of the `notifications/.../list_changed` channel.
+    /// The reader task owns the cloned sender; when this transport (and
+    /// thus the reader task) is dropped, the channel closes naturally.
+    /// Taken at most once by [`take_list_changed_receiver`].
+    list_changed_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<ListChangedKind>>>,
+    /// Receiver half of the `notifications/resources/updated` channel.
+    /// Each event is the URI of an updated resource. Mirrors the
+    /// list_changed pattern — one-shot, taken via
+    /// [`take_resource_updated_receiver`].
+    resource_updated_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<String>>>,
+    /// Client-defined roots advertised to the server during `initialize`
+    /// and served on subsequent `roots/list` requests. Empty = roots
+    /// capability not advertised. Held as an `Arc` so the spawned
+    /// reader task can share it cheaply with the initialize path.
+    roots: Arc<Vec<Root>>,
 }
 
 impl ProgressAwareStdioTransport {
     pub(crate) async fn connect(
         config: &McpServerConnectionConfig,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
+        roots: Arc<Vec<Root>>,
     ) -> Result<Self, McpTransportError> {
         let command = config.command.as_ref().ok_or_else(|| {
             McpTransportError::TransportError("Stdio transport requires command".to_string())
@@ -518,6 +667,11 @@ impl ProgressAwareStdioTransport {
         let per_call_sampling: PerCallSamplingHandlers =
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
         let per_call_sampling_reader = Arc::clone(&per_call_sampling);
+        let (list_changed_tx, list_changed_rx) = mpsc::unbounded_channel::<ListChangedKind>();
+        let list_changed_tx_reader = list_changed_tx.clone();
+        let (resource_updated_tx, resource_updated_rx) = mpsc::unbounded_channel::<String>();
+        let resource_updated_tx_reader = resource_updated_tx.clone();
+        let roots_reader = Arc::clone(&roots);
         let mut reader = BufReader::new(stdout);
         tokio::spawn(async move {
             let mut line = String::new();
@@ -539,17 +693,32 @@ impl ProgressAwareStdioTransport {
                             }
                         }
                         Ok(JsonRpcMessage::Notification(notification)) => {
-                            handle_progress_notification(&progress_reader, notification).await;
+                            if let Some(kind) = list_changed_method(&notification.method) {
+                                // Best-effort: if the host hasn't taken
+                                // the receiver yet (or has dropped it),
+                                // a send error just means the host is
+                                // not interested — drop silently.
+                                let _ = list_changed_tx_reader.send(kind);
+                            } else if let Some(uri) = resource_updated_uri(&notification) {
+                                let _ = resource_updated_tx_reader.send(uri);
+                            } else {
+                                handle_progress_notification(&progress_reader, notification).await;
+                            }
                         }
                         Ok(JsonRpcMessage::Request(request)) => {
                             let fallback = sampling_handler_reader.clone();
                             let per_call = Arc::clone(&per_call_sampling_reader);
                             let wtx = write_tx_reader.clone();
+                            let roots = Arc::clone(&roots_reader);
                             tokio::spawn(async move {
                                 let chosen =
                                     select_sampling_handler(&per_call, fallback.as_ref()).await;
-                                let response =
-                                    handle_server_request(chosen.as_deref(), &request).await;
+                                let response = handle_server_request(
+                                    chosen.as_deref(),
+                                    roots.as_slice(),
+                                    &request,
+                                )
+                                .await;
                                 let line = format!(
                                     "{}\n",
                                     serde_json::to_string(&response).unwrap_or_default()
@@ -598,6 +767,12 @@ impl ProgressAwareStdioTransport {
             }
         });
 
+        // Drop the originating senders so the only live senders are the
+        // reader task's clones — when the reader exits (child stdout
+        // EOF), the channels naturally close and the host consumer
+        // tasks wake up.
+        drop(list_changed_tx);
+        drop(resource_updated_tx);
         let transport = Self {
             write_tx,
             pending,
@@ -609,11 +784,24 @@ impl ProgressAwareStdioTransport {
             timeout: Duration::from_secs(config.timeout_secs),
             capabilities: None,
             per_call_sampling,
+            list_changed_rx: tokio::sync::Mutex::new(Some(list_changed_rx)),
+            resource_updated_rx: tokio::sync::Mutex::new(Some(resource_updated_rx)),
+            roots: Arc::clone(&roots),
         };
 
         let mut capabilities = InitializeCapabilities::default();
         if sampling_handler.is_some() {
             capabilities.sampling = Some(SamplingCapabilities::default());
+        }
+        if !transport.roots.is_empty() {
+            // Spec 2025-06-18 §Client features: clients advertising
+            // `roots` MUST be prepared to respond to `roots/list`. Our
+            // roots are static post-construction (set via the
+            // constructor arg, no runtime mutation today), so we
+            // advertise `listChanged: false`.
+            capabilities.roots = Some(mcp::transport::RootsCapabilities {
+                list_changed: Some(false),
+            });
         }
         let init_result = match transport
             .send_request(
@@ -632,6 +820,15 @@ impl ProgressAwareStdioTransport {
                 return Err(err);
             }
         };
+        // Validate the server-echoed protocolVersion BEFORE emitting
+        // `notifications/initialized`. A mismatch means the rest of the
+        // session would speak wire shapes the server can't parse —
+        // better to fail fast at handshake than have every subsequent
+        // tools/call surface a confusing parse error.
+        if let Err(err) = negotiate_protocol_version(&init_result.protocol_version) {
+            let _ = transport.close().await;
+            return Err(err);
+        }
         let _ = transport
             .send_notification("notifications/initialized", Some(json!({})))
             .await;
@@ -935,6 +1132,37 @@ impl McpToolTransport for ProgressAwareStdioTransport {
         Ok(self.capabilities.clone())
     }
 
+    async fn take_list_changed_receiver(&self) -> Option<mpsc::UnboundedReceiver<ListChangedKind>> {
+        self.list_changed_rx.lock().await.take()
+    }
+
+    async fn take_resource_updated_receiver(&self) -> Option<mpsc::UnboundedReceiver<String>> {
+        self.resource_updated_rx.lock().await.take()
+    }
+
+    async fn subscribe_resource(&self, uri: &str) -> Result<(), McpTransportError> {
+        self.send_request("resources/subscribe", Some(json!({ "uri": uri })), None)
+            .await
+            .map(|_| ())
+    }
+
+    async fn unsubscribe_resource(&self, uri: &str) -> Result<(), McpTransportError> {
+        self.send_request("resources/unsubscribe", Some(json!({ "uri": uri })), None)
+            .await
+            .map(|_| ())
+    }
+
+    async fn complete(&self, params: CompleteParams) -> Result<CompleteResult, McpTransportError> {
+        let result = self
+            .send_request(
+                "completion/complete",
+                Some(serde_json::to_value(&params)?),
+                None,
+            )
+            .await?;
+        serde_json::from_value(result).map_err(Into::into)
+    }
+
     async fn read_resource(&self, uri: &str) -> Result<Value, McpTransportError> {
         self.send_request("resources/read", Some(json!({ "uri": uri })), None)
             .await
@@ -983,6 +1211,25 @@ pub(crate) struct ProgressAwareHttpTransport {
     /// by `handle_server_request` for `sampling/createMessage`. See
     /// `select_sampling_handler` for the routing rule.
     per_call_sampling: PerCallSamplingHandlers,
+    /// Sender for `notifications/.../list_changed` events observed on
+    /// the HTTP SSE listening stream (and on per-request SSE streams).
+    /// Cloned into the listening-stream task at the point we add one;
+    /// for now, [`process_sse_event`] dispatches synchronously through
+    /// this sender so per-request streams report list_changed too.
+    list_changed_tx: mpsc::UnboundedSender<ListChangedKind>,
+    /// One-shot receiver, taken at most once by
+    /// [`take_list_changed_receiver`].
+    list_changed_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<ListChangedKind>>>,
+    /// Sender for `notifications/resources/updated` events; cloned by
+    /// `process_sse_event` to forward each notification.
+    resource_updated_tx: mpsc::UnboundedSender<String>,
+    /// One-shot receiver for resource-updated events; same pattern as
+    /// `list_changed_rx`.
+    resource_updated_rx: tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<String>>>,
+    /// Client-defined roots; same semantics as the stdio variant.
+    /// Non-empty → roots capability advertised at initialize and
+    /// `roots/list` is served from this list.
+    roots: Arc<Vec<Root>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -995,6 +1242,7 @@ impl ProgressAwareHttpTransport {
     pub(crate) fn connect(
         config: &McpServerConnectionConfig,
         sampling_handler: Option<Arc<dyn SamplingHandler>>,
+        roots: Arc<Vec<Root>>,
     ) -> Result<Self, McpTransportError> {
         let endpoint = config.url.as_ref().ok_or_else(|| {
             McpTransportError::TransportError("HTTP transport requires URL".to_string())
@@ -1007,6 +1255,8 @@ impl ProgressAwareHttpTransport {
                 McpTransportError::TransportError(format!("Failed to create HTTP client: {}", e))
             })?;
 
+        let (list_changed_tx, list_changed_rx) = mpsc::unbounded_channel::<ListChangedKind>();
+        let (resource_updated_tx, resource_updated_rx) = mpsc::unbounded_channel::<String>();
         Ok(Self {
             endpoint: endpoint.clone(),
             client,
@@ -1016,6 +1266,11 @@ impl ProgressAwareHttpTransport {
             session: tokio::sync::RwLock::new(HttpSessionState::default()),
             sampling_handler,
             per_call_sampling: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            list_changed_tx,
+            list_changed_rx: tokio::sync::Mutex::new(Some(list_changed_rx)),
+            resource_updated_tx,
+            resource_updated_rx: tokio::sync::Mutex::new(Some(resource_updated_rx)),
+            roots,
         })
     }
 
@@ -1030,13 +1285,29 @@ impl ProgressAwareHttpTransport {
     }
 
     async fn initialize(&self) -> Result<ServerCapabilities, McpTransportError> {
+        // Build advertised capabilities the same way the stdio path
+        // does: sampling iff a handler is configured, roots iff we
+        // have roots to serve. HTTP used to send empty capabilities
+        // (`{}`), which masked the sampling support — the server
+        // would refuse to call `sampling/createMessage` even though
+        // the client could handle it. Fix as part of the roots work.
+        let mut caps = InitializeCapabilities::default();
+        if self.sampling_handler.is_some() {
+            caps.sampling = Some(SamplingCapabilities::default());
+        }
+        if !self.roots.is_empty() {
+            caps.roots = Some(mcp::transport::RootsCapabilities {
+                list_changed: Some(false),
+            });
+        }
+        let caps_value = serde_json::to_value(&caps).unwrap_or_else(|_| json!({}));
         let request_id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let response = self
             .post_message(
                 JsonRpcMessage::Request(JsonRpcRequest::new(
                     JsonRpcId::Number(request_id),
                     "initialize".to_string(),
-                    Some(initialize_params(json!({}), Value::Null)),
+                    Some(initialize_params(caps_value, Value::Null)),
                 )),
                 false,
             )
@@ -1057,10 +1328,16 @@ impl ProgressAwareHttpTransport {
             .map_err(|e| McpTransportError::ProtocolError(format!("initialize failed: {e}")))?;
         let result: InitializeResult = serde_json::from_value(body)?;
 
+        // Validate the server-echoed protocolVersion BEFORE accepting
+        // the session id or emitting `notifications/initialized`. On
+        // mismatch we leave session state empty so the next attempt
+        // re-handshakes rather than half-living with an unusable session.
+        let negotiated = negotiate_protocol_version(&result.protocol_version)?;
+
         {
             let mut session = self.session.write().await;
             session.session_id = session_id;
-            session.protocol_version = Some(result.protocol_version.clone());
+            session.protocol_version = Some(negotiated.to_string());
         }
 
         self.send_notification("notifications/initialized", Some(json!({})))
@@ -1357,7 +1634,13 @@ impl ProgressAwareHttpTransport {
                 Ok(None)
             }
             JsonRpcMessage::Notification(notification) => {
-                if let (Some(expected_key), Some(sender)) = (progress_key, progress_tx)
+                if let Some(kind) = list_changed_method(&notification.method) {
+                    // Forward to the host's `take_list_changed_receiver`
+                    // consumer; best-effort if no one subscribed.
+                    let _ = self.list_changed_tx.send(kind);
+                } else if let Some(uri) = resource_updated_uri(&notification) {
+                    let _ = self.resource_updated_tx.send(uri);
+                } else if let (Some(expected_key), Some(sender)) = (progress_key, progress_tx)
                     && let Some((key, update)) = decode_progress_notification(notification)
                     && key == *expected_key
                 {
@@ -1392,7 +1675,8 @@ impl ProgressAwareHttpTransport {
                         None => self.sampling_handler.clone(),
                     }
                 };
-                let response = handle_server_request(chosen.as_deref(), &request).await;
+                let response =
+                    handle_server_request(chosen.as_deref(), self.roots.as_slice(), &request).await;
                 self.send_response_message(response).await?;
                 Ok(None)
             }
@@ -1630,6 +1914,37 @@ impl McpToolTransport for ProgressAwareHttpTransport {
         Ok(Some(self.initialize_if_needed().await?))
     }
 
+    async fn take_list_changed_receiver(&self) -> Option<mpsc::UnboundedReceiver<ListChangedKind>> {
+        self.list_changed_rx.lock().await.take()
+    }
+
+    async fn take_resource_updated_receiver(&self) -> Option<mpsc::UnboundedReceiver<String>> {
+        self.resource_updated_rx.lock().await.take()
+    }
+
+    async fn subscribe_resource(&self, uri: &str) -> Result<(), McpTransportError> {
+        self.send_initialized_request("resources/subscribe", Some(json!({ "uri": uri })), None)
+            .await
+            .map(|_| ())
+    }
+
+    async fn unsubscribe_resource(&self, uri: &str) -> Result<(), McpTransportError> {
+        self.send_initialized_request("resources/unsubscribe", Some(json!({ "uri": uri })), None)
+            .await
+            .map(|_| ())
+    }
+
+    async fn complete(&self, params: CompleteParams) -> Result<CompleteResult, McpTransportError> {
+        let result = self
+            .send_initialized_request(
+                "completion/complete",
+                Some(serde_json::to_value(&params)?),
+                None,
+            )
+            .await?;
+        serde_json::from_value(result).map_err(Into::into)
+    }
+
     async fn read_resource(&self, uri: &str) -> Result<Value, McpTransportError> {
         self.send_initialized_request("resources/read", Some(json!({ "uri": uri })), None)
             .await
@@ -1718,14 +2033,16 @@ impl ProgressAwareHttpTransport {
 pub(crate) async fn connect_transport(
     config: &McpServerConnectionConfig,
     sampling_handler: Option<Arc<dyn SamplingHandler>>,
+    roots: Arc<Vec<Root>>,
 ) -> Result<Arc<dyn McpToolTransport>, McpTransportError> {
     match config.transport {
         TransportTypeId::Stdio => {
-            let transport = ProgressAwareStdioTransport::connect(config, sampling_handler).await?;
+            let transport =
+                ProgressAwareStdioTransport::connect(config, sampling_handler, roots).await?;
             Ok(Arc::new(transport))
         }
         TransportTypeId::Http => {
-            let transport = ProgressAwareHttpTransport::connect(config, sampling_handler)?;
+            let transport = ProgressAwareHttpTransport::connect(config, sampling_handler, roots)?;
             Ok(Arc::new(transport))
         }
     }
@@ -1916,6 +2233,7 @@ async fn select_sampling_handler(
 
 pub(crate) async fn handle_server_request(
     sampling_handler: Option<&dyn SamplingHandler>,
+    roots: &[Root],
     request: &JsonRpcRequest,
 ) -> JsonRpcResponse {
     match request.method.as_str() {
@@ -1950,6 +2268,30 @@ pub(crate) async fn handle_server_request(
                 }
                 Err(e) => JsonRpcResponse::error(request.id.clone(), -32000, e.to_string(), None),
             }
+        }
+        // Spec 2025-06-18 §Client features / Roots: server may call
+        // `roots/list` only if the client advertised the `roots`
+        // capability during initialize. We advertise based on whether
+        // the roots vec was non-empty at construction, so an empty
+        // slice here reflects either a non-advertising client or a
+        // race during disable — return method-not-supported, NOT an
+        // empty list, so a misbehaving server learns it asked for
+        // something we never agreed to.
+        "roots/list" => {
+            if roots.is_empty() {
+                return JsonRpcResponse::error(
+                    request.id.clone(),
+                    -32601,
+                    "roots/list not supported (client did not advertise roots capability)"
+                        .to_string(),
+                    None,
+                );
+            }
+            let result = ListRootsResult {
+                roots: roots.to_vec(),
+            };
+            let result_value = serde_json::to_value(&result).unwrap_or(Value::Null);
+            JsonRpcResponse::success(request.id.clone(), result_value)
         }
         _ => JsonRpcResponse::error(
             request.id.clone(),
@@ -1994,6 +2336,118 @@ mod tests {
 
     use super::*;
     use mcp::CreateMessageResult;
+
+    // ── notifications/resources/updated parsing ──
+
+    #[test]
+    fn resource_updated_uri_extracts_uri() {
+        let notification = JsonRpcNotification::new(
+            "notifications/resources/updated",
+            Some(json!({ "uri": "file:///tmp/notes.md" })),
+        );
+        assert_eq!(
+            resource_updated_uri(&notification),
+            Some("file:///tmp/notes.md".to_string())
+        );
+    }
+
+    #[test]
+    fn resource_updated_uri_ignores_other_methods() {
+        let notification = JsonRpcNotification::new(
+            "notifications/tools/list_changed",
+            Some(json!({ "uri": "file:///irrelevant" })),
+        );
+        assert_eq!(resource_updated_uri(&notification), None);
+    }
+
+    #[test]
+    fn resource_updated_uri_rejects_missing_or_non_string_uri() {
+        // Defensive: malformed notifications shouldn't crash the
+        // reader; just yield None so they're ignored.
+        let no_params = JsonRpcNotification::new("notifications/resources/updated", None);
+        assert_eq!(resource_updated_uri(&no_params), None);
+
+        let int_uri = JsonRpcNotification::new(
+            "notifications/resources/updated",
+            Some(json!({ "uri": 42 })),
+        );
+        assert_eq!(resource_updated_uri(&int_uri), None);
+
+        let no_uri_field = JsonRpcNotification::new(
+            "notifications/resources/updated",
+            Some(json!({ "other": "x" })),
+        );
+        assert_eq!(resource_updated_uri(&no_uri_field), None);
+    }
+
+    // ── list_changed notification parsing ──
+
+    #[test]
+    fn list_changed_method_recognises_three_kinds() {
+        assert_eq!(
+            list_changed_method("notifications/tools/list_changed"),
+            Some(ListChangedKind::Tools)
+        );
+        assert_eq!(
+            list_changed_method("notifications/prompts/list_changed"),
+            Some(ListChangedKind::Prompts)
+        );
+        assert_eq!(
+            list_changed_method("notifications/resources/list_changed"),
+            Some(ListChangedKind::Resources)
+        );
+    }
+
+    #[test]
+    fn list_changed_method_ignores_other_methods() {
+        // Strict match: nothing else (progress, cancelled, custom)
+        // should be misclassified as list_changed.
+        assert_eq!(list_changed_method("notifications/progress"), None);
+        assert_eq!(list_changed_method("notifications/cancelled"), None);
+        assert_eq!(list_changed_method("notifications/initialized"), None);
+        assert_eq!(list_changed_method("notifications/tools/listChanged"), None); // wrong casing
+        assert_eq!(list_changed_method(""), None);
+        assert_eq!(list_changed_method("tools/list_changed"), None); // missing prefix
+    }
+
+    // ── protocol-version negotiation ──
+
+    #[test]
+    fn negotiate_protocol_version_accepts_current_spec() {
+        // The version awaken sends on the wire must always be in the
+        // supported list — otherwise initialize would always reject
+        // ourselves.
+        let negotiated =
+            negotiate_protocol_version(MCP_PROTOCOL_VERSION).expect("current version is supported");
+        assert_eq!(negotiated, MCP_PROTOCOL_VERSION);
+        assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&MCP_PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn negotiate_protocol_version_rejects_unknown() {
+        // Server replies with a version older than anything we know we
+        // can wire-compat-talk on. Hard reject; the alternative is
+        // sending `params._meta` (added in 2025-06-18) or
+        // `Mcp-Session-Id` semantics that older servers can't parse.
+        let err = negotiate_protocol_version("2000-01-01").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("2000-01-01"),
+            "error names the version we got: {msg}"
+        );
+        assert!(
+            msg.contains(MCP_PROTOCOL_VERSION),
+            "error names the version we expect: {msg}"
+        );
+    }
+
+    #[test]
+    fn negotiate_protocol_version_rejects_empty() {
+        // Defensive: a misbehaving server could echo back "" — should
+        // surface as a clear handshake error rather than be silently
+        // accepted.
+        assert!(negotiate_protocol_version("").is_err());
+    }
 
     // ── handle_server_request tests ──
 
@@ -2056,7 +2510,7 @@ mod tests {
                 "maxTokens": 100,
             }),
         );
-        let response = handle_server_request(Some(&handler), &request).await;
+        let response = handle_server_request(Some(&handler), &[], &request).await;
         match response.payload {
             mcp::JsonRpcPayload::Success { result } => {
                 assert_eq!(result["model"], json!("mock-model"));
@@ -2077,7 +2531,7 @@ mod tests {
                 "maxTokens": 100,
             }),
         );
-        let response = handle_server_request(None, &request).await;
+        let response = handle_server_request(None, &[], &request).await;
         match response.payload {
             mcp::JsonRpcPayload::Error { error } => {
                 assert!(error.to_string().contains("Sampling not supported"));
@@ -2092,7 +2546,7 @@ mod tests {
             response_text: "unused".to_string(),
         };
         let request = sampling_request(3, json!({"invalid": true}));
-        let response = handle_server_request(Some(&handler), &request).await;
+        let response = handle_server_request(Some(&handler), &[], &request).await;
         match response.payload {
             mcp::JsonRpcPayload::Error { error } => {
                 assert!(error.to_string().contains("Invalid sampling/createMessage"));
@@ -2111,7 +2565,7 @@ mod tests {
                 "maxTokens": 100,
             }),
         );
-        let response = handle_server_request(Some(&handler), &request).await;
+        let response = handle_server_request(Some(&handler), &[], &request).await;
         match response.payload {
             mcp::JsonRpcPayload::Error { error } => {
                 assert!(error.to_string().contains("handler failed"));
@@ -2127,13 +2581,73 @@ mod tests {
             "unknown/method".to_string(),
             Some(json!({})),
         );
-        let response = handle_server_request(None, &request).await;
+        let response = handle_server_request(None, &[], &request).await;
         match response.payload {
             mcp::JsonRpcPayload::Error { error } => {
                 assert!(error.to_string().contains("Method not supported"));
                 assert!(error.to_string().contains("unknown/method"));
             }
             _ => panic!("expected error response"),
+        }
+    }
+
+    // ── roots/list handling (R7 #3) ──
+
+    #[tokio::test]
+    async fn handle_roots_list_returns_configured_roots() {
+        let roots = vec![
+            Root {
+                uri: "file:///home/user/project".to_string(),
+                name: Some("project".to_string()),
+                meta: None,
+            },
+            Root {
+                uri: "file:///tmp/scratch".to_string(),
+                name: None,
+                meta: None,
+            },
+        ];
+        let request = JsonRpcRequest::new(
+            JsonRpcId::Number(10),
+            "roots/list".to_string(),
+            Some(json!({})),
+        );
+        let response = handle_server_request(None, &roots, &request).await;
+        match response.payload {
+            mcp::JsonRpcPayload::Success { result } => {
+                let parsed: ListRootsResult =
+                    serde_json::from_value(result).expect("ListRootsResult parses");
+                assert_eq!(parsed.roots.len(), 2);
+                assert_eq!(parsed.roots[0].uri, "file:///home/user/project");
+                assert_eq!(parsed.roots[0].name.as_deref(), Some("project"));
+                assert_eq!(parsed.roots[1].uri, "file:///tmp/scratch");
+                assert!(parsed.roots[1].name.is_none());
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_roots_list_rejects_when_empty() {
+        // Empty roots = capability was not advertised at initialize.
+        // A misbehaving server still calling `roots/list` MUST see
+        // method-not-supported (not an empty result), so it can't
+        // continue assuming the client agreed to participate.
+        let request = JsonRpcRequest::new(
+            JsonRpcId::Number(11),
+            "roots/list".to_string(),
+            Some(json!({})),
+        );
+        let response = handle_server_request(None, &[], &request).await;
+        match response.payload {
+            mcp::JsonRpcPayload::Error { error } => {
+                let msg = error.to_string();
+                assert!(
+                    msg.contains("roots/list not supported"),
+                    "expected not-supported error, got: {msg}"
+                );
+            }
+            other => panic!("expected error, got {other:?}"),
         }
     }
 
@@ -2173,7 +2687,8 @@ mod tests {
             "http-close",
             "http://127.0.0.1:9".to_string(),
         );
-        let transport = ProgressAwareHttpTransport::connect(&cfg, None).unwrap();
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new())).unwrap();
 
         transport.close().await.unwrap();
         transport.close().await.unwrap();
@@ -2210,7 +2725,8 @@ mod tests {
         });
 
         let cfg = mcp::transport::McpServerConnectionConfig::http("http-close-delete", url);
-        let transport = ProgressAwareHttpTransport::connect(&cfg, None).unwrap();
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new())).unwrap();
         // Pretend init already happened so close() has a session id to terminate.
         transport.session.write().await.session_id = Some("test-session-abc".into());
 
@@ -2363,6 +2879,12 @@ mod tests {
         let _ = std::fs::remove_file(&scratch);
         let scratch_str = scratch.to_string_lossy().to_string();
 
+        // Mock server's `initialize` response echoes back the version
+        // awaken sent (current `MCP_PROTOCOL_VERSION`) — anything else
+        // would now be rejected by the negotiation check (see
+        // `negotiate_protocol_version`), which is correct production
+        // behaviour but would prevent this cancellation test from
+        // reaching the assert.
         let script = format!(
             r#"
 while IFS= read -r LINE; do
@@ -2370,12 +2892,13 @@ while IFS= read -r LINE; do
     case "$LINE" in
         *'"method":"initialize"'*)
             ID=$(printf '%s' "$LINE" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
-            printf '{{"jsonrpc":"2.0","id":%s,"result":{{"protocolVersion":"2024-11-05","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"mock","version":"0"}}}}}}\n' "$ID"
+            printf '{{"jsonrpc":"2.0","id":%s,"result":{{"protocolVersion":"{version}","capabilities":{{"tools":{{}}}},"serverInfo":{{"name":"mock","version":"0"}}}}}}\n' "$ID"
             ;;
     esac
 done
 "#,
-            scratch = scratch_str
+            scratch = scratch_str,
+            version = MCP_PROTOCOL_VERSION,
         );
 
         let mut cfg = mcp::transport::McpServerConnectionConfig::stdio(
@@ -2386,7 +2909,7 @@ done
         cfg.timeout_secs = 30;
 
         let transport = Arc::new(
-            ProgressAwareStdioTransport::connect(&cfg, None)
+            ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()))
                 .await
                 .expect("stdio transport connects"),
         );
@@ -2456,6 +2979,62 @@ done
         assert_eq!(parsed["params"]["reason"], "client run cancelled");
 
         let _ = std::fs::remove_file(&scratch);
+    }
+
+    /// End-to-end smoke test for R7 #2: the reflective stdio server
+    /// emits `notifications/tools/list_changed` after `initialize`; the
+    /// transport must forward the parsed `ListChangedKind::Tools` event
+    /// to the host via `take_list_changed_receiver`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stdio_forwards_tools_list_changed_notification() {
+        let script = format!(
+            r#"
+while IFS= read -r LINE; do
+    case "$LINE" in
+        *'"method":"initialize"'*)
+            ID=$(printf '%s' "$LINE" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+            printf '{{"jsonrpc":"2.0","id":%s,"result":{{"protocolVersion":"{version}","capabilities":{{"tools":{{"listChanged":true}}}},"serverInfo":{{"name":"mock","version":"0"}}}}}}\n' "$ID"
+            # Push a list_changed notification right after the
+            # initialize response. The transport's reader must classify
+            # it as a list_changed (NOT a progress notification) and
+            # forward it to the receiver.
+            printf '{{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}}\n'
+            ;;
+    esac
+done
+"#,
+            version = MCP_PROTOCOL_VERSION,
+        );
+
+        let mut cfg = mcp::transport::McpServerConnectionConfig::stdio(
+            "stdio-list-changed",
+            "/bin/sh",
+            vec!["-c".to_string(), script],
+        );
+        cfg.timeout_secs = 30;
+
+        let transport = ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new()))
+            .await
+            .expect("stdio transport connects");
+
+        let mut rx = transport
+            .take_list_changed_receiver()
+            .await
+            .expect("transport exposes list_changed receiver");
+
+        // The server fires the notification eagerly after initialize, so
+        // it should arrive within a few hundred ms. Tolerate scheduling
+        // jitter on slow CI by waiting up to a couple of seconds.
+        let kind = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("did not observe list_changed within timeout")
+            .expect("channel closed before notification arrived");
+        assert_eq!(kind, ListChangedKind::Tools);
+
+        // Receiver is one-shot — a second take returns None even when
+        // the first call succeeded (and crucially does not panic).
+        assert!(transport.take_list_changed_receiver().await.is_none());
     }
 
     // ── Per-call sampling routing tests (R1 #P1b) ──
@@ -2742,7 +3321,8 @@ done
         });
 
         let cfg = mcp::transport::McpServerConnectionConfig::http("http-close-no-session", url);
-        let transport = ProgressAwareHttpTransport::connect(&cfg, None).unwrap();
+        let transport =
+            ProgressAwareHttpTransport::connect(&cfg, None, Arc::new(Vec::new())).unwrap();
         // No session id set.
         transport.close().await.unwrap();
 
@@ -2773,7 +3353,8 @@ done
         );
         cfg.timeout_secs = 1;
 
-        let err = match ProgressAwareStdioTransport::connect(&cfg, None).await {
+        let err = match ProgressAwareStdioTransport::connect(&cfg, None, Arc::new(Vec::new())).await
+        {
             Ok(_) => panic!("expected stdio initialization failure"),
             Err(err) => err,
         };
@@ -3627,7 +4208,7 @@ done
             "sampling/createMessage".to_string(),
             None,
         );
-        let response = handle_server_request(Some(&handler), &request).await;
+        let response = handle_server_request(Some(&handler), &[], &request).await;
         match response.payload {
             mcp::JsonRpcPayload::Error { error } => {
                 assert!(error.to_string().contains("Invalid sampling/createMessage"));
@@ -3646,7 +4227,7 @@ done
             "tools/call".to_string(),
             Some(json!({})),
         );
-        let response = handle_server_request(Some(&handler), &request).await;
+        let response = handle_server_request(Some(&handler), &[], &request).await;
         match response.payload {
             mcp::JsonRpcPayload::Error { error } => {
                 assert!(error.to_string().contains("Method not supported"));

--- a/crates/awaken-ext-mcp/tests/e2e_server_everything.rs
+++ b/crates/awaken-ext-mcp/tests/e2e_server_everything.rs
@@ -14,9 +14,9 @@
 //!   1. `MCP_E2E_SERVER_BIN` env var (path to a pre-installed
 //!      `mcp-server-everything` executable). Preferred in CI so each
 //!      test doesn't pay the `npx` startup cost.
-//!   2. Fallback to `npx -y @modelcontextprotocol/server-everything
-//!      stdio`. First run downloads (~5s); subsequent runs hit the
-//!      npm cache.
+//!   2. Fallback to the pinned `npx -y
+//!      @modelcontextprotocol/server-everything@2026.1.26 stdio`.
+//!      First run downloads (~5s); subsequent runs hit the npm cache.
 //!
 //! ## Scope
 //!
@@ -35,6 +35,7 @@ use std::time::{Duration, Instant};
 use tokio::process::{Child, Command};
 
 static E2E_SERVER_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+const SERVER_EVERYTHING_PACKAGE: &str = "@modelcontextprotocol/server-everything@2026.1.26";
 
 async fn e2e_server_lock() -> tokio::sync::MutexGuard<'static, ()> {
     E2E_SERVER_LOCK
@@ -53,7 +54,7 @@ fn server_command() -> (String, Vec<String>) {
         "npx".to_string(),
         vec![
             "-y".to_string(),
-            "@modelcontextprotocol/server-everything".to_string(),
+            SERVER_EVERYTHING_PACKAGE.to_string(),
             "stdio".to_string(),
         ],
     )
@@ -67,7 +68,7 @@ fn streamable_http_server_command() -> (String, Vec<String>) {
         "npx".to_string(),
         vec![
             "-y".to_string(),
-            "@modelcontextprotocol/server-everything".to_string(),
+            SERVER_EVERYTHING_PACKAGE.to_string(),
             "streamableHttp".to_string(),
         ],
     )

--- a/crates/awaken-ext-mcp/tests/e2e_server_everything.rs
+++ b/crates/awaken-ext-mcp/tests/e2e_server_everything.rs
@@ -1,0 +1,356 @@
+//! End-to-end MCP tests against the official reference server
+//! [`@modelcontextprotocol/server-everything`].
+//!
+//! These tests are `#[ignore]`'d so the default `cargo test` run does
+//! not require Node.js or a network download. Opt in with:
+//!
+//! ```text
+//! cargo test --test e2e_server_everything -- --ignored
+//! ```
+//!
+//! ## Server resolution
+//!
+//! Tests resolve the server binary in this order:
+//!   1. `MCP_E2E_SERVER_BIN` env var (path to a pre-installed
+//!      `mcp-server-everything` executable). Preferred in CI so each
+//!      test doesn't pay the `npx` startup cost.
+//!   2. Fallback to `npx -y @modelcontextprotocol/server-everything
+//!      stdio`. First run downloads (~5s); subsequent runs hit the
+//!      npm cache.
+//!
+//! ## Scope
+//!
+//! Happy-path validation against a spec-compliant server. The wire
+//! shape (protocol negotiation, tool dispatch, resource reads,
+//! completion, list_changed) is exercised end-to-end. Fault paths
+//! (404 session expired, mid-stream drops, malformed events) stay in
+//! the synthetic mock tests in `mcp_tests.rs` — the reference server
+//! doesn't fault on demand.
+
+use awaken_contract::contract::tool::ToolCallContext;
+use awaken_ext_mcp::{McpServerConnectionConfig, McpToolRegistryManager};
+use serde_json::{Value, json};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tokio::process::{Child, Command};
+
+static E2E_SERVER_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+async fn e2e_server_lock() -> tokio::sync::MutexGuard<'static, ()> {
+    E2E_SERVER_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}
+
+/// Resolve the command + args to spawn the reference server. See
+/// module docs for the resolution order.
+fn server_command() -> (String, Vec<String>) {
+    if let Ok(path) = std::env::var("MCP_E2E_SERVER_BIN") {
+        return (path, vec!["stdio".to_string()]);
+    }
+    (
+        "npx".to_string(),
+        vec![
+            "-y".to_string(),
+            "@modelcontextprotocol/server-everything".to_string(),
+            "stdio".to_string(),
+        ],
+    )
+}
+
+fn streamable_http_server_command() -> (String, Vec<String>) {
+    if let Ok(path) = std::env::var("MCP_E2E_SERVER_BIN") {
+        return (path, vec!["streamableHttp".to_string()]);
+    }
+    (
+        "npx".to_string(),
+        vec![
+            "-y".to_string(),
+            "@modelcontextprotocol/server-everything".to_string(),
+            "streamableHttp".to_string(),
+        ],
+    )
+}
+
+fn make_config(name: &str) -> McpServerConnectionConfig {
+    let (cmd, args) = server_command();
+    let mut cfg = McpServerConnectionConfig::stdio(name, cmd, args);
+    // `npx` first-run + npm install can take a while; give the
+    // initialize handshake enough headroom.
+    cfg.timeout_secs = 60;
+    cfg
+}
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    async fn stop(mut self) {
+        let _ = self.child.start_kill();
+        let _ = self.child.wait().await;
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+fn reserve_local_port() -> u16 {
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port for HTTP e2e");
+    listener.local_addr().expect("read ephemeral port").port()
+}
+
+async fn spawn_streamable_http_server() -> (ChildGuard, String) {
+    let port = reserve_local_port();
+    let (cmd, args) = streamable_http_server_command();
+    let child = Command::new(cmd)
+        .args(args)
+        .env("PORT", port.to_string())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn server-everything streamableHttp");
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "server-everything streamableHttp did not open port {port}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    (ChildGuard { child }, format!("http://127.0.0.1:{port}/mcp"))
+}
+
+/// Find a tool by substring (the server-everything tool names use
+/// `-` separators, which awaken's `to_tool_id` rewrites to `_`; tests
+/// search rather than equality-match so a future server rename
+/// doesn't break this layer).
+fn find_tool_id(ids: &[String], needle: &str) -> Option<String> {
+    ids.iter().find(|id| id.contains(needle)).cloned()
+}
+
+/// Smoke: connect → tools/list → tools/call(echo). Validates the
+/// full happy-path surface awaken claims to support: initialize
+/// handshake (protocol version negotiation against the server's
+/// `2025-11-25`), capability advertisement, tools/list discovery,
+/// tool id mapping, and a tools/call round trip.
+#[tokio::test]
+#[ignore]
+async fn e2e_initialize_and_echo_tool() {
+    let _guard = e2e_server_lock().await;
+    let cfg = make_config("e2e-echo");
+    let manager = McpToolRegistryManager::connect([cfg])
+        .await
+        .expect("connect to server-everything");
+    let registry = manager.registry();
+    let ids: Vec<String> = registry.ids().into_iter().collect();
+
+    let echo_id = find_tool_id(&ids, "echo")
+        .unwrap_or_else(|| panic!("server-everything should expose an echo tool; got {ids:?}"));
+    let tool = registry
+        .get(&echo_id)
+        .expect("registry returns tool for known id");
+
+    let ctx = ToolCallContext::test_default();
+    let result = tool
+        .execute(json!({"message": "hello-e2e"}), &ctx)
+        .await
+        .expect("echo tool call succeeds");
+
+    let text = result.result.data.to_string();
+    assert!(
+        text.contains("hello-e2e"),
+        "echo result should round-trip our input; got: {text}"
+    );
+}
+
+/// Real Streamable HTTP e2e against the official reference server.
+/// server-everything returns initialize as `text/event-stream` and
+/// assigns `MCP-Session-Id`, so this covers the stateful HTTP path that
+/// the synthetic integration tests exercise under failure conditions.
+#[tokio::test]
+#[ignore]
+async fn e2e_streamable_http_initialize_and_echo_tool() {
+    let _guard = e2e_server_lock().await;
+    let (server, endpoint) = spawn_streamable_http_server().await;
+    let mut cfg = McpServerConnectionConfig::http("e2e-http", endpoint);
+    cfg.timeout_secs = 60;
+
+    let manager = McpToolRegistryManager::connect([cfg])
+        .await
+        .expect("connect to server-everything streamableHttp");
+    let registry = manager.registry();
+    let ids: Vec<String> = registry.ids().into_iter().collect();
+
+    let echo_id = find_tool_id(&ids, "echo").unwrap_or_else(|| {
+        panic!("server-everything streamableHttp should expose an echo tool; got {ids:?}")
+    });
+    let tool = registry
+        .get(&echo_id)
+        .expect("registry returns tool for known HTTP id");
+
+    let result = tool
+        .execute(
+            json!({"message": "hello-streamable-http"}),
+            &ToolCallContext::test_default(),
+        )
+        .await
+        .expect("HTTP echo tool call succeeds");
+
+    let text = result.result.data.to_string();
+    assert!(
+        text.contains("hello-streamable-http"),
+        "HTTP echo result should round-trip our input; got: {text}"
+    );
+
+    manager.close_all().await.expect("close HTTP MCP manager");
+    server.stop().await;
+}
+
+/// Structured arguments + numeric result. server-everything's `get-sum`
+/// tool takes two numbers and returns their sum; exercises numeric
+/// argument serialization and result deserialization.
+#[tokio::test]
+#[ignore]
+async fn e2e_get_sum_structured_args() {
+    let _guard = e2e_server_lock().await;
+    let cfg = make_config("e2e-sum");
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let ids: Vec<String> = registry.ids().into_iter().collect();
+
+    let sum_id = find_tool_id(&ids, "get_sum")
+        .unwrap_or_else(|| panic!("server-everything should expose get-sum; got {ids:?}"));
+    let tool = registry.get(&sum_id).unwrap();
+    let ctx = ToolCallContext::test_default();
+
+    let result = tool
+        .execute(json!({"a": 7, "b": 35}), &ctx)
+        .await
+        .expect("get-sum call succeeds");
+
+    // The server formats the sum into the tool result text.
+    let text = result.result.data.to_string();
+    assert!(
+        text.contains("42"),
+        "sum of 7 + 35 should appear in result; got: {text}"
+    );
+}
+
+/// resources/list + read. server-everything exposes a fixed set of
+/// numbered text resources (`test://static/resource/<n>`); we don't
+/// pin a specific URI shape, just that:
+///   - list_resources returns at least one entry,
+///   - read_resource on that entry returns content.
+#[tokio::test]
+#[ignore]
+async fn e2e_resources_list_and_read() {
+    let _guard = e2e_server_lock().await;
+    let cfg = make_config("e2e-resources");
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+
+    let resources = manager.list_resources().await.expect("list_resources");
+    assert!(
+        !resources.is_empty(),
+        "server-everything exposes resources; list must be non-empty"
+    );
+
+    // Read the first resource. The wire shape is a `Value` containing
+    // the server's `ReadResourceResult` (`{ contents: [...] }`).
+    let first = &resources[0];
+    let body = manager
+        .read_resource(&first.server_name, &first.resource.uri)
+        .await
+        .expect("read_resource on the first listed entry");
+
+    // Don't pin the exact content shape — server-everything's text
+    // resources have prose bodies that may evolve. Just verify the
+    // server returned a `contents` array with at least one entry.
+    let contents = body
+        .get("contents")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("read_resource result missing `contents` array: {body}"));
+    assert!(
+        !contents.is_empty(),
+        "contents array should be non-empty for {}",
+        first.resource.uri
+    );
+}
+
+/// prompts/list. server-everything ships several reference prompts.
+/// Just verify discovery works against a real server (the local mock
+/// tests already cover the wire shape).
+#[tokio::test]
+#[ignore]
+async fn e2e_prompts_list() {
+    let _guard = e2e_server_lock().await;
+    let cfg = make_config("e2e-prompts");
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let prompts = manager.list_prompts().await.expect("list_prompts");
+    assert!(
+        !prompts.is_empty(),
+        "server-everything ships reference prompts; list must be non-empty"
+    );
+}
+
+/// completion/complete against a known prompt ref. server-everything
+/// advertises `completions: {}` and supports argument autocomplete
+/// for its `simple_prompt` / `complex_prompt` prompts. We probe
+/// `complex_prompt`'s `temperature` argument — the exact completion
+/// set isn't pinned (server-side data may evolve); we just verify
+/// the call succeeds and returns a `CompleteResult` shape.
+#[tokio::test]
+#[ignore]
+async fn e2e_completion_complete() {
+    let _guard = e2e_server_lock().await;
+    use mcp::{CompleteArgument, CompleteParams};
+
+    let cfg = make_config("e2e-complete");
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+
+    // First discover the prompt name so the test isn't brittle to
+    // server-side renames.
+    let prompts = manager.list_prompts().await.expect("list_prompts");
+    let target = prompts
+        .iter()
+        .find(|p| p.prompt.name.contains("prompt"))
+        .unwrap_or_else(|| panic!("expected at least one prompt; got {prompts:?}"))
+        .clone();
+
+    let params = CompleteParams {
+        r#ref: json!({
+            "type": "ref/prompt",
+            "name": target.prompt.name,
+        }),
+        argument: CompleteArgument {
+            name: "temperature".to_string(),
+            value: "".to_string(),
+        },
+        context: None,
+    };
+
+    // The call must succeed against a server that advertises
+    // completions. The result's `values` array MAY be empty (the
+    // prompt may not have suggestions for this argument); we only
+    // assert the wire round-trip didn't error.
+    let result = manager
+        .complete(&target.server_name, params)
+        .await
+        .expect("completion/complete round trip");
+    // The completion result struct is well-formed if `values` is a
+    // (possibly empty) Vec. The deserializer would've already
+    // rejected an unexpected shape.
+    let _ = result.completion.values;
+}

--- a/crates/awaken-ext-mcp/tests/mcp_tests.rs
+++ b/crates/awaken-ext-mcp/tests/mcp_tests.rs
@@ -1,16 +1,16 @@
 //! Integration tests for the awaken-ext-mcp crate.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use awaken_contract::contract::tool::ToolCallContext;
+use awaken_contract::{AgentSpec, CancellationToken, contract::tool::ToolCallContext};
 use awaken_ext_mcp::{
     McpError, McpProgressUpdate, McpPromptArgument, McpPromptDefinition, McpPromptMessage,
     McpPromptResult, McpResourceDefinition, McpServerConnectionConfig, McpToolRegistryManager,
-    McpToolTransport, SamplingHandler,
+    McpToolTransport, SamplingHandler, SamplingHandlerFactory,
 };
 use mcp::transport::{McpTransportError, ServerCapabilities, TransportTypeId};
 use mcp::{
@@ -328,7 +328,15 @@ impl McpToolTransport for FakeUiTransport {
 
 #[derive(Clone)]
 struct HttpRequestSpec {
+    /// HTTP method (e.g. `GET`, `POST`, `DELETE`). Captured from the
+    /// first line of the request so listening-stream tests can
+    /// distinguish the POST initialize/tools-call traffic from the
+    /// GET that opens the server-push SSE stream.
+    method: String,
     headers: std::collections::HashMap<String, String>,
+    /// Parsed JSON body. `Value::Null` when the request had no body
+    /// (GET, OPTIONS, or any other Content-Length: 0 request) — the
+    /// previous parser failed silently in that case.
     body: Value,
 }
 
@@ -391,6 +399,21 @@ impl HttpResponseSpec {
             headers: Vec::new(),
         }
     }
+
+    fn sse_with_headers(
+        body: impl Into<String>,
+        headers: Vec<(impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        Self {
+            status: 200,
+            content_type: "text/event-stream",
+            body: body.into(),
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        }
+    }
 }
 
 fn status_text(status: u16) -> &'static str {
@@ -398,6 +421,8 @@ fn status_text(status: u16) -> &'static str {
         200 => "OK",
         202 => "Accepted",
         400 => "Bad Request",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
         500 => "Internal Server Error",
         _ => "OK",
     }
@@ -419,6 +444,24 @@ fn content_length(headers: &str) -> usize {
             }
         })
         .unwrap_or(0)
+}
+
+async fn write_http_response(stream: &mut TcpStream, response: HttpResponseSpec) {
+    let payload = response.body;
+    let mut head = format!(
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        response.status,
+        status_text(response.status),
+        response.content_type,
+        payload.len()
+    );
+    for (key, value) in response.headers {
+        head.push_str(&format!("{key}: {value}\r\n"));
+    }
+    head.push_str("\r\n");
+    let _ = stream.write_all(head.as_bytes()).await;
+    let _ = stream.write_all(payload.as_bytes()).await;
+    let _ = stream.shutdown().await;
 }
 
 fn parse_headers(raw: &str) -> std::collections::HashMap<String, String> {
@@ -456,16 +499,51 @@ async fn read_http_request(stream: &mut TcpStream) -> Option<HttpRequestSpec> {
         buf.extend_from_slice(&chunk[..n]);
     }
 
-    let headers = std::str::from_utf8(&buf[..header_end_pos]).ok()?;
-    let body = serde_json::from_slice(&buf[header_end_pos..header_end_pos + body_len]).ok()?;
+    let headers_text = std::str::from_utf8(&buf[..header_end_pos]).ok()?;
+    let method = headers_text
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .unwrap_or("")
+        .to_string();
+    // Bodies with Content-Length: 0 (GET, OPTIONS, body-less DELETE)
+    // are common in spec-compliant clients — surface them as
+    // `Value::Null` instead of failing parse, so handlers can switch
+    // on `method`.
+    let body = if body_len == 0 {
+        Value::Null
+    } else {
+        serde_json::from_slice(&buf[header_end_pos..header_end_pos + body_len]).ok()?
+    };
     Some(HttpRequestSpec {
-        headers: parse_headers(headers),
+        method,
+        headers: parse_headers(headers_text),
         body,
     })
 }
 
 async fn spawn_http_server(
     handler: Arc<dyn Fn(HttpRequestSpec) -> HttpResponseSpec + Send + Sync>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    spawn_http_server_with_response_observer(handler, None).await
+}
+
+async fn spawn_http_server_with_response_observer(
+    handler: Arc<dyn Fn(HttpRequestSpec) -> HttpResponseSpec + Send + Sync>,
+    response_observer: Option<Arc<dyn Fn(HttpRequestSpec) + Send + Sync>>,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let response_handler = response_observer.map(|observer| {
+        Arc::new(move |request| {
+            observer(request);
+            HttpResponseSpec::accepted()
+        }) as Arc<dyn Fn(HttpRequestSpec) -> HttpResponseSpec + Send + Sync>
+    });
+    spawn_http_server_with_response_handler(handler, response_handler).await
+}
+
+async fn spawn_http_server_with_response_handler(
+    handler: Arc<dyn Fn(HttpRequestSpec) -> HttpResponseSpec + Send + Sync>,
+    response_handler: Option<Arc<dyn Fn(HttpRequestSpec) -> HttpResponseSpec + Send + Sync>>,
 ) -> (String, tokio::task::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -477,6 +555,7 @@ async fn spawn_http_server(
                 break;
             };
             let handler = Arc::clone(&handler);
+            let response_handler = response_handler.clone();
             tokio::spawn(async move {
                 let Some(request) = read_http_request(&mut stream).await else {
                     return;
@@ -484,25 +563,15 @@ async fn spawn_http_server(
                 let response = if request.body["method"].is_null()
                     && (request.body.get("result").is_some() || request.body.get("error").is_some())
                 {
-                    HttpResponseSpec::accepted()
+                    if let Some(response_handler) = response_handler {
+                        response_handler(request.clone())
+                    } else {
+                        HttpResponseSpec::accepted()
+                    }
                 } else {
                     handler(request)
                 };
-                let payload = response.body;
-                let mut head = format!(
-                    "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n",
-                    response.status,
-                    status_text(response.status),
-                    response.content_type,
-                    payload.len()
-                );
-                for (key, value) in response.headers {
-                    head.push_str(&format!("{key}: {value}\r\n"));
-                }
-                head.push_str("\r\n");
-                let _ = stream.write_all(head.as_bytes()).await;
-                let _ = stream.write_all(payload.as_bytes()).await;
-                let _ = stream.shutdown().await;
+                write_http_response(&mut stream, response).await;
             });
         }
     });
@@ -1677,6 +1746,1888 @@ async fn connect_http_registry_discovers_tools_and_executes() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn http_initialize_accepts_sse_response() {
+    let seen_requests = Arc::new(std::sync::Mutex::new(Vec::<HttpRequestSpec>::new()));
+    let seen_requests_for_handler = Arc::clone(&seen_requests);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        seen_requests_for_handler
+            .lock()
+            .unwrap()
+            .push(request.clone());
+
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => HttpResponseSpec::sse_with_headers(
+                format!(
+                    "id: init-1\ndata: {}\n\n",
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "http-sse-init", "version": "1.0.0"}
+                        }
+                    })
+                ),
+                vec![("MCP-Session-Id", "sse-init-session")],
+            ),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "sse_init_tool",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_sse_init", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg])
+        .await
+        .expect("SSE initialize response should negotiate successfully");
+    let registry = manager.registry();
+    assert!(
+        registry
+            .ids()
+            .into_iter()
+            .any(|id| id.ends_with("__sse_init_tool")),
+        "tool discovered after SSE initialize"
+    );
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    let seen_requests = seen_requests.lock().unwrap();
+    let initialized = seen_requests
+        .iter()
+        .find(|request| request.body["method"] == "notifications/initialized")
+        .expect("initialized notification");
+    assert_eq!(
+        initialized
+            .headers
+            .get("mcp-session-id")
+            .map(String::as_str),
+        Some("sse-init-session")
+    );
+    let tools_list = seen_requests
+        .iter()
+        .find(|request| request.body["method"] == "tools/list")
+        .expect("tools/list request");
+    assert_eq!(
+        tools_list.headers.get("mcp-session-id").map(String::as_str),
+        Some("sse-init-session")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_initialize_sse_resumes_after_clean_close_with_last_event_id() {
+    let initialize_id = Arc::new(std::sync::Mutex::new(None::<Value>));
+    let initialize_id_for_handler = Arc::clone(&initialize_id);
+    let resume_last_ids = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let resume_last_ids_for_handler = Arc::clone(&resume_last_ids);
+    let seen_requests = Arc::new(std::sync::Mutex::new(Vec::<HttpRequestSpec>::new()));
+    let seen_requests_for_handler = Arc::clone(&seen_requests);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        seen_requests_for_handler
+            .lock()
+            .unwrap()
+            .push(request.clone());
+
+        if request.method == "GET" {
+            let Some(last_event_id) = request.headers.get("last-event-id").cloned() else {
+                return HttpResponseSpec::text(405, "background listener disabled");
+            };
+            resume_last_ids_for_handler
+                .lock()
+                .unwrap()
+                .push(last_event_id);
+            assert_eq!(
+                request.headers.get("mcp-session-id").map(String::as_str),
+                Some("init-resume-session")
+            );
+            assert_eq!(
+                request
+                    .headers
+                    .get("mcp-protocol-version")
+                    .map(String::as_str),
+                Some(mcp::MCP_PROTOCOL_VERSION),
+                "initialize resume GET should carry the client protocol version"
+            );
+            let request_id = initialize_id_for_handler
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("initialize id captured before resume");
+            return HttpResponseSpec::sse(format!(
+                "id: init-2\ndata: {}\n\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "http-sse-init-resume", "version": "1.0.0"}
+                    }
+                })
+            ));
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                *initialize_id_for_handler.lock().unwrap() = Some(request.body["id"].clone());
+                HttpResponseSpec::sse_with_headers(
+                    "id: init-1\nretry: 1\ndata:\n\n",
+                    vec![("MCP-Session-Id", "init-resume-session")],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "sse_init_resume_tool",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_sse_init_resume", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg])
+        .await
+        .expect("SSE initialize response should resume through Last-Event-ID");
+    let registry = manager.registry();
+    assert!(
+        registry
+            .ids()
+            .into_iter()
+            .any(|id| id.ends_with("__sse_init_resume_tool")),
+        "tool discovered after resumed SSE initialize"
+    );
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(
+        resume_last_ids.lock().unwrap().as_slice(),
+        &["init-1".to_string()]
+    );
+    let seen_requests = seen_requests.lock().unwrap();
+    let initialized = seen_requests
+        .iter()
+        .find(|request| request.body["method"] == "notifications/initialized")
+        .expect("initialized notification");
+    assert_eq!(
+        initialized
+            .headers
+            .get("mcp-session-id")
+            .map(String::as_str),
+        Some("init-resume-session")
+    );
+    assert_eq!(
+        initialized
+            .headers
+            .get("mcp-protocol-version")
+            .map(String::as_str),
+        Some(mcp::MCP_PROTOCOL_VERSION)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_streamable_without_session_uses_protocol_header_and_no_delete() {
+    let seen_requests = Arc::new(std::sync::Mutex::new(Vec::<HttpRequestSpec>::new()));
+    let seen_requests_for_handler = Arc::clone(&seen_requests);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        seen_requests_for_handler
+            .lock()
+            .unwrap()
+            .push(request.clone());
+
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "stateless listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(500, "stateless close must not DELETE");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "stateless-http", "version": "1.0.0"}
+                }
+            })),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "stateless_echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "content": [{"type": "text", "text": "stateless ok"}]
+                }
+            })),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_stateless", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg])
+        .await
+        .expect("stateless HTTP initialize should connect");
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__stateless_echo"))
+        .expect("discover stateless_echo tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+    let result = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("stateless tool call succeeds");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(result.result.data, json!("stateless ok"));
+    let seen_requests = seen_requests.lock().unwrap();
+    assert!(
+        !seen_requests
+            .iter()
+            .any(|request| request.method == "DELETE"),
+        "stateless close must not send DELETE without a server session id"
+    );
+
+    for method in ["notifications/initialized", "tools/list", "tools/call"] {
+        let request = seen_requests
+            .iter()
+            .find(|request| request.body["method"] == method)
+            .unwrap_or_else(|| panic!("missing request for {method}"));
+        assert!(
+            !request.headers.contains_key("mcp-session-id"),
+            "{method} must not carry MCP-Session-Id when server did not assign one"
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("mcp-protocol-version")
+                .map(String::as_str),
+            Some(mcp::MCP_PROTOCOL_VERSION),
+            "{method} must carry negotiated MCP-Protocol-Version"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_initialize_unsupported_protocol_deletes_provisional_session() {
+    let seen_requests = Arc::new(std::sync::Mutex::new(Vec::<HttpRequestSpec>::new()));
+    let seen_requests_for_handler = Arc::clone(&seen_requests);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        seen_requests_for_handler
+            .lock()
+            .unwrap()
+            .push(request.clone());
+
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "initialize" => HttpResponseSpec::json_with_headers(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "protocolVersion": "1900-01-01",
+                        "capabilities": {},
+                        "serverInfo": {"name": "bad-protocol", "version": "1.0.0"}
+                    }
+                }),
+                vec![("MCP-Session-Id", "unsupported-session")],
+            ),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_init_bad_protocol", endpoint);
+    let err = McpToolRegistryManager::connect([cfg])
+        .await
+        .expect_err("unsupported protocol should fail initialize");
+
+    assert!(
+        format!("{err}").contains("unsupported protocolVersion"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            seen_requests
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|request| request.method == "DELETE")
+        })
+        .await,
+        "initialize failure should DELETE the provisional session"
+    );
+    server.abort();
+
+    let seen_requests = seen_requests.lock().unwrap();
+    let delete_requests: Vec<_> = seen_requests
+        .iter()
+        .filter(|request| request.method == "DELETE")
+        .collect();
+    assert_eq!(delete_requests.len(), 1);
+    assert_eq!(
+        delete_requests[0]
+            .headers
+            .get("mcp-session-id")
+            .map(String::as_str),
+        Some("unsupported-session")
+    );
+    assert!(
+        !seen_requests
+            .iter()
+            .any(|request| request.body["method"] == "notifications/initialized"),
+        "initialized notification must not be sent after protocol negotiation failure"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_initialize_notification_failure_deletes_provisional_session() {
+    let seen_requests = Arc::new(std::sync::Mutex::new(Vec::<HttpRequestSpec>::new()));
+    let seen_requests_for_handler = Arc::clone(&seen_requests);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        seen_requests_for_handler
+            .lock()
+            .unwrap()
+            .push(request.clone());
+
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "initialize" => HttpResponseSpec::json_with_headers(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "serverInfo": {"name": "init-notify-fail", "version": "1.0.0"}
+                    }
+                }),
+                vec![("MCP-Session-Id", "notify-fail-session")],
+            ),
+            "notifications/initialized" => HttpResponseSpec::text(400, "initialized rejected"),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_init_notify_fail", endpoint);
+    let err = McpToolRegistryManager::connect([cfg])
+        .await
+        .expect_err("initialized notification failure should fail initialize");
+
+    assert!(
+        format!("{err}").contains("initialized rejected"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            seen_requests
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|request| request.method == "DELETE")
+        })
+        .await,
+        "initialized failure should DELETE the provisional session"
+    );
+    server.abort();
+
+    let seen_requests = seen_requests.lock().unwrap();
+    let initialized = seen_requests
+        .iter()
+        .find(|request| request.body["method"] == "notifications/initialized")
+        .expect("initialized notification request");
+    assert_eq!(
+        initialized
+            .headers
+            .get("mcp-session-id")
+            .map(String::as_str),
+        Some("notify-fail-session")
+    );
+    let delete_requests: Vec<_> = seen_requests
+        .iter()
+        .filter(|request| request.method == "DELETE")
+        .collect();
+    assert_eq!(delete_requests.len(), 1);
+    assert_eq!(
+        delete_requests[0]
+            .headers
+            .get("mcp-session-id")
+            .map(String::as_str),
+        Some("notify-fail-session")
+    );
+    assert_eq!(
+        delete_requests[0]
+            .headers
+            .get("mcp-protocol-version")
+            .map(String::as_str),
+        Some(mcp::MCP_PROTOCOL_VERSION)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_per_request_sse_resumes_after_clean_close_with_last_event_id() {
+    let tools_call_id = Arc::new(std::sync::Mutex::new(None::<Value>));
+    let resume_last_ids = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_id_for_handler = Arc::clone(&tools_call_id);
+    let resume_last_ids_for_handler = Arc::clone(&resume_last_ids);
+    let get_count_for_handler = Arc::clone(&get_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+            let Some(last_event_id) = request.headers.get("last-event-id").cloned() else {
+                return HttpResponseSpec::text(405, "background listener disabled");
+            };
+            resume_last_ids_for_handler
+                .lock()
+                .unwrap()
+                .push(last_event_id);
+            let request_id = tools_call_id_for_handler
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("tools/call id captured before resume");
+            return HttpResponseSpec::sse(format!(
+                "id: 2\ndata: {}\n\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": "resumed ok"}]
+                    }
+                })
+            ));
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "resume_http",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                *tools_call_id_for_handler.lock().unwrap() = Some(request.body["id"].clone());
+                let token = request.body["params"]["_meta"]["progressToken"].clone();
+                HttpResponseSpec::sse(format!(
+                    "id: 1\nretry: 1\ndata: {}\n\n",
+                    json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/progress",
+                        "params": {
+                            "progressToken": token,
+                            "progress": 1.0,
+                            "message": "halfway"
+                        }
+                    })
+                ))
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_sse_resume", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__resume_http"))
+        .expect("discover resume tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let result = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("SSE response should resume after clean close");
+
+    server.abort();
+    assert!(result.result.is_success());
+    assert_eq!(result.result.data, json!("resumed ok"));
+    assert!(get_count.load(Ordering::SeqCst) >= 1);
+    assert_eq!(
+        resume_last_ids.lock().unwrap().clone(),
+        vec!["1".to_string()]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_per_request_sse_progress_can_exceed_request_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind raw http listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let Some(request) = read_http_request(&mut stream).await else {
+                    return;
+                };
+                if request.method == "GET" {
+                    write_http_response(
+                        &mut stream,
+                        HttpResponseSpec::text(405, "background listener disabled"),
+                    )
+                    .await;
+                    return;
+                }
+
+                match request.body["method"].as_str().unwrap_or_default() {
+                    "notifications/initialized" => {
+                        write_http_response(&mut stream, HttpResponseSpec::accepted()).await;
+                    }
+                    "initialize" => {
+                        write_http_response(
+                            &mut stream,
+                            initialize_response(&request, json!({"tools": {}})),
+                        )
+                        .await;
+                    }
+                    "tools/list" => {
+                        write_http_response(
+                            &mut stream,
+                            HttpResponseSpec::json(json!({
+                                "jsonrpc": "2.0",
+                                "id": request.body["id"].clone(),
+                                "result": {
+                                    "tools": [{
+                                        "name": "long_sse",
+                                        "inputSchema": {"type": "object", "properties": {}}
+                                    }]
+                                }
+                            })),
+                        )
+                        .await;
+                    }
+                    "tools/call" => {
+                        let head = concat!(
+                            "HTTP/1.1 200 OK\r\n",
+                            "Content-Type: text/event-stream\r\n",
+                            "Connection: close\r\n\r\n"
+                        );
+                        let _ = stream.write_all(head.as_bytes()).await;
+                        for _ in 0..5 {
+                            let _ = stream.write_all(b": progress\n\n").await;
+                            let _ = stream.flush().await;
+                            tokio::time::sleep(Duration::from_millis(300)).await;
+                        }
+                        let final_event = format!(
+                            "data: {}\n\n",
+                            json!({
+                                "jsonrpc": "2.0",
+                                "id": request.body["id"].clone(),
+                                "result": {
+                                    "content": [{"type": "text", "text": "long ok"}]
+                                }
+                            })
+                        );
+                        let _ = stream.write_all(final_event.as_bytes()).await;
+                        let _ = stream.shutdown().await;
+                    }
+                    other => panic!("unexpected method: {other}"),
+                }
+            });
+        }
+    });
+
+    let mut cfg = McpServerConnectionConfig::http("http_long_sse", format!("http://{addr}"));
+    cfg.timeout_secs = 1;
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__long_sse"))
+        .expect("discover long_sse tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        tool.execute(json!({}), &ToolCallContext::test_default()),
+    )
+    .await
+    .expect("stream should outlive request timeout without hanging")
+    .expect("long SSE should succeed");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(result.result.data, json!("long ok"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_per_request_sse_rejects_oversized_line() {
+    let oversized = "x".repeat(70 * 1024);
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "oversized_sse",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::sse(format!("data: {oversized}\n\n")),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_oversized_sse", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__oversized_sse"))
+        .expect("discover oversized_sse tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let err = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect_err("oversized SSE line must be rejected");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert!(
+        format!("{err}").contains("SSE line exceeded"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_per_request_sse_rejects_retry_delay_above_limit() {
+    let resume_get_count = Arc::new(AtomicUsize::new(0));
+    let resume_get_count_for_handler = Arc::clone(&resume_get_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if request.headers.contains_key("last-event-id") {
+                resume_get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+                return HttpResponseSpec::text(500, "oversized retry should not resume");
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "huge_retry_sse",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::sse("id: 1\nretry: 86400000\ndata:\n\n"),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_huge_retry_sse", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__huge_retry_sse"))
+        .expect("discover huge_retry_sse tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let err = tokio::time::timeout(
+        Duration::from_secs(1),
+        tool.execute(json!({}), &ToolCallContext::test_default()),
+    )
+    .await
+    .expect("oversized retry must fail without sleeping for the server delay")
+    .expect_err("oversized retry delay must be rejected");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert!(
+        format!("{err}").contains("SSE retry delay exceeded"),
+        "unexpected error: {err}"
+    );
+    assert_eq!(
+        resume_get_count.load(Ordering::SeqCst),
+        0,
+        "client must reject the retry before issuing Last-Event-ID resume"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_per_request_sse_ignores_retry_delay_when_final_response_arrives() {
+    let resume_get_count = Arc::new(AtomicUsize::new(0));
+    let resume_get_count_for_handler = Arc::clone(&resume_get_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if request.headers.contains_key("last-event-id") {
+                resume_get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "final_with_retry",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::sse(format!(
+                "id: 1\nretry: 86400000\ndata: {}\n\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "content": [{"type": "text", "text": "final ok"}]
+                    }
+                })
+            )),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_final_with_retry", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__final_with_retry"))
+        .expect("discover final_with_retry tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let result = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("final response should not be rejected by an unused retry field");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(result.result.data, json!("final ok"));
+    assert_eq!(
+        resume_get_count.load(Ordering::SeqCst),
+        0,
+        "final response should complete without Last-Event-ID resume"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_resume_404_after_accepted_call_is_not_replayed() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count_for_handler = Arc::clone(&tools_call_count);
+    let resume_get_count = Arc::new(AtomicUsize::new(0));
+    let resume_get_count_for_handler = Arc::clone(&resume_get_count);
+    let tool_call_sessions = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+    let tool_call_sessions_for_handler = Arc::clone(&tool_call_sessions);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if request.headers.contains_key("last-event-id") {
+                resume_get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+                return HttpResponseSpec::text(404, "session expired");
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "resume_404",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                let n = tools_call_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                tool_call_sessions_for_handler
+                    .lock()
+                    .unwrap()
+                    .push(request.headers.get("mcp-session-id").cloned());
+                if n == 1 {
+                    HttpResponseSpec::sse(format!(
+                        "id: 1\ndata: {}\n\n",
+                        json!({
+                            "jsonrpc": "2.0",
+                            "method": "notifications/progress",
+                            "params": {"progressToken": "p", "progress": 1}
+                        })
+                    ))
+                } else {
+                    HttpResponseSpec::json(json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "content": [{"type": "text", "text": "retry ok"}]
+                        }
+                    }))
+                }
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_sse_resume_404", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__resume_404"))
+        .expect("discover resume_404 tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let err = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect_err("resume 404 after an accepted SSE call must not replay tools/call");
+
+    server.abort();
+
+    assert!(
+        format!("{err}").contains("request was accepted"),
+        "accepted-call resume failure should surface without silent replay, got: {err}"
+    );
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 1);
+    assert_eq!(resume_get_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        tool_call_sessions.lock().unwrap().as_slice(),
+        &[Some("session-1".to_string())]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_resume_404_after_body_io_error_is_not_replayed() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let resume_get_count = Arc::new(AtomicUsize::new(0));
+    let tool_call_sessions = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind raw http listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let initialize_count_for_server = Arc::clone(&initialize_count);
+    let tools_call_count_for_server = Arc::clone(&tools_call_count);
+    let resume_get_count_for_server = Arc::clone(&resume_get_count);
+    let tool_call_sessions_for_server = Arc::clone(&tool_call_sessions);
+    let server = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let initialize_count = Arc::clone(&initialize_count_for_server);
+            let tools_call_count = Arc::clone(&tools_call_count_for_server);
+            let resume_get_count = Arc::clone(&resume_get_count_for_server);
+            let tool_call_sessions = Arc::clone(&tool_call_sessions_for_server);
+            tokio::spawn(async move {
+                let Some(request) = read_http_request(&mut stream).await else {
+                    return;
+                };
+                if request.method == "GET" {
+                    let response = if request.headers.contains_key("last-event-id") {
+                        resume_get_count.fetch_add(1, Ordering::SeqCst);
+                        HttpResponseSpec::text(404, "session expired")
+                    } else {
+                        HttpResponseSpec::text(405, "background listener disabled")
+                    };
+                    write_http_response(&mut stream, response).await;
+                    return;
+                }
+
+                match request.body["method"].as_str().unwrap_or_default() {
+                    "notifications/initialized" => {
+                        write_http_response(&mut stream, HttpResponseSpec::accepted()).await;
+                    }
+                    "initialize" => {
+                        let n = initialize_count.fetch_add(1, Ordering::SeqCst) + 1;
+                        write_http_response(
+                            &mut stream,
+                            HttpResponseSpec::json_with_headers(
+                                json!({
+                                    "jsonrpc": "2.0",
+                                    "id": request.body["id"].clone(),
+                                    "result": {
+                                        "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                                        "capabilities": {"tools": {}},
+                                        "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                                    }
+                                }),
+                                vec![("MCP-Session-Id", format!("session-{n}"))],
+                            ),
+                        )
+                        .await;
+                    }
+                    "tools/list" => {
+                        write_http_response(
+                            &mut stream,
+                            HttpResponseSpec::json(json!({
+                                "jsonrpc": "2.0",
+                                "id": request.body["id"].clone(),
+                                "result": {
+                                    "tools": [{
+                                        "name": "io_error_resume_404",
+                                        "inputSchema": {"type": "object", "properties": {}}
+                                    }]
+                                }
+                            })),
+                        )
+                        .await;
+                    }
+                    "tools/call" => {
+                        let n = tools_call_count.fetch_add(1, Ordering::SeqCst) + 1;
+                        tool_call_sessions
+                            .lock()
+                            .unwrap()
+                            .push(request.headers.get("mcp-session-id").cloned());
+                        if n == 1 {
+                            let payload = format!(
+                                "id: 1\ndata: {}\n\n",
+                                json!({
+                                    "jsonrpc": "2.0",
+                                    "method": "notifications/progress",
+                                    "params": {"progressToken": "p", "progress": 1}
+                                })
+                            );
+                            let head = format!(
+                                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                                payload.len() + 1024
+                            );
+                            let _ = stream.write_all(head.as_bytes()).await;
+                            let _ = stream.write_all(payload.as_bytes()).await;
+                            let _ = stream.shutdown().await;
+                        } else {
+                            write_http_response(
+                                &mut stream,
+                                HttpResponseSpec::json(json!({
+                                    "jsonrpc": "2.0",
+                                    "id": request.body["id"].clone(),
+                                    "result": {
+                                        "content": [{"type": "text", "text": "retry ok"}]
+                                    }
+                                })),
+                            )
+                            .await;
+                        }
+                    }
+                    other => panic!("unexpected method: {other}"),
+                }
+            });
+        }
+    });
+
+    let cfg =
+        McpServerConnectionConfig::http("http_sse_io_error_resume_404", format!("http://{addr}"));
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__io_error_resume_404"))
+        .expect("discover io_error_resume_404 tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let err = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect_err("resume 404 after an accepted streaming body must not replay tools/call");
+
+    server.abort();
+
+    assert!(
+        format!("{err}").contains("request was accepted"),
+        "accepted-call resume failure should surface without silent replay, got: {err}"
+    );
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 1);
+    assert_eq!(resume_get_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        tool_call_sessions.lock().unwrap().as_slice(),
+        &[Some("session-1".to_string())]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_resume_after_session_cleared_is_not_replayed() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count_for_handler = Arc::clone(&tools_call_count);
+    let background_get_count = Arc::new(AtomicUsize::new(0));
+    let background_get_count_for_handler = Arc::clone(&background_get_count);
+    let resume_get_count = Arc::new(AtomicUsize::new(0));
+    let resume_get_count_for_handler = Arc::clone(&resume_get_count);
+    let release_background_404 = Arc::new(AtomicBool::new(false));
+    let release_background_404_for_handler = Arc::clone(&release_background_404);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if request.headers.contains_key("last-event-id") {
+                resume_get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+                return HttpResponseSpec::text(500, "resume GET should not be sent");
+            }
+            let n = background_get_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == 1 {
+                while !release_background_404_for_handler.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                return HttpResponseSpec::text(404, "session expired");
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "resume_without_session",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                let n = tools_call_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    HttpResponseSpec::sse(format!(
+                        "id: 1\nretry: 300\ndata: {}\n\n",
+                        json!({
+                            "jsonrpc": "2.0",
+                            "method": "notifications/progress",
+                            "params": {"progressToken": "p", "progress": 1}
+                        })
+                    ))
+                } else {
+                    HttpResponseSpec::json(json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "content": [{"type": "text", "text": "retry ok"}]
+                        }
+                    }))
+                }
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_resume_without_session", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            background_get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "background GET should be in flight"
+    );
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__resume_without_session"))
+        .expect("discover resume_without_session tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+    let call = tokio::spawn(async move {
+        tool.execute(json!({}), &ToolCallContext::test_default())
+            .await
+    });
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            tools_call_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "first tools/call should enter SSE resume path"
+    );
+    release_background_404.store(true, Ordering::SeqCst);
+    let err = call
+        .await
+        .expect("tool task joins")
+        .expect_err("session-cleared accepted SSE call must not be replayed");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert!(
+        format!("{err}").contains("request was accepted"),
+        "accepted-call resume failure should surface without silent replay, got: {err}"
+    );
+    assert_eq!(
+        resume_get_count.load(Ordering::SeqCst),
+        0,
+        "resume path must not send Last-Event-ID GET without a negotiated session"
+    );
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 1);
+    assert_eq!(tools_call_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_resume_after_reinitialize_is_not_replayed() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let primary_started = Arc::new(AtomicBool::new(false));
+    let primary_started_for_handler = Arc::clone(&primary_started);
+    let resetter_expired = Arc::new(AtomicBool::new(false));
+    let resetter_expired_for_handler = Arc::clone(&resetter_expired);
+    let tool_call_sessions = Arc::new(Mutex::new(Vec::<(String, Option<String>)>::new()));
+    let tool_call_sessions_for_handler = Arc::clone(&tool_call_sessions);
+    let resume_get_headers = Arc::new(Mutex::new(
+        Vec::<std::collections::HashMap<String, String>>::new(),
+    ));
+    let resume_get_headers_for_handler = Arc::clone(&resume_get_headers);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if request.headers.contains_key("last-event-id") {
+                resume_get_headers_for_handler
+                    .lock()
+                    .unwrap()
+                    .push(request.headers.clone());
+                return HttpResponseSpec::text(500, "cross-session resume GET forbidden");
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "cross_session_resume",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"message": {"type": "string"}}
+                        }
+                    }]
+                }
+            })),
+            "tools/call" => {
+                let message = request.body["params"]["arguments"]["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                tool_call_sessions_for_handler.lock().unwrap().push((
+                    message.clone(),
+                    request.headers.get("mcp-session-id").cloned(),
+                ));
+
+                if message == "primary" && !primary_started_for_handler.swap(true, Ordering::SeqCst)
+                {
+                    return HttpResponseSpec::sse("id: old-1\nretry: 1000\n\n");
+                }
+                if message == "resetter"
+                    && !resetter_expired_for_handler.swap(true, Ordering::SeqCst)
+                {
+                    return HttpResponseSpec::text(404, "session gone");
+                }
+
+                HttpResponseSpec::json(json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "content": [{"type": "text", "text": format!("{message} ok")}]
+                    }
+                }))
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_cross_session_resume", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__cross_session_resume"))
+        .expect("discover cross_session_resume tool");
+    let primary_tool = registry.get(&tool_id).expect("registry tool");
+    let resetter_tool = registry.get(&tool_id).expect("registry tool");
+
+    let primary = tokio::spawn(async move {
+        primary_tool
+            .execute(
+                json!({"message": "primary"}),
+                &ToolCallContext::test_default(),
+            )
+            .await
+    });
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            primary_started.load(Ordering::SeqCst)
+        })
+        .await,
+        "primary call should enter SSE resume sleep with old-1 cursor"
+    );
+
+    let resetter = resetter_tool
+        .execute(
+            json!({"message": "resetter"}),
+            &ToolCallContext::test_default(),
+        )
+        .await
+        .expect("resetter should reinitialize after 404");
+    assert_eq!(resetter.result.data, json!("resetter ok"));
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 2);
+
+    let primary_err = primary
+        .await
+        .expect("primary task joins")
+        .expect_err("accepted primary SSE call must not replay after another call reinitializes");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert!(
+        format!("{primary_err}").contains("request was accepted"),
+        "accepted-call resume failure should surface without silent replay, got: {primary_err}"
+    );
+    assert!(
+        resume_get_headers.lock().unwrap().is_empty(),
+        "resume path must not send session-2 + old Last-Event-ID: {:?}",
+        resume_get_headers.lock().unwrap()
+    );
+    assert_eq!(
+        tool_call_sessions.lock().unwrap().as_slice(),
+        &[
+            ("primary".to_string(), Some("session-1".to_string())),
+            ("resetter".to_string(), Some("session-1".to_string())),
+            ("resetter".to_string(), Some("session-2".to_string())),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_cancelled_notification_uses_original_session_after_reinitialize() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let resetter_expired = Arc::new(AtomicBool::new(false));
+    let resetter_expired_for_handler = Arc::clone(&resetter_expired);
+    let slow_started = Arc::new(AtomicBool::new(false));
+    let slow_started_for_handler = Arc::clone(&slow_started);
+    let tool_call_sessions = Arc::new(Mutex::new(Vec::<(String, Option<String>)>::new()));
+    let tool_call_sessions_for_handler = Arc::clone(&tool_call_sessions);
+    let cancel_sessions = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+    let cancel_sessions_for_handler = Arc::clone(&cancel_sessions);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "notifications/cancelled" => {
+                cancel_sessions_for_handler
+                    .lock()
+                    .unwrap()
+                    .push(request.headers.get("mcp-session-id").cloned());
+                HttpResponseSpec::accepted()
+            }
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "cancel_session_race",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {"message": {"type": "string"}}
+                        }
+                    }]
+                }
+            })),
+            "tools/call" => {
+                let message = request.body["params"]["arguments"]["message"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                tool_call_sessions_for_handler.lock().unwrap().push((
+                    message.clone(),
+                    request.headers.get("mcp-session-id").cloned(),
+                ));
+
+                if message == "slow" {
+                    slow_started_for_handler.store(true, Ordering::SeqCst);
+                    return HttpResponseSpec::sse("id: slow-1\nretry: 5000\ndata:\n\n");
+                }
+                if message == "resetter"
+                    && !resetter_expired_for_handler.swap(true, Ordering::SeqCst)
+                {
+                    return HttpResponseSpec::text(404, "session gone");
+                }
+
+                HttpResponseSpec::json(json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "content": [{"type": "text", "text": format!("{message} ok")}]
+                    }
+                }))
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_cancel_session_race", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__cancel_session_race"))
+        .expect("discover cancel_session_race tool");
+    let slow_tool = registry.get(&tool_id).expect("registry tool");
+    let resetter_tool = registry.get(&tool_id).expect("registry tool");
+
+    let token = CancellationToken::new();
+    let mut slow_ctx = ToolCallContext::test_default();
+    slow_ctx.cancellation_token = Some(token.clone());
+    let slow = tokio::spawn(async move {
+        slow_tool
+            .execute(json!({"message": "slow"}), &slow_ctx)
+            .await
+    });
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            slow_started.load(Ordering::SeqCst)
+        })
+        .await,
+        "slow call should enter per-request SSE under session-1"
+    );
+
+    let resetter = resetter_tool
+        .execute(
+            json!({"message": "resetter"}),
+            &ToolCallContext::test_default(),
+        )
+        .await
+        .expect("resetter should reinitialize after POST 404");
+    assert_eq!(resetter.result.data, json!("resetter ok"));
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 2);
+
+    token.cancel();
+    let slow_err = slow
+        .await
+        .expect("slow task joins")
+        .expect_err("slow call should return cancellation");
+    assert!(
+        format!("{slow_err}").contains("cancel"),
+        "expected cancellation error, got: {slow_err}"
+    );
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(
+        cancel_sessions.lock().unwrap().as_slice(),
+        &[Some("session-1".to_string())],
+        "cancellation must use the original tools/call session, not session-2"
+    );
+    assert_eq!(
+        tool_call_sessions.lock().unwrap().as_slice(),
+        &[
+            ("slow".to_string(), Some("session-1".to_string())),
+            ("resetter".to_string(), Some("session-1".to_string())),
+            ("resetter".to_string(), Some("session-2".to_string())),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_final_event_without_newline_is_processed() {
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "unterminated_sse",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::sse(format!(
+                "data: {}",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "content": [{"type": "text", "text": "unterminated ok"}]
+                    }
+                })
+            )),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_unterminated_sse", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__unterminated_sse"))
+        .expect("discover unterminated_sse tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let result = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("unterminated final SSE event should be processed");
+
+    server.abort();
+
+    assert_eq!(result.result.data, json!("unterminated ok"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_id_reset_clears_resume_cursor() {
+    let resume_last_ids = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let resume_last_ids_for_handler = Arc::clone(&resume_last_ids);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if let Some(last_event_id) = request.headers.get("last-event-id").cloned() {
+                resume_last_ids_for_handler
+                    .lock()
+                    .unwrap()
+                    .push(last_event_id);
+            }
+            return HttpResponseSpec::text(405, "no resumable cursor");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "reset_cursor",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::sse(format!(
+                "id: 1\ndata: {}\n\nid:\ndata: {}\n\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/progress",
+                    "params": {
+                        "progressToken": request.body["params"]["_meta"]["progressToken"].clone(),
+                        "progress": 1.0
+                    }
+                }),
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/progress",
+                    "params": {
+                        "progressToken": request.body["params"]["_meta"]["progressToken"].clone(),
+                        "progress": 2.0
+                    }
+                })
+            )),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_sse_id_reset", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__reset_cursor"))
+        .expect("discover reset cursor tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let err = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect_err("missing final response after id reset should fail without resume");
+
+    server.abort();
+    assert!(
+        format!("{err}").contains("Missing response"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        resume_last_ids.lock().unwrap().is_empty(),
+        "empty id: must clear stale Last-Event-ID, got {:?}",
+        resume_last_ids.lock().unwrap()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_resume_rejects_non_sse_content_type() {
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if request.headers.contains_key("last-event-id") {
+                return HttpResponseSpec::json(json!({"status": "not-sse"}));
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "bad_resume_type",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::sse(format!(
+                "id: 1\ndata: {}\n\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/progress",
+                    "params": {
+                        "progressToken": request.body["params"]["_meta"]["progressToken"].clone(),
+                        "progress": 1.0
+                    }
+                })
+            )),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_bad_resume_type", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__bad_resume_type"))
+        .expect("discover bad resume tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let err = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect_err("resume GET with JSON content-type must fail");
+
+    server.abort();
+    assert!(
+        format!("{err}").contains("expected Content-Type text/event-stream"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_sse_resume_rejects_response_for_different_request_id() {
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            if request.headers.contains_key("last-event-id") {
+                return HttpResponseSpec::sse(format!(
+                    "id: 2\ndata: {}\n\n",
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 999,
+                        "result": {
+                            "content": [{"type": "text", "text": "wrong stream"}]
+                        }
+                    })
+                ));
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "wrong_resume",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => HttpResponseSpec::sse(format!(
+                "id: 1\ndata: {}\n\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/progress",
+                    "params": {
+                        "progressToken": request.body["params"]["_meta"]["progressToken"].clone(),
+                        "progress": 1.0
+                    }
+                })
+            )),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_wrong_resume", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__wrong_resume"))
+        .expect("discover wrong resume tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+
+    let err = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect_err("wrong response id on resumed stream must fail");
+
+    server.abort();
+    assert!(
+        format!("{err}").contains("returned response for different id"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn manager_close_all_sends_http_delete_for_live_session() {
+    let delete_sessions = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let delete_sessions_for_handler = Arc::clone(&delete_sessions);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "no listening stream");
+        }
+        if request.method == "DELETE" {
+            delete_sessions_for_handler
+                .lock()
+                .unwrap()
+                .push(request.headers["mcp-session-id"].clone());
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_close_all", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+
+    manager.close_all().await.expect("close all transports");
+    server.abort();
+
+    assert_eq!(
+        delete_sessions.lock().unwrap().clone(),
+        vec!["test-session".to_string()]
+    );
+    assert!(manager.registry().ids().is_empty());
+}
+
 #[tokio::test]
 async fn http_non_success_status_is_reported() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
@@ -1695,9 +3646,1296 @@ async fn http_non_success_status_is_reported() {
     assert!(matches!(err, McpError::Transport(_)));
 }
 
+/// R9 #3 / R10 #5 regression: after initialize, the HTTP transport
+/// opens a background GET listening stream so the server can push
+/// notifications (and requests) that aren't tied to a POST response.
+/// We assert the full chain end-to-end: a server-pushed
+/// `notifications/tools/list_changed` on the GET stream drives the
+/// manager's watcher to re-run `tools/list`. Before R9, no GET
+/// listener existed and the notification was unreachable during idle
+/// periods.
+#[tokio::test]
+async fn http_listening_stream_drives_tools_refresh() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let tools_list_count = Arc::new(AtomicUsize::new(0));
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let tools_list_count_clone = Arc::clone(&tools_list_count);
+    let get_count_clone = Arc::clone(&get_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        // GET = the background listening stream that R9 #3 added.
+        // First GET responds with a single list_changed SSE event,
+        // then closes; subsequent GETs (the listener reconnects after
+        // each clean close) return 405 so the listener gives up
+        // gracefully after proving the reconnect path was entered.
+        if request.method == "GET" {
+            let n = get_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == 1 {
+                return HttpResponseSpec::sse(
+                    "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}\n\n"
+                        .to_string(),
+                );
+            }
+            return HttpResponseSpec::text(405, "no more streams");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({})),
+            "tools/list" => {
+                let n = tools_list_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                // Issue a different tool catalog on the refresh so we
+                // can also verify the rebuild_snapshot path (R8 #3)
+                // surfaces the new tool through the manager — not
+                // just that refresh_server ran.
+                let tool_name = if n == 1 { "echo" } else { "echov2" };
+                HttpResponseSpec::json(json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "tools": [{
+                            "name": tool_name,
+                            "inputSchema": {"type": "object", "properties": {}}
+                        }]
+                    }
+                }))
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_listener", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+
+    // Discovery ran tools/list once during connect. Initial catalog
+    // is "echo".
+    let registry = manager.registry();
+    let initial_ids: Vec<String> = registry.ids().into_iter().collect();
+    assert!(
+        initial_ids.iter().any(|id| id.contains("echo")),
+        "initial registry must contain echo. ids = {initial_ids:?}"
+    );
+    assert!(
+        !initial_ids.iter().any(|id| id.contains("echov2")),
+        "initial registry must NOT contain echov2. ids = {initial_ids:?}"
+    );
+
+    // Wait for: (a) the background GET to be issued; (b) the
+    // list_changed event to propagate; (c) the watcher to call
+    // tools/list a second time; (d) rebuild_snapshot to publish.
+    let observed = wait_until(Duration::from_secs(5), Duration::from_millis(50), || {
+        let manager_ids: Vec<String> = manager.registry().ids().into_iter().collect();
+        manager_ids.iter().any(|id| id.contains("echov2"))
+    })
+    .await;
+
+    server.abort();
+
+    assert!(
+        observed,
+        "expected echov2 to appear in registry after list_changed-driven refresh. \
+         tools/list count = {}, GET count = {}",
+        tools_list_count.load(Ordering::SeqCst),
+        get_count.load(Ordering::SeqCst)
+    );
+
+    // Sanity: the listener actually fired and was the trigger.
+    assert!(
+        get_count.load(Ordering::SeqCst) >= 1,
+        "GET listening stream must have been opened at least once"
+    );
+    assert!(
+        tools_list_count.load(Ordering::SeqCst) >= 2,
+        "tools/list must have run at least twice (discovery + refresh)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_listening_stream_backs_off_on_non_sse_success() {
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+            return HttpResponseSpec::json(json!({"status": "not-sse"}));
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_listener_non_sse", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "background GET should be attempted"
+    );
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(
+        get_count.load(Ordering::SeqCst),
+        1,
+        "non-SSE 200 response should back off instead of hot-looping"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_listening_stream_respects_retry_after_clean_close() {
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+            return HttpResponseSpec::sse("retry: 500\n\n");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_listener_retry", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "background GET should be attempted"
+    );
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(
+        get_count.load(Ordering::SeqCst),
+        1,
+        "retry: 500 should prevent an immediate clean-close reconnect"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_listening_stream_404_pauses_until_reinitialize() {
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+    let expire_get = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let expire_get_for_handler = Arc::clone(&expire_get);
+    let get_headers = Arc::new(Mutex::new(
+        Vec::<std::collections::HashMap<String, String>>::new(),
+    ));
+    let get_headers_for_handler = Arc::clone(&get_headers);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            get_count_for_handler.fetch_add(1, Ordering::SeqCst);
+            get_headers_for_handler
+                .lock()
+                .unwrap()
+                .push(request.headers.clone());
+            if expire_get_for_handler.load(Ordering::SeqCst) {
+                return HttpResponseSpec::text(404, "session expired");
+            }
+            return HttpResponseSpec::sse("retry: 1000\n\n");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => initialize_response(&request, json!({"tools": {}})),
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_listener_404_pause", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "initial background GET should be attempted"
+    );
+    expire_get.store(true, Ordering::SeqCst);
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 2
+        })
+        .await,
+        "listener should observe the session-expired 404"
+    );
+    tokio::time::sleep(Duration::from_millis(700)).await;
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    let headers = get_headers.lock().unwrap().clone();
+    assert_eq!(
+        headers.len(),
+        2,
+        "listener must not keep issuing GETs while protocol_version is cleared"
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|headers| headers.contains_key("mcp-protocol-version")),
+        "every GET issued by an initialized listener must carry MCP-Protocol-Version: {headers:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_listening_stream_drops_last_event_id_after_reinitialize() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count_for_handler = Arc::clone(&tools_call_count);
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+    let get_headers = Arc::new(Mutex::new(
+        Vec::<std::collections::HashMap<String, String>>::new(),
+    ));
+    let get_headers_for_handler = Arc::clone(&get_headers);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            let n = get_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+            get_headers_for_handler
+                .lock()
+                .unwrap()
+                .push(request.headers.clone());
+            if n == 1 {
+                return HttpResponseSpec::sse("id: old-1\nretry: 300\n\n");
+            }
+            return HttpResponseSpec::text(405, "listener stopped");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "listener_cursor",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                let n = tools_call_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    HttpResponseSpec::text(404, "session gone")
+                } else {
+                    HttpResponseSpec::json(json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "content": [{"type": "text", "text": "retry ok"}]
+                        }
+                    }))
+                }
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_listener_cursor", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "listener should capture an event id on session-1"
+    );
+
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__listener_cursor"))
+        .expect("discover listener_cursor tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+    let result = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("tools/call should reinitialize after 404");
+    assert_eq!(result.result.data, json!("retry ok"));
+
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 2
+        })
+        .await,
+        "listener should reconnect after reinitialize"
+    );
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 2);
+    assert_eq!(tools_call_count.load(Ordering::SeqCst), 2);
+    let headers = get_headers.lock().unwrap().clone();
+    assert!(
+        headers.len() >= 2,
+        "expected at least two listener GETs, got {headers:?}"
+    );
+    assert_eq!(
+        headers[1].get("mcp-session-id"),
+        Some(&"session-2".to_string())
+    );
+    assert!(
+        !headers[1].contains_key("last-event-id"),
+        "new session must not inherit old Last-Event-ID: {:?}",
+        headers[1]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_listening_stream_request_is_not_answered_on_new_session() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count_for_handler = Arc::clone(&tools_call_count);
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+    let release_stale_stream = Arc::new(AtomicBool::new(false));
+    let release_stale_stream_for_handler = Arc::clone(&release_stale_stream);
+    let stale_stream_sent = Arc::new(AtomicBool::new(false));
+    let stale_stream_sent_for_handler = Arc::clone(&stale_stream_sent);
+    let listener_response_posts = Arc::new(Mutex::new(Vec::<HttpRequestSpec>::new()));
+    let listener_response_posts_for_handler = Arc::clone(&listener_response_posts);
+
+    let main_handler = Arc::new(move |request: HttpRequestSpec| {
+        if request.method == "GET" {
+            let n = get_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == 1 {
+                while !release_stale_stream_for_handler.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                stale_stream_sent_for_handler.store(true, Ordering::SeqCst);
+                return HttpResponseSpec::sse(format!(
+                    "data: {}\n\n",
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": 77,
+                        "method": "roots/list"
+                    })
+                ));
+            }
+            return HttpResponseSpec::text(405, "listener stopped");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "stale_listener_request",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                let n = tools_call_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    HttpResponseSpec::text(404, "session gone")
+                } else {
+                    HttpResponseSpec::json(json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "content": [{"type": "text", "text": "retry ok"}]
+                        }
+                    }))
+                }
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    });
+    let response_handler = Arc::new(move |request: HttpRequestSpec| {
+        listener_response_posts_for_handler
+            .lock()
+            .unwrap()
+            .push(request);
+        HttpResponseSpec::accepted()
+    });
+    let (endpoint, server) =
+        spawn_http_server_with_response_handler(main_handler, Some(response_handler)).await;
+
+    let cfg = McpServerConnectionConfig::http("http_stale_listener_request", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "session-1 listener GET should be in flight"
+    );
+
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__stale_listener_request"))
+        .expect("discover stale_listener_request tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+    let result = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("tools/call should reinitialize after 404");
+    assert_eq!(result.result.data, json!("retry ok"));
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 2);
+
+    release_stale_stream.store(true, Ordering::SeqCst);
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            stale_stream_sent.load(Ordering::SeqCst)
+        })
+        .await,
+        "stale session-1 stream should send its server request"
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert!(
+        listener_response_posts.lock().unwrap().is_empty(),
+        "client must not answer stale stream requests using the new session: {:?}",
+        listener_response_posts
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|request| request.headers.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_listener_404_after_initialize_forces_next_call_reinitialize() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+    let release_get_404 = Arc::new(AtomicBool::new(false));
+    let release_get_404_for_handler = Arc::clone(&release_get_404);
+    let get_404_count = Arc::new(AtomicUsize::new(0));
+    let get_404_count_for_handler = Arc::clone(&get_404_count);
+    let tool_call_sessions = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+    let tool_call_sessions_for_handler = Arc::clone(&tool_call_sessions);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            let n = get_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == 1 {
+                while !release_get_404_for_handler.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                get_404_count_for_handler.fetch_add(1, Ordering::SeqCst);
+                return HttpResponseSpec::text(404, "session expired");
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                tool_call_sessions_for_handler
+                    .lock()
+                    .unwrap()
+                    .push(request.headers.get("mcp-session-id").cloned());
+                HttpResponseSpec::json(json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "content": [{"type": "text", "text": "ok"}]
+                    }
+                }))
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_listener_init_404", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "listener GET should be issued after initialize capabilities are committed"
+    );
+    release_get_404.store(true, Ordering::SeqCst);
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_404_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "listener should observe immediate session-expired 404"
+    );
+
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__echo"))
+        .expect("discover echo tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+    tool.execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("next call should reinitialize after listener 404");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(
+        initialize_count.load(Ordering::SeqCst),
+        2,
+        "listener 404 after initialize must clear capabilities so the next call reinitializes"
+    );
+    assert_eq!(
+        tool_call_sessions.lock().unwrap().as_slice(),
+        &[Some("session-2".to_string())]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn http_listener_response_404_resets_session_before_next_call() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let response_404_count = Arc::new(AtomicUsize::new(0));
+    let response_404_count_for_handler = Arc::clone(&response_404_count);
+    let tool_call_sessions = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+    let tool_call_sessions_for_handler = Arc::clone(&tool_call_sessions);
+
+    let main_handler = Arc::new(move |request: HttpRequestSpec| {
+        if request.method == "GET" {
+            return HttpResponseSpec::sse(format!(
+                "data: {}\n\n",
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "roots/list"
+                })
+            ));
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                tool_call_sessions_for_handler
+                    .lock()
+                    .unwrap()
+                    .push(request.headers.get("mcp-session-id").cloned());
+                HttpResponseSpec::json(json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "content": [{"type": "text", "text": "ok"}]
+                    }
+                }))
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    });
+    let response_handler = Arc::new(move |_request: HttpRequestSpec| {
+        response_404_count_for_handler.fetch_add(1, Ordering::SeqCst);
+        HttpResponseSpec::text(404, "session expired")
+    });
+    let (endpoint, server) =
+        spawn_http_server_with_response_handler(main_handler, Some(response_handler)).await;
+
+    let cfg = McpServerConnectionConfig::http("http_listener_response_404", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            response_404_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "listener should POST a response and observe the 404"
+    );
+
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__echo"))
+        .expect("discover echo tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+    tool.execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("call should reinitialize after listener response 404");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert!(
+        initialize_count.load(Ordering::SeqCst) >= 2,
+        "listener response 404 should force a fresh initialize before the next call"
+    );
+    assert_eq!(
+        tool_call_sessions.lock().unwrap().as_slice(),
+        &[Some("session-2".to_string())],
+        "next tool call should use the reinitialized session"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stale_listener_get_404_does_not_clear_fresh_session() {
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count_for_handler = Arc::clone(&initialize_count);
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+    let release_stale_get = Arc::new(AtomicBool::new(false));
+    let release_stale_get_for_handler = Arc::clone(&release_stale_get);
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count_for_handler = Arc::clone(&tools_call_count);
+    let tool_call_sessions = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
+    let tool_call_sessions_for_handler = Arc::clone(&tool_call_sessions);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            let n = get_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+            if n == 1 {
+                while !release_stale_get_for_handler.load(Ordering::SeqCst) {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                return HttpResponseSpec::text(404, "old session expired");
+            }
+            return HttpResponseSpec::text(405, "background listener disabled");
+        }
+        if request.method == "DELETE" {
+            return HttpResponseSpec::text(200, "");
+        }
+
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "test-server", "version": "1.0.0"}
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{
+                        "name": "echo",
+                        "inputSchema": {"type": "object", "properties": {}}
+                    }]
+                }
+            })),
+            "tools/call" => {
+                let n = tools_call_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                tool_call_sessions_for_handler
+                    .lock()
+                    .unwrap()
+                    .push(request.headers.get("mcp-session-id").cloned());
+                if n == 1 {
+                    HttpResponseSpec::text(404, "session expired")
+                } else {
+                    HttpResponseSpec::json(json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "content": [{"type": "text", "text": format!("call #{n} ok")}]
+                        }
+                    }))
+                }
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_stale_listener_404", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 1
+        })
+        .await,
+        "background GET should be in flight under session-1"
+    );
+
+    let registry = manager.registry();
+    let tool_id = registry
+        .ids()
+        .into_iter()
+        .find(|id| id.ends_with("__echo"))
+        .expect("discover echo tool");
+    let tool = registry.get(&tool_id).expect("registry tool");
+    tool.execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("first call should reinitialize after POST 404");
+    assert_eq!(
+        initialize_count.load(Ordering::SeqCst),
+        2,
+        "first call should install session-2"
+    );
+
+    release_stale_get.store(true, Ordering::SeqCst);
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            get_count.load(Ordering::SeqCst) >= 2
+        })
+        .await,
+        "listener should continue after the stale 404 without clearing session-2"
+    );
+
+    tool.execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("second call should keep using session-2");
+
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    assert_eq!(
+        initialize_count.load(Ordering::SeqCst),
+        2,
+        "stale listener 404 must not force a third initialize"
+    );
+    assert_eq!(
+        tool_call_sessions.lock().unwrap().as_slice(),
+        &[
+            Some("session-1".to_string()),
+            Some("session-2".to_string()),
+            Some("session-2".to_string())
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn factory_only_sampling_rejects_background_get_request() {
+    struct OkSamplingHandler;
+
+    #[async_trait]
+    impl SamplingHandler for OkSamplingHandler {
+        async fn handle_create_message(
+            &self,
+            _params: CreateMessageParams,
+        ) -> Result<CreateMessageResult, McpTransportError> {
+            use mcp::{Role, SamplingContent};
+            Ok(CreateMessageResult {
+                role: Role::Assistant,
+                content: vec![SamplingContent::Text {
+                    text: "ok".to_string(),
+                    annotations: None,
+                    meta: None,
+                }],
+                model: "test-model".to_string(),
+                stop_reason: None,
+                meta: None,
+            })
+        }
+    }
+
+    struct AlwaysSamplingFactory {
+        handler: Arc<dyn SamplingHandler>,
+    }
+
+    #[async_trait]
+    impl SamplingHandlerFactory for AlwaysSamplingFactory {
+        async fn for_agent(&self, _agent_spec: &AgentSpec) -> Option<Arc<dyn SamplingHandler>> {
+            Some(Arc::clone(&self.handler))
+        }
+    }
+
+    let get_count = Arc::new(AtomicUsize::new(0));
+    let get_count_for_handler = Arc::clone(&get_count);
+    let initialize_capabilities = Arc::new(std::sync::Mutex::new(None::<Value>));
+    let initialize_capabilities_for_handler = Arc::clone(&initialize_capabilities);
+    let sampling_responses = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+    let sampling_responses_for_observer = Arc::clone(&sampling_responses);
+
+    let (endpoint, server) = spawn_http_server_with_response_observer(
+        Arc::new(move |request| {
+            if request.method == "GET" {
+                let n = get_count_for_handler.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    return HttpResponseSpec::sse(format!(
+                        "data: {}\n\n",
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": 99,
+                            "method": "sampling/createMessage",
+                            "params": {
+                                "messages": [],
+                                "maxTokens": 1
+                            }
+                        })
+                    ));
+                }
+                return HttpResponseSpec::text(405, "listening stream closed");
+            }
+            if request.method == "DELETE" {
+                return HttpResponseSpec::text(200, "");
+            }
+
+            match request.body["method"].as_str().unwrap_or_default() {
+                "notifications/initialized" => HttpResponseSpec::accepted(),
+                "initialize" => {
+                    *initialize_capabilities_for_handler.lock().unwrap() =
+                        Some(request.body["params"]["capabilities"].clone());
+                    initialize_response(&request, json!({"tools": {}}))
+                }
+                "tools/list" => HttpResponseSpec::json(json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {
+                        "tools": [{
+                            "name": "echo",
+                            "inputSchema": {"type": "object", "properties": {}}
+                        }]
+                    }
+                })),
+                other => panic!("unexpected method: {other}"),
+            }
+        }),
+        Some(Arc::new(move |request| {
+            sampling_responses_for_observer
+                .lock()
+                .unwrap()
+                .push(request.body);
+        })),
+    )
+    .await;
+
+    let handler = Arc::new(OkSamplingHandler) as Arc<dyn SamplingHandler>;
+    let factory = Arc::new(AlwaysSamplingFactory { handler }) as Arc<dyn SamplingHandlerFactory>;
+    let cfg = McpServerConnectionConfig::http("http_factory_only_sampling", endpoint);
+    let manager = McpToolRegistryManager::connect_with_sampling_factory([cfg], None, Some(factory))
+        .await
+        .expect("connect factory-only sampling registry");
+
+    assert!(
+        !initialize_capabilities
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("initialize capabilities captured")
+            .as_object()
+            .expect("capabilities object")
+            .contains_key("sampling"),
+        "factory-only sampling must not advertise global sampling capability"
+    );
+    assert!(
+        wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
+            !sampling_responses.lock().unwrap().is_empty()
+        })
+        .await,
+        "background GET sampling response should be posted"
+    );
+    manager.close_all().await.expect("close manager");
+    server.abort();
+
+    let responses = sampling_responses.lock().unwrap();
+    let response = responses.first().expect("sampling error response");
+    assert_eq!(response["id"], json!(99));
+    assert_eq!(response["error"]["code"], json!(-32601));
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("Sampling not supported")
+    );
+}
+
+/// R8 #5 / R10 #4 regression: HTTP `call_tool` retries once on 404
+/// "MCP session expired". The first `tools/call` after a session
+/// invalidation gets a 404; the transport must `reset_session`,
+/// re-initialize, allocate a fresh request id, and re-send. Without
+/// the retry, every `tools/call` after a server-side session purge
+/// fails — even though the spec explicitly allows reconnection.
+#[tokio::test]
+async fn http_call_tool_retries_once_on_session_expired() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count_clone = Arc::clone(&tools_call_count);
+    let initialize_count_clone = Arc::clone(&initialize_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "no listening stream");
+        }
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                // Issue a fresh session id on each initialize so the
+                // test can detect that a NEW session was established
+                // (the second one) rather than the original being reused.
+                let n = initialize_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {},
+                            "serverInfo": {
+                                "name": "test-server",
+                                "version": "1.0.0"
+                            }
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{"name": "echo", "inputSchema": {"type": "object", "properties": {}}}]
+                }
+            })),
+            "tools/call" => {
+                let n = tools_call_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    // First call: simulate session expiry. The 404
+                    // path in `post_message` maps this to
+                    // `ProtocolError("MCP session expired")` when the
+                    // request carried a session id (which it did,
+                    // because initialize set one). The retry loop in
+                    // HTTP `call_tool` then resets + re-initializes +
+                    // retries with a new id.
+                    HttpResponseSpec::text(404, "session gone")
+                } else {
+                    HttpResponseSpec::json(json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "content": [{"type": "text", "text": format!("call #{n} ok")}]
+                        }
+                    }))
+                }
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_session_retry", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry.ids().into_iter().next().unwrap();
+    let tool = registry.get(&tool_id).unwrap();
+    let status_before = manager
+        .server_status_snapshot("http_session_retry")
+        .await
+        .expect("initial server status");
+    assert_eq!(status_before.session_id.as_deref(), Some("session-1"));
+    let initial_last_init_at = status_before
+        .last_init_at
+        .expect("initial last_init_at should be set");
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let ctx = ToolCallContext::test_default();
+    let result = tool
+        .execute(json!({"message":"x"}), &ctx)
+        .await
+        .expect("call_tool should succeed via session-expired retry");
+    let status_after = manager
+        .server_status_snapshot("http_session_retry")
+        .await
+        .expect("status after silent reinitialize");
+
+    server.abort();
+
+    // The second tools/call (retry) succeeded — the result text
+    // contains the "call #2 ok" from our handler.
+    let text = result.result.data.to_string();
+    assert!(
+        text.contains("call #2 ok"),
+        "expected retry response in result, got: {text}"
+    );
+    assert_eq!(status_after.session_id.as_deref(), Some("session-2"));
+    assert!(
+        status_after.last_init_at.expect("updated last_init_at") > initial_last_init_at,
+        "silent reinitialize must update live last_init_at; before={initial_last_init_at:?}, after={:?}",
+        status_after.last_init_at
+    );
+
+    // Verify the wire trace: initialize ran twice (original + post-404
+    // re-initialize), and tools/call ran twice (first 404'd, second
+    // succeeded). One retry, not infinite.
+    assert_eq!(
+        initialize_count.load(Ordering::SeqCst),
+        2,
+        "initialize must run twice: original + retry after session reset"
+    );
+    assert_eq!(
+        tools_call_count.load(Ordering::SeqCst),
+        2,
+        "tools/call must run twice: first 404, retry succeeds. No infinite retry."
+    );
+}
+
+#[tokio::test]
+async fn manager_uses_live_capabilities_after_http_silent_reinitialize() {
+    let tools_call_count = Arc::new(AtomicUsize::new(0));
+    let initialize_count = Arc::new(AtomicUsize::new(0));
+    let subscribe_count = Arc::new(AtomicUsize::new(0));
+    let tools_call_count_clone = Arc::clone(&tools_call_count);
+    let initialize_count_clone = Arc::clone(&initialize_count);
+    let subscribe_count_clone = Arc::clone(&subscribe_count);
+
+    let (endpoint, server) = spawn_http_server(Arc::new(move |request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "no listening stream");
+        }
+        match request.body["method"].as_str().unwrap_or_default() {
+            "notifications/initialized" => HttpResponseSpec::accepted(),
+            "initialize" => {
+                let n = initialize_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                let can_subscribe = n >= 2;
+                HttpResponseSpec::json_with_headers(
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "protocolVersion": mcp::MCP_PROTOCOL_VERSION,
+                            "capabilities": {
+                                "resources": {"subscribe": can_subscribe}
+                            },
+                            "serverInfo": {
+                                "name": "test-server",
+                                "version": "1.0.0"
+                            }
+                        }
+                    }),
+                    vec![("MCP-Session-Id", format!("session-{n}"))],
+                )
+            }
+            "tools/list" => HttpResponseSpec::json(json!({
+                "jsonrpc": "2.0",
+                "id": request.body["id"].clone(),
+                "result": {
+                    "tools": [{"name": "echo", "inputSchema": {"type": "object", "properties": {}}}]
+                }
+            })),
+            "tools/call" => {
+                let n = tools_call_count_clone.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    HttpResponseSpec::text(404, "session gone")
+                } else {
+                    HttpResponseSpec::json(json!({
+                        "jsonrpc": "2.0",
+                        "id": request.body["id"].clone(),
+                        "result": {
+                            "content": [{"type": "text", "text": "retry ok"}]
+                        }
+                    }))
+                }
+            }
+            "resources/subscribe" => {
+                subscribe_count_clone.fetch_add(1, Ordering::SeqCst);
+                HttpResponseSpec::json(json!({
+                    "jsonrpc": "2.0",
+                    "id": request.body["id"].clone(),
+                    "result": {}
+                }))
+            }
+            other => panic!("unexpected method: {other}"),
+        }
+    }))
+    .await;
+
+    let cfg = McpServerConnectionConfig::http("http_live_caps_retry", endpoint);
+    let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let registry = manager.registry();
+    let tool_id = registry.ids().into_iter().next().unwrap();
+    let tool = registry.get(&tool_id).unwrap();
+    tool.execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .expect("call_tool should reinitialize after session expiry");
+
+    manager
+        .subscribe_resource("http_live_caps_retry", "file:///tmp/item")
+        .await
+        .expect("manager should gate subscribe with live post-reinitialize capabilities");
+
+    server.abort();
+
+    assert_eq!(initialize_count.load(Ordering::SeqCst), 2);
+    assert_eq!(tools_call_count.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        subscribe_count.load(Ordering::SeqCst),
+        1,
+        "subscribe_resource should be sent after live capabilities refresh"
+    );
+}
+
 #[tokio::test]
 async fn http_call_tool_with_is_error_result_returns_server_error() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "no listening stream");
+        }
         match request.body["method"].as_str().unwrap_or_default() {
             "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({})),
@@ -1742,6 +4980,9 @@ async fn http_call_tool_with_is_error_result_returns_server_error() {
 #[tokio::test]
 async fn http_call_tool_preserves_structured_content() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "no listening stream");
+        }
         match request.body["method"].as_str().unwrap_or_default() {
             "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({})),
@@ -1786,6 +5027,9 @@ async fn http_call_tool_preserves_structured_content() {
 #[tokio::test]
 async fn http_list_prompts_parses_prompt_definitions() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "no listening stream");
+        }
         match request.body["method"].as_str().unwrap_or_default() {
             "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({"prompts": {}})),
@@ -1828,6 +5072,9 @@ async fn http_list_prompts_parses_prompt_definitions() {
 #[tokio::test]
 async fn http_list_resources_parses_resource_definitions() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
+        if request.method == "GET" {
+            return HttpResponseSpec::text(405, "no listening stream");
+        }
         match request.body["method"].as_str().unwrap_or_default() {
             "notifications/initialized" => HttpResponseSpec::accepted(),
             "initialize" => initialize_response(&request, json!({"resources": {}})),

--- a/crates/awaken-ext-mcp/tests/mcp_tests.rs
+++ b/crates/awaken-ext-mcp/tests/mcp_tests.rs
@@ -80,7 +80,7 @@ impl McpToolTransport for FakeTransport {
         &self,
         name: &str,
         args: Value,
-        _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         self.calls.lock().unwrap().push((name.to_string(), args));
@@ -105,20 +105,62 @@ impl McpToolTransport for FakeProgressTransport {
         &self,
         _name: &str,
         _args: Value,
-        progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         if let Some(progress_tx) = progress_tx {
-            let _ = progress_tx.send(McpProgressUpdate {
+            let _ = progress_tx.try_send(McpProgressUpdate {
                 progress: 3.0,
                 total: Some(10.0),
                 message: Some("working".to_string()),
             });
-            let _ = progress_tx.send(McpProgressUpdate {
+            let _ = progress_tx.try_send(McpProgressUpdate {
                 progress: 10.0,
                 total: Some(10.0),
                 message: Some("done".to_string()),
             });
+        }
+        Ok(ok_text_result("ok"))
+    }
+
+    fn transport_type(&self) -> TransportTypeId {
+        TransportTypeId::Stdio
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FakeProgressFloodTransport {
+    attempted: Arc<AtomicUsize>,
+    accepted: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl McpToolTransport for FakeProgressFloodTransport {
+    async fn list_tools(&self) -> Result<Vec<McpToolDefinition>, McpTransportError> {
+        Ok(vec![McpToolDefinition::new("echo")])
+    }
+
+    async fn call_tool(
+        &self,
+        _name: &str,
+        _args: Value,
+        progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
+        _context: awaken_ext_mcp::McpCallContext,
+    ) -> Result<CallToolResult, McpTransportError> {
+        if let Some(progress_tx) = progress_tx {
+            for i in 0..10_000usize {
+                self.attempted.fetch_add(1, Ordering::SeqCst);
+                if progress_tx
+                    .try_send(McpProgressUpdate {
+                        progress: i as f64,
+                        total: Some(10_000.0),
+                        message: None,
+                    })
+                    .is_ok()
+                {
+                    self.accepted.fetch_add(1, Ordering::SeqCst);
+                }
+            }
         }
         Ok(ok_text_result("ok"))
     }
@@ -143,7 +185,7 @@ impl McpToolTransport for FakeStructuredTransport {
         &self,
         _name: &str,
         _args: Value,
-        _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(self.result.clone())
@@ -243,7 +285,7 @@ impl McpToolTransport for FakeCatalogTransport {
         &self,
         _name: &str,
         _args: Value,
-        _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(ok_text_result("ok"))
@@ -269,6 +311,7 @@ impl McpToolTransport for FakeCatalogTransport {
 struct FakeUiTransport {
     tools: Vec<McpToolDefinition>,
     resources: HashMap<String, (String, String)>, // uri -> (text, mimeType)
+    read_delay: Option<Duration>,
 }
 
 impl FakeUiTransport {
@@ -276,6 +319,7 @@ impl FakeUiTransport {
         Self {
             tools,
             resources: HashMap::new(),
+            read_delay: None,
         }
     }
 
@@ -287,6 +331,11 @@ impl FakeUiTransport {
     ) -> Self {
         self.resources
             .insert(uri.into(), (text.into(), mime.into()));
+        self
+    }
+
+    fn with_read_delay(mut self, delay: Duration) -> Self {
+        self.read_delay = Some(delay);
         self
     }
 }
@@ -301,7 +350,7 @@ impl McpToolTransport for FakeUiTransport {
         &self,
         _name: &str,
         _args: Value,
-        _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
         _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(ok_text_result("ok"))
@@ -312,6 +361,9 @@ impl McpToolTransport for FakeUiTransport {
     }
 
     async fn read_resource(&self, uri: &str) -> Result<Value, McpTransportError> {
+        if let Some(delay) = self.read_delay {
+            tokio::time::sleep(delay).await;
+        }
         match self.resources.get(uri) {
             Some((text, mime)) => Ok(json!({
                 "contents": [{"uri": uri, "text": text, "mimeType": mime}]
@@ -858,6 +910,31 @@ async fn mcp_tool_forwards_progress_to_activity_reports() {
 }
 
 #[tokio::test]
+async fn mcp_tool_progress_flood_is_bounded_and_non_fatal() {
+    let attempted = Arc::new(AtomicUsize::new(0));
+    let accepted = Arc::new(AtomicUsize::new(0));
+    let transport = Arc::new(FakeProgressFloodTransport {
+        attempted: Arc::clone(&attempted),
+        accepted: Arc::clone(&accepted),
+    }) as Arc<dyn McpToolTransport>;
+    let manager = McpToolRegistryManager::from_transports([(cfg("s1"), transport)])
+        .await
+        .unwrap();
+    let reg = manager.registry();
+    let tool = reg.get("mcp__s1__echo").unwrap();
+
+    let ctx = ToolCallContext::test_default();
+    let result = tool.execute(json!({}), &ctx).await.unwrap();
+
+    assert!(result.result.is_success());
+    assert_eq!(attempted.load(Ordering::SeqCst), 10_000);
+    assert!(
+        accepted.load(Ordering::SeqCst) < attempted.load(Ordering::SeqCst),
+        "progress sender should apply bounded backpressure/drop instead of buffering flood"
+    );
+}
+
+#[tokio::test]
 async fn structured_mcp_results_are_preserved_in_tool_output() {
     let transport = Arc::new(FakeStructuredTransport {
         result: CallToolResult {
@@ -1075,7 +1152,7 @@ async fn manager_keeps_unsupported_fallback_when_capabilities_are_unknown() {
             &self,
             _name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: awaken_ext_mcp::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(ok_text_result("ok"))
@@ -1337,6 +1414,51 @@ async fn mcp_tool_execute_ui_fetch_failure_non_fatal() {
     assert!(result.result.is_success());
     // UI content should not be present when fetch fails
     assert!(!result.result.metadata.contains_key("mcp.ui.content"));
+    let status = manager.server_status_snapshot("s1").await.unwrap();
+    assert_eq!(
+        status.consecutive_failures, 0,
+        "optional UI resource hydration failures must not pollute MCP runtime health"
+    );
+}
+
+#[tokio::test]
+async fn mcp_tool_execute_ui_fetch_timeout_non_fatal() {
+    let mut def = McpToolDefinition::new("slow_ui");
+    def.meta = Some(json!({"ui": {"resourceUri": "ui://slow/render"}}));
+
+    let transport = Arc::new(
+        FakeUiTransport::new(vec![def.clone()])
+            .with_resource("ui://slow/render", "<html>slow</html>", "text/html")
+            .with_read_delay(Duration::from_secs(2)),
+    );
+    let manager = McpToolRegistryManager::from_transports([(
+        cfg("s1"),
+        transport as Arc<dyn McpToolTransport>,
+    )])
+    .await
+    .unwrap();
+    let reg = manager.registry();
+    let tool_id = reg
+        .ids()
+        .into_iter()
+        .find(|id| id.contains("slow_ui"))
+        .expect("slow_ui tool");
+    let tool = reg.get(&tool_id).unwrap();
+
+    let started = Instant::now();
+    let result = tool
+        .execute(json!({}), &ToolCallContext::test_default())
+        .await
+        .unwrap();
+
+    assert!(result.result.is_success());
+    assert!(!result.result.metadata.contains_key("mcp.ui.content"));
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "optional UI hydration should not stall the tool result hot path"
+    );
+    let status = manager.server_status_snapshot("s1").await.unwrap();
+    assert_eq!(status.consecutive_failures, 0);
 }
 
 #[tokio::test]
@@ -1507,7 +1629,7 @@ async fn mcp_tool_returns_error_for_transport_call_failure() {
             &self,
             _name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
             _context: awaken_ext_mcp::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Err(McpTransportError::TransportError(
@@ -4962,7 +5084,7 @@ async fn manager_uses_live_capabilities_after_http_silent_reinitialize() {
 }
 
 #[tokio::test]
-async fn http_call_tool_with_is_error_result_returns_server_error() {
+async fn http_call_tool_with_is_error_result_returns_tool_error_result() {
     let (endpoint, server) = spawn_http_server(Arc::new(|request| {
         if request.method == "GET" {
             return HttpResponseSpec::text(405, "no listening stream");
@@ -4997,15 +5119,22 @@ async fn http_call_tool_with_is_error_result_returns_server_error() {
     let tool = registry.get(&tool_id).unwrap();
 
     let ctx = ToolCallContext::test_default();
-    let err = tool
+    let output = tool
         .execute(json!({"message":"x"}), &ctx)
         .await
-        .expect_err("should fail");
+        .expect("MCP tool execution errors are successful JSON-RPC results");
     server.abort();
-    assert!(matches!(
-        err,
-        awaken_contract::contract::tool::ToolError::ExecutionFailed(_)
-    ));
+    assert!(output.result.is_error());
+    assert_eq!(output.result.data, Value::String("tool failed".to_string()));
+    assert_eq!(output.result.message.as_deref(), Some("tool failed"));
+    assert_eq!(
+        output.result.metadata["mcp.result.isError"],
+        Value::Bool(true)
+    );
+    assert_eq!(
+        output.result.metadata["mcp.result.content"],
+        json!([{"type": "text", "text": "tool failed"}])
+    );
 }
 
 #[tokio::test]

--- a/crates/awaken-ext-mcp/tests/mcp_tests.rs
+++ b/crates/awaken-ext-mcp/tests/mcp_tests.rs
@@ -81,6 +81,8 @@ impl McpToolTransport for FakeTransport {
         name: &str,
         args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _metadata: awaken_ext_mcp::McpCallMetadata,
+        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError> {
         self.calls.lock().unwrap().push((name.to_string(), args));
         Ok(ok_text_result("ok"))
@@ -105,6 +107,8 @@ impl McpToolTransport for FakeProgressTransport {
         _name: &str,
         _args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _metadata: awaken_ext_mcp::McpCallMetadata,
+        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError> {
         if let Some(progress_tx) = progress_tx {
             let _ = progress_tx.send(McpProgressUpdate {
@@ -142,6 +146,8 @@ impl McpToolTransport for FakeStructuredTransport {
         _name: &str,
         _args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _metadata: awaken_ext_mcp::McpCallMetadata,
+        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(self.result.clone())
     }
@@ -241,6 +247,8 @@ impl McpToolTransport for FakeCatalogTransport {
         _name: &str,
         _args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _metadata: awaken_ext_mcp::McpCallMetadata,
+        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(ok_text_result("ok"))
     }
@@ -298,6 +306,8 @@ impl McpToolTransport for FakeUiTransport {
         _name: &str,
         _args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+        _metadata: awaken_ext_mcp::McpCallMetadata,
+        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(ok_text_result("ok"))
     }
@@ -1002,6 +1012,8 @@ async fn manager_keeps_unsupported_fallback_when_capabilities_are_unknown() {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: awaken_ext_mcp::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(ok_text_result("ok"))
         }
@@ -1433,6 +1445,8 @@ async fn mcp_tool_returns_error_for_transport_call_failure() {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _metadata: awaken_ext_mcp::McpCallMetadata,
+            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
         ) -> Result<CallToolResult, McpTransportError> {
             Err(McpTransportError::TransportError(
                 "connection reset".to_string(),

--- a/crates/awaken-ext-mcp/tests/mcp_tests.rs
+++ b/crates/awaken-ext-mcp/tests/mcp_tests.rs
@@ -4264,6 +4264,9 @@ async fn http_listener_404_after_initialize_forces_next_call_reinitialize() {
                 }
             })),
             "tools/call" => {
+                if request.headers.get("mcp-session-id").map(String::as_str) == Some("session-1") {
+                    return HttpResponseSpec::text(404, "session expired");
+                }
                 tool_call_sessions_for_handler
                     .lock()
                     .unwrap()
@@ -4400,12 +4403,36 @@ async fn http_listener_response_404_resets_session_before_next_call() {
 
     let cfg = McpServerConnectionConfig::http("http_listener_response_404", endpoint);
     let manager = McpToolRegistryManager::connect([cfg]).await.unwrap();
+    let initial_session_generation = manager
+        .server_status_snapshot("http_listener_response_404")
+        .await
+        .expect("initial status")
+        .session_generation;
     assert!(
         wait_until(Duration::from_secs(2), Duration::from_millis(10), || {
             response_404_count.load(Ordering::SeqCst) >= 1
         })
         .await,
         "listener should POST a response and observe the 404"
+    );
+    let start = Instant::now();
+    let mut reset_observed = initialize_count.load(Ordering::SeqCst) >= 2;
+    while start.elapsed() <= Duration::from_secs(2) {
+        let status = manager
+            .server_status_snapshot("http_listener_response_404")
+            .await
+            .expect("status after listener response 404");
+        if status.session_generation > initial_session_generation
+            || initialize_count.load(Ordering::SeqCst) >= 2
+        {
+            reset_observed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        reset_observed,
+        "listener response 404 should reset HTTP session generation"
     );
 
     let registry = manager.registry();
@@ -4788,7 +4815,7 @@ async fn http_call_tool_retries_once_on_session_expired() {
         .server_status_snapshot("http_session_retry")
         .await
         .expect("initial server status");
-    assert_eq!(status_before.session_id.as_deref(), Some("session-1"));
+    let initial_session_generation = status_before.session_generation;
     let initial_last_init_at = status_before
         .last_init_at
         .expect("initial last_init_at should be set");
@@ -4813,7 +4840,11 @@ async fn http_call_tool_retries_once_on_session_expired() {
         text.contains("call #2 ok"),
         "expected retry response in result, got: {text}"
     );
-    assert_eq!(status_after.session_id.as_deref(), Some("session-2"));
+    assert!(
+        status_after.session_generation > initial_session_generation,
+        "silent reinitialize must advance session_generation; before={initial_session_generation:?}, after={:?}",
+        status_after.session_generation
+    );
     assert!(
         status_after.last_init_at.expect("updated last_init_at") > initial_last_init_at,
         "silent reinitialize must update live last_init_at; before={initial_last_init_at:?}, after={:?}",

--- a/crates/awaken-ext-mcp/tests/mcp_tests.rs
+++ b/crates/awaken-ext-mcp/tests/mcp_tests.rs
@@ -81,8 +81,7 @@ impl McpToolTransport for FakeTransport {
         name: &str,
         args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        _metadata: awaken_ext_mcp::McpCallMetadata,
-        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+        _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         self.calls.lock().unwrap().push((name.to_string(), args));
         Ok(ok_text_result("ok"))
@@ -107,8 +106,7 @@ impl McpToolTransport for FakeProgressTransport {
         _name: &str,
         _args: Value,
         progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        _metadata: awaken_ext_mcp::McpCallMetadata,
-        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+        _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         if let Some(progress_tx) = progress_tx {
             let _ = progress_tx.send(McpProgressUpdate {
@@ -146,8 +144,7 @@ impl McpToolTransport for FakeStructuredTransport {
         _name: &str,
         _args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        _metadata: awaken_ext_mcp::McpCallMetadata,
-        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+        _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(self.result.clone())
     }
@@ -247,8 +244,7 @@ impl McpToolTransport for FakeCatalogTransport {
         _name: &str,
         _args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        _metadata: awaken_ext_mcp::McpCallMetadata,
-        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+        _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(ok_text_result("ok"))
     }
@@ -306,8 +302,7 @@ impl McpToolTransport for FakeUiTransport {
         _name: &str,
         _args: Value,
         _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-        _metadata: awaken_ext_mcp::McpCallMetadata,
-        _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+        _context: awaken_ext_mcp::McpCallContext,
     ) -> Result<CallToolResult, McpTransportError> {
         Ok(ok_text_result("ok"))
     }
@@ -1012,8 +1007,7 @@ async fn manager_keeps_unsupported_fallback_when_capabilities_are_unknown() {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: awaken_ext_mcp::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: awaken_ext_mcp::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Ok(ok_text_result("ok"))
         }
@@ -1445,8 +1439,7 @@ async fn mcp_tool_returns_error_for_transport_call_failure() {
             _name: &str,
             _args: Value,
             _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
-            _metadata: awaken_ext_mcp::McpCallMetadata,
-            _cancellation: Option<awaken_contract::cancellation::CancellationToken>,
+            _context: awaken_ext_mcp::McpCallContext,
         ) -> Result<CallToolResult, McpTransportError> {
             Err(McpTransportError::TransportError(
                 "connection reset".to_string(),

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -803,6 +803,7 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("listening on {addr}");
 
+    let config_runtime_manager = state.config_runtime_manager.clone();
     let app = build_service_router(state)?;
 
     let result = serve_with_shutdown(listener, app, timeout).await;
@@ -810,6 +811,11 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
         && let Err(error) = mailbox_lifecycle.shutdown().await
     {
         tracing::warn!(error = %error, "failed to stop mailbox lifecycle cleanly");
+    }
+    if let Some(manager) = config_runtime_manager
+        && let Err(error) = manager.shutdown().await
+    {
+        tracing::warn!(error = %error, "failed to stop config runtime manager cleanly");
     }
     result
 }

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -529,6 +529,7 @@ async fn get_mcp_server_status(
     // 404 when the id is unknown to the active registry.
     let status = manager
         .mcp_server_status(&id)
+        .await
         .ok_or_else(|| ConfigRouteError::Api(ApiError::NotFound(format!("mcp-server/{id}"))))?;
 
     Ok(Json(json!({

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -5,7 +5,6 @@ use axum::routing::{delete as delete_route, get, patch, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
 #[derive(Deserialize, Default)]
@@ -545,24 +544,10 @@ async fn get_mcp_server_status(
         "last_success_at": status.last_success_at.and_then(systime_to_secs),
         "reconnecting": status.reconnecting,
         "permanently_failed": status.permanently_failed,
-        // This is a stable digest of the live HTTP session id, not the
-        // raw MCP-Session-Id header value. Operators can still spot
-        // session rotation without receiving a bearer-like identifier
-        // that could be replayed against a permissive MCP server.
-        "session_id": status.session_id.as_deref().map(redact_mcp_session_id),
-        "reconnect_count": status.reconnect_count,
+        "session_generation": status.session_generation,
+        "transport_reconnect_count": status.transport_reconnect_count,
         "last_init_at": status.last_init_at.and_then(systime_to_secs),
     })))
-}
-
-fn redact_mcp_session_id(session_id: &str) -> String {
-    let digest = Sha256::digest(session_id.as_bytes());
-    let mut out = String::with_capacity("sha256:".len() + 16);
-    out.push_str("sha256:");
-    for byte in digest.iter().take(8) {
-        out.push_str(&format!("{byte:02x}"));
-    }
-    out
 }
 
 fn systime_to_secs(t: std::time::SystemTime) -> Option<u64> {

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -5,6 +5,7 @@ use axum::routing::{delete as delete_route, get, patch, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
 #[derive(Deserialize, Default)]
@@ -544,7 +545,24 @@ async fn get_mcp_server_status(
         "last_success_at": status.last_success_at.and_then(systime_to_secs),
         "reconnecting": status.reconnecting,
         "permanently_failed": status.permanently_failed,
+        // This is a stable digest of the live HTTP session id, not the
+        // raw MCP-Session-Id header value. Operators can still spot
+        // session rotation without receiving a bearer-like identifier
+        // that could be replayed against a permissive MCP server.
+        "session_id": status.session_id.as_deref().map(redact_mcp_session_id),
+        "reconnect_count": status.reconnect_count,
+        "last_init_at": status.last_init_at.and_then(systime_to_secs),
     })))
+}
+
+fn redact_mcp_session_id(session_id: &str) -> String {
+    let digest = Sha256::digest(session_id.as_bytes());
+    let mut out = String::with_capacity("sha256:".len() + 16);
+    out.push_str("sha256:");
+    for byte in digest.iter().take(8) {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
 }
 
 fn systime_to_secs(t: std::time::SystemTime) -> Option<u64> {

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -456,10 +456,9 @@ impl McpRegistryFactory for DefaultMcpRegistryFactory {
             .map(mcp_spec_to_connection_config)
             .collect::<Result<Vec<_>, _>>()?;
         // No fixed fallback handler — per-agent factory (when set) is
-        // the single source of sampling handlers. The transport's
-        // server-request path will reject `sampling/createMessage` with
-        // a "method not supported" error when neither factory nor
-        // fallback resolves a handler.
+        // request-bound routing infrastructure only. It is not
+        // advertised as global MCP sampling capability, and unattributed
+        // server requests (stdio / HTTP GET listener) are rejected.
         let manager = McpToolRegistryManager::connect_with_sampling_factory(
             configs,
             None,

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -268,25 +268,64 @@ pub trait McpRegistryFactory: Send + Sync {
 /// handler (also typically `None` at registry construction) decide.
 pub(crate) struct RegistryDrivenSamplingHandlerFactory {
     runtime: Weak<AgentRuntime>,
+    /// Cache of `(agent_id, model_id)` → `Arc<DefaultSamplingHandler>`.
+    ///
+    /// `for_agent` is called on **every** `tools/call`, so the
+    /// underlying registry lookup + handler construction pays off
+    /// whenever the executor itself is non-trivial to instantiate (per-
+    /// tenant OAuth token mint, lazy connection pool warm-up, etc).
+    /// The agent's `(id, model_id)` tuple uniquely identifies the
+    /// handler — changing either creates a fresh entry, leaving the
+    /// stale one in place until the factory is reconstructed alongside
+    /// the runtime. Since runtime rebuilds drop this factory, stale
+    /// entries don't outlive the registry generation that produced
+    /// them.
+    cache: std::sync::Mutex<HashMap<(String, String), Arc<dyn SamplingHandler>>>,
 }
 
 impl RegistryDrivenSamplingHandlerFactory {
     pub(crate) fn new(runtime: Weak<AgentRuntime>) -> Self {
-        Self { runtime }
+        Self {
+            runtime,
+            cache: std::sync::Mutex::new(HashMap::new()),
+        }
     }
 }
 
 #[async_trait]
 impl SamplingHandlerFactory for RegistryDrivenSamplingHandlerFactory {
     async fn for_agent(&self, agent_spec: &AgentSpec) -> Option<Arc<dyn SamplingHandler>> {
+        let key = (agent_spec.id.clone(), agent_spec.model_id.clone());
+        // Fast path: cache hit. Sync mutex is fine here — the locked
+        // region is a HashMap::get + Arc::clone, no await.
+        if let Some(cached) = self
+            .cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&key)
+            .cloned()
+        {
+            return Some(cached);
+        }
+
         let runtime = self.runtime.upgrade()?;
         let registries = runtime.registry_set()?;
         let binding = registries.models.get_model(&agent_spec.model_id)?;
         let executor = registries.providers.get_provider(&binding.provider_id)?;
-        Some(Arc::new(DefaultSamplingHandler::new(
+        let handler: Arc<dyn SamplingHandler> = Arc::new(DefaultSamplingHandler::new(
             executor,
             binding.upstream_model,
-        )))
+        ));
+        // Race tolerated: two concurrent first-callers for the same
+        // (agent, model) may both reach here and both insert. Either
+        // entry is correct (both wrap the same executor); the second
+        // insert overwrites the first and the now-orphaned Arc is
+        // dropped — harmless.
+        self.cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(key, Arc::clone(&handler));
+        Some(handler)
     }
 }
 

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -13,7 +13,8 @@ use awaken_contract::{
     PeriodicRefresher, ProviderSpec,
 };
 use awaken_ext_mcp::{
-    McpServerConnectionConfig, McpServerStatusSnapshot, McpToolRegistry, McpToolRegistryManager,
+    DefaultSamplingHandler, McpServerConnectionConfig, McpServerStatusSnapshot, McpToolRegistry,
+    McpToolRegistryManager, SamplingHandler, SamplingHandlerFactory,
 };
 use awaken_runtime::engine::GenaiExecutor;
 use awaken_runtime::registry::BackendRegistry;
@@ -229,7 +230,11 @@ pub trait ManagedMcpRegistry: Send + Sync {
     fn periodic_refresh_running(&self) -> bool;
     fn start_periodic_refresh(&self, interval: Duration) -> Result<(), ConfigRuntimeError>;
     async fn stop_periodic_refresh(&self) -> bool;
-    fn server_status(&self, _server_name: &str) -> Option<McpServerStatusSnapshot> {
+    /// Async so the implementation can pull the live HTTP session id
+    /// from the transport — without this, a silent session-id rotation
+    /// (after `MCP session expired` triggers a fresh `initialize`)
+    /// wouldn't surface to admin/observability consumers.
+    async fn server_status(&self, _server_name: &str) -> Option<McpServerStatusSnapshot> {
         None
     }
     async fn reconnect(&self, server_name: &str) -> Result<(), ConfigRuntimeError> {
@@ -247,8 +252,84 @@ pub trait McpRegistryFactory: Send + Sync {
     ) -> Result<Option<Arc<dyn ManagedMcpRegistry>>, ConfigRuntimeError>;
 }
 
-#[derive(Default)]
-pub struct DefaultMcpRegistryFactory;
+/// Resolves a per-agent [`SamplingHandler`] by walking the live runtime
+/// registry: `agent.model_id` → `ModelBinding` → provider →
+/// `LlmExecutor` → [`DefaultSamplingHandler`].
+///
+/// Wired into [`DefaultMcpRegistryFactory`] so server-initiated
+/// `sampling/createMessage` requests during an agent's MCP tool call
+/// route to the **same** executor that agent uses for its own inference,
+/// not a fixed registry-level handler. Closes the multi-agent sampling
+/// leak documented in the MCP audit.
+///
+/// Holds a `Weak<AgentRuntime>` so the factory doesn't extend the
+/// runtime's lifetime. On `for_agent` we upgrade — if the runtime is
+/// already torn down, return `None` and let the transport's fallback
+/// handler (also typically `None` at registry construction) decide.
+pub(crate) struct RegistryDrivenSamplingHandlerFactory {
+    runtime: Weak<AgentRuntime>,
+}
+
+impl RegistryDrivenSamplingHandlerFactory {
+    pub(crate) fn new(runtime: Weak<AgentRuntime>) -> Self {
+        Self { runtime }
+    }
+}
+
+#[async_trait]
+impl SamplingHandlerFactory for RegistryDrivenSamplingHandlerFactory {
+    async fn for_agent(&self, agent_spec: &AgentSpec) -> Option<Arc<dyn SamplingHandler>> {
+        let runtime = self.runtime.upgrade()?;
+        let registries = runtime.registry_set()?;
+        let binding = registries.models.get_model(&agent_spec.model_id)?;
+        let executor = registries.providers.get_provider(&binding.provider_id)?;
+        Some(Arc::new(DefaultSamplingHandler::new(
+            executor,
+            binding.upstream_model,
+        )))
+    }
+}
+
+/// Default MCP registry factory.
+///
+/// When `sampling_handler_factory` is set, the connect path threads it
+/// to `McpToolRegistryManager::connect_with_sampling_factory` so the
+/// per-call sampling routing kicks in. When unset (e.g. an awaken
+/// deployment that opts out of sampling), MCP tool calls work normally
+/// but `sampling/createMessage` requests from servers get rejected with
+/// "method not supported" — the same legacy behaviour as before P1c.
+pub struct DefaultMcpRegistryFactory {
+    sampling_handler_factory: Option<Arc<dyn SamplingHandlerFactory>>,
+}
+
+impl DefaultMcpRegistryFactory {
+    /// Default factory with no sampling support — preserves the
+    /// pre-R1c behaviour. New code should prefer
+    /// [`DefaultMcpRegistryFactory::with_runtime`].
+    pub fn new() -> Self {
+        Self {
+            sampling_handler_factory: None,
+        }
+    }
+
+    /// Factory wired to per-agent sampling: server-initiated
+    /// `sampling/createMessage` during an agent's MCP tool call routes
+    /// to that agent's `LlmExecutor` via
+    /// [`RegistryDrivenSamplingHandlerFactory`].
+    pub fn with_runtime(runtime: Weak<AgentRuntime>) -> Self {
+        Self {
+            sampling_handler_factory: Some(Arc::new(RegistryDrivenSamplingHandlerFactory::new(
+                runtime,
+            ))),
+        }
+    }
+}
+
+impl Default for DefaultMcpRegistryFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[derive(Clone)]
 struct RealManagedMcpRegistry {
@@ -276,8 +357,8 @@ impl ManagedMcpRegistry for RealManagedMcpRegistry {
         self.manager.stop_periodic_refresh().await
     }
 
-    fn server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot> {
-        self.manager.server_status_snapshot(server_name).ok()
+    async fn server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot> {
+        self.manager.server_status_snapshot(server_name).await.ok()
     }
 
     async fn reconnect(&self, server_name: &str) -> Result<(), ConfigRuntimeError> {
@@ -302,11 +383,20 @@ impl McpRegistryFactory for DefaultMcpRegistryFactory {
             .iter()
             .map(mcp_spec_to_connection_config)
             .collect::<Result<Vec<_>, _>>()?;
-        let manager = McpToolRegistryManager::connect(configs)
-            .await
-            .map_err(|error| {
-                ConfigRuntimeError::InvalidConfig(format!("failed to connect MCP servers: {error}"))
-            })?;
+        // No fixed fallback handler — per-agent factory (when set) is
+        // the single source of sampling handlers. The transport's
+        // server-request path will reject `sampling/createMessage` with
+        // a "method not supported" error when neither factory nor
+        // fallback resolves a handler.
+        let manager = McpToolRegistryManager::connect_with_sampling_factory(
+            configs,
+            None,
+            self.sampling_handler_factory.clone(),
+        )
+        .await
+        .map_err(|error| {
+            ConfigRuntimeError::InvalidConfig(format!("failed to connect MCP servers: {error}"))
+        })?;
 
         Ok(Some(Arc::new(RealManagedMcpRegistry {
             tool_registry: Arc::new(DynamicMcpToolRegistry::new(manager.registry())),
@@ -394,6 +484,17 @@ impl ConfigRuntimeManager {
             .ok_or(ConfigRuntimeError::RuntimeNotConfigurable)?;
         let discovered_agents = DiscoveredAgentRegistry::from_registry(registries.agents.clone());
 
+        // Wire the MCP registry factory with a Weak handle to this
+        // runtime so per-agent sampling can resolve `agent.model_id` →
+        // provider → `LlmExecutor` at each `tools/call`. `Weak` is
+        // load-bearing: an `Arc` here would create a self-referential
+        // cycle (runtime owns ConfigRuntimeManager → manager owns
+        // mcp_factory → factory owns runtime) that leaks the runtime
+        // for the process lifetime.
+        let mcp_registry_factory: Arc<dyn McpRegistryFactory> = Arc::new(
+            DefaultMcpRegistryFactory::with_runtime(Arc::downgrade(&runtime)),
+        );
+
         Ok(Self {
             runtime,
             store,
@@ -403,7 +504,7 @@ impl ConfigRuntimeManager {
             discovered_agents,
             provider_factory: Arc::new(GenaiProviderExecutorFactory),
             change_notifier: None,
-            mcp_registry_factory: Arc::new(DefaultMcpRegistryFactory),
+            mcp_registry_factory,
             apply_lock: tokio::sync::Mutex::new(()),
             active_mcp_registry: Mutex::new(None),
             last_applied_fingerprint: RwLock::new(None),
@@ -632,11 +733,19 @@ impl ConfigRuntimeManager {
     ///
     /// Returns `None` when no MCP registry is active (i.e. the runtime has no
     /// MCP servers configured) or the server name is unknown to the registry.
-    pub fn mcp_server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot> {
-        self.active_mcp_registry
-            .lock()
-            .as_ref()
-            .and_then(|active| active.handle.server_status(server_name))
+    ///
+    /// Async so the snapshot includes the **live** HTTP session id rather
+    /// than a value cached at connect/reconnect — `MCP session expired`
+    /// rotations re-initialise silently and the cached value goes stale.
+    pub async fn mcp_server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot> {
+        let handle = {
+            let guard = self.active_mcp_registry.lock();
+            guard.as_ref().map(|active| Arc::clone(&active.handle))
+        };
+        match handle {
+            Some(handle) => handle.server_status(server_name).await,
+            None => None,
+        }
     }
 
     /// Trigger an immediate reconnect for the named MCP server.
@@ -1573,6 +1682,49 @@ mod tests {
     /// Tests that don't care about broker state share-ability use this.
     fn test_broker() -> Arc<dyn awaken_runtime::credentials::CredentialBroker> {
         Arc::new(awaken_runtime::credentials::AwakenCredentialBroker::new())
+    }
+
+    /// Verifies the factory's defensive `None` path: when the underlying
+    /// runtime has been dropped, `for_agent` returns `None` instead of
+    /// panicking or trying to dereference a dangling weak handle. This
+    /// is the "graceful degradation" the transport's fallback handler
+    /// counts on — without it the factory could mistake "runtime is
+    /// gone" for "this agent can't sample" silently.
+    #[tokio::test]
+    async fn registry_factory_returns_none_when_runtime_dropped() {
+        // Build an AgentRuntime, downgrade to Weak, then drop the Arc.
+        // The factory should then refuse to produce a handler.
+        let runtime = Arc::new(
+            awaken_runtime::AgentRuntimeBuilder::new()
+                .build()
+                .expect("minimal runtime builds"),
+        );
+        let weak = Arc::downgrade(&runtime);
+        drop(runtime);
+
+        let factory = RegistryDrivenSamplingHandlerFactory::new(weak);
+        let spec = AgentSpec {
+            id: "alpha".into(),
+            model_id: "any-model".into(),
+            system_prompt: String::new(),
+            ..AgentSpec::default()
+        };
+        assert!(
+            factory.for_agent(&spec).await.is_none(),
+            "factory must not produce a handler for a dropped runtime"
+        );
+    }
+
+    /// `with_runtime` constructs a factory; `new()` (the `Default` path)
+    /// gives a sampling-less factory. This pins the public surface so
+    /// future refactors don't accidentally make `new()` synthesize a
+    /// fixed factory that runs cross-agent (the very bug R1 fixed).
+    #[test]
+    fn default_factory_has_no_sampling_handler_factory() {
+        let factory = DefaultMcpRegistryFactory::new();
+        assert!(factory.sampling_handler_factory.is_none());
+        let factory = DefaultMcpRegistryFactory::default();
+        assert!(factory.sampling_handler_factory.is_none());
     }
 
     #[test]

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -230,6 +230,10 @@ pub trait ManagedMcpRegistry: Send + Sync {
     fn periodic_refresh_running(&self) -> bool;
     fn start_periodic_refresh(&self, interval: Duration) -> Result<(), ConfigRuntimeError>;
     async fn stop_periodic_refresh(&self) -> bool;
+    async fn close(&self) -> Result<(), ConfigRuntimeError> {
+        self.stop_periodic_refresh().await;
+        Ok(())
+    }
     /// Async so the implementation can pull the live HTTP session id
     /// from the transport — without this, a silent session-id rotation
     /// (after `MCP session expired` triggers a fresh `initialize`)
@@ -266,28 +270,40 @@ pub trait McpRegistryFactory: Send + Sync {
 /// runtime's lifetime. On `for_agent` we upgrade — if the runtime is
 /// already torn down, return `None` and let the transport's fallback
 /// handler (also typically `None` at registry construction) decide.
+/// Cache state held by [`RegistryDrivenSamplingHandlerFactory`].
+///
+/// `version` is the [`AgentRuntime::registry_version`] under which the
+/// `entries` were built. Each publish bumps the runtime's version (see
+/// `replace_registry_set`), so a version mismatch on lookup means the
+/// underlying `ModelBinding` / provider / `LlmExecutor` may have
+/// changed — wipe the cache before serving. Without this, a published
+/// config that changes (say) a model's `upstream_model` while leaving
+/// the agent spec's `model_id` intact would keep routing sampling
+/// requests to the previous executor, silently.
+struct SamplingFactoryCacheState {
+    version: u64,
+    entries: HashMap<(String, String), Arc<dyn SamplingHandler>>,
+}
+
+impl SamplingFactoryCacheState {
+    fn empty() -> Self {
+        Self {
+            version: 0,
+            entries: HashMap::new(),
+        }
+    }
+}
+
 pub(crate) struct RegistryDrivenSamplingHandlerFactory {
     runtime: Weak<AgentRuntime>,
-    /// Cache of `(agent_id, model_id)` → `Arc<DefaultSamplingHandler>`.
-    ///
-    /// `for_agent` is called on **every** `tools/call`, so the
-    /// underlying registry lookup + handler construction pays off
-    /// whenever the executor itself is non-trivial to instantiate (per-
-    /// tenant OAuth token mint, lazy connection pool warm-up, etc).
-    /// The agent's `(id, model_id)` tuple uniquely identifies the
-    /// handler — changing either creates a fresh entry, leaving the
-    /// stale one in place until the factory is reconstructed alongside
-    /// the runtime. Since runtime rebuilds drop this factory, stale
-    /// entries don't outlive the registry generation that produced
-    /// them.
-    cache: std::sync::Mutex<HashMap<(String, String), Arc<dyn SamplingHandler>>>,
+    cache: std::sync::Mutex<SamplingFactoryCacheState>,
 }
 
 impl RegistryDrivenSamplingHandlerFactory {
     pub(crate) fn new(runtime: Weak<AgentRuntime>) -> Self {
         Self {
             runtime,
-            cache: std::sync::Mutex::new(HashMap::new()),
+            cache: std::sync::Mutex::new(SamplingFactoryCacheState::empty()),
         }
     }
 }
@@ -295,36 +311,46 @@ impl RegistryDrivenSamplingHandlerFactory {
 #[async_trait]
 impl SamplingHandlerFactory for RegistryDrivenSamplingHandlerFactory {
     async fn for_agent(&self, agent_spec: &AgentSpec) -> Option<Arc<dyn SamplingHandler>> {
+        let runtime = self.runtime.upgrade()?;
+        // Atomic capture: `registry_snapshot()` returns
+        // `(version, RegistrySet)` from a single observation. Resolving
+        // the agent's model + provider via this snapshot and then
+        // inserting under THIS version closes the race window where a
+        // separate `registry_version()` + `registry_set()` pair could
+        // straddle a `replace_registry_set` and cache a stale-built
+        // handler under the new version.
+        let snapshot = runtime.registry_snapshot()?;
+        let version = snapshot.version();
         let key = (agent_spec.id.clone(), agent_spec.model_id.clone());
-        // Fast path: cache hit. Sync mutex is fine here — the locked
-        // region is a HashMap::get + Arc::clone, no await.
-        if let Some(cached) = self
-            .cache
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(&key)
-            .cloned()
+
+        // Fast path: cache hit at this snapshot's version.
         {
-            return Some(cached);
+            let cache = self.cache.lock().unwrap_or_else(|p| p.into_inner());
+            if cache.version == version
+                && let Some(cached) = cache.entries.get(&key).cloned()
+            {
+                return Some(cached);
+            }
         }
 
-        let runtime = self.runtime.upgrade()?;
-        let registries = runtime.registry_set()?;
+        let registries = snapshot.registries();
         let binding = registries.models.get_model(&agent_spec.model_id)?;
         let executor = registries.providers.get_provider(&binding.provider_id)?;
         let handler: Arc<dyn SamplingHandler> = Arc::new(DefaultSamplingHandler::new(
             executor,
             binding.upstream_model,
         ));
-        // Race tolerated: two concurrent first-callers for the same
-        // (agent, model) may both reach here and both insert. Either
-        // entry is correct (both wrap the same executor); the second
-        // insert overwrites the first and the now-orphaned Arc is
-        // dropped — harmless.
-        self.cache
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(key, Arc::clone(&handler));
+
+        // Insert under the SNAPSHOT's version (the one the handler
+        // was actually built from), not a freshly-read live version.
+        // If the registry was replaced concurrently, the next call
+        // will see version > cache.version and wipe — that's correct.
+        let mut cache = self.cache.lock().unwrap_or_else(|p| p.into_inner());
+        if cache.version != version {
+            cache.entries.clear();
+            cache.version = version;
+        }
+        cache.entries.insert(key, Arc::clone(&handler));
         Some(handler)
     }
 }
@@ -396,6 +422,13 @@ impl ManagedMcpRegistry for RealManagedMcpRegistry {
         self.manager.stop_periodic_refresh().await
     }
 
+    async fn close(&self) -> Result<(), ConfigRuntimeError> {
+        self.manager
+            .close_all()
+            .await
+            .map_err(|error| ConfigRuntimeError::InvalidConfig(error.to_string()))
+    }
+
     async fn server_status(&self, server_name: &str) -> Option<McpServerStatusSnapshot> {
         self.manager.server_status_snapshot(server_name).await.ok()
     }
@@ -459,8 +492,13 @@ struct PreparedMcpRegistry {
 
 impl PreparedMcpRegistry {
     async fn cleanup(self) {
-        if let Some(active) = self.next_state {
-            active.handle.stop_periodic_refresh().await;
+        if let Some(active) = self.next_state
+            && let Err(error) = active.handle.close().await
+        {
+            tracing::warn!(
+                error = %error,
+                "failed to close prepared MCP registry after publish failure"
+            );
         }
     }
 }
@@ -764,6 +802,16 @@ impl ConfigRuntimeManager {
         stopped_config || stopped_listener || stopped_mcp
     }
 
+    pub async fn shutdown(&self) -> Result<(), ConfigRuntimeError> {
+        self.periodic_refresh.stop().await;
+        self.stop_change_listener().await;
+        let active = self.active_mcp_registry.lock().take();
+        if let Some(active) = active {
+            active.handle.close().await?;
+        }
+        Ok(())
+    }
+
     pub fn periodic_refresh_running(&self) -> bool {
         self.periodic_refresh.is_running()
     }
@@ -872,8 +920,13 @@ impl ConfigRuntimeManager {
 
         *self.last_applied_fingerprint.write() = Some(managed.fingerprint);
 
-        if let Some(previous) = previous_mcp {
-            previous.handle.stop_periodic_refresh().await;
+        if let Some(previous) = previous_mcp
+            && let Err(error) = previous.handle.close().await
+        {
+            tracing::warn!(
+                error = %error,
+                "failed to close replaced MCP registry"
+            );
         }
 
         Ok(version)
@@ -895,7 +948,7 @@ impl ConfigRuntimeManager {
             });
         }
 
-        let next_state = self
+        let mut next_state = self
             .mcp_registry_factory
             .connect(specs)
             .await?
@@ -905,8 +958,19 @@ impl ConfigRuntimeManager {
                 handle,
             });
 
-        if let Some(ref active) = next_state {
-            self.ensure_mcp_periodic_refresh(&active.handle)?;
+        let refresh_error = next_state
+            .as_ref()
+            .and_then(|active| self.ensure_mcp_periodic_refresh(&active.handle).err());
+        if let Some(error) = refresh_error {
+            if let Some(active) = next_state.take()
+                && let Err(close_error) = active.handle.close().await
+            {
+                tracing::warn!(
+                    error = %close_error,
+                    "failed to close prepared MCP registry after refresh setup failure"
+                );
+            }
+            return Err(error);
         }
 
         Ok(PreparedMcpRegistry {
@@ -1754,6 +1818,157 @@ mod tests {
         );
     }
 
+    /// R8 #2 / R10 #3 regression: sampling-factory cache must drop
+    /// stale entries when the underlying [`AgentRuntime`]'s
+    /// `RegistrySet` is replaced. The cache key
+    /// `(agent_id, model_id)` alone is not sufficient — model bindings
+    /// can change underneath without the key changing. We tag entries
+    /// with `registry_version()`; a mismatch wipes the cache so the
+    /// next lookup walks the live registry.
+    #[tokio::test]
+    async fn registry_factory_cache_invalidates_on_registry_replace() {
+        use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest};
+        use awaken_contract::contract::inference::{StreamResult, TokenUsage};
+        use awaken_runtime::registry::memory::{
+            MapAgentSpecRegistry, MapModelRegistry, MapPluginSource, MapProviderRegistry,
+            MapToolRegistry,
+        };
+        use awaken_runtime::registry::{ModelBinding, RegistrySet};
+
+        // Two distinct executors so we can tell which one the cache
+        // hands back. Mock returns its label in the response text so a
+        // sampling round trip would expose which executor ran — but we
+        // only need Arc identity for this assertion.
+        struct LabelExecutor {
+            label: &'static str,
+        }
+        #[async_trait::async_trait]
+        impl LlmExecutor for LabelExecutor {
+            async fn execute(
+                &self,
+                _request: InferenceRequest,
+            ) -> Result<StreamResult, InferenceExecutionError> {
+                Ok(StreamResult {
+                    content: vec![awaken_contract::contract::content::ContentBlock::text(
+                        self.label.to_string(),
+                    )],
+                    tool_calls: vec![],
+                    usage: Some(TokenUsage::default()),
+                    stop_reason: None,
+                    has_incomplete_tool_calls: false,
+                })
+            }
+            fn name(&self) -> &str {
+                "label"
+            }
+        }
+
+        fn registry_set_pointing_at(executor_label: &'static str) -> RegistrySet {
+            let mut agents = MapAgentSpecRegistry::new();
+            agents
+                .register_spec(AgentSpec {
+                    id: "alpha".into(),
+                    model_id: "m".into(),
+                    system_prompt: String::new(),
+                    ..Default::default()
+                })
+                .unwrap();
+            let mut models = MapModelRegistry::new();
+            models
+                .register_model(
+                    "m",
+                    ModelBinding {
+                        provider_id: "p".into(),
+                        upstream_model: format!("upstream-{executor_label}"),
+                    },
+                )
+                .unwrap();
+            let mut providers = MapProviderRegistry::new();
+            providers
+                .register_provider(
+                    "p",
+                    Arc::new(LabelExecutor {
+                        label: executor_label,
+                    }) as Arc<dyn LlmExecutor>,
+                )
+                .unwrap();
+            RegistrySet {
+                agents: Arc::new(agents),
+                tools: Arc::new(MapToolRegistry::new()),
+                models: Arc::new(models),
+                providers: Arc::new(providers),
+                plugins: Arc::new(MapPluginSource::new()),
+                backends: Arc::new(awaken_runtime::registry::memory::MapBackendRegistry::new()),
+            }
+        }
+
+        let runtime = Arc::new(
+            awaken_runtime::AgentRuntimeBuilder::new()
+                .with_provider("p", Arc::new(LabelExecutor { label: "v1" }))
+                .with_model_binding(
+                    "m",
+                    ModelBinding {
+                        provider_id: "p".into(),
+                        upstream_model: "upstream-v1".into(),
+                    },
+                )
+                .with_agent_spec(AgentSpec {
+                    id: "alpha".into(),
+                    model_id: "m".into(),
+                    system_prompt: String::new(),
+                    ..Default::default()
+                })
+                .build()
+                .expect("v1 runtime builds"),
+        );
+
+        let v1_version = runtime.registry_version().expect("v1 registered");
+        let factory = RegistryDrivenSamplingHandlerFactory::new(Arc::downgrade(&runtime));
+        let spec = AgentSpec {
+            id: "alpha".into(),
+            model_id: "m".into(),
+            system_prompt: String::new(),
+            ..AgentSpec::default()
+        };
+
+        let handler_v1 = factory
+            .for_agent(&spec)
+            .await
+            .expect("factory yields handler for v1");
+
+        // Same key → same cached Arc (the cache hit path).
+        let handler_v1_again = factory
+            .for_agent(&spec)
+            .await
+            .expect("factory yields handler for v1 again");
+        assert!(
+            Arc::ptr_eq(&handler_v1, &handler_v1_again),
+            "second lookup at the same registry version must be a cache hit (same Arc)"
+        );
+
+        // Replace the registry with a v2 set that points the SAME
+        // (agent_id, model_id) pair at a DIFFERENT executor. Without
+        // version-tagged invalidation, the cache would happily return
+        // the v1 handler — the bug R8 #2 fixed.
+        let new_version = runtime
+            .replace_registry_set(registry_set_pointing_at("v2"))
+            .expect("replace_registry_set yields a fresh version");
+        assert!(
+            new_version > v1_version,
+            "replace_registry_set must bump registry_version (was {v1_version}, got {new_version})"
+        );
+
+        let handler_v2 = factory
+            .for_agent(&spec)
+            .await
+            .expect("factory yields handler for v2");
+        assert!(
+            !Arc::ptr_eq(&handler_v1, &handler_v2),
+            "cache must invalidate on registry_version bump — got the same Arc back, \
+             which means sampling would still route to the OLD executor"
+        );
+    }
+
     /// `with_runtime` constructs a factory; `new()` (the `Default` path)
     /// gives a sampling-less factory. This pins the public surface so
     /// future refactors don't accidentally make `new()` synthesize a
@@ -2566,6 +2781,99 @@ mod tests {
         );
         let manager = ConfigRuntimeManager::new(runtime, store.clone()).expect("manager");
         (manager, store)
+    }
+
+    #[tokio::test]
+    async fn publish_closes_prepared_mcp_registry_when_refresh_start_fails() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct RefreshFailingRegistry {
+            tool_registry: Arc<dyn ToolRegistry>,
+            close_count: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl ManagedMcpRegistry for RefreshFailingRegistry {
+            fn tool_registry(&self) -> Arc<dyn ToolRegistry> {
+                Arc::clone(&self.tool_registry)
+            }
+
+            fn periodic_refresh_running(&self) -> bool {
+                false
+            }
+
+            fn start_periodic_refresh(
+                &self,
+                _interval: Duration,
+            ) -> Result<(), ConfigRuntimeError> {
+                Err(ConfigRuntimeError::PeriodicRefresh(
+                    "scripted MCP refresh failure".to_string(),
+                ))
+            }
+
+            async fn stop_periodic_refresh(&self) -> bool {
+                false
+            }
+
+            async fn close(&self) -> Result<(), ConfigRuntimeError> {
+                self.close_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        struct RefreshFailingFactory {
+            close_count: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl McpRegistryFactory for RefreshFailingFactory {
+            async fn connect(
+                &self,
+                specs: &[McpServerSpec],
+            ) -> Result<Option<Arc<dyn ManagedMcpRegistry>>, ConfigRuntimeError> {
+                assert!(!specs.is_empty(), "test must exercise a real MCP state");
+                Ok(Some(Arc::new(RefreshFailingRegistry {
+                    tool_registry: Arc::new(
+                        awaken_runtime::registry::memory::MapToolRegistry::new(),
+                    ),
+                    close_count: Arc::clone(&self.close_count),
+                }) as Arc<dyn ManagedMcpRegistry>))
+            }
+        }
+
+        let close_count = Arc::new(AtomicUsize::new(0));
+        let (manager, _) = make_manager_with_store().await;
+        let manager = manager.with_mcp_registry_factory(Arc::new(RefreshFailingFactory {
+            close_count: Arc::clone(&close_count),
+        }));
+        *manager.mcp_refresh_interval.write() = Some(Duration::from_secs(30));
+
+        let err = manager
+            .publish(ManagedConfigSnapshot {
+                providers: Vec::new(),
+                models: Vec::new(),
+                agents: Vec::new(),
+                mcp_servers: vec![McpServerSpec {
+                    id: "demo".to_string(),
+                    transport: McpTransportKind::Http,
+                    url: Some("http://mcp.example.invalid".to_string()),
+                    ..McpServerSpec::default()
+                }],
+                tools: Vec::new(),
+                fingerprint: 1,
+            })
+            .await
+            .expect_err("refresh setup failure must abort publish");
+
+        assert!(
+            matches!(err, ConfigRuntimeError::PeriodicRefresh(_)),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(
+            close_count.load(Ordering::SeqCst),
+            1,
+            "prepared MCP registry must be closed when refresh setup fails"
+        );
     }
 
     #[tokio::test]

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -258,6 +258,7 @@ struct TrackingManagedMcpRegistryState {
     periodic_refresh_running: AtomicBool,
     start_calls: AtomicUsize,
     stop_calls: AtomicUsize,
+    close_calls: AtomicUsize,
 }
 
 struct TrackingManagedMcpRegistry {
@@ -295,6 +296,12 @@ impl ManagedMcpRegistry for TrackingManagedMcpRegistry {
             .swap(false, Ordering::Relaxed)
     }
 
+    async fn close(&self) -> Result<(), ConfigRuntimeError> {
+        self.state.close_calls.fetch_add(1, Ordering::Relaxed);
+        self.stop_periodic_refresh().await;
+        Ok(())
+    }
+
     async fn server_status(
         &self,
         _server_name: &str,
@@ -320,6 +327,13 @@ impl TrackingMcpRegistryFactory {
             .first()
             .cloned()
             .expect("tracking factory should have created one registry")
+    }
+
+    fn states(&self) -> Vec<Arc<TrackingManagedMcpRegistryState>> {
+        self.states
+            .lock()
+            .expect("tracking factory lock poisoned")
+            .clone()
     }
 }
 
@@ -1715,7 +1729,7 @@ async fn duplicate_create_returns_conflict_status() {
 }
 
 #[tokio::test]
-async fn failed_publish_stops_prepared_mcp_registry() {
+async fn failed_publish_closes_prepared_mcp_registry() {
     let factory = Arc::new(TrackingMcpRegistryFactory::default());
     let (runtime, store, manager) = make_runtime_manager_with_options(
         None,
@@ -1757,6 +1771,7 @@ async fn failed_publish_stops_prepared_mcp_registry() {
 
     let state = factory.single_state();
     assert_eq!(state.start_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(state.close_calls.load(Ordering::Relaxed), 1);
     assert_eq!(state.stop_calls.load(Ordering::Relaxed), 1);
     assert!(!state.periodic_refresh_running.load(Ordering::Relaxed));
 
@@ -1768,6 +1783,89 @@ async fn failed_publish_stops_prepared_mcp_registry() {
         !resolved.tools.contains_key("mcp__cleanup__ping"),
         "failed publish must not leak prepared MCP tools into the live runtime"
     );
+}
+
+#[tokio::test]
+async fn replacing_mcp_registry_closes_previous_registry() {
+    let factory = Arc::new(TrackingMcpRegistryFactory::default());
+    let (_runtime, store, manager) = make_runtime_manager_with_options(
+        None,
+        factory.clone() as Arc<dyn McpRegistryFactory>,
+        Some(Duration::from_secs(5)),
+    )
+    .await;
+
+    ConfigStore::put(
+        store.as_ref(),
+        "mcp-servers",
+        "first",
+        &json!({
+            "id": "first",
+            "transport": "stdio",
+            "command": "first-mcp"
+        }),
+    )
+    .await
+    .expect("write first managed mcp server");
+    manager.apply().await.expect("apply first mcp registry");
+
+    let first_state = factory.single_state();
+    assert_eq!(first_state.start_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(first_state.close_calls.load(Ordering::Relaxed), 0);
+
+    ConfigStore::put(
+        store.as_ref(),
+        "mcp-servers",
+        "second",
+        &json!({
+            "id": "second",
+            "transport": "stdio",
+            "command": "second-mcp"
+        }),
+    )
+    .await
+    .expect("write second managed mcp server");
+    manager.apply().await.expect("replace mcp registry");
+
+    let states = factory.states();
+    assert_eq!(states.len(), 2);
+    assert_eq!(first_state.close_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(first_state.stop_calls.load(Ordering::Relaxed), 1);
+    assert!(!first_state.periodic_refresh_running.load(Ordering::Relaxed));
+    assert_eq!(states[1].start_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(states[1].close_calls.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn shutdown_closes_active_mcp_registry() {
+    let factory = Arc::new(TrackingMcpRegistryFactory::default());
+    let (_runtime, store, manager) = make_runtime_manager_with_options(
+        None,
+        factory.clone() as Arc<dyn McpRegistryFactory>,
+        Some(Duration::from_secs(5)),
+    )
+    .await;
+
+    ConfigStore::put(
+        store.as_ref(),
+        "mcp-servers",
+        "active",
+        &json!({
+            "id": "active",
+            "transport": "stdio",
+            "command": "active-mcp"
+        }),
+    )
+    .await
+    .expect("write active managed mcp server");
+    manager.apply().await.expect("apply active mcp registry");
+
+    let state = factory.single_state();
+    manager.shutdown().await.expect("shutdown config runtime");
+
+    assert_eq!(state.close_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(state.stop_calls.load(Ordering::Relaxed), 1);
+    assert!(!state.periodic_refresh_running.load(Ordering::Relaxed));
 }
 
 // ── apply / apply_if_changed semantics ──────────────────────────────
@@ -2089,6 +2187,148 @@ async fn mcp_status_returns_404_for_unknown_server() {
     )
     .await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// R9 #2 regression: the manager snapshot has `session_id`,
+/// `reconnect_count`, and `last_init_at` fields. The HTTP wire
+/// response forgot to surface them before R9; this test pins the
+/// fix so a future refactor of `get_mcp_server_status` doesn't
+/// silently drop them again. The session id is redacted on the wire;
+/// the raw MCP-Session-Id must never be returned by this route.
+#[tokio::test]
+async fn mcp_status_route_surfaces_session_reconnect_init_fields() {
+    use std::time::SystemTime;
+
+    /// Test-only registry that returns a fully-populated snapshot for
+    /// every server name. We don't care about the tool list here, just
+    /// that the new diagnostic fields make it onto the wire.
+    struct SnapshotStubRegistry {
+        tool_registry: Arc<dyn ToolRegistry>,
+    }
+
+    #[async_trait]
+    impl ManagedMcpRegistry for SnapshotStubRegistry {
+        fn tool_registry(&self) -> Arc<dyn ToolRegistry> {
+            Arc::clone(&self.tool_registry)
+        }
+        fn periodic_refresh_running(&self) -> bool {
+            false
+        }
+        fn start_periodic_refresh(&self, _interval: Duration) -> Result<(), ConfigRuntimeError> {
+            Ok(())
+        }
+        async fn stop_periodic_refresh(&self) -> bool {
+            false
+        }
+        async fn server_status(
+            &self,
+            _server_name: &str,
+        ) -> Option<awaken_ext_mcp::McpServerStatusSnapshot> {
+            Some(awaken_ext_mcp::McpServerStatusSnapshot {
+                connected: true,
+                last_error: None,
+                tools: vec![],
+                consecutive_failures: 0,
+                last_attempt_at: None,
+                last_success_at: None,
+                reconnecting: false,
+                permanently_failed: false,
+                session_id: Some("test-session-xyz".to_string()),
+                reconnect_count: 3,
+                // 2026-05-13 12:00:00 UTC, picked so the conversion to
+                // unix seconds is non-zero and we can assert on it.
+                last_init_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_778_846_400)),
+            })
+        }
+        async fn reconnect(&self, _server_name: &str) -> Result<(), ConfigRuntimeError> {
+            Ok(())
+        }
+    }
+
+    struct SnapshotStubFactory;
+
+    #[async_trait]
+    impl McpRegistryFactory for SnapshotStubFactory {
+        async fn connect(
+            &self,
+            specs: &[McpServerSpec],
+        ) -> Result<Option<Arc<dyn ManagedMcpRegistry>>, ConfigRuntimeError> {
+            if specs.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(Arc::new(SnapshotStubRegistry {
+                tool_registry: Arc::new(MapToolRegistry::new()),
+            }) as Arc<dyn ManagedMcpRegistry>))
+        }
+    }
+
+    let notifier = Arc::new(TestConfigChangeNotifier::new());
+    let (runtime, store, manager) = make_runtime_manager_with_options(
+        Some(notifier.clone() as Arc<dyn ConfigChangeNotifier>),
+        Arc::new(SnapshotStubFactory),
+        None,
+    )
+    .await;
+    let config_store = store.clone() as Arc<dyn ConfigStore>;
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+        store.clone(),
+        "mcp-status-fields-test".into(),
+        MailboxConfig::default(),
+    ));
+    let state = AppState::new(
+        runtime.clone(),
+        mailbox,
+        store.clone(),
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(manager.clone());
+    let router = build_router(&state).with_state(state);
+
+    // Register an MCP server so the factory's `connect` is called and
+    // the stub registry becomes active.
+    let (status, _) = request_json(
+        &router,
+        Method::POST,
+        "/v1/config/mcp-servers",
+        Some(json!({
+            "id": "demo",
+            "transport": "http",
+            "url": "http://invalid.test"
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, body) =
+        request_json(&router, Method::GET, "/v1/mcp-servers/demo/status", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["session_id"]
+            .as_str()
+            .map(|value| value.starts_with("sha256:")),
+        Some(true),
+        "session_id must be a redacted digest; body = {body}"
+    );
+    assert_ne!(
+        body["session_id"], "test-session-xyz",
+        "raw MCP session id must not surface on wire; body = {body}"
+    );
+    assert_eq!(
+        body["reconnect_count"], 3,
+        "reconnect_count must surface; body = {body}"
+    );
+    assert_eq!(
+        body["last_init_at"], 1_778_846_400,
+        "last_init_at must surface as unix seconds; body = {body}"
+    );
+    // Sanity: existing fields still present (no accidental drop while
+    // adding the new ones).
+    assert_eq!(body["connected"], true);
+    assert_eq!(body["reconnecting"], false);
 }
 
 #[tokio::test]

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -2189,12 +2189,11 @@ async fn mcp_status_returns_404_for_unknown_server() {
     assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
-/// R9 #2 regression: the manager snapshot has `session_id`,
-/// `reconnect_count`, and `last_init_at` fields. The HTTP wire
-/// response forgot to surface them before R9; this test pins the
-/// fix so a future refactor of `get_mcp_server_status` doesn't
-/// silently drop them again. The session id is redacted on the wire;
-/// the raw MCP-Session-Id must never be returned by this route.
+/// R9 #2 regression: the manager snapshot has session diagnostics
+/// and `last_init_at`. The HTTP wire response forgot to surface them
+/// before R9; this test pins the fix so a future refactor of
+/// `get_mcp_server_status` doesn't silently drop them again. The raw
+/// MCP-Session-Id must never be returned by this route.
 #[tokio::test]
 async fn mcp_status_route_surfaces_session_reconnect_init_fields() {
     use std::time::SystemTime;
@@ -2233,8 +2232,8 @@ async fn mcp_status_route_surfaces_session_reconnect_init_fields() {
                 last_success_at: None,
                 reconnecting: false,
                 permanently_failed: false,
-                session_id: Some("test-session-xyz".to_string()),
-                reconnect_count: 3,
+                session_generation: Some(7),
+                transport_reconnect_count: 3,
                 // 2026-05-13 12:00:00 UTC, picked so the conversion to
                 // unix seconds is non-zero and we can assert on it.
                 last_init_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1_778_846_400)),
@@ -2307,19 +2306,24 @@ async fn mcp_status_route_surfaces_session_reconnect_init_fields() {
         request_json(&router, Method::GET, "/v1/mcp-servers/demo/status", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
-        body["session_id"]
-            .as_str()
-            .map(|value| value.starts_with("sha256:")),
-        Some(true),
-        "session_id must be a redacted digest; body = {body}"
-    );
-    assert_ne!(
-        body["session_id"], "test-session-xyz",
-        "raw MCP session id must not surface on wire; body = {body}"
+        body["session_generation"], 7,
+        "session_generation must surface; body = {body}"
     );
     assert_eq!(
-        body["reconnect_count"], 3,
-        "reconnect_count must surface; body = {body}"
+        body["transport_reconnect_count"], 3,
+        "transport_reconnect_count must surface; body = {body}"
+    );
+    assert!(
+        body.get("session_id").is_none(),
+        "raw MCP session id must not surface"
+    );
+    assert!(
+        body.get("session_id_digest").is_none(),
+        "session digest is intentionally omitted"
+    );
+    assert!(
+        body.get("reconnect_count").is_none(),
+        "ambiguous reconnect_count key must not surface"
     );
     assert_eq!(
         body["last_init_at"], 1_778_846_400,

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -214,7 +214,10 @@ impl ManagedMcpRegistry for TestManagedMcpRegistry {
         self.periodic_refresh_running.swap(false, Ordering::Relaxed)
     }
 
-    fn server_status(&self, _server_name: &str) -> Option<awaken_ext_mcp::McpServerStatusSnapshot> {
+    async fn server_status(
+        &self,
+        _server_name: &str,
+    ) -> Option<awaken_ext_mcp::McpServerStatusSnapshot> {
         None
     }
 
@@ -292,7 +295,10 @@ impl ManagedMcpRegistry for TrackingManagedMcpRegistry {
             .swap(false, Ordering::Relaxed)
     }
 
-    fn server_status(&self, _server_name: &str) -> Option<awaken_ext_mcp::McpServerStatusSnapshot> {
+    async fn server_status(
+        &self,
+        _server_name: &str,
+    ) -> Option<awaken_ext_mcp::McpServerStatusSnapshot> {
         None
     }
 

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -171,13 +171,19 @@ Current built-in namespaces:
   "last_attempt_at": 1777708820,       // unix seconds, null until first probe
   "last_success_at": 1777708820,       // unix seconds, null until first success
   "reconnecting": false,
-  "permanently_failed": false          // true once the manager has given up
+  "permanently_failed": false,         // true once the manager has given up
+  "session_id": "sha256:0123abcd...",  // redacted digest, null for stdio/no session
+  "reconnect_count": 0,                // successful runtime re-creations
+  "last_init_at": 1777708820           // unix seconds, null before initialize
 }
 ```
 
 `consecutive_failures` + `last_success_at` are surfaced from the existing
 `McpRefreshHealth` budget. There is no separate "errors in last 24h"
 counter — the health budget is the source of truth.
+
+`session_id` is a stable SHA-256 prefix of the live HTTP MCP session id, not
+the raw `MCP-Session-Id` header value.
 
 ### Admin audit log
 

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -172,8 +172,8 @@ Current built-in namespaces:
   "last_success_at": 1777708820,       // unix seconds, null until first success
   "reconnecting": false,
   "permanently_failed": false,         // true once the manager has given up
-  "session_id": "sha256:0123abcd...",  // redacted digest, null for stdio/no session
-  "reconnect_count": 0,                // successful runtime re-creations
+  "session_generation": 2,             // HTTP session reset/reinitialize generation
+  "transport_reconnect_count": 0,      // successful runtime re-creations
   "last_init_at": 1777708820           // unix seconds, null before initialize
 }
 ```
@@ -182,8 +182,10 @@ Current built-in namespaces:
 `McpRefreshHealth` budget. There is no separate "errors in last 24h"
 counter — the health budget is the source of truth.
 
-`session_id` is a stable SHA-256 prefix of the live HTTP MCP session id, not
-the raw `MCP-Session-Id` header value.
+The raw HTTP `MCP-Session-Id` is intentionally not exposed by this endpoint.
+`transport_reconnect_count` counts runtime tear-down/recreate cycles; HTTP
+404 session reset churn is visible through `session_generation` and
+`last_init_at`.
 
 ### Admin audit log
 


### PR DESCRIPTION
## TL;DR

This PR brings MCP integration closer to spec-compliant behavior for MCP `2025-11-25` across `awaken-ext-mcp` and server runtime wiring.

- Hardened MCP initialize, notifications, resources, prompts, completions, roots, and sampling handling.
- Added per-call/per-agent sampling routing infrastructure without installing a registry-wide production fallback handler.
- Improved Streamable HTTP/SSE behavior: JSON and SSE responses, stateful/stateless sessions, `Last-Event-ID` resume, initialize SSE resume, 404 session reset, DELETE-on-close, listener races, content-type validation, bounded SSE buffers, bounded `retry:`, and long-running SSE without total body timeout.
- Added cleanup guards for initialized transports/runtimes and provisional HTTP sessions.
- Removed raw HTTP `MCP-Session-Id` exposure from admin status snapshots/responses; status now reports `session_generation`, `transport_reconnect_count`, and `last_init_at`.
- Added real MCP server happy-path e2e coverage for official `@modelcontextprotocol/server-everything` over stdio and Streamable HTTP, pinned to `@modelcontextprotocol/server-everything@2026.1.26` in the default e2e path.
- Added a CI gate for the official MCP reference e2e test target.

Non-MCP admin/e2e coverage was split out of this PR into #197; this PR now keeps only MCP implementation, MCP server wiring/status/types, MCP docs/API surface notes, and MCP-focused tests.

## Latest Review Follow-Up

Folded into the cleaned six-commit history ending at `1764437b8`:

- `a34590dda` folds the Streamable HTTP/SSE review fixes: streaming client split, JSON/SSE response handling, initialize SSE/resume, provisional session DELETE, bounded SSE buffers and `retry:`, accepted-call no-replay, session-bound cancellation, listener/session races, stateful/stateless HTTP, DELETE-on-close, and content-type validation.
- `5f0ee5fed` covers cancellation health semantics, session status semantics, raw session-id removal, factory-only sampling boundaries, stdio fixed-fallback-only sampling, advisory `modelPreferences`, terminal HTTP close semantics, stale SSE sampling guard, and related regression tests.
- `1764437b8` covers MCP tool-error preservation, bounded progress/resource/list-change queues, coalesced tools refresh, optional UI hydration timeout/non-health path, dynamic `McpPlugin` registration boundary tests, the pinned reference e2e package, and the explicit reference e2e CI gate.

Previously handled HTTP/SSE review items are now folded into the relevant commits above instead of kept as standalone review-fix commits.

## MCP Commit Log

All timestamps below are local time (`Asia/Shanghai`, UTC+08:00). The sequence is chronological from the PR merge-base to the current PR head.

### Core Protocol And Capabilities

| Commit | Time | Subject |
| --- | --- | --- |
| `61c39033b` | `2026-05-15 07:10:00 +0800` | `🔒 fix(ext-mcp): implement MCP protocol compliance` |
| `184f4edae` | `2026-05-15 07:12:00 +0800` | `✨ feat(mcp): add sampling routing and protocol surfaces` |
| `8346e8617` | `2026-05-15 07:14:00 +0800` | `✨ feat(mcp): support roots resources completions and notifications` |

### Streamable HTTP/SSE Reliability

| Commit | Time | Subject |
| --- | --- | --- |
| `a34590dda` | `2026-05-15 07:16:00 +0800` | `🛠️ fix(mcp): harden streamable HTTP and SSE sessions` |

### Review Hardening And Runtime Semantics

| Commit | Time | Subject |
| --- | --- | --- |
| `5f0ee5fed` | `2026-05-15 08:20:00 +0800` | `🛠️ fix(mcp): tighten sampling and session status semantics` |
| `1764437b8` | `2026-05-16 07:24:07 +0800` | `🛠️ fix(mcp): bound updates and clarify dynamic refresh` |

## MCP Compatibility Scope

Supported protocol version: `2025-11-25` only. The client advertises `2025-11-25`, accepts that version during negotiation, and rejects unknown versions rather than silently downgrading.

Covered client-side surfaces:

- Transports: stdio and Streamable HTTP.
- Streamable HTTP: JSON/SSE responses, stateful/stateless sessions, `MCP-Protocol-Version`, `MCP-Session-Id`, DELETE termination, GET listener, `Last-Event-ID` resume, bounded `retry:`, 404 reset, and content-type validation.
- Tools: `tools/list`, `tools/call`, structured content, tool execution errors (`isError: true`), progress notifications, and cancellation notifications.
- Resources: `resources/list`, `resources/read`, subscribe/unsubscribe, and resource update notifications.
- Prompts/completions: `prompts/list`, `prompts/get`, `completion/complete`.
- Client features: roots/list and sampling/createMessage where the client explicitly advertises those capabilities.

Known boundaries:

- Factory-only sampling is isolation/routing infrastructure and is not advertised as global sampling support without a fixed fallback or future explicit safe opt-in.
- Stdio cannot safely correlate server-initiated sampling to a specific in-flight `tools/call`; stdio uses only fixed fallback sampling.
- The default sampling handler is basic text sampling: it maps system prompt, temperature, and maxTokens; it ignores advisory `modelPreferences`; it still rejects fields that would require unsupported behavior (`includeContext`, `tools`, `toolChoice`, non-empty `stopSequences`).
- The manager registry handles `notifications/tools/list_changed` reactively, but `McpPlugin` registration is still per resolve/register cycle; existing awaken runtimes do not hot-add or hot-remove tools.
- Reference-server e2e is a happy-path/reference-shape smoke suite. Fault paths such as 404 session expiry, mid-stream drops, malformed events, and cancellation races are covered by synthetic integration tests.
- HTTP auth/OAuth policy is deployment/configuration-owned and outside this transport layer.
- Elicitation and optional future MCP capabilities are not claimed unless listed above.

## Verification

Latest local verification at `1764437b8` after history cleanup:

- `cargo fmt --check` — clean.
- `cargo test -p awaken-ext-mcp` — 232 unit tests and 79 integration tests passed; ignored real-server e2e excluded by default.
- `cargo test --locked -p awaken-ext-mcp --test e2e_server_everything -- --ignored --test-threads=1` — pinned official `@modelcontextprotocol/server-everything@2026.1.26`: 6 passed, including stdio and Streamable HTTP.
- `cargo clippy -p awaken-ext-mcp --all-targets -- -D warnings` — clean.
- Pre-push hook completed during force-push; `admin-console-ci` and `validate` were skipped by hook file filters because the final tree was unchanged by history cleanup.

Earlier focused verification before final history cleanup:

- `cargo test -p awaken-contract` — full contract crate test suite passed.
- `cargo test -p awaken-server mcp_status_route_surfaces_session_reconnect_init_fields` — 1 passed.
- `cargo clippy -p awaken-ext-mcp -p awaken-server --all-targets -- -D warnings` — clean.
- `npm run typecheck` in `apps/admin-console` — clean.