### PR TITLE
🧪 test(admin): split non-MCP coverage

### DIFF
--- a/apps/admin-console/package-lock.json
+++ b/apps/admin-console/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4",
+        "@vitest/coverage-v8": "^4.1.2",
         "autoprefixer": "^10.4",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
@@ -362,9 +363,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -464,6 +465,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -2893,6 +2904,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -3342,6 +3384,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4231,9 +4292,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5424,6 +5485,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -6063,6 +6131,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -6446,6 +6553,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-to-jsx": {
@@ -8000,9 +8148,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/apps/admin-console/package.json
+++ b/apps/admin-console/package.json
@@ -42,6 +42,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
+    "@vitest/coverage-v8": "^4.1.2",
     "autoprefixer": "^10.4",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",

--- a/apps/admin-console/src/components/admin-layout.test.tsx
+++ b/apps/admin-console/src/components/admin-layout.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Link, MemoryRouter, Route, Routes } from "react-router";
+import { AdminLayout } from "./admin-layout";
+
+vi.mock("./admin-sidebar", () => ({
+  AdminSidebar: ({ drawerOpen, onCloseDrawer }: { drawerOpen: boolean; onCloseDrawer: () => void }) => (
+    <aside data-open={drawerOpen ? "true" : "false"}>
+      <button type="button" onClick={onCloseDrawer}>sidebar close</button>
+    </aside>
+  ),
+}));
+
+vi.mock("./admin-topbar", () => ({
+  AdminTopbar: ({ onOpenDrawer }: { onOpenDrawer: () => void }) => (
+    <button type="button" onClick={onOpenDrawer}>open drawer</button>
+  ),
+}));
+
+vi.mock("./command-palette", () => ({
+  CommandPaletteProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function renderLayout(initialEntry = "/") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route element={<AdminLayout />}>
+          <Route index element={<Link to="/next">go next</Link>} />
+          <Route path="next" element={<div>next page</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  document.body.style.overflow = "";
+});
+
+describe("AdminLayout", () => {
+  it("opens and closes the mobile drawer while locking body scroll", async () => {
+    const { unmount } = renderLayout();
+
+    expect(screen.getByRole("complementary").getAttribute("data-open")).toBe("false");
+
+    fireEvent.click(screen.getByRole("button", { name: "open drawer" }));
+    expect(screen.getByRole("complementary").getAttribute("data-open")).toBe("true");
+    expect(screen.getByRole("button", { name: "Close menu" })).toBeTruthy();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.click(screen.getByRole("button", { name: "Close menu" }));
+    await waitFor(() => expect(screen.getByRole("complementary").getAttribute("data-open")).toBe("false"));
+    expect(document.body.style.overflow).toBe("");
+
+    fireEvent.click(screen.getByRole("button", { name: "open drawer" }));
+    expect(document.body.style.overflow).toBe("hidden");
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("auto-closes the drawer after route navigation", async () => {
+    renderLayout();
+
+    fireEvent.click(screen.getByRole("button", { name: "open drawer" }));
+    expect(screen.getByRole("complementary").getAttribute("data-open")).toBe("true");
+
+    fireEvent.click(screen.getByRole("link", { name: "go next" }));
+    expect(await screen.findByText("next page")).toBeTruthy();
+    await waitFor(() => expect(screen.getByRole("complementary").getAttribute("data-open")).toBe("false"));
+  });
+});

--- a/apps/admin-console/src/components/command-palette.test.tsx
+++ b/apps/admin-console/src/components/command-palette.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, act } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, act, waitFor } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider, createRoutesFromElements, Route, Outlet } from "react-router";
 import "../lib/i18n";
 import { CommandPaletteProvider, useCommandPalette } from "./command-palette";
@@ -29,6 +29,8 @@ function renderHost(initialPath = "/") {
         <Route index element={<div>home</div>} />
         <Route path="agents" element={<div>agents-page</div>} />
         <Route path="agents/new" element={<div>new-agent</div>} />
+        <Route path="agents/:id" element={<div>agent-editor:agent-a</div>} />
+        <Route path="assistant" element={<div>assistant-page</div>} />
       </Route>,
     ),
     { initialEntries: [initialPath] },
@@ -36,26 +38,41 @@ function renderHost(initialPath = "/") {
   return render(<RouterProvider router={router} />);
 }
 
-beforeEach(() => {
+function stubPaletteFetch({
+  agents = [],
+  tools = [],
+}: {
+  agents?: Array<{ id: string; model_id: string }>;
+  tools?: Array<{ id: string; name: string; description: string }>;
+} = {}) {
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      text: async () =>
-        JSON.stringify({
-          items: [],
-          total: 0,
-          agents: [],
-          tools: [],
-          plugins: [],
-          skills: [],
-          models: [],
-          providers: [],
-          namespaces: [],
-        }),
-    })),
+    vi.fn(async (input: string | URL | Request) => {
+      const href = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const body = href.includes("/v1/config/agents")
+        ? { namespace: "agents", items: agents, offset: 0, limit: 100 }
+        : {
+            items: [],
+            total: 0,
+            agents: [],
+            tools,
+            plugins: [],
+            skills: [],
+            models: [],
+            providers: [],
+            namespaces: [],
+          };
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(body),
+      };
+    }),
   );
+}
+
+beforeEach(() => {
+  stubPaletteFetch();
 });
 
 afterEach(() => {
@@ -89,5 +106,56 @@ describe("CommandPalette", () => {
     const input = await screen.findByPlaceholderText(/Search agents/i);
     fireEvent.change(input, { target: { value: "audit" } });
     expect(await screen.findByText("Audit Log")).toBeDefined();
+  });
+
+  it("renders fetched agents and opens the selected agent with keyboard", async () => {
+    stubPaletteFetch({
+      agents: [{ id: "agent-a", model_id: "model-a" }],
+      tools: [{ id: "tool-a", name: "Tool A", description: "Tool from registry" }],
+    });
+    renderHost();
+
+    fireEvent.click(screen.getByText("open"));
+    const input = await screen.findByPlaceholderText(/Search agents/i);
+    fireEvent.change(input, { target: { value: "agent-a" } });
+    await screen.findByText("agent-a");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowUp" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await screen.findByText("agent-editor:agent-a");
+    expect(screen.queryByRole("dialog", { name: "Command palette" })).toBeNull();
+  });
+
+  it("opens tools through the assistant route and supports empty results", async () => {
+    stubPaletteFetch({
+      tools: [{ id: "tool.files.read", name: "Read file", description: "Read from filesystem" }],
+    });
+    renderHost();
+
+    fireEvent.click(screen.getByText("open"));
+    const input = await screen.findByPlaceholderText(/Search agents/i);
+    fireEvent.change(input, { target: { value: "tool.files.read" } });
+    await screen.findByText("Read from filesystem");
+    fireEvent.click(screen.getByRole("button", { name: /tool\.files\.read/i }));
+
+    await screen.findByText("assistant-page");
+    expect(screen.queryByRole("dialog", { name: "Command palette" })).toBeNull();
+
+    fireEvent.click(screen.getByText("open"));
+    const reopenedInput = await screen.findByPlaceholderText(/Search agents/i);
+    fireEvent.change(reopenedInput, { target: { value: "no-such-command" } });
+    expect(await screen.findByText("No matches.")).toBeDefined();
+  });
+
+  it("closes when the backdrop is clicked", async () => {
+    renderHost();
+    fireEvent.click(screen.getByText("open"));
+    await screen.findByRole("dialog", { name: "Command palette" });
+
+    fireEvent.click(screen.getByRole("dialog", { name: "Command palette" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Command palette" })).toBeNull(),
+    );
   });
 });

--- a/apps/admin-console/src/components/editors/permission-editor.test.tsx
+++ b/apps/admin-console/src/components/editors/permission-editor.test.tsx
@@ -96,4 +96,59 @@ describe("PermissionConfigEditor", () => {
       }),
     );
   });
