### PR TITLE
refactor: catalog semantics with explicit modes and cross-layer validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ Development work lands here before the next versioned release.
 - Tool catalog semantics: `AgentSpec.allowed_tools` / `excluded_tools` now use explicit catalog
   values: `["*"]` for allow-all, `[]` for block-none on `excluded_tools`, and
   tool-id patterns matched by `awaken_tool_pattern::tool_id_match`. Existing
-  catalog entries containing an unescaped `*` change from exact-string matching
-  to wildcard matching; escape literal stars as `\*` when a real tool id
-  contains `*`.
+  catalog entries containing an unescaped `*` or a literal `\` change from
+  exact-string matching to pattern matching; escape literal stars as `\*`
+  and literal backslashes as `\\` when a real tool id contains either
+  character.
 
 ## [0.5.0] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 Development work lands here before the next versioned release.
 
+### Changed
+
+- Tool catalog semantics: `AgentSpec.allowed_tools` / `excluded_tools` now use explicit catalog
+  values: `["*"]` for allow-all, `[]` for block-none on `excluded_tools`, and
+  tool-id patterns matched by `awaken_tool_pattern::tool_id_match`. Existing
+  catalog entries containing an unescaped `*` change from exact-string matching
+  to wildcard matching; escape literal stars as `\*` when a real tool id
+  contains `*`.
+
 ## [0.5.0] - 2026-05-10
 
 The headline work since 0.4.0: every config record now flows through a CAS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "awaken-protocol-a2a",
  "awaken-runtime",
  "awaken-stores",
+ "awaken-tool-pattern",
  "futures",
  "genai",
  "jsonschema",

--- a/apps/admin-console/src/components/tool-selector.test.tsx
+++ b/apps/admin-console/src/components/tool-selector.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
-import { cleanup, render, screen, act, fireEvent } from "@testing-library/react";
+import { cleanup, render, screen, act, fireEvent, within } from "@testing-library/react";
 import { ToolSelector } from "./tool-selector";
 import type { ToolInfo } from "@/lib/config-api";
 
@@ -25,6 +25,9 @@ interface SelectorProps {
   onChange?: Mock;
   tools?: ToolInfo[];
   variant?: "include" | "exclude";
+  overridden?: boolean;
+  onReset?: Mock;
+  resetLabel?: string;
 }
 
 function renderSelector(overrides: SelectorProps = {}) {
@@ -32,7 +35,7 @@ function renderSelector(overrides: SelectorProps = {}) {
   const props = {
     title: "Allowed Tools",
     description: "Configure which tools this agent can use.",
-    value: undefined as string[] | null | undefined,
+    value: undefined as string[] | undefined,
     onChange,
     tools: TOOLS,
     ...overrides,
@@ -54,9 +57,7 @@ describe("ToolSelector — default All-tools mode", () => {
     expect(radio.checked).toBe(true);
 
     // allBody description should be visible
-    expect(
-      screen.getByText(/Every tool published to the runtime/),
-    ).toBeTruthy();
+    expect(screen.getByText(/Every tool published to the runtime/)).toBeTruthy();
 
     // Group headers should NOT appear
     expect(screen.queryByText("Built-in")).toBeNull();
@@ -84,7 +85,16 @@ describe("ToolSelector — switching to Custom mode", () => {
     // But since value is controlled, let's render with an explicit array to see groups.
     cleanup();
 
-    renderSelector({ value: ["Bash", "Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"] });
+    renderSelector({
+      value: [
+        "Bash",
+        "Read",
+        "plugin:reminder/add",
+        "plugin:reminder/list",
+        "mcp:weather/forecast",
+        "mcp:db/query",
+      ],
+    });
 
     // Tab strip exposes broad source kinds (Built-in/Plugin/MCP), each group
     // panel below exposes the specific source label. The text "Built-in" can
@@ -106,7 +116,16 @@ describe("ToolSelector — switching to Custom mode", () => {
 
 describe("ToolSelector — search filtering", () => {
   it("filters tools to only matching group when searching 'forecast'", () => {
-    renderSelector({ value: ["Bash", "Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"] });
+    renderSelector({
+      value: [
+        "Bash",
+        "Read",
+        "plugin:reminder/add",
+        "plugin:reminder/list",
+        "mcp:weather/forecast",
+        "mcp:db/query",
+      ],
+    });
 
     const searchInput = screen.getByRole("searchbox");
     act(() => {
@@ -130,7 +149,13 @@ describe("ToolSelector — search filtering", () => {
 describe("ToolSelector — group Select all / Clear buttons", () => {
   it("calls onChange with full set when 'Select all' is clicked on the built-in group", () => {
     // value = all except Bash — so built-in group is partially selected
-    const value = ["Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"];
+    const value = [
+      "Read",
+      "plugin:reminder/add",
+      "plugin:reminder/list",
+      "mcp:weather/forecast",
+      "mcp:db/query",
+    ];
     const { props } = renderSelector({ value });
 
     // Find "Select all" buttons — the built-in group is first
@@ -140,14 +165,20 @@ describe("ToolSelector — group Select all / Clear buttons", () => {
     });
 
     expect(props.onChange).toHaveBeenCalledOnce();
-    // setGroupSelection with all builtin tools selected plus existing — all 6 tools = collapse to explicit null
+    // setGroupSelection with every tool selected for include variant collapses to ["*"].
     const result = props.onChange.mock.calls[0][0];
-    // When every tool ends up selected, setGroupSelection returns null (explicit "all" override).
-    expect(result).toBeNull();
+    expect(result).toEqual(["*"]);
   });
 
   it("calls onChange excluding group tools when 'Clear' is clicked on the built-in group", () => {
-    const value = ["Bash", "Read", "plugin:reminder/add", "plugin:reminder/list", "mcp:weather/forecast", "mcp:db/query"];
+    const value = [
+      "Bash",
+      "Read",
+      "plugin:reminder/add",
+      "plugin:reminder/list",
+      "mcp:weather/forecast",
+      "mcp:db/query",
+    ];
     const { props } = renderSelector({ value });
 
     const clearBtns = screen.getAllByRole("button", { name: "Clear" });
@@ -183,7 +214,9 @@ describe("ToolSelector — group selection state badge", () => {
   });
 
   it("shows '1 of 2 selected' for the plugin group when one is selected", () => {
-    renderSelector({ value: ["Bash", "Read", "plugin:reminder/add", "mcp:weather/forecast", "mcp:db/query"] });
+    renderSelector({
+      value: ["Bash", "Read", "plugin:reminder/add", "mcp:weather/forecast", "mcp:db/query"],
+    });
 
     // Plugin group: 2 tools, 1 selected
     expect(screen.getByText("1 of 2 selected")).toBeTruthy();
@@ -192,26 +225,20 @@ describe("ToolSelector — group selection state badge", () => {
 
 describe("ToolSelector — variant='exclude' labels", () => {
   it("shows 'Block none' instead of 'All tools' for the all-mode radio", () => {
-    renderSelector({ value: undefined, variant: "exclude" });
+    renderSelector({ value: [], variant: "exclude" });
 
     expect(screen.getByText("Block none")).toBeTruthy();
     expect(screen.queryByText("All tools")).toBeNull();
   });
 
-  it("shows exclude-mode body text when value is undefined", () => {
-    renderSelector({ value: undefined, variant: "exclude" });
+  it("shows exclude-mode body text when value is the explicit empty list", () => {
+    renderSelector({ value: [], variant: "exclude" });
 
     expect(screen.getByText(/No tools are explicitly excluded/)).toBeTruthy();
   });
-});
 
-// R8 #1 — Regression suite for the exclude-variant data-loss bug. The
-// previous helpers were include-only: switching to "Custom exclusion"
-// from "Block none" would seed `excluded_tools` with every published
-// tool id, immediately stripping the agent of access to everything.
-describe("ToolSelector — variant='exclude' switching to Custom exclusion (R8 #1)", () => {
-  it("seeds custom mode with NO excluded tools (not the full tool list)", () => {
-    const { props } = renderSelector({ value: undefined, variant: "exclude" });
+  it("allows entering Custom exclusion from the explicit empty list", () => {
+    const { props } = renderSelector({ value: [], variant: "exclude" });
 
     const customLabel = screen.getByText("Custom exclusion");
     const customRadio = customLabel
@@ -222,19 +249,44 @@ describe("ToolSelector — variant='exclude' switching to Custom exclusion (R8 #
       fireEvent.click(customRadio);
     });
 
-    expect(props.onChange).toHaveBeenCalledOnce();
-    const result = props.onChange.mock.calls[0][0];
-    // Must be `[]` — every published tool would mean "block all tools",
-    // i.e. the agent would lose access to everything immediately on
-    // mode toggle.
-    expect(result).toEqual([]);
+    expect(props.onChange).toHaveBeenCalledWith([]);
+    expect(screen.getAllByText("Built-in").length).toBeGreaterThan(0);
+    expect(screen.getByText("Bash")).toBeTruthy();
   });
 
-  it("checking a tool from the empty excluded set ADDS that one tool", () => {
-    const { props } = renderSelector({ value: [], variant: "exclude" });
+  it("allows entering Custom exclusion from legacy null", () => {
+    renderSelector({ value: null, variant: "exclude" });
 
-    const bashIdEl = screen.getByText("Bash");
-    const bashLabel = bashIdEl.closest("label")!;
+    const customLabel = screen.getByText("Custom exclusion");
+    const customRadio = customLabel
+      .closest("label")!
+      .querySelector("input[type='radio']") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.click(customRadio);
+    });
+
+    expect(screen.getAllByText("Built-in").length).toBeGreaterThan(0);
+    expect(screen.getByText("Bash")).toBeTruthy();
+  });
+
+  it("selects only the clicked excluded tool after legacy null is normalized", () => {
+    const view = renderSelector({ value: null, variant: "exclude" });
+
+    const customLabel = screen.getByText("Custom exclusion");
+    const customRadio = customLabel
+      .closest("label")!
+      .querySelector("input[type='radio']") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.click(customRadio);
+    });
+
+    expect(view.props.onChange).toHaveBeenCalledWith([]);
+
+    view.rerender(<ToolSelector {...view.props} value={[]} />);
+
+    const bashLabel = screen.getByText("Bash").closest("label")!;
     const bashCheckbox = bashLabel.querySelector("input[type='checkbox']") as HTMLInputElement;
     expect(bashCheckbox.checked).toBe(false);
 
@@ -242,27 +294,43 @@ describe("ToolSelector — variant='exclude' switching to Custom exclusion (R8 #
       fireEvent.click(bashCheckbox);
     });
 
-    expect(props.onChange).toHaveBeenCalledOnce();
-    const result = props.onChange.mock.calls[0][0];
-    // Old helper returned `undefined` here (no add path for exclude),
-    // silently dropping the user's click.
-    expect(result).toEqual(["Bash"]);
+    expect(view.props.onChange).toHaveBeenLastCalledWith(["Bash"]);
+  });
+});
+
+describe("ToolSelector — legacy null deprecation hint", () => {
+  it("shows a deprecation banner when value is null", () => {
+    renderSelector({ value: null });
+    expect(screen.getByText(/Legacy config detected/)).toBeTruthy();
+    expect(screen.getByText(/Runtime treats this as the explicit \["\*"\] form/)).toBeTruthy();
+    expect(screen.queryByText(/Save to migrate/)).toBeNull();
   });
 
-  it("'Block none' radio emits explicit null (not undefined) so customized save overrides base", () => {
-    const { props } = renderSelector({ value: ["Bash"], variant: "exclude" });
+  it("shows a neutral exclude deprecation banner when value is null", () => {
+    renderSelector({ value: null, variant: "exclude" });
+    expect(screen.getByText(/Runtime treats this as the explicit \[\] form/)).toBeTruthy();
+    expect(screen.queryByText(/Save to migrate/)).toBeNull();
+  });
 
-    const blockNoneLabel = screen.getByText("Block none");
-    const blockNoneRadio = blockNoneLabel
+  it("does NOT show the banner when value is the explicit ['*']", () => {
+    renderSelector({ value: ["*"] });
+    expect(screen.queryByText(/Legacy config detected/)).toBeNull();
+  });
+
+  it("does NOT show the banner when value is the explicit empty list", () => {
+    renderSelector({ value: [] });
+    expect(screen.queryByText(/Legacy config detected/)).toBeNull();
+  });
+});
+
+describe("ToolSelector — explicit ['*'] all-mode", () => {
+  it("treats ['*'] as the 'all' mode (radio checked)", () => {
+    renderSelector({ value: ["*"] });
+    const allLabel = screen.getByText("All tools");
+    const radio = allLabel
       .closest("label")!
       .querySelector("input[type='radio']") as HTMLInputElement;
-
-    act(() => {
-      fireEvent.click(blockNoneRadio);
-    });
-
-    expect(props.onChange).toHaveBeenCalledOnce();
-    expect(props.onChange.mock.calls[0][0]).toBeNull();
+    expect(radio.checked).toBe(true);
   });
 });
 
@@ -305,5 +373,85 @@ describe("ToolSelector — toggling individual tool", () => {
     // Adding Bash to Read still not all tools, so should be explicit array
     expect(Array.isArray(result)).toBe(true);
     expect((result as string[]).sort()).toEqual(["Bash", "Read"].sort());
+  });
+});
+
+describe("ToolSelector — glob-backed selections", () => {
+  it("renders glob-matched tools as checked but not directly editable", () => {
+    const { props } = renderSelector({ value: ["mcp:weather/*"] });
+
+    const forecastIdEl = screen.getByText("mcp:weather/forecast");
+    const forecastLabel = forecastIdEl.closest("label")!;
+    const forecastCheckbox = forecastLabel.querySelector(
+      "input[type='checkbox']",
+    ) as HTMLInputElement;
+
+    expect(forecastCheckbox.checked).toBe(true);
+    expect(forecastCheckbox.disabled).toBe(true);
+    expect(screen.getByText("mcp:weather/*")).toBeTruthy();
+
+    act(() => {
+      fireEvent.click(forecastCheckbox);
+    });
+
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+
+  it("disables group Clear when a group contains glob-backed selections", () => {
+    renderSelector({ value: ["mcp:weather/*"] });
+
+    const weatherGroup = screen.getByText("MCP · weather").closest("div.rounded-md") as HTMLElement;
+    const clearButton = within(weatherGroup).getByRole("button", { name: "Clear" });
+
+    expect((clearButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("protects the exclude-all wildcard from checkbox edits", () => {
+    const { props } = renderSelector({ value: ["*"], variant: "exclude" });
+
+    const bashLabel = screen.getByText("Bash").closest("label")!;
+    const bashCheckbox = bashLabel.querySelector("input[type='checkbox']") as HTMLInputElement;
+
+    expect(bashCheckbox.checked).toBe(true);
+    expect(bashCheckbox.disabled).toBe(true);
+    expect(screen.getAllByText("*").length).toBeGreaterThan(0);
+
+    act(() => {
+      fireEvent.click(bashCheckbox);
+    });
+
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+
+  it("protects the exclude-all wildcard from group clear", () => {
+    const { props } = renderSelector({ value: ["*"], variant: "exclude" });
+
+    const builtInLabels = screen.getAllByText("Built-in");
+    const builtInGroup = builtInLabels[builtInLabels.length - 1].closest("div.rounded-md")!;
+    const clearButton = within(builtInGroup as HTMLElement).getByRole("button", { name: "Clear" });
+
+    expect((clearButton as HTMLButtonElement).disabled).toBe(true);
+
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+
+    expect(props.onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("ToolSelector — reset override control", () => {
+  it("calls onReset from the section reset button", () => {
+    const onReset = vi.fn();
+    renderSelector({
+      value: ["Bash"],
+      overridden: true,
+      onReset,
+      resetLabel: "Reset allowed_tools to default",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset allowed_tools to default" }));
+
+    expect(onReset).toHaveBeenCalledOnce();
   });
 });

--- a/apps/admin-console/src/components/tool-selector.test.tsx
+++ b/apps/admin-console/src/components/tool-selector.test.tsx
@@ -461,6 +461,42 @@ describe("ToolSelector — pattern / unmanaged catalog entries", () => {
     expect(screen.getByText(/Matches mcp:weather\/forecast/)).toBeTruthy();
   });
 
+  it("disables every checkbox matched by a wildcard entry that equals a tool id", () => {
+    const { props } = renderSelector({
+      value: ["tool*id"],
+      tools: [
+        { id: "tool*id", name: "Literal Star", description: "Literal star id" },
+        { id: "toolXid", name: "Expanded Match", description: "Wildcard match" },
+      ],
+    });
+
+    const [literalCheckbox, expandedCheckbox] = screen.getAllByRole(
+      "checkbox",
+    ) as HTMLInputElement[];
+    expect(literalCheckbox.checked).toBe(true);
+    expect(expandedCheckbox.checked).toBe(true);
+    expect(literalCheckbox.disabled).toBe(true);
+    expect(expandedCheckbox.disabled).toBe(true);
+
+    fireEvent.click(literalCheckbox);
+    expect(props.onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(props.onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("labels escaped literal star entries without marking them unmanaged", () => {
+    renderSelector({
+      value: ["foo\\*bar"],
+      tools: [{ id: "foo*bar", name: "Literal Star", description: "Literal star id" }],
+    });
+
+    expect(screen.getAllByText("foo\\*bar").length).toBeGreaterThan(0);
+    expect(screen.getByText("escaped literal")).toBeTruthy();
+    expect(screen.getByText("Escaped literal for foo*bar")).toBeTruthy();
+    expect(screen.queryByText("unmanaged")).toBeNull();
+  });
+
   it("keeps catalog controls visible when no tools are published", () => {
     const { props } = renderSelector({ value: ["stale:*"], tools: [] });
 

--- a/apps/admin-console/src/components/tool-selector.test.tsx
+++ b/apps/admin-console/src/components/tool-selector.test.tsx
@@ -388,7 +388,7 @@ describe("ToolSelector — glob-backed selections", () => {
 
     expect(forecastCheckbox.checked).toBe(true);
     expect(forecastCheckbox.disabled).toBe(true);
-    expect(screen.getByText("mcp:weather/*")).toBeTruthy();
+    expect(screen.getAllByText("mcp:weather/*").length).toBeGreaterThan(0);
 
     act(() => {
       fireEvent.click(forecastCheckbox);
@@ -437,6 +437,40 @@ describe("ToolSelector — glob-backed selections", () => {
     });
 
     expect(props.onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("ToolSelector — pattern / unmanaged catalog entries", () => {
+  it("lists unmatched catalog entries and removes them by raw value", () => {
+    const { props } = renderSelector({ value: ["Bash", "stale:*"] });
+
+    expect(screen.getByText("Pattern / unmanaged catalog entries")).toBeTruthy();
+    expect(screen.getByText("stale:*")).toBeTruthy();
+    expect(screen.getByText("No current tool matches")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(props.onChange).toHaveBeenCalledWith(["Bash"]);
+  });
+
+  it("shows matching tools for wildcard entries", () => {
+    renderSelector({ value: ["mcp:weather/*"] });
+
+    expect(screen.getByText("Pattern / unmanaged catalog entries")).toBeTruthy();
+    expect(screen.getAllByText("mcp:weather/*").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Matches mcp:weather\/forecast/)).toBeTruthy();
+  });
+
+  it("keeps catalog controls visible when no tools are published", () => {
+    const { props } = renderSelector({ value: ["stale:*"], tools: [] });
+
+    expect(screen.getByText("Allowed Tools")).toBeTruthy();
+    expect(screen.getAllByText("No tools are currently published.").length).toBeGreaterThan(0);
+    expect(screen.getByText("stale:*")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(props.onChange).toHaveBeenCalledWith([]);
   });
 });
 

--- a/apps/admin-console/src/components/tool-selector.tsx
+++ b/apps/admin-console/src/components/tool-selector.tsx
@@ -372,7 +372,12 @@ function CatalogEntryList({
                     wildcard
                   </span>
                 ) : null}
-                {!entry.exactToolExists ? (
+                {entry.escapedLiteral ? (
+                  <span className="rounded-pill bg-muted px-1.5 text-[10px] font-medium text-fg-soft">
+                    escaped literal
+                  </span>
+                ) : null}
+                {!entry.exactToolExists && !entry.matchesCurrentToolOnly ? (
                   <span className="rounded-pill bg-muted px-1.5 text-[10px] font-medium text-fg-soft">
                     unmanaged
                   </span>
@@ -396,6 +401,7 @@ function CatalogEntryList({
 
 function catalogEntryMatchSummary(entry: CatalogEntryInspection): string {
   if (entry.matches.length === 0) return "No current tool matches";
+  if (entry.escapedLiteral) return `Escaped literal for ${entry.matches[0]}`;
   const shown = entry.matches.slice(0, 4).join(", ");
   const remaining = entry.matches.length - 4;
   return remaining > 0 ? `Matches ${shown} +${remaining} more` : `Matches ${shown}`;

--- a/apps/admin-console/src/components/tool-selector.tsx
+++ b/apps/admin-console/src/components/tool-selector.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import type { ToolInfo } from "@/lib/config-api";
 import {
   applyToolSelectionMode,
+  catalogEntryInspections,
   groupSelectionState,
   groupToolsBySource,
   isLegacyCatalogValue,
@@ -9,8 +10,10 @@ import {
   isToolSelectionPatternBacked,
   toolSelectionPattern,
   nextAllowedTools,
+  removeCatalogEntry,
   setGroupSelection,
   toolSelectionMode,
+  type CatalogEntryInspection,
   type CatalogVariant,
   type ToolSelectionMode,
 } from "@/lib/agent-tool-selection";
@@ -99,6 +102,10 @@ export function ToolSelector({
   const derivedMode = toolSelectionMode(value, variant);
   const mode = modeOverride ?? derivedMode;
   const labels = LABELS_BY_VARIANT[variant];
+  const catalogEntries = useMemo(
+    () => catalogEntryInspections(value, allToolIds, variant),
+    [allToolIds, value, variant],
+  );
 
   useEffect(() => {
     if (!modeOverride) return;
@@ -132,6 +139,10 @@ export function ToolSelector({
       return;
     }
     onChange(setGroupSelection(value, allToolIds, groupToolIds, selected, variant));
+  }
+
+  function removeEntry(entry: string) {
+    onChange(removeCatalogEntry(value, entry));
   }
 
   const legacy = isLegacyCatalogValue(value);
@@ -233,7 +244,7 @@ export function ToolSelector({
 
           {filteredGroups.length === 0 ? (
             <div className="mt-4 rounded-md border border-dashed border-line px-4 py-3 text-sm text-fg-soft">
-              No tools match the current search.
+              {tools.length === 0 ? "No tools are currently published." : "No tools match the current search."}
             </div>
           ) : (
             <div className="mt-4 space-y-5">
@@ -268,7 +279,7 @@ export function ToolSelector({
                           disabled={hasPatternBackedSelection}
                           title={
                             hasPatternBackedSelection
-                              ? "This group includes glob-matched entries that cannot be cleared here."
+                              ? "This group includes pattern-backed entries that cannot be cleared here."
                               : undefined
                           }
                           className="rounded-md border border-line-strong bg-surface px-2 py-1 text-fg-soft hover:bg-muted"
@@ -287,7 +298,7 @@ export function ToolSelector({
                             key={tool.id}
                             title={
                               patternBacked
-                                ? `Matched by glob pattern \`${matchingPattern}\` — edit that entry in the raw config to change it.`
+                                ? `Matched by tool-id pattern \`${matchingPattern}\`.`
                                 : undefined
                             }
                             className={[
@@ -330,8 +341,64 @@ export function ToolSelector({
       ) : (
         <p className="mt-4 text-sm text-fg-soft">{labels.allBody}</p>
       )}
+      {catalogEntries.length > 0 ? (
+        <CatalogEntryList entries={catalogEntries} onRemove={removeEntry} />
+      ) : null}
     </section>
   );
+}
+
+function CatalogEntryList({
+  entries,
+  onRemove,
+}: {
+  entries: CatalogEntryInspection[];
+  onRemove: (entry: string) => void;
+}) {
+  return (
+    <div className="mt-4 rounded-md border border-line bg-soft p-4">
+      <div className="text-sm font-semibold text-fg-strong">Pattern / unmanaged catalog entries</div>
+      <div className="mt-3 space-y-2">
+        {entries.map((entry) => (
+          <div
+            key={entry.entry}
+            className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-line bg-surface px-3 py-2 text-sm"
+          >
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-xs text-fg-strong">{entry.entry}</span>
+                {entry.usesWildcard ? (
+                  <span className="rounded-pill bg-muted px-1.5 text-[10px] font-medium text-fg-soft">
+                    wildcard
+                  </span>
+                ) : null}
+                {!entry.exactToolExists ? (
+                  <span className="rounded-pill bg-muted px-1.5 text-[10px] font-medium text-fg-soft">
+                    unmanaged
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-1 text-xs text-fg-soft">{catalogEntryMatchSummary(entry)}</div>
+            </div>
+            <button
+              type="button"
+              onClick={() => onRemove(entry.entry)}
+              className="rounded-md border border-line-strong bg-surface px-2 py-1 text-xs font-medium text-fg-soft hover:bg-muted"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function catalogEntryMatchSummary(entry: CatalogEntryInspection): string {
+  if (entry.matches.length === 0) return "No current tool matches";
+  const shown = entry.matches.slice(0, 4).join(", ");
+  const remaining = entry.matches.length - 4;
+  return remaining > 0 ? `Matches ${shown} +${remaining} more` : `Matches ${shown}`;
 }
 
 function ModeRadio({

--- a/apps/admin-console/src/components/tool-selector.tsx
+++ b/apps/admin-console/src/components/tool-selector.tsx
@@ -1,13 +1,17 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ToolInfo } from "@/lib/config-api";
 import {
   applyToolSelectionMode,
   groupSelectionState,
   groupToolsBySource,
+  isLegacyCatalogValue,
   isToolAllowed,
+  isToolSelectionPatternBacked,
+  toolSelectionPattern,
   nextAllowedTools,
   setGroupSelection,
   toolSelectionMode,
+  type CatalogVariant,
   type ToolSelectionMode,
 } from "@/lib/agent-tool-selection";
 
@@ -16,21 +20,18 @@ interface ToolSelectorProps {
   title: string;
   /// Free-form caption explaining the semantics.
   description: string;
-  /// `undefined` or `null` = mode "all"; explicit list = mode "custom".
-  /// (Backend serializes `Option<Vec<String>>` as JSON null, so accept both.)
+  /// New explicit semantics: `["*"]` = all, `[]` = none, list = subset.
+  /// `null`/`undefined` accepted as legacy and surfaces a deprecation hint.
   value: string[] | null | undefined;
-  /// Selection changes emit `null` (not `undefined`) for the "all" /
-  /// "block none" radio. `null` is an explicit override on the wire,
-  /// which is what customized agents need — `undefined` would land in
-  /// the save-path's clear list and DELETE the override, re-inheriting
-  /// the base record's restricted list (R8 #1).
-  onChange: (next: string[] | null) => void;
+  onChange: (next: string[]) => void;
   tools: ToolInfo[];
-  /// "include" matches `allowed_tools` semantics (default = every tool
-  /// allowed). "exclude" matches `excluded_tools` (default = no tool
-  /// excluded). The wire-shape is identical but checkbox semantics
-  /// invert — the helpers know the difference, so always pass `variant`.
-  variant?: "include" | "exclude";
+  /// "include" — emits `["*"]` for All. "exclude" — emits `[]` for Block none.
+  /// The auto-collapse to `["*"]` when every tool ends up selected applies
+  /// only to the include variant.
+  variant?: CatalogVariant;
+  overridden?: boolean;
+  onReset?: () => void;
+  resetLabel?: string;
 }
 
 type SourceKindFilter = "all" | "builtin" | "plugin" | "mcp";
@@ -48,9 +49,13 @@ export function ToolSelector({
   onChange,
   tools,
   variant = "include",
+  overridden = false,
+  onReset,
+  resetLabel,
 }: ToolSelectorProps) {
   const [search, setSearch] = useState("");
   const [sourceFilter, setSourceFilter] = useState<SourceKindFilter>("all");
+  const [modeOverride, setModeOverride] = useState<ToolSelectionMode | null>(null);
   const allToolIds = useMemo(() => tools.map((tool) => tool.id), [tools]);
   const groups = useMemo(() => groupToolsBySource(tools), [tools]);
 
@@ -83,40 +88,84 @@ export function ToolSelector({
           trimmed.length === 0
             ? group.tools
             : group.tools.filter((tool) => {
-                const haystack = `${tool.id} ${tool.name ?? ""} ${tool.description ?? ""}`
-                  .toLowerCase();
+                const haystack =
+                  `${tool.id} ${tool.name ?? ""} ${tool.description ?? ""}`.toLowerCase();
                 return haystack.includes(trimmed);
               }),
       }))
       .filter((group) => group.tools.length > 0);
   }, [groups, search, sourceFilter]);
 
-  const mode = toolSelectionMode(value);
+  const derivedMode = toolSelectionMode(value, variant);
+  const mode = modeOverride ?? derivedMode;
   const labels = LABELS_BY_VARIANT[variant];
 
+  useEffect(() => {
+    if (!modeOverride) return;
+    if (modeOverride === derivedMode) {
+      setModeOverride(null);
+      return;
+    }
+    if (
+      modeOverride === "custom" &&
+      variant === "exclude" &&
+      (value == null || (Array.isArray(value) && value.length === 0))
+    ) {
+      return;
+    }
+    setModeOverride(null);
+  }, [derivedMode, modeOverride, value, variant]);
+
   function setMode(next: ToolSelectionMode) {
-    onChange(applyToolSelectionMode(value, next, allToolIds, variant));
+    const nextValue = applyToolSelectionMode(value, next, allToolIds, variant);
+    setModeOverride(toolSelectionMode(nextValue, variant) === next ? null : next);
+    onChange(nextValue);
   }
 
   function toggleTool(toolId: string, checked: boolean) {
+    if (isToolSelectionPatternBacked(value, toolId, variant)) return;
     onChange(nextAllowedTools(value, allToolIds, toolId, checked, variant));
   }
 
   function toggleGroup(groupToolIds: string[], selected: boolean) {
+    if (!selected && groupToolIds.some((id) => isToolSelectionPatternBacked(value, id, variant))) {
+      return;
+    }
     onChange(setGroupSelection(value, allToolIds, groupToolIds, selected, variant));
   }
 
+  const legacy = isLegacyCatalogValue(value);
+  const legacyHint = LEGACY_HINT_BY_VARIANT[variant];
+
   return (
     <section className="rounded-md border border-line bg-surface p-5 shadow-sm">
+      {legacy ? (
+        <div
+          role="status"
+          className="mb-4 rounded-md border border-line-strong bg-soft px-3 py-2 text-xs text-fg"
+        >
+          {legacyHint}
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h3 className="text-lg font-semibold text-fg-strong">{title}</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-semibold text-fg-strong">{title}</h3>
+            {overridden && onReset ? (
+              <button
+                type="button"
+                onClick={onReset}
+                aria-label={resetLabel ?? `Reset ${title} to default`}
+                title={resetLabel ?? `Reset ${title} to default`}
+                className="inline-flex h-5 w-5 items-center justify-center rounded-full text-xs text-tone-warn transition hover:bg-tone-warn/15"
+              >
+                ↺
+              </button>
+            ) : null}
+          </div>
           <p className="mt-2 max-w-xl text-sm text-fg-soft">{description}</p>
         </div>
-        <fieldset
-          aria-label={`${title} mode`}
-          className="flex shrink-0 gap-2"
-        >
+        <fieldset aria-label={`${title} mode`} className="flex shrink-0 gap-2">
           <ModeRadio
             checked={mode === "all"}
             onChange={() => setMode("all")}
@@ -191,11 +240,11 @@ export function ToolSelector({
               {filteredGroups.map((group) => {
                 const groupIds = group.tools.map((tool) => tool.id);
                 const state = groupSelectionState(value, groupIds, variant);
+                const hasPatternBackedSelection = groupIds.some((id) =>
+                  isToolSelectionPatternBacked(value, id, variant),
+                );
                 return (
-                  <div
-                    key={group.source.key}
-                    className="rounded-md border border-line bg-soft p-4"
-                  >
+                  <div key={group.source.key} className="rounded-md border border-line bg-soft p-4">
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div className="flex items-center gap-3">
                         <span className="text-sm font-semibold text-fg-strong">
@@ -216,6 +265,12 @@ export function ToolSelector({
                         <button
                           type="button"
                           onClick={() => toggleGroup(groupIds, false)}
+                          disabled={hasPatternBackedSelection}
+                          title={
+                            hasPatternBackedSelection
+                              ? "This group includes glob-matched entries that cannot be cleared here."
+                              : undefined
+                          }
                           className="rounded-md border border-line-strong bg-surface px-2 py-1 text-fg-soft hover:bg-muted"
                         >
                           Clear
@@ -225,21 +280,38 @@ export function ToolSelector({
                     <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
                       {group.tools.map((tool) => {
                         const checked = isToolAllowed(value, tool.id, variant);
+                        const matchingPattern = toolSelectionPattern(value, tool.id, variant);
+                        const patternBacked = matchingPattern !== null;
                         return (
                           <label
                             key={tool.id}
-                            className="flex gap-3 rounded-xl border border-line bg-surface px-3 py-2 text-sm text-fg"
+                            title={
+                              patternBacked
+                                ? `Matched by glob pattern \`${matchingPattern}\` — edit that entry in the raw config to change it.`
+                                : undefined
+                            }
+                            className={[
+                              "flex gap-3 rounded-xl border border-line bg-surface px-3 py-2 text-sm text-fg",
+                              patternBacked ? "opacity-70" : "",
+                            ].join(" ")}
                           >
                             <input
                               type="checkbox"
                               checked={checked}
-                              onChange={(event) =>
-                                toggleTool(tool.id, event.target.checked)
-                              }
+                              disabled={patternBacked}
+                              onChange={(event) => toggleTool(tool.id, event.target.checked)}
                             />
                             <div className="min-w-0">
-                              <div className="font-mono text-xs text-fg-strong">
-                                {tool.id}
+                              <div className="flex flex-wrap items-center gap-2">
+                                <div className="font-mono text-xs text-fg-strong">{tool.id}</div>
+                                {patternBacked ? (
+                                  <span
+                                    title={`Pattern: ${matchingPattern}`}
+                                    className="rounded-pill border border-line-strong bg-soft px-1.5 font-mono text-[10px] font-medium text-fg-soft"
+                                  >
+                                    {matchingPattern}
+                                  </span>
+                                ) : null}
                               </div>
                               <div className="mt-0.5 text-xs text-fg-soft">
                                 {tool.description || tool.name}
@@ -282,18 +354,12 @@ function ModeRadio({
           : "border-line bg-surface text-fg hover:border-line-strong hover:bg-soft",
       ].join(" ")}
     >
-      <input
-        type="radio"
-        className="sr-only"
-        checked={checked}
-        onChange={onChange}
-      />
+      <input type="radio" className="sr-only" checked={checked} onChange={onChange} />
       <div className="font-semibold">{label}</div>
       <div
-        className={[
-          "mt-0.5 text-xs leading-5",
-          checked ? "text-fg-faint" : "text-fg-soft",
-        ].join(" ")}
+        className={["mt-0.5 text-xs leading-5", checked ? "text-fg-faint" : "text-fg-soft"].join(
+          " ",
+        )}
       >
         {hint}
       </div>
@@ -306,7 +372,7 @@ function summariseSelection(
   total: number,
   value: string[] | null | undefined,
   groupToolIds: string[],
-  variant: "include" | "exclude",
+  variant: CatalogVariant,
 ): string {
   if (total === 0) return "0 tools";
   if (state === "all") return `${total} of ${total} selected`;
@@ -318,8 +384,15 @@ function summariseSelection(
   return `${selected} of ${total} selected`;
 }
 
+const LEGACY_HINT_BY_VARIANT: Record<CatalogVariant, string> = {
+  include:
+    'Legacy config detected: allowed_tools is null. Runtime treats this as the explicit ["*"] form.',
+  exclude:
+    "Legacy config detected: excluded_tools is null. Runtime treats this as the explicit [] form.",
+};
+
 const LABELS_BY_VARIANT: Record<
-  "include" | "exclude",
+  CatalogVariant,
   {
     allLabel: string;
     allHint: string;

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -344,6 +344,37 @@ describe("nextAllowedTools", () => {
     ).toEqual(["foo\\bar"]);
   });
 
+  it("removes the escaped literal entry when unchecking from ['*']", () => {
+    // Expanding from ["*"] seeds the baseline with escaped literal entries
+    // for any tool id that contains `*` or `\`. Unchecking the matching tool
+    // must drop that seed entry — otherwise the tool stays authorised even
+    // though the user just turned it off.
+    expect(
+      nextAllowedTools(["*"], ["tool*id", "Other"], "tool*id", false),
+    ).toEqual(["Other"]);
+  });
+
+  it("removes the escaped backslash entry when unchecking from ['*']", () => {
+    expect(
+      nextAllowedTools(["*"], ["foo\\bar", "Other"], "foo\\bar", false),
+    ).toEqual(["Other"]);
+  });
+
+  it("removes the escaped literal entry when unchecking from legacy allow-all", () => {
+    expect(
+      nextAllowedTools(undefined, ["tool*id", "Other"], "tool*id", false),
+    ).toEqual(["Other"]);
+  });
+
+  it("removes a pre-existing escaped literal entry when unchecking it", () => {
+    // The Admin already wrote `tool\*id` (the safe escaped form for the
+    // current tool id). A subsequent uncheck must remove it — keeping it
+    // would leave the tool authorised after the user turned it off.
+    expect(
+      nextAllowedTools(["tool\\*id", "Other"], ["tool*id", "Other"], "tool*id", false),
+    ).toEqual(["Other"]);
+  });
+
   it("refuses to collapse to ['*'] while an unmanaged entry remains", () => {
     // Every current tool id is now covered, but the catalog still holds an
     // unmanaged "unknown" entry — collapsing would silently extend its
@@ -681,5 +712,15 @@ describe("toolSelectionPattern", () => {
   it("returns ['*'] only as the pattern source for exclude variant", () => {
     expect(toolSelectionPattern(["*"], "Bash", "include")).toBe(null);
     expect(toolSelectionPattern(["*"], "Bash", "exclude")).toBe("*");
+  });
+
+  it("flags text-equal entries with dangling backslash as pattern-backed", () => {
+    // Entry and tool id are the same 2-char string `X\`. The matcher treats
+    // the dangling escape as a literal `\`, so the entry happens to match
+    // its own text. It is still grammatically a pattern (a plain raw
+    // literal must be free of catalog escape syntax), so the UI must
+    // manage it through the entry list rather than offer a checkbox toggle.
+    expect(toolSelectionPattern(["X\\"], "X\\")).toBe("X\\");
+    expect(isToolSelectionPatternBacked(["X\\"], "X\\")).toBe(true);
   });
 });

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -120,12 +120,16 @@ describe("catalogEntryInspections", () => {
       {
         entry: "OldTool",
         exactToolExists: false,
+        matchesCurrentToolOnly: false,
+        escapedLiteral: false,
         usesWildcard: false,
         matches: [],
       },
       {
         entry: "mcp:*",
         exactToolExists: false,
+        matchesCurrentToolOnly: false,
+        escapedLiteral: false,
         usesWildcard: true,
         matches: ["mcp:weather/forecast", "mcp:db/query"],
       },
@@ -137,8 +141,23 @@ describe("catalogEntryInspections", () => {
       {
         entry: "tool*id",
         exactToolExists: true,
+        matchesCurrentToolOnly: false,
+        escapedLiteral: false,
         usesWildcard: true,
         matches: ["tool*id", "toolXid"],
+      },
+    ]);
+  });
+
+  it("classifies escaped literal stars as current exact matches", () => {
+    expect(catalogEntryInspections(["foo\\*bar"], ["foo*bar"])).toEqual([
+      {
+        entry: "foo\\*bar",
+        exactToolExists: false,
+        matchesCurrentToolOnly: true,
+        escapedLiteral: true,
+        usesWildcard: false,
+        matches: ["foo*bar"],
       },
     ]);
   });
@@ -204,6 +223,12 @@ describe("nextAllowedTools", () => {
     ).toEqual(["mcp__github__*"]);
   });
 
+  it("preserves wildcard entries that are text-equal to a current tool id", () => {
+    expect(nextAllowedTools(["tool*id"], ["tool*id", "toolXid"], "tool*id", false)).toEqual([
+      "tool*id",
+    ]);
+  });
+
   it("preserves glob patterns when checking a non-matching tool", () => {
     expect(
       nextAllowedTools(
@@ -236,6 +261,12 @@ describe("isToolSelectionPatternBacked", () => {
     // No-longer-supported glob chars are literal, so they don't match those tool ids.
     expect(isToolSelectionPatternBacked(["mcp__github__read?"], "mcp__github__read1")).toBe(false);
     expect(isToolSelectionPatternBacked(["mcp__[ab]*"], "mcp__a_tool")).toBe(false);
+  });
+
+  it("treats text-equal wildcard entries as pattern-backed", () => {
+    expect(toolSelectionPattern(["tool*id"], "tool*id")).toBe("tool*id");
+    expect(isToolSelectionPatternBacked(["tool*id"], "tool*id")).toBe(true);
+    expect(isToolSelectionPatternBacked(["tool*id"], "toolXid")).toBe(true);
   });
 
   it("does not treat the include explicit-all sentinel as an unmanaged glob", () => {

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   applyToolSelectionMode,
+  catalogEntryInspections,
   groupSelectionState,
   groupToolsBySource,
+  hasUnescapedCatalogWildcard,
   isExplicitAll,
   isLegacyCatalogValue,
   isToolAllowed,
   isToolSelectionPatternBacked,
   nextAllowedTools,
+  removeCatalogEntry,
   setGroupSelection,
   toolSelectionMode,
   toolSelectionPattern,
@@ -102,6 +105,51 @@ describe("isExplicitAll / isLegacyCatalogValue", () => {
     expect(isLegacyCatalogValue(undefined)).toBe(true);
     expect(isLegacyCatalogValue(["*"])).toBe(false);
     expect(isLegacyCatalogValue([])).toBe(false);
+  });
+});
+
+describe("catalogEntryInspections", () => {
+  it("lists stale exact entries and wildcard entries", () => {
+    expect(
+      catalogEntryInspections(["Bash", "OldTool", "mcp:*"], [
+        "Bash",
+        "mcp:weather/forecast",
+        "mcp:db/query",
+      ]),
+    ).toEqual([
+      {
+        entry: "OldTool",
+        exactToolExists: false,
+        usesWildcard: false,
+        matches: [],
+      },
+      {
+        entry: "mcp:*",
+        exactToolExists: false,
+        usesWildcard: true,
+        matches: ["mcp:weather/forecast", "mcp:db/query"],
+      },
+    ]);
+  });
+
+  it("does not hide exact current tool ids that contain an unescaped wildcard", () => {
+    expect(catalogEntryInspections(["tool*id"], ["tool*id", "toolXid"])).toEqual([
+      {
+        entry: "tool*id",
+        exactToolExists: true,
+        usesWildcard: true,
+        matches: ["tool*id", "toolXid"],
+      },
+    ]);
+  });
+
+  it("recognises escaped literal star entries", () => {
+    expect(hasUnescapedCatalogWildcard("\\*literal")).toBe(false);
+    expect(hasUnescapedCatalogWildcard("*literal")).toBe(true);
+  });
+
+  it("removes raw catalog entries without expanding patterns", () => {
+    expect(removeCatalogEntry(["Bash", "mcp:*", "Read"], "mcp:*")).toEqual(["Bash", "Read"]);
   });
 });
 

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -4,149 +4,255 @@ import {
   applyToolSelectionMode,
   groupSelectionState,
   groupToolsBySource,
+  isExplicitAll,
+  isLegacyCatalogValue,
   isToolAllowed,
-  isToolSelected,
+  isToolSelectionPatternBacked,
   nextAllowedTools,
-  nextToolSelection,
   setGroupSelection,
   toolSelectionMode,
+  toolSelectionPattern,
   toolSourceFor,
   type ApiToolSource,
 } from "./agent-tool-selection";
 
-describe("agent tool selection (include variant)", () => {
-  const allToolIds = ["search", "write", "read"];
-
-  it("treats undefined allowed_tools as unrestricted", () => {
+describe("isToolAllowed", () => {
+  it("treats undefined as legacy implicit allow-all", () => {
     expect(isToolAllowed(undefined, "search")).toBe(true);
+  });
+
+  it("treats null as legacy implicit allow-all", () => {
+    expect(isToolAllowed(null, "search")).toBe(true);
+  });
+
+  it("treats null as legacy block-none for the exclude variant", () => {
+    expect(isToolAllowed(null, "search", "exclude")).toBe(false);
+  });
+
+  it("treats ['*'] as explicit allow-all", () => {
+    expect(isToolAllowed(["*"], "search")).toBe(true);
+    expect(isToolAllowed(["*"], "mcp__github__pr")).toBe(true);
   });
 
   it("treats an empty allowed_tools list as no tools selected", () => {
     expect(isToolAllowed([], "search")).toBe(false);
   });
 
+  it("matches literal tool id entries", () => {
+    expect(isToolAllowed(["search", "read"], "search")).toBe(true);
+    expect(isToolAllowed(["search", "read"], "write")).toBe(false);
+  });
+
+  it("matches glob entries", () => {
+    expect(isToolAllowed(["mcp__github__*"], "mcp__github__pr")).toBe(true);
+    expect(isToolAllowed(["mcp__github__*"], "mcp__gitlab__pr")).toBe(false);
+    expect(isToolAllowed(["read_*"], "read_file")).toBe(true);
+  });
+
+  it("uses catalog tool-id wildcard semantics", () => {
+    // '*' matches any sequence, including '/', ':' and '_'
+    expect(isToolAllowed(["*"], "Bash")).toBe(true);
+    expect(isToolAllowed(["*"], "mcp:weather/forecast")).toBe(true);
+    expect(isToolAllowed(["tool/id/*"], "tool/id/read")).toBe(true);
+    expect(isToolAllowed(["tool/id/*"], "tool/id/read/nested")).toBe(true);
+    expect(isToolAllowed(["mcp:*"], "mcp:weather/forecast")).toBe(true);
+    expect(isToolAllowed(["mcp:*"], "plugin:reminder/add")).toBe(false);
+    expect(isToolAllowed(["*issue"], "mcp__github__read_issue")).toBe(true);
+
+    // Multiple consecutive '*'s are still just wildcards (no path-glob semantics).
+    expect(isToolAllowed(["**"], "tool/id/read")).toBe(true);
+
+    // Path-glob, regex, arg-syntax, and leading-! are *not* catalog features;
+    // their characters are matched literally.
+    expect(isToolAllowed(["mcp__github__read?"], "mcp__github__read1")).toBe(false);
+    expect(isToolAllowed(["mcp__github__read?"], "mcp__github__read?")).toBe(true);
+    expect(isToolAllowed(["mcp__[ab]*"], "mcp__a_tool")).toBe(false);
+    expect(isToolAllowed(["mcp__{github,gitlab}__*"], "mcp__gitlab__issue")).toBe(false);
+    expect(isToolAllowed(["!Bash"], "Read")).toBe(false);
+    expect(isToolAllowed(["!Bash"], "!Bash")).toBe(true);
+    expect(isToolAllowed(["/B.*/"], "Bash")).toBe(false);
+    expect(isToolAllowed(["Bash(npm *)"], "Bash")).toBe(false);
+  });
+
+  it("treats '\\\\' as an escape so '\\\\*' matches a literal star", () => {
+    expect(isToolAllowed(["\\*literal"], "*literal")).toBe(true);
+    expect(isToolAllowed(["\\*literal"], "Xliteral")).toBe(false);
+    expect(isToolAllowed(["\\!Bash"], "!Bash")).toBe(true);
+  });
+
+  it("does not throw on dangling escape or unusual chars", () => {
+    expect(() => isToolAllowed(["\\"], "\\")).not.toThrow();
+    expect(() => isToolAllowed(["["], "[")).not.toThrow();
+    expect(isToolAllowed(["["], "[")).toBe(true);
+    expect(isToolAllowed(["["], "Bash")).toBe(false);
+  });
+});
+
+describe("isExplicitAll / isLegacyCatalogValue", () => {
+  it("recognises the explicit-all sentinel", () => {
+    expect(isExplicitAll(["*"])).toBe(true);
+    expect(isExplicitAll([])).toBe(false);
+    expect(isExplicitAll(["a"])).toBe(false);
+    expect(isExplicitAll(null)).toBe(false);
+    expect(isExplicitAll(undefined)).toBe(false);
+  });
+
+  it("flags only null/undefined as legacy catalog values", () => {
+    expect(isLegacyCatalogValue(null)).toBe(true);
+    expect(isLegacyCatalogValue(undefined)).toBe(true);
+    expect(isLegacyCatalogValue(["*"])).toBe(false);
+    expect(isLegacyCatalogValue([])).toBe(false);
+  });
+});
+
+describe("nextAllowedTools", () => {
+  const allToolIds = ["search", "write", "read"];
+
   it("starts from all tools when removing one from the unrestricted state", () => {
-    expect(nextAllowedTools(undefined, allToolIds, "write", false)).toEqual([
-      "search",
-      "read",
-    ]);
+    expect(nextAllowedTools(undefined, allToolIds, "write", false)).toEqual(["search", "read"]);
+  });
+
+  it("expands ['*'] before toggling a tool off", () => {
+    expect(nextAllowedTools(["*"], allToolIds, "write", false)).toEqual(["search", "read"]);
   });
 
   it("can re-add a tool after the user removed all selections", () => {
     expect(nextAllowedTools([], allToolIds, "read", true)).toEqual(["read"]);
   });
 
-  it("collapses to explicit null (not undefined) when every tool is selected again", () => {
-    // R8 #1: a customized agent picking "all tools" must PATCH an
-    // explicit null override, not DELETE the override (which would
-    // re-inherit the base's restricted list).
-    expect(nextAllowedTools(["search", "write"], ["search", "write"], "search", true)).toBeNull();
+  it("collapses to ['*'] for the include variant when every tool ends up selected", () => {
+    expect(nextAllowedTools(["search", "write"], ["search", "write"], "search", true)).toEqual([
+      "*",
+    ]);
+  });
+
+  it("does NOT collapse to ['*'] for the exclude variant", () => {
+    expect(
+      nextAllowedTools(["search", "write"], ["search", "write"], "search", true, "exclude"),
+    ).toEqual(expect.arrayContaining(["search", "write"]));
+  });
+
+  it("starts from no tools when checking one from legacy exclude null", () => {
+    expect(nextAllowedTools(null, ["Bash", "Read"], "Bash", true, "exclude")).toEqual(["Bash"]);
+  });
+
+  it("keeps legacy exclude null empty when unchecking a tool", () => {
+    expect(nextAllowedTools(null, ["Bash", "Read"], "Bash", false, "exclude")).toEqual([]);
+  });
+
+  it("preserves the exclude-all wildcard when toggling a tool", () => {
+    expect(nextAllowedTools(["*"], ["Bash", "Read"], "Bash", false, "exclude")).toEqual(["*"]);
+    expect(nextAllowedTools(["*"], ["Bash", "Read"], "Bash", true, "exclude")).toEqual(["*"]);
+  });
+
+  it("preserves glob patterns when unchecking a glob-matched tool", () => {
+    expect(
+      nextAllowedTools(
+        ["mcp__github__*"],
+        ["mcp__github__issue", "mcp__github__pr"],
+        "mcp__github__issue",
+        false,
+      ),
+    ).toEqual(["mcp__github__*"]);
+  });
+
+  it("preserves glob patterns when checking a non-matching tool", () => {
+    expect(
+      nextAllowedTools(
+        ["mcp__github__*"],
+        ["mcp__github__issue", "some_other_tool"],
+        "some_other_tool",
+        true,
+      ),
+    ).toEqual(["mcp__github__*", "some_other_tool"]);
+  });
+
+  it("does not collapse pattern-backed selections to ['*']", () => {
+    expect(
+      nextAllowedTools(
+        ["mcp__github__*"],
+        ["mcp__github__issue", "some_other_tool"],
+        "some_other_tool",
+        true,
+      ),
+    ).not.toEqual(["*"]);
+  });
+});
+
+describe("isToolSelectionPatternBacked", () => {
+  it("detects tool selections created by a wildcard entry", () => {
+    expect(isToolSelectionPatternBacked(["mcp__github__*"], "mcp__github__issue")).toBe(true);
+    expect(isToolSelectionPatternBacked(["mcp__github__*"], "Read")).toBe(false);
+    expect(isToolSelectionPatternBacked(["*issue"], "mcp__github__read_issue")).toBe(true);
+    expect(isToolSelectionPatternBacked(["mcp:*"], "mcp:weather/forecast")).toBe(true);
+    // No-longer-supported glob chars are literal, so they don't match those tool ids.
+    expect(isToolSelectionPatternBacked(["mcp__github__read?"], "mcp__github__read1")).toBe(false);
+    expect(isToolSelectionPatternBacked(["mcp__[ab]*"], "mcp__a_tool")).toBe(false);
+  });
+
+  it("does not treat the include explicit-all sentinel as an unmanaged glob", () => {
+    expect(isToolSelectionPatternBacked(["*"], "Read")).toBe(false);
+  });
+
+  it("treats the exclude explicit-all wildcard as pattern-backed", () => {
+    expect(isToolSelectionPatternBacked(["*"], "Read", "exclude")).toBe(true);
   });
 });
 
 describe("toolSelectionMode", () => {
-  it("classifies undefined as the default 'all' mode", () => {
+  it("classifies undefined as the 'all' mode (legacy)", () => {
     expect(toolSelectionMode(undefined)).toBe("all");
   });
 
-  it("classifies explicit null as the default 'all' mode", () => {
-    expect(toolSelectionMode(null)).toBe("all");
+  it("classifies ['*'] as the 'all' mode for include variant", () => {
+    expect(toolSelectionMode(["*"])).toBe("all");
   });
 
-  it("treats an explicit list as 'custom', even if it lists every tool", () => {
+  it("classifies [] as 'custom' for include variant (zero tools allowed)", () => {
     expect(toolSelectionMode([])).toBe("custom");
+  });
+
+  it("classifies [] as the 'all' mode for exclude variant (block none)", () => {
+    expect(toolSelectionMode([], "exclude")).toBe("all");
+  });
+
+  it("classifies ['*'] as 'custom' for exclude variant (block everything)", () => {
+    expect(toolSelectionMode(["*"], "exclude")).toBe("custom");
+  });
+
+  it("treats an explicit subset as 'custom' regardless of variant", () => {
     expect(toolSelectionMode(["search"])).toBe("custom");
+    expect(toolSelectionMode(["search"], "exclude")).toBe("custom");
   });
 });
 
-describe("applyToolSelectionMode (include)", () => {
-  it("returns explicit null when switching to 'all' (forces explicit override)", () => {
-    expect(applyToolSelectionMode(["search"], "all", ["search", "write"])).toBeNull();
+describe("applyToolSelectionMode", () => {
+  it("returns ['*'] when switching to 'all' for include variant", () => {
+    expect(applyToolSelectionMode(["search"], "all", ["search", "write"])).toEqual(["*"]);
+  });
+
+  it("returns [] when switching to 'all' for exclude variant", () => {
+    expect(applyToolSelectionMode(["search"], "all", ["search", "write"], "exclude")).toEqual([]);
   });
 
   it("preserves the existing custom list when re-entering custom mode", () => {
-    expect(applyToolSelectionMode(["search"], "custom", ["search", "write"])).toEqual([
-      "search",
-    ]);
+    expect(applyToolSelectionMode(["search"], "custom", ["search", "write"])).toEqual(["search"]);
   });
 
-  it("seeds custom mode with every known tool when there is no prior list", () => {
+  it("seeds custom mode with every known tool when prior value is undefined", () => {
     expect(applyToolSelectionMode(undefined, "custom", ["a", "b"])).toEqual(["a", "b"]);
   });
-});
 
-// R8 #1 — `excluded_tools` shares the wire shape with `allowed_tools` but
-// has inverted defaults: undefined/null = "no tool excluded" (not
-// "every tool excluded"). The component reuses the same helpers with a
-// `variant` discriminator; these tests pin the inverted semantics.
-describe("agent tool selection (exclude variant)", () => {
-  const allToolIds = ["search", "write", "read"];
-
-  it("treats undefined excluded_tools as 'no tool excluded'", () => {
-    expect(isToolSelected(undefined, "search", "exclude")).toBe(false);
-  });
-
-  it("treats null excluded_tools the same as undefined", () => {
-    expect(isToolSelected(null, "search", "exclude")).toBe(false);
-  });
-
-  it("treats an empty list as 'no tool excluded'", () => {
-    expect(isToolSelected([], "search", "exclude")).toBe(false);
-  });
-
-  it("treats an explicit list entry as excluded", () => {
-    expect(isToolSelected(["search"], "search", "exclude")).toBe(true);
-    expect(isToolSelected(["search"], "read", "exclude")).toBe(false);
-  });
-
-  it("checking a tool from null adds only that tool to the excluded list", () => {
-    // R8 #1: without the exclude variant, the previous helpers returned
-    // undefined here — checking a tool would NOT add it to the excluded
-    // list, so the UI checkbox state and the underlying value silently
-    // diverged.
-    expect(nextToolSelection(null, allToolIds, "search", true, "exclude")).toEqual([
-      "search",
-    ]);
-  });
-
-  it("checking another tool appends to the excluded list", () => {
-    expect(
-      nextToolSelection(["search"], allToolIds, "write", true, "exclude"),
-    ).toEqual(["search", "write"]);
-  });
-
-  it("unchecking the last tool collapses to null (explicit 'block none')", () => {
-    expect(
-      nextToolSelection(["search"], allToolIds, "search", false, "exclude"),
-    ).toBeNull();
-  });
-
-  it("unchecking a tool not in the list is a no-op", () => {
-    expect(nextToolSelection(null, allToolIds, "search", false, "exclude")).toBeNull();
-    expect(
-      nextToolSelection(["write"], allToolIds, "search", false, "exclude"),
-    ).toEqual(["write"]);
-  });
-});
-
-describe("applyToolSelectionMode (exclude)", () => {
-  it("custom mode from null seeds with [] (NOT every tool — that would block all tools)", () => {
-    // R8 #1: this was the data-loss bug — the previous helper returned
-    // `[...allToolIds]`, i.e. every tool in `excluded_tools`, so the
-    // moment a user clicked "Custom exclusion" the agent lost access to
-    // every tool.
+  it("seeds exclude custom mode with no tools when prior value is undefined", () => {
     expect(applyToolSelectionMode(undefined, "custom", ["a", "b"], "exclude")).toEqual([]);
+  });
+
+  it("seeds exclude custom mode with no tools when prior value is null", () => {
     expect(applyToolSelectionMode(null, "custom", ["a", "b"], "exclude")).toEqual([]);
   });
 
-  it("custom mode preserves a non-empty existing list", () => {
-    expect(
-      applyToolSelectionMode(["a"], "custom", ["a", "b"], "exclude"),
-    ).toEqual(["a"]);
-  });
-
-  it("'block none' mode emits explicit null (customized save → override)", () => {
-    expect(applyToolSelectionMode(["a"], "all", ["a", "b"], "exclude")).toBeNull();
+  it("seeds custom mode with every known tool when prior value is ['*']", () => {
+    expect(applyToolSelectionMode(["*"], "custom", ["a", "b"])).toEqual(["a", "b"]);
   });
 });
 
@@ -234,10 +340,7 @@ describe("groupToolsBySource", () => {
     const builtin = groups[0];
     expect(builtin.tools.map((t) => t.id)).toEqual(["Bash", "Read"]);
     const weather = groups[3];
-    expect(weather.tools.map((t) => t.id)).toEqual([
-      "mcp:weather/forecast",
-      "mcp:weather/now",
-    ]);
+    expect(weather.tools.map((t) => t.id)).toEqual(["mcp:weather/forecast", "mcp:weather/now"]);
   });
 
   it("uses explicit source field when present, ignoring id prefix", () => {
@@ -246,22 +349,26 @@ describe("groupToolsBySource", () => {
       { id: "some-tool", source: { kind: "plugin" as const, id: "reminder" } },
       { id: "Bash", source: { kind: "builtin" as const } },
     ]);
-    expect(groups.map((g) => g.source.key)).toEqual([
-      "builtin",
-      "plugin:reminder",
-      "mcp:weather",
-    ]);
+    expect(groups.map((g) => g.source.key)).toEqual(["builtin", "plugin:reminder", "mcp:weather"]);
     expect(groups[0].tools.map((t) => t.id)).toEqual(["Bash"]);
     expect(groups[1].tools.map((t) => t.id)).toEqual(["some-tool"]);
     expect(groups[2].tools.map((t) => t.id)).toEqual(["mcp__weather__forecast"]);
   });
 });
 
-describe("groupSelectionState (include)", () => {
+describe("groupSelectionState", () => {
   const groupIds = ["a", "b"];
 
   it("treats undefined allowed_tools as everything selected", () => {
     expect(groupSelectionState(undefined, groupIds)).toBe("all");
+  });
+
+  it("treats ['*'] as everything selected", () => {
+    expect(groupSelectionState(["*"], groupIds)).toBe("all");
+  });
+
+  it("treats null as no group members selected for exclude variant", () => {
+    expect(groupSelectionState(null, groupIds, "exclude")).toBe("none");
   });
 
   it("returns 'none' when no group member is in the allowed list", () => {
@@ -271,37 +378,62 @@ describe("groupSelectionState (include)", () => {
   it("returns 'some' when only part of the group is selected", () => {
     expect(groupSelectionState(["a"], groupIds)).toBe("some");
   });
-});
 
-describe("groupSelectionState (exclude)", () => {
-  const groupIds = ["a", "b"];
-
-  it("treats undefined excluded_tools as everything UN-selected (block none)", () => {
-    expect(groupSelectionState(undefined, groupIds, "exclude")).toBe("none");
-  });
-
-  it("returns 'all' when every group member is in the excluded list", () => {
-    expect(groupSelectionState(["a", "b"], groupIds, "exclude")).toBe("all");
-  });
-
-  it("returns 'some' when only part of the group is excluded", () => {
-    expect(groupSelectionState(["a"], groupIds, "exclude")).toBe("some");
+  it("returns 'all' when a glob entry covers every group member", () => {
+    expect(groupSelectionState(["*"], ["x", "y", "z"])).toBe("all");
   });
 });
 
-describe("setGroupSelection (include)", () => {
+describe("setGroupSelection", () => {
   const allToolIds = ["a", "b", "c"];
 
-  it("adds every group tool when selecting (collapses to explicit null when complete)", () => {
-    expect(setGroupSelection(["c"], allToolIds, ["a", "b"], true)).toBeNull();
+  it("collapses to ['*'] for include variant when every tool is selected", () => {
+    expect(setGroupSelection(["c"], allToolIds, ["a", "b"], true)).toEqual(["*"]);
   });
 
   it("removes every group tool when deselecting", () => {
     expect(setGroupSelection(undefined, allToolIds, ["a", "b"], false)).toEqual(["c"]);
   });
 
-  it("collapses to explicit null when the result covers every known tool", () => {
-    expect(setGroupSelection([], allToolIds, ["a", "b", "c"], true)).toBeNull();
+  it("collapses to ['*'] when the result covers every known tool", () => {
+    expect(setGroupSelection([], allToolIds, ["a", "b", "c"], true)).toEqual(["*"]);
+  });
+
+  it("does NOT collapse to ['*'] for the exclude variant", () => {
+    expect(setGroupSelection(["c"], allToolIds, ["a", "b"], true, "exclude")).toEqual(
+      expect.arrayContaining(["a", "b", "c"]),
+    );
+  });
+
+  it("starts from no tools when selecting a group from legacy exclude null", () => {
+    expect(setGroupSelection(null, allToolIds, ["a", "b"], true, "exclude")).toEqual(["a", "b"]);
+  });
+
+  it("preserves the exclude-all wildcard when toggling a group", () => {
+    expect(setGroupSelection(["*"], allToolIds, ["a", "b"], false, "exclude")).toEqual(["*"]);
+    expect(setGroupSelection(["*"], allToolIds, ["a", "b"], true, "exclude")).toEqual(["*"]);
+  });
+
+  it("preserves glob patterns when clearing a glob-backed group", () => {
+    expect(
+      setGroupSelection(
+        ["mcp__github__*"],
+        ["mcp__github__issue", "mcp__github__pr"],
+        ["mcp__github__issue", "mcp__github__pr"],
+        false,
+      ),
+    ).toEqual(["mcp__github__*"]);
+  });
+
+  it("does not collapse glob-backed group selection to ['*']", () => {
+    expect(
+      setGroupSelection(
+        ["mcp__github__*"],
+        ["mcp__github__issue", "some_other_tool"],
+        ["some_other_tool"],
+        true,
+      ),
+    ).toEqual(["mcp__github__*", "some_other_tool"]);
   });
 
   it("ignores group ids that are not part of the catalog", () => {
@@ -309,36 +441,27 @@ describe("setGroupSelection (include)", () => {
   });
 });
 
-describe("setGroupSelection (exclude)", () => {
-  const allToolIds = ["a", "b", "c"];
-
-  it("adds every group tool to the excluded list when 'Select all' is clicked", () => {
-    expect(setGroupSelection(null, allToolIds, ["a", "b"], true, "exclude")).toEqual([
-      "a",
-      "b",
-    ]);
+describe("toolSelectionPattern", () => {
+  it("flags glob entries that match the tool", () => {
+    expect(toolSelectionPattern(["mcp__github__*"], "mcp__github__pr")).toBe("mcp__github__*");
   });
 
-  it("collapses to explicit null when the excluded list ends up empty", () => {
-    expect(
-      setGroupSelection(["a"], allToolIds, ["a"], false, "exclude"),
-    ).toBeNull();
+  it("flags escaped-literal entries as pattern-backed", () => {
+    // Docs advertise `\!` as a literal leading bang. The raw entry differs
+    // from the tool id, so the checkbox must surface this as pattern-backed
+    // (and disabled) — otherwise a click would try to remove `!Bash`, miss
+    // the actual `\!Bash` entry, and leave the user stuck.
+    expect(toolSelectionPattern(["\\!Bash"], "!Bash")).toBe("\\!Bash");
+    expect(isToolSelectionPatternBacked(["\\!Bash"], "!Bash")).toBe(true);
   });
 
-  it("removes only the group tools, preserving other excluded entries", () => {
-    expect(
-      setGroupSelection(["a", "c"], allToolIds, ["a"], false, "exclude"),
-    ).toEqual(["c"]);
+  it("returns null for exact literal matches", () => {
+    expect(toolSelectionPattern(["Bash"], "Bash")).toBe(null);
+    expect(isToolSelectionPatternBacked(["Bash"], "Bash")).toBe(false);
   });
 
-  it("does NOT collapse when every tool is excluded — that's an intentional 'block all' state", () => {
-    // Distinct from include semantics: a fully-populated allowed_tools
-    // collapses to "all" because it's a redundant restriction; a fully-
-    // populated excluded_tools is the meaningful "block every tool"
-    // signal and must NOT collapse to null (which would mean the
-    // opposite — "block none").
-    expect(
-      setGroupSelection([], allToolIds, ["a", "b", "c"], true, "exclude"),
-    ).toEqual(["a", "b", "c"]);
+  it("returns ['*'] only as the pattern source for exclude variant", () => {
+    expect(toolSelectionPattern(["*"], "Bash", "include")).toBe(null);
+    expect(toolSelectionPattern(["*"], "Bash", "exclude")).toBe("*");
   });
 });

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyToolSelectionMode,
   catalogEntryInspections,
+  escapeCatalogLiteral,
   groupSelectionState,
   groupToolsBySource,
   hasUnescapedCatalogWildcard,
@@ -88,6 +89,35 @@ describe("isToolAllowed", () => {
     expect(() => isToolAllowed(["["], "[")).not.toThrow();
     expect(isToolAllowed(["["], "[")).toBe(true);
     expect(isToolAllowed(["["], "Bash")).toBe(false);
+  });
+});
+
+describe("escapeCatalogLiteral", () => {
+  it("returns plain tool ids untouched", () => {
+    expect(escapeCatalogLiteral("Bash")).toBe("Bash");
+    expect(escapeCatalogLiteral("mcp__github__issue")).toBe("mcp__github__issue");
+    expect(escapeCatalogLiteral("")).toBe("");
+  });
+
+  it("escapes unescaped stars to literal stars", () => {
+    expect(escapeCatalogLiteral("tool*id")).toBe("tool\\*id");
+    expect(escapeCatalogLiteral("*literal")).toBe("\\*literal");
+    expect(escapeCatalogLiteral("a*b*c")).toBe("a\\*b\\*c");
+  });
+
+  it("escapes backslashes before stars to preserve grammar", () => {
+    // "tool\id" must encode as "tool\\id" so the runtime treats it as literal.
+    expect(escapeCatalogLiteral("tool\\id")).toBe("tool\\\\id");
+    // "a\\*b" — backslash + star — escapes both so the runtime still sees
+    // literal `\` followed by literal `*`.
+    expect(escapeCatalogLiteral("a\\*b")).toBe("a\\\\\\*b");
+  });
+
+  it("produces output that round-trips through toolIdMatch", () => {
+    // The escaped form must match exactly its source tool id and nothing else.
+    expect(isToolAllowed([escapeCatalogLiteral("tool*id")], "tool*id")).toBe(true);
+    expect(isToolAllowed([escapeCatalogLiteral("tool*id")], "toolXid")).toBe(false);
+    expect(isToolAllowed([escapeCatalogLiteral("tool\\id")], "tool\\id")).toBe(true);
   });
 });
 
@@ -250,6 +280,33 @@ describe("nextAllowedTools", () => {
       ),
     ).not.toEqual(["*"]);
   });
+
+  it("escapes literal tool ids when adding via checkbox", () => {
+    // Raw `tool*id` would be interpreted by the runtime as a wildcard.
+    // The Admin UI must write the escaped form so the entry only authorises
+    // the current literal tool id.
+    expect(nextAllowedTools([], ["tool*id", "toolXid"], "tool*id", true)).toEqual([
+      "tool\\*id",
+    ]);
+  });
+
+  it("does not collapse text-equal wildcard entries to ['*']", () => {
+    // ["tool*id"] is a wildcard entry whose text happens to equal a current
+    // tool id. Adding `Other` must NOT auto-collapse to ["*"] because the
+    // wildcard would silently expand to cover every future tool too.
+    expect(
+      nextAllowedTools(["tool*id"], ["tool*id", "Other"], "Other", true),
+    ).not.toEqual(["*"]);
+  });
+
+  it("refuses to collapse to ['*'] while an unmanaged entry remains", () => {
+    // Every current tool id is now covered, but the catalog still holds an
+    // unmanaged "unknown" entry — collapsing would silently extend its
+    // authority to every future tool too.
+    expect(
+      nextAllowedTools(["unknown", "a"], ["a", "b"], "b", true),
+    ).toEqual(["unknown", "a", "b"]);
+  });
 });
 
 describe("isToolSelectionPatternBacked", () => {
@@ -332,6 +389,19 @@ describe("applyToolSelectionMode", () => {
 
   it("seeds custom mode with every known tool when prior value is ['*']", () => {
     expect(applyToolSelectionMode(["*"], "custom", ["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("escapes literal tool ids when seeding custom mode from legacy state", () => {
+    expect(applyToolSelectionMode(undefined, "custom", ["tool*id"])).toEqual([
+      "tool\\*id",
+    ]);
+  });
+
+  it("escapes literal tool ids when seeding custom mode from ['*']", () => {
+    expect(applyToolSelectionMode(["*"], "custom", ["tool*id", "Other"])).toEqual([
+      "tool\\*id",
+      "Other",
+    ]);
   });
 });
 
@@ -517,6 +587,21 @@ describe("setGroupSelection", () => {
 
   it("ignores group ids that are not part of the catalog", () => {
     expect(setGroupSelection(["a"], allToolIds, ["a", "z"], false)).toEqual([]);
+  });
+
+  it("escapes literal tool ids when adding a group selection", () => {
+    expect(setGroupSelection([], ["tool*id", "Other"], ["tool*id"], true)).toEqual([
+      "tool\\*id",
+    ]);
+  });
+
+  it("does not collapse to ['*'] when escaped literals cover every tool id", () => {
+    // Even though every tool ends up addressable, the escaped literal entry
+    // is not text-equal to the raw tool id, so the safest behaviour is to
+    // keep the explicit subset instead of writing ["*"].
+    expect(
+      setGroupSelection([], ["tool*id", "Other"], ["tool*id", "Other"], true),
+    ).toEqual(["tool\\*id", "Other"]);
   });
 });
 

--- a/apps/admin-console/src/lib/agent-tool-selection.test.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.test.ts
@@ -84,6 +84,15 @@ describe("isToolAllowed", () => {
     expect(isToolAllowed(["\\!Bash"], "!Bash")).toBe(true);
   });
 
+  it("requires escaped literal backslash to select the literal backslash tool id", () => {
+    // Raw `foo\bar` is interpreted as `foo` + `\b` (literal `b`) + `ar`, so
+    // it matches `foobar`, not the tool id that literally contains a
+    // backslash. Selecting the literal `foo\bar` requires `foo\\bar`.
+    expect(isToolAllowed(["foo\\bar"], "foo\\bar")).toBe(false);
+    expect(isToolAllowed(["foo\\bar"], "foobar")).toBe(true);
+    expect(isToolAllowed(["foo\\\\bar"], "foo\\bar")).toBe(true);
+  });
+
   it("does not throw on dangling escape or unusual chars", () => {
     expect(() => isToolAllowed(["\\"], "\\")).not.toThrow();
     expect(() => isToolAllowed(["["], "[")).not.toThrow();
@@ -176,6 +185,23 @@ describe("catalogEntryInspections", () => {
         usesWildcard: true,
         matches: ["tool*id", "toolXid"],
       },
+    ]);
+  });
+
+  it("does not hide raw backslash entries that equal a current tool id", () => {
+    // Catalog grammar treats `\` as the escape character, so a raw `foo\bar`
+    // entry whose text happens to equal a current tool id is NOT a safe
+    // literal — at runtime `\b` matches a literal `b`, so the entry
+    // authorises `foobar` instead of `foo\bar`. The Admin must surface the
+    // entry so the user can fix or remove it.
+    expect(
+      catalogEntryInspections(["foo\\bar"], ["foo\\bar", "foobar"]),
+    ).toEqual([
+      expect.objectContaining({
+        entry: "foo\\bar",
+        exactToolExists: true,
+        matches: ["foobar"],
+      }),
     ]);
   });
 
@@ -297,6 +323,25 @@ describe("nextAllowedTools", () => {
     expect(
       nextAllowedTools(["tool*id"], ["tool*id", "Other"], "Other", true),
     ).not.toEqual(["*"]);
+  });
+
+  it("does not collapse raw backslash entries to ['*']", () => {
+    // Same hazard as the wildcard case: `\` is the catalog escape character,
+    // so a raw entry whose text equals a tool id is still a pattern, not a
+    // safe literal — auto-collapsing would silently extend it to every
+    // future tool.
+    expect(
+      nextAllowedTools(["foo\\bar"], ["foo\\bar", "Other"], "Other", true),
+    ).not.toEqual(["*"]);
+  });
+
+  it("preserves raw backslash entries on uncheck", () => {
+    // Pattern-like entries (wildcard OR backslash-escaped) are managed
+    // through the catalog entry list, not the checkbox row, so unchecking
+    // their text-equal tool id must not silently drop them.
+    expect(
+      nextAllowedTools(["foo\\bar"], ["foo\\bar"], "foo\\bar", false),
+    ).toEqual(["foo\\bar"]);
   });
 
   it("refuses to collapse to ['*'] while an unmanaged entry remains", () => {
@@ -602,6 +647,15 @@ describe("setGroupSelection", () => {
     expect(
       setGroupSelection([], ["tool*id", "Other"], ["tool*id", "Other"], true),
     ).toEqual(["tool\\*id", "Other"]);
+  });
+
+  it("preserves raw backslash entries when clearing a group", () => {
+    // A raw `foo\bar` entry is not actually authorising the literal
+    // `foo\bar` tool, so clearing the group must not silently delete it;
+    // removal stays in the catalog entry list.
+    expect(
+      setGroupSelection(["foo\\bar", "Other"], ["foo\\bar", "Other"], ["foo\\bar"], false),
+    ).toEqual(["foo\\bar", "Other"]);
   });
 });
 

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -103,6 +103,8 @@ function isKnownToolId(entry: string, allToolIds: string[]): boolean {
 export interface CatalogEntryInspection {
   entry: string;
   exactToolExists: boolean;
+  matchesCurrentToolOnly: boolean;
+  escapedLiteral: boolean;
   usesWildcard: boolean;
   matches: string[];
 }
@@ -123,11 +125,15 @@ export function catalogEntryInspections(
     const usesWildcard = hasUnescapedCatalogWildcard(entry);
     const exactToolExists = isKnownToolId(entry, allToolIds);
     if (exactToolExists && !usesWildcard) continue;
+    const matches = allToolIds.filter((toolId) => toolIdMatch(entry, toolId));
+    const matchesCurrentToolOnly = !usesWildcard && matches.length === 1;
     entries.push({
       entry,
       exactToolExists,
+      matchesCurrentToolOnly,
+      escapedLiteral: matchesCurrentToolOnly && entry !== matches[0],
       usesWildcard,
-      matches: allToolIds.filter((toolId) => toolIdMatch(entry, toolId)),
+      matches,
     });
   }
   return entries;
@@ -182,7 +188,9 @@ export function toolSelectionPattern(
   if (!Array.isArray(allowedTools)) return null;
   if (isExplicitAll(allowedTools)) return variant === "exclude" ? EXPLICIT_ALL : null;
   for (const entry of allowedTools) {
-    if (entry !== toolId && toolIdMatch(entry, toolId)) return entry;
+    if (toolIdMatch(entry, toolId) && (entry !== toolId || hasUnescapedCatalogWildcard(entry))) {
+      return entry;
+    }
   }
   return null;
 }
@@ -214,7 +222,7 @@ export function nextAllowedTools(
     }
     return next;
   }
-  return baseline.filter((id) => id !== toolId);
+  return baseline.filter((id) => id !== toolId || hasUnescapedCatalogWildcard(id));
 }
 
 export type ToolSelectionMode = "all" | "custom";

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -41,6 +41,15 @@ export function hasUnescapedCatalogWildcard(entry: string): boolean {
   return false;
 }
 
+/// Encode a literal tool id as a catalog entry. Catalog grammar treats `*`
+/// as a wildcard and `\` as the escape character, so any tool id containing
+/// either must be escaped before being written to `allowed_tools` /
+/// `excluded_tools` — otherwise the runtime expands the entry into a
+/// pattern that can authorise unrelated tools.
+export function escapeCatalogLiteral(toolId: string): string {
+  return toolId.replace(/\\/g, "\\\\").replace(/\*/g, "\\*");
+}
+
 /// Match a tool-id pattern against a literal tool id. Mirrors the runtime's
 /// `awaken_tool_pattern::tool_id_match` — see the shared parity fixture at
 /// `crates/awaken-tool-pattern/tests/fixtures/catalog-glob-parity.json`.
@@ -162,8 +171,10 @@ function expandSubset(
   allToolIds: string[],
   variant: CatalogVariant,
 ): string[] {
-  if (value == null) return variant === "include" ? [...allToolIds] : [];
-  if (isExplicitAll(value)) return [...allToolIds];
+  if (value == null) {
+    return variant === "include" ? allToolIds.map(escapeCatalogLiteral) : [];
+  }
+  if (isExplicitAll(value)) return allToolIds.map(escapeCatalogLiteral);
   return [...value];
 }
 
@@ -195,8 +206,19 @@ export function toolSelectionPattern(
   return null;
 }
 
-function hasUnmanagedCatalogEntries(value: string[], allToolIds: string[]): boolean {
-  return value.some((entry) => !isKnownToolId(entry, allToolIds));
+/// Decide whether a catalog subset can safely be re-written as `["*"]`.
+/// Only collapse when every entry is a plain raw literal that is part of
+/// the current tool id set AND every tool id is covered by exactly one
+/// such literal. Wildcard entries, escaped-literal entries (whose text
+/// differs from the raw tool id) and unmanaged entries all keep their
+/// individual form so the catalog never silently widens to include
+/// tools that were not previously authorised.
+function canCollapseToExplicitAll(entries: string[], allToolIds: string[]): boolean {
+  return (
+    entries.every(
+      (entry) => isKnownToolId(entry, allToolIds) && !hasUnescapedCatalogWildcard(entry),
+    ) && allToolIds.every((toolId) => entries.includes(toolId))
+  );
 }
 
 export function nextAllowedTools(
@@ -210,14 +232,11 @@ export function nextAllowedTools(
 
   const baseline = expandSubset(allowedTools, allToolIds, variant);
   if (checked) {
+    const entry = escapeCatalogLiteral(toolId);
     const next = isKnownToolId(toolId, allToolIds)
-      ? Array.from(new Set([...baseline, toolId]))
+      ? Array.from(new Set([...baseline, entry]))
       : baseline;
-    if (
-      variant === "include" &&
-      !hasUnmanagedCatalogEntries(next, allToolIds) &&
-      allToolIds.every((id) => next.includes(id))
-    ) {
+    if (variant === "include" && canCollapseToExplicitAll(next, allToolIds)) {
       return [EXPLICIT_ALL];
     }
     return next;
@@ -248,7 +267,7 @@ export function applyToolSelectionMode(
   if (mode === "all") return allModeValue(variant);
   if (current != null && !isExplicitAll(current)) return [...current];
   if (variant === "exclude" && current == null) return [];
-  return [...allToolIds];
+  return allToolIds.map(escapeCatalogLiteral);
 }
 
 export type ToolSourceKind = "mcp" | "plugin" | "builtin";
@@ -347,21 +366,17 @@ export function setGroupSelection(
 
   if (selected) {
     for (const id of groupToolIds) {
-      if (isKnownToolId(id, allToolIds)) baseline.add(id);
+      if (isKnownToolId(id, allToolIds)) baseline.add(escapeCatalogLiteral(id));
     }
   } else {
     for (const id of groupToolIds) {
       baseline.delete(id);
+      baseline.delete(escapeCatalogLiteral(id));
     }
   }
 
   const next = Array.from(baseline);
-  if (
-    selected &&
-    variant === "include" &&
-    !hasUnmanagedCatalogEntries(next, allToolIds) &&
-    allToolIds.every((id) => baseline.has(id))
-  ) {
+  if (selected && variant === "include" && canCollapseToExplicitAll(next, allToolIds)) {
     return [EXPLICIT_ALL];
   }
 

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -2,7 +2,7 @@
 ///
 ///   ["*"]            - explicit all-pattern (matches every tool)
 ///   []               - explicit empty (matches nothing)
-///   ["a", "b*"]      - subset; entries may be literal ids or globs
+///   ["a", "b*"]      - subset; entries may be literal ids or tool-id patterns
 ///   null / undefined - deprecated legacy value; save migrates to explicit form
 ///
 /// The legacy `null`/`undefined` shape is retained for read compatibility
@@ -23,6 +23,22 @@ export function isLegacyCatalogValue(value: string[] | null | undefined): boolea
 
 export function isExplicitAll(value: string[] | null | undefined): boolean {
   return Array.isArray(value) && value.length === 1 && value[0] === EXPLICIT_ALL;
+}
+
+export function hasUnescapedCatalogWildcard(entry: string): boolean {
+  let escaped = false;
+  for (const char of entry) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === EXPLICIT_ALL) return true;
+  }
+  return false;
 }
 
 /// Match a tool-id pattern against a literal tool id. Mirrors the runtime's
@@ -82,6 +98,47 @@ export function toolIdMatch(pattern: string, value: string): boolean {
 
 function isKnownToolId(entry: string, allToolIds: string[]): boolean {
   return allToolIds.includes(entry);
+}
+
+export interface CatalogEntryInspection {
+  entry: string;
+  exactToolExists: boolean;
+  usesWildcard: boolean;
+  matches: string[];
+}
+
+export function catalogEntryInspections(
+  value: string[] | null | undefined,
+  allToolIds: string[],
+  variant: CatalogVariant = "include",
+): CatalogEntryInspection[] {
+  if (!Array.isArray(value)) return [];
+  if (variant === "include" && isExplicitAll(value)) return [];
+
+  const seen = new Set<string>();
+  const entries: CatalogEntryInspection[] = [];
+  for (const entry of value) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    const usesWildcard = hasUnescapedCatalogWildcard(entry);
+    const exactToolExists = isKnownToolId(entry, allToolIds);
+    if (exactToolExists && !usesWildcard) continue;
+    entries.push({
+      entry,
+      exactToolExists,
+      usesWildcard,
+      matches: allToolIds.filter((toolId) => toolIdMatch(entry, toolId)),
+    });
+  }
+  return entries;
+}
+
+export function removeCatalogEntry(
+  value: string[] | null | undefined,
+  entry: string,
+): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((candidate) => candidate !== entry);
 }
 
 export function isToolAllowed(

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -1,135 +1,191 @@
-/// Variant-aware tool selection helpers.
+/// Catalog semantics for `allowed_tools` / `excluded_tools`.
 ///
-/// `ToolSelector` is used for two AgentSpec fields with opposite semantics:
+///   ["*"]            - explicit all-pattern (matches every tool)
+///   []               - explicit empty (matches nothing)
+///   ["a", "b*"]      - subset; entries may be literal ids or globs
+///   null / undefined - deprecated legacy value; save migrates to explicit form
 ///
-///   - `allowed_tools` (variant `"include"`)
-///       null / undefined → every published tool is allowed (default)
-///       string[]         → only these tools are allowed
-///
-///   - `excluded_tools` (variant `"exclude"`)
-///       null / undefined → no tool is excluded (default)
-///       string[]         → these tools are removed from the allow-list
-///
-/// The wire-shape (`Option<Vec<String>>`) is identical for both, so we
-/// route through a single component, but the *semantics* (what `null`
-/// means, what a checkbox "checked" means, what to seed on mode toggle)
-/// are inverted. These helpers carry an explicit `variant` so the
-/// component never gets the wrong default — silently emitting "all tools
-/// excluded" on a Custom-exclusion toggle was R8 #1.
-///
-/// Mode toggles emit an explicit `null` for "all" (include) / "block
-/// none" (exclude) rather than `undefined`. For customized agents this
-/// matters: a `null` patch overrides the base record's restricted list
-/// with an explicit "no whitelist" / "no blacklist" override; a
-/// `undefined` value would land in the save-path's clear list and
-/// DELETE the override, re-inheriting the base's restriction — the
-/// opposite of what the user picked.
+/// The legacy `null`/`undefined` shape is retained for read compatibility
+/// only — every helper below normalises it but `isLegacyCatalogValue` lets
+/// callers (e.g. the editor UI) surface a deprecation hint.
 
-export type ToolSelectionVariant = "include" | "exclude";
+const EXPLICIT_ALL = "*";
 
-/// Whether a tool's checkbox should render checked.
-///
-/// - include: checked = "tool is in the allow-list". Defaults to true on
-///   null/undefined (no whitelist means every tool is allowed).
-/// - exclude: checked = "tool is in the exclude-list". Defaults to false
-///   on null/undefined (no blacklist means no tool is excluded).
-export function isToolSelected(
-  value: string[] | null | undefined,
-  toolId: string,
-  variant: ToolSelectionVariant = "include",
-): boolean {
-  if (variant === "exclude") {
-    return value ? value.includes(toolId) : false;
-  }
-  return value ? value.includes(toolId) : true;
+export type CatalogVariant = "include" | "exclude";
+
+function allModeValue(variant: CatalogVariant): string[] {
+  return variant === "include" ? [EXPLICIT_ALL] : [];
 }
 
-/// Backward-compat alias — older include-only call sites.
-export const isToolAllowed = isToolSelected;
+export function isLegacyCatalogValue(value: string[] | null | undefined): boolean {
+  return value == null;
+}
 
-/// Compute the next value after a checkbox toggle.
+export function isExplicitAll(value: string[] | null | undefined): boolean {
+  return Array.isArray(value) && value.length === 1 && value[0] === EXPLICIT_ALL;
+}
+
+/// Match a tool-id pattern against a literal tool id. Mirrors the runtime's
+/// `awaken_tool_pattern::tool_id_match` — see the shared parity fixture at
+/// `crates/awaken-tool-pattern/tests/fixtures/catalog-glob-parity.json`.
 ///
-/// For include: `checked` = "add to allow-list".
-/// For exclude: `checked` = "add to exclude-list".
+/// Grammar:
+/// - The full pattern must match the full tool id (anchored).
+/// - `*` matches any sequence of characters (including `/`, `:`, `_`).
+/// - `\` escapes the next character (`\*` = literal `*`; `\\` = literal `\`).
+/// - Every other character is a literal — there is no `**`, `?`, `[...]`,
+///   `{a,b}`, leading-`!` negation, or regex syntax at this layer.
 ///
-/// Returns explicit `null` when the resulting set means "default
-/// everywhere" (every tool allowed / nothing excluded) so customized
-/// agents persist the user's intent as an override rather than
-/// inheriting the base record.
-export function nextToolSelection(
+/// Exported for the parity test fixture; prefer `isToolAllowed` in component code.
+export function toolIdMatch(pattern: string, value: string): boolean {
+  const p = pattern;
+  const v = value;
+  let pi = 0;
+  let vi = 0;
+  let starPi: number | null = null;
+  let starVi = 0;
+
+  while (vi < v.length) {
+    if (pi < p.length) {
+      const c = p[pi];
+      if (c === "\\" && pi + 1 < p.length) {
+        if (p[pi + 1] === v[vi]) {
+          pi += 2;
+          vi += 1;
+          continue;
+        }
+      } else if (c === "*") {
+        starPi = pi;
+        starVi = vi;
+        pi += 1;
+        continue;
+      } else if (c === v[vi]) {
+        pi += 1;
+        vi += 1;
+        continue;
+      }
+    }
+    // Mismatch — backtrack to the last `*` and consume one more value char.
+    if (starPi !== null) {
+      pi = starPi + 1;
+      starVi += 1;
+      vi = starVi;
+    } else {
+      return false;
+    }
+  }
+  while (pi < p.length && p[pi] === "*") {
+    pi += 1;
+  }
+  return pi === p.length;
+}
+
+function isKnownToolId(entry: string, allToolIds: string[]): boolean {
+  return allToolIds.includes(entry);
+}
+
+export function isToolAllowed(
+  allowedTools: string[] | null | undefined,
+  toolId: string,
+  variant: CatalogVariant = "include",
+): boolean {
+  if (allowedTools == null) return variant === "include";
+  if (isExplicitAll(allowedTools)) return true;
+  return allowedTools.some((entry) => toolIdMatch(entry, toolId));
+}
+
+function expandSubset(
   value: string[] | null | undefined,
+  allToolIds: string[],
+  variant: CatalogVariant,
+): string[] {
+  if (value == null) return variant === "include" ? [...allToolIds] : [];
+  if (isExplicitAll(value)) return [...allToolIds];
+  return [...value];
+}
+
+export function isToolSelectionPatternBacked(
+  allowedTools: string[] | null | undefined,
+  toolId: string,
+  variant: CatalogVariant = "include",
+): boolean {
+  return toolSelectionPattern(allowedTools, toolId, variant) !== null;
+}
+
+/// Return the entry from `allowedTools` that pattern-matched `toolId` (so
+/// the UI can show which pattern is responsible). Any non-literal entry
+/// that grants access counts — including escaped literals such as `\!Bash`
+/// that the docs advertise as valid catalog grammar. Returns `null` when
+/// the tool's selection comes from an exact literal entry or nothing.
+export function toolSelectionPattern(
+  allowedTools: string[] | null | undefined,
+  toolId: string,
+  variant: CatalogVariant = "include",
+): string | null {
+  if (!Array.isArray(allowedTools)) return null;
+  if (isExplicitAll(allowedTools)) return variant === "exclude" ? EXPLICIT_ALL : null;
+  for (const entry of allowedTools) {
+    if (entry !== toolId && toolIdMatch(entry, toolId)) return entry;
+  }
+  return null;
+}
+
+function hasUnmanagedCatalogEntries(value: string[], allToolIds: string[]): boolean {
+  return value.some((entry) => !isKnownToolId(entry, allToolIds));
+}
+
+export function nextAllowedTools(
+  allowedTools: string[] | null | undefined,
   allToolIds: string[],
   toolId: string,
   checked: boolean,
-  variant: ToolSelectionVariant = "include",
-): string[] | null {
-  if (variant === "exclude") {
-    const current = value ?? [];
-    if (checked) {
-      const next = Array.from(new Set([...current, toolId])).filter((id) =>
-        allToolIds.includes(id),
-      );
-      return next.length === 0 ? null : next;
-    }
-    if (current.length === 0) return null;
-    const next = current.filter((id) => id !== toolId);
-    return next.length === 0 ? null : next;
-  }
-  // include
-  if (checked) {
-    if (!value) {
-      // Already "all tools allowed"; checking an already-checked tool is
-      // a no-op. Persist as explicit null so customized save emits an
-      // override rather than DELETE-ing it (which would inherit the
-      // base's restricted list).
-      return null;
-    }
-    const next = Array.from(new Set([...value, toolId])).filter((id) =>
-      allToolIds.includes(id),
-    );
-    return next.length >= allToolIds.length ? null : next;
-  }
-  const baseAllowed = value ?? allToolIds;
-  return baseAllowed.filter((id) => id !== toolId);
-}
+  variant: CatalogVariant = "include",
+): string[] {
+  if (variant === "exclude" && isExplicitAll(allowedTools)) return [EXPLICIT_ALL];
 
-/// Backward-compat alias.
-export const nextAllowedTools = nextToolSelection;
+  const baseline = expandSubset(allowedTools, allToolIds, variant);
+  if (checked) {
+    const next = isKnownToolId(toolId, allToolIds)
+      ? Array.from(new Set([...baseline, toolId]))
+      : baseline;
+    if (
+      variant === "include" &&
+      !hasUnmanagedCatalogEntries(next, allToolIds) &&
+      allToolIds.every((id) => next.includes(id))
+    ) {
+      return [EXPLICIT_ALL];
+    }
+    return next;
+  }
+  return baseline.filter((id) => id !== toolId);
+}
 
 export type ToolSelectionMode = "all" | "custom";
 
 export function toolSelectionMode(
-  value: string[] | null | undefined,
+  allowedTools: string[] | null | undefined,
+  variant: CatalogVariant = "include",
 ): ToolSelectionMode {
-  return value == null ? "all" : "custom";
+  if (allowedTools == null) return "all";
+  // For include variant: "all" means "allow every tool" — ["*"].
+  // For exclude variant: "all" means "block none" — [].
+  if (variant === "include" && isExplicitAll(allowedTools)) return "all";
+  if (variant === "exclude" && allowedTools.length === 0) return "all";
+  return "custom";
 }
 
-/// Switch between modes without losing user data.
-///
-/// "all" → explicit `null` (forces "all tools" / "block none" as an
-/// override; does NOT mean "inherit base").
-///
-/// "custom" with no prior list:
-///   - include: seeded with every known tool (so checkboxes start
-///     checked and the user deselects to narrow the list).
-///   - exclude: seeded with `[]` (so checkboxes start UNCHECKED — seeding
-///     with every tool would mean every tool is excluded, i.e. the agent
-///     loses access to everything; this was R8 #1).
 export function applyToolSelectionMode(
   current: string[] | null | undefined,
   mode: ToolSelectionMode,
   allToolIds: string[],
-  variant: ToolSelectionVariant = "include",
-): string[] | null {
-  if (mode === "all") return null;
-  if (current && current.length > 0) return current;
-  if (variant === "exclude") return [];
+  variant: CatalogVariant = "include",
+): string[] {
+  if (mode === "all") return allModeValue(variant);
+  if (current != null && !isExplicitAll(current)) return [...current];
+  if (variant === "exclude" && current == null) return [];
   return [...allToolIds];
 }
 
-/// Source bucket for grouping tools in the UI. We classify by id prefix:
-/// `mcp:server-id/...` → an MCP server; `plugin:...` → a plugin tool;
-/// otherwise it's a built-in.
 export type ToolSourceKind = "mcp" | "plugin" | "builtin";
 
 export interface ToolSource {
@@ -140,18 +196,12 @@ export interface ToolSource {
   key: string;
 }
 
-/// Backend-supplied source descriptor (from `/v1/capabilities`).
 export interface ApiToolSource {
   kind: "builtin" | "plugin" | "mcp";
   id?: string;
 }
 
-/// Derive a ToolSource from a backend-supplied source descriptor when present,
-/// falling back to id-prefix inference for tools without an explicit source.
-export function toolSourceFor(
-  toolId: string,
-  apiSource?: ApiToolSource,
-): ToolSource {
+export function toolSourceFor(toolId: string, apiSource?: ApiToolSource): ToolSource {
   if (apiSource) {
     if (apiSource.kind === "mcp") {
       const server = apiSource.id ?? "";
@@ -165,7 +215,6 @@ export function toolSourceFor(
     }
     return { kind: "builtin", label: "Built-in", key: "builtin" };
   }
-  // Fallback: infer from id prefix (legacy / tools without explicit source).
   if (toolId.startsWith("mcp:")) {
     const remainder = toolId.slice(4);
     const slash = remainder.indexOf("/");
@@ -220,58 +269,49 @@ const SOURCE_ORDER: Record<ToolSourceKind, number> = {
   mcp: 2,
 };
 
-/// "Select all" / "Clear" buttons on a group.
-///
-/// For include: selected=true means "allow every tool in this group" —
-/// collapses to `null` when every known tool ends up allowed.
-///
-/// For exclude: selected=true means "exclude every tool in this group" —
-/// collapses to `null` when no tool ends up excluded.
 export function setGroupSelection(
-  value: string[] | null | undefined,
+  allowedTools: string[] | null | undefined,
   allToolIds: string[],
   groupToolIds: string[],
   selected: boolean,
-  variant: ToolSelectionVariant = "include",
-): string[] | null {
-  if (variant === "exclude") {
-    const baseline = new Set(value ?? []);
-    if (selected) {
-      for (const id of groupToolIds) baseline.add(id);
-    } else {
-      for (const id of groupToolIds) baseline.delete(id);
-    }
-    const next = Array.from(baseline).filter((id) => allToolIds.includes(id));
-    return next.length === 0 ? null : next;
-  }
-  const baseline = new Set(value ?? allToolIds);
+  variant: CatalogVariant = "include",
+): string[] {
+  if (variant === "exclude" && isExplicitAll(allowedTools)) return [EXPLICIT_ALL];
+
+  const baseline = new Set(expandSubset(allowedTools, allToolIds, variant));
 
   if (selected) {
-    for (const id of groupToolIds) baseline.add(id);
+    for (const id of groupToolIds) {
+      if (isKnownToolId(id, allToolIds)) baseline.add(id);
+    }
   } else {
-    for (const id of groupToolIds) baseline.delete(id);
+    for (const id of groupToolIds) {
+      baseline.delete(id);
+    }
   }
 
-  if (selected && allToolIds.every((id) => baseline.has(id))) {
-    return null;
+  const next = Array.from(baseline);
+  if (
+    selected &&
+    variant === "include" &&
+    !hasUnmanagedCatalogEntries(next, allToolIds) &&
+    allToolIds.every((id) => baseline.has(id))
+  ) {
+    return [EXPLICIT_ALL];
   }
 
-  return Array.from(baseline).filter((id) => allToolIds.includes(id));
+  return next;
 }
 
-/// Selection state of a group of tools — used for the per-group "X of N
-/// selected" summary and the indeterminate visual state on group
-/// buttons. "Selected" follows the variant: included for `"include"`,
-/// excluded for `"exclude"`.
 export function groupSelectionState(
-  value: string[] | null | undefined,
+  allowedTools: string[] | null | undefined,
   groupToolIds: string[],
-  variant: ToolSelectionVariant = "include",
+  variant: CatalogVariant = "include",
 ): "all" | "some" | "none" {
   if (groupToolIds.length === 0) return "none";
   let selected = 0;
   for (const id of groupToolIds) {
-    if (isToolSelected(value, id, variant)) selected += 1;
+    if (isToolAllowed(allowedTools, id, variant)) selected += 1;
   }
   if (selected === 0) return "none";
   if (selected === groupToolIds.length) return "all";

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -222,7 +222,12 @@ export function toolSelectionPattern(
   if (!Array.isArray(allowedTools)) return null;
   if (isExplicitAll(allowedTools)) return variant === "exclude" ? EXPLICIT_ALL : null;
   for (const entry of allowedTools) {
-    if (toolIdMatch(entry, toolId) && (entry !== toolId || hasUnescapedCatalogWildcard(entry))) {
+    if (
+      toolIdMatch(entry, toolId) &&
+      (entry !== toolId ||
+        hasUnescapedCatalogWildcard(entry) ||
+        hasCatalogEscape(entry))
+    ) {
       return entry;
     }
   }
@@ -263,10 +268,17 @@ export function nextAllowedTools(
     }
     return next;
   }
-  return baseline.filter(
-    (id) =>
-      id !== toolId || hasUnescapedCatalogWildcard(id) || hasCatalogEscape(id),
-  );
+  // Unchecking the tool must drop both forms the Admin would have written
+  // for it — the bare literal id (when it is a plain raw literal) and the
+  // escaped literal seeded by `expandSubset` from `["*"]` / legacy
+  // allow-all. Wildcard, backslash-bearing and unmanaged entries stay put;
+  // those are managed exclusively through the explicit catalog entry list.
+  const literalEntry = escapeCatalogLiteral(toolId);
+  return baseline.filter((entry) => {
+    if (entry === literalEntry) return false;
+    if (entry === toolId && isPlainRawCatalogLiteral(entry, allToolIds)) return false;
+    return true;
+  });
 }
 
 export type ToolSelectionMode = "all" | "custom";

--- a/apps/admin-console/src/lib/agent-tool-selection.ts
+++ b/apps/admin-console/src/lib/agent-tool-selection.ts
@@ -41,6 +41,29 @@ export function hasUnescapedCatalogWildcard(entry: string): boolean {
   return false;
 }
 
+/// `\` is the catalog escape character — its mere presence means the entry
+/// is parsed as a pattern, not a literal, even when no `*` follows. A raw
+/// `foo\bar` entry matches the literal tool id `foobar` (the `\b` escapes
+/// the `b`), not `foo\bar`. Anything containing `\` therefore cannot be
+/// treated as a safe text-equal literal.
+function hasCatalogEscape(entry: string): boolean {
+  return entry.includes("\\");
+}
+
+/// A "plain raw literal" is a catalog entry whose raw text equals a current
+/// tool id AND contains no catalog grammar characters. These are the only
+/// entries the Admin can manage purely through checkbox toggles —
+/// everything else (wildcard entries, backslash-escaped entries, unmanaged
+/// entries) belongs in the explicit catalog entry list so the user can
+/// see and remove it without accidentally widening or narrowing access.
+function isPlainRawCatalogLiteral(entry: string, allToolIds: string[]): boolean {
+  return (
+    isKnownToolId(entry, allToolIds) &&
+    !hasUnescapedCatalogWildcard(entry) &&
+    !hasCatalogEscape(entry)
+  );
+}
+
 /// Encode a literal tool id as a catalog entry. Catalog grammar treats `*`
 /// as a wildcard and `\` as the escape character, so any tool id containing
 /// either must be escaped before being written to `allowed_tools` /
@@ -131,9 +154,9 @@ export function catalogEntryInspections(
   for (const entry of value) {
     if (seen.has(entry)) continue;
     seen.add(entry);
+    if (isPlainRawCatalogLiteral(entry, allToolIds)) continue;
     const usesWildcard = hasUnescapedCatalogWildcard(entry);
     const exactToolExists = isKnownToolId(entry, allToolIds);
-    if (exactToolExists && !usesWildcard) continue;
     const matches = allToolIds.filter((toolId) => toolIdMatch(entry, toolId));
     const matchesCurrentToolOnly = !usesWildcard && matches.length === 1;
     entries.push({
@@ -207,17 +230,16 @@ export function toolSelectionPattern(
 }
 
 /// Decide whether a catalog subset can safely be re-written as `["*"]`.
-/// Only collapse when every entry is a plain raw literal that is part of
-/// the current tool id set AND every tool id is covered by exactly one
-/// such literal. Wildcard entries, escaped-literal entries (whose text
-/// differs from the raw tool id) and unmanaged entries all keep their
-/// individual form so the catalog never silently widens to include
-/// tools that were not previously authorised.
+/// Only collapse when every entry is a plain raw literal — a current tool
+/// id with no wildcard and no `\` escape — and every tool id is covered.
+/// Wildcard entries, backslash-bearing entries, escaped-literal entries
+/// and unmanaged entries all keep their individual form so the catalog
+/// never silently widens to include tools that were not previously
+/// authorised.
 function canCollapseToExplicitAll(entries: string[], allToolIds: string[]): boolean {
   return (
-    entries.every(
-      (entry) => isKnownToolId(entry, allToolIds) && !hasUnescapedCatalogWildcard(entry),
-    ) && allToolIds.every((toolId) => entries.includes(toolId))
+    entries.every((entry) => isPlainRawCatalogLiteral(entry, allToolIds)) &&
+    allToolIds.every((toolId) => entries.includes(toolId))
   );
 }
 
@@ -241,7 +263,10 @@ export function nextAllowedTools(
     }
     return next;
   }
-  return baseline.filter((id) => id !== toolId || hasUnescapedCatalogWildcard(id));
+  return baseline.filter(
+    (id) =>
+      id !== toolId || hasUnescapedCatalogWildcard(id) || hasCatalogEscape(id),
+  );
 }
 
 export type ToolSelectionMode = "all" | "custom";
@@ -370,7 +395,9 @@ export function setGroupSelection(
     }
   } else {
     for (const id of groupToolIds) {
-      baseline.delete(id);
+      if (isPlainRawCatalogLiteral(id, allToolIds)) {
+        baseline.delete(id);
+      }
       baseline.delete(escapeCatalogLiteral(id));
     }
   }

--- a/apps/admin-console/src/lib/catalog-glob-parity.test.ts
+++ b/apps/admin-console/src/lib/catalog-glob-parity.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { toolIdMatch } from "./agent-tool-selection";
+
+interface Case {
+  pattern: string;
+  value: string;
+  expected: boolean;
+  note: string;
+}
+
+// Single source of truth shared with the Rust runtime test
+// (crates/awaken-tool-pattern/tests/catalog_glob_parity.rs). Drift between
+// the two matchers is what this test exists to catch.
+const fixturePath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../crates/awaken-tool-pattern/tests/fixtures/catalog-glob-parity.json",
+);
+const cases: Case[] = JSON.parse(readFileSync(fixturePath, "utf-8"));
+
+describe("catalog tool-id pattern parity vs awaken-tool-pattern runtime", () => {
+  it.each(cases)(
+    "pattern=$pattern  value=$value  expected=$expected — $note",
+    ({ pattern, value, expected }) => {
+      expect(toolIdMatch(pattern, value)).toBe(expected);
+    },
+  );
+});

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -141,6 +141,101 @@ describe("agent editor catalog save normalization", () => {
   });
 });
 
+describe("agent editor tool catalog preview", () => {
+  async function renderToolsPreview(overrides: Partial<AgentSpec>) {
+    const agentId = `preview-${Math.random().toString(36).slice(2, 8)}`;
+    const agentBody = {
+      ...agentSpec(agentId),
+      ...overrides,
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const href = fetchHref(input);
+        const method = init?.method?.toUpperCase() ?? "GET";
+        if (method === "GET" && href.includes("/v1/capabilities")) {
+          return jsonResponse({
+            agents: [],
+            tools: [
+              {
+                id: "Read",
+                name: "Read",
+                description: "Read local files",
+                source: { kind: "builtin" },
+              },
+              {
+                id: "mcp:weather/forecast",
+                name: "Forecast",
+                description: "Weather forecast",
+                source: { kind: "mcp", id: "weather" },
+              },
+              {
+                id: "mcp:db/query",
+                name: "Query",
+                description: "Database query",
+                source: { kind: "mcp", id: "db" },
+              },
+            ],
+            plugins: [],
+            skills: [],
+            models: [{ id: "model-a", upstream_model: "gpt-test" }],
+            providers: [],
+            namespaces: [],
+          });
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+          return jsonResponse({
+            source: { kind: "user" },
+            hidden: false,
+            user_overrides: null,
+            created_at: 0,
+            updated_at: 0,
+          });
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+          return jsonResponse(agentBody);
+        }
+        if (method === "GET" && href.includes("/v1/audit-log")) {
+          return jsonResponse({ items: [] });
+        }
+        throw new Error(`Unexpected fetch: ${method} ${href}`);
+      }),
+    );
+
+    renderEditorRoute(`/agents/${agentId}?tab=tools`);
+    await screen.findByText("Allowed/excluded tools (pre-permission)");
+    return screen.getByTestId("catalog-preview-count").textContent ?? "";
+  }
+
+  it("treats allowed_tools ['*'] as every published tool", async () => {
+    const count = await renderToolsPreview({
+      allowed_tools: ["*"],
+      excluded_tools: [],
+    });
+
+    expect(count).toContain("3 / 3");
+  });
+
+  it("applies tool-id patterns in allowed_tools", async () => {
+    const count = await renderToolsPreview({
+      allowed_tools: ["mcp:*"],
+      excluded_tools: [],
+    });
+
+    expect(count).toContain("2 / 3");
+  });
+
+  it("applies tool-id patterns in excluded_tools", async () => {
+    const count = await renderToolsPreview({
+      allowed_tools: ["*"],
+      excluded_tools: ["mcp:*"],
+    });
+
+    expect(count).toContain("1 / 3");
+  });
+});
+
 describe("agent editor tab ARIA semantics", () => {
   async function waitForBasicsPanel() {
     await screen.findByLabelText("Agent ID", undefined, { timeout: 5000 });
@@ -1927,6 +2022,8 @@ describe("agent editor Save → PATCH vs PUT branching", () => {
 
     await screen.findByText(`Agent "${agentId}" saved (no patchable changes)`);
     expect(patchCalled).toBe(false);
+    expect(screen.getByText("Up to date")).toBeTruthy();
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
   });
 
   it("does not PATCH legacy catalog normalization as builtin override fields", async () => {

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -11,6 +11,7 @@ import { ADMIN_TOKEN_STORAGE_KEY } from "../lib/config-api";
 import type { AgentSpec } from "../lib/config-api";
 import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
 import { withQueryClient } from "../test/query";
+import { diffPatchableFields, normalizeCatalogForSave } from "./agent-editor/spec-helpers";
 
 function stubCapabilitiesFetch() {
   const fetchSpy = vi.fn(async () => ({
@@ -111,6 +112,33 @@ afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
   __resetAuthInterceptorForTesting();
+});
+
+describe("agent editor catalog save normalization", () => {
+  it("turns legacy null catalog fields into explicit save values", () => {
+    const legacySpec = {
+      ...agentSpec("legacy-agent"),
+      allowed_tools: null,
+      excluded_tools: null,
+    };
+
+    expect(normalizeCatalogForSave(legacySpec)).toMatchObject({
+      allowed_tools: ["*"],
+      excluded_tools: [],
+    });
+  });
+
+  it("does not turn legacy catalog normalization into builtin override patch fields", () => {
+    const legacySpec = {
+      ...agentSpec("legacy-agent"),
+      allowed_tools: null,
+      excluded_tools: null,
+    };
+
+    expect(
+      diffPatchableFields(normalizeCatalogForSave(legacySpec), normalizeCatalogForSave(legacySpec)),
+    ).toEqual({});
+  });
 });
 
 describe("agent editor tab ARIA semantics", () => {
@@ -1403,6 +1431,71 @@ describe("agent editor source badges", () => {
       ).toBe("default prompt");
     });
   });
+
+  it("shows per-field reset controls for customized tool catalog overrides", async () => {
+    const agentId = "tools-customized";
+    let resetAllowedCalled = false;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [
+            { id: "Bash", name: "Bash", description: "Run shell commands" },
+            { id: "Read", name: "Read", description: "Read files" },
+          ],
+          plugins: [],
+          skills: [],
+          models: [],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (
+        method === "DELETE" &&
+        href.endsWith(`/v1/config/agents/${agentId}/overrides/allowed_tools`)
+      ) {
+        resetAllowedCalled = true;
+        return jsonResponse({});
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+        return jsonResponse({
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          user_overrides: {
+            allowed_tools: ["Read"],
+            excluded_tools: ["Bash"],
+          },
+          created_at: 0,
+          updated_at: 0,
+        });
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+        return jsonResponse({
+          ...agentSpec(agentId),
+          allowed_tools: ["Read"],
+          excluded_tools: ["Bash"],
+        });
+      }
+      if (method === "GET" && href.includes("/v1/audit-log")) {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText("Customized");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Tools" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reset allowed_tools to default" }));
+
+    await waitFor(() => {
+      expect(resetAllowedCalled).toBe(true);
+    });
+  });
 });
 
 // ── endpoint override banner (R14) ───────────────────────────────────────────
@@ -1832,6 +1925,131 @@ describe("agent editor Save → PATCH vs PUT branching", () => {
 
     await screen.findByText(`Agent "${agentId}" saved (no patchable changes)`);
     expect(patchCalled).toBe(false);
+  });
+
+  it("does not PATCH legacy catalog normalization as builtin override fields", async () => {
+    const agentId = "legacy-builtin";
+    const agentBody = {
+      ...agentSpec(agentId),
+      allowed_tools: null,
+      excluded_tools: null,
+    };
+    let patchCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const href = fetchHref(input);
+        const method = init?.method?.toUpperCase() ?? "GET";
+        if (method === "GET" && href.includes("/v1/capabilities")) {
+          return jsonResponse({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          });
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+          return jsonResponse({
+            source: { kind: "builtin", binary_version: "1.0" },
+            hidden: false,
+            user_overrides: null,
+            created_at: 0,
+            updated_at: 0,
+          });
+        }
+        if (method === "PATCH" && href.endsWith(`/v1/config/agents/${agentId}/overrides`)) {
+          patchCalled = true;
+          return jsonResponse(agentBody);
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+          return jsonResponse(agentBody);
+        }
+        if (method === "GET" && href.includes("/v1/audit-log")) {
+          return jsonResponse({ items: [] });
+        }
+        throw new Error(`Unexpected fetch: ${method} ${href}`);
+      }),
+    );
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await screen.findByText(`Agent "${agentId}" saved (no patchable changes)`);
+    expect(patchCalled).toBe(false);
+  });
+
+  it("normalizes legacy null catalog fields for user record PUT payloads", async () => {
+    const agentId = "legacy-user";
+    const agentBody = {
+      ...agentSpec(agentId),
+      allowed_tools: null,
+      excluded_tools: null,
+    };
+    let patchCalled = false;
+    let putCalled = false;
+    let putBody: Record<string, unknown> = {};
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const href = fetchHref(input);
+        const method = init?.method?.toUpperCase() ?? "GET";
+        if (method === "GET" && href.includes("/v1/capabilities")) {
+          return jsonResponse({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          });
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+          return jsonResponse({
+            source: { kind: "user" },
+            hidden: false,
+            user_overrides: null,
+            created_at: 0,
+            updated_at: 0,
+          });
+        }
+        if (method === "PATCH" && href.endsWith(`/v1/config/agents/${agentId}/overrides`)) {
+          patchCalled = true;
+          return jsonResponse(agentBody);
+        }
+        if (method === "PUT" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+          putCalled = true;
+          putBody = JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>;
+          return jsonResponse(putBody);
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+          return jsonResponse(agentBody);
+        }
+        if (method === "GET" && href.includes("/v1/audit-log")) {
+          return jsonResponse({ items: [] });
+        }
+        throw new Error(`Unexpected fetch: ${method} ${href}`);
+      }),
+    );
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText("User-defined");
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(putCalled).toBe(true);
+    });
+
+    expect(patchCalled).toBe(false);
+    expect(putBody).toMatchObject({
+      allowed_tools: ["*"],
+      excluded_tools: [],
+    });
   });
 
   it("Save calls PATCH /overrides for Builtin records", async () => {

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -575,6 +575,8 @@ describe("agent editor save API flows", () => {
       max_continuation_retries: 2,
       plugin_ids: [],
       sections: {},
+      allowed_tools: ["*"],
+      excluded_tools: [],
       delegates: [],
     });
   });

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -18,10 +18,10 @@ import { type AuditEvent, formatActor, summarizeChange } from "@/lib/audit-log";
 import { Field } from "@/components/form-components";
 import { AgentPreviewPanel } from "@/components/agent-preview-panel";
 import { PluginConfigWorkspace } from "@/components/plugin-config-workspace";
-import { ToolSelector } from "@/components/tool-selector";
 import { useToast } from "@/components/toast-provider";
 import { useConfirmDialog } from "@/components/confirm-dialog";
 import { useUnsavedChangesGuard } from "@/components/unsaved-changes-guard";
+import { ToolsPanel } from "./agent-editor/panels/tools-panel";
 import { useTranslation } from "react-i18next";
 import {
   AGENT_EDITOR_TABS,
@@ -61,6 +61,7 @@ import {
   unknownAgentSpecFields,
 } from "@/lib/agent-editor-helpers";
 import { safeErrorMessage } from "@/lib/safe-error-message";
+import { normalizeCatalogForSave } from "./agent-editor/spec-helpers";
 
 const EMPTY_AGENT: AgentSpec = {
   id: "",
@@ -231,7 +232,7 @@ export function AgentEditorPage() {
     let customizedSaveInFlight = false;
     try {
       const payload = {
-        ...spec,
+        ...normalizeCatalogForSave(spec),
         plugin_ids: [...(spec.plugin_ids ?? [])],
         delegates: [...(spec.delegates ?? [])],
       };
@@ -248,7 +249,10 @@ export function AgentEditorPage() {
         customizedSaveInFlight = true;
         // For Builtin/Customized records, use PATCH /overrides to preserve
         // upgrade tracking. Only patchable fields are included.
-        const plan = diffPatchableAgentFields(spec, originalSpec ?? spec);
+        const plan = diffPatchableAgentFields(
+          normalizeCatalogForSave(spec),
+          normalizeCatalogForSave(originalSpec ?? spec),
+        );
         const hasUpserts = Object.keys(plan.patch).length > 0;
         const hasClears = plan.clear.length > 0;
         if (!hasUpserts && !hasClears) {
@@ -632,9 +636,19 @@ export function AgentEditorPage() {
                   spec={spec}
                   capabilities={capabilities}
                   updateField={updateField}
-                  agentSaved={!isNew && savedSpec !== null}
-                  savedSpec={savedSpec}
-                />
+                  canResetFields={!isNew && isCustomized}
+                  overriddenFields={overriddenFields}
+                  onResetField={(field) => void handleResetField(field)}
+                >
+                  {capabilities ? (
+                    <AllowedExcludedToolsSection
+                      spec={spec}
+                      capabilities={capabilities}
+                      agentSaved={!isNew && savedSpec !== null}
+                      savedSpec={savedSpec}
+                    />
+                  ) : null}
+                </ToolsPanel>
               )}
               {tab.id === "plugins" && (
                 <PluginsPanel
@@ -1359,55 +1373,6 @@ function promptStats(value: string): { chars: number; lines: number; tokenEstima
   const lines = value.split("\n").length;
   const tokenEstimate = Math.ceil(chars / 4);
   return { chars, lines, tokenEstimate };
-}
-
-function ToolsPanel({
-  spec,
-  capabilities,
-  updateField,
-  agentSaved,
-  savedSpec,
-}: {
-  spec: AgentSpec;
-  capabilities: Capabilities | null;
-  updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
-  agentSaved: boolean;
-  savedSpec: AgentSpec | null;
-}) {
-  if (!capabilities || capabilities.tools.length === 0) {
-    return (
-      <div className="rounded-md border border-dashed border-line bg-surface p-6 text-sm text-fg-soft">
-        No tools are currently published. Once plugins or MCP servers register tools, they will
-        appear here.
-      </div>
-    );
-  }
-  return (
-    <div className="space-y-6">
-      <ToolSelector
-        title="Allowed Tools"
-        description='"All tools" is the default — every published tool is exposed. Switch to Custom to restrict the agent to a specific subset.'
-        tools={capabilities.tools}
-        value={spec.allowed_tools}
-        onChange={(next) => updateField("allowed_tools", next)}
-        variant="include"
-      />
-      <ToolSelector
-        title="Excluded Tools"
-        description="Excluded tools are removed from the effective allow-list, even if they appear in 'All tools'. Useful for keeping a tool published to other agents but blocking it here."
-        tools={capabilities.tools}
-        value={spec.excluded_tools}
-        onChange={(next) => updateField("excluded_tools", next)}
-        variant="exclude"
-      />
-      <AllowedExcludedToolsSection
-        spec={spec}
-        capabilities={capabilities}
-        agentSaved={agentSaved}
-        savedSpec={savedSpec}
-      />
-    </div>
-  );
 }
 
 /**

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -62,6 +62,11 @@ import {
 } from "@/lib/agent-editor-helpers";
 import { safeErrorMessage } from "@/lib/safe-error-message";
 import { normalizeCatalogForSave } from "./agent-editor/spec-helpers";
+import {
+  catalogFieldsEqual,
+  catalogSpecsEqual,
+  computeCatalogPreviewTools,
+} from "./agent-editor/catalog-preview";
 
 const EMPTY_AGENT: AgentSpec = {
   id: "",
@@ -141,10 +146,10 @@ export function AgentEditorPage() {
       // so users could lose unsaved edits in context_policy, allowed/excluded
       // tools, delegates, reasoning_effort, sections, or Raw JSON without
       // triggering the unsaved-changes guard.
-      return !deepEqualCanonical(spec, EMPTY_AGENT);
+      return !catalogSpecsEqual(spec, EMPTY_AGENT);
     }
     if (!savedSpec) return false;
-    return !deepEqualCanonical(spec, savedSpec);
+    return !catalogSpecsEqual(spec, savedSpec);
   }, [spec, savedSpec, isNew, saving]);
 
   useUnsavedChangesGuard({ enabled: isDirty });
@@ -1381,19 +1386,6 @@ function promptStats(value: string): { chars: number; lines: number; tokenEstima
  * BeforeInference hook removes unconditionally-denied tools on top of this.
  * See `awaken-ext-permission::PermissionRuleset::unconditionally_denied_tools`.
  */
-function computeAllowedTools(
-  tools: Capabilities["tools"],
-  allowed: AgentSpec["allowed_tools"],
-  excluded: AgentSpec["excluded_tools"],
-): Capabilities["tools"] {
-  const excludedSet = new Set(excluded ?? []);
-  return tools.filter((tool) => {
-    if (allowed !== null && allowed !== undefined && !allowed.includes(tool.id)) return false;
-    if (excludedSet.has(tool.id)) return false;
-    return true;
-  });
-}
-
 function AllowedExcludedToolsSection({
   spec,
   capabilities,
@@ -1411,7 +1403,7 @@ function AllowedExcludedToolsSection({
   savedSpec: AgentSpec | null;
 }) {
   const visible = useMemo(
-    () => computeAllowedTools(capabilities.tools, spec.allowed_tools, spec.excluded_tools),
+    () => computeCatalogPreviewTools(capabilities.tools, spec.allowed_tools, spec.excluded_tools),
     [capabilities.tools, spec.allowed_tools, spec.excluded_tools],
   );
   const total = capabilities.tools.length;
@@ -1457,8 +1449,7 @@ function AllowedExcludedToolsSection({
       canonicalStringify([...savedPluginIds].sort()) ||
       canonicalStringify([...draftHookFilter].sort()) !==
         canonicalStringify([...savedHookFilter].sort()) ||
-      !deepEqualCanonical(spec.allowed_tools ?? null, savedSpec?.allowed_tools ?? null) ||
-      !deepEqualCanonical(spec.excluded_tools ?? null, savedSpec?.excluded_tools ?? null) ||
+      !catalogFieldsEqual(spec, savedSpec) ||
       !deepEqualCanonical(draftPermissionSection, savedPermissionSection));
   // Fetch the server-computed permission preview when the agent is saved
   // AND the saved spec has the permission plugin enabled.
@@ -1488,7 +1479,10 @@ function AllowedExcludedToolsSection({
           </p>
         </div>
         <div className="text-right">
-          <div className="font-mono text-xl font-semibold text-fg-strong">
+          <div
+            className="font-mono text-xl font-semibold text-fg-strong"
+            data-testid="catalog-preview-count"
+          >
             {visible.length}
             <span className="text-fg-faint"> / {total}</span>
           </div>

--- a/apps/admin-console/src/pages/agent-editor/catalog-preview.ts
+++ b/apps/admin-console/src/pages/agent-editor/catalog-preview.ts
@@ -1,0 +1,30 @@
+import type { AgentSpec, Capabilities } from "@/lib/config-api";
+import { deepEqualCanonical } from "@/lib/agent-editor-canonical";
+import { isToolAllowed } from "@/lib/agent-tool-selection";
+import { normalizeCatalogForSave } from "./spec-helpers";
+
+export function catalogSpecsEqual(left: AgentSpec, right: AgentSpec): boolean {
+  return deepEqualCanonical(normalizeCatalogForSave(left), normalizeCatalogForSave(right));
+}
+
+export function catalogFieldsEqual(left: AgentSpec, right: AgentSpec | null): boolean {
+  if (!right) return false;
+  const normalizedLeft = normalizeCatalogForSave(left);
+  const normalizedRight = normalizeCatalogForSave(right);
+  return (
+    deepEqualCanonical(normalizedLeft.allowed_tools, normalizedRight.allowed_tools) &&
+    deepEqualCanonical(normalizedLeft.excluded_tools, normalizedRight.excluded_tools)
+  );
+}
+
+export function computeCatalogPreviewTools(
+  tools: Capabilities["tools"],
+  allowed: AgentSpec["allowed_tools"],
+  excluded: AgentSpec["excluded_tools"],
+): Capabilities["tools"] {
+  return tools.filter(
+    (tool) =>
+      isToolAllowed(allowed, tool.id, "include") &&
+      !isToolAllowed(excluded, tool.id, "exclude"),
+  );
+}

--- a/apps/admin-console/src/pages/agent-editor/editor-panels.tsx
+++ b/apps/admin-console/src/pages/agent-editor/editor-panels.tsx
@@ -81,7 +81,14 @@ export function AgentEditorPanels({
             />
           )}
           {tab.id === "tools" && (
-            <ToolsPanel spec={spec} capabilities={capabilities} updateField={updateField} />
+            <ToolsPanel
+              spec={spec}
+              capabilities={capabilities}
+              updateField={updateField}
+              canResetFields={canResetFields}
+              overriddenFields={overriddenFields}
+              onResetField={onResetField}
+            />
           )}
           {tab.id === "plugins" && (
             <PluginsPanel

--- a/apps/admin-console/src/pages/agent-editor/panels/tools-panel.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor/panels/tools-panel.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ToolsPanel } from "./tools-panel";
+import type { AgentSpec, Capabilities } from "@/lib/config-api";
+
+afterEach(() => {
+  cleanup();
+});
+
+const emptyCapabilities: Capabilities = {
+  agents: [],
+  tools: [],
+  plugins: [],
+  skills: [],
+  models: [],
+  providers: [],
+  namespaces: [],
+};
+
+const spec: AgentSpec = {
+  id: "agent-a",
+  model_id: "model-a",
+  system_prompt: "",
+  max_rounds: 8,
+  plugin_ids: [],
+  sections: {},
+  delegates: [],
+  allowed_tools: ["stale:*"],
+  excluded_tools: [],
+};
+
+describe("ToolsPanel", () => {
+  it("keeps catalog fields editable when no tools are published", () => {
+    const updateField = vi.fn();
+
+    render(
+      <ToolsPanel spec={spec} capabilities={emptyCapabilities} updateField={updateField} />,
+    );
+
+    expect(screen.getByText("Allowed Tools")).toBeTruthy();
+    expect(screen.getByText("Excluded Tools")).toBeTruthy();
+    expect(screen.getByText("stale:*")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(updateField).toHaveBeenCalledWith("allowed_tools", []);
+  });
+});

--- a/apps/admin-console/src/pages/agent-editor/panels/tools-panel.tsx
+++ b/apps/admin-console/src/pages/agent-editor/panels/tools-panel.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from "react";
 import { type AgentSpec, type Capabilities } from "@/lib/config-api";
 import { ToolSelector } from "@/components/tool-selector";
 
@@ -8,6 +9,7 @@ export function ToolsPanel({
   canResetFields,
   overriddenFields,
   onResetField,
+  children,
 }: {
   spec: AgentSpec;
   capabilities: Capabilities | null;
@@ -15,6 +17,7 @@ export function ToolsPanel({
   canResetFields?: boolean;
   overriddenFields?: Set<string>;
   onResetField?: (field: string) => void;
+  children?: ReactNode;
 }) {
   if (!capabilities || capabilities.tools.length === 0) {
     return (
@@ -35,7 +38,7 @@ export function ToolsPanel({
     } as const;
   };
   return (
-    <>
+    <div className="space-y-6">
       <ToolSelector
         title="Allowed Tools"
         description='"All tools" is the default — every published tool is exposed. Switch to Custom to restrict the agent to a specific subset.'
@@ -54,6 +57,7 @@ export function ToolsPanel({
         variant="exclude"
         {...resetProps("excluded_tools")}
       />
-    </>
+      {children}
+    </div>
   );
 }

--- a/apps/admin-console/src/pages/agent-editor/panels/tools-panel.tsx
+++ b/apps/admin-console/src/pages/agent-editor/panels/tools-panel.tsx
@@ -5,10 +5,16 @@ export function ToolsPanel({
   spec,
   capabilities,
   updateField,
+  canResetFields,
+  overriddenFields,
+  onResetField,
 }: {
   spec: AgentSpec;
   capabilities: Capabilities | null;
   updateField: <K extends keyof AgentSpec>(key: K, value: AgentSpec[K]) => void;
+  canResetFields?: boolean;
+  overriddenFields?: Set<string>;
+  onResetField?: (field: string) => void;
 }) {
   if (!capabilities || capabilities.tools.length === 0) {
     return (
@@ -18,6 +24,16 @@ export function ToolsPanel({
       </div>
     );
   }
+  const resetProps = (field: "allowed_tools" | "excluded_tools") => {
+    if (!canResetFields || !overriddenFields?.has(field) || !onResetField) {
+      return {};
+    }
+    return {
+      overridden: true,
+      onReset: () => onResetField(field),
+      resetLabel: `Reset ${field} to default`,
+    } as const;
+  };
   return (
     <>
       <ToolSelector
@@ -27,6 +43,7 @@ export function ToolsPanel({
         value={spec.allowed_tools}
         onChange={(next) => updateField("allowed_tools", next)}
         variant="include"
+        {...resetProps("allowed_tools")}
       />
       <ToolSelector
         title="Excluded Tools"
@@ -35,6 +52,7 @@ export function ToolsPanel({
         value={spec.excluded_tools}
         onChange={(next) => updateField("excluded_tools", next)}
         variant="exclude"
+        {...resetProps("excluded_tools")}
       />
     </>
   );

--- a/apps/admin-console/src/pages/agent-editor/panels/tools-panel.tsx
+++ b/apps/admin-console/src/pages/agent-editor/panels/tools-panel.tsx
@@ -19,14 +19,7 @@ export function ToolsPanel({
   onResetField?: (field: string) => void;
   children?: ReactNode;
 }) {
-  if (!capabilities || capabilities.tools.length === 0) {
-    return (
-      <div className="rounded-md border border-dashed border-line bg-surface p-6 text-sm text-fg-soft">
-        No tools are currently published. Once plugins or MCP servers register tools, they will
-        appear here.
-      </div>
-    );
-  }
+  const tools = capabilities?.tools ?? [];
   const resetProps = (field: "allowed_tools" | "excluded_tools") => {
     if (!canResetFields || !overriddenFields?.has(field) || !onResetField) {
       return {};
@@ -39,10 +32,15 @@ export function ToolsPanel({
   };
   return (
     <div className="space-y-6">
+      {tools.length === 0 ? (
+        <div className="rounded-md border border-dashed border-line bg-surface p-4 text-sm text-fg-soft">
+          No tools are currently published.
+        </div>
+      ) : null}
       <ToolSelector
         title="Allowed Tools"
         description='"All tools" is the default — every published tool is exposed. Switch to Custom to restrict the agent to a specific subset.'
-        tools={capabilities.tools}
+        tools={tools}
         value={spec.allowed_tools}
         onChange={(next) => updateField("allowed_tools", next)}
         variant="include"
@@ -51,7 +49,7 @@ export function ToolsPanel({
       <ToolSelector
         title="Excluded Tools"
         description="Excluded tools are removed from the effective allow-list, even if they appear in 'All tools'. Useful for keeping a tool published to other agents but blocking it here."
-        tools={capabilities.tools}
+        tools={tools}
         value={spec.excluded_tools}
         onChange={(next) => updateField("excluded_tools", next)}
         variant="exclude"

--- a/apps/admin-console/src/pages/agent-editor/spec-helpers.ts
+++ b/apps/admin-console/src/pages/agent-editor/spec-helpers.ts
@@ -100,11 +100,20 @@ export function diffPatchableFields(
   return patch;
 }
 
-export function fullAgentSavePayload(spec: AgentSpec): AgentSpec {
+export function normalizeCatalogForSave(spec: AgentSpec): AgentSpec {
   return {
     ...spec,
-    plugin_ids: [...(spec.plugin_ids ?? [])],
-    delegates: [...(spec.delegates ?? [])],
+    allowed_tools: spec.allowed_tools ?? ["*"],
+    excluded_tools: spec.excluded_tools ?? [],
+  };
+}
+
+export function fullAgentSavePayload(spec: AgentSpec): AgentSpec {
+  const normalizedSpec = normalizeCatalogForSave(spec);
+  return {
+    ...normalizedSpec,
+    plugin_ids: [...(normalizedSpec.plugin_ids ?? [])],
+    delegates: [...(normalizedSpec.delegates ?? [])],
   };
 }
 
@@ -114,7 +123,10 @@ export function agentSavePayload(
   mode: AgentSaveMode,
 ): AgentSpec | Record<string, unknown> {
   if (mode === "patch-overrides") {
-    return diffPatchableFields(spec, originalSpec ?? spec);
+    return diffPatchableFields(
+      normalizeCatalogForSave(spec),
+      normalizeCatalogForSave(originalSpec ?? spec),
+    );
   }
   return fullAgentSavePayload(spec);
 }

--- a/crates/awaken-runtime/Cargo.toml
+++ b/crates/awaken-runtime/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["artificial-intelligence", "asynchronous"]
 [dependencies]
 awaken-contract = { workspace = true }
 awaken-protocol-a2a = { workspace = true }
+awaken-tool-pattern = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/awaken-runtime/src/registry/resolve/pipeline.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline.rs
@@ -1,6 +1,8 @@
 //! Resolution pipeline: `agent_id` + `RegistrySet` -> `ResolvedAgent` /
 //! `ResolvedExecution`.
 
+mod catalog;
+
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -19,6 +21,7 @@ use crate::registry::traits::RegistrySet;
 use awaken_contract::registry_spec::AgentSpec;
 
 use super::error::ResolveError;
+use catalog::{filter_tools, permission_rules_without_catalog_match};
 
 // ---------------------------------------------------------------------------
 // inject_default_plugins()
@@ -265,6 +268,16 @@ fn build_tool_set(
     // Apply allow/exclude filtering to the full merged tool set
     filter_tools(&mut tools, spec);
 
+    // Cross-layer check: warn about permission rules referencing absent tools.
+    let retained: Vec<String> = tools.keys().cloned().collect();
+    for orphan in permission_rules_without_catalog_match(&spec.sections, &retained) {
+        tracing::warn!(
+            agent_id = %spec.id,
+            rule = %orphan,
+            "permission rule references tool not in catalog — rule will never fire"
+        );
+    }
+
     Ok(tools)
 }
 
@@ -460,24 +473,6 @@ fn collect_global_tools(registries: &RegistrySet) -> HashMap<String, Arc<dyn Too
     tools
 }
 
-/// Apply allow/exclude filtering to a mutable tool map.
-///
-/// - `allowed_tools = None` -> keep all.
-/// - `allowed_tools = Some(list)` -> keep only those IDs.
-/// - `excluded_tools` -> remove from the set.
-fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &AgentSpec) {
-    if let Some(allow) = &spec.allowed_tools {
-        let allowed: HashSet<&str> = allow.iter().map(|s| s.as_str()).collect();
-        tools.retain(|id, _| allowed.contains(id.as_str()));
-    }
-
-    if let Some(exclude) = &spec.excluded_tools {
-        for id in exclude {
-            tools.remove(id);
-        }
-    }
-}
-
 /// Resolve plugins by IDs from the spec.
 fn resolve_plugins(
     registries: &RegistrySet,
@@ -500,6 +495,8 @@ fn resolve_plugins(
 
 #[cfg(test)]
 mod tests {
+    mod catalog;
+
     use super::*;
     #[cfg(feature = "a2a")]
     use crate::extensions::a2a::{

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
@@ -26,6 +26,7 @@ use awaken_contract::registry_spec::AgentSpec;
 pub(super) fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &AgentSpec) {
     let original_tool_ids: Vec<String> = tools.keys().cloned().collect();
     if let Some(allow) = &spec.allowed_tools {
+        warn_catalog_wildcard_entries(&spec.id, "allowed_tools", allow);
         warn_catalog_argument_patterns(&spec.id, "allowed_tools", allow, &original_tool_ids);
         warn_unmatched_catalog_patterns(&spec.id, "allowed_tools", allow, &original_tool_ids);
         tools.retain(|id, _| catalog_pattern_matches(allow, id));
@@ -34,6 +35,7 @@ pub(super) fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &Ag
     }
 
     if let Some(exclude) = &spec.excluded_tools {
+        warn_catalog_wildcard_entries(&spec.id, "excluded_tools", exclude);
         warn_catalog_argument_patterns(&spec.id, "excluded_tools", exclude, &original_tool_ids);
         warn_unmatched_catalog_patterns(&spec.id, "excluded_tools", exclude, &original_tool_ids);
         tools.retain(|id, _| !catalog_pattern_matches(exclude, id));
@@ -75,13 +77,26 @@ pub(super) fn is_argument_syntax_for_registered_tool(pattern: &str, tool_ids: &[
     if !pattern.contains('(') {
         return false;
     }
-    let Ok(parsed) = awaken_tool_pattern::parse_pattern(pattern) else {
-        return false;
+    let parsed = match awaken_tool_pattern::parse_pattern(pattern) {
+        Ok(parsed) => parsed,
+        Err(_) => return registered_tool_argument_syntax_prefix(pattern, tool_ids),
     };
+    if matches!(parsed.args, awaken_tool_pattern::ArgMatcher::Any) {
+        return false;
+    }
     if !tool_matcher_matches_any(&parsed.tool, tool_ids) {
         return false;
     }
     true
+}
+
+fn registered_tool_argument_syntax_prefix(pattern: &str, tool_ids: &[String]) -> bool {
+    tool_ids.iter().any(|tool_id| {
+        let Some(arg_part) = pattern.strip_prefix(tool_id) else {
+            return false;
+        };
+        arg_part.starts_with('(') && arg_part.ends_with(')') && arg_part.len() > 2
+    })
 }
 
 pub(super) fn is_argument_level_catalog_pattern(pattern: &str) -> bool {
@@ -95,6 +110,64 @@ pub(super) fn is_argument_level_catalog_pattern(pattern: &str) -> bool {
             value.chars().any(|ch| matches!(ch, '*' | '?' | '[' | ']')) || value.contains(' ')
         }
     }
+}
+
+pub(super) const CATALOG_WILDCARD_AUDIT_WARN_CACHE_LIMIT: usize = 1024;
+
+fn warn_catalog_wildcard_entries(agent_id: &str, field: &str, patterns: &[String]) {
+    static WARNED_ENTRIES: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+    let warned_entries = WARNED_ENTRIES.get_or_init(|| Mutex::new(VecDeque::new()));
+
+    for pattern in patterns {
+        if pattern == "*" || !has_unescaped_catalog_wildcard(pattern) {
+            continue;
+        }
+        let cache_key = format!("{agent_id}\0{field}\0{pattern}");
+        if !should_warn_catalog_wildcard_entry(&cache_key, warned_entries) {
+            continue;
+        }
+        tracing::warn!(
+            agent_id = %agent_id,
+            field = %field,
+            pattern = %pattern,
+            "catalog entry contains an unescaped '*' wildcard; escape it as '\\*' if this was intended as a literal tool id"
+        );
+    }
+}
+
+pub(super) fn has_unescaped_catalog_wildcard(pattern: &str) -> bool {
+    let mut escaped = false;
+    for ch in pattern.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == '*' {
+            return true;
+        }
+    }
+    false
+}
+
+pub(super) fn should_warn_catalog_wildcard_entry(
+    cache_key: &str,
+    warned_entries: &Mutex<VecDeque<String>>,
+) -> bool {
+    let mut warned_entries = warned_entries
+        .lock()
+        .expect("catalog wildcard warning cache poisoned");
+    if warned_entries.iter().any(|warned| warned == cache_key) {
+        return false;
+    }
+    if warned_entries.len() >= CATALOG_WILDCARD_AUDIT_WARN_CACHE_LIMIT {
+        warned_entries.pop_front();
+    }
+    warned_entries.push_back(cache_key.to_string());
+    true
 }
 
 pub(super) fn unmatched_catalog_patterns(patterns: &[String], tool_ids: &[String]) -> Vec<String> {

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
@@ -24,10 +24,10 @@ use awaken_contract::registry_spec::AgentSpec;
 /// Argument-level expressions (`Bash(npm *)`) belong in the permission plugin
 /// (`sections.permission`) and have no meaning here.
 pub(super) fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &AgentSpec) {
+    let original_tool_ids: Vec<String> = tools.keys().cloned().collect();
     if let Some(allow) = &spec.allowed_tools {
         warn_catalog_argument_patterns(&spec.id, "allowed_tools", allow);
-        let available_tool_ids: Vec<String> = tools.keys().cloned().collect();
-        warn_unmatched_catalog_patterns(&spec.id, "allowed_tools", allow, &available_tool_ids);
+        warn_unmatched_catalog_patterns(&spec.id, "allowed_tools", allow, &original_tool_ids);
         tools.retain(|id, _| catalog_pattern_matches(allow, id));
     } else {
         warn_legacy_allow_all(&spec.id);
@@ -35,8 +35,7 @@ pub(super) fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &Ag
 
     if let Some(exclude) = &spec.excluded_tools {
         warn_catalog_argument_patterns(&spec.id, "excluded_tools", exclude);
-        let available_tool_ids: Vec<String> = tools.keys().cloned().collect();
-        warn_unmatched_catalog_patterns(&spec.id, "excluded_tools", exclude, &available_tool_ids);
+        warn_unmatched_catalog_patterns(&spec.id, "excluded_tools", exclude, &original_tool_ids);
         tools.retain(|id, _| !catalog_pattern_matches(exclude, id));
     }
 }
@@ -66,10 +65,16 @@ fn warn_catalog_argument_patterns(agent_id: &str, field: &str, patterns: &[Strin
 }
 
 pub(super) fn is_argument_level_catalog_pattern(pattern: &str) -> bool {
-    // Heuristic: `(` at this layer is almost always a misplaced permission-rule
-    // pattern such as `Bash(npm *)`. A literal `(` in a real tool id is rare
-    // enough that a stray warning is acceptable.
-    pattern.contains('(')
+    let Ok(parsed) = awaken_tool_pattern::parse_pattern(pattern) else {
+        return false;
+    };
+    match parsed.args {
+        awaken_tool_pattern::ArgMatcher::Any => false,
+        awaken_tool_pattern::ArgMatcher::Fields(_) => true,
+        awaken_tool_pattern::ArgMatcher::Primary { value, .. } => {
+            value.chars().any(|ch| matches!(ch, '*' | '?' | '[' | ']')) || value.contains(' ')
+        }
+    }
 }
 
 pub(super) fn unmatched_catalog_patterns(patterns: &[String], tool_ids: &[String]) -> Vec<String> {
@@ -99,7 +104,7 @@ fn warn_unmatched_catalog_patterns(
             agent_id = %agent_id,
             field = %field,
             pattern = %pattern,
-            "catalog pattern matches no available tools — check the tool id or wildcard"
+            "catalog pattern matches no registered tools — check the tool id or wildcard"
         );
     }
 }

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
@@ -1,0 +1,176 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use awaken_contract::contract::tool::Tool;
+use awaken_contract::registry_spec::AgentSpec;
+
+/// Apply allow/exclude filtering to a mutable tool map.
+///
+/// Catalog semantics — answers "is this tool visible to the agent?":
+///
+/// - `allowed_tools = Some(["*"])` -> explicit allow-all (keeps every tool).
+/// - `allowed_tools = Some([])` -> explicit empty (removes every tool).
+/// - `allowed_tools = Some([patterns..])` -> keep tools whose ID matches any pattern.
+/// - `allowed_tools = None` -> deprecated allow-all (emits a rate-limited warning).
+///
+/// Entries are **tool-id patterns**, not filesystem globs. The grammar is
+/// intentionally minimal so `/`, `:`, and `_` are ordinary characters:
+///
+/// - The full pattern must match the full tool id.
+/// - `*` matches any sequence of characters, including `/`, `:`, and `_`.
+/// - `\*` and `\\` escape literal `*` and `\`.
+/// - Every other character is a literal.
+///
+/// Argument-level expressions (`Bash(npm *)`) belong in the permission plugin
+/// (`sections.permission`) and have no meaning here.
+pub(super) fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &AgentSpec) {
+    if let Some(allow) = &spec.allowed_tools {
+        warn_catalog_argument_patterns(&spec.id, "allowed_tools", allow);
+        let available_tool_ids: Vec<String> = tools.keys().cloned().collect();
+        warn_unmatched_catalog_patterns(&spec.id, "allowed_tools", allow, &available_tool_ids);
+        tools.retain(|id, _| catalog_pattern_matches(allow, id));
+    } else {
+        warn_legacy_allow_all(&spec.id);
+    }
+
+    if let Some(exclude) = &spec.excluded_tools {
+        warn_catalog_argument_patterns(&spec.id, "excluded_tools", exclude);
+        let available_tool_ids: Vec<String> = tools.keys().cloned().collect();
+        warn_unmatched_catalog_patterns(&spec.id, "excluded_tools", exclude, &available_tool_ids);
+        tools.retain(|id, _| !catalog_pattern_matches(exclude, id));
+    }
+}
+
+/// Return true if any pattern in `patterns` matches `tool_id` under the
+/// catalog tool-id grammar (see `awaken_tool_pattern::tool_id_match`).
+pub(super) fn catalog_pattern_matches(patterns: &[String], tool_id: &str) -> bool {
+    patterns
+        .iter()
+        .any(|p| awaken_tool_pattern::tool_id_match(p, tool_id))
+}
+
+/// Warn when a catalog entry parses as an argument-level pattern (`Bash(npm *)`).
+/// Catalog matching is tool-name only; such entries silently never match.
+fn warn_catalog_argument_patterns(agent_id: &str, field: &str, patterns: &[String]) {
+    for p in patterns {
+        if is_argument_level_catalog_pattern(p) {
+            tracing::warn!(
+                agent_id = %agent_id,
+                field = %field,
+                pattern = %p,
+                "catalog patterns are tool-name only — argument syntax has no effect; \
+                 move this rule to sections[\"permission\"] for argument-level matching"
+            );
+        }
+    }
+}
+
+pub(super) fn is_argument_level_catalog_pattern(pattern: &str) -> bool {
+    // Heuristic: `(` at this layer is almost always a misplaced permission-rule
+    // pattern such as `Bash(npm *)`. A literal `(` in a real tool id is rare
+    // enough that a stray warning is acceptable.
+    pattern.contains('(')
+}
+
+pub(super) fn unmatched_catalog_patterns(patterns: &[String], tool_ids: &[String]) -> Vec<String> {
+    if tool_ids.is_empty() {
+        return Vec::new();
+    }
+    patterns
+        .iter()
+        .filter(|pattern| !is_argument_level_catalog_pattern(pattern))
+        .filter(|pattern| {
+            !tool_ids
+                .iter()
+                .any(|tool_id| awaken_tool_pattern::tool_id_match(pattern, tool_id))
+        })
+        .cloned()
+        .collect()
+}
+
+fn warn_unmatched_catalog_patterns(
+    agent_id: &str,
+    field: &str,
+    patterns: &[String],
+    tool_ids: &[String],
+) {
+    for pattern in unmatched_catalog_patterns(patterns, tool_ids) {
+        tracing::warn!(
+            agent_id = %agent_id,
+            field = %field,
+            pattern = %pattern,
+            "catalog pattern matches no available tools — check the tool id or wildcard"
+        );
+    }
+}
+
+pub(super) const LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT: usize = 1024;
+
+/// Emit a bounded, per-agent deprecation warning when `allowed_tools` is `null`/absent.
+fn warn_legacy_allow_all(agent_id: &str) {
+    static WARNED_AGENTS: OnceLock<Mutex<VecDeque<String>>> = OnceLock::new();
+    let warned_agents = WARNED_AGENTS.get_or_init(|| Mutex::new(VecDeque::new()));
+
+    if should_warn_legacy_allow_all(agent_id, warned_agents) {
+        tracing::warn!(
+            agent_id = %agent_id,
+            "allowed_tools=null is deprecated; use [\"*\"] for explicit allow-all \
+             or list patterns explicitly (repeated warnings are rate-limited per agent)"
+        );
+    }
+}
+
+pub(super) fn should_warn_legacy_allow_all(
+    agent_id: &str,
+    warned_agents: &Mutex<VecDeque<String>>,
+) -> bool {
+    let mut warned_agents = warned_agents
+        .lock()
+        .expect("legacy allowed_tools warning cache poisoned");
+    if warned_agents.iter().any(|warned| warned == agent_id) {
+        return false;
+    }
+    if warned_agents.len() >= LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT {
+        warned_agents.pop_front();
+    }
+    warned_agents.push_back(agent_id.to_string());
+    true
+}
+
+/// Cross-layer consistency check: emit warnings for permission rules in
+/// `sections["permission"]` that reference tools excluded by the catalog.
+///
+/// Reads the section as raw JSON to avoid taking a dependency on the
+/// permission plugin crate. Returns the list of rule pattern strings whose
+/// tool-name portion does not match any retained catalog tool.
+pub(super) fn permission_rules_without_catalog_match(
+    sections: &HashMap<String, serde_json::Value>,
+    retained_tool_ids: &[String],
+) -> Vec<String> {
+    let Some(section) = sections.get("permission") else {
+        return Vec::new();
+    };
+    let Some(rules) = section.get("rules").and_then(serde_json::Value::as_array) else {
+        return Vec::new();
+    };
+
+    let mut orphans = Vec::new();
+    for rule in rules {
+        let Some(pattern_str) = rule.get("tool").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        // Parse pattern; on parse error skip (plugin validation will surface it).
+        let Ok(pattern) = awaken_tool_pattern::parse_pattern(pattern_str) else {
+            continue;
+        };
+        let matched = retained_tool_ids.iter().any(|id| match &pattern.tool {
+            awaken_tool_pattern::ToolMatcher::Exact(name) => name == id,
+            awaken_tool_pattern::ToolMatcher::Glob(g) => awaken_tool_pattern::wildcard_match(g, id),
+            awaken_tool_pattern::ToolMatcher::Regex(r) => r.is_match(id),
+        });
+        if !matched {
+            orphans.push(pattern_str.to_string());
+        }
+    }
+    orphans
+}

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/catalog.rs
@@ -26,7 +26,7 @@ use awaken_contract::registry_spec::AgentSpec;
 pub(super) fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &AgentSpec) {
     let original_tool_ids: Vec<String> = tools.keys().cloned().collect();
     if let Some(allow) = &spec.allowed_tools {
-        warn_catalog_argument_patterns(&spec.id, "allowed_tools", allow);
+        warn_catalog_argument_patterns(&spec.id, "allowed_tools", allow, &original_tool_ids);
         warn_unmatched_catalog_patterns(&spec.id, "allowed_tools", allow, &original_tool_ids);
         tools.retain(|id, _| catalog_pattern_matches(allow, id));
     } else {
@@ -34,7 +34,7 @@ pub(super) fn filter_tools(tools: &mut HashMap<String, Arc<dyn Tool>>, spec: &Ag
     }
 
     if let Some(exclude) = &spec.excluded_tools {
-        warn_catalog_argument_patterns(&spec.id, "excluded_tools", exclude);
+        warn_catalog_argument_patterns(&spec.id, "excluded_tools", exclude, &original_tool_ids);
         warn_unmatched_catalog_patterns(&spec.id, "excluded_tools", exclude, &original_tool_ids);
         tools.retain(|id, _| !catalog_pattern_matches(exclude, id));
     }
@@ -50,9 +50,16 @@ pub(super) fn catalog_pattern_matches(patterns: &[String], tool_id: &str) -> boo
 
 /// Warn when a catalog entry parses as an argument-level pattern (`Bash(npm *)`).
 /// Catalog matching is tool-name only; such entries silently never match.
-fn warn_catalog_argument_patterns(agent_id: &str, field: &str, patterns: &[String]) {
+fn warn_catalog_argument_patterns(
+    agent_id: &str,
+    field: &str,
+    patterns: &[String],
+    tool_ids: &[String],
+) {
     for p in patterns {
-        if is_argument_level_catalog_pattern(p) {
+        if is_argument_level_catalog_pattern(p)
+            || is_argument_syntax_for_registered_tool(p, tool_ids)
+        {
             tracing::warn!(
                 agent_id = %agent_id,
                 field = %field,
@@ -62,6 +69,19 @@ fn warn_catalog_argument_patterns(agent_id: &str, field: &str, patterns: &[Strin
             );
         }
     }
+}
+
+pub(super) fn is_argument_syntax_for_registered_tool(pattern: &str, tool_ids: &[String]) -> bool {
+    if !pattern.contains('(') {
+        return false;
+    }
+    let Ok(parsed) = awaken_tool_pattern::parse_pattern(pattern) else {
+        return false;
+    };
+    if !tool_matcher_matches_any(&parsed.tool, tool_ids) {
+        return false;
+    }
+    true
 }
 
 pub(super) fn is_argument_level_catalog_pattern(pattern: &str) -> bool {
@@ -83,7 +103,10 @@ pub(super) fn unmatched_catalog_patterns(patterns: &[String], tool_ids: &[String
     }
     patterns
         .iter()
-        .filter(|pattern| !is_argument_level_catalog_pattern(pattern))
+        .filter(|pattern| {
+            !is_argument_level_catalog_pattern(pattern)
+                && !is_argument_syntax_for_registered_tool(pattern, tool_ids)
+        })
         .filter(|pattern| {
             !tool_ids
                 .iter()
@@ -178,4 +201,15 @@ pub(super) fn permission_rules_without_catalog_match(
         }
     }
     orphans
+}
+
+fn tool_matcher_matches_any(
+    matcher: &awaken_tool_pattern::ToolMatcher,
+    tool_ids: &[String],
+) -> bool {
+    tool_ids.iter().any(|id| match matcher {
+        awaken_tool_pattern::ToolMatcher::Exact(name) => name == id,
+        awaken_tool_pattern::ToolMatcher::Glob(g) => awaken_tool_pattern::wildcard_match(g, id),
+        awaken_tool_pattern::ToolMatcher::Regex(r) => r.is_match(id),
+    })
 }

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
@@ -1,0 +1,313 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use serde_json::json;
+
+use super::*;
+use crate::registry::resolve::pipeline::catalog::{
+    LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT, catalog_pattern_matches, is_argument_level_catalog_pattern,
+    permission_rules_without_catalog_match, should_warn_legacy_allow_all,
+    unmatched_catalog_patterns,
+};
+
+#[test]
+fn resolve_allow_list_supports_glob_patterns() {
+    let spec = AgentSpec {
+        allowed_tools: Some(vec!["read_*".into(), "mcp__github__*".into()]),
+        ..make_spec("a")
+    };
+
+    let regs = build_registries(
+        vec![
+            (
+                "read_file",
+                Arc::new(MockTool {
+                    id: "read_file".into(),
+                }),
+            ),
+            (
+                "read_url",
+                Arc::new(MockTool {
+                    id: "read_url".into(),
+                }),
+            ),
+            (
+                "write_file",
+                Arc::new(MockTool {
+                    id: "write_file".into(),
+                }),
+            ),
+            (
+                "mcp__github__pr",
+                Arc::new(MockTool {
+                    id: "mcp__github__pr".into(),
+                }),
+            ),
+            (
+                "mcp__gitlab__pr",
+                Arc::new(MockTool {
+                    id: "mcp__gitlab__pr".into(),
+                }),
+            ),
+        ],
+        "test-model",
+        ModelBinding {
+            provider_id: "p".into(),
+            upstream_model: "n".into(),
+        },
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        spec,
+    );
+
+    let run = resolve(&regs, "a").unwrap();
+    assert_eq!(
+        run.tools.len(),
+        3,
+        "tools kept: {:?}",
+        run.tools.keys().collect::<Vec<_>>()
+    );
+    assert!(run.tools.contains_key("read_file"));
+    assert!(run.tools.contains_key("read_url"));
+    assert!(run.tools.contains_key("mcp__github__pr"));
+    assert!(!run.tools.contains_key("write_file"));
+    assert!(!run.tools.contains_key("mcp__gitlab__pr"));
+}
+
+#[test]
+fn resolve_allow_list_wildcard_keeps_all() {
+    let spec = AgentSpec {
+        allowed_tools: Some(vec!["*".into()]),
+        ..make_spec("a")
+    };
+
+    let regs = build_registries(
+        vec![
+            ("read", Arc::new(MockTool { id: "read".into() })),
+            ("write", Arc::new(MockTool { id: "write".into() })),
+            (
+                "delete",
+                Arc::new(MockTool {
+                    id: "delete".into(),
+                }),
+            ),
+        ],
+        "test-model",
+        ModelBinding {
+            provider_id: "p".into(),
+            upstream_model: "n".into(),
+        },
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        spec,
+    );
+
+    let run = resolve(&regs, "a").unwrap();
+    assert_eq!(run.tools.len(), 3, "[\"*\"] should keep every tool");
+}
+
+#[test]
+fn legacy_allow_all_warning_is_once_per_agent() {
+    let warned_agents = Mutex::new(VecDeque::new());
+
+    assert!(should_warn_legacy_allow_all("agent-a", &warned_agents));
+    assert!(!should_warn_legacy_allow_all("agent-a", &warned_agents));
+    assert!(should_warn_legacy_allow_all("agent-b", &warned_agents));
+}
+
+#[test]
+fn legacy_allow_all_warning_cache_is_bounded() {
+    let warned_agents = Mutex::new(VecDeque::new());
+
+    for i in 0..(LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT + 1) {
+        assert!(should_warn_legacy_allow_all(
+            &format!("agent-{i}"),
+            &warned_agents
+        ));
+    }
+
+    let warned_agents = warned_agents.lock().unwrap();
+    assert_eq!(warned_agents.len(), LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT);
+    assert!(!warned_agents.iter().any(|agent_id| agent_id == "agent-0"));
+}
+
+#[test]
+fn catalog_tool_id_match_handles_basic_wildcards() {
+    let cases = [
+        ("Bash", "Bash", true),
+        ("Bash", "Read", false),
+        ("Bash", "BashExtra", false),
+        ("*", "Bash", true),
+        ("*", "mcp:weather/forecast", true),
+        ("mcp:*", "mcp:weather/forecast", true),
+        ("mcp:*", "plugin:reminder/add", false),
+        ("mcp:weather/*", "mcp:weather/forecast", true),
+        ("mcp:weather/*", "mcp:weather/foo/bar", true),
+        ("mcp__github__*", "mcp__github__read_issue", true),
+        ("*issue", "mcp__github__read_issue", true),
+        ("a*b", "a/b", true),
+        ("a*/b", "a/x/b", true),
+        ("\\*literal", "*literal", true),
+        ("\\*literal", "Xliteral", false),
+        ("mcp__github__read?", "mcp__github__read1", false),
+        ("mcp__github__read?", "mcp__github__read?", true),
+        ("mcp__[ab]*", "mcp__a_tool", false),
+        ("{Bash}", "Bash", false),
+        ("{Bash}", "{Bash}", true),
+        ("!Bash", "!Bash", true),
+        ("!Bash", "Bash", false),
+        ("/B.*/", "Bash", false),
+        ("Bash(npm *)", "Bash", false),
+    ];
+
+    for (pattern, value, expected) in cases {
+        assert_eq!(
+            catalog_pattern_matches(&[pattern.to_string()], value),
+            expected,
+            "pattern={pattern:?} value={value:?}"
+        );
+    }
+}
+
+#[test]
+fn catalog_argument_pattern_detection_flags_parens() {
+    assert!(!is_argument_level_catalog_pattern("Bash"));
+    assert!(!is_argument_level_catalog_pattern("mcp__github__*"));
+    assert!(is_argument_level_catalog_pattern("Bash(npm *)"));
+    assert!(is_argument_level_catalog_pattern(
+        r#"Edit(file_path ~ "src/**/*.rs")"#
+    ));
+    assert!(is_argument_level_catalog_pattern("Bash(npm *"));
+}
+
+#[test]
+fn unmatched_catalog_patterns_returns_typos() {
+    let patterns = vec![
+        "read_*".to_string(),
+        "mcp_github_*".to_string(),
+        "Bash(npm *)".to_string(),
+    ];
+    let tool_ids = vec!["read_file".to_string(), "mcp__github__issue".to_string()];
+
+    assert_eq!(
+        unmatched_catalog_patterns(&patterns, &tool_ids),
+        vec!["mcp_github_*".to_string()]
+    );
+}
+
+#[test]
+fn unmatched_catalog_patterns_skips_empty_catalogs() {
+    let patterns = vec!["read_*".to_string()];
+    let tool_ids = Vec::new();
+
+    assert!(unmatched_catalog_patterns(&patterns, &tool_ids).is_empty());
+}
+
+#[test]
+fn permission_rule_orphan_detected_when_tool_not_in_catalog() {
+    let mut sections = HashMap::new();
+    sections.insert(
+        "permission".into(),
+        json!({
+            "rules": [
+                { "tool": "Bash(npm *)", "behavior": "ask" },
+                { "tool": "read_file", "behavior": "allow" },
+            ]
+        }),
+    );
+
+    let retained = vec!["read_file".to_string(), "Edit".to_string()];
+    let orphans = permission_rules_without_catalog_match(&sections, &retained);
+    assert_eq!(orphans, vec!["Bash(npm *)".to_string()]);
+}
+
+#[test]
+fn permission_rule_orphan_glob_pattern_matches_catalog() {
+    let mut sections = HashMap::new();
+    sections.insert(
+        "permission".into(),
+        json!({
+            "rules": [
+                { "tool": "mcp__github__*", "behavior": "ask" },
+            ]
+        }),
+    );
+
+    let retained = vec!["mcp__github__pr".to_string()];
+    let orphans = permission_rules_without_catalog_match(&sections, &retained);
+    assert!(orphans.is_empty(), "glob pattern should match catalog tool");
+}
+
+#[test]
+fn permission_rule_orphan_no_permission_section_is_noop() {
+    let sections = HashMap::new();
+    let retained = vec!["Bash".to_string()];
+    assert!(permission_rules_without_catalog_match(&sections, &retained).is_empty());
+}
+
+#[test]
+fn permission_rule_orphan_unparseable_pattern_skipped() {
+    let mut sections = HashMap::new();
+    sections.insert(
+        "permission".into(),
+        json!({
+            "rules": [
+                { "tool": "((((invalid", "behavior": "ask" },
+            ]
+        }),
+    );
+
+    let retained = vec!["Bash".to_string()];
+    let orphans = permission_rules_without_catalog_match(&sections, &retained);
+    assert!(orphans.is_empty());
+}
+
+#[test]
+fn resolve_exclude_list_supports_glob_patterns() {
+    let spec = AgentSpec {
+        excluded_tools: Some(vec!["mcp__gitlab__*".into()]),
+        ..make_spec("a")
+    };
+
+    let regs = build_registries(
+        vec![
+            ("read", Arc::new(MockTool { id: "read".into() })),
+            (
+                "mcp__github__pr",
+                Arc::new(MockTool {
+                    id: "mcp__github__pr".into(),
+                }),
+            ),
+            (
+                "mcp__gitlab__pr",
+                Arc::new(MockTool {
+                    id: "mcp__gitlab__pr".into(),
+                }),
+            ),
+            (
+                "mcp__gitlab__merge",
+                Arc::new(MockTool {
+                    id: "mcp__gitlab__merge".into(),
+                }),
+            ),
+        ],
+        "test-model",
+        ModelBinding {
+            provider_id: "p".into(),
+            upstream_model: "n".into(),
+        },
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        spec,
+    );
+
+    let run = resolve(&regs, "a").unwrap();
+    assert_eq!(run.tools.len(), 2);
+    assert!(run.tools.contains_key("read"));
+    assert!(run.tools.contains_key("mcp__github__pr"));
+    assert!(!run.tools.contains_key("mcp__gitlab__pr"));
+    assert!(!run.tools.contains_key("mcp__gitlab__merge"));
+}

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
@@ -6,8 +6,8 @@ use serde_json::json;
 use super::*;
 use crate::registry::resolve::pipeline::catalog::{
     LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT, catalog_pattern_matches, is_argument_level_catalog_pattern,
-    permission_rules_without_catalog_match, should_warn_legacy_allow_all,
-    unmatched_catalog_patterns,
+    is_argument_syntax_for_registered_tool, permission_rules_without_catalog_match,
+    should_warn_legacy_allow_all, unmatched_catalog_patterns,
 };
 
 #[test]
@@ -184,6 +184,25 @@ fn catalog_argument_pattern_detection_flags_permission_style_args() {
 }
 
 #[test]
+fn registered_tool_argument_syntax_detection_flags_simple_args() {
+    let tool_ids = vec!["Bash".to_string(), "literal(paren)".to_string()];
+
+    assert!(is_argument_syntax_for_registered_tool(
+        "Bash(npm)",
+        &tool_ids
+    ));
+    assert!(is_argument_syntax_for_registered_tool("Bash(*)", &tool_ids));
+    assert!(!is_argument_syntax_for_registered_tool(
+        "literal(paren)",
+        &tool_ids
+    ));
+    assert!(!is_argument_syntax_for_registered_tool(
+        "Other(npm)",
+        &tool_ids
+    ));
+}
+
+#[test]
 fn unmatched_catalog_patterns_returns_typos() {
     let patterns = vec![
         "read_*".to_string(),
@@ -196,6 +215,14 @@ fn unmatched_catalog_patterns_returns_typos() {
         unmatched_catalog_patterns(&patterns, &tool_ids),
         vec!["mcp_github_*".to_string()]
     );
+}
+
+#[test]
+fn unmatched_catalog_patterns_skips_registered_tool_argument_syntax() {
+    let patterns = vec!["Bash(npm)".to_string(), "literal(paren)".to_string()];
+    let tool_ids = vec!["Bash".to_string(), "literal(paren)".to_string()];
+
+    assert!(unmatched_catalog_patterns(&patterns, &tool_ids).is_empty());
 }
 
 #[test]

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
@@ -5,9 +5,10 @@ use serde_json::json;
 
 use super::*;
 use crate::registry::resolve::pipeline::catalog::{
-    LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT, catalog_pattern_matches, is_argument_level_catalog_pattern,
+    CATALOG_WILDCARD_AUDIT_WARN_CACHE_LIMIT, LEGACY_ALLOW_ALL_WARN_CACHE_LIMIT,
+    catalog_pattern_matches, has_unescaped_catalog_wildcard, is_argument_level_catalog_pattern,
     is_argument_syntax_for_registered_tool, permission_rules_without_catalog_match,
-    should_warn_legacy_allow_all, unmatched_catalog_patterns,
+    should_warn_catalog_wildcard_entry, should_warn_legacy_allow_all, unmatched_catalog_patterns,
 };
 
 #[test]
@@ -188,10 +189,20 @@ fn registered_tool_argument_syntax_detection_flags_simple_args() {
     let tool_ids = vec!["Bash".to_string(), "literal(paren)".to_string()];
 
     assert!(is_argument_syntax_for_registered_tool(
+        r#"Bash(= "ls")"#,
+        &tool_ids
+    ));
+    assert!(is_argument_syntax_for_registered_tool(
         "Bash(npm)",
         &tool_ids
     ));
-    assert!(is_argument_syntax_for_registered_tool("Bash(*)", &tool_ids));
+    assert!(is_argument_syntax_for_registered_tool(
+        r#"Bash(command = "ls")"#,
+        &tool_ids
+    ));
+    assert!(!is_argument_syntax_for_registered_tool(
+        "Bash(*)", &tool_ids
+    ));
     assert!(!is_argument_syntax_for_registered_tool(
         "literal(paren)",
         &tool_ids
@@ -219,10 +230,50 @@ fn unmatched_catalog_patterns_returns_typos() {
 
 #[test]
 fn unmatched_catalog_patterns_skips_registered_tool_argument_syntax() {
-    let patterns = vec!["Bash(npm)".to_string(), "literal(paren)".to_string()];
+    let patterns = vec![
+        r#"Bash(= "ls")"#.to_string(),
+        "Bash(npm)".to_string(),
+        r#"Bash(command = "ls")"#.to_string(),
+        "literal(paren)".to_string(),
+    ];
     let tool_ids = vec!["Bash".to_string(), "literal(paren)".to_string()];
 
     assert!(unmatched_catalog_patterns(&patterns, &tool_ids).is_empty());
+}
+
+#[test]
+fn catalog_wildcard_audit_detects_unescaped_stars() {
+    assert!(has_unescaped_catalog_wildcard("mcp:*"));
+    assert!(has_unescaped_catalog_wildcard("tool*id"));
+    assert!(!has_unescaped_catalog_wildcard(r"tool\*id"));
+    assert!(!has_unescaped_catalog_wildcard("Bash"));
+}
+
+#[test]
+fn catalog_wildcard_audit_warning_cache_is_bounded() {
+    let warned = Mutex::new(VecDeque::new());
+    assert!(should_warn_catalog_wildcard_entry(
+        "agent\0allowed_tools\0mcp:*",
+        &warned
+    ));
+    assert!(!should_warn_catalog_wildcard_entry(
+        "agent\0allowed_tools\0mcp:*",
+        &warned
+    ));
+
+    for n in 0..(CATALOG_WILDCARD_AUDIT_WARN_CACHE_LIMIT + 1) {
+        assert!(should_warn_catalog_wildcard_entry(
+            &format!("agent\0allowed_tools\0pattern-{n}*"),
+            &warned,
+        ));
+    }
+    assert_eq!(
+        warned
+            .lock()
+            .expect("test catalog wildcard warning cache poisoned")
+            .len(),
+        CATALOG_WILDCARD_AUDIT_WARN_CACHE_LIMIT
+    );
 }
 
 #[test]

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/tests/catalog.rs
@@ -172,14 +172,15 @@ fn catalog_tool_id_match_handles_basic_wildcards() {
 }
 
 #[test]
-fn catalog_argument_pattern_detection_flags_parens() {
+fn catalog_argument_pattern_detection_flags_permission_style_args() {
     assert!(!is_argument_level_catalog_pattern("Bash"));
     assert!(!is_argument_level_catalog_pattern("mcp__github__*"));
+    assert!(!is_argument_level_catalog_pattern("literal(paren)"));
+    assert!(!is_argument_level_catalog_pattern("Bash(npm *"));
     assert!(is_argument_level_catalog_pattern("Bash(npm *)"));
     assert!(is_argument_level_catalog_pattern(
         r#"Edit(file_path ~ "src/**/*.rs")"#
     ));
-    assert!(is_argument_level_catalog_pattern("Bash(npm *"));
 }
 
 #[test]

--- a/crates/awaken-tool-pattern/src/lib.rs
+++ b/crates/awaken-tool-pattern/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod matcher;
 mod parser;
+mod tool_id;
 mod types;
 
 pub use matcher::{
@@ -13,6 +14,7 @@ pub use matcher::{
     schema_has_path, validate_pattern_fields, value_to_string, wildcard_match,
 };
 pub use parser::{PatternParseError, parse_pattern};
+pub use tool_id::tool_id_match;
 pub use types::{
     ArgMatcher, FieldCondition, MatchOp, MatchResult, PathSegment, Specificity, ToolCallPattern,
     ToolMatcher,

--- a/crates/awaken-tool-pattern/src/tool_id.rs
+++ b/crates/awaken-tool-pattern/src/tool_id.rs
@@ -1,0 +1,57 @@
+/// Match a tool-id pattern against a literal tool id (catalog filtering for
+/// `AgentSpec.allowed_tools` / `excluded_tools`).
+///
+/// Tool ids are opaque strings, so this matcher is intentionally simpler than
+/// `wildcard_match`: `/`, `:`, and `_` are ordinary characters and there is
+/// no path / glob / regex / negation semantics.
+///
+/// Grammar:
+///
+/// - The full pattern must match the full tool id (anchored).
+/// - `*` matches any sequence of characters, including `/`, `:`, `_`.
+/// - `\` escapes the next character (`\*` is a literal `*`; `\\` a literal `\`).
+/// - Every other character is a literal.
+#[must_use]
+pub fn tool_id_match(pattern: &str, tool_id: &str) -> bool {
+    let p = pattern.as_bytes();
+    let v = tool_id.as_bytes();
+    let mut pi = 0usize;
+    let mut vi = 0usize;
+    let mut star_pi: Option<usize> = None;
+    let mut star_vi = 0usize;
+
+    while vi < v.len() {
+        if pi < p.len() {
+            let c = p[pi];
+            if c == b'\\' && pi + 1 < p.len() {
+                if p[pi + 1] == v[vi] {
+                    pi += 2;
+                    vi += 1;
+                    continue;
+                }
+            } else if c == b'*' {
+                star_pi = Some(pi);
+                star_vi = vi;
+                pi += 1;
+                continue;
+            } else if c == v[vi] {
+                pi += 1;
+                vi += 1;
+                continue;
+            }
+        }
+        // Mismatch — backtrack to the last `*` and consume one more value byte.
+        if let Some(sp) = star_pi {
+            pi = sp + 1;
+            star_vi += 1;
+            vi = star_vi;
+        } else {
+            return false;
+        }
+    }
+    // Consume any trailing `*`s left in the pattern.
+    while pi < p.len() && p[pi] == b'*' {
+        pi += 1;
+    }
+    pi == p.len()
+}

--- a/crates/awaken-tool-pattern/tests/catalog_glob_parity.rs
+++ b/crates/awaken-tool-pattern/tests/catalog_glob_parity.rs
@@ -1,0 +1,42 @@
+//! Catalog tool-id pattern parity oracle.
+//!
+//! Loads `tests/fixtures/catalog-glob-parity.json` and asserts the documented
+//! behavior of [`awaken_tool_pattern::tool_id_match`] — the matcher used by
+//! the catalog filter on `AgentSpec.allowed_tools` / `excluded_tools`. The
+//! same fixture is consumed by the admin-console frontend matcher tests so
+//! any divergence between runtime and UI is caught here.
+
+use awaken_tool_pattern::tool_id_match;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Case {
+    pattern: String,
+    value: String,
+    expected: bool,
+    #[allow(dead_code)]
+    note: String,
+}
+
+#[test]
+fn catalog_tool_id_parity_oracle() {
+    let raw = include_str!("fixtures/catalog-glob-parity.json");
+    let cases: Vec<Case> = serde_json::from_str(raw).expect("parse fixture");
+
+    let mut failures = Vec::new();
+    for case in &cases {
+        let got = tool_id_match(&case.pattern, &case.value);
+        if got != case.expected {
+            failures.push(format!(
+                "  pattern={:?} value={:?} expected={} got={}  ({})",
+                case.pattern, case.value, case.expected, got, case.note
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "catalog tool-id parity mismatches:\n{}",
+        failures.join("\n")
+    );
+}

--- a/crates/awaken-tool-pattern/tests/fixtures/catalog-glob-parity.json
+++ b/crates/awaken-tool-pattern/tests/fixtures/catalog-glob-parity.json
@@ -1,0 +1,38 @@
+[
+  { "pattern": "Bash",             "value": "Bash",                          "expected": true,  "note": "literal exact match" },
+  { "pattern": "Bash",             "value": "Read",                          "expected": false, "note": "literal mismatch" },
+  { "pattern": "Bash",             "value": "BashExtra",                     "expected": false, "note": "literal is anchored full-string" },
+
+  { "pattern": "*",                "value": "anything",                      "expected": true,  "note": "wildcard matches any string" },
+  { "pattern": "*",                "value": "mcp:weather/forecast",          "expected": true,  "note": "wildcard crosses ':' and '/'" },
+  { "pattern": "*",                "value": "",                              "expected": true,  "note": "wildcard matches the empty string" },
+
+  { "pattern": "mcp:*",            "value": "mcp:weather/forecast",          "expected": true,  "note": "prefix wildcard, ':' is literal" },
+  { "pattern": "mcp:*",            "value": "plugin:reminder/add",           "expected": false, "note": "prefix mismatch" },
+  { "pattern": "mcp:weather/*",    "value": "mcp:weather/forecast",          "expected": true,  "note": "'/' is literal char in a tool id" },
+  { "pattern": "mcp:weather/*",    "value": "mcp:weather/foo/bar",           "expected": true,  "note": "wildcard spans multiple slashes" },
+  { "pattern": "mcp__github__*",   "value": "mcp__github__read_issue",       "expected": true,  "note": "underscore-prefixed wildcard" },
+  { "pattern": "mcp__github__*",   "value": "mcp__gitlab__issue",            "expected": false, "note": "prefix mismatch" },
+  { "pattern": "*issue",           "value": "mcp__github__read_issue",       "expected": true,  "note": "suffix wildcard" },
+  { "pattern": "*weather*",        "value": "mcp:weather/forecast",          "expected": true,  "note": "substring wildcard" },
+  { "pattern": "a*b",              "value": "a/b",                           "expected": true,  "note": "wildcard crosses '/' (no path semantics)" },
+  { "pattern": "a*/b",             "value": "a/x/b",                         "expected": true,  "note": "wildcard absorbs the extra '/' segment" },
+
+  { "pattern": "\\*literal",       "value": "*literal",                      "expected": true,  "note": "'\\*' is a literal star" },
+  { "pattern": "\\*literal",       "value": "Xliteral",                      "expected": false, "note": "literal star does not match other chars" },
+  { "pattern": "foo\\\\bar",       "value": "foo\\bar",                      "expected": true,  "note": "'\\\\' is a literal backslash" },
+
+  { "pattern": "!Bash",            "value": "!Bash",                         "expected": true,  "note": "'!' is an ordinary character, no negation" },
+  { "pattern": "!Bash",            "value": "Bash",                          "expected": false, "note": "literal full-string mismatch" },
+  { "pattern": "\\!Bash",          "value": "!Bash",                         "expected": true,  "note": "escaping '!' has no effect; both are literal" },
+
+  { "pattern": "{Bash}",           "value": "{Bash}",                        "expected": true,  "note": "braces are literal — no brace alternation" },
+  { "pattern": "{Bash}",           "value": "Bash",                          "expected": false, "note": "no brace expansion" },
+  { "pattern": "[abc]",            "value": "[abc]",                         "expected": true,  "note": "brackets are literal — no character class" },
+  { "pattern": "[abc]",            "value": "a",                             "expected": false, "note": "no character class" },
+  { "pattern": "tool?id",          "value": "tool?id",                       "expected": true,  "note": "'?' is literal — no single-char wildcard" },
+  { "pattern": "tool?id",          "value": "toolXid",                       "expected": false, "note": "'?' is literal — no wildcard" },
+
+  { "pattern": "Bash(npm *)",      "value": "Bash",                          "expected": false, "note": "argument syntax belongs in permission plugin, not catalog" },
+  { "pattern": "/B.*/",            "value": "Bash",                          "expected": false, "note": "regex syntax belongs in permission plugin, not catalog" }
+]

--- a/docs/book/src/explanation/agent-resolution.md
+++ b/docs/book/src/explanation/agent-resolution.md
@@ -126,9 +126,9 @@ After merging, the spec's `allowed_tools` and `excluded_tools` fields are applie
 
 - `allowed_tools = Some(["*"])` -- all tools are kept.
 - `allowed_tools = Some([])` -- all tools are removed.
-- `allowed_tools = Some(list)` -- only tools whose ID matches a literal or glob entry is kept.
+- `allowed_tools = Some(list)` -- only tools whose ID matches a literal or tool-id pattern entry is kept.
 - `allowed_tools = None` -- deprecated legacy allow-all.
-- `excluded_tools = Some(list)` -- any tool whose ID matches a literal or glob entry is removed, even if it was in the allow list.
+- `excluded_tools = Some(list)` -- any tool whose ID matches a literal or tool-id pattern entry is removed, even if it was in the allow list.
 - `excluded_tools = None` -- no additional tools are removed.
 
 ## ExecutionEnv

--- a/docs/book/src/explanation/agent-resolution.md
+++ b/docs/book/src/explanation/agent-resolution.md
@@ -124,9 +124,12 @@ If a plugin-registered tool has the same ID as a global tool, resolution fails w
 
 After merging, the spec's `allowed_tools` and `excluded_tools` fields are applied:
 
-- `allowed_tools = None` -- all tools are kept.
-- `allowed_tools = Some(list)` -- only tools whose ID appears in the list are kept. Everything else is dropped.
-- `excluded_tools` -- any tool whose ID appears in this list is removed, even if it was in the allow list.
+- `allowed_tools = Some(["*"])` -- all tools are kept.
+- `allowed_tools = Some([])` -- all tools are removed.
+- `allowed_tools = Some(list)` -- only tools whose ID matches a literal or glob entry is kept.
+- `allowed_tools = None` -- deprecated legacy allow-all.
+- `excluded_tools = Some(list)` -- any tool whose ID matches a literal or glob entry is removed, even if it was in the allow list.
+- `excluded_tools = None` -- no additional tools are removed.
 
 ## ExecutionEnv
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -65,7 +65,7 @@ state, argument-level rules) is a separate concern; see `sections["permission"]`
 | `allowed_tools: []`          | Allow no tools                                         |
 | `excluded_tools: ["*"]`      | Block all tools after the allow-list is applied        |
 | `excluded_tools: []`         | Block none                                             |
-| `["a", "mcp__*"]`           | Subset; entries may be literal tool ids or wildcards (`*`) |
+| `["a", "mcp__*"]`           | Subset; entries may be literal tool ids or tool-id patterns |
 
 Legacy `null` / missing values should be migrated to explicit values:
 
@@ -92,15 +92,16 @@ The grammar (see `awaken_tool_pattern::tool_id_match`):
 | `*`        | Matches any sequence of characters, including `/`, `:`, `_`         |
 | `\*`       | A literal `*`                                                        |
 | `\\`       | A literal `\`                                                        |
-| every other char | Literal (no special meaning, including `?`, `[`, `{`, `!`)    |
+| every other char | Literal (no special meaning, including `?`, `[`, `]`, `{`, `}`, `!`) |
 
-Filesystem-glob features (`**` path segments, `?` single-char wildcard,
-`[abc]` character classes, `{a,b}` alternation, leading-`!` negation), regex
-syntax (`/.../`) and argument-level patterns (`Bash(npm *)`,
-`Edit(file_path ~ "src/**")`) are intentionally absent — they belong to the
-permission-rule layer in `sections["permission"]`. To express "allow every
-tool except `Bash`", use `allowed_tools: ["*"]` plus `excluded_tools: ["Bash"]`,
-not `allowed_tools: ["!Bash"]`.
+Catalog entries are not permission globs. Filesystem-glob features (`**` path
+segments, `?` single-char wildcard, `[abc]` character classes, `{a,b}`
+alternation, leading-`!` negation), regex syntax (`/.../`), and argument-level
+patterns (`Bash(npm *)`, `Edit(file_path ~ "src/**")`) are intentionally absent
+— they belong to the permission-rule layer in `sections["permission"]`. In the
+catalog layer, `!Bash`, `Bash?`, and `Bash[0]` are literal tool-id patterns. To
+express "allow every tool except `Bash`", use `allowed_tools: ["*"]` plus
+`excluded_tools: ["Bash"]`, not `allowed_tools: ["!Bash"]`.
 
 The Admin Console parity test
 (`apps/admin-console/src/lib/catalog-glob-parity.test.ts`) and the runtime

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -74,6 +74,12 @@ Legacy `null` / missing values should be migrated to explicit values:
 | `allowed_tools`  | Allow all                 | `["*"]`              |
 | `excluded_tools` | Exclude none / block none | `[]`                 |
 
+Migration note: before catalog tool-id patterns were introduced, catalog
+entries were exact strings. Any existing entry containing an unescaped `*`
+now has wildcard semantics. Escape literal stars as `\*` before upgrading if
+the intended tool id contains a real `*`, and review entries such as `mcp:*`
+or `Bash*` because they may expose or remove more tools than before.
+
 Catalog entries are **tool-id patterns**, not filesystem globs. Tool ids are
 opaque strings, so `/`, `:`, and `_` are ordinary characters — `mcp:*` will
 match `mcp:weather/forecast`, and `tool/id/*` will match `tool/id/foo/bar`.
@@ -101,15 +107,17 @@ The Admin Console parity test
 oracle (`crates/awaken-tool-pattern/tests/catalog_glob_parity.rs`) share a
 single fixture; add cases there when reasoning about edge behavior.
 
-The Admin Console preserves existing pattern entries and marks tools selected
-by those entries as pattern-backed. The checkbox UI edits literal tool IDs;
-edit the JSON payload or raw config to change or remove pattern entries.
+The Admin Console preserves existing pattern/unmanaged entries, lists entries
+that are not a current exact tool id, shows which current tools they match, and
+allows removing stale entries directly from the Tools tab. Tools selected by a
+pattern are marked as pattern-backed; checkbox edits only add or remove literal
+current tool ids.
 
-When a non-empty catalog pattern matches no currently available tools, the
+When a non-empty catalog pattern matches no registered catalog tool, the
 resolver logs:
 
 ```text
-WARN catalog pattern matches no available tools — check the tool id or wildcard
+WARN catalog pattern matches no registered tools — check the tool id or wildcard
      agent_id=<id> field=<allowed_tools|excluded_tools> pattern=<pattern>
 ```
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -52,6 +52,81 @@ fn config<K: PluginConfigKey>(&self) -> Result<K::Config, StateError>
 fn set_config<K: PluginConfigKey>(&mut self, config: K::Config) -> Result<(), StateError>
 ```
 
+### Tool catalog (`allowed_tools` / `excluded_tools`)
+
+`allowed_tools` and `excluded_tools` define **which tools the agent can see**.
+This is the *catalog* layer — filtering happens once at resolve time and
+removed tools never reach the LLM. Runtime permission gating (the `Ask`
+state, argument-level rules) is a separate concern; see `sections["permission"]`.
+
+| Field + value                | Meaning                                                |
+|------------------------------|--------------------------------------------------------|
+| `allowed_tools: ["*"]`       | Explicit allow-all                                     |
+| `allowed_tools: []`          | Allow no tools                                         |
+| `excluded_tools: ["*"]`      | Block all tools after the allow-list is applied        |
+| `excluded_tools: []`         | Block none                                             |
+| `["a", "mcp__*"]`           | Subset; entries may be literal tool ids or wildcards (`*`) |
+
+Legacy `null` / missing values should be migrated to explicit values:
+
+| Field            | Legacy meaning            | Explicit replacement |
+|------------------|---------------------------|----------------------|
+| `allowed_tools`  | Allow all                 | `["*"]`              |
+| `excluded_tools` | Exclude none / block none | `[]`                 |
+
+Catalog entries are **tool-id patterns**, not filesystem globs. Tool ids are
+opaque strings, so `/`, `:`, and `_` are ordinary characters — `mcp:*` will
+match `mcp:weather/forecast`, and `tool/id/*` will match `tool/id/foo/bar`.
+
+The grammar (see `awaken_tool_pattern::tool_id_match`):
+
+| Construct  | Meaning                                                              |
+|------------|----------------------------------------------------------------------|
+| literal    | A literal pattern matches the entire tool id exactly                |
+| `*`        | Matches any sequence of characters, including `/`, `:`, `_`         |
+| `\*`       | A literal `*`                                                        |
+| `\\`       | A literal `\`                                                        |
+| every other char | Literal (no special meaning, including `?`, `[`, `{`, `!`)    |
+
+Filesystem-glob features (`**` path segments, `?` single-char wildcard,
+`[abc]` character classes, `{a,b}` alternation, leading-`!` negation), regex
+syntax (`/.../`) and argument-level patterns (`Bash(npm *)`,
+`Edit(file_path ~ "src/**")`) are intentionally absent — they belong to the
+permission-rule layer in `sections["permission"]`. To express "allow every
+tool except `Bash`", use `allowed_tools: ["*"]` plus `excluded_tools: ["Bash"]`,
+not `allowed_tools: ["!Bash"]`.
+
+The Admin Console parity test
+(`apps/admin-console/src/lib/catalog-glob-parity.test.ts`) and the runtime
+oracle (`crates/awaken-tool-pattern/tests/catalog_glob_parity.rs`) share a
+single fixture; add cases there when reasoning about edge behavior.
+
+The Admin Console preserves existing pattern entries and marks tools selected
+by those entries as pattern-backed. The checkbox UI edits literal tool IDs;
+edit the JSON payload or raw config to change or remove pattern entries.
+
+When a non-empty catalog pattern matches no currently available tools, the
+resolver logs:
+
+```text
+WARN catalog pattern matches no available tools — check the tool id or wildcard
+     agent_id=<id> field=<allowed_tools|excluded_tools> pattern=<pattern>
+```
+
+When `sections["permission"]` contains a rule whose tool-name portion
+matches no surviving catalog tool, the resolver logs:
+
+```text
+WARN permission rule references tool not in catalog — rule will never fire
+     agent_id=<id> rule=<pattern>
+```
+
+This is the safety net for the classic dual-track bug where a permission
+rule is configured but the underlying tool was already excluded by the
+catalog. Fix by checking that the tool is registered, adding it to
+`allowed_tools` if the allow-list omitted it, or removing/narrowing the
+`excluded_tools` entry that filtered it out. If the rule is stale, remove it.
+
 ### Runtime-managed plugin config
 
 `AgentSpec.sections` is the source of truth for plugin configuration whether

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -76,8 +76,11 @@ Legacy `null` / missing values should be migrated to explicit values:
 
 Migration note: before catalog tool-id patterns were introduced, catalog
 entries were exact strings. Any existing entry containing an unescaped `*`
-now has wildcard semantics. Escape literal stars as `\*` before upgrading if
-the intended tool id contains a real `*`, and review entries such as `mcp:*`
+or a literal `\` now has pattern semantics. Escape literal stars as `\*`
+and literal backslashes as `\\` before upgrading if the intended tool id
+contains either character; for example, a raw `foo\bar` entry no longer
+matches the tool id `foo\bar` — the `\b` is parsed as a literal `b`, so
+the entry matches `foobar` instead. Also review entries such as `mcp:*`
 or `Bash*` because they may expose or remove more tools than before.
 
 Catalog entries are **tool-id patterns**, not filesystem globs. Tool ids are

--- a/docs/book/src/zh-CN/explanation/agent-resolution.md
+++ b/docs/book/src/zh-CN/explanation/agent-resolution.md
@@ -121,9 +121,12 @@ flowchart LR
 
 合并后，应用规格的 `allowed_tools` 和 `excluded_tools` 字段：
 
-- `allowed_tools = None` -- 保留所有工具。
-- `allowed_tools = Some(list)` -- 仅保留 ID 出现在列表中的工具。其余全部丢弃。
-- `excluded_tools` -- 任何 ID 出现在此列表中的工具都会被移除，即使它在允许列表中。
+- `allowed_tools = Some(["*"])` -- 保留所有工具。
+- `allowed_tools = Some([])` -- 移除所有工具。
+- `allowed_tools = Some(list)` -- 仅保留 ID 匹配字面条目或 glob 条目的工具。
+- `allowed_tools = None` -- 已废弃的旧 allow-all 语义。
+- `excluded_tools = Some(list)` -- 任何 ID 匹配字面条目或 glob 条目的工具都会被移除，即使它在允许列表中。
+- `excluded_tools = None` -- 不额外移除任何工具。
 
 ## ExecutionEnv
 

--- a/docs/book/src/zh-CN/explanation/agent-resolution.md
+++ b/docs/book/src/zh-CN/explanation/agent-resolution.md
@@ -123,9 +123,9 @@ flowchart LR
 
 - `allowed_tools = Some(["*"])` -- 保留所有工具。
 - `allowed_tools = Some([])` -- 移除所有工具。
-- `allowed_tools = Some(list)` -- 仅保留 ID 匹配字面条目或 glob 条目的工具。
+- `allowed_tools = Some(list)` -- 仅保留 ID 匹配字面条目或 tool-id pattern 条目的工具。
 - `allowed_tools = None` -- 已废弃的旧 allow-all 语义。
-- `excluded_tools = Some(list)` -- 任何 ID 匹配字面条目或 glob 条目的工具都会被移除，即使它在允许列表中。
+- `excluded_tools = Some(list)` -- 任何 ID 匹配字面条目或 tool-id pattern 条目的工具都会被移除，即使它在允许列表中。
 - `excluded_tools = None` -- 不额外移除任何工具。
 
 ## ExecutionEnv

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -71,9 +71,11 @@ fn set_config<K: PluginConfigKey>(&mut self, config: K::Config) -> Result<(), St
 | `excluded_tools` | 不排除任何工具 / block none | `[]`       |
 
 迁移说明：引入 catalog tool-id pattern 之前，catalog 条目是精确字符串。
-现有条目中未转义的 `*` 现在具有 wildcard 语义。如果真实 tool id 包含字面
-`*`，升级前请写成 `\*`；也请检查 `mcp:*`、`Bash*` 等条目，因为它们可能
-暴露或移除比以前更多的工具。
+现有条目中未转义的 `*` 或字面 `\` 现在都具有 pattern 语义。如果真实
+tool id 含有这两个字符，升级前请把字面 `*` 写成 `\*`、字面 `\` 写成
+`\\`——例如 `foo\bar` 这种 raw 条目不再匹配 tool id `foo\bar`，`\b`
+会被解析为字面 `b`，条目会改去匹配 `foobar`。同时请检查 `mcp:*`、
+`Bash*` 等条目，因为它们可能暴露或移除比以前更多的工具。
 
 Catalog 条目是 **tool-id pattern**，不是文件系统 glob。Tool id 是不透明
 字符串，所以 `/`、`:`、`_` 都是普通字符——`mcp:*` 会匹配

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -61,7 +61,7 @@ fn set_config<K: PluginConfigKey>(&mut self, config: K::Config) -> Result<(), St
 | `allowed_tools: []`        | 不允许任何工具                                         |
 | `excluded_tools: ["*"]`    | 在 allow-list 应用后阻断全部工具                       |
 | `excluded_tools: []`       | 不额外阻断任何工具                                     |
-| `["a", "mcp__*"]`         | 子集；条目可以是字面 tool id 或 wildcard（`*`）        |
+| `["a", "mcp__*"]`         | 子集；条目可以是字面 tool id 或 tool-id pattern        |
 
 旧的 `null` / 缺失值应迁移为显式值：
 
@@ -69,6 +69,11 @@ fn set_config<K: PluginConfigKey>(&mut self, config: K::Config) -> Result<(), St
 |------------------|---------------------------|------------|
 | `allowed_tools`  | 允许全部工具              | `["*"]`    |
 | `excluded_tools` | 不排除任何工具 / block none | `[]`       |
+
+迁移说明：引入 catalog tool-id pattern 之前，catalog 条目是精确字符串。
+现有条目中未转义的 `*` 现在具有 wildcard 语义。如果真实 tool id 包含字面
+`*`，升级前请写成 `\*`；也请检查 `mcp:*`、`Bash*` 等条目，因为它们可能
+暴露或移除比以前更多的工具。
 
 Catalog 条目是 **tool-id pattern**，不是文件系统 glob。Tool id 是不透明
 字符串，所以 `/`、`:`、`_` 都是普通字符——`mcp:*` 会匹配
@@ -95,14 +100,15 @@ Admin Console 的 parity 测试（`apps/admin-console/src/lib/catalog-glob-parit
 与 runtime oracle（`crates/awaken-tool-pattern/tests/catalog_glob_parity.rs`）
 共用同一份 fixture——边缘语义请在那里新增 case。
 
-Admin Console 会保留已有 pattern 条目，并把由这些条目选中的工具标记为
-pattern-backed。复选框 UI 只编辑字面 tool id；修改或删除 pattern 条目需要编辑
-JSON payload 或原始配置。
+Admin Console 会保留已有 pattern / unmanaged 条目，列出不是当前精确 tool id
+的条目，显示它们当前匹配了哪些工具，并允许在 Tools tab 里直接删除 stale
+条目。由 pattern 选中的工具会标记为 pattern-backed；复选框 UI 只新增或移除
+当前字面 tool id。
 
-当非空 catalog pattern 没有匹配到当前可用工具时，resolver 会输出：
+当非空 catalog pattern 没有匹配到已注册 catalog 工具时，resolver 会输出：
 
 ```text
-WARN catalog pattern matches no available tools — check the tool id or wildcard
+WARN catalog pattern matches no registered tools — check the tool id or wildcard
      agent_id=<id> field=<allowed_tools|excluded_tools> pattern=<pattern>
 ```
 

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -87,13 +87,14 @@ Catalog 条目是 **tool-id pattern**，不是文件系统 glob。Tool id 是不
 | `*`        | 匹配任意字符序列，包括 `/`、`:`、`_`                            |
 | `\*`       | 字面 `*`                                                       |
 | `\\`       | 字面 `\`                                                       |
-| 其它字符    | 字面（`?`、`[`、`{`、`!` 都没有特殊含义）                       |
+| 其它字符    | 字面（`?`、`[`、`]`、`{`、`}`、`!` 都没有特殊含义）              |
 
-文件系统 glob 特性（`**` 路径段、`?` 单字符通配、`[abc]` 字符类、
-`{a,b}` 分支、开头 `!` 取反）、regex 语法（`/.../`）和参数级模式
-（`Bash(npm *)`、`Edit(file_path ~ "src/**")`）在 catalog 层**不**存在——
-它们属于 `sections["permission"]` 层。要表达"允许除 Bash 外所有工具"，
-请用 `allowed_tools: ["*"]` 加 `excluded_tools: ["Bash"]`，
+Catalog 条目不是 permission glob。文件系统 glob 特性（`**` 路径段、`?`
+单字符通配、`[abc]` 字符类、`{a,b}` 分支、开头 `!` 取反）、regex 语法
+（`/.../`）和参数级模式（`Bash(npm *)`、`Edit(file_path ~ "src/**")`）在
+catalog 层**不**存在——它们属于 `sections["permission"]` 层。在 catalog
+层，`!Bash`、`Bash?`、`Bash[0]` 都是字面 tool-id pattern。要表达"允许除
+Bash 外所有工具"，请用 `allowed_tools: ["*"]` 加 `excluded_tools: ["Bash"]`，
 而**不是** `allowed_tools: ["!Bash"]`。
 
 Admin Console 的 parity 测试（`apps/admin-console/src/lib/catalog-glob-parity.test.ts`）

--- a/docs/book/src/zh-CN/reference/config.md
+++ b/docs/book/src/zh-CN/reference/config.md
@@ -48,6 +48,77 @@ fn config<K: PluginConfigKey>(&self) -> Result<K::Config, StateError>
 fn set_config<K: PluginConfigKey>(&mut self, config: K::Config) -> Result<(), StateError>
 ```
 
+### 工具目录（`allowed_tools` / `excluded_tools`）
+
+`allowed_tools` 与 `excluded_tools` 决定**这个 agent 能看见哪些工具**——
+这是 catalog 层，在 resolve 阶段做一次性过滤，被排除的工具不会出现在 LLM 的工具
+列表里。运行时的权限门禁（`Ask` 状态、参数级规则）是另一层，见
+`sections["permission"]`。
+
+| 字段和值                    | 含义                                                   |
+|----------------------------|--------------------------------------------------------|
+| `allowed_tools: ["*"]`     | 显式 allow-all                                        |
+| `allowed_tools: []`        | 不允许任何工具                                         |
+| `excluded_tools: ["*"]`    | 在 allow-list 应用后阻断全部工具                       |
+| `excluded_tools: []`       | 不额外阻断任何工具                                     |
+| `["a", "mcp__*"]`         | 子集；条目可以是字面 tool id 或 wildcard（`*`）        |
+
+旧的 `null` / 缺失值应迁移为显式值：
+
+| 字段             | 旧语义                    | 显式替代值 |
+|------------------|---------------------------|------------|
+| `allowed_tools`  | 允许全部工具              | `["*"]`    |
+| `excluded_tools` | 不排除任何工具 / block none | `[]`       |
+
+Catalog 条目是 **tool-id pattern**，不是文件系统 glob。Tool id 是不透明
+字符串，所以 `/`、`:`、`_` 都是普通字符——`mcp:*` 会匹配
+`mcp:weather/forecast`，`tool/id/*` 会匹配 `tool/id/foo/bar`。
+
+语法（见 `awaken_tool_pattern::tool_id_match`）：
+
+| 构造        | 含义                                                            |
+|------------|----------------------------------------------------------------|
+| literal    | 字面 pattern 与 tool id 完整精确匹配                            |
+| `*`        | 匹配任意字符序列，包括 `/`、`:`、`_`                            |
+| `\*`       | 字面 `*`                                                       |
+| `\\`       | 字面 `\`                                                       |
+| 其它字符    | 字面（`?`、`[`、`{`、`!` 都没有特殊含义）                       |
+
+文件系统 glob 特性（`**` 路径段、`?` 单字符通配、`[abc]` 字符类、
+`{a,b}` 分支、开头 `!` 取反）、regex 语法（`/.../`）和参数级模式
+（`Bash(npm *)`、`Edit(file_path ~ "src/**")`）在 catalog 层**不**存在——
+它们属于 `sections["permission"]` 层。要表达"允许除 Bash 外所有工具"，
+请用 `allowed_tools: ["*"]` 加 `excluded_tools: ["Bash"]`，
+而**不是** `allowed_tools: ["!Bash"]`。
+
+Admin Console 的 parity 测试（`apps/admin-console/src/lib/catalog-glob-parity.test.ts`）
+与 runtime oracle（`crates/awaken-tool-pattern/tests/catalog_glob_parity.rs`）
+共用同一份 fixture——边缘语义请在那里新增 case。
+
+Admin Console 会保留已有 pattern 条目，并把由这些条目选中的工具标记为
+pattern-backed。复选框 UI 只编辑字面 tool id；修改或删除 pattern 条目需要编辑
+JSON payload 或原始配置。
+
+当非空 catalog pattern 没有匹配到当前可用工具时，resolver 会输出：
+
+```text
+WARN catalog pattern matches no available tools — check the tool id or wildcard
+     agent_id=<id> field=<allowed_tools|excluded_tools> pattern=<pattern>
+```
+
+当 `sections["permission"]` 中的规则其 tool 名部分无法匹配任何保留下来的
+catalog 工具时，resolver 会输出：
+
+```text
+WARN permission rule references tool not in catalog — rule will never fire
+     agent_id=<id> rule=<pattern>
+```
+
+这条 warning 是双轨陷阱的安全网——避免"配置了权限规则但工具早被 catalog 排除，
+规则静默不生效"的典型问题。解决方式：确认工具已注册；如果 allow-list 漏掉了它，
+将其加入 `allowed_tools`；如果是 `excluded_tools` 过滤掉了它，删除或收窄对应排除
+项；如果规则已过时，则删除规则。
+
 ### 运行时管理的插件配置
 
 无论 agent spec 是在 Rust 中构造、从 JSON/YAML 加载，还是通过运行时配置 API


### PR DESCRIPTION
## Summary

- Rework `AgentSpec.allowed_tools` / `excluded_tools` catalog matching: explicit `["*"]` / `[]` modes plus tool-id patterns via `awaken_tool_pattern::tool_id_match`. Catalog matching only treats unescaped `*` as special; `?`, `[ ]`, `{ }`, and leading `!` stay literal.
- Add migration/release notes for the exact-match-to-pattern semantic change: existing catalog entries containing an unescaped `*` *or* a literal `\` now have pattern semantics; escape literal stars as `\*` and literal backslashes as `\\` (e.g. a raw `foo\bar` entry no longer matches the tool id `foo\bar` — the `\b` becomes a literal `b`, so it matches `foobar` instead).
- Add runtime audit warnings for catalog entries that contain an unescaped `*` wildcard, excluding the explicit `["*"]` sentinel. Warnings are bounded and emitted once per agent/field/pattern so migrated literal-star entries can be spotted without log spam.
- Keep permission argument rules on `awaken-tool-pattern`; catalog filters match tool names only and do not support argument-level syntax in `allowed_tools` / `excluded_tools`. Runtime diagnostics flag registered-tool argument syntax such as `Bash(npm)`, `Bash(= "ls")`, and `Bash(command = "ls")` as permission-layer misuse while leaving literal tool ids such as `literal(paren)` alone.
- Add resolver warnings for catalog entries that look like permission-style argument patterns and permission rules that reference tools filtered out by the catalog. `excluded_tools` unmatched checks now compare against the original merged catalog so tools already removed by `allowed_tools` are not misreported as nonexistent.
- Admin console `ToolSelector` updated: emits `["*"]` (include) / `[]` (exclude) for all mode, preserves and displays pattern/unmanaged catalog entries, shows their current matches, supports deleting stale entries from the Tools tab, keeps catalog controls visible when no tools are published, protects `excluded_tools: ["*"]` from silent expansion, and uses neutral legacy-null banners.
- Admin checkbox editing now treats any unescaped-wildcard entry as pattern-backed even when the raw entry text equals a current tool id, so `allowed_tools: ["tool*id"]` cannot be silently removed by unchecking the literal `tool*id` row. Raw pattern removal stays in the catalog entry list.
- Admin catalog entry inspection now recognizes escaped literal entries such as `foo\*bar` as semantically matching `foo*bar`, labels them as escaped literals, and does not mark them stale/unmanaged.
- Admin console catalog preview now uses the same tool-id pattern semantics as runtime for `allowed_tools` / `excluded_tools`, including `["*"]`, allow patterns such as `mcp:*`, and exclude patterns such as `mcp:*`.
- Agent editor save handling normalizes legacy catalog fields for user-record saves, avoids legacy catalog normalization as builtin/customized overrides, and uses normalized catalog comparison for dirty/preview-stale state.
- Admin catalog writes now encode literal tool ids via `escapeCatalogLiteral`: checkbox add, "Custom selection" seeding from legacy/`["*"]`, and "Select all" on a group all emit `\*` / `\\` for any tool id containing `*` or `\`. Without this, raw `tool*id` would be re-read by the runtime as a wildcard authorising every text-matching tool.
- Admin auto-collapse to `["*"]` is now gated by `canCollapseToExplicitAll`: it only fires when every catalog entry is a plain raw literal (current tool id with no `*` and no `\`) AND every tool id is covered. Wildcard entries, backslash-bearing entries, escaped-literal entries, and unmanaged entries keep their individual form, so adding the last remaining tool to a catalog that still holds `tool*id` or `foo\bar` no longer silently widens to `["*"]`.
- Admin inspection / collapse / clear paths now treat raw backslash entries the same as wildcards: a raw `foo\bar` entry whose text equals a current tool id is surfaced in the catalog entry list (not hidden as a safe exact match) and is preserved on group "Clear". `isPlainRawCatalogLiteral` unifies the check across `catalogEntryInspections`, `canCollapseToExplicitAll`, and `setGroupSelection`'s clear branch.
- Admin checkbox uncheck now mirrors group "Clear": `nextAllowedTools` removes both the plain raw literal AND the `escapeCatalogLiteral(toolId)` form of the current tool id, so unchecking a tool with `*` or `\` in its id from `["*"]` / legacy / pre-existing escaped state actually drops the seeded entry. Wildcard, backslash-bearing, and unmanaged entries are preserved and continue to be managed via the entry list. `toolSelectionPattern` now also flags text-equal entries with `\` (dangling escapes, self-matching backslash) as pattern-backed.
- Docs (`CHANGELOG.md`, `docs/book/src/reference/config.md`, and zh-CN config/resolution references) explain catalog vs permission-policy separation, explicit catalog value forms, tool-id pattern semantics, migration risk for both `*` and `\`, and cross-layer warnings. Config docs explicitly state that `?`, `[ ]`, `{ }`, and leading `!` are literals in catalog entries.

**Plugin untouched:** `awaken-ext-permission` schema and runtime behavior is unchanged. Architecture unchanged; permission stays plugin-driven.

## Verification

- `cargo test -p awaken-runtime registry::resolve::pipeline::tests::catalog --lib`: 17 passed
- `cargo clippy -p awaken-runtime --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `git diff --check`: clean
- `apps/admin-console npm test`: 76 test files / 980 passed / 10 skipped (`agent-tool-selection.test.ts` now 96 passed, covering escape-on-add, collapse-safety, raw-backslash inspection/uncheck/clear, and uncheck-from-allow-all dropping the seeded escaped literal)
- `apps/admin-console npm run lint`: clean
- `apps/admin-console npm run typecheck`: clean
- `e2e npm run test:admin -- tests/admin-config-ui.spec.ts`: 9 passed, 1 skipped (`BIGMODEL_API_KEY` not set)
- Browser smoke: legacy null banners visible in Tools tab; All tools save emitted `allowed_tools: ["*"]` / `excluded_tools: []`; Custom selection saved and persisted after reload
- Pre-commit hooks: rustfmt, file length, code quality, hidden Unicode, secret/license/root-file checks passed
- Pre-push `admin-console-ci`: 76 test files passed, 980 passed / 10 skipped; lint, typecheck, and production build clean
- Pre-push `validate`: clean
- Diff scan vs `main` with lefthook's hidden-Unicode regex (`U+200B-200F, 202A-202E, 2066-2069, FEFF`): zero matches in changed files.

## Test plan

- [x] Migration check: existing user agent spec with `allowed_tools: null` / `excluded_tools: null` saves as `["*"]` / `[]` in user-record PUT payloads.
- [x] Tools tab with no published tools still renders catalog controls and unmanaged entries.
- [x] Pattern/unmanaged catalog entries display matching tools, identify unmatched stale entries, and can be removed without expanding patterns.
- [x] Admin pre-permission preview matches runtime catalog semantics for `["*"]`, allow pattern `mcp:*`, and exclude pattern `mcp:*`.
- [x] Text-equal wildcard entries such as `tool*id` are treated as pattern-backed, disable every matched checkbox, and can only be removed through the raw catalog entry list.
- [x] Escaped literal-star entries such as `foo\*bar` are shown as semantic matches for current tool ids rather than stale/unmanaged entries.
- [x] Catalog argument-rule diagnostics cover registered-tool primary/field args such as `Bash(= "ls")`, `Bash(npm)`, and `Bash(command = "ls")`; allow/exclude catalog fields remain tool-name only.
- [x] Runtime wildcard audit detects unescaped-star entries and keeps the warning cache bounded.
- [x] Legacy catalog normalization does not keep the editor dirty after a no-op builtin/customized save.
- [x] Admin catalog writes: checking `tool*id` via checkbox saves `["tool\*id"]`, not `["tool*id"]`. Seeding Custom mode from legacy/`["*"]` and "Select all" on a group both apply the same escaping.
- [x] Admin auto-collapse safety: adding the final remaining tool to a catalog that still holds a wildcard or backslash entry (e.g. `["tool*id"]` or `["foo\bar"]` + selecting `Other`) yields the explicit subset, never `["*"]`.
- [x] Admin raw-backslash inspection: a raw `foo\bar` entry whose text equals a current tool id is surfaced in the catalog entry list with its actual `matches` (e.g. `foobar`), not silently hidden as a safe exact match. Group "Clear" preserves it; removal goes through the entry list.
- [x] Admin checkbox uncheck symmetry: unchecking `tool*id` from `["*"]` / legacy allow-all / pre-existing `["tool\*id", "Other"]` produces `["Other"]` — the seeded escaped literal is dropped, not silently preserved. Same for tool ids containing `\`.
- [x] Runtime grammar parity for backslash: `isToolAllowed(["foo\\bar"], "foo\\bar")` is `false` while `isToolAllowed(["foo\\\\bar"], "foo\\bar")` is `true` — proving the Admin honours the same `\` escape semantics as `awaken_tool_pattern::tool_id_match`.
- [x] e2e Playwright `admin-config-ui.spec.ts`.
- [x] Browser manual smoke: open Agent editor → Tools tab → verify "All tools" emits `["*"]`, custom mode persists, legacy banner shows on `null` configs.