+
+  it("renders any-tool rules with less common scopes and can promote the selected rule", () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionConfigEditor
+        value={{
+          default_behavior: "allow",
+          rules: [
+            { tool: "", behavior: "allow", scope: "once" },
+            { tool: "Read(src/**)", behavior: "deny", scope: "user" },
+          ],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByText("(any tool)")).toBeTruthy();
+    expect(screen.getByText("Scope · Once")).toBeTruthy();
+    expect(screen.getByText("Scope · User")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Read(src/**)").closest("button")!);
+    fireEvent.click(screen.getByRole("button", { name: "Move up" }));
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({ tool: "Read(src/**)", scope: "user" }),
+          expect.objectContaining({ tool: "", scope: "once" }),
+        ],
+      }),
+    );
+  });
+
+  it("removing the only rule emits an empty ruleset", () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionConfigEditor
+        value={{
+          default_behavior: "ask",
+          rules: [{ tool: "Bash(*)", behavior: "ask", scope: "project" }],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Move up" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Move down" }).hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      default_behavior: "ask",
+      rules: [],
+    });
+  });
 });

--- a/apps/admin-console/src/components/editors/permission-editor.test.tsx
+++ b/apps/admin-console/src/components/editors/permission-editor.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { PermissionConfigEditor } from "./permission-editor";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function clickChoice(label: string, occurrence = 0) {
+  const matches = screen.getAllByText(label);
+  const target = matches.at(occurrence)?.closest("button");
+  expect(target, `choice ${label}`).toBeTruthy();
+  fireEvent.click(target!);
+}
+
+describe("PermissionConfigEditor", () => {
+  it("serializes default decisions and newly added rules", () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionConfigEditor
+        value={{ default_behavior: "ask", rules: [] }}
+        onChange={onChange}
+      />,
+    );
+
+    clickChoice("Allow");
+    expect(onChange).toHaveBeenLastCalledWith({
+      default_behavior: "allow",
+      rules: [],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      default_behavior: "ask",
+      rules: [{ tool: "", behavior: "ask", scope: "project" }],
+    });
+  });
+
+  it("updates, reorders, and removes explicit permission rules", () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionConfigEditor
+        value={{
+          default_behavior: "deny",
+          rules: [
+            { tool: "Bash(npm *)", behavior: "ask", scope: "project" },
+            { tool: "Read(docs/**)", behavior: "allow", scope: "session" },
+          ],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Tool pattern"), {
+      target: { value: "Bash(cargo test *)" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({ tool: "Bash(cargo test *)" }),
+          expect.objectContaining({ tool: "Read(docs/**)" }),
+        ],
+      }),
+    );
+
+    clickChoice("Deny", -1);
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [expect.objectContaining({ behavior: "deny" }), expect.any(Object)],
+      }),
+    );
+
+    clickChoice("Thread");
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [expect.objectContaining({ scope: "thread" }), expect.any(Object)],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Move down" }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({ tool: "Read(docs/**)" }),
+          expect.objectContaining({ tool: "Bash(npm *)" }),
+        ],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [expect.objectContaining({ tool: "Bash(npm *)" })],
+      }),
+    );
+  });
+});

--- a/apps/admin-console/src/components/editors/reminder-editor.test.tsx
+++ b/apps/admin-console/src/components/editors/reminder-editor.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ReminderConfigEditor } from "./reminder-editor";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function clickChoice(label: string, occurrence = 0) {
+  const matches = screen.getAllByText(label);
+  const target = matches.at(occurrence)?.closest("button");
+  expect(target, `choice ${label}`).toBeTruthy();
+  fireEvent.click(target!);
+}
+
+describe("ReminderConfigEditor", () => {
+  it("serializes a newly added reminder rule", () => {
+    const onChange = vi.fn();
+    render(<ReminderConfigEditor value={{ rules: [] }} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add reminder" }));
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      rules: [
+        {
+          name: undefined,
+          tool: "",
+          output: "any",
+          message: { target: "system", content: "", cooldown_turns: 0 },
+        },
+      ],
+    });
+  });
+
+  it("updates field matchers and reminder payload with serialized output", () => {
+    const onChange = vi.fn();
+    render(
+      <ReminderConfigEditor
+        value={{
+          rules: [
+            {
+              name: "weather fields",
+              tool: "get_weather",
+              output: {
+                content: {
+                  fields: [{ path: "", op: "glob", value: "" }],
+                },
+              },
+              message: {
+                target: "system",
+                content: "Bring an umbrella.",
+                cooldown_turns: 0,
+              },
+            },
+          ],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Path"), {
+      target: { value: "error.code" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: {
+              content: {
+                fields: [expect.objectContaining({ path: "error.code" })],
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Operation"), {
+      target: { value: "exact" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: {
+              content: {
+                fields: [expect.objectContaining({ op: "exact" })],
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "403" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: {
+              content: {
+                fields: [expect.objectContaining({ value: "403" })],
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    clickChoice("Conversation");
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            message: expect.objectContaining({ target: "conversation" }),
+          }),
+        ],
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Reminder content"), {
+      target: { value: "Escalate permission errors." },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            message: expect.objectContaining({ content: "Escalate permission errors." }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("updates status/text rules and preserves rule ordering operations", () => {
+    const onChange = vi.fn();
+    render(
+      <ReminderConfigEditor
+        value={{
+          rules: [
+            {
+              name: "permission denied",
+              tool: "Bash(*)",
+              output: { status: "success", content: "*denied*" },
+              message: { target: "system", content: "Check access.", cooldown_turns: 1 },
+            },
+            {
+              name: "fallback",
+              tool: "",
+              output: "any",
+              message: { target: "session", content: "Fallback reminder.", cooldown_turns: 0 },
+            },
+          ],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Rule name"), {
+      target: { value: "permission failure" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [expect.objectContaining({ name: "permission failure" }), expect.any(Object)],
+      }),
+    );
+
+    clickChoice("Error");
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: { status: "error", content: "*denied*" },
+          }),
+          expect.any(Object),
+        ],
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Content text matcher"), {
+      target: { value: "*permission denied*" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: { status: "success", content: "*permission denied*" },
+          }),
+          expect.any(Object),
+        ],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Move down" }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({ name: "fallback" }),
+          expect.objectContaining({ name: "permission denied" }),
+        ],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [expect.objectContaining({ name: "permission denied" })],
+      }),
+    );
+  });
+});

--- a/apps/admin-console/src/components/editors/reminder-editor.test.tsx
+++ b/apps/admin-console/src/components/editors/reminder-editor.test.tsx
@@ -134,6 +134,30 @@ describe("ReminderConfigEditor", () => {
         ],
       }),
     );
+
+    fireEvent.change(screen.getByLabelText("Cooldown turns"), {
+      target: { value: "3" },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            message: expect.objectContaining({ cooldown_turns: 3 }),
+          }),
+        ],
+      }),
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" }).at(-1)!);
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: { content: { fields: [] } },
+          }),
+        ],
+      }),
+    );
   });
 
   it("updates status/text rules and preserves rule ordering operations", () => {
@@ -209,6 +233,69 @@ describe("ReminderConfigEditor", () => {
     expect(onChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
         rules: [expect.objectContaining({ name: "permission denied" })],
+      }),
+    );
+  });
+
+  it("renders reminder mode labels and summarizes more than two targets", () => {
+    const onChange = vi.fn();
+    render(
+      <ReminderConfigEditor
+        value={{
+          rules: [
+            {
+              name: "status",
+              tool: "job_status",
+              output: { status: "pending" },
+              message: { target: "system", content: "Wait.", cooldown_turns: 0 },
+            },
+            {
+              name: "text",
+              tool: "Bash(*)",
+              output: { content: "*denied*" },
+              message: { target: "suffix_system", content: "Check permissions.", cooldown_turns: 1 },
+            },
+            {
+              name: "fields",
+              tool: "get_weather",
+              output: { content: { fields: [] } },
+              message: { target: "session", content: "Remember weather.", cooldown_turns: 2 },
+            },
+            {
+              name: "status fields",
+              tool: "api_call",
+              output: { status: "error", content: { fields: [] } },
+              message: { target: "conversation", content: "Inspect response.", cooldown_turns: 3 },
+            },
+          ],
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByText("System, Suffix system +2")).toBeTruthy();
+    expect(screen.getByText("Status")).toBeTruthy();
+    expect(screen.getByText("Text")).toBeTruthy();
+    expect(screen.getByText("Fields")).toBeTruthy();
+    expect(screen.getAllByText("Status + fields").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByText("fields").closest("button")!);
+    expect(screen.getByText("No field conditions configured yet.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Add field condition" }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        rules: [
+          expect.any(Object),
+          expect.any(Object),
+          expect.objectContaining({
+            output: {
+              content: {
+                fields: [expect.objectContaining({ path: "", op: "glob", value: "" })],
+              },
+            },
+          }),
+          expect.any(Object),
+        ],
       }),
     );
   });

--- a/apps/admin-console/src/components/plugin-config-workspace.test.tsx
+++ b/apps/admin-console/src/components/plugin-config-workspace.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  PluginConfigWorkspace,
+  type PluginConfigEntry,
+} from "./plugin-config-workspace";
+import { pluginConfigEntryKey } from "@/lib/plugin-config";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function entry(
+  pluginId: string,
+  schemaKey: string,
+  selected = true,
+  hasStoredConfig = false,
+): PluginConfigEntry {
+  return {
+    plugin: {
+      id: pluginId,
+      config_schemas: [
+        {
+          key: schemaKey,
+          schema: {
+            type: "object",
+            title: `${pluginId} schema`,
+            description: `${schemaKey} configuration`,
+            properties: {
+              enabled: { type: "boolean", title: "Enabled" },
+            },
+          },
+        },
+      ],
+    },
+    schema: {
+      key: schemaKey,
+      schema: {
+        type: "object",
+        title: `${pluginId} schema`,
+        description: `${schemaKey} configuration`,
+        properties: {
+          enabled: { type: "boolean", title: "Enabled" },
+        },
+      },
+    },
+    selected,
+    hasStoredConfig,
+  };
+}
+
+function renderWorkspace(
+  overrides: Partial<Parameters<typeof PluginConfigWorkspace>[0]> = {},
+) {
+  const onSelectEntry = vi.fn();
+  const onUpdateSection = vi.fn();
+  const props = {
+    entries: [] as PluginConfigEntry[],
+    sections: {},
+    activeEntryKey: null,
+    onSelectEntry,
+    onUpdateSection,
+    ...overrides,
+  };
+  return {
+    ...render(<PluginConfigWorkspace {...props} />),
+    onSelectEntry,
+    onUpdateSection,
+  };
+}
+
+describe("PluginConfigWorkspace", () => {
+  it("shows an empty state when no configurable plugin is selected", () => {
+    renderWorkspace();
+
+    expect(
+      screen.getByText(/Select a configurable plugin to edit/),
+    ).toBeTruthy();
+  });
+
+  it("selects entries and warns when stored config belongs to a disabled plugin", () => {
+    const reminder = entry("reminder", "reminder", false, true);
+    const activeEntryKey = pluginConfigEntryKey("reminder", "reminder");
+    const { onSelectEntry } = renderWorkspace({
+      entries: [reminder],
+      activeEntryKey,
+      sections: { reminder: { rules: [] } },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Reminders/ }));
+
+    expect(onSelectEntry).toHaveBeenCalledWith(activeEntryKey);
+    expect(screen.getByText("stored only")).toBeTruthy();
+    expect(screen.getByText("plugin disabled")).toBeTruthy();
+    expect(screen.getByText(/only takes effect after re-enabling/)).toBeTruthy();
+  });
+
+  it("edits permission config before serializing the section update", () => {
+    const activeEntryKey = pluginConfigEntryKey("permission", "permission");
+    const { onUpdateSection } = renderWorkspace({
+      entries: [entry("permission", "permission")],
+      activeEntryKey,
+      sections: {
+        permission: {
+          default_behavior: "ask",
+          rules: [{ tool: "", behavior: "ask", scope: "project" }],
+        },
+      },
+    });
+
+    fireEvent.change(screen.getByLabelText("Tool pattern"), {
+      target: { value: "Bash(npm *)" },
+    });
+    expect(onUpdateSection).toHaveBeenLastCalledWith(
+      "permission",
+      expect.objectContaining({
+        rules: [expect.objectContaining({ tool: "Bash(npm *)" })],
+      }),
+    );
+
+    fireEvent.click(screen.getAllByText("Deny").at(-1)!.closest("button")!);
+    expect(onUpdateSection).toHaveBeenLastCalledWith(
+      "permission",
+      expect.objectContaining({
+        rules: [expect.objectContaining({ behavior: "deny" })],
+      }),
+    );
+  });
+
+  it("edits reminder field rules before serializing the section update", () => {
+    const activeEntryKey = pluginConfigEntryKey("reminder", "reminder");
+    const { onUpdateSection } = renderWorkspace({
+      entries: [entry("reminder", "reminder")],
+      activeEntryKey,
+      sections: {
+        reminder: {
+          rules: [
+            {
+              name: "weather fields",
+              tool: "get_weather",
+              output: {
+                content: {
+                  fields: [{ path: "", op: "exact", value: "" }],
+                },
+              },
+              message: {
+                target: "system",
+                content: "Bring an umbrella.",
+                cooldown_turns: 0,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    fireEvent.change(screen.getByLabelText("Path"), {
+      target: { value: "error.code" },
+    });
+    expect(onUpdateSection).toHaveBeenLastCalledWith(
+      "reminder",
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: expect.objectContaining({
+              content: expect.objectContaining({
+                fields: [expect.objectContaining({ path: "error.code" })],
+              }),
+            }),
+          }),
+        ],
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Value"), {
+      target: { value: "403" },
+    });
+    expect(onUpdateSection).toHaveBeenLastCalledWith(
+      "reminder",
+      expect.objectContaining({
+        rules: [
+          expect.objectContaining({
+            output: expect.objectContaining({
+              content: expect.objectContaining({
+                fields: [
+                  expect.objectContaining({
+                    value: "403",
+                  }),
+                ],
+              }),
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("edits generative UI config with the specialized editor", () => {
+    const activeEntryKey = pluginConfigEntryKey(
+      "generative-ui",
+      "generative-ui",
+    );
+    const { onUpdateSection } = renderWorkspace({
+      entries: [entry("generative-ui", "generative-ui")],
+      activeEntryKey,
+      sections: { "generative-ui": {} },
+    });
+
+    fireEvent.change(screen.getByLabelText("Catalog ID"), {
+      target: { value: "catalog://default" },
+    });
+
+    expect(onUpdateSection).toHaveBeenLastCalledWith("generative-ui", {
+      catalog_id: "catalog://default",
+    });
+  });
+});

--- a/apps/admin-console/src/components/unsaved-changes-guard.test.tsx
+++ b/apps/admin-console/src/components/unsaved-changes-guard.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { useUnsavedChangesGuard } from "./unsaved-changes-guard";
+
+const guardState = vi.hoisted(() => ({
+  blocker: {
+    state: "unblocked" as "unblocked" | "blocked",
+    proceed: vi.fn(),
+    reset: vi.fn(),
+  },
+  predicate: null as null | ((input: { currentLocation: { pathname: string }; nextLocation: { pathname: string } }) => boolean),
+  confirmDialog: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  useBlocker: (predicate: typeof guardState.predicate) => {
+    guardState.predicate = predicate;
+    return guardState.blocker;
+  },
+}));
+
+vi.mock("./confirm-dialog", () => ({
+  useConfirmDialog: () => guardState.confirmDialog,
+}));
+
+function GuardHarness({ enabled = true }: { enabled?: boolean }) {
+  useUnsavedChangesGuard({
+    enabled,
+    title: "Leave page?",
+    description: "Discard local edits?",
+    confirmLabel: "Discard",
+    cancelLabel: "Stay",
+  });
+  return <div>guard mounted</div>;
+}
+
+beforeEach(() => {
+  guardState.blocker = {
+    state: "unblocked",
+    proceed: vi.fn(),
+    reset: vi.fn(),
+  };
+  guardState.predicate = null;
+  guardState.confirmDialog = vi.fn(async () => true);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useUnsavedChangesGuard", () => {
+  it("blocks only cross-path navigation while enabled", () => {
+    render(<GuardHarness enabled />);
+
+    expect(guardState.predicate?.({
+      currentLocation: { pathname: "/models" },
+      nextLocation: { pathname: "/models" },
+    })).toBe(false);
+    expect(guardState.predicate?.({
+      currentLocation: { pathname: "/models" },
+      nextLocation: { pathname: "/providers" },
+    })).toBe(true);
+
+    cleanup();
+    render(<GuardHarness enabled={false} />);
+    expect(guardState.predicate?.({
+      currentLocation: { pathname: "/models" },
+      nextLocation: { pathname: "/providers" },
+    })).toBe(false);
+  });
+
+  it("proceeds or resets blocked navigation based on the confirm result", async () => {
+    guardState.blocker.state = "blocked";
+    guardState.confirmDialog = vi.fn(async () => true);
+    render(<GuardHarness enabled />);
+
+    await waitFor(() => expect(guardState.blocker.proceed).toHaveBeenCalledTimes(1));
+    expect(guardState.confirmDialog).toHaveBeenCalledWith({
+      title: "Leave page?",
+      description: "Discard local edits?",
+      confirmLabel: "Discard",
+      cancelLabel: "Stay",
+      tone: "destructive",
+    });
+
+    cleanup();
+    guardState.blocker = { state: "blocked", proceed: vi.fn(), reset: vi.fn() };
+    guardState.confirmDialog = vi.fn(async () => false);
+    render(<GuardHarness enabled />);
+
+    await waitFor(() => expect(guardState.blocker.reset).toHaveBeenCalledTimes(1));
+    expect(guardState.blocker.proceed).not.toHaveBeenCalled();
+  });
+
+  it("registers browser beforeunload only while enabled", () => {
+    const { rerender } = render(<GuardHarness enabled={false} />);
+    const disabledEvent = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(disabledEvent);
+    expect(disabledEvent.defaultPrevented).toBe(false);
+
+    rerender(<GuardHarness enabled />);
+    const enabledEvent = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(enabledEvent);
+    expect(enabledEvent.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/admin-console/src/lib/api/agents.test.ts
+++ b/apps/admin-console/src/lib/api/agents.test.ts
@@ -119,10 +119,9 @@ describe("agentsApi.agentPermissionPreview", () => {
   it("re-throws ConfigApiError on 404", async () => {
     mockFetch(404, { error: "agent not found: ghost-agent" });
 
-    await expect(agentsApi.agentPermissionPreview("ghost-agent")).rejects.toBeInstanceOf(
-      ConfigApiError,
-    );
-    await expect(agentsApi.agentPermissionPreview("ghost-agent")).rejects.toMatchObject({
+    const request = agentsApi.agentPermissionPreview("ghost-agent");
+    await expect(request).rejects.toBeInstanceOf(ConfigApiError);
+    await expect(request).rejects.toMatchObject({
       status: 404,
     });
   });

--- a/apps/admin-console/src/lib/api/agents.test.ts
+++ b/apps/admin-console/src/lib/api/agents.test.ts
@@ -1,38 +1,122 @@
-// @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-
 import { agentsApi } from "./agents";
-import { ConfigApiError } from "./http";
+import { BACKEND_URL, ConfigApiError } from "./http";
+import type { AgentRuntimeSnapshot } from "./types";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function runtimeSnapshot(overrides: Partial<AgentRuntimeSnapshot> = {}): AgentRuntimeSnapshot {
+  return {
+    agent_id: "agent/a",
+    window_seconds: 3600,
+    bucket_window_seconds: 60,
+    bucket_count: 60,
+    inference_count: 2,
+    error_count: 0,
+    input_tokens: 10,
+    output_tokens: 20,
+    avg_inference_duration_ms: 100,
+    min_inference_duration_ms: 80,
+    max_inference_duration_ms: 120,
+    p50_inference_duration_ms: 100,
+    p95_inference_duration_ms: 115,
+    p99_inference_duration_ms: 120,
+    suspensions: 0,
+    handoffs: 0,
+    delegations: 0,
+    tool_calls_by_tool: [],
+    ...overrides,
+  };
+}
+
+function mockFetch(status: number, body: unknown) {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(body, status)));
+}
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
-function mockFetch(status: number, body: unknown) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async () => ({
-      ok: status >= 200 && status < 300,
-      status,
-      text: async () =>
-        typeof body === "string" ? body : JSON.stringify(body),
-    })) as unknown as typeof fetch,
-  );
-}
+describe("agentsApi", () => {
+  it("returns all runtime stats when the registry is available", async () => {
+    const payload = { agents: [runtimeSnapshot({ agent_id: "alpha" })] };
+    const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(payload));
+    vi.stubGlobal("fetch", fetchSpy);
 
-describe("agentsApi.agentPermissionPreview — feature-gate vs missing-agent (R10 #1)", () => {
-  it("returns null when the route reports 503 (feature not compiled)", async () => {
+    await expect(agentsApi.agentsRuntimeStats()).resolves.toEqual(payload);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND_URL}/v1/agents/runtime-stats`,
+      undefined,
+    );
+  });
+
+  it("returns null when runtime stats are disabled", async () => {
+    mockFetch(503, { error: "runtime stats disabled" });
+
+    await expect(agentsApi.agentsRuntimeStats()).resolves.toBeNull();
+  });
+
+  it("rethrows non-503 runtime stats errors", async () => {
+    mockFetch(403, { error: "forbidden" });
+
+    await expect(agentsApi.agentsRuntimeStats()).rejects.toMatchObject({
+      name: "ConfigApiError",
+      status: 403,
+      message: "forbidden",
+    });
+  });
+
+  it("patches agent overrides with encoded ids and JSON", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(jsonResponse({ id: "agent/a" }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await agentsApi.patchAgentOverrides("agent/a", { model_id: "fast", max_rounds: null });
+
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      `${BACKEND_URL}/v1/config/agents/agent%2Fa/overrides`,
+    );
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PATCH");
+    expect(new Headers(init.headers).get("content-type")).toBe("application/json");
+    expect(init.body).toBe(JSON.stringify({ model_id: "fast", max_rounds: null }));
+  });
+
+  it("clears all overrides or a single override field", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ id: "agent/a" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "agent/a" }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await agentsApi.clearAgentOverrides("agent/a");
+    await agentsApi.clearAgentOverrideField("agent/a", "system/prompt");
+
+    expect(fetchSpy.mock.calls[0]).toEqual([
+      `${BACKEND_URL}/v1/config/agents/agent%2Fa/overrides`,
+      { method: "DELETE" },
+    ]);
+    expect(fetchSpy.mock.calls[1]).toEqual([
+      `${BACKEND_URL}/v1/config/agents/agent%2Fa/overrides/system%2Fprompt`,
+      { method: "DELETE" },
+    ]);
+  });
+});
+
+describe("agentsApi.agentPermissionPreview", () => {
+  it("returns null when the route reports 503", async () => {
     mockFetch(503, { error: "permission feature not compiled into this server build" });
 
     const result = await agentsApi.agentPermissionPreview("any-agent");
     expect(result).toBeNull();
   });
 
-  it("re-throws ConfigApiError on 404 (agent record not found)", async () => {
-    // The route is registered unconditionally on the server, so a 404
-    // means the agent itself is missing — NOT that the feature is
-    // disabled. Surface as a real error so the editor doesn't
-    // silently render "feature unavailable" for a stale agent id.
+  it("re-throws ConfigApiError on 404", async () => {
     mockFetch(404, { error: "agent not found: ghost-agent" });
 
     await expect(agentsApi.agentPermissionPreview("ghost-agent")).rejects.toBeInstanceOf(

--- a/apps/admin-console/src/lib/api/config-resource.test.ts
+++ b/apps/admin-console/src/lib/api/config-resource.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configResourceApi } from "./config-resource";
+import { BACKEND_URL } from "./http";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("configResourceApi", () => {
+  it("lists and fetches config records with encoded ids", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ namespace: "agents", items: [] }))
+      .mockResolvedValueOnce(jsonResponse({ id: "team/a" }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configResourceApi.list("agents", 25, 50);
+    await configResourceApi.get("agents", "team/a");
+
+    expect(fetchSpy.mock.calls[0]).toEqual([
+      `${BACKEND_URL}/v1/config/agents?offset=25&limit=50`,
+      undefined,
+    ]);
+    expect(fetchSpy.mock.calls[1]).toEqual([
+      `${BACKEND_URL}/v1/config/agents/team%2Fa`,
+      undefined,
+    ]);
+  });
+
+  it("creates and updates config records with JSON payloads", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ id: "agent/a" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "agent/a", model_id: "fast" }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configResourceApi.create("agents", { id: "agent/a" });
+    await configResourceApi.update("agents", "agent/a", { model_id: "fast" });
+
+    expect(fetchSpy.mock.calls[0][0]).toBe(`${BACKEND_URL}/v1/config/agents`);
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ id: "agent/a" }),
+    });
+    expect(new Headers((fetchSpy.mock.calls[0][1] as RequestInit).headers).get("content-type")).toBe(
+      "application/json",
+    );
+    expect(fetchSpy.mock.calls[1][0]).toBe(`${BACKEND_URL}/v1/config/agents/agent%2Fa`);
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({
+      method: "PUT",
+      body: JSON.stringify({ model_id: "fast" }),
+    });
+  });
+
+  it("deletes records with optional force", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configResourceApi.delete("agents", "agent/a");
+    await configResourceApi.delete("agents", "agent/a", { force: true });
+
+    expect(fetchSpy.mock.calls[0]).toEqual([
+      `${BACKEND_URL}/v1/config/agents/agent%2Fa`,
+      { method: "DELETE" },
+    ]);
+    expect(fetchSpy.mock.calls[1]).toEqual([
+      `${BACKEND_URL}/v1/config/agents/agent%2Fa?force=true`,
+      { method: "DELETE" },
+    ]);
+  });
+
+  it("validates and restores records with encoded query/path parameters", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ ok: true, normalized: { id: "agent/a" } }))
+      .mockResolvedValueOnce(jsonResponse({ id: "agent/a", restored: true }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await configResourceApi.validateConfig("agents/special", { id: "agent/a" }, { id: "agent/a" });
+    await configResourceApi.restoreConfig("agents/special", "agent/a", "event/1");
+
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      `${BACKEND_URL}/v1/config/agents%2Fspecial/validate?id=agent%2Fa`,
+    );
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ id: "agent/a" }),
+    });
+    expect(fetchSpy.mock.calls[1][0]).toBe(
+      `${BACKEND_URL}/v1/config/agents%2Fspecial/agent%2Fa/restore`,
+    );
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ version: "event/1" }),
+    });
+  });
+
+  it("loads record metadata endpoints", async () => {
+    const meta = {
+      source: { kind: "user" },
+      hidden: false,
+      created_at: 1,
+      updated_at: 2,
+    };
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(meta))
+      .mockResolvedValueOnce(jsonResponse([{ id: "agent/a", meta }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(configResourceApi.getMeta("agents", "agent/a")).resolves.toEqual(meta);
+    await expect(configResourceApi.listMeta("agents")).resolves.toEqual([{ id: "agent/a", meta }]);
+    expect(fetchSpy.mock.calls[0][0]).toBe(`${BACKEND_URL}/v1/config/agents/agent%2Fa/meta`);
+    expect(fetchSpy.mock.calls[1][0]).toBe(`${BACKEND_URL}/v1/config/agents/meta`);
+  });
+});

--- a/apps/admin-console/src/lib/api/providers.test.ts
+++ b/apps/admin-console/src/lib/api/providers.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BACKEND_URL } from "./http";
+import { providersApi } from "./providers";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("providersApi", () => {
+  it("posts to the provider test endpoint with encoded ids", async () => {
+    const payload = { ok: true, latency_ms: 42, network_tested: true };
+    const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(payload));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(providersApi.testProvider("vertex/us")).resolves.toEqual(payload);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${BACKEND_URL}/v1/providers/vertex%2Fus/test`,
+      { method: "POST" },
+    );
+  });
+});

--- a/apps/admin-console/src/lib/api/tools.test.ts
+++ b/apps/admin-console/src/lib/api/tools.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BACKEND_URL } from "./http";
+import { toolsApi } from "./tools";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("toolsApi", () => {
+  it("lists and fetches tools with encoded ids", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ namespace: "tools", items: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ id: "tool/a", name: "Tool A", description: "Search" }),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(toolsApi.listTools()).resolves.toEqual({ namespace: "tools", items: [] });
+    await expect(toolsApi.getTool("tool/a")).resolves.toMatchObject({ id: "tool/a" });
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(1, `${BACKEND_URL}/v1/config/tools`, undefined);
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      `${BACKEND_URL}/v1/config/tools/tool%2Fa`,
+      undefined,
+    );
+  });
+
+  it("patches tool overrides with JSON and encoded ids", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse({ id: "builtin/search", name: "search", description: "Updated" }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await toolsApi.patchToolOverrides("builtin/search", { description: "Updated" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      `${BACKEND_URL}/v1/config/tools/builtin%2Fsearch/overrides`,
+    );
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe("PATCH");
+    expect(new Headers(init.headers).get("content-type")).toBe("application/json");
+    expect(init.body).toBe(JSON.stringify({ description: "Updated" }));
+  });
+
+  it("clears all overrides or a single override field", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ id: "tool/a" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "tool/a" }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await toolsApi.clearToolOverrides("tool/a");
+    await toolsApi.clearToolOverrideField("tool/a", "display/name");
+
+    expect(fetchSpy.mock.calls[0]).toEqual([
+      `${BACKEND_URL}/v1/config/tools/tool%2Fa/overrides`,
+      { method: "DELETE" },
+    ]);
+    expect(fetchSpy.mock.calls[1]).toEqual([
+      `${BACKEND_URL}/v1/config/tools/tool%2Fa/overrides/display%2Fname`,
+      { method: "DELETE" },
+    ]);
+  });
+});

--- a/apps/admin-console/src/lib/list-url-state.test.ts
+++ b/apps/admin-console/src/lib/list-url-state.test.ts
@@ -317,6 +317,21 @@ describe("writeFixtureFilter", () => {
 // ---------------------------------------------------------------------------
 
 describe("readAuditFilter", () => {
+  it("deserialises all audit filter fields", () => {
+    const state = readAuditFilter(
+      p(
+        "since=2026-05-14T00%3A00%3A00Z&until=2026-05-15T00%3A00%3A00Z&action=update&resource=agents%2Frouter&actor=admin",
+      ),
+    );
+    expect(state).toEqual({
+      since: "2026-05-14T00:00:00Z",
+      until: "2026-05-15T00:00:00Z",
+      action: "update",
+      resource: "agents/router",
+      actor: "admin",
+    });
+  });
+
   it("deserialises ?action=restore correctly", () => {
     const state = readAuditFilter(p("action=restore"));
     expect(state.action).toBe("restore");
@@ -338,5 +353,32 @@ describe("readAuditFilter", () => {
     expect(written.get("action")).toBe("restore");
     const recovered = readAuditFilter(written);
     expect(recovered.action).toBe("restore");
+  });
+
+  it("writes and clears every non-default audit filter without losing unrelated params", () => {
+    const written = writeAuditFilter(p("tab=history"), {
+      since: "2026-05-14T00:00:00Z",
+      until: "2026-05-15T00:00:00Z",
+      action: "delete",
+      resource: "providers/main",
+      actor: "ops",
+    });
+    expect(written.get("tab")).toBe("history");
+    expect(readAuditFilter(written)).toEqual({
+      since: "2026-05-14T00:00:00Z",
+      until: "2026-05-15T00:00:00Z",
+      action: "delete",
+      resource: "providers/main",
+      actor: "ops",
+    });
+
+    const cleared = writeAuditFilter(written, {
+      since: "",
+      until: "",
+      action: "",
+      resource: "",
+      actor: "",
+    });
+    expect(cleared.toString()).toBe("tab=history");
   });
 });

--- a/apps/admin-console/src/lib/plugin-config.test.ts
+++ b/apps/admin-console/src/lib/plugin-config.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, it } from "vitest";
 import {
+  createReminderField,
   createReminderRule,
+  moveItem,
+  normalizeGenerativeUiConfig,
   normalizeReminderConfig,
   normalizePermissionConfig,
+  pluginConfigEntryKey,
   pluginConfigDisplaySummary,
+  pluginDisplayName,
+  schemaDescription,
+  schemaTitle,
+  serializeGenerativeUiConfig,
+  serializePermissionConfig,
   serializeReminderConfig,
 } from "./plugin-config";
 
@@ -78,5 +87,160 @@ describe("plugin config helpers", () => {
         },
       ],
     });
+  });
+
+  it("names known plugins and builds stable config entry keys", () => {
+    expect(pluginConfigEntryKey("permission", "rules")).toBe("permission:rules");
+    expect(pluginDisplayName("permission")).toBe("Permissions");
+    expect(pluginDisplayName("reminder")).toBe("Reminders");
+    expect(pluginDisplayName("generative-ui")).toBe("Generative UI");
+    expect(pluginDisplayName("ext-deferred-tools")).toBe("Deferred Tools");
+    expect(pluginDisplayName("frontend_tools")).toBe("Frontend Tools");
+    expect(pluginDisplayName("custom-plugin")).toBe("custom-plugin");
+  });
+
+  it("summarizes generic and generative-ui config states", () => {
+    expect(pluginConfigDisplaySummary("reminder", "reminder", { rules: [] })).toBe(
+      "No reminder rules",
+    );
+    expect(pluginConfigDisplaySummary("generative-ui", "generative-ui", {})).toBe(
+      "Prompt defaults",
+    );
+    expect(
+      pluginConfigDisplaySummary("generative-ui", "generative-ui", {
+        instructions: "Use cards",
+        catalog_id: "catalog-a",
+        examples: "Example",
+      }),
+    ).toBe("instruction override · catalog override · examples");
+    expect(pluginConfigDisplaySummary("custom", "settings", { enabled: true })).toBe(
+      "Configured",
+    );
+    expect(pluginConfigDisplaySummary("custom", "settings", { empty: "" })).toBe(
+      "Schema form",
+    );
+  });
+
+  it("normalizes and serializes generative-ui config with trimmed optional fields", () => {
+    expect(
+      normalizeGenerativeUiConfig({
+        catalog_id: " catalog-a ",
+        examples: "Example",
+        instructions: "Use cards",
+      }),
+    ).toEqual({
+      catalog_id: " catalog-a ",
+      examples: "Example",
+      instructions: "Use cards",
+    });
+    expect(
+      serializeGenerativeUiConfig({
+        catalog_id: " catalog-a ",
+        examples: "",
+        instructions: "Use cards",
+      }),
+    ).toEqual({
+      catalog_id: "catalog-a",
+      instructions: "Use cards",
+    });
+  });
+
+  it("falls back safely for invalid permission and reminder enum values", () => {
+    expect(
+      normalizePermissionConfig({
+        default_behavior: "invalid",
+        rules: [{ tool: 12, behavior: "invalid", scope: "invalid" }],
+      }),
+    ).toEqual({
+      default_behavior: "ask",
+      rules: [{ tool: "", behavior: "ask", scope: "project" }],
+    });
+
+    expect(
+      normalizeReminderConfig({
+        rules: [
+          {
+            name: 12,
+            tool: 34,
+            output: { status: "invalid", content: { fields: [{ op: "invalid" }] } },
+            message: { target: "invalid", content: 56, cooldown_turns: Number.NaN },
+          },
+        ],
+      }).rules[0],
+    ).toMatchObject({
+      name: "",
+      tool: "",
+      mode: "status_and_fields",
+      status: "success",
+      fields: [{ path: "", op: "glob", value: "" }],
+      target: "system",
+      content: "",
+      cooldown_turns: 0,
+    });
+  });
+
+  it("serializes permission and every reminder output mode", () => {
+    expect(
+      serializePermissionConfig({
+        default_behavior: "allow",
+        rules: [{ tool: "Bash(*)", behavior: "deny", scope: "thread" }],
+      }),
+    ).toEqual({
+      default_behavior: "allow",
+      rules: [{ tool: "Bash(*)", behavior: "deny", scope: "thread" }],
+    });
+
+    const base = createReminderRule();
+    expect(serializeReminderConfig({ rules: [{ ...base, mode: "status", status: "pending" }] }))
+      .toEqual({
+        rules: [
+          {
+            name: undefined,
+            tool: "",
+            output: { status: "pending" },
+            message: { target: "system", content: "", cooldown_turns: 0 },
+          },
+        ],
+      });
+    expect(serializeReminderConfig({ rules: [{ ...base, mode: "content_text", text: "*ok*" }] }))
+      .toEqual({
+        rules: [
+          {
+            name: undefined,
+            tool: "",
+            output: { content: "*ok*" },
+            message: { target: "system", content: "", cooldown_turns: 0 },
+          },
+        ],
+      });
+    expect(
+      serializeReminderConfig({
+        rules: [
+          {
+            ...base,
+            mode: "content_fields",
+            fields: [{ path: "status", op: "not_exact", value: "ok" }],
+          },
+        ],
+      }),
+    ).toEqual({
+      rules: [
+        {
+          name: undefined,
+          tool: "",
+          output: { content: { fields: [{ path: "status", op: "not_exact", value: "ok" }] } },
+          message: { target: "system", content: "", cooldown_turns: 0 },
+        },
+      ],
+    });
+  });
+
+  it("reads schema metadata and exposes small collection helpers", () => {
+    expect(schemaTitle({ title: " Settings " })).toBe(" Settings ");
+    expect(schemaTitle({ title: " " })).toBeNull();
+    expect(schemaDescription({ description: "Helpful copy" })).toBe("Helpful copy");
+    expect(schemaDescription({ description: "" })).toBeNull();
+    expect(moveItem(["a", "b", "c"], 0, 2)).toEqual(["b", "c", "a"]);
+    expect(createReminderField()).toEqual({ path: "", op: "glob", value: "" });
   });
 });

--- a/apps/admin-console/src/pages/agent-dashboard-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-dashboard-page.test.tsx
@@ -95,11 +95,11 @@ afterEach(() => {
 describe("AgentDashboardPage", () => {
   it("renders missing id, loading, query error, and server error states", () => {
     renderDashboard("/missing");
-    expect(screen.getByText("Missing agent id.")).toBeTruthy();
+    expect(screen.getByText("Missing agent id.")).not.toBeNull();
 
     cleanup();
     const { rerender } = renderDashboard();
-    expect(screen.getByText("Loading runtime stats…")).toBeTruthy();
+    expect(screen.getByText("Loading runtime stats…")).not.toBeNull();
 
     statsState.value = { ...statsState.value, error: new Error("stats unavailable") };
     rerender(
@@ -109,7 +109,7 @@ describe("AgentDashboardPage", () => {
         </Routes>
       </MemoryRouter>,
     );
-    expect(screen.getByText("stats unavailable")).toBeTruthy();
+    expect(screen.getByText("stats unavailable")).not.toBeNull();
 
     statsState.value = {
       ...statsState.value,
@@ -123,7 +123,7 @@ describe("AgentDashboardPage", () => {
         </Routes>
       </MemoryRouter>,
     );
-    expect(screen.getByText("HTTP 500: runtime failed")).toBeTruthy();
+    expect(screen.getByText("HTTP 500: runtime failed")).not.toBeNull();
     expect(screen.getByRole("link", { name: "Edit configuration" }).getAttribute("href")).toBe(
       "/agents/research-agent",
     );
@@ -136,7 +136,7 @@ describe("AgentDashboardPage", () => {
     };
     const { rerender } = renderDashboard();
 
-    expect(screen.getByText("Runtime stats not configured")).toBeTruthy();
+    expect(screen.getByText("Runtime stats not configured")).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(statsState.value.refetch).toHaveBeenCalledTimes(1);
 
@@ -153,8 +153,8 @@ describe("AgentDashboardPage", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("No runtime activity yet")).toBeTruthy();
-    expect(screen.getByText("new-agent")).toBeTruthy();
+    expect(screen.getByText("No runtime activity yet")).not.toBeNull();
+    expect(screen.getByText("new-agent")).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     expect(statsState.value.refetch).toHaveBeenCalledTimes(1);
     expect(screen.getByRole("link", { name: "Audit history" }).getAttribute("href")).toContain(
@@ -170,14 +170,14 @@ describe("AgentDashboardPage", () => {
 
     renderDashboard("/agents/research-agent/dashboard?window=1h");
 
-    expect(screen.getByText("Dashboard · research-agent")).toBeTruthy();
-    expect(screen.getByText("Runtime health")).toBeTruthy();
+    expect(screen.getByText("Dashboard · research-agent")).not.toBeNull();
+    expect(screen.getByText("Runtime health")).not.toBeNull();
     expect(screen.getAllByText("20.0%")).toHaveLength(2);
-    expect(screen.getByText("Inference latency distribution")).toBeTruthy();
-    expect(screen.getByText("Lifecycle events")).toBeTruthy();
-    expect(screen.getByText("Tool failure rate")).toBeTruthy();
+    expect(screen.getByText("Inference latency distribution")).not.toBeNull();
+    expect(screen.getByText("Lifecycle events")).not.toBeNull();
+    expect(screen.getByText("Tool failure rate")).not.toBeNull();
     expect(screen.getAllByText("web.search")).toHaveLength(2);
-    expect(screen.getByText("Tool latency distributions")).toBeTruthy();
+    expect(screen.getByText("Tool latency distributions")).not.toBeNull();
     expect(screen.getByRole("link", { name: "Permission rules" }).getAttribute("href")).toBe(
       "/agents/research-agent?tab=plugins",
     );
@@ -209,9 +209,9 @@ describe("AgentDashboardPage", () => {
     renderDashboard();
 
     expect(screen.getAllByText("0.0%")).toHaveLength(2);
-    expect(screen.getByText("Refreshing…")).toBeTruthy();
+    expect(screen.getByText("Refreshing…")).not.toBeNull();
     expect(screen.queryByText("Inference latency distribution")).toBeNull();
-    expect(screen.getByText("No tool invocations recorded in the current window.")).toBeTruthy();
+    expect(screen.getByText("No tool invocations recorded in the current window.")).not.toBeNull();
     expect(screen.queryByText("Tool latency distributions")).toBeNull();
   });
 });

--- a/apps/admin-console/src/pages/agent-dashboard-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-dashboard-page.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { AgentDashboardPage, type AgentRuntimeSnapshot } from "./agent-dashboard-page";
+import type { AgentRuntimeStatsResult } from "@/lib/agent-stats";
+
+const statsState = vi.hoisted(() => ({
+  value: {
+    data: undefined as AgentRuntimeStatsResult | undefined,
+    error: null as unknown,
+    isFetching: false,
+    refetch: vi.fn(),
+  },
+  calls: [] as Array<{ id: string | undefined; window: string }>,
+}));
+
+vi.mock("@/lib/query/hooks/agent-stats", () => ({
+  useAgentRuntimeStatsQuery: (id: string | undefined, window: string) => {
+    statsState.calls.push({ id, window });
+    return statsState.value;
+  },
+}));
+
+function snapshot(overrides: Partial<AgentRuntimeSnapshot> = {}): AgentRuntimeSnapshot {
+  return {
+    agent_id: "research-agent",
+    window_seconds: 3600,
+    bucket_window_seconds: 60,
+    bucket_count: 60,
+    inference_count: 10,
+    error_count: 2,
+    input_tokens: 1234,
+    output_tokens: 567,
+    avg_inference_duration_ms: 321.5,
+    min_inference_duration_ms: 50,
+    max_inference_duration_ms: 900,
+    p50_inference_duration_ms: 300,
+    p95_inference_duration_ms: 700,
+    p99_inference_duration_ms: 850,
+    inference_duration_histogram: [
+      { upper_bound_ms: 250, count: 4 },
+      { upper_bound_ms: null, count: 1 },
+    ],
+    suspensions: 1,
+    handoffs: 2,
+    delegations: 3,
+    tool_calls_by_tool: [
+      {
+        tool: "web.search",
+        call_count: 5,
+        failure_count: 1,
+        total_duration_ms: 250,
+        avg_duration_ms: 50,
+        min_duration_ms: 10,
+        max_duration_ms: 100,
+        p50_duration_ms: 45,
+        p95_duration_ms: 90,
+        p99_duration_ms: 100,
+        duration_histogram: [
+          { upper_bound_ms: 50, count: 3 },
+          { upper_bound_ms: null, count: 2 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function renderDashboard(entry = "/agents/research-agent/dashboard") {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/agents/:id/dashboard" element={<AgentDashboardPage />} />
+        <Route path="/missing" element={<AgentDashboardPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  statsState.value = {
+    data: undefined,
+    error: null,
+    isFetching: false,
+    refetch: vi.fn(),
+  };
+  statsState.calls = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AgentDashboardPage", () => {
+  it("renders missing id, loading, query error, and server error states", () => {
+    renderDashboard("/missing");
+    expect(screen.getByText("Missing agent id.")).toBeTruthy();
+
+    cleanup();
+    const { rerender } = renderDashboard();
+    expect(screen.getByText("Loading runtime stats…")).toBeTruthy();
+
+    statsState.value = { ...statsState.value, error: new Error("stats unavailable") };
+    rerender(
+      <MemoryRouter initialEntries={["/agents/research-agent/dashboard"]}>
+        <Routes>
+          <Route path="/agents/:id/dashboard" element={<AgentDashboardPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("stats unavailable")).toBeTruthy();
+
+    statsState.value = {
+      ...statsState.value,
+      error: null,
+      data: { kind: "error", status: 500, message: "runtime failed" },
+    };
+    rerender(
+      <MemoryRouter initialEntries={["/agents/research-agent/dashboard"]}>
+        <Routes>
+          <Route path="/agents/:id/dashboard" element={<AgentDashboardPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("HTTP 500: runtime failed")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Edit configuration" }).getAttribute("href")).toBe(
+      "/agents/research-agent",
+    );
+  });
+
+  it("renders registry disabled and not-yet-seen states with retry actions", () => {
+    statsState.value = {
+      ...statsState.value,
+      data: { kind: "registry_disabled" },
+    };
+    const { rerender } = renderDashboard();
+
+    expect(screen.getByText("Runtime stats not configured")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(statsState.value.refetch).toHaveBeenCalledTimes(1);
+
+    statsState.value = {
+      ...statsState.value,
+      data: { kind: "not_found", agent_id: "new-agent" },
+      refetch: vi.fn(),
+    };
+    rerender(
+      <MemoryRouter initialEntries={["/agents/research-agent/dashboard"]}>
+        <Routes>
+          <Route path="/agents/:id/dashboard" element={<AgentDashboardPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("No runtime activity yet")).toBeTruthy();
+    expect(screen.getByText("new-agent")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(statsState.value.refetch).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("link", { name: "Audit history" }).getAttribute("href")).toContain(
+      "agents%2Fnew-agent",
+    );
+  });
+
+  it("renders a populated runtime snapshot with histograms, tools, quick actions, and window changes", () => {
+    statsState.value = {
+      ...statsState.value,
+      data: { kind: "ok", snapshot: snapshot() },
+    };
+
+    renderDashboard("/agents/research-agent/dashboard?window=1h");
+
+    expect(screen.getByText("Dashboard · research-agent")).toBeTruthy();
+    expect(screen.getByText("Runtime health")).toBeTruthy();
+    expect(screen.getAllByText("20.0%")).toHaveLength(2);
+    expect(screen.getByText("Inference latency distribution")).toBeTruthy();
+    expect(screen.getByText("Lifecycle events")).toBeTruthy();
+    expect(screen.getByText("Tool failure rate")).toBeTruthy();
+    expect(screen.getAllByText("web.search")).toHaveLength(2);
+    expect(screen.getByText("Tool latency distributions")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Permission rules" }).getAttribute("href")).toBe(
+      "/agents/research-agent?tab=plugins",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(statsState.value.refetch).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByLabelText("Window:"), { target: { value: "7d" } });
+    expect(statsState.calls.at(-1)).toEqual({ id: "research-agent", window: "7d" });
+
+    fireEvent.change(screen.getByLabelText("Window:"), { target: { value: "" } });
+    expect(statsState.calls.at(-1)).toEqual({ id: "research-agent", window: "" });
+  });
+
+  it("renders zero-error and no-tools snapshots without optional histogram sections", () => {
+    statsState.value = {
+      ...statsState.value,
+      isFetching: true,
+      data: {
+        kind: "ok",
+        snapshot: snapshot({
+          error_count: 0,
+          inference_duration_histogram: [],
+          tool_calls_by_tool: [],
+        }),
+      },
+    };
+
+    renderDashboard();
+
+    expect(screen.getAllByText("0.0%")).toHaveLength(2);
+    expect(screen.getByText("Refreshing…")).toBeTruthy();
+    expect(screen.queryByText("Inference latency distribution")).toBeNull();
+    expect(screen.getByText("No tool invocations recorded in the current window.")).toBeTruthy();
+    expect(screen.queryByText("Tool latency distributions")).toBeNull();
+  });
+});

--- a/apps/admin-console/src/pages/agent-editor-page.test.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.test.tsx
@@ -31,6 +31,12 @@ function stubCapabilitiesFetch() {
   return fetchSpy;
 }
 
+function fetchHref(input: string | URL | Request): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
 function jsonResponse(data: unknown, init?: { ok?: boolean; status?: number }) {
   return {
     ok: init?.ok ?? true,
@@ -374,6 +380,511 @@ describe("agent editor preview Recent runs wiring", () => {
     fireEvent.change(idInput, { target: { value: "my-new-agent" } });
 
     expect(screen.queryByTestId("open-recent-traces")).toBeNull();
+  });
+});
+
+describe("agent editor validate and override guards", () => {
+  it("posts the current draft to dry-run validation and reports success", async () => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [{ id: "model-a", upstream_model: "gpt-test" }],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (method === "POST" && href.endsWith("/v1/config/agents/validate")) {
+        return jsonResponse({ ok: true, normalized: JSON.parse(String(init?.body)) });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    fireEvent.change(screen.getByLabelText("Agent ID"), { target: { value: "validate-agent" } });
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "model-a" } });
+    fireEvent.change(screen.getByLabelText("System prompt"), {
+      target: { value: "Validate before saving." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+
+    await screen.findByText(/Validation passed/i);
+    const [, validateInit] = fetchSpy.mock.calls.find(([input, init]) => {
+      const href = fetchHref(input as string | URL | Request);
+      return init?.method === "POST" && href.endsWith("/v1/config/agents/validate");
+    })!;
+    expect(JSON.parse(String(validateInit?.body))).toMatchObject({
+      id: "validate-agent",
+      model_id: "model-a",
+      system_prompt: "Validate before saving.",
+    });
+  });
+
+  it("surfaces dry-run validation errors without saving", async () => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [{ id: "model-a", upstream_model: "gpt-test" }],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (method === "POST" && href.endsWith("/v1/config/agents/validate")) {
+        return jsonResponse({ error: "model is not published" }, { ok: false, status: 422 });
+      }
+      if (method === "POST" && href.endsWith("/v1/config/agents")) {
+        return jsonResponse({ error: "should not save" }, { ok: false, status: 500 });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+    fireEvent.change(screen.getByLabelText("Agent ID"), { target: { value: "invalid-agent" } });
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "model-a" } });
+    fireEvent.click(screen.getByRole("button", { name: "Validate" }));
+
+    await screen.findByText(/Validation failed: model is not published/i);
+    expect(
+      fetchSpy.mock.calls.some(([input, init]) => {
+        const href = fetchHref(input as string | URL | Request);
+        return init?.method === "POST" && href.endsWith("/v1/config/agents");
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("agent editor save API flows", () => {
+  it("creates a new agent with the normalized editor payload", async () => {
+    const fetchSpy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [{ id: "model-a", upstream_model: "gpt-test" }],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (method === "POST" && href.endsWith("/v1/config/agents")) {
+        return jsonResponse(JSON.parse(String(init?.body)));
+      }
+      if (method === "GET" && href.endsWith("/v1/config/agents/new-agent/meta")) {
+        return jsonResponse({
+          source: { kind: "user" },
+          hidden: false,
+          user_overrides: null,
+          created_at: 0,
+          updated_at: 0,
+        });
+      }
+      if (method === "GET" && href.endsWith("/v1/config/agents/new-agent")) {
+        return jsonResponse({
+          id: "new-agent",
+          model_id: "model-a",
+          system_prompt: "Respond with facts only.",
+          max_rounds: 12,
+          max_continuation_retries: 2,
+          plugin_ids: [],
+          sections: {},
+          delegates: [],
+        });
+      }
+      if (method === "GET" && href.includes("/v1/audit-log")) {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    fireEvent.change(screen.getByLabelText("Agent ID"), { target: { value: "new-agent" } });
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "model-a" } });
+    fireEvent.change(screen.getByLabelText("Max rounds"), { target: { value: "12" } });
+    fireEvent.change(screen.getByLabelText("System prompt"), {
+      target: { value: "Respond with facts only." },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.filter(([input, init]) => {
+          const href = fetchHref(input as string | URL | Request);
+          return init?.method === "POST" && href.endsWith("/v1/config/agents");
+        }),
+      ).toHaveLength(1);
+    });
+    const [, createInit] = fetchSpy.mock.calls.find(([input, init]) => {
+      const href = fetchHref(input as string | URL | Request);
+      return init?.method === "POST" && href.endsWith("/v1/config/agents");
+    })!;
+    expect(JSON.parse(String(createInit?.body))).toEqual({
+      id: "new-agent",
+      model_id: "model-a",
+      system_prompt: "Respond with facts only.",
+      max_rounds: 12,
+      max_continuation_retries: 2,
+      plugin_ids: [],
+      sections: {},
+      delegates: [],
+    });
+  });
+
+  it("keeps edited draft visible when user-agent save fails", async () => {
+    const agentId = "user-save-fails";
+    const fetchSpy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [{ id: "model-a", upstream_model: "gpt-test" }],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+        return jsonResponse({
+          source: { kind: "user" },
+          hidden: false,
+          user_overrides: null,
+          created_at: 0,
+          updated_at: 0,
+        });
+      }
+      if (method === "PUT" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+        return jsonResponse({ error: "validation failed" }, { ok: false, status: 422 });
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+        return jsonResponse({
+          id: agentId,
+          model_id: "model-a",
+          system_prompt: "original prompt",
+          max_rounds: 8,
+          max_continuation_retries: 2,
+          plugin_ids: [],
+          sections: {},
+          delegates: [],
+        });
+      }
+      if (method === "GET" && href.includes("/v1/audit-log")) {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+
+    const promptTextarea = screen.getByRole("textbox", { name: /system prompt/i });
+    fireEvent.change(promptTextarea, { target: { value: "edited prompt" } });
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await screen.findByText("validation failed");
+    expect((promptTextarea as HTMLTextAreaElement).value).toBe("edited prompt");
+    const [, updateInit] = fetchSpy.mock.calls.find(([input, init]) => {
+      const href = fetchHref(input as string | URL | Request);
+      return init?.method === "PUT" && href.endsWith(`/v1/config/agents/${agentId}`);
+    })!;
+    expect(JSON.parse(String(updateInit?.body))).toMatchObject({
+      id: agentId,
+      system_prompt: "edited prompt",
+    });
+  });
+
+  it("saves tool allow-list, plugin selection, and delegates from their tabs", async () => {
+    let createdAgent: unknown = null;
+    const fetchSpy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: ["new-agent", "helper-agent"],
+          tools: [
+            {
+              id: "tool-alpha",
+              name: "Alpha",
+              description: "Alpha tool",
+              source: { kind: "builtin" },
+            },
+            {
+              id: "tool-beta",
+              name: "Beta",
+              description: "Beta tool",
+              source: { kind: "plugin", id: "files" },
+            },
+          ],
+          plugins: [{ id: "logger-plugin", config_schemas: [] }],
+          skills: [],
+          models: [{ id: "model-a", upstream_model: "gpt-test" }],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (method === "POST" && href.endsWith("/v1/config/agents")) {
+        createdAgent = JSON.parse(String(init?.body));
+        return jsonResponse(createdAgent);
+      }
+      if (method === "GET" && href.endsWith("/v1/config/agents/new-agent/meta")) {
+        return jsonResponse({
+          source: { kind: "user" },
+          hidden: false,
+          user_overrides: null,
+          created_at: 0,
+          updated_at: 0,
+        });
+      }
+      if (method === "GET" && href.endsWith("/v1/config/agents/new-agent")) {
+        return jsonResponse(
+          createdAgent ?? {
+            id: "new-agent",
+            model_id: "model-a",
+            system_prompt: "",
+            max_rounds: 16,
+            max_continuation_retries: 2,
+            plugin_ids: ["logger-plugin"],
+            allowed_tools: ["tool-alpha"],
+            delegates: ["helper-agent"],
+            sections: {},
+          },
+        );
+      }
+      if (method === "GET" && href.includes("/v1/audit-log")) {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    renderEditorRoute("/agents/new");
+    await screen.findByLabelText("Agent ID");
+
+    fireEvent.change(screen.getByLabelText("Agent ID"), { target: { value: "new-agent" } });
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "model-a" } });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Tools" }));
+    fireEvent.click(screen.getByLabelText(/Custom selection/i));
+    fireEvent.click(screen.getByLabelText(/tool-beta/i));
+
+    fireEvent.click(screen.getByRole("tab", { name: "Plugins" }));
+    fireEvent.click(screen.getByLabelText(/logger-plugin/i));
+
+    fireEvent.click(screen.getByRole("tab", { name: "Delegates" }));
+    fireEvent.click(screen.getByLabelText("helper-agent"));
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.filter(([input, init]) => {
+          const href = fetchHref(input as string | URL | Request);
+          return init?.method === "POST" && href.endsWith("/v1/config/agents");
+        }),
+      ).toHaveLength(1);
+    });
+    const [, createInit] = fetchSpy.mock.calls.find(([input, init]) => {
+      const href = fetchHref(input as string | URL | Request);
+      return init?.method === "POST" && href.endsWith("/v1/config/agents");
+    })!;
+    expect(JSON.parse(String(createInit?.body))).toMatchObject({
+      id: "new-agent",
+      model_id: "model-a",
+      allowed_tools: ["tool-alpha"],
+      plugin_ids: ["logger-plugin"],
+      delegates: ["helper-agent"],
+    });
+  });
+});
+
+describe("agent editor review and history flows", () => {
+  it("shows a semantic diff for dirty existing agents and closes the modal", async () => {
+    const agentId = "diff-agent";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const href = fetchHref(input);
+        if (href.includes("/v1/capabilities")) {
+          return jsonResponse({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [{ id: "model-a", upstream_model: "gpt-test" }],
+            providers: [],
+            namespaces: [],
+          });
+        }
+        if (href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+          return jsonResponse({
+            source: { kind: "user" },
+            hidden: false,
+            user_overrides: null,
+            created_at: 0,
+            updated_at: 0,
+          });
+        }
+        if (href.endsWith(`/v1/config/agents/${agentId}`)) {
+          return jsonResponse({
+            id: agentId,
+            model_id: "model-a",
+            system_prompt: "old prompt",
+            max_rounds: 8,
+            max_continuation_retries: 2,
+            plugin_ids: [],
+            sections: { nested: { enabled: true } },
+            delegates: [],
+          });
+        }
+        if (href.includes("/v1/audit-log")) {
+          return jsonResponse({ items: [] });
+        }
+        throw new Error(`Unexpected fetch: ${href}`);
+      }),
+    );
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+
+    fireEvent.change(screen.getByLabelText("System prompt"), {
+      target: { value: "new prompt" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Diff vs published" }));
+
+    await screen.findByRole("dialog", { name: "Diff vs published" });
+    expect(screen.getByText("system_prompt")).toBeDefined();
+    expect(screen.getByText("old prompt")).toBeDefined();
+    expect(screen.getAllByText("new prompt").length).toBeGreaterThanOrEqual(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("dialog", { name: "Diff vs published" })).toBeNull();
+  });
+
+  it("opens audit details and restores an agent version from history", async () => {
+    const agentId = "history-agent";
+    const event = {
+      id: "evt-restore-001",
+      ts: "2026-01-02T00:00:00Z",
+      actor: "hash9/admin",
+      action: "update",
+      resource: `agents/${agentId}`,
+      before: {
+        id: agentId,
+        model_id: "model-a",
+        system_prompt: "old prompt",
+        max_rounds: 8,
+      },
+      after: {
+        id: agentId,
+        model_id: "model-a",
+        system_prompt: "restored prompt",
+        max_rounds: 8,
+      },
+    };
+    let restored = false;
+    const fetchSpy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [{ id: "model-a", upstream_model: "gpt-test" }],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+        return jsonResponse({
+          source: { kind: "user" },
+          hidden: false,
+          user_overrides: null,
+          created_at: 0,
+          updated_at: 0,
+        });
+      }
+      if (
+        method === "POST" &&
+        href.endsWith(`/v1/config/agents/${agentId}/restore`)
+      ) {
+        restored = true;
+        return jsonResponse({});
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+        return jsonResponse({
+          id: agentId,
+          model_id: "model-a",
+          system_prompt: restored ? "restored prompt" : "current prompt",
+          max_rounds: 8,
+          max_continuation_retries: 2,
+          plugin_ids: [],
+          sections: {},
+          delegates: [],
+        });
+      }
+      if (method === "GET" && href.includes("/v1/audit-log")) {
+        return jsonResponse({ items: [event] });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+    fireEvent.click(screen.getByRole("tab", { name: "History" }));
+
+    await screen.findByText("hash9");
+    fireEvent.click(screen.getByRole("button", { name: "View" }));
+    await screen.findByRole("dialog", { name: "Audit event details" });
+    expect(screen.getByText("evt-restore-001")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    await screen.findByRole("dialog", { name: "Restore agent to this version?" });
+    fireEvent.click(screen.getAllByRole("button", { name: "Restore" }).at(-1)!);
+
+    await screen.findByText("Agent restored to version evt-rest");
+    expect(
+      fetchSpy.mock.calls.some(([input, init]) => {
+        const href = fetchHref(input as string | URL | Request);
+        return (
+          init?.method === "POST" &&
+          href.endsWith(`/v1/config/agents/${agentId}/restore`) &&
+          JSON.parse(String(init.body)).version === "evt-restore-001"
+        );
+      }),
+    ).toBe(true);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Basics" }));
+    expect((screen.getByLabelText("System prompt") as HTMLTextAreaElement).value).toBe(
+      "restored prompt",
+    );
   });
 });
 
@@ -825,6 +1336,73 @@ describe("agent editor source badges", () => {
       expect(deleteOverridesCalled).toBe(true);
     });
   });
+
+  it("clears one overridden field and refreshes the displayed draft", async () => {
+    const agentId = "field-reset";
+    let fieldResetCalled = false;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const href = fetchHref(input);
+      const method = init?.method?.toUpperCase() ?? "GET";
+      if (method === "GET" && href.includes("/v1/capabilities")) {
+        return jsonResponse({
+          agents: [],
+          tools: [],
+          plugins: [],
+          skills: [],
+          models: [{ id: "m1", upstream_model: "model-one" }],
+          providers: [],
+          namespaces: [],
+        });
+      }
+      if (
+        method === "DELETE" &&
+        href.endsWith(`/v1/config/agents/${agentId}/overrides/system_prompt`)
+      ) {
+        fieldResetCalled = true;
+        return jsonResponse({});
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+        return jsonResponse({
+          source: { kind: "builtin", binary_version: "1.0" },
+          hidden: false,
+          user_overrides: fieldResetCalled ? null : { system_prompt: "custom prompt" },
+          created_at: 0,
+          updated_at: 0,
+        });
+      }
+      if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+        return jsonResponse({
+          id: agentId,
+          model_id: "m1",
+          system_prompt: fieldResetCalled ? "default prompt" : "custom prompt",
+          max_rounds: 8,
+          plugin_ids: [],
+          sections: {},
+          delegates: [],
+        });
+      }
+      if (method === "GET" && href.includes("/v1/audit-log")) {
+        return jsonResponse({ items: [] });
+      }
+      throw new Error(`Unexpected fetch: ${method} ${href}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+    expect((screen.getByRole("textbox", { name: /system prompt/i }) as HTMLTextAreaElement).value).toBe(
+      "custom prompt",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^Reset to default$/i }));
+
+    await waitFor(() => {
+      expect(fieldResetCalled).toBe(true);
+      expect(
+        (screen.getByRole("textbox", { name: /system prompt/i }) as HTMLTextAreaElement).value,
+      ).toBe("default prompt");
+    });
+  });
 });
 
 // ── endpoint override banner (R14) ───────────────────────────────────────────
@@ -1197,6 +1775,65 @@ describe("agent editor context policy inputs", () => {
 // ── Save → PATCH vs PUT branching ────────────────────────────────────────────
 
 describe("agent editor Save → PATCH vs PUT branching", () => {
+  it("does not PATCH a builtin agent when no patchable fields changed", async () => {
+    const agentId = "unchanged-builtin";
+    const agentBody = {
+      id: agentId,
+      model_id: "m1",
+      system_prompt: "default prompt",
+      max_rounds: 8,
+      plugin_ids: [],
+      sections: {},
+      delegates: [],
+    };
+    let patchCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const href = fetchHref(input);
+        const method = init?.method?.toUpperCase() ?? "GET";
+        if (method === "GET" && href.includes("/v1/capabilities")) {
+          return jsonResponse({
+            agents: [],
+            tools: [],
+            plugins: [],
+            skills: [],
+            models: [{ id: "m1", upstream_model: "model-one" }],
+            providers: [],
+            namespaces: [],
+          });
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}/meta`)) {
+          return jsonResponse({
+            source: { kind: "builtin", binary_version: "1.0" },
+            hidden: false,
+            user_overrides: null,
+            created_at: 0,
+            updated_at: 0,
+          });
+        }
+        if (method === "PATCH" && href.endsWith(`/v1/config/agents/${agentId}/overrides`)) {
+          patchCalled = true;
+          return jsonResponse({});
+        }
+        if (method === "GET" && href.endsWith(`/v1/config/agents/${agentId}`)) {
+          return jsonResponse(agentBody);
+        }
+        if (method === "GET" && href.includes("/v1/audit-log")) {
+          return jsonResponse({ items: [] });
+        }
+        throw new Error(`Unexpected fetch: ${method} ${href}`);
+      }),
+    );
+
+    renderEditorRoute(`/agents/${agentId}`);
+    await screen.findByText(new RegExp(`Edit ${agentId}`, "i"));
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await screen.findByText(`Agent "${agentId}" saved (no patchable changes)`);
+    expect(patchCalled).toBe(false);
+  });
+
   it("Save calls PATCH /overrides for Builtin records", async () => {
     const agentId = "builtin-agent";
     const agentBody = {

--- a/apps/admin-console/src/pages/agents-page.test.tsx
+++ b/apps/admin-console/src/pages/agents-page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { RouterProvider, createMemoryRouter, createRoutesFromElements } from "react-router";
 import { appRoutes } from "../app";
 import { AuthProvider } from "../components/auth-provider";
@@ -15,9 +15,37 @@ function agentItem(id: string, modelId = "bootstrap") {
     model_id: modelId,
     system_prompt: "test",
     max_rounds: 8,
-    plugin_ids: [],
-    delegates: [],
+    plugin_ids: [] as string[],
+    delegates: [] as string[],
     updated_at: 1_700_000_000,
+  };
+}
+
+function runtimeSnapshot(agentId: string) {
+  return {
+    agent_id: agentId,
+    window_seconds: 86_400,
+    bucket_window_seconds: 300,
+    bucket_count: 12,
+    inference_count: 12,
+    error_count: 1,
+    input_tokens: 120,
+    output_tokens: 80,
+    avg_inference_duration_ms: 50,
+    min_inference_duration_ms: 10,
+    max_inference_duration_ms: 120,
+    p50_inference_duration_ms: 40,
+    p95_inference_duration_ms: 95,
+    p99_inference_duration_ms: 110,
+    inference_duration_histogram: [
+      { upper_bound_ms: 10, count: 1 },
+      { upper_bound_ms: 50, count: 3 },
+      { upper_bound_ms: 100, count: 8 },
+    ],
+    suspensions: 0,
+    handoffs: 0,
+    delegations: 0,
+    tool_calls_by_tool: [],
   };
 }
 
@@ -42,10 +70,18 @@ function metaItem(
 function buildFetchMock(
   agents: ReturnType<typeof agentItem>[],
   metaItems: ReturnType<typeof metaItem>[],
+  options?: {
+    runtimeStats?: unknown;
+    runtimeStatus?: number;
+    deleteStatus?: number;
+  },
 ) {
-  return vi.fn(async (url: string | URL | Request) => {
+  const deletedIds = new Set<string>();
+  return vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
     const href =
       typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+    const parsed = new URL(href);
+    const method = init?.method?.toUpperCase() ?? "GET";
 
     if (href.includes("/v1/capabilities")) {
       return {
@@ -65,12 +101,17 @@ function buildFetchMock(
     }
 
     // Runtime stats — not enabled in test
-    if (href.includes("/runtime-stats")) {
-      return { ok: false, status: 503, text: async () => "" };
+    if (parsed.pathname === "/v1/agents/runtime-stats") {
+      const status = options?.runtimeStatus ?? 503;
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => JSON.stringify(options?.runtimeStats ?? { agents: [] }),
+      };
     }
 
     // List agents meta
-    if (href.includes("/v1/config/agents/meta")) {
+    if (method === "GET" && parsed.pathname === "/v1/config/agents/meta") {
       return {
         ok: true,
         status: 200,
@@ -78,13 +119,30 @@ function buildFetchMock(
       };
     }
 
+    if (method === "DELETE" && parsed.pathname.startsWith("/v1/config/agents/")) {
+      const status = options?.deleteStatus ?? 204;
+      if (status >= 200 && status < 300) {
+        deletedIds.add(decodeURIComponent(parsed.pathname.split("/").at(-1) ?? ""));
+      }
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => (status === 204 ? "" : JSON.stringify({ error: "delete failed" })),
+      };
+    }
+
     // List agents
-    if (href.includes("/v1/config/agents")) {
+    if (method === "GET" && parsed.pathname === "/v1/config/agents") {
       return {
         ok: true,
         status: 200,
         text: async () =>
-          JSON.stringify({ namespace: "agents", items: agents, offset: 0, limit: 100 }),
+          JSON.stringify({
+            namespace: "agents",
+            items: agents.filter((agent) => !deletedIds.has(agent.id)),
+            offset: 0,
+            limit: 100,
+          }),
       };
     }
 
@@ -221,5 +279,89 @@ describe("AgentsPage source badges", () => {
     // No badge rendered when metaMap has no entry
     expect(screen.queryByText("Built-in")).toBeNull();
     expect(screen.queryByText("User-defined")).toBeNull();
+  });
+
+  it("filters by search/model/plugin and deletes only after confirmation", async () => {
+    const alpha = { ...agentItem("alpha-agent", "model-a"), plugin_ids: ["plugin-a"] };
+    const beta = { ...agentItem("beta-agent", "model-b"), plugin_ids: ["plugin-b"] };
+    const fetchMock = buildFetchMock(
+      [alpha, beta],
+      [metaItem("alpha-agent", "user"), metaItem("beta-agent", "user")],
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAgentsPage();
+
+    await screen.findByText("alpha-agent", undefined, { timeout: 5_000 });
+    fireEvent.change(screen.getByPlaceholderText(/search by id/i), {
+      target: { value: "beta" },
+    });
+    expect(screen.getByText("beta-agent")).toBeDefined();
+    expect(screen.queryByText("alpha-agent")).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText(/search by id/i), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText("model"), { target: { value: "model-a" } });
+    expect(screen.getByText("alpha-agent")).toBeDefined();
+    expect(screen.queryByText("beta-agent")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("model"), { target: { value: "any" } });
+    fireEvent.change(screen.getByLabelText("plugin"), { target: { value: "plugin-b" } });
+    expect(screen.getByText("beta-agent")).toBeDefined();
+    expect(screen.queryByText("alpha-agent")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("plugin"), { target: { value: "any" } });
+    const alphaRow = screen.getByText("alpha-agent").closest("tr");
+    expect(alphaRow).not.toBeNull();
+    fireEvent.click(within(alphaRow!).getByRole("button", { name: "Delete" }));
+    let dialog = await screen.findByRole("dialog", { name: "Delete agent?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Cancel" }));
+    expect(
+      fetchMock.mock.calls.filter(([url, init]) => {
+        const href =
+          typeof url === "string" ? url : url instanceof URL ? url.href : (url as Request).url;
+        return init?.method === "DELETE" && new URL(href).pathname === "/v1/config/agents/alpha-agent";
+      }),
+    ).toHaveLength(0);
+
+    fireEvent.click(within(alphaRow!).getByRole("button", { name: "Delete" }));
+    dialog = await screen.findByRole("dialog", { name: "Delete agent?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(screen.queryByText("alpha-agent")).toBeNull());
+    expect(screen.getByText('Agent "alpha-agent" deleted')).toBeDefined();
+  });
+
+  it("renders runtime stats including errors, p95 latency, unavailable, and missing snapshots", async () => {
+    const fetchMock = buildFetchMock(
+      [agentItem("with-stats"), agentItem("without-stats")],
+      [metaItem("with-stats", "user"), metaItem("without-stats", "user")],
+      { runtimeStatus: 200, runtimeStats: { agents: [runtimeSnapshot("with-stats")] } },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderAgentsPage();
+
+    const statsRow = (await screen.findByText("with-stats")).closest("tr");
+    expect(statsRow).not.toBeNull();
+    expect(within(statsRow!).getByText("12")).toBeDefined();
+    expect(within(statsRow!).getByText(/1 err/)).toBeDefined();
+    expect(within(statsRow!).getByText("p95 95ms")).toBeDefined();
+
+    const missingRow = screen.getByText("without-stats").closest("tr");
+    expect(missingRow).not.toBeNull();
+    expect(within(missingRow!).getByText("—")).toBeDefined();
+
+    cleanup();
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock([agentItem("disabled-stats")], [metaItem("disabled-stats", "user")]),
+    );
+    renderAgentsPage();
+    await screen.findByText("Runtime stats disabled.", undefined, { timeout: 5_000 });
+    const disabledRow = screen.getByText("disabled-stats").closest("tr");
+    expect(disabledRow).not.toBeNull();
+    expect(within(disabledRow!).getByText("n/a")).toBeDefined();
   });
 });

--- a/apps/admin-console/src/pages/dashboard-page.test.tsx
+++ b/apps/admin-console/src/pages/dashboard-page.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { DashboardPage } from "./dashboard-page";
+import type { DashboardData } from "@/lib/query/hooks/dashboard";
+
+const dashboardState = vi.hoisted(() => ({
+  value: {
+    data: undefined as DashboardData | undefined,
+    error: null as unknown,
+  },
+  ranges: [] as string[],
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (!params || Object.keys(params).length === 0) return key;
+      return `${key} ${Object.entries(params)
+        .map(([name, value]) => `${name}=${String(value)}`)
+        .join(" ")}`;
+    },
+  }),
+}));
+
+vi.mock("@/lib/query/hooks/dashboard", () => ({
+  useDashboardQuery: (range: string) => {
+    dashboardState.ranges.push(range);
+    return dashboardState.value;
+  },
+}));
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <DashboardPage />
+    </MemoryRouter>,
+  );
+}
+
+function dashboardData(overrides: Partial<DashboardData> = {}): DashboardData {
+  const agents = Array.from({ length: 9 }, (_, index) => ({
+    id: `agent-${index}`,
+    model_id: index % 2 === 0 ? "gpt-main" : "claude-main",
+    system_prompt: "Assist users",
+    plugin_ids: [],
+    delegates: [],
+  }));
+
+  return {
+    capabilities: {
+      agents: agents.map((agent) => agent.id),
+      skills: [
+        {
+          id: "imagegen",
+          name: "Image Generator",
+          description: "Generate images",
+          allowed_tools: ["image_gen"],
+          when_to_use: "bitmap output",
+          arguments: [],
+          user_invocable: true,
+          model_invocable: true,
+          context: "inline",
+          paths: [],
+        },
+      ],
+      tools: [
+        { id: "tool.describe", name: "Describe", description: "Detailed tool" },
+        { id: "tool.fallback", name: "Fallback Tool", description: "" },
+      ],
+      plugins: [
+        { id: "permission", config_schemas: [{ key: "approval", schema: {} }] },
+        { id: "stateless", config_schemas: [] },
+      ],
+      models: [],
+      providers: [],
+      namespaces: [],
+    },
+    mcpServers: [
+      {
+        id: "filesystem",
+        transport: "stdio",
+        command: "node",
+        args: ["server.js"],
+        timeout_secs: 30,
+        config: {},
+        restart_policy: { enabled: true },
+      },
+      {
+        id: "docs-http",
+        transport: "http",
+        url: "https://mcp.example.test",
+        timeout_secs: 30,
+        config: {},
+        restart_policy: { enabled: false },
+      },
+    ],
+    providers: [
+      { id: "openai", adapter: "openai", has_api_key: true },
+      { id: "local", adapter: "ollama", has_api_key: false },
+    ],
+    models: [
+      { id: "gpt-main", provider_id: "openai", upstream_model: "gpt-4.1" },
+      { id: "claude-main", provider_id: "local", upstream_model: "qwen3" },
+    ],
+    agents,
+    auditPage: {
+      items: [
+        {
+          id: "evt-1",
+          ts: "2026-05-15T00:00:00.000Z",
+          actor: "abc123/research-agent",
+          action: "create",
+          resource: "agents/research-agent",
+        },
+        {
+          id: "evt-2",
+          ts: "2026-05-15T00:01:00.000Z",
+          actor: "system",
+          action: "delete",
+          resource: "models/old-model",
+        },
+      ],
+    },
+    auditDisabled: false,
+    systemInfo: {
+      version: "1.2.3-test",
+      uptime_seconds: 90_000,
+      config_store_enabled: true,
+      audit_log_enabled: true,
+      runtime_stats_enabled: false,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  dashboardState.value = { data: undefined, error: null };
+  dashboardState.ranges = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DashboardPage", () => {
+  it("renders loading and error states with exact messages", () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Loading dashboard...")).toBeTruthy();
+
+    dashboardState.value = { data: undefined, error: new Error("dashboard unavailable") };
+    rerender(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("dashboard unavailable")).toBeTruthy();
+  });
+
+  it("renders populated health, activity, graph, system, plugin, and tool sections", () => {
+    dashboardState.value = { data: dashboardData(), error: null };
+
+    renderDashboard();
+
+    expect(screen.getByText("dashboard.title")).toBeTruthy();
+    expect(screen.getByText("dashboard.counters.agents")).toBeTruthy();
+    expect(screen.getByText("dashboard.activity.viewAll")).toBeTruthy();
+    expect(screen.getByText("create")).toBeTruthy();
+    expect(screen.getByText("agents/research-agent")).toBeTruthy();
+    expect(screen.getByText("delete")).toBeTruthy();
+    expect(screen.getByText("models/old-model")).toBeTruthy();
+
+    expect(screen.getAllByText("openai").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("dashboard.health.keySet")).toBeTruthy();
+    expect(screen.getAllByText("local").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("dashboard.health.noKey")).toBeTruthy();
+    expect(screen.getByText("filesystem")).toBeTruthy();
+    expect(screen.getByText("dashboard.health.autoRestart")).toBeTruthy();
+    expect(screen.getByText("docs-http")).toBeTruthy();
+    expect(screen.getByText("dashboard.health.manual")).toBeTruthy();
+
+    expect(screen.getByRole("figure", { name: "agents to models to providers" })).toBeTruthy();
+    expect(screen.getByText("dashboard.refGraph.viewAll")).toBeTruthy();
+    expect(screen.getByText("1.2.3-test")).toBeTruthy();
+    expect(screen.getByText("1d 1h")).toBeTruthy();
+    expect(screen.getAllByText("dashboard.system.on").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("dashboard.system.off")).toBeTruthy();
+
+    expect(screen.getByText("permission")).toBeTruthy();
+    expect(screen.getByText(/dashboard\.plugins\.configSections sections=approval/)).toBeTruthy();
+    expect(screen.getByText("stateless")).toBeTruthy();
+    expect(screen.getByText("tool.describe")).toBeTruthy();
+    expect(screen.getByText("Detailed tool")).toBeTruthy();
+    expect(screen.getByText("tool.fallback")).toBeTruthy();
+    expect(screen.getByText("Fallback Tool")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("radio", { name: "1h" }));
+    expect(dashboardState.ranges).toContain("1h");
+  });
+
+  it("renders disabled audit and empty capability states without system info", () => {
+    dashboardState.value = {
+      data: dashboardData({
+        capabilities: {
+          agents: [],
+          skills: [],
+          tools: [],
+          plugins: [],
+          models: [],
+          providers: [],
+          namespaces: [],
+        },
+        mcpServers: [],
+        providers: [],
+        models: [],
+        agents: [],
+        auditPage: null,
+        auditDisabled: true,
+        systemInfo: null,
+      }),
+      error: null,
+    };
+
+    renderDashboard();
+
+    expect(screen.getByText("Audit log is disabled on this server")).toBeTruthy();
+    expect(screen.getByText(/AdminApiConfig\.audit_log_enabled/)).toBeTruthy();
+    expect(screen.getByText("dashboard.health.noProviders")).toBeTruthy();
+    expect(screen.getByText("dashboard.health.noMcp")).toBeTruthy();
+    expect(screen.getByText("dashboard.plugins.noConfig")).toBeTruthy();
+    expect(screen.getByText("dashboard.tools.empty")).toBeTruthy();
+    expect(screen.queryByText("dashboard.system.title")).toBeNull();
+  });
+});

--- a/apps/admin-console/src/pages/eval-reports-page.test.tsx
+++ b/apps/admin-console/src/pages/eval-reports-page.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { EvalReportsPage } from "./eval-reports-page";
+import type { ReplayReport } from "@/lib/eval-reports";
+import type { FixtureStatusFilter } from "@/lib/eval-reports-filter";
+
+const filterState = vi.hoisted(() => ({
+  status: "all" as FixtureStatusFilter,
+  search: "",
+  apply: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (!params || Object.keys(params).length === 0) return key;
+      return `${key} ${Object.entries(params)
+        .map(([name, value]) => `${name}=${String(value)}`)
+        .join(" ")}`;
+    },
+  }),
+}));
+
+vi.mock("@/lib/list-url-state", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/list-url-state")>();
+  return {
+    ...actual,
+    useFixtureFilterUrlState: () => filterState,
+  };
+});
+
+function report(overrides: Partial<ReplayReport>): ReplayReport {
+  return {
+    fixture_id: "fixture-pass",
+    passed: true,
+    failures: [],
+    final_text: "final answer",
+    inference_count: 1,
+    tool_count: 0,
+    tool_failures: 0,
+    total_input_tokens: 10,
+    total_output_tokens: 20,
+    session_duration_ms: 100,
+    elapsed_ms: 120,
+    tool_calls_by_agent: [],
+    ...overrides,
+  };
+}
+
+function ndjsonFile(name: string, rows: Array<ReplayReport | string>): File {
+  return new File(
+    [
+      rows
+        .map((row) => (typeof row === "string" ? row : JSON.stringify(row)))
+        .join("\n"),
+    ],
+    name,
+    { type: "application/x-ndjson" },
+  );
+}
+
+function renderReports() {
+  return render(<EvalReportsPage />);
+}
+
+async function upload(input: HTMLInputElement, file: File) {
+  fireEvent.change(input, { target: { files: [file] } });
+  await screen.findByText(file.name);
+}
+
+beforeEach(() => {
+  filterState.status = "all";
+  filterState.search = "";
+  filterState.apply = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("EvalReportsPage", () => {
+  it("loads report and baseline NDJSON, renders summary/diff/tool panels, and opens trace details", async () => {
+    const current = ndjsonFile("current.ndjson", [
+      report({
+        fixture_id: "fixture-pass",
+        passed: true,
+        total_input_tokens: 100,
+        total_output_tokens: 50,
+        session_duration_ms: 250,
+        tool_count: 1,
+        tool_calls_by_agent: [
+          { agent_id: "planner", tool: "search", call_count: 2, failure_count: 0, total_duration_ms: 40 },
+        ],
+      }),
+      report({
+        fixture_id: "fixture-regression",
+        passed: false,
+        failures: [
+          { kind: "answer_missing_phrase", phrase: "approved" },
+          { kind: "judge_below_threshold", threshold: 0.8, actual: 0.5 },
+        ],
+        final_text: "missing required content",
+        total_input_tokens: 30,
+        total_output_tokens: 10,
+        session_duration_ms: 600,
+        elapsed_ms: 650,
+        tool_count: 1,
+        tool_failures: 1,
+        tool_calls_by_agent: [
+          { agent_id: "writer", tool: "browser", call_count: 1, failure_count: 1, total_duration_ms: 80 },
+        ],
+      }),
+      report({ fixture_id: "fixture-fixed", passed: true, final_text: "fixed now" }),
+      "{bad json",
+    ]);
+    const baseline = ndjsonFile("baseline.ndjson", [
+      report({ fixture_id: "fixture-pass", passed: true }),
+      report({ fixture_id: "fixture-regression", passed: true }),
+      report({
+        fixture_id: "fixture-fixed",
+        passed: false,
+        failures: [{ kind: "forbidden_tool_used", tool: "shell" }],
+      }),
+    ]);
+
+    const { container } = renderReports();
+    const fileInputs = Array.from(container.querySelectorAll('input[type="file"]')) as HTMLInputElement[];
+    expect(fileInputs).toHaveLength(2);
+
+    await upload(fileInputs[0], current);
+    await upload(fileInputs[1], baseline);
+
+    expect(screen.getByText("evals.title")).toBeTruthy();
+    expect(screen.getByText("current.ndjson")).toBeTruthy();
+    expect(screen.getByText(/1 parse issue\(s\)/)).toBeTruthy();
+    expect(screen.getByText("baseline.ndjson")).toBeTruthy();
+    expect(screen.getByText("Baseline diff")).toBeTruthy();
+    expect(screen.getByText("Blocking")).toBeTruthy();
+    expect(screen.getByText("Tool calls by agent")).toBeTruthy();
+    expect(screen.getByText("planner")).toBeTruthy();
+    expect(screen.getByText("writer")).toBeTruthy();
+    expect(screen.getByText("Report parse issues (1)")).toBeTruthy();
+    expect(screen.getByText(/line 4:/)).toBeTruthy();
+
+    expect(screen.getByText("fixture-pass")).toBeTruthy();
+    expect(screen.getByText("fixture-regression")).toBeTruthy();
+    expect(screen.getByText('Missing phrase: "approved"')).toBeTruthy();
+    expect(screen.getByText("Judge score 0.50 below threshold 0.80")).toBeTruthy();
+    expect(screen.getByText("Regression: answer_missing_phrase, judge_below_threshold")).toBeTruthy();
+    expect(screen.getAllByText("Fixed").length).toBeGreaterThanOrEqual(1);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Regressions" }));
+    expect(filterState.apply).toHaveBeenCalledWith({ status: "regressions" });
+    fireEvent.change(screen.getByPlaceholderText("Search by fixture id…"), {
+      target: { value: "fixture-regression" },
+    });
+    expect(filterState.apply).toHaveBeenCalledWith({ search: "fixture-regression" });
+
+    fireEvent.click(screen.getByText("fixture-regression").closest("tr")!);
+    expect(await screen.findByRole("dialog", { name: "trace.title" })).toBeTruthy();
+    expect(screen.getByText("missing required content")).toBeTruthy();
+    expect(screen.getByText("trace.scorers.fail")).toBeTruthy();
+    expect(screen.getByText("LLM judge")).toBeTruthy();
+    expect(screen.getByText("heuristic")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "common.close" })[1]);
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "trace.title" })).toBeNull());
+  });
+
+  it("disables diff-only filters until a baseline is loaded and shows empty filtered results", async () => {
+    filterState.status = "regressions";
+    filterState.search = "missing";
+    const current = ndjsonFile("single.ndjson", [report({ fixture_id: "fixture-pass" })]);
+
+    const { container } = renderReports();
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    await upload(input, current);
+
+    expect((screen.getByRole("tab", { name: "Regressions" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByRole("tab", { name: "Newly fixed" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(screen.getByText("No fixtures match the current filter.")).toBeTruthy();
+  });
+
+  it("renders an empty report table and clears selected files", async () => {
+    const empty = ndjsonFile("empty.ndjson", []);
+
+    const { container } = renderReports();
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    await upload(input, empty);
+
+    expect(screen.getByText("The report contained no fixtures.")).toBeTruthy();
+
+    fireEvent.click(screen.getAllByText("Clear")[0]);
+    expect(screen.queryByText("empty.ndjson")).toBeNull();
+    expect(screen.queryByText("The report contained no fixtures.")).toBeNull();
+  });
+});

--- a/apps/admin-console/src/pages/models-page.test.tsx
+++ b/apps/admin-console/src/pages/models-page.test.tsx
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { ModelsPage } from "./models-page";
+import type { ModelBindingSpec } from "@/lib/config-api";
+import type { SortState } from "@/lib/list-view";
+
+const pageState = vi.hoisted(() => ({
+  crud: {} as {
+    items: ModelBindingSpec[];
+    draft: ModelBindingSpec | null;
+    loading: boolean;
+    saving: boolean;
+    error: string | null;
+    isEditingExisting: boolean;
+    auxiliaryData: string[];
+    setDraft: ReturnType<typeof vi.fn>;
+    setError: ReturnType<typeof vi.fn>;
+    startEdit: ReturnType<typeof vi.fn>;
+    startNew: ReturnType<typeof vi.fn>;
+    cancelEdit: ReturnType<typeof vi.fn>;
+    handleSave: ReturnType<typeof vi.fn>;
+    handleDelete: ReturnType<typeof vi.fn>;
+  },
+  list: {
+    search: "",
+    sort: { key: "id", direction: "asc" } as SortState<"id" | "provider_id" | "upstream_model" | "updated_at">,
+    pageSize: 10,
+    page: 1,
+    apply: vi.fn(),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/use-crud-page", () => ({
+  useCrudPage: () => pageState.crud,
+}));
+
+vi.mock("@/lib/list-url-state", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/list-url-state")>();
+  return {
+    ...actual,
+    useListUrlState: () => pageState.list,
+  };
+});
+
+function model(overrides: Partial<ModelBindingSpec>): ModelBindingSpec {
+  return {
+    id: "gpt-main",
+    provider_id: "openai",
+    upstream_model: "gpt-4.1",
+    updated_at: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function resetCrud(overrides: Partial<typeof pageState.crud> = {}) {
+  pageState.crud = {
+    items: [
+      model({ id: "beta", provider_id: "anthropic", upstream_model: "claude-3.7" }),
+      model({ id: "alpha", provider_id: "openai", upstream_model: "gpt-4.1" }),
+    ],
+    draft: null,
+    loading: false,
+    saving: false,
+    error: null,
+    isEditingExisting: false,
+    auxiliaryData: ["anthropic", "openai"],
+    setDraft: vi.fn(),
+    setError: vi.fn(),
+    startEdit: vi.fn(),
+    startNew: vi.fn(),
+    cancelEdit: vi.fn(),
+    handleSave: vi.fn(async () => undefined),
+    handleDelete: vi.fn(async () => undefined),
+    ...overrides,
+  };
+  pageState.list = {
+    search: "",
+    sort: { key: "id", direction: "asc" },
+    pageSize: 10,
+    page: 1,
+    apply: vi.fn(),
+  };
+}
+
+function renderModels() {
+  return render(
+    <MemoryRouter initialEntries={["/models"]}>
+      <ModelsPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  resetCrud();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ModelsPage", () => {
+  it("renders sorted rows and wires search, page-size, sort, edit, and delete actions", () => {
+    renderModels();
+
+    expect(screen.getByText("models.title")).toBeTruthy();
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.getByText("beta")).toBeTruthy();
+    expect(screen.getByText("gpt-4.1")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("models.searchPh"), {
+      target: { value: "claude" },
+    });
+    expect(pageState.list.apply).toHaveBeenCalledWith({ search: "claude", page: 1 });
+
+    fireEvent.change(screen.getByDisplayValue("10"), { target: { value: "20" } });
+    expect(pageState.list.apply).toHaveBeenCalledWith({ pageSize: 20, page: 1 });
+
+    fireEvent.click(screen.getByRole("button", { name: /Provider/ }));
+    expect(pageState.list.apply).toHaveBeenCalledWith({
+      sort: { key: "provider_id", direction: "asc" },
+      page: 1,
+    });
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]);
+    expect(pageState.crud.startEdit).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "alpha", provider_id: "openai" }),
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
+    expect(pageState.crud.handleDelete).toHaveBeenCalledWith("alpha");
+  });
+
+  it("shows pagination and applies corrected page state when the URL page is out of range", async () => {
+    pageState.list = {
+      ...pageState.list,
+      pageSize: 1,
+      page: 3,
+      apply: vi.fn(),
+    };
+
+    renderModels();
+
+    expect(screen.getByText("2/2")).toBeTruthy();
+    await waitFor(() => {
+      expect(pageState.list.apply).toHaveBeenCalledWith({ page: 2 });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "‹ Prev" }));
+    expect(pageState.list.apply).toHaveBeenCalledWith({ page: 1 });
+  });
+
+  it("blocks save for empty drafts and renders all required field errors", () => {
+    resetCrud({ draft: model({ id: "", provider_id: "", upstream_model: "" }) });
+
+    renderModels();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts).toHaveLength(3);
+    expect(alerts.every((node) => node.textContent === "validation.required")).toBe(true);
+    expect(pageState.crud.handleSave).not.toHaveBeenCalled();
+  });
+
+  it("preserves an edited model id, keeps missing providers selectable, and saves valid drafts", () => {
+    const draft = model({ id: "legacy-model", provider_id: "legacy", upstream_model: "old-name" });
+    resetCrud({
+      draft,
+      isEditingExisting: true,
+      auxiliaryData: ["openai"],
+    });
+
+    renderModels();
+
+    expect(screen.getByText("models.formTitle.edit")).toBeTruthy();
+    expect((screen.getByDisplayValue("legacy-model") as HTMLInputElement).disabled).toBe(true);
+    expect(screen.getByRole("link", { name: "History" }).getAttribute("href")).toContain(
+      "models%2Flegacy-model",
+    );
+
+    const providerSelect = screen
+      .getAllByRole("combobox")
+      .find((node) => (node as HTMLSelectElement).value === "legacy") as HTMLSelectElement;
+    expect(providerSelect).toBeTruthy();
+    expect(Array.from(providerSelect.options).map((option) => option.value)).toEqual([
+      "",
+      "legacy",
+      "openai",
+    ]);
+
+    fireEvent.change(providerSelect, { target: { value: "openai" } });
+    let updater = pageState.crud.setDraft.mock.calls.at(-1)?.[0] as (
+      current: ModelBindingSpec | null,
+    ) => ModelBindingSpec | null;
+    expect(updater(draft)).toEqual({ ...draft, provider_id: "openai" });
+
+    fireEvent.change(screen.getByDisplayValue("old-name"), { target: { value: "gpt-4.1" } });
+    updater = pageState.crud.setDraft.mock.calls.at(-1)?.[0] as (
+      current: ModelBindingSpec | null,
+    ) => ModelBindingSpec | null;
+    expect(updater(draft)).toEqual({ ...draft, upstream_model: "gpt-4.1" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(pageState.crud.handleSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(pageState.crud.cancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders empty, filtered-empty, and loading list states", () => {
+    resetCrud({ items: [] });
+    const { rerender, container } = renderModels();
+
+    expect(screen.getByText("models.empty.title")).toBeTruthy();
+    fireEvent.click(screen.getAllByRole("button", { name: "models.new" })[0]);
+    expect(pageState.crud.startNew).toHaveBeenCalledWith({
+      id: "",
+      provider_id: "",
+      upstream_model: "",
+    });
+
+    resetCrud();
+    pageState.list = { ...pageState.list, search: "missing" };
+    rerender(
+      <MemoryRouter initialEntries={["/models"]}>
+        <ModelsPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("No models match the current filter.")).toBeTruthy();
+
+    resetCrud({ loading: true });
+    rerender(
+      <MemoryRouter initialEntries={["/models"]}>
+        <ModelsPage />
+      </MemoryRouter>,
+    );
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/admin-console/src/pages/providers-page.test.tsx
+++ b/apps/admin-console/src/pages/providers-page.test.tsx
@@ -19,7 +19,10 @@ const PROVIDER_RECORD = {
   updated_at: 2000,
 };
 
-function stubFetch(overrides?: Record<string, unknown>) {
+function stubFetch(
+  overrides?: Record<string, unknown>,
+  supportedAdapters = ["openai", "anthropic"],
+) {
   const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
     const method = init?.method?.toUpperCase() ?? "GET";
     const urlStr = String(url);
@@ -37,7 +40,7 @@ function stubFetch(overrides?: Record<string, unknown>) {
             skills: [],
             models: [],
             providers: [],
-            supported_adapters: ["openai", "anthropic"],
+            supported_adapters: supportedAdapters,
             namespaces: [],
           }),
       };
@@ -107,6 +110,75 @@ afterEach(() => {
 });
 
 describe("ProvidersPage — Test connection button", () => {
+
+  it("runs provider tests from table rows and shows a toast", async () => {
+    const fetchSpy = stubFetch({ ok: true, latency_ms: 64, network_tested: false });
+    renderProviders();
+
+    const rowTestButton = await screen.findByRole("button", { name: /^test$/i }, { timeout: 5_000 });
+    await act(async () => {
+      fireEvent.click(rowTestButton);
+    });
+
+    await screen.findByText(/my-openai config OK · 64ms/i, undefined, { timeout: 5_000 });
+    const testCall = fetchSpy.mock.calls.find(([url, init]) => {
+      const method = (init as RequestInit | undefined)?.method?.toUpperCase();
+      return method === "POST" && String(url).includes("/v1/providers/my-openai/test");
+    });
+    expect(testCall).toBeDefined();
+  });
+
+  it("filters the provider list by search text", async () => {
+    stubFetch();
+    renderProviders();
+
+    await screen.findByText("my-openai", undefined, { timeout: 5_000 });
+    const search = screen.getByPlaceholderText(/search by id/i);
+
+    fireEvent.change(search, { target: { value: "missing" } });
+    expect(screen.getByText("No providers match the current filter.")).toBeTruthy();
+    expect(screen.queryByText("my-openai")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "openai" } });
+    expect(screen.getByText("my-openai")).toBeTruthy();
+  });
+
+  it("validates service-account JSON before saving a Vertex provider", async () => {
+    const fetchSpy = stubFetch(undefined, ["anthropic", "openai", "vertex"]);
+    renderProviders();
+
+    const newButton = await screen.findByRole(
+      "button",
+      { name: /new provider/i },
+      { timeout: 5_000 },
+    );
+    fireEvent.click(newButton);
+    await screen.findByText(/create provider/i, undefined, { timeout: 5_000 });
+
+    fireEvent.change(screen.getByLabelText("Provider ID"), { target: { value: "vertex-main" } });
+    fireEvent.change(screen.getByLabelText("Adapter"), { target: { value: "vertex" } });
+    fireEvent.change(screen.getByLabelText("Credentials type"), {
+      target: { value: "service_account_json" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/paste the full json/i), {
+      target: { value: "not json" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+    });
+
+    expect(
+      screen.getAllByRole("alert").some((node) =>
+        (node.textContent ?? "").includes("Not valid JSON"),
+      ),
+    ).toBe(true);
+    const createCall = fetchSpy.mock.calls.find(([url, init]) => {
+      const method = (init as RequestInit | undefined)?.method?.toUpperCase();
+      return method === "POST" && String(url).includes("/v1/config/providers");
+    });
+    expect(createCall).toBeUndefined();
+  });
   it("does not show Test connection button when creating a new provider", async () => {
     stubFetch();
     renderProviders();

--- a/apps/admin-console/src/pages/providers-page.test.tsx
+++ b/apps/admin-console/src/pages/providers-page.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, act } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { RouterProvider, createMemoryRouter, createRoutesFromElements } from "react-router";
 import { appRoutes } from "../app";
 import { AuthProvider } from "../components/auth-provider";
@@ -9,6 +9,7 @@ import { ToastProvider } from "../components/toast-provider";
 import { ADMIN_TOKEN_STORAGE_KEY } from "../lib/config-api";
 import { __resetAuthInterceptorForTesting } from "../lib/auth-interceptor";
 import { withQueryClient } from "../test/query";
+import { callsFor, jsonResponse, listResponse, requestMethod, requestUrl } from "../test/http";
 
 const PROVIDER_RECORD = {
   id: "my-openai",
@@ -19,64 +20,72 @@ const PROVIDER_RECORD = {
   updated_at: 2000,
 };
 
+
 function stubFetch(
   overrides?: Record<string, unknown>,
   supportedAdapters = ["openai", "anthropic"],
+  options?: {
+    listItems?: unknown[];
+    saveResponse?: unknown;
+    testStatus?: number;
+    testBody?: unknown;
+  },
 ) {
-  const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
-    const method = init?.method?.toUpperCase() ?? "GET";
-    const urlStr = String(url);
+  const providerItems = options?.listItems ?? [PROVIDER_RECORD];
+  const fetchSpy = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = requestUrl(input);
+    const method = requestMethod(init);
+    const path = url.pathname;
 
-    // capabilities
-    if (urlStr.includes("/v1/capabilities")) {
-      return {
-        ok: true,
-        status: 200,
-        text: async () =>
-          JSON.stringify({
-            agents: [],
-            tools: [],
-            plugins: [],
-            skills: [],
-            models: [],
-            providers: [],
-            supported_adapters: supportedAdapters,
-            namespaces: [],
-          }),
-      };
+    if (method === "GET" && path === "/v1/capabilities") {
+      return jsonResponse({
+        agents: [],
+        tools: [],
+        plugins: [],
+        skills: [],
+        models: [],
+        providers: [],
+        supported_adapters: supportedAdapters,
+        namespaces: [],
+      });
     }
 
-    // list providers
-    if (urlStr.includes("/v1/config/providers") && method === "GET") {
-      return {
-        ok: true,
-        status: 200,
-        text: async () =>
-          JSON.stringify({
-            namespace: "providers",
-            items: [PROVIDER_RECORD],
-            offset: 0,
-            limit: 100,
-          }),
-      };
+    if (method === "GET" && path === "/v1/system/info") {
+      return jsonResponse({
+        version: "test",
+        uptime_seconds: 60,
+        config_store_enabled: true,
+        audit_log_enabled: true,
+        runtime_stats_enabled: true,
+      });
     }
 
-    // test provider
-    if (urlStr.includes("/v1/providers/") && urlStr.endsWith("/test") && method === "POST") {
+    if (method === "GET" && path === "/v1/config/providers") {
+      return listResponse("providers", providerItems);
+    }
+
+    if (method === "POST" && path === "/v1/config/providers") {
+      return jsonResponse(options?.saveResponse ?? JSON.parse(String(init?.body)));
+    }
+
+    if (method === "PUT" && path === "/v1/config/providers/my-openai") {
+      return jsonResponse(options?.saveResponse ?? JSON.parse(String(init?.body)));
+    }
+
+    if (method === "GET" && path === "/v1/config/mcp-servers") {
+      return listResponse("mcp-servers");
+    }
+
+    if (method === "GET" && path === "/v1/config/agents") {
+      return listResponse("agents");
+    }
+
+    if (method === "POST" && path === "/v1/providers/my-openai/test") {
       const defaults = { ok: true, latency_ms: 42, network_tested: false };
-      return {
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({ ...defaults, ...overrides }),
-      };
+      return jsonResponse(options?.testBody ?? { ...defaults, ...overrides }, options?.testStatus ?? 200);
     }
 
-    // fallback
-    return {
-      ok: true,
-      status: 200,
-      text: async () => JSON.stringify({}),
-    };
+    throw new Error(`Unexpected fetch: ${method} ${url.href}`);
   });
   vi.stubGlobal("fetch", fetchSpy);
   return fetchSpy;
@@ -110,22 +119,21 @@ afterEach(() => {
 });
 
 describe("ProvidersPage — Test connection button", () => {
-
   it("runs provider tests from table rows and shows a toast", async () => {
     const fetchSpy = stubFetch({ ok: true, latency_ms: 64, network_tested: false });
     renderProviders();
 
-    const rowTestButton = await screen.findByRole("button", { name: /^test$/i }, { timeout: 5_000 });
+    const rowTestButton = await screen.findByRole(
+      "button",
+      { name: /^test$/i },
+      { timeout: 5_000 },
+    );
     await act(async () => {
       fireEvent.click(rowTestButton);
     });
 
     await screen.findByText(/my-openai config OK · 64ms/i, undefined, { timeout: 5_000 });
-    const testCall = fetchSpy.mock.calls.find(([url, init]) => {
-      const method = (init as RequestInit | undefined)?.method?.toUpperCase();
-      return method === "POST" && String(url).includes("/v1/providers/my-openai/test");
-    });
-    expect(testCall).toBeDefined();
+    expect(callsFor(fetchSpy, "/v1/providers/my-openai/test", "POST")).toHaveLength(1);
   });
 
   it("filters the provider list by search text", async () => {
@@ -136,11 +144,11 @@ describe("ProvidersPage — Test connection button", () => {
     const search = screen.getByPlaceholderText(/search by id/i);
 
     fireEvent.change(search, { target: { value: "missing" } });
-    expect(screen.getByText("No providers match the current filter.")).toBeTruthy();
+    expect(screen.getByText("No providers match the current filter.")).not.toBeNull();
     expect(screen.queryByText("my-openai")).toBeNull();
 
     fireEvent.change(search, { target: { value: "openai" } });
-    expect(screen.getByText("my-openai")).toBeTruthy();
+    expect(screen.getByText("my-openai")).not.toBeNull();
   });
 
   it("validates service-account JSON before saving a Vertex provider", async () => {
@@ -173,12 +181,37 @@ describe("ProvidersPage — Test connection button", () => {
         (node.textContent ?? "").includes("Not valid JSON"),
       ),
     ).toBe(true);
-    const createCall = fetchSpy.mock.calls.find(([url, init]) => {
-      const method = (init as RequestInit | undefined)?.method?.toUpperCase();
-      return method === "POST" && String(url).includes("/v1/config/providers");
-    });
-    expect(createCall).toBeUndefined();
+    expect(callsFor(fetchSpy, "/v1/config/providers", "POST")).toHaveLength(0);
   });
+
+  it("requires client_email and private_key in service-account JSON before save", async () => {
+    const fetchSpy = stubFetch(undefined, ["anthropic", "openai", "vertex"]);
+    renderProviders();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new provider/i }, { timeout: 5_000 }),
+    );
+    await screen.findByText(/create provider/i, undefined, { timeout: 5_000 });
+
+    fireEvent.change(screen.getByLabelText("Provider ID"), { target: { value: "vertex-main" } });
+    fireEvent.change(screen.getByLabelText("Adapter"), { target: { value: "vertex" } });
+    fireEvent.change(screen.getByLabelText("Credentials type"), {
+      target: { value: "service_account_json" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/paste the full json/i), {
+      target: { value: JSON.stringify({ project_id: "proj" }) },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+    });
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "JSON must include client_email and private_key",
+    );
+    expect(callsFor(fetchSpy, "/v1/config/providers", "POST")).toHaveLength(0);
+  });
+
   it("does not show Test connection button when creating a new provider", async () => {
     stubFetch();
     renderProviders();
@@ -203,7 +236,9 @@ describe("ProvidersPage — Test connection button", () => {
     fireEvent.click(editButton);
 
     await screen.findByText(/edit provider/i, undefined, { timeout: 5_000 });
-    expect(screen.getByRole("button", { name: /test connection/i })).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /test connection/i }).hasAttribute("disabled"),
+    ).toBe(false);
   });
 
   it("calls testProvider and shows config-only success status badge on OK result", async () => {
@@ -223,11 +258,7 @@ describe("ProvidersPage — Test connection button", () => {
     // status badge should appear
     await screen.findByText(/Config OK — 55ms/i, undefined, { timeout: 5_000 });
 
-    // fetch was called with the test endpoint
-    const testCall = fetchSpy.mock.calls.find(([url]) =>
-      String(url).includes("/v1/providers/my-openai/test"),
-    );
-    expect(testCall).toBeDefined();
+    expect(callsFor(fetchSpy, "/v1/providers/my-openai/test", "POST")).toHaveLength(1);
   });
 
   it("shows connection success status when the provider test reached the network", async () => {
@@ -271,11 +302,7 @@ describe("ProvidersPage — Test connection button", () => {
     expect(alerts.some((node) => /required/i.test(node.textContent ?? ""))).toBe(true);
 
     // No POST issued — Save was gated client-side.
-    const postCall = fetchSpy.mock.calls.find(([url, init]) => {
-      const method = (init as RequestInit | undefined)?.method?.toUpperCase();
-      return method === "POST" && String(url).includes("/v1/config/providers");
-    });
-    expect(postCall).toBeUndefined();
+    expect(callsFor(fetchSpy, "/v1/config/providers", "POST")).toHaveLength(0);
   });
 
   it("shows failure status badge when test returns ok=false", async () => {
@@ -293,5 +320,149 @@ describe("ProvidersPage — Test connection button", () => {
     });
 
     await screen.findByText(/Failed.*unsupported adapter: stub/i, undefined, { timeout: 5_000 });
+  });
+
+  it("shows server errors from the edit form connection test", async () => {
+    stubFetch(undefined, ["openai", "anthropic"], {
+      testStatus: 503,
+      testBody: { error: "provider runtime unavailable" },
+    });
+    renderProviders();
+
+    fireEvent.click(await screen.findByRole("button", { name: /edit/i }, { timeout: 5_000 }));
+    await screen.findByText(/edit provider/i, undefined, { timeout: 5_000 });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+    });
+
+    await screen.findByText(/Failed: provider runtime unavailable/i, undefined, {
+      timeout: 5_000,
+    });
+  });
+
+  it("reports row-level provider test failures without opening the editor", async () => {
+    stubFetch({ ok: false, latency_ms: 9, error: "missing api key" });
+    renderProviders();
+
+    await act(async () => {
+      fireEvent.click(
+        await screen.findByRole("button", { name: /^test$/i }, { timeout: 5_000 }),
+      );
+    });
+
+    await screen.findByText(/my-openai: missing api key/i, undefined, { timeout: 5_000 });
+    expect(screen.queryByText(/edit provider/i)).toBeNull();
+  });
+
+  it("drops service-account metadata when switching a Vertex provider back to bearer auth", async () => {
+    const fetchSpy = stubFetch(undefined, ["openai", "vertex"], {
+      listItems: [
+        {
+          ...PROVIDER_RECORD,
+          adapter: "vertex",
+          adapter_options: { credentials_kind: "service_account_json" },
+        },
+      ],
+    });
+    renderProviders();
+
+    fireEvent.click(await screen.findByRole("button", { name: /edit/i }, { timeout: 5_000 }));
+    await screen.findByText(/edit provider/i, undefined, { timeout: 5_000 });
+    fireEvent.change(screen.getByLabelText("Adapter"), { target: { value: "openai" } });
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")).toHaveLength(1);
+    });
+    const [, updateInit] = callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")[0];
+    expect(JSON.parse(String(updateInit?.body))).toEqual({
+      id: "my-openai",
+      adapter: "openai",
+      has_api_key: true,
+      timeout_secs: 300,
+      created_at: 1000,
+      updated_at: 2000,
+    });
+  });
+
+  it("creates a Vertex provider with service-account JSON credentials", async () => {
+    const serviceAccountJson = JSON.stringify({
+      client_email: "svc@example.iam.gserviceaccount.com",
+      private_key: "test-private-key",
+      project_id: "proj",
+    });
+    const fetchSpy = stubFetch(undefined, ["anthropic", "openai", "vertex"], {
+      listItems: [],
+    });
+    renderProviders();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new provider/i }, { timeout: 5_000 }),
+    );
+    await screen.findByText(/create provider/i, undefined, { timeout: 5_000 });
+
+    fireEvent.change(screen.getByLabelText("Provider ID"), { target: { value: "vertex-main" } });
+    fireEvent.change(screen.getByLabelText("Adapter"), { target: { value: "vertex" } });
+    fireEvent.change(screen.getByLabelText("Credentials type"), {
+      target: { value: "service_account_json" },
+    });
+    fireEvent.change(screen.getByLabelText("Base URL"), {
+      target: { value: "https://us-central1-aiplatform.googleapis.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Timeout (seconds)"), { target: { value: "120" } });
+    fireEvent.change(screen.getByPlaceholderText(/paste the full json/i), {
+      target: { value: serviceAccountJson },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(callsFor(fetchSpy, "/v1/config/providers", "POST")).toHaveLength(1);
+    });
+    const [, createInit] = callsFor(fetchSpy, "/v1/config/providers", "POST")[0];
+    expect(JSON.parse(String(createInit?.body))).toEqual({
+      id: "vertex-main",
+      adapter: "vertex",
+      base_url: "https://us-central1-aiplatform.googleapis.com",
+      timeout_secs: 120,
+      adapter_options: { credentials_kind: "service_account_json" },
+      api_key: serviceAccountJson,
+    });
+  });
+
+  it("preserves, clears, and replaces existing provider credentials explicitly", async () => {
+    const fetchSpy = stubFetch();
+    renderProviders();
+
+    fireEvent.click(await screen.findByRole("button", { name: /edit/i }, { timeout: 5_000 }));
+    await screen.findByText(/edit provider/i, undefined, { timeout: 5_000 });
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")).toHaveLength(1);
+    });
+    let [, updateInit] = callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")[0];
+    expect(JSON.parse(String(updateInit?.body))).not.toHaveProperty("api_key");
+
+    fireEvent.click(await screen.findByRole("button", { name: /edit/i }, { timeout: 5_000 }));
+    fireEvent.click(screen.getByRole("radio", { name: "Clear key" }));
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")).toHaveLength(2);
+    });
+    [, updateInit] = callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")[1];
+    expect(JSON.parse(String(updateInit?.body))).toMatchObject({ api_key: "" });
+
+    fireEvent.click(await screen.findByRole("button", { name: /edit/i }, { timeout: 5_000 }));
+    fireEvent.click(screen.getByRole("radio", { name: "Set new key" }));
+    fireEvent.change(screen.getByPlaceholderText("sk-…"), { target: { value: "rotated-test-key" } });
+    fireEvent.click(screen.getAllByRole("button", { name: /^save$/i })[0]);
+
+    await waitFor(() => {
+      expect(callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")).toHaveLength(3);
+    });
+    [, updateInit] = callsFor(fetchSpy, "/v1/config/providers/my-openai", "PUT")[2];
+    expect(JSON.parse(String(updateInit?.body))).toMatchObject({ api_key: "rotated-test-key" });
   });
 });

--- a/apps/admin-console/src/pages/skill-detail-page.test.tsx
+++ b/apps/admin-console/src/pages/skill-detail-page.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { SkillDetailPage } from "./skill-detail-page";
+import type { AgentSpec, SkillInfo } from "@/lib/api";
+
+const queryState = vi.hoisted(() => ({
+  capabilities: {
+    data: undefined as { skills: SkillInfo[] } | undefined,
+    isPending: false,
+    error: null as unknown,
+  },
+  agents: {
+    data: undefined as { items: AgentSpec[] } | undefined,
+    isPending: false,
+    error: null as unknown,
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/query/hooks/capabilities", () => ({
+  useCapabilitiesQuery: () => queryState.capabilities,
+}));
+
+vi.mock("@/lib/query/hooks/config", () => ({
+  useConfigListQuery: () => queryState.agents,
+}));
+
+function skill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    id: "imagegen",
+    name: "Image Generator",
+    description: "Generate raster images from prompts",
+    allowed_tools: ["image_gen"],
+    when_to_use: "Use when a bitmap asset is needed",
+    arguments: [
+      { name: "prompt", description: "Image prompt", required: true },
+      { name: "size", description: null, required: false },
+    ],
+    user_invocable: true,
+    model_invocable: true,
+    context: "inline",
+    paths: ["assets/**"],
+    ...overrides,
+  };
+}
+
+function agent(overrides: Partial<AgentSpec>): AgentSpec {
+  return {
+    id: "agent-a",
+    model_id: "model-a",
+    system_prompt: "help",
+    ...overrides,
+  };
+}
+
+function renderDetail(path: string, route = "/skills/:id") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={route} element={<SkillDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  queryState.capabilities = { data: undefined, isPending: false, error: null };
+  queryState.agents = { data: undefined, isPending: false, error: null };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillDetailPage", () => {
+  it("renders a missing-id state when no route param is present", () => {
+    renderDetail("/skills", "/skills");
+
+    expect(screen.getByText("Missing skill id.")).toBeTruthy();
+  });
+
+  it("shows loading, error, and not-found states from the capabilities query", () => {
+    const { unmount } = renderDetail("/skills/imagegen");
+    expect(screen.getByText("common.loading")).toBeTruthy();
+    unmount();
+
+    queryState.capabilities = {
+      data: undefined,
+      isPending: false,
+      error: new Error("capabilities unavailable"),
+    };
+    const errorView = renderDetail("/skills/imagegen");
+    expect(screen.getByText("capabilities unavailable")).toBeTruthy();
+    errorView.unmount();
+
+    queryState.capabilities = { data: { skills: [] }, isPending: false, error: null };
+    renderDetail("/skills/imagegen");
+    expect(screen.getByText("trace.notFound")).toBeTruthy();
+  });
+
+  it("renders details, injection preview, and all supported agent reference shapes", () => {
+    queryState.capabilities = {
+      data: { skills: [skill()] },
+      isPending: false,
+      error: null,
+    };
+    queryState.agents = {
+      data: {
+        items: [
+          agent({ id: "plugin-agent", model_id: "claude", plugin_ids: ["imagegen"] }),
+          agent({
+            id: "allowlist-agent",
+            model_id: "gpt",
+            sections: { skills: { allowlist: ["imagegen"] } },
+          }),
+          agent({
+            id: "ids-agent",
+            model_id: "local",
+            sections: { "skills-discovery": { ids: ["imagegen"] } },
+          }),
+          agent({ id: "other-agent", model_id: "other", plugin_ids: ["other"] }),
+        ],
+      },
+      isPending: false,
+      error: null,
+    };
+
+    renderDetail("/skills/imagegen");
+
+    expect(screen.getByRole("heading", { name: "Image Generator" })).toBeTruthy();
+    expect(screen.getByText("imagegen")).toBeTruthy();
+    expect(screen.getByText("Generate raster images from prompts")).toBeTruthy();
+    expect(screen.getByText("Use when a bitmap asset is needed")).toBeTruthy();
+    expect(screen.getByText("image_gen")).toBeTruthy();
+    expect(screen.getByText("assets/**")).toBeTruthy();
+    expect(screen.getByText("prompt")).toBeTruthy();
+    expect(screen.getByText("Image prompt")).toBeTruthy();
+    expect(screen.getByText("size")).toBeTruthy();
+    expect(screen.getByText("skills.required")).toBeTruthy();
+    expect(screen.getByText("skills.optional")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "plugin-agent" }).getAttribute("href")).toBe(
+      "/agents/plugin-agent",
+    );
+    expect(screen.getByRole("link", { name: "allowlist-agent" }).getAttribute("href")).toBe(
+      "/agents/allowlist-agent",
+    );
+    expect(screen.getByRole("link", { name: "ids-agent" }).getAttribute("href")).toBe(
+      "/agents/ids-agent",
+    );
+    expect(screen.queryByText("other-agent")).toBeNull();
+    const preview = screen.getByText(/# Skill: Image Generator/);
+    expect(preview.textContent).toContain("Arguments:\n  - prompt (required): Image prompt");
+  });
+
+  it("renders empty optional sections without inventing tool, path, argument, or agent data", () => {
+    queryState.capabilities = {
+      data: {
+        skills: [
+          skill({
+            id: "planner",
+            name: "planner",
+            description: "Plan work",
+            allowed_tools: [],
+            when_to_use: null,
+            arguments: [],
+            user_invocable: false,
+            model_invocable: false,
+            context: "fork",
+            paths: [],
+          }),
+        ],
+      },
+      isPending: false,
+      error: null,
+    };
+    queryState.agents = { data: { items: [] }, isPending: false, error: null };
+
+    renderDetail("/skills/planner");
+
+    expect(screen.getByRole("heading", { name: "planner" })).toBeTruthy();
+    expect(screen.queryByText("When to use")).toBeNull();
+    expect(screen.getByText("skills.noToolFilter")).toBeTruthy();
+    expect(screen.getByText("skills.unscopedPath")).toBeTruthy();
+    expect(screen.getByText("skills.noArguments")).toBeTruthy();
+    expect(screen.getByText("No agents reference this skill.")).toBeTruthy();
+    expect(screen.queryByText("skills.user")).toBeNull();
+    expect(screen.queryByText("skills.model")).toBeNull();
+  });
+});

--- a/apps/admin-console/src/pages/skills-page.test.tsx
+++ b/apps/admin-console/src/pages/skills-page.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { SkillsPage } from "./skills-page";
+import type { SkillInfo } from "@/lib/api";
+
+const queryState = vi.hoisted(() => ({
+  value: {
+    data: undefined as { skills: SkillInfo[] } | undefined,
+    isPending: false,
+    error: null as unknown,
+  },
+  toastError: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/lib/query/hooks/capabilities", () => ({
+  useCapabilitiesQuery: () => queryState.value,
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({ error: queryState.toastError }),
+}));
+
+function skill(overrides: Partial<SkillInfo>): SkillInfo {
+  return {
+    id: "imagegen",
+    name: "Image Generator",
+    description: "Generate raster images from prompts",
+    allowed_tools: ["image_gen"],
+    when_to_use: "Use when a bitmap asset is needed",
+    arguments: [{ name: "prompt", description: "Image prompt", required: true }],
+    user_invocable: true,
+    model_invocable: false,
+    context: "inline",
+    paths: ["assets/**"],
+    ...overrides,
+  };
+}
+
+function renderSkills() {
+  return render(
+    <MemoryRouter initialEntries={["/skills"]}>
+      <SkillsPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  queryState.value = { data: undefined, isPending: false, error: null };
+  queryState.toastError.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SkillsPage", () => {
+  it("renders skill cards with activation hints, tools, paths, arguments, and injection preview", () => {
+    queryState.value = {
+      isPending: false,
+      error: null,
+      data: {
+        skills: [
+          skill({ id: "imagegen", name: "Image Generator" }),
+          skill({
+            id: "planner",
+            name: "planner",
+            description: "Internal planning helper",
+            allowed_tools: [],
+            when_to_use: null,
+            arguments: [],
+            user_invocable: false,
+            model_invocable: false,
+            context: "fork",
+            paths: [],
+          }),
+        ],
+      },
+    };
+
+    renderSkills();
+
+    expect(screen.getByText("Image Generator")).toBeTruthy();
+    expect(screen.getByText("Generate raster images from prompts")).toBeTruthy();
+    expect(screen.getByText("Use when a bitmap asset is needed")).toBeTruthy();
+    expect(screen.getByText("image_gen")).toBeTruthy();
+    expect(screen.getByText("assets/**")).toBeTruthy();
+    expect(screen.getByText("prompt")).toBeTruthy();
+    expect(screen.getByText("required")).toBeTruthy();
+    expect(screen.getByText(/# Skill: Image Generator/)).toBeTruthy();
+    expect(screen.getByText("2 of 2 shown")).toBeTruthy();
+
+    expect(screen.getByText("planner")).toBeTruthy();
+    expect(screen.getByText("No explicit tool filter.")).toBeTruthy();
+    expect(screen.getByText("Unscoped (any path).")).toBeTruthy();
+    expect(screen.getByText("No formal arguments declared.")).toBeTruthy();
+  });
+
+  it("filters by search, caller type, and context using URL-backed controls", () => {
+    queryState.value = {
+      isPending: false,
+      error: null,
+      data: {
+        skills: [
+          skill({ id: "imagegen", name: "Image Generator" }),
+          skill({
+            id: "code-review",
+            name: "Code Review",
+            description: "Review patches and tests",
+            allowed_tools: ["Read", "Grep"],
+            user_invocable: false,
+            model_invocable: true,
+            context: "inline",
+          }),
+          skill({
+            id: "internal-plan",
+            name: "Internal Planner",
+            description: "Private fork planning",
+            allowed_tools: [],
+            arguments: [],
+            user_invocable: false,
+            model_invocable: false,
+            context: "fork",
+          }),
+        ],
+      },
+    };
+
+    renderSkills();
+
+    fireEvent.change(screen.getByPlaceholderText(/Search by id/), {
+      target: { value: "review" },
+    });
+    expect(screen.getByText("1 of 3 shown")).toBeTruthy();
+    expect(screen.getByText("Code Review")).toBeTruthy();
+    expect(screen.queryByText("Image Generator")).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Caller"), {
+      target: { value: "internal" },
+    });
+    expect(screen.getByText("0 of 3 shown")).toBeTruthy();
+    expect(screen.getByText("skills.noMatches.title")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText(/Search by id/), {
+      target: { value: "" },
+    });
+    fireEvent.change(screen.getByLabelText("Context"), {
+      target: { value: "fork" },
+    });
+    expect(screen.getByText("1 of 3 shown")).toBeTruthy();
+    expect(screen.getByText("Internal Planner")).toBeTruthy();
+  });
+
+  it("shows empty and error states with exact user-facing signals", () => {
+    queryState.value = {
+      isPending: false,
+      error: new Error("capabilities unavailable"),
+      data: { skills: [] },
+    };
+
+    renderSkills();
+
+    expect(screen.getByText("skills.empty.title")).toBeTruthy();
+    expect(screen.getByText("skills.empty.desc")).toBeTruthy();
+    expect(queryState.toastError).toHaveBeenCalledWith("capabilities unavailable");
+  });
+});

--- a/apps/admin-console/src/test/http.ts
+++ b/apps/admin-console/src/test/http.ts
@@ -1,0 +1,34 @@
+import { BACKEND_URL } from "@/lib/config-api";
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export function listResponse(namespace: string, items: unknown[] = []): Response {
+  return jsonResponse({ namespace, items, offset: 0, limit: 100 });
+}
+
+export function requestUrl(input: string | URL | Request): URL {
+  const raw = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  return new URL(raw);
+}
+
+export function requestMethod(init?: RequestInit): string {
+  return init?.method?.toUpperCase() ?? "GET";
+}
+
+interface FetchSpyLike {
+  mock: {
+    calls: Array<[string | URL | Request, RequestInit?]>;
+  };
+}
+
+export function callsFor(fetchSpy: FetchSpyLike, path: string, method = "GET") {
+  return fetchSpy.mock.calls.filter(([input, init]) => {
+    const url = requestUrl(input);
+    return url.href === `${BACKEND_URL}${path}` && requestMethod(init) === method;
+  });
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "test": "playwright test",
+    "test:api-surface": "playwright test -c playwright.api-surface.config.ts",
     "test:interop": "playwright test -c playwright.interop.config.ts",
     "test:admin": "env -u NO_COLOR -u FORCE_COLOR playwright test -c playwright.admin.config.ts",
     "test:headed": "playwright test --headed"

--- a/e2e/playwright.admin.config.ts
+++ b/e2e/playwright.admin.config.ts
@@ -8,7 +8,7 @@ export const TEST_ADMIN_TOKEN = 'test-bearer-abc';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /admin-.*\.spec\.ts/,
+  testMatch: '**/admin-*.spec.ts',
   timeout: 180_000,
   expect: { timeout: 30_000 },
   retries: 0,

--- a/e2e/playwright.admin.config.ts
+++ b/e2e/playwright.admin.config.ts
@@ -8,7 +8,7 @@ export const TEST_ADMIN_TOKEN = 'test-bearer-abc';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /admin-config-ui\.spec\.ts/,
+  testMatch: /admin-.*\.spec\.ts/,
   timeout: 180_000,
   expect: { timeout: 30_000 },
   retries: 0,

--- a/e2e/playwright.api-surface.config.ts
+++ b/e2e/playwright.api-surface.config.ts
@@ -1,12 +1,12 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  testIgnore: /(admin-.*|api-surface)\.spec\.ts/,
+  testMatch: /api-surface\.spec\.ts/,
   timeout: 120_000,
   expect: { timeout: 30_000 },
   retries: 0,
-  workers: 4,
+  workers: 1,
   use: {
     baseURL: 'http://127.0.0.1:38080',
   },

--- a/e2e/tests/a2a.spec.ts
+++ b/e2e/tests/a2a.spec.ts
@@ -1,5 +1,17 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type APIRequestContext } from '@playwright/test';
 import { a2aSendMessagePayload } from './a2a-test-utils';
+
+async function waitForTask(request: APIRequestContext, path: string) {
+  await expect
+    .poll(async () => {
+      const res = await request.get(path);
+      return res.status();
+    })
+    .toBe(200);
+  const res = await request.get(path);
+  expect(res.ok()).toBeTruthy();
+  return res.json();
+}
 
 test.describe('A2A protocol', () => {
   test('well-known agent card returns latest JSON shape', async ({ request }) => {
@@ -29,9 +41,7 @@ test.describe('A2A protocol', () => {
     expect(body.task?.contextId).toBe(taskId);
     expect(body.task?.status?.state).toMatch(/^TASK_STATE_/);
 
-    const taskRes = await request.get(`/v1/a2a/tasks/${taskId}?historyLength=10`);
-    expect(taskRes.ok()).toBeTruthy();
-    const task = await taskRes.json();
+    const task = await waitForTask(request, `/v1/a2a/tasks/${taskId}?historyLength=10`);
     expect(task.id).toBe(taskId);
     expect(task.contextId).toBe(taskId);
     expect(task.status?.state).toMatch(/^TASK_STATE_/);
@@ -45,9 +55,7 @@ test.describe('A2A protocol', () => {
     const body = await sendRes.json();
     expect(body.task?.id).toBe(taskId);
 
-    const taskRes = await request.get(`/v1/a2a/limited/tasks/${taskId}`);
-    expect(taskRes.ok()).toBeTruthy();
-    const task = await taskRes.json();
+    const task = await waitForTask(request, `/v1/a2a/limited/tasks/${taskId}`);
     expect(task.id).toBe(taskId);
     expect(task.contextId).toBe(taskId);
   });
@@ -71,6 +79,17 @@ test.describe('A2A protocol', () => {
     const sendRes = await request.post('/v1/a2a/message:send', { data });
     expect(sendRes.ok()).toBeTruthy();
 
+    await expect
+      .poll(async () => {
+        const taskRes = await request.get(`/v1/a2a/tasks/${taskId}`);
+        if (!taskRes.ok()) {
+          return `${taskRes.status()}`;
+        }
+        const task = await taskRes.json();
+        return task.status?.state ?? 'missing-state';
+      })
+      .toBe('TASK_STATE_COMPLETED');
+
     const createRes = await request.post(`/v1/a2a/tasks/${taskId}/pushNotificationConfigs`, {
       data: {
         url: 'https://example.com/webhook',
@@ -86,12 +105,18 @@ test.describe('A2A protocol', () => {
     expect(listRes.ok()).toBeTruthy();
     const listed = await listRes.json();
     expect(Array.isArray(listed.configs)).toBe(true);
-    expect(listed.configs[0]?.id).toBe(created.id);
-
-    const getRes = await request.get(
-      `/v1/a2a/tasks/${taskId}/pushNotificationConfigs/${created.id}`,
+    expect(listed.configs.some((config: { id?: string }) => config.id === created.id)).toBe(
+      true,
     );
-    expect(getRes.ok()).toBeTruthy();
+
+    await expect
+      .poll(async () => {
+        const getRes = await request.get(
+          `/v1/a2a/tasks/${taskId}/pushNotificationConfigs/${created.id}`,
+        );
+        return getRes.status();
+      })
+      .toBe(200);
 
     const deleteRes = await request.delete(
       `/v1/a2a/tasks/${taskId}/pushNotificationConfigs/${created.id}`,

--- a/e2e/tests/admin-api.spec.ts
+++ b/e2e/tests/admin-api.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test } from '@playwright/test';
+import { TEST_ADMIN_TOKEN } from '../playwright.admin.config';
+
+const BACKEND_URL = process.env.AWAKEN_BACKEND_URL ?? 'http://127.0.0.1:38080';
+
+function uniqueId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${TEST_ADMIN_TOKEN}` };
+}
+
+async function expectNoServerError(
+  label: string,
+  response: Awaited<ReturnType<import('@playwright/test').APIRequestContext['get']>>,
+) {
+  expect(response.status(), label).toBeLessThan(500);
+}
+
+test.describe('admin API surface coverage', () => {
+  test('covers capabilities, config CRUD, overrides, diagnostics, stats, and audit routes', async ({
+    request,
+  }) => {
+    const providerId = uniqueId('api-provider');
+    const modelId = uniqueId('api-model');
+    const agentId = uniqueId('api-agent');
+    const headers = authHeaders();
+
+    const capabilityChecks = [
+      ['GET /v1/capabilities', request.get(`${BACKEND_URL}/v1/capabilities`, { headers })],
+      ['GET /v1/system/info', request.get(`${BACKEND_URL}/v1/system/info`, { headers })],
+      [
+        'GET /v1/agents/runtime-stats',
+        request.get(`${BACKEND_URL}/v1/agents/runtime-stats`, { headers }),
+      ],
+      [
+        'GET /v1/agents/:id/runtime-stats',
+        request.get(`${BACKEND_URL}/v1/agents/default/runtime-stats`, { headers }),
+      ],
+      [
+        'GET /v1/config/diagnostics',
+        request.get(`${BACKEND_URL}/v1/config/diagnostics`, { headers }),
+      ],
+      ['GET /v1/audit-log', request.get(`${BACKEND_URL}/v1/audit-log`, { headers })],
+      ['GET /v1/agents', request.get(`${BACKEND_URL}/v1/agents`, { headers })],
+      ['GET /v1/agents/:id', request.get(`${BACKEND_URL}/v1/agents/default`, { headers })],
+    ] as const;
+
+    for (const [label, pending] of capabilityChecks) {
+      await expectNoServerError(label, await pending);
+    }
+
+    const providerPayload = { id: providerId, adapter: 'openai', timeout_secs: 30 };
+    const providerValidate = await request.post(`${BACKEND_URL}/v1/config/providers/validate`, {
+      headers,
+      data: providerPayload,
+    });
+    expect(providerValidate.ok(), 'POST /v1/config/:namespace/validate').toBeTruthy();
+
+    const providerCreate = await request.post(`${BACKEND_URL}/v1/config/providers`, {
+      headers,
+      data: providerPayload,
+    });
+    expect(providerCreate.status(), 'POST /v1/config/:namespace').toBe(201);
+
+    const modelPayload = {
+      id: modelId,
+      provider_id: providerId,
+      upstream_model: 'coverage-model',
+    };
+    const modelCreate = await request.post(`${BACKEND_URL}/v1/config/models`, {
+      headers,
+      data: modelPayload,
+    });
+    expect(modelCreate.status(), 'POST /v1/config/models').toBe(201);
+
+    const agentPayload = {
+      id: agentId,
+      model_id: modelId,
+      system_prompt: 'Admin API coverage agent',
+      max_rounds: 1,
+    };
+    const agentCreate = await request.post(`${BACKEND_URL}/v1/config/agents`, {
+      headers,
+      data: agentPayload,
+    });
+    expect(agentCreate.status(), 'POST /v1/config/agents').toBe(201);
+
+    const configChecks = [
+      [
+        'GET /v1/config/:namespace',
+        request.get(`${BACKEND_URL}/v1/config/providers?limit=20&offset=0`, { headers }),
+      ],
+      [
+        'GET /v1/config/:namespace/:id',
+        request.get(`${BACKEND_URL}/v1/config/providers/${providerId}`, { headers }),
+      ],
+      [
+        'PUT /v1/config/:namespace/:id',
+        request.put(`${BACKEND_URL}/v1/config/providers/${providerId}`, {
+          headers,
+          data: { ...providerPayload, timeout_secs: 31 },
+        }),
+      ],
+      [
+        'GET /v1/config/:namespace/:id/meta',
+        request.get(`${BACKEND_URL}/v1/config/providers/${providerId}/meta`, { headers }),
+      ],
+      [
+        'GET /v1/config/:namespace/meta',
+        request.get(`${BACKEND_URL}/v1/config/providers/meta?limit=20&offset=0`, { headers }),
+      ],
+      [
+        'GET /v1/config/:namespace/$schema',
+        request.get(`${BACKEND_URL}/v1/config/providers/$schema`, { headers }),
+      ],
+      [
+        'POST /v1/config/:namespace/:id/restore',
+        request.post(`${BACKEND_URL}/v1/config/providers/${providerId}/restore`, {
+          headers,
+          data: { version: 'missing-version-for-route-coverage' },
+        }),
+      ],
+      [
+        'GET /v1/config/providers/:id/removal-preview',
+        request.get(`${BACKEND_URL}/v1/config/providers/${providerId}/removal-preview`, {
+          headers,
+        }),
+      ],
+      [
+        'POST /v1/providers/:id/test',
+        request.post(`${BACKEND_URL}/v1/providers/${providerId}/test`, { headers }),
+      ],
+    ] as const;
+
+    for (const [label, pending] of configChecks) {
+      await expectNoServerError(label, await pending);
+    }
+
+    const overrideChecks = [
+      [
+        'PATCH /v1/config/agents/:id/overrides',
+        request.patch(`${BACKEND_URL}/v1/config/agents/${agentId}/overrides`, {
+          headers,
+          data: { system_prompt: 'override route coverage' },
+        }),
+      ],
+      [
+        'DELETE /v1/config/agents/:id/overrides/:field',
+        request.delete(`${BACKEND_URL}/v1/config/agents/${agentId}/overrides/system_prompt`, {
+          headers,
+        }),
+      ],
+      [
+        'DELETE /v1/config/agents/:id/overrides',
+        request.delete(`${BACKEND_URL}/v1/config/agents/${agentId}/overrides`, { headers }),
+      ],
+      [
+        'PATCH /v1/config/tools/:id/overrides',
+        request.patch(`${BACKEND_URL}/v1/config/tools/get_weather/overrides`, {
+          headers,
+          data: { description: 'weather override coverage' },
+        }),
+      ],
+      [
+        'DELETE /v1/config/tools/:id/overrides/:field',
+        request.delete(`${BACKEND_URL}/v1/config/tools/get_weather/overrides/description`, {
+          headers,
+        }),
+      ],
+      [
+        'DELETE /v1/config/tools/:id/overrides',
+        request.delete(`${BACKEND_URL}/v1/config/tools/get_weather/overrides`, { headers }),
+      ],
+    ] as const;
+
+    for (const [label, pending] of overrideChecks) {
+      await expectNoServerError(label, await pending);
+    }
+
+    const deleteAgent = await request.delete(`${BACKEND_URL}/v1/config/agents/${agentId}`, {
+      headers,
+    });
+    expect(deleteAgent.status(), 'DELETE /v1/config/agents/:id').toBe(204);
+    const deleteModel = await request.delete(`${BACKEND_URL}/v1/config/models/${modelId}`, {
+      headers,
+    });
+    expect(deleteModel.status(), 'DELETE /v1/config/models/:id').toBe(204);
+    const deleteProvider = await request.delete(
+      `${BACKEND_URL}/v1/config/providers/${providerId}?force=true`,
+      { headers },
+    );
+    expect(deleteProvider.status(), 'DELETE /v1/config/providers/:id').toBe(204);
+  });
+});

--- a/e2e/tests/api-surface.spec.ts
+++ b/e2e/tests/api-surface.spec.ts
@@ -1,0 +1,326 @@
+import { expect, test, type APIResponse } from "@playwright/test";
+import { a2aSendMessagePayload } from "./a2a-test-utils";
+import { aiSdkTextMessages } from "./ai-sdk-test-utils";
+
+function uniqueId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sseJsonEvents(raw: string): any[] {
+  return raw
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => {
+      try {
+        return JSON.parse(line.slice(5).trim());
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function firstRunId(raw: string): string | null {
+  for (const event of sseJsonEvents(raw)) {
+    if (typeof event.run_id === "string") {
+      return event.run_id;
+    }
+    if (typeof event.runId === "string") {
+      return event.runId;
+    }
+    if (typeof event.run?.run_id === "string") {
+      return event.run.run_id;
+    }
+  }
+  return null;
+}
+
+async function expectNoServerError(label: string, response: APIResponse) {
+  expect(response.status(), label).toBeLessThan(500);
+}
+
+test.describe("HTTP API surface coverage", () => {
+  test("covers public, runtime, protocol, and observability routes", async ({
+    request,
+  }) => {
+    const health = await request.get("/health");
+    expect(health.ok(), "/health").toBeTruthy();
+    const live = await request.get("/health/live");
+    expect(live.ok(), "/health/live").toBeTruthy();
+    const metrics = await request.get("/metrics");
+    expect(metrics.ok(), "/metrics").toBeTruthy();
+
+    const threadRes = await request.post("/v1/threads", {
+      data: { title: "API surface thread" },
+    });
+    expect(threadRes.ok(), "POST /v1/threads").toBeTruthy();
+    const thread = await threadRes.json();
+    const threadId = thread.id;
+
+    const threadChecks = [
+      ["GET /v1/threads", () => request.get("/v1/threads?limit=10&offset=0")],
+      ["GET /v1/threads/summaries", () => request.get("/v1/threads/summaries")],
+      ["GET /v1/threads/:id", () => request.get(`/v1/threads/${threadId}`)],
+      [
+        "PATCH /v1/threads/:id",
+        () =>
+          request.patch(`/v1/threads/${threadId}`, {
+            data: { title: "API surface thread updated" },
+          }),
+      ],
+      [
+        "PATCH /v1/threads/:id/metadata",
+        () =>
+          request.patch(`/v1/threads/${threadId}/metadata`, {
+            data: { custom: { source: "api-surface" } },
+          }),
+      ],
+      [
+        "POST /v1/threads/:id/messages",
+        () =>
+          request.post(`/v1/threads/${threadId}/messages`, {
+            data: {
+              messages: [{ role: "user", content: "message route coverage" }],
+            },
+          }),
+      ],
+      [
+        "GET /v1/threads/:id/messages",
+        () => request.get(`/v1/threads/${threadId}/messages`),
+      ],
+      [
+        "POST /v1/threads/:id/mailbox",
+        () =>
+          request.post(`/v1/threads/${threadId}/mailbox`, {
+            data: { kind: "api.surface", payload: { ok: true } },
+          }),
+      ],
+      [
+        "GET /v1/threads/:id/mailbox",
+        () => request.get(`/v1/threads/${threadId}/mailbox`),
+      ],
+      [
+        "POST /v1/threads/:id/cancel",
+        () => request.post(`/v1/threads/${threadId}/cancel`),
+      ],
+      [
+        "POST /v1/threads/:id/interrupt",
+        () => request.post(`/v1/threads/${threadId}/interrupt`),
+      ],
+      [
+        "POST /v1/threads/:id/decision",
+        () =>
+          request.post(`/v1/threads/${threadId}/decision`, {
+            data: { toolCallId: "no-active-tool-call", action: "cancel" },
+          }),
+      ],
+    ] as const;
+
+    for (const [label, send] of threadChecks) {
+      await expectNoServerError(label, await send());
+    }
+
+    const runRes = await request.post("/v1/runs", {
+      data: {
+        agentId: "limited",
+        threadId,
+        messages: [{ role: "user", content: "run route coverage" }],
+      },
+    });
+    expect(runRes.ok(), "POST /v1/runs").toBeTruthy();
+    const runBody = await runRes.text();
+    const runId = firstRunId(runBody);
+    expect(runId, "SSE run id").toBeTruthy();
+
+    const runChecks = [
+      ["GET /v1/runs", () => request.get("/v1/runs")],
+      ["GET /v1/runs?status=done", () => request.get("/v1/runs?status=done")],
+      ["GET /v1/runs/:id", () => request.get(`/v1/runs/${runId}`)],
+      [
+        "POST /v1/runs/:id/inputs",
+        () =>
+          request.post(`/v1/runs/${runId}/inputs`, {
+            data: {
+              messages: [{ role: "user", content: "late input coverage" }],
+            },
+          }),
+      ],
+      [
+        "POST /v1/runs/:id/cancel",
+        () => request.post(`/v1/runs/${runId}/cancel`),
+      ],
+      [
+        "POST /v1/runs/:id/decision",
+        () =>
+          request.post(`/v1/runs/${runId}/decision`, {
+            data: { toolCallId: "no-active-tool-call", action: "cancel" },
+          }),
+      ],
+      [
+        "GET /v1/threads/:id/runs",
+        () => request.get(`/v1/threads/${threadId}/runs`),
+      ],
+      [
+        "GET /v1/threads/:id/runs/active",
+        () => request.get(`/v1/threads/${threadId}/runs/active`),
+      ],
+      [
+        "GET /v1/threads/:id/runs/latest",
+        () => request.get(`/v1/threads/${threadId}/runs/latest`),
+      ],
+      ["GET /v1/traces", () => request.get("/v1/traces")],
+      ["GET /v1/traces/:run_id", () => request.get(`/v1/traces/${runId}`)],
+      [
+        "POST /v1/traces/:run_id/pin",
+        () => request.post(`/v1/traces/${runId}/pin`),
+      ],
+    ] as const;
+
+    for (const [label, send] of runChecks) {
+      await expectNoServerError(label, await send());
+    }
+
+    const aiSdkPayload = {
+      agentId: "limited",
+      messages: aiSdkTextMessages([
+        { role: "user", text: "AI SDK route coverage" },
+      ]),
+    };
+    const protocolChecks = [
+      [
+        "POST /v1/ai-sdk/chat",
+        () => request.post("/v1/ai-sdk/chat", { data: aiSdkPayload }),
+      ],
+      [
+        "POST /v1/ai-sdk/threads/:thread_id/runs",
+        () =>
+          request.post(`/v1/ai-sdk/threads/${threadId}/runs`, {
+            data: aiSdkPayload,
+          }),
+      ],
+      [
+        "POST /v1/ai-sdk/agents/:agent_id/runs",
+        () =>
+          request.post("/v1/ai-sdk/agents/limited/runs", {
+            data: { messages: aiSdkPayload.messages },
+          }),
+      ],
+      [
+        "POST /v1/ai-sdk/agent-previews/runs",
+        () =>
+          request.post("/v1/ai-sdk/agent-previews/runs", {
+            data: {
+              agent: {
+                id: uniqueId("preview-agent"),
+                model_id: "default",
+                system_prompt: "Preview route coverage",
+                max_rounds: 1,
+              },
+              messages: aiSdkPayload.messages,
+            },
+          }),
+      ],
+      [
+        "GET /v1/ai-sdk/chat/:thread_id/stream",
+        () => request.get(`/v1/ai-sdk/chat/${threadId}/stream`),
+      ],
+      [
+        "GET /v1/ai-sdk/threads/:thread_id/stream",
+        () => request.get(`/v1/ai-sdk/threads/${threadId}/stream`),
+      ],
+      [
+        "GET /v1/ai-sdk/threads/:thread_id/messages",
+        () => request.get(`/v1/ai-sdk/threads/${threadId}/messages`),
+      ],
+      [
+        "POST /v1/ai-sdk/threads/:thread_id/cancel",
+        () => request.post(`/v1/ai-sdk/threads/${threadId}/cancel`),
+      ],
+      [
+        "POST /v1/ai-sdk/threads/:thread_id/interrupt",
+        () => request.post(`/v1/ai-sdk/threads/${threadId}/interrupt`),
+      ],
+      [
+        "POST /v1/ag-ui/run",
+        () =>
+          request.post("/v1/ag-ui/run", {
+            data: {
+              agentId: "limited",
+              messages: [{ role: "user", content: "AG-UI coverage" }],
+            },
+          }),
+      ],
+      [
+        "POST /v1/ag-ui/threads/:thread_id/runs",
+        () =>
+          request.post(`/v1/ag-ui/threads/${threadId}/runs`, {
+            data: {
+              agentId: "limited",
+              messages: [{ role: "user", content: "AG-UI threaded" }],
+            },
+          }),
+      ],
+      [
+        "POST /v1/ag-ui/agents/:agent_id/runs",
+        () =>
+          request.post("/v1/ag-ui/agents/limited/runs", {
+            data: {
+              messages: [{ role: "user", content: "AG-UI agent scoped" }],
+            },
+          }),
+      ],
+      [
+        "POST /v1/ag-ui/threads/:thread_id/interrupt",
+        () => request.post(`/v1/ag-ui/threads/${threadId}/interrupt`),
+      ],
+      [
+        "GET /v1/ag-ui/threads/:id/messages",
+        () => request.get(`/v1/ag-ui/threads/${threadId}/messages`),
+      ],
+    ] as const;
+
+    for (const [label, send] of protocolChecks) {
+      await expectNoServerError(label, await send());
+    }
+
+    const card = await request.get("/.well-known/agent-card.json");
+    expect(card.ok(), "GET /.well-known/agent-card.json").toBeTruthy();
+    const { taskId, data } = a2aSendMessagePayload("A2A route surface");
+    const a2aSend = await request.post("/v1/a2a/message:send", { data });
+    expect(a2aSend.ok(), "POST /v1/a2a/message:send").toBeTruthy();
+    const a2aChecks = [
+      [
+        "POST /v1/a2a/message:stream",
+        () => request.post("/v1/a2a/message:stream", { data }),
+      ],
+      ["GET /v1/a2a/tasks/:id", () => request.get(`/v1/a2a/tasks/${taskId}`)],
+      [
+        "POST /v1/a2a/tasks/:id/pushNotificationConfigs",
+        () =>
+          request.post(`/v1/a2a/tasks/${taskId}/pushNotificationConfigs`, {
+            data: {
+              url: "https://example.com/coverage-webhook",
+              token: "coverage-token",
+            },
+          }),
+      ],
+      [
+        "GET /v1/a2a/tasks/:id/pushNotificationConfigs",
+        () => request.get(`/v1/a2a/tasks/${taskId}/pushNotificationConfigs`),
+      ],
+      [
+        "POST /v1/a2a/:agentId/message:send",
+        () =>
+          request.post("/v1/a2a/limited/message:send", {
+            data: a2aSendMessagePayload("tenant A2A coverage").data,
+          }),
+      ],
+    ] as const;
+    for (const [label, send] of a2aChecks) {
+      await expectNoServerError(label, await send());
+    }
+
+    const deleteThread = await request.delete(`/v1/threads/${threadId}`);
+    await expectNoServerError("DELETE /v1/threads/:id", deleteThread);
+  });
+});

--- a/e2e/tests/api-surface.spec.ts
+++ b/e2e/tests/api-surface.spec.ts
@@ -39,6 +39,13 @@ async function expectNoServerError(label: string, response: APIResponse) {
   expect(response.status(), label).toBeLessThan(500);
 }
 
+async function expectJsonObject(label: string, response: APIResponse) {
+  expect(response.ok(), label).toBeTruthy();
+  const body = await response.json();
+  expect(body, `${label} body`).toEqual(expect.any(Object));
+  return body;
+}
+
 test.describe("HTTP API surface coverage", () => {
   test("covers public, runtime, protocol, and observability routes", async ({
     request,
@@ -53,9 +60,10 @@ test.describe("HTTP API surface coverage", () => {
     const threadRes = await request.post("/v1/threads", {
       data: { title: "API surface thread" },
     });
-    expect(threadRes.ok(), "POST /v1/threads").toBeTruthy();
-    const thread = await threadRes.json();
+    const thread = await expectJsonObject("POST /v1/threads", threadRes);
     const threadId = thread.id;
+    expect(threadId, "created thread id").toEqual(expect.any(String));
+    expect(thread.metadata?.title).toBe("API surface thread");
 
     const threadChecks = [
       ["GET /v1/threads", () => request.get("/v1/threads?limit=10&offset=0")],
@@ -120,15 +128,46 @@ test.describe("HTTP API surface coverage", () => {
       await expectNoServerError(label, await send());
     }
 
+    const listedThreads = await expectJsonObject(
+      "GET /v1/threads shape",
+      await request.get("/v1/threads?limit=10&offset=0"),
+    );
+    expect(Array.isArray(listedThreads.items), "thread list items").toBe(true);
+    expect(typeof listedThreads.limit).toBe("number");
+    const patchedThread = await expectJsonObject(
+      "GET /v1/threads/:id after patch",
+      await request.get(`/v1/threads/${threadId}`),
+    );
+    expect(patchedThread.metadata?.title).toBe("API surface thread updated");
+    expect(patchedThread.metadata?.custom?.source).toBe("api-surface");
+    const messages = await expectJsonObject(
+      "GET /v1/threads/:id/messages shape",
+      await request.get(`/v1/threads/${threadId}/messages`),
+    );
+    expect(Array.isArray(messages.messages), "thread messages").toBe(true);
+    expect(typeof messages.total).toBe("number");
+
+    const runThreadRes = await request.post("/v1/threads", {
+      data: { title: "API surface run thread" },
+    });
+    const runThread = await expectJsonObject(
+      "POST /v1/threads for run coverage",
+      runThreadRes,
+    );
+    const runThreadId = runThread.id;
+    expect(runThread.metadata?.title).toBe("API surface run thread");
+
     const runRes = await request.post("/v1/runs", {
       data: {
         agentId: "limited",
-        threadId,
+        threadId: runThreadId,
         messages: [{ role: "user", content: "run route coverage" }],
       },
     });
     expect(runRes.ok(), "POST /v1/runs").toBeTruthy();
     const runBody = await runRes.text();
+    const runEvents = sseJsonEvents(runBody);
+    expect(runEvents.length, "run SSE event count").toBeGreaterThan(0);
     const runId = firstRunId(runBody);
     expect(runId, "SSE run id").toBeTruthy();
 
@@ -158,15 +197,15 @@ test.describe("HTTP API surface coverage", () => {
       ],
       [
         "GET /v1/threads/:id/runs",
-        () => request.get(`/v1/threads/${threadId}/runs`),
+        () => request.get(`/v1/threads/${runThreadId}/runs`),
       ],
       [
         "GET /v1/threads/:id/runs/active",
-        () => request.get(`/v1/threads/${threadId}/runs/active`),
+        () => request.get(`/v1/threads/${runThreadId}/runs/active`),
       ],
       [
         "GET /v1/threads/:id/runs/latest",
-        () => request.get(`/v1/threads/${threadId}/runs/latest`),
+        () => request.get(`/v1/threads/${runThreadId}/runs/latest`),
       ],
       ["GET /v1/traces", () => request.get("/v1/traces")],
       ["GET /v1/traces/:run_id", () => request.get(`/v1/traces/${runId}`)],
@@ -178,6 +217,17 @@ test.describe("HTTP API surface coverage", () => {
 
     for (const [label, send] of runChecks) {
       await expectNoServerError(label, await send());
+    }
+    const runs = await expectJsonObject("GET /v1/runs shape", await request.get("/v1/runs"));
+    expect(Array.isArray(runs.items), "run list items").toBe(true);
+    expect(typeof runs.total).toBe("number");
+    const threadRuns = await expectJsonObject(
+      "GET /v1/threads/:id/runs shape",
+      await request.get(`/v1/threads/${runThreadId}/runs`),
+    );
+    expect(Array.isArray(threadRuns.items), "thread run list items").toBe(true);
+    for (const item of threadRuns.items) {
+      expect(item.thread_id).toBe(runThreadId);
     }
 
     const aiSdkPayload = {
@@ -194,7 +244,7 @@ test.describe("HTTP API surface coverage", () => {
       [
         "POST /v1/ai-sdk/threads/:thread_id/runs",
         () =>
-          request.post(`/v1/ai-sdk/threads/${threadId}/runs`, {
+          request.post(`/v1/ai-sdk/threads/${runThreadId}/runs`, {
             data: aiSdkPayload,
           }),
       ],
@@ -222,23 +272,23 @@ test.describe("HTTP API surface coverage", () => {
       ],
       [
         "GET /v1/ai-sdk/chat/:thread_id/stream",
-        () => request.get(`/v1/ai-sdk/chat/${threadId}/stream`),
+        () => request.get(`/v1/ai-sdk/chat/${runThreadId}/stream`),
       ],
       [
         "GET /v1/ai-sdk/threads/:thread_id/stream",
-        () => request.get(`/v1/ai-sdk/threads/${threadId}/stream`),
+        () => request.get(`/v1/ai-sdk/threads/${runThreadId}/stream`),
       ],
       [
         "GET /v1/ai-sdk/threads/:thread_id/messages",
-        () => request.get(`/v1/ai-sdk/threads/${threadId}/messages`),
+        () => request.get(`/v1/ai-sdk/threads/${runThreadId}/messages`),
       ],
       [
         "POST /v1/ai-sdk/threads/:thread_id/cancel",
-        () => request.post(`/v1/ai-sdk/threads/${threadId}/cancel`),
+        () => request.post(`/v1/ai-sdk/threads/${runThreadId}/cancel`),
       ],
       [
         "POST /v1/ai-sdk/threads/:thread_id/interrupt",
-        () => request.post(`/v1/ai-sdk/threads/${threadId}/interrupt`),
+        () => request.post(`/v1/ai-sdk/threads/${runThreadId}/interrupt`),
       ],
       [
         "POST /v1/ag-ui/run",
@@ -253,7 +303,7 @@ test.describe("HTTP API surface coverage", () => {
       [
         "POST /v1/ag-ui/threads/:thread_id/runs",
         () =>
-          request.post(`/v1/ag-ui/threads/${threadId}/runs`, {
+          request.post(`/v1/ag-ui/threads/${runThreadId}/runs`, {
             data: {
               agentId: "limited",
               messages: [{ role: "user", content: "AG-UI threaded" }],
@@ -271,11 +321,11 @@ test.describe("HTTP API surface coverage", () => {
       ],
       [
         "POST /v1/ag-ui/threads/:thread_id/interrupt",
-        () => request.post(`/v1/ag-ui/threads/${threadId}/interrupt`),
+        () => request.post(`/v1/ag-ui/threads/${runThreadId}/interrupt`),
       ],
       [
         "GET /v1/ag-ui/threads/:id/messages",
-        () => request.get(`/v1/ag-ui/threads/${threadId}/messages`),
+        () => request.get(`/v1/ag-ui/threads/${runThreadId}/messages`),
       ],
     ] as const;
 
@@ -284,14 +334,30 @@ test.describe("HTTP API surface coverage", () => {
     }
 
     const card = await request.get("/.well-known/agent-card.json");
-    expect(card.ok(), "GET /.well-known/agent-card.json").toBeTruthy();
+    const cardBody = await expectJsonObject("GET /.well-known/agent-card.json", card);
+    expect(cardBody.capabilities?.streaming).toBe(true);
+    expect(cardBody.supportedInterfaces?.[0]?.url).toContain("/v1/a2a");
     const { taskId, data } = a2aSendMessagePayload("A2A route surface");
     const a2aSend = await request.post("/v1/a2a/message:send", { data });
-    expect(a2aSend.ok(), "POST /v1/a2a/message:send").toBeTruthy();
+    const a2aSendBody = await expectJsonObject("POST /v1/a2a/message:send", a2aSend);
+    expect(a2aSendBody.task?.id).toBe(taskId);
+    await expect
+      .poll(async () => {
+        const taskRes = await request.get(`/v1/a2a/tasks/${taskId}`);
+        if (!taskRes.ok()) {
+          return `${taskRes.status()}`;
+        }
+        const task = await taskRes.json();
+        return task.status?.state ?? "missing-state";
+      })
+      .toBe("TASK_STATE_COMPLETED");
     const a2aChecks = [
       [
         "POST /v1/a2a/message:stream",
-        () => request.post("/v1/a2a/message:stream", { data }),
+        () =>
+          request.post("/v1/a2a/message:stream", {
+            data: a2aSendMessagePayload("A2A stream surface").data,
+          }),
       ],
       ["GET /v1/a2a/tasks/:id", () => request.get(`/v1/a2a/tasks/${taskId}`)],
       [
@@ -319,8 +385,21 @@ test.describe("HTTP API surface coverage", () => {
     for (const [label, send] of a2aChecks) {
       await expectNoServerError(label, await send());
     }
+    const a2aTask = await expectJsonObject(
+      "GET /v1/a2a/tasks/:id shape",
+      await request.get(`/v1/a2a/tasks/${taskId}`),
+    );
+    expect(a2aTask.id).toBe(taskId);
+    expect(a2aTask.contextId).toBe(taskId);
+    const pushConfigs = await expectJsonObject(
+      "GET /v1/a2a/tasks/:id/pushNotificationConfigs shape",
+      await request.get(`/v1/a2a/tasks/${taskId}/pushNotificationConfigs`),
+    );
+    expect(Array.isArray(pushConfigs.configs), "A2A push configs").toBe(true);
 
     const deleteThread = await request.delete(`/v1/threads/${threadId}`);
     await expectNoServerError("DELETE /v1/threads/:id", deleteThread);
+    const deleteRunThread = await request.delete(`/v1/threads/${runThreadId}`);
+    await expectNoServerError("DELETE /v1/threads/:run-thread-id", deleteRunThread);
   });
 });


### PR DESCRIPTION
## Summary
- Split non-MCP admin-console and e2e test coverage onto a standalone branch.
- Added focused admin API, editor, dashboard, providers, skills, list-state, and plugin-config tests.
- Added Playwright API surface/admin e2e coverage while excluding MCP crate tests, MCP server page tests, and MCP real-server e2e tests.
- Fixed two test-quality issues found during validation: mocked Response body reuse and admin Playwright spec selection matching the worktree path.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm exec -- vitest run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reportsDirectory ../../target/coverage/admin-console`
  - 74 test files passed; 876 passed, 10 skipped
  - statements 86.07%, branches 76.15%, functions 83.58%, lines 87.76%
- `npm run test:api-surface`
  - 1 passed
- `npm run test:admin`
  - 10 passed, 1 skipped
- pre-push hook
  - admin-console-ci passed
  - Rust validate passed