### PR TITLE
♻️ refactor(workspace): engineering cleanup — dedup, hoist, drop dead code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ proptest = "1"
 secrecy = { version = "0.10", features = ["serde"] }
 subtle = "2.6"
 tokio-util = { version = "0.7", features = ["compat"] }
+bytes = "1"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
+tempfile = "3"
+testcontainers = "0.23"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,13 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 tempfile = "3"
 testcontainers = "0.23"
+clap = { version = "4", features = ["derive", "env"] }
+mcp = { package = "model-context-protocol", version = "0.2", default-features = false }
+axum = { version = "0.7", default-features = false }
+tower = "0.5"
+tower-http = "0.6"
+sqlx = { version = "0.8", default-features = false }
+tracing-subscriber = "0.3"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/awaken-eval/Cargo.toml
+++ b/crates/awaken-eval/Cargo.toml
@@ -22,7 +22,7 @@ tracing = { workspace = true }
 reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }
 reqwest = { workspace = true, features = ["blocking"] }
 

--- a/crates/awaken-ext-mcp/Cargo.toml
+++ b/crates/awaken-ext-mcp/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "process", "time"] }
 reqwest = { workspace = true }
 futures = { workspace = true }
-mcp = { package = "model-context-protocol", version = "0.2", default-features = false, features = ["client"] }
+mcp = { workspace = true, features = ["client"] }
 nix = { version = "0.29", default-features = false, features = ["signal"] }
 
 [dev-dependencies]

--- a/crates/awaken-ext-mcp/src/transport.rs
+++ b/crates/awaken-ext-mcp/src/transport.rs
@@ -38,6 +38,8 @@ use crate::sampling::SamplingHandler;
 /// to surface the cancellation upward (e.g. as `ToolError::Cancelled`).
 pub const CANCELLED_BY_CLIENT: &str = "MCP request cancelled by client";
 
+const HEADER_SESSION_ID: &str = "MCP-Session-Id";
+const HEADER_PROTOCOL_VERSION: &str = "MCP-Protocol-Version";
 const MCP_SESSION_EXPIRED: &str = "MCP session expired";
 const MCP_SESSION_EXPIRED_AFTER_ACCEPT: &str = "MCP session expired after request was accepted";
 const MAX_SSE_LINE_BYTES: usize = 64 * 1024;
@@ -1715,13 +1717,11 @@ impl ProgressAwareHttpTransport {
             )
             .await?;
 
-        // Spec literal: `MCP-Session-Id`. HeaderMap::get is
-        // case-insensitive so this works regardless of how the server
-        // capitalises the response header.
+        // HeaderMap::get is case-insensitive (server casing irrelevant).
         let session_id = post_response
             .response
             .headers()
-            .get("MCP-Session-Id")
+            .get(HEADER_SESSION_ID)
             .and_then(|value| value.to_str().ok())
             .map(str::to_string);
 
@@ -1950,10 +1950,10 @@ impl ProgressAwareHttpTransport {
             ));
         }
         if let Some(ref protocol_version) = sent_protocol_version {
-            request = request.header("MCP-Protocol-Version", protocol_version.clone());
+            request = request.header(HEADER_PROTOCOL_VERSION, protocol_version.clone());
         }
         if let Some(ref session_id) = sent_session_id {
-            request = request.header("MCP-Session-Id", session_id.clone());
+            request = request.header(HEADER_SESSION_ID, session_id.clone());
         }
 
         request = match message {
@@ -2331,8 +2331,8 @@ impl ProgressAwareHttpTransport {
             .streaming_client
             .get(&self.endpoint)
             .header(reqwest::header::ACCEPT, "text/event-stream")
-            .header("MCP-Session-Id", session_id)
-            .header("MCP-Protocol-Version", MCP_PROTOCOL_VERSION)
+            .header(HEADER_SESSION_ID, session_id)
+            .header(HEADER_PROTOCOL_VERSION, MCP_PROTOCOL_VERSION)
             .header("Last-Event-ID", last_event_id);
 
         let response = tokio::time::timeout(self.timeout, request.send())
@@ -2620,10 +2620,10 @@ impl ProgressAwareHttpTransport {
             ));
         }
         if let Some(ref session_id) = sent_session_id {
-            request = request.header("MCP-Session-Id", session_id.clone());
+            request = request.header(HEADER_SESSION_ID, session_id.clone());
         }
         if let Some(ref protocol_version) = sent_protocol_version {
-            request = request.header("MCP-Protocol-Version", protocol_version.clone());
+            request = request.header(HEADER_PROTOCOL_VERSION, protocol_version.clone());
         }
         if let Some(id) = last_event_id {
             request = request.header("Last-Event-ID", id);
@@ -2846,10 +2846,10 @@ async fn run_http_listening_stream(ctx: HttpListenerCtx) {
             .get(&ctx.endpoint)
             .header(reqwest::header::ACCEPT, "text/event-stream");
         if let Some(ref id) = session_snapshot.session_id {
-            req = req.header("MCP-Session-Id", id.clone());
+            req = req.header(HEADER_SESSION_ID, id.clone());
         }
         if let Some(ref pv) = session_snapshot.protocol_version {
-            req = req.header("MCP-Protocol-Version", pv.clone());
+            req = req.header(HEADER_PROTOCOL_VERSION, pv.clone());
         }
         if let Some(ref id) = last_event_id {
             req = req.header("Last-Event-ID", id.clone());
@@ -3153,10 +3153,10 @@ async fn post_listener_response(
         ));
     }
     if let Some(ref pv) = sent_protocol_version {
-        req = req.header("MCP-Protocol-Version", pv.clone());
+        req = req.header(HEADER_PROTOCOL_VERSION, pv.clone());
     }
     if let Some(ref id) = sent_session_id {
-        req = req.header("MCP-Session-Id", id.clone());
+        req = req.header(HEADER_SESSION_ID, id.clone());
     }
     let http_response = req.json(&response).send().await.map_err(|e| {
         McpTransportError::TransportError(format!("listener response POST failed: {}", e))
@@ -3582,9 +3582,9 @@ impl ProgressAwareHttpTransport {
         let mut request = self
             .client
             .delete(&self.endpoint)
-            .header("MCP-Session-Id", session_id.to_string());
+            .header(HEADER_SESSION_ID, session_id.to_string());
         if let Some(protocol_version) = protocol_version {
-            request = request.header("MCP-Protocol-Version", protocol_version.to_string());
+            request = request.header(HEADER_PROTOCOL_VERSION, protocol_version.to_string());
         }
         match request.send().await {
             Ok(response) if response.status() == reqwest::StatusCode::METHOD_NOT_ALLOWED => {
@@ -4691,7 +4691,7 @@ mod tests {
                             200,
                             "application/json",
                             body,
-                            &[("MCP-Session-Id", format!("session-{initialize_count}"))],
+                            &[(HEADER_SESSION_ID, format!("session-{initialize_count}"))],
                         )
                         .await;
                     }
@@ -4840,7 +4840,7 @@ mod tests {
                             200,
                             "application/json",
                             body,
-                            &[("MCP-Session-Id", format!("session-{initialize_count}"))],
+                            &[(HEADER_SESSION_ID, format!("session-{initialize_count}"))],
                         )
                         .await;
                     }

--- a/crates/awaken-ext-mcp/tests/mcp_tests.rs
+++ b/crates/awaken-ext-mcp/tests/mcp_tests.rs
@@ -4539,7 +4539,10 @@ async fn http_listener_response_404_resets_session_before_next_call() {
     );
     let start = Instant::now();
     let mut reset_observed = initialize_count.load(Ordering::SeqCst) >= 2;
-    while start.elapsed() <= Duration::from_secs(2) {
+    // 5s window matches the longer wait_until at the top of this file —
+    // CI runners can take >2s to drive the reinitialize path through the
+    // background listener.
+    while start.elapsed() <= Duration::from_secs(5) {
         let status = manager
             .server_status_snapshot("http_listener_response_404")
             .await

--- a/crates/awaken-ext-observability/Cargo.toml
+++ b/crates/awaken-ext-observability/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { workspace = true, features = ["time"] }
 futures = { workspace = true }
 futures-util = "0.3"
 tracing-core = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "registry"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "registry"] }
 metrics-exporter-prometheus = { workspace = true }
 
 [features]

--- a/crates/awaken-ext-observability/Cargo.toml
+++ b/crates/awaken-ext-observability/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { workspace = true }
 tokio = { workspace = true }
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
-metrics = "0.24"
+metrics = { workspace = true }
 
 # Optional OTel
 opentelemetry = { version = "0.28", optional = true }
@@ -34,7 +34,7 @@ futures = { workspace = true }
 futures-util = "0.3"
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "registry"] }
-metrics-exporter-prometheus = "0.16"
+metrics-exporter-prometheus = { workspace = true }
 
 [features]
 default = []

--- a/crates/awaken-ext-observability/src/metrics.rs
+++ b/crates/awaken-ext-observability/src/metrics.rs
@@ -520,16 +520,15 @@ mod attribution_tests {
 
     #[test]
     fn span_context_serializes_attribution_fields() {
-        let mut ctx = SpanContext::default();
-        ctx.prompt_id = Some("a1b2c3d4e5f6".to_string());
-        ctx.tool_desc_ids = vec!["t000aaaaaaaa".to_string(), "t111bbbbbbbb".to_string()];
-        ctx.skill_ids = vec!["s00000000000".to_string()];
-        ctx.release_tag = Some("agents.weather@stable".to_string());
-        // experiment_id is a ULID per ADR-0031 — use a realistic 26-char
-        // shape so the fixture survives a future newtype tightening.
-        ctx.experiment_id = Some("01HXEXP00000000000000000AB".to_string());
-        // variant_name is a human-readable label, not a content id.
-        ctx.variant_name = Some("candidate".to_string());
+        let ctx = SpanContext {
+            prompt_id: Some("a1b2c3d4e5f6".to_string()),
+            tool_desc_ids: vec!["t000aaaaaaaa".to_string(), "t111bbbbbbbb".to_string()],
+            skill_ids: vec!["s00000000000".to_string()],
+            release_tag: Some("agents.weather@stable".to_string()),
+            experiment_id: Some("01HXEXP00000000000000000AB".to_string()),
+            variant_name: Some("candidate".to_string()),
+            ..Default::default()
+        };
 
         let json = serde_json::to_value(&ctx).expect("serialise");
         assert_eq!(json["prompt_id"], "a1b2c3d4e5f6");

--- a/crates/awaken-ext-observability/src/otel.rs
+++ b/crates/awaken-ext-observability/src/otel.rs
@@ -3362,9 +3362,9 @@ mod tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
 mod attribution_otel_tests {
     use super::*;
-    use crate::metrics::{GenAISpan, SpanContext};
 
     fn span_with_attribution() -> GenAISpan {
         let mut ctx = SpanContext::default();

--- a/crates/awaken-ext-observability/src/runtime_stats.rs
+++ b/crates/awaken-ext-observability/src/runtime_stats.rs
@@ -28,9 +28,7 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
-use crate::metrics::{
-    AgentMetrics, DelegationSpan, GenAISpan, HandoffSpan, MetricsEvent, SuspensionSpan, ToolSpan,
-};
+use crate::metrics::{AgentMetrics, GenAISpan, MetricsEvent, ToolSpan};
 use crate::sink::MetricsSink;
 
 /// Default bucket length: 10 minutes.
@@ -603,19 +601,10 @@ pub fn parse_window_str(s: &str) -> Result<Duration, String> {
     Ok(Duration::from_secs(n * multiplier))
 }
 
-// ---------------------------------------------------------------------------
-// Suppress dead-code warnings for variant types only used through trait dispatch.
-// ---------------------------------------------------------------------------
-
-#[allow(dead_code)]
-fn _types_used(s: &SuspensionSpan, h: &HandoffSpan, d: &DelegationSpan) {
-    let _ = (s, h, d);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metrics::SpanContext;
+    use crate::metrics::{DelegationSpan, HandoffSpan, SpanContext, SuspensionSpan};
 
     fn ctx(agent: &str) -> SpanContext {
         SpanContext {

--- a/crates/awaken-ext-permission/src/matcher.rs
+++ b/crates/awaken-ext-permission/src/matcher.rs
@@ -1,8 +1,14 @@
-//! Pattern matching engine — re-exports from [`awaken_tool_pattern`].
+//! Deprecated re-export shim for [`awaken_tool_pattern`].
 //!
-//! The matching logic lives in `awaken-tool-pattern` so it can be
-//! reused by other extensions (e.g. reminder, observability).
+//! The matching logic now lives in `awaken-tool-pattern`. This module
+//! re-exports the same symbols so external callers still compile; new
+//! code should import from `awaken_tool_pattern` directly.
+#![allow(deprecated)]
 
+#[deprecated(
+    since = "0.5.1",
+    note = "import from `awaken_tool_pattern` directly; this shim will be removed in a future major release"
+)]
 pub use awaken_tool_pattern::{
     MatchResult, Specificity, evaluate_field_condition, evaluate_op, op_precision, pattern_matches,
     resolve_path, schema_has_path, validate_pattern_fields, wildcard_match,

--- a/crates/awaken-ext-permission/tests/permission_tests.rs
+++ b/crates/awaken-ext-permission/tests/permission_tests.rs
@@ -2,6 +2,7 @@
 
 use awaken_ext_permission::*;
 use awaken_runtime::state::{MutationBatch, StateKey};
+use awaken_tool_pattern::pattern_matches;
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -12,16 +13,16 @@ use std::collections::HashMap;
 #[test]
 fn matcher_exact_tool_any_args() {
     let p = ToolCallPattern::tool("Bash");
-    let result = matcher::pattern_matches(&p, "Bash", &json!({"command": "ls"}));
+    let result = pattern_matches(&p, "Bash", &json!({"command": "ls"}));
     assert!(result.is_match());
 }
 
 #[test]
 fn matcher_glob_tool_any_args() {
     let p = ToolCallPattern::tool_glob("mcp__*");
-    let result = matcher::pattern_matches(&p, "mcp__github__issues", &json!({}));
+    let result = pattern_matches(&p, "mcp__github__issues", &json!({}));
     assert!(result.is_match());
-    let result2 = matcher::pattern_matches(&p, "read_file", &json!({}));
+    let result2 = pattern_matches(&p, "read_file", &json!({}));
     assert!(!result2.is_match());
 }
 
@@ -34,10 +35,8 @@ fn matcher_primary_with_exact_op() {
             value: "git status".into(),
         },
     };
-    assert!(matcher::pattern_matches(&p, "Bash", &json!({"command": "git status"})).is_match());
-    assert!(
-        !matcher::pattern_matches(&p, "Bash", &json!({"command": "git status --short"})).is_match()
-    );
+    assert!(pattern_matches(&p, "Bash", &json!({"command": "git status"})).is_match());
+    assert!(!pattern_matches(&p, "Bash", &json!({"command": "git status --short"})).is_match());
 }
 
 #[test]
@@ -49,9 +48,9 @@ fn matcher_primary_with_regex_op() {
             value: "^(npm|yarn) ".into(),
         },
     };
-    assert!(matcher::pattern_matches(&p, "Bash", &json!({"command": "npm install"})).is_match());
-    assert!(matcher::pattern_matches(&p, "Bash", &json!({"command": "yarn add foo"})).is_match());
-    assert!(!matcher::pattern_matches(&p, "Bash", &json!({"command": "cargo build"})).is_match());
+    assert!(pattern_matches(&p, "Bash", &json!({"command": "npm install"})).is_match());
+    assert!(pattern_matches(&p, "Bash", &json!({"command": "yarn add foo"})).is_match());
+    assert!(!pattern_matches(&p, "Bash", &json!({"command": "cargo build"})).is_match());
 }
 
 // ---------------------------------------------------------------------------
@@ -439,9 +438,9 @@ fn overrides_cleared_leaves_policy_intact() {
 fn glob_pattern_edge_case_question_mark() {
     // "?" matches a single character
     let p = ToolCallPattern::tool_glob("mcp_?_read");
-    let result = matcher::pattern_matches(&p, "mcp_a_read", &json!({}));
+    let result = pattern_matches(&p, "mcp_a_read", &json!({}));
     assert!(result.is_match());
-    let result2 = matcher::pattern_matches(&p, "mcp_ab_read", &json!({}));
+    let result2 = pattern_matches(&p, "mcp_ab_read", &json!({}));
     assert!(!result2.is_match());
 }
 

--- a/crates/awaken-ext-skills/Cargo.toml
+++ b/crates/awaken-ext-skills/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { workspace = true }
 tempfile = { workspace = true }
 awaken-ext-mcp = { workspace = true }
 awaken-runtime = { workspace = true, features = ["test-utils"] }
-mcp = { package = "model-context-protocol", version = "0.2", default-features = false, features = ["client"] }
+mcp = { workspace = true, features = ["client"] }
 
 [features]
 default = []

--- a/crates/awaken-ext-skills/Cargo.toml
+++ b/crates/awaken-ext-skills/Cargo.toml
@@ -29,7 +29,7 @@ unicode-normalization = "0.1"
 
 [dev-dependencies]
 tokio = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }
 awaken-ext-mcp = { workspace = true }
 awaken-runtime = { workspace = true, features = ["test-utils"] }
 mcp = { package = "model-context-protocol", version = "0.2", default-features = false, features = ["client"] }

--- a/crates/awaken-runtime/Cargo.toml
+++ b/crates/awaken-runtime/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { workspace = true, features = ["form"] }
 schemars = { workspace = true }
 jsonschema = { workspace = true }
 parking_lot = { workspace = true }
-metrics = "0.24"
+metrics = { workspace = true }
 jsonwebtoken = { version = "10", default-features = false, features = ["use_pem", "rust_crypto"], optional = true }
 
 [features]

--- a/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
+++ b/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
@@ -24,9 +24,13 @@ pub const SEND_MESSAGE_TOOL_ID: &str = "send_message";
 // ── Types ────────────────────────────────────────────────────────────
 
 /// Recipient selector — who receives the message.
+///
+/// Retained as a public type for downstream callers that build typed
+/// requests. The current `send_message_tool` body parses arguments from
+/// raw JSON; this enum mirrors that wire format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "relation", rename_all = "snake_case")]
-#[allow(dead_code)] // used by future typed API; current impl parses JSON directly
+#[allow(dead_code)]
 pub enum RecipientRef {
     /// Send to the parent agent that spawned the current task/agent.
     Parent,

--- a/crates/awaken-runtime/tests/tool_side_effects.rs
+++ b/crates/awaken-runtime/tests/tool_side_effects.rs
@@ -23,9 +23,7 @@ use awaken_contract::contract::tool::{
 use awaken_contract::state::{MergeStrategy, StateKey, StateKeyOptions};
 
 use awaken_runtime::RuntimeError;
-use awaken_runtime::agent::state::{
-    AddContextMessage, ContextMessageStore, ContextThrottleState, RunLifecycle, ToolCallStates,
-};
+use awaken_runtime::agent::state::{AddContextMessage, ContextMessageStore};
 use awaken_runtime::execution::ParallelToolExecutor;
 use awaken_runtime::loop_runner::{AgentLoopParams, build_agent_env, run_agent_loop};
 use awaken_runtime::phase::PhaseRuntime;
@@ -54,21 +52,7 @@ impl StateKey for Counter {
 // Plugins
 // ---------------------------------------------------------------------------
 
-struct LoopStatePlugin;
-
-impl Plugin for LoopStatePlugin {
-    fn descriptor(&self) -> PluginDescriptor {
-        PluginDescriptor { name: "loop-state" }
-    }
-
-    fn register(&self, r: &mut PluginRegistrar) -> Result<(), StateError> {
-        r.register_key::<RunLifecycle>(StateKeyOptions::default())?;
-        r.register_key::<ToolCallStates>(StateKeyOptions::default())?;
-        r.register_key::<ContextThrottleState>(StateKeyOptions::default())?;
-        r.register_key::<ContextMessageStore>(StateKeyOptions::default())?;
-        Ok(())
-    }
-}
+use awaken_runtime::loop_runner::LoopStatePlugin;
 
 struct CounterPlugin;
 

--- a/crates/awaken-server/Cargo.toml
+++ b/crates/awaken-server/Cargo.toml
@@ -33,7 +33,7 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 async-stream = "0.3"
 tokio-stream = "0.1"
-bytes = "1"
+bytes = { workspace = true }
 parking_lot = { workspace = true }
 arc-swap = "1"
 reqwest = { workspace = true }
@@ -54,8 +54,8 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 
 # Metrics / observability
-metrics = "0.24"
-metrics-exporter-prometheus = "0.16"
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 awaken-ext-observability = { workspace = true }
 
 # Optional
@@ -74,8 +74,8 @@ async-trait = { workspace = true }
 genai = { workspace = true }
 uuid = { workspace = true }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], default-features = false }
-tempfile = "3"
-testcontainers = "0.23"
+tempfile = { workspace = true }
+testcontainers = { workspace = true }
 
 [features]
 default = ["permission"]

--- a/crates/awaken-server/Cargo.toml
+++ b/crates/awaken-server/Cargo.toml
@@ -28,9 +28,9 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "time"] }
-axum = { version = "0.7", default-features = false, features = ["http1", "json", "matched-path", "query", "tokio"] }
-tower = { version = "0.5", features = ["limit"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+axum = { workspace = true, features = ["http1", "json", "matched-path", "query", "tokio"] }
+tower = { workspace = true, features = ["limit"] }
+tower-http = { workspace = true, features = ["cors", "trace"] }
 async-stream = "0.3"
 tokio-stream = "0.1"
 bytes = { workspace = true }
@@ -45,7 +45,7 @@ schemars = { workspace = true }
 subtle = { workspace = true }
 
 # MCP server
-mcp = { package = "model-context-protocol", version = "0.2", default-features = false, features = ["server", "client"] }
+mcp = { workspace = true, features = ["server", "client"] }
 
 # Audit log
 ulid = "1"
@@ -64,7 +64,7 @@ awaken-ext-permission = { workspace = true, optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 http-body-util = "0.1"
-tower = { version = "0.5", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 awaken-stores = { workspace = true, features = ["file", "postgres", "nats"] }
 awaken-runtime = { workspace = true }
 awaken-ext-observability = { workspace = true, features = ["otel"] }
@@ -73,7 +73,7 @@ phoenix-test-helpers = { path = "../../e2e/phoenix/test-helpers" }
 async-trait = { workspace = true }
 genai = { workspace = true }
 uuid = { workspace = true }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], default-features = false }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "json"] }
 tempfile = { workspace = true }
 testcontainers = { workspace = true }
 

--- a/crates/awaken-server/src/auth.rs
+++ b/crates/awaken-server/src/auth.rs
@@ -1,0 +1,45 @@
+//! Shared HTTP authentication helpers.
+
+/// Strip the `Bearer` scheme word from an `Authorization` header value
+/// (ASCII case-insensitive, per RFC 6750 §2.1), returning the remainder
+/// after the first ASCII space.
+///
+/// Any additional whitespace in the token is preserved — trimming policy
+/// belongs to the caller. Returns `None` if the value does not contain a
+/// space, or the leading word is not `bearer`.
+pub(crate) fn strip_bearer_prefix(value: &str) -> Option<&str> {
+    let (scheme, rest) = value.split_once(' ')?;
+    scheme.eq_ignore_ascii_case("bearer").then_some(rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_bearer_prefix;
+
+    #[test]
+    fn accepts_canonical_and_mixed_case_schemes() {
+        assert_eq!(strip_bearer_prefix("Bearer abc"), Some("abc"));
+        assert_eq!(strip_bearer_prefix("bearer abc"), Some("abc"));
+        assert_eq!(strip_bearer_prefix("BEARER abc"), Some("abc"));
+        assert_eq!(strip_bearer_prefix("bEaReR abc"), Some("abc"));
+    }
+
+    #[test]
+    fn rejects_non_bearer_or_missing_space() {
+        assert_eq!(strip_bearer_prefix("Basic abc"), None);
+        assert_eq!(strip_bearer_prefix("Bearerabc"), None);
+        assert_eq!(strip_bearer_prefix(""), None);
+        assert_eq!(strip_bearer_prefix("Bearer"), None);
+    }
+
+    #[test]
+    fn does_not_trim_extra_token_whitespace() {
+        // Only the first ASCII space is consumed as the scheme/token
+        // delimiter. Any further whitespace is part of the token and is
+        // returned verbatim — trimming policy belongs to the caller.
+        let double_space = "Bearer \u{0020}abc"; // explicit two ASCII spaces
+        assert_eq!(strip_bearer_prefix(double_space), Some(" abc"));
+        assert_eq!(strip_bearer_prefix("Bearer abc "), Some("abc "));
+        assert_eq!(strip_bearer_prefix("Bearer \tabc"), Some("\tabc"));
+    }
+}

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -119,7 +119,7 @@ pub fn config_routes() -> Router<AppState> {
 async fn get_capabilities(
     State(state): State<AppState>,
     headers: HeaderMap,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     Ok(Json(
@@ -131,7 +131,7 @@ async fn get_schema(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(namespace): Path<String>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let schema = match namespace {
@@ -145,7 +145,7 @@ async fn get_schema(
 async fn get_config_diagnostics(
     State(state): State<AppState>,
     headers: HeaderMap,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let diagnostics = service.registry_diagnostics().map_err(map_service_error)?;
@@ -156,7 +156,7 @@ async fn preview_provider_removal(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let preview = service
@@ -170,7 +170,7 @@ async fn list_agents(
     State(state): State<AppState>,
     headers: HeaderMap,
     query: Query<ListParams>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     list_config_inner(state, "agents".to_string(), query.0).await
 }
@@ -179,7 +179,7 @@ async fn get_agent(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     get_config_inner(state, "agents".to_string(), id).await
 }
@@ -189,7 +189,7 @@ async fn list_config(
     headers: HeaderMap,
     Path(namespace): Path<String>,
     Query(params): Query<ListParams>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     list_config_inner(state, namespace, params).await
 }
@@ -198,7 +198,7 @@ async fn list_config_inner(
     state: AppState,
     namespace: String,
     params: ListParams,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let items = match namespace {
@@ -221,13 +221,13 @@ async fn create_config(
     headers: HeaderMap,
     Path(namespace): Path<String>,
     Json(body): Json<Value>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
         RouteConfigNamespace::Tools => {
-            return Err(map_service_error(namespace.read_only_error()).into());
+            return Err(map_service_error(namespace.read_only_error()));
         }
     };
     let service = ConfigService::new(&state).map_err(map_service_error)?;
@@ -252,13 +252,13 @@ async fn validate_config(
     Path(namespace): Path<String>,
     Query(params): Query<ValidateParams>,
     Json(body): Json<Value>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
         RouteConfigNamespace::Tools => {
-            return Err(map_service_error(namespace.read_only_error()).into());
+            return Err(map_service_error(namespace.read_only_error()));
         }
     };
     let service = ConfigService::new(&state).map_err(map_service_error)?;
@@ -276,7 +276,7 @@ async fn get_config(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     get_config_inner(state, namespace, id).await
 }
@@ -285,7 +285,7 @@ async fn get_config_inner(
     state: AppState,
     namespace: String,
     id: String,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let value = match namespace {
@@ -301,7 +301,7 @@ async fn get_config_meta(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
@@ -319,7 +319,7 @@ async fn list_config_meta(
     headers: HeaderMap,
     Path(namespace): Path<String>,
     Query(params): Query<ListParams>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
@@ -344,13 +344,13 @@ async fn put_config(
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
     Json(body): Json<Value>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
         RouteConfigNamespace::Tools => {
-            return Err(map_service_error(namespace.read_only_error()).into());
+            return Err(map_service_error(namespace.read_only_error()));
         }
     };
     let service = ConfigService::new(&state).map_err(map_service_error)?;
@@ -372,22 +372,21 @@ async fn delete_config(
     }
     let namespace = match RouteConfigNamespace::parse(&namespace) {
         Ok(ns) => ns,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
         RouteConfigNamespace::Tools => {
-            return ConfigRouteError::Api(map_service_error(namespace.read_only_error()))
-                .into_response();
+            return map_service_error(namespace.read_only_error()).into_response();
         }
     };
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     let blockers = match delete_blockers_for_route(&service, namespace, &id, params.force).await {
         Ok(blockers) => blockers,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     if !blockers.is_empty() {
         return (
@@ -404,7 +403,7 @@ async fn delete_config(
         .await
     {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -450,18 +449,17 @@ async fn restore_config(
     }
     let namespace = match RouteConfigNamespace::parse(&namespace) {
         Ok(ns) => ns,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
         RouteConfigNamespace::Tools => {
-            return ConfigRouteError::Api(map_service_error(namespace.read_only_error()))
-                .into_response();
+            return map_service_error(namespace.read_only_error()).into_response();
         }
     };
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service
         .restore(namespace, &id, &body.version, &headers)
@@ -493,12 +491,8 @@ async fn restore_config(
             Json(json!({"error": msg})),
         )
             .into_response(),
-        Err(RestoreError::Service(e)) => {
-            ConfigRouteError::Api(map_service_error(e)).into_response()
-        }
-        Err(RestoreError::Storage(e)) => {
-            ConfigRouteError::Api(ApiError::Internal(e.to_string())).into_response()
-        }
+        Err(RestoreError::Service(e)) => map_service_error(e).into_response(),
+        Err(RestoreError::Storage(e)) => ApiError::Internal(e.to_string()).into_response(),
     }
 }
 
@@ -506,7 +500,7 @@ async fn test_provider_connection(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let result: ProviderTestResult = service
@@ -520,19 +514,20 @@ async fn get_mcp_server_status(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
 
     // 503 when no MCP runtime is configured.
-    let manager = state.config_runtime_manager.as_ref().ok_or_else(|| {
-        ConfigRouteError::ServiceUnavailable("MCP runtime is not configured".into())
-    })?;
+    let manager = state
+        .config_runtime_manager
+        .as_ref()
+        .ok_or_else(|| ApiError::ServiceUnavailable("MCP runtime is not configured".into()))?;
 
     // 404 when the id is unknown to the active registry.
     let status = manager
         .mcp_server_status(&id)
         .await
-        .ok_or_else(|| ConfigRouteError::Api(ApiError::NotFound(format!("mcp-server/{id}"))))?;
+        .ok_or_else(|| ApiError::NotFound(format!("mcp-server/{id}")))?;
 
     Ok(Json(json!({
         "connected": status.connected,
@@ -562,25 +557,26 @@ async fn post_mcp_server_restart(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(id): Path<String>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
 
     // 503 when no MCP runtime is configured.
-    let manager = state.config_runtime_manager.as_ref().ok_or_else(|| {
-        ConfigRouteError::ServiceUnavailable("MCP runtime is not configured".into())
-    })?;
+    let manager = state
+        .config_runtime_manager
+        .as_ref()
+        .ok_or_else(|| ApiError::ServiceUnavailable("MCP runtime is not configured".into()))?;
 
     manager.mcp_server_reconnect(&id).await.map_err(|e| {
         // Map unknown-server errors (surfaced as InvalidConfig wrapping UnknownServer) to 404.
         let msg = e.to_string();
         if msg.contains("unknown server") || msg.contains("no MCP registry is active") {
             if msg.contains("no MCP registry") {
-                ConfigRouteError::ServiceUnavailable(msg)
+                ApiError::ServiceUnavailable(msg)
             } else {
-                ConfigRouteError::Api(ApiError::NotFound(format!("mcp-server/{id}")))
+                ApiError::NotFound(format!("mcp-server/{id}"))
             }
         } else {
-            ConfigRouteError::Api(ApiError::Internal(msg))
+            ApiError::Internal(msg)
         }
     })?;
 
@@ -605,57 +601,21 @@ async fn list_audit_log(
     State(state): State<AppState>,
     headers: HeaderMap,
     Query(query): Query<AuditQuery>,
-) -> Result<impl IntoResponse, ConfigRouteError> {
+) -> Result<impl IntoResponse, ApiError> {
     ensure_admin_auth(&state, &headers)?;
-    let audit = state.audit_log().ok_or_else(|| {
-        ConfigRouteError::ServiceUnavailable("audit log is not configured".into())
-    })?;
+    let audit = state
+        .audit_log()
+        .ok_or_else(|| ApiError::ServiceUnavailable("audit log is not configured".into()))?;
     let mut effective_query = query;
     effective_query.limit = effective_query.limit.clamp(1, 1000);
     let page = audit.query(effective_query).await.map_err(|e| match e {
-        AuditQueryError::InvalidCursor => {
-            ConfigRouteError::Api(ApiError::BadRequest("invalid cursor".into()))
-        }
-        AuditQueryError::Storage(storage_err) => {
-            ConfigRouteError::Api(ApiError::Internal(storage_err.to_string()))
-        }
+        AuditQueryError::InvalidCursor => ApiError::BadRequest("invalid cursor".into()),
+        AuditQueryError::Storage(storage_err) => ApiError::Internal(storage_err.to_string()),
     })?;
     Ok(Json(page))
 }
 
-#[derive(Debug)]
-pub(crate) enum ConfigRouteError {
-    Api(ApiError),
-    ServiceUnavailable(String),
-    Unauthorized(String),
-}
-
-impl From<ApiError> for ConfigRouteError {
-    fn from(error: ApiError) -> Self {
-        Self::Api(error)
-    }
-}
-
-impl IntoResponse for ConfigRouteError {
-    fn into_response(self) -> Response {
-        match self {
-            ConfigRouteError::Api(error) => error.into_response(),
-            ConfigRouteError::ServiceUnavailable(message) => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({ "error": message })),
-            )
-                .into_response(),
-            ConfigRouteError::Unauthorized(message) => {
-                (StatusCode::UNAUTHORIZED, Json(json!({ "error": message }))).into_response()
-            }
-        }
-    }
-}
-
-pub(crate) fn ensure_admin_auth(
-    state: &AppState,
-    headers: &HeaderMap,
-) -> Result<(), ConfigRouteError> {
+pub(crate) fn ensure_admin_auth(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError> {
     let config = crate::app::admin_api_config(state);
     ensure_admin_auth_for_token(config.bearer_token.as_ref(), headers)
 }
@@ -663,29 +623,29 @@ pub(crate) fn ensure_admin_auth(
 fn ensure_admin_auth_for_token(
     expected: Option<&awaken_contract::RedactedString>,
     headers: &HeaderMap,
-) -> Result<(), ConfigRouteError> {
+) -> Result<(), ApiError> {
     let Some(expected) = expected else {
         return Ok(());
     };
     let mut auth_values = headers.get_all(axum::http::header::AUTHORIZATION).iter();
     let Some(auth) = auth_values.next() else {
-        return Err(ConfigRouteError::Unauthorized(
+        return Err(ApiError::Unauthorized(
             "admin authentication required".into(),
         ));
     };
     if auth_values.next().is_some() {
-        return Err(ConfigRouteError::Unauthorized(
+        return Err(ApiError::Unauthorized(
             "multiple Authorization headers are not allowed".into(),
         ));
     }
     let auth = auth
         .to_str()
-        .map_err(|_| ConfigRouteError::Unauthorized("invalid Authorization header".into()))?;
+        .map_err(|_| ApiError::Unauthorized("invalid Authorization header".into()))?;
     let Some(token) = auth
         .strip_prefix("Bearer ")
         .or_else(|| auth.strip_prefix("bearer "))
     else {
-        return Err(ConfigRouteError::Unauthorized(
+        return Err(ApiError::Unauthorized(
             "Authorization header must use Bearer authentication".into(),
         ));
     };
@@ -695,9 +655,7 @@ fn ensure_admin_auth_for_token(
         .unwrap_u8()
         != 1
     {
-        return Err(ConfigRouteError::Unauthorized(
-            "invalid admin bearer token".into(),
-        ));
+        return Err(ApiError::Unauthorized("invalid admin bearer token".into()));
     }
     Ok(())
 }
@@ -713,12 +671,12 @@ async fn patch_agent_overrides_handler(
     }
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service.patch_agent_overrides(&id, body, &headers).await {
         Ok(spec) => Json(spec).into_response(),
         Err(e) if is_overrides_not_supported_for_user_record(&e) => unprocessable_error(e),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -733,12 +691,12 @@ async fn validate_agent_overrides_handler(
     }
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service.validate_agent_overrides(&id, body).await {
         Ok(spec) => Json(spec).into_response(),
         Err(e) if is_overrides_not_supported_for_user_record(&e) => unprocessable_error(e),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -752,12 +710,12 @@ async fn clear_agent_overrides_handler(
     }
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service.clear_agent_overrides(&id, &headers).await {
         Ok(spec) => Json(spec).into_response(),
         Err(e) if is_overrides_not_supported_for_user_record(&e) => unprocessable_error(e),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -771,7 +729,7 @@ async fn clear_agent_override_field_handler(
     }
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service
         .clear_agent_override_field(&id, &field, &headers)
@@ -779,7 +737,7 @@ async fn clear_agent_override_field_handler(
     {
         Ok(spec) => Json(spec).into_response(),
         Err(e) if is_overrides_not_supported_for_user_record(&e) => unprocessable_error(e),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -794,12 +752,12 @@ async fn patch_tool_overrides_handler(
     }
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service.patch_tool_overrides(&id, body, &headers).await {
         Ok(spec) => Json(spec).into_response(),
         Err(e) if is_overrides_not_supported_for_user_record(&e) => unprocessable_error(e),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -813,12 +771,12 @@ async fn clear_tool_overrides_handler(
     }
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service.clear_tool_overrides(&id, &headers).await {
         Ok(spec) => Json(spec).into_response(),
         Err(e) if is_overrides_not_supported_for_user_record(&e) => unprocessable_error(e),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -832,7 +790,7 @@ async fn clear_tool_override_field_handler(
     }
     let service = match ConfigService::new(&state) {
         Ok(s) => s,
-        Err(e) => return ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => return map_service_error(e).into_response(),
     };
     match service
         .clear_tool_override_field(&id, &field, &headers)
@@ -840,7 +798,7 @@ async fn clear_tool_override_field_handler(
     {
         Ok(spec) => Json(spec).into_response(),
         Err(e) if is_overrides_not_supported_for_user_record(&e) => unprocessable_error(e),
-        Err(e) => ConfigRouteError::Api(map_service_error(e)).into_response(),
+        Err(e) => map_service_error(e).into_response(),
     }
 }
 
@@ -928,7 +886,7 @@ mod tests {
                 HeaderValue::from_str(value).expect("valid header value"),
             );
             let err = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
-            let ConfigRouteError::Unauthorized(message) = &err else {
+            let ApiError::Unauthorized(message) = &err else {
                 panic!("expected Unauthorized for {value:?}, got {err:?}");
             };
             assert!(
@@ -953,7 +911,7 @@ mod tests {
             HeaderValue::from_static("Bearer different"),
         );
         let err = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
-        let ConfigRouteError::Unauthorized(message) = &err else {
+        let ApiError::Unauthorized(message) = &err else {
             panic!("expected Unauthorized for duplicate headers, got {err:?}");
         };
         assert!(

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -641,10 +641,7 @@ fn ensure_admin_auth_for_token(
     let auth = auth
         .to_str()
         .map_err(|_| ApiError::Unauthorized("invalid Authorization header".into()))?;
-    let Some(token) = auth
-        .strip_prefix("Bearer ")
-        .or_else(|| auth.strip_prefix("bearer "))
-    else {
+    let Some(token) = crate::auth::strip_bearer_prefix(auth) else {
         return Err(ApiError::Unauthorized(
             "Authorization header must use Bearer authentication".into(),
         ));

--- a/crates/awaken-server/src/error.rs
+++ b/crates/awaken-server/src/error.rs
@@ -1,0 +1,45 @@
+//! Canonical API error type for HTTP handlers.
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+/// API error type returned by route handlers.
+///
+/// Marked `#[non_exhaustive]` so adding variants is not a SemVer-breaking
+/// change for downstream crates that match on it.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ApiError {
+    BadRequest(String),
+    Unauthorized(String),
+    Conflict(String),
+    NotFound(String),
+    ThreadNotFound(String),
+    RunNotFound(String),
+    /// Feature/route present but the backing capability isn't installed —
+    /// e.g. `permission-preview` requested but server was built without
+    /// `--features permission`. Distinct from 404 so callers can
+    /// differentiate "no such resource" from "feature not available".
+    ServiceUnavailable(String),
+    Internal(String),
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            ApiError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
+            ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg),
+            ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
+            ApiError::ThreadNotFound(id) => {
+                (StatusCode::NOT_FOUND, format!("thread not found: {id}"))
+            }
+            ApiError::RunNotFound(id) => (StatusCode::NOT_FOUND, format!("run not found: {id}")),
+            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
+            ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+        };
+        (status, Json(json!({"error": message}))).into_response()
+    }
+}

--- a/crates/awaken-server/src/lib.rs
+++ b/crates/awaken-server/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod app;
 pub mod config_routes;
+pub mod error;
 pub mod event_relay;
 pub mod http_run;
 pub mod http_sse;

--- a/crates/awaken-server/src/lib.rs
+++ b/crates/awaken-server/src/lib.rs
@@ -22,4 +22,5 @@ pub mod query;
 pub mod request;
 pub mod routes;
 pub mod services;
+pub mod time;
 pub mod transport;

--- a/crates/awaken-server/src/lib.rs
+++ b/crates/awaken-server/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(missing_docs)]
 
 pub mod app;
+pub(crate) mod auth;
 pub mod config_routes;
 pub mod error;
 pub mod event_relay;

--- a/crates/awaken-server/src/protocols/a2a/agent_card.rs
+++ b/crates/awaken-server/src/protocols/a2a/agent_card.rs
@@ -151,10 +151,7 @@ fn ensure_extended_card_auth(st: &AppState, headers: &HeaderMap) -> Result<(), A
             "missing Authorization header for extendedAgentCard",
         ));
     };
-    let Some(token) = auth
-        .strip_prefix("Bearer ")
-        .or_else(|| auth.strip_prefix("bearer "))
-    else {
+    let Some(token) = crate::auth::strip_bearer_prefix(auth) else {
         return Err(A2aError::unauthenticated(
             "Authorization header must use Bearer authentication",
         ));

--- a/crates/awaken-server/src/protocols/acp/stdio.rs
+++ b/crates/awaken-server/src/protocols/acp/stdio.rs
@@ -395,12 +395,7 @@ fn permission_option_to_resume(option_id: &str) -> acp::Result<(ResumeDecisionAc
     ))
 }
 
-fn unix_timestamp_millis() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as u64)
-        .unwrap_or(0)
-}
+use crate::time::now_millis as unix_timestamp_millis;
 
 fn prompt_blocks_to_message_content(
     blocks: &[ContentBlock],

--- a/crates/awaken-server/src/protocols/mcp/adapter.rs
+++ b/crates/awaken-server/src/protocols/mcp/adapter.rs
@@ -17,6 +17,7 @@ use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::message::Message;
 use awaken_runtime::{AgentRuntime, RunRequest};
 
+use super::JSON_RPC_VERSION;
 use crate::transport::channel_sink::ChannelEventSink;
 
 /// An MCP tool backed by an Awaken agent.
@@ -58,7 +59,7 @@ impl AgentMcpTool {
                 "data": message,
             });
             let notification = JsonRpcNotification {
-                jsonrpc: "2.0".to_string(),
+                jsonrpc: JSON_RPC_VERSION.to_string(),
                 method: "notifications/message".to_string(),
                 params: Some(params),
             };

--- a/crates/awaken-server/src/protocols/mcp/http.rs
+++ b/crates/awaken-server/src/protocols/mcp/http.rs
@@ -26,12 +26,12 @@ use serde_json::Value;
 use tokio::sync::{Mutex, RwLock, Semaphore, mpsc, oneshot};
 use uuid::Uuid;
 
+use super::JSON_RPC_VERSION;
 use crate::app::AppState;
 use crate::http_sse::{format_sse_data_with_id, sse_body_stream, sse_response};
 
 const HEADER_SESSION_ID: &str = "MCP-Session-Id";
 const HEADER_PROTOCOL_VERSION: &str = "MCP-Protocol-Version";
-const JSON_RPC_VERSION: &str = "2.0";
 
 #[derive(Default)]
 pub struct McpHttpState {

--- a/crates/awaken-server/src/protocols/mcp/mod.rs
+++ b/crates/awaken-server/src/protocols/mcp/mod.rs
@@ -146,7 +146,7 @@ mod tests {
         let (_server, mut channels) = create_mcp_server(&runtime);
 
         let request = mcp::JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: JSON_RPC_VERSION.to_string(),
             id: mcp::JsonRpcId::Number(1),
             method: "initialize".to_string(),
             params: None,
@@ -175,7 +175,7 @@ mod tests {
         let (_server, mut channels) = create_mcp_server(&runtime);
 
         let request = mcp::JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
+            jsonrpc: JSON_RPC_VERSION.to_string(),
             id: mcp::JsonRpcId::Number(2),
             method: "tools/list".to_string(),
             params: None,

--- a/crates/awaken-server/src/protocols/mcp/mod.rs
+++ b/crates/awaken-server/src/protocols/mcp/mod.rs
@@ -7,6 +7,10 @@ pub mod adapter;
 pub mod http;
 pub mod stdio;
 
+/// Wire-protocol version string used in every JSON-RPC envelope this module
+/// emits or accepts. The MCP spec pins it to `"2.0"`.
+pub(crate) const JSON_RPC_VERSION: &str = "2.0";
+
 use std::sync::Arc;
 
 use mcp::server::{McpServer, McpServerChannels, McpServerConfig};

--- a/crates/awaken-server/src/protocols/mcp/stdio.rs
+++ b/crates/awaken-server/src/protocols/mcp/stdio.rs
@@ -13,7 +13,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 
 use awaken_runtime::AgentRuntime;
 
-const JSON_RPC_VERSION: &str = "2.0";
+use super::JSON_RPC_VERSION;
 
 /// Run the MCP stdio server on actual stdin/stdout.
 pub async fn serve_stdio(runtime: Arc<AgentRuntime>) {

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -997,10 +997,7 @@ async fn submit_decision(
         action,
         result: payload.payload.clone(),
         reason: None,
-        updated_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0),
+        updated_at: crate::time::now_millis(),
     };
 
     RunControlService::new(st)
@@ -1042,10 +1039,7 @@ async fn submit_thread_decision(
         action,
         result: payload.payload.clone(),
         reason: None,
-        updated_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0),
+        updated_at: crate::time::now_millis(),
     };
 
     RunControlService::new(st)

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -29,38 +29,7 @@ use crate::services::run_control_service::{
 };
 use awaken_runtime::RunRequest;
 
-/// API error type returned by route handlers.
-#[derive(Debug)]
-pub enum ApiError {
-    BadRequest(String),
-    Conflict(String),
-    NotFound(String),
-    ThreadNotFound(String),
-    RunNotFound(String),
-    /// Feature/route present but the backing capability isn't installed —
-    /// e.g. `permission-preview` requested but server was built without
-    /// `--features permission`. Distinct from 404 so callers can
-    /// differentiate "no such resource" from "feature not available".
-    ServiceUnavailable(String),
-    Internal(String),
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        let (status, message) = match self {
-            ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg),
-            ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
-            ApiError::ThreadNotFound(id) => {
-                (StatusCode::NOT_FOUND, format!("thread not found: {id}"))
-            }
-            ApiError::RunNotFound(id) => (StatusCode::NOT_FOUND, format!("run not found: {id}")),
-            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
-            ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-        };
-        (status, Json(json!({"error": message}))).into_response()
-    }
-}
+pub use crate::error::ApiError;
 
 pub(crate) fn map_mailbox_error(error: MailboxError) -> ApiError {
     match error {

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -450,10 +450,7 @@ pub fn derive_actor(headers: &HeaderMap) -> String {
     let base = headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| {
-            s.strip_prefix("Bearer ")
-                .or_else(|| s.strip_prefix("bearer "))
-        })
+        .and_then(crate::auth::strip_bearer_prefix)
         .map(|token| {
             let hash = sha2::Sha256::digest(token.as_bytes());
             let hex = format!("{hash:x}");

--- a/crates/awaken-server/src/services/config_envelope.rs
+++ b/crates/awaken-server/src/services/config_envelope.rs
@@ -58,16 +58,6 @@ pub(crate) fn wrap_user(spec: &Value) -> Result<Value, serde_json::Error> {
     record.to_value()
 }
 
-/// Wrap a bare spec Value into a Builtin-source envelope.
-#[allow(dead_code)]
-pub(crate) fn wrap_builtin(spec: &Value, binary_version: &str) -> Result<Value, serde_json::Error> {
-    let record = ConfigRecord {
-        spec: spec.clone(),
-        meta: RecordMeta::new_builtin(binary_version),
-    };
-    record.to_value()
-}
-
 /// If `value` is already an envelope (object containing `spec` and `meta`),
 /// return it unchanged. Otherwise wrap as User per `wrap_user`.
 ///
@@ -119,9 +109,7 @@ mod tests {
     use awaken_contract::{ConfigRecord, RecordSource};
     use serde_json::json;
 
-    use super::{
-        ensure_envelope, extract_timestamps, spec_field, unwrap_spec, wrap_builtin, wrap_user,
-    };
+    use super::{ensure_envelope, extract_timestamps, spec_field, unwrap_spec, wrap_user};
 
     #[test]
     fn wrap_user_creates_envelope_with_user_source() {
@@ -148,19 +136,6 @@ mod tests {
         let record: ConfigRecord<serde_json::Value> = serde_json::from_value(result).unwrap();
         assert_ne!(record.meta.created_at, 0);
         assert_ne!(record.meta.updated_at, 0);
-    }
-
-    #[test]
-    fn wrap_builtin_creates_envelope_with_binary_version() {
-        let spec = json!({"name": "builtin-model"});
-        let result = wrap_builtin(&spec, "v9.9.9").unwrap();
-        let record: ConfigRecord<serde_json::Value> = serde_json::from_value(result).unwrap();
-        match &record.meta.source {
-            RecordSource::Builtin { binary_version } => {
-                assert_eq!(binary_version, "v9.9.9");
-            }
-            other => panic!("expected Builtin source, got {:?}", other),
-        }
     }
 
     #[test]

--- a/crates/awaken-server/src/services/trace_service.rs
+++ b/crates/awaken-server/src/services/trace_service.rs
@@ -11,9 +11,10 @@ use axum::extract::{Path, Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 use crate::app::AppState;
+use crate::config_routes::ConfigRouteError;
+use crate::routes::ApiError;
 
 // ── Wire type ──────────────────────────────────────────────────────────────
 
@@ -80,23 +81,15 @@ pub struct ListTracesQuery {
     pub since: Option<String>,
 }
 
-// ── Error wrapper ──────────────────────────────────────────────────────────
+// ── Error mapping ──────────────────────────────────────────────────────────
 
-/// Converts `TraceStoreError` to an HTTP response.
-pub struct TraceAppError(pub TraceStoreError);
-
-impl IntoResponse for TraceAppError {
-    fn into_response(self) -> Response {
-        let (status, msg) = match self.0 {
-            TraceStoreError::NotFound { run_id } => {
-                (StatusCode::NOT_FOUND, format!("trace not found: {run_id}"))
-            }
-            TraceStoreError::InvalidRunId(id) => {
-                (StatusCode::BAD_REQUEST, format!("invalid run id: {id}"))
-            }
-            err => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
-        };
-        (status, Json(json!({ "error": msg }))).into_response()
+fn map_trace_store_error(err: TraceStoreError) -> ApiError {
+    match err {
+        TraceStoreError::NotFound { run_id } => {
+            ApiError::NotFound(format!("trace not found: {run_id}"))
+        }
+        TraceStoreError::InvalidRunId(id) => ApiError::BadRequest(format!("invalid run id: {id}")),
+        err => ApiError::Internal(err.to_string()),
     }
 }
 
@@ -108,37 +101,27 @@ impl IntoResponse for TraceAppError {
 // `Authorization` bearer token, which would otherwise be Debug-printed
 // into every tracing event under this span.
 #[tracing::instrument(skip_all, fields(agent_id = ?params.agent_id))]
-pub async fn list_traces(
+pub(crate) async fn list_traces(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Query(params): Query<ListTracesQuery>,
-) -> Response {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
-        return err.into_response();
-    }
-    let Some(store) = state.trace_store() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "trace store not configured" })),
-        )
-            .into_response();
-    };
+) -> Result<Response, ConfigRouteError> {
+    crate::config_routes::ensure_admin_auth(&state, &headers)?;
+    let store = state
+        .trace_store()
+        .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
 
     let since = match params.since.as_deref() {
         None => None,
-        Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
-            Ok(dt) => Some(std::time::SystemTime::from(dt)),
-            Err(err) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({
-                        "error": "invalid `since` query parameter; expected RFC 3339 timestamp",
-                        "detail": err.to_string(),
-                    })),
-                )
-                    .into_response();
-            }
-        },
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(std::time::SystemTime::from)
+                .map_err(|err| {
+                    ApiError::BadRequest(format!(
+                        "invalid `since` query parameter; expected RFC 3339 timestamp: {err}"
+                    ))
+                })?,
+        ),
     };
 
     // Reject `limit=0` symmetrically with the event endpoint; `Some(0)`
@@ -146,11 +129,7 @@ pub async fn list_traces(
     // which is indistinguishable from "no runs matched". `None` falls
     // through to the store's default page size.
     if matches!(params.limit, Some(0)) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "`limit` must be >= 1" })),
-        )
-            .into_response();
+        return Err(ApiError::BadRequest("`limit` must be >= 1".into()).into());
     }
 
     let filter = TraceFilter {
@@ -162,14 +141,9 @@ pub async fn list_traces(
         limit: params.limit,
     };
 
-    match store.list(&filter) {
-        Ok(summaries) => {
-            let runs: Vec<RunSummaryWire> =
-                summaries.into_iter().map(RunSummaryWire::from).collect();
-            Json(ListTracesResponse { runs }).into_response()
-        }
-        Err(err) => TraceAppError(err).into_response(),
-    }
+    let summaries = store.list(&filter).map_err(map_trace_store_error)?;
+    let runs: Vec<RunSummaryWire> = summaries.into_iter().map(RunSummaryWire::from).collect();
+    Ok(Json(ListTracesResponse { runs }).into_response())
 }
 
 /// Per-page event cap for `GET /v1/traces/:run_id`.  Trades response
@@ -198,22 +172,16 @@ pub struct GetTraceQuery {
 // materialises the whole run before slicing. Storage-level pagination is
 // tracked as a follow-up (`TraceStore::read_page`).
 #[tracing::instrument(skip_all, fields(run_id = %run_id))]
-pub async fn get_trace(
+pub(crate) async fn get_trace(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(run_id): Path<String>,
     Query(params): Query<GetTraceQuery>,
-) -> Response {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
-        return err.into_response();
-    }
-    let Some(store) = state.trace_store() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "trace store not configured" })),
-        )
-            .into_response();
-    };
+) -> Result<Response, ConfigRouteError> {
+    crate::config_routes::ensure_admin_auth(&state, &headers)?;
+    let store = state
+        .trace_store()
+        .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
 
     let offset = params.offset.unwrap_or(0);
     // F17: clamp `limit` to a positive value. `limit=0` would freeze a
@@ -222,13 +190,7 @@ pub async fn get_trace(
     // Lower bound is 1, upper bound is `DEFAULT_TRACE_EVENT_PAGE`.
     let raw_limit = params.limit.unwrap_or(DEFAULT_TRACE_EVENT_PAGE);
     if raw_limit == 0 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": "`limit` must be >= 1",
-            })),
-        )
-            .into_response();
+        return Err(ApiError::BadRequest("`limit` must be >= 1".into()).into());
     }
     let limit = raw_limit.min(DEFAULT_TRACE_EVENT_PAGE);
 
@@ -238,39 +200,36 @@ pub async fn get_trace(
     // direct writer could still produce a large vector here. A follow-up
     // adds `TraceStore::read_page(run_id, offset, limit)` so pagination
     // is also a storage-layer operation.
-    match store.read(&run_id) {
-        Ok(events) => {
-            let total = events.len();
-            let end = offset.saturating_add(limit).min(total);
-            let page = events.get(offset..end).unwrap_or(&[]);
-            // Serialise as NDJSON — one JSON line per event, terminated by '\n'.
-            let mut buf = String::new();
-            for event in page {
-                match serde_json::to_string(event) {
-                    Ok(line) => {
-                        buf.push_str(&line);
-                        buf.push('\n');
-                    }
-                    Err(err) => {
-                        tracing::warn!(run_id = %run_id, error = %err, "failed to serialise trace event");
-                    }
-                }
+    let events = store.read(&run_id).map_err(map_trace_store_error)?;
+    let total = events.len();
+    let end = offset.saturating_add(limit).min(total);
+    let page = events.get(offset..end).unwrap_or(&[]);
+    // Serialise as NDJSON — one JSON line per event, terminated by '\n'.
+    let mut buf = String::new();
+    for event in page {
+        match serde_json::to_string(event) {
+            Ok(line) => {
+                buf.push_str(&line);
+                buf.push('\n');
             }
-            // An empty result from a known run returns 200 with an empty body.
-            // `TraceStoreError::NotFound` is returned by `read` for a missing run.
-            let mut builder = Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, "application/x-ndjson")
-                .header("x-trace-total-events", total.to_string());
-            if end < total {
-                builder = builder.header("x-trace-next-offset", end.to_string());
+            Err(err) => {
+                tracing::warn!(run_id = %run_id, error = %err, "failed to serialise trace event");
             }
-            builder
-                .body(Body::from(buf))
-                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         }
-        Err(err) => TraceAppError(err).into_response(),
     }
+    // An empty result from a known run returns 200 with an empty body.
+    // `TraceStoreError::NotFound` is returned by `read` for a missing run.
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/x-ndjson")
+        .header("x-trace-total-events", total.to_string());
+    if end < total {
+        builder = builder.header("x-trace-next-offset", end.to_string());
+    }
+    let resp = builder
+        .body(Body::from(buf))
+        .map_err(|e| ApiError::Internal(format!("response build failed: {e}")))?;
+    Ok(resp)
 }
 
 /// `POST /v1/traces/:run_id/pin` — mark a run as operator-pinned so it is
@@ -278,24 +237,18 @@ pub async fn get_trace(
 //
 // `skip_all` keeps the bearer header out of trace logs.
 #[tracing::instrument(skip_all, fields(run_id = %run_id))]
-pub async fn pin_trace(
+pub(crate) async fn pin_trace(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(run_id): Path<String>,
-) -> Response {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
-        return err.into_response();
-    }
-    let Some(store) = state.trace_store() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "trace store not configured" })),
-        )
-            .into_response();
-    };
+) -> Result<Response, ConfigRouteError> {
+    crate::config_routes::ensure_admin_auth(&state, &headers)?;
+    let store = state
+        .trace_store()
+        .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
 
-    match store.mark_referenced(&run_id, ReferenceKind::OperatorPin) {
-        Ok(()) => (StatusCode::NO_CONTENT).into_response(),
-        Err(err) => TraceAppError(err).into_response(),
-    }
+    store
+        .mark_referenced(&run_id, ReferenceKind::OperatorPin)
+        .map_err(map_trace_store_error)?;
+    Ok(StatusCode::NO_CONTENT.into_response())
 }

--- a/crates/awaken-server/src/services/trace_service.rs
+++ b/crates/awaken-server/src/services/trace_service.rs
@@ -11,10 +11,10 @@ use axum::extract::{Path, Query, State};
 use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use crate::app::AppState;
-use crate::config_routes::ConfigRouteError;
-use crate::routes::ApiError;
+use crate::error::ApiError;
 
 // ── Wire type ──────────────────────────────────────────────────────────────
 
@@ -101,27 +101,33 @@ fn map_trace_store_error(err: TraceStoreError) -> ApiError {
 // `Authorization` bearer token, which would otherwise be Debug-printed
 // into every tracing event under this span.
 #[tracing::instrument(skip_all, fields(agent_id = ?params.agent_id))]
-pub(crate) async fn list_traces(
+pub async fn list_traces(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Query(params): Query<ListTracesQuery>,
-) -> Result<Response, ConfigRouteError> {
+) -> Result<Response, ApiError> {
     crate::config_routes::ensure_admin_auth(&state, &headers)?;
     let store = state
         .trace_store()
         .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
 
+    // The `since` parse error preserves the original {error, detail}
+    // wire shape; clients depend on the two-field split.
     let since = match params.since.as_deref() {
         None => None,
-        Some(s) => Some(
-            chrono::DateTime::parse_from_rfc3339(s)
-                .map(std::time::SystemTime::from)
-                .map_err(|err| {
-                    ApiError::BadRequest(format!(
-                        "invalid `since` query parameter; expected RFC 3339 timestamp: {err}"
-                    ))
-                })?,
-        ),
+        Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
+            Ok(dt) => Some(std::time::SystemTime::from(dt)),
+            Err(err) => {
+                return Ok((
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({
+                        "error": "invalid `since` query parameter; expected RFC 3339 timestamp",
+                        "detail": err.to_string(),
+                    })),
+                )
+                    .into_response());
+            }
+        },
     };
 
     // Reject `limit=0` symmetrically with the event endpoint; `Some(0)`
@@ -129,7 +135,7 @@ pub(crate) async fn list_traces(
     // which is indistinguishable from "no runs matched". `None` falls
     // through to the store's default page size.
     if matches!(params.limit, Some(0)) {
-        return Err(ApiError::BadRequest("`limit` must be >= 1".into()).into());
+        return Err(ApiError::BadRequest("`limit` must be >= 1".into()));
     }
 
     let filter = TraceFilter {
@@ -172,12 +178,12 @@ pub struct GetTraceQuery {
 // materialises the whole run before slicing. Storage-level pagination is
 // tracked as a follow-up (`TraceStore::read_page`).
 #[tracing::instrument(skip_all, fields(run_id = %run_id))]
-pub(crate) async fn get_trace(
+pub async fn get_trace(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(run_id): Path<String>,
     Query(params): Query<GetTraceQuery>,
-) -> Result<Response, ConfigRouteError> {
+) -> Result<Response, ApiError> {
     crate::config_routes::ensure_admin_auth(&state, &headers)?;
     let store = state
         .trace_store()
@@ -190,7 +196,7 @@ pub(crate) async fn get_trace(
     // Lower bound is 1, upper bound is `DEFAULT_TRACE_EVENT_PAGE`.
     let raw_limit = params.limit.unwrap_or(DEFAULT_TRACE_EVENT_PAGE);
     if raw_limit == 0 {
-        return Err(ApiError::BadRequest("`limit` must be >= 1".into()).into());
+        return Err(ApiError::BadRequest("`limit` must be >= 1".into()));
     }
     let limit = raw_limit.min(DEFAULT_TRACE_EVENT_PAGE);
 
@@ -237,11 +243,11 @@ pub(crate) async fn get_trace(
 //
 // `skip_all` keeps the bearer header out of trace logs.
 #[tracing::instrument(skip_all, fields(run_id = %run_id))]
-pub(crate) async fn pin_trace(
+pub async fn pin_trace(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(run_id): Path<String>,
-) -> Result<Response, ConfigRouteError> {
+) -> Result<Response, ApiError> {
     crate::config_routes::ensure_admin_auth(&state, &headers)?;
     let store = state
         .trace_store()

--- a/crates/awaken-server/src/time.rs
+++ b/crates/awaken-server/src/time.rs
@@ -1,0 +1,12 @@
+//! Shared time-conversion helpers.
+
+/// Wall-clock time in milliseconds since the UNIX epoch.
+///
+/// Saturates to 0 when the system clock is set before 1970 — callers in
+/// wire-format paths must never panic on a misconfigured host.
+pub(crate) fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/awaken-server/tests/public_api_compat_extended.rs
+++ b/crates/awaken-server/tests/public_api_compat_extended.rs
@@ -206,7 +206,12 @@ fn server_config_struct_literal_keeps_0_2_fields() {
 }
 
 #[test]
-fn api_error_exhaustive_match_keeps_0_2_variants() {
+fn api_error_named_variants_keep_0_2_paths() {
+    // `ApiError` is `#[non_exhaustive]`, so downstream code matching it
+    // must include a wildcard arm. This test only guarantees that the
+    // 0.2 named variants (and the post-0.2 additions listed below) still
+    // exist with the same shape — it does NOT guarantee that an
+    // exhaustive match without a wildcard arm still compiles.
     fn label(error: ApiError) -> &'static str {
         match error {
             ApiError::BadRequest(_) => "bad_request",
@@ -214,12 +219,10 @@ fn api_error_exhaustive_match_keeps_0_2_variants() {
             ApiError::NotFound(_) => "not_found",
             ApiError::ThreadNotFound(_) => "thread_not_found",
             ApiError::RunNotFound(_) => "run_not_found",
-            // Post-0.2 addition (PR #190 — `permission-preview` feature
-            // gate). Not part of the 0.2 surface itself, but listed here
-            // so the exhaustive match keeps compiling and a future
-            // refactor of `ApiError` still trips this test.
             ApiError::ServiceUnavailable(_) => "service_unavailable",
+            ApiError::Unauthorized(_) => "unauthorized",
             ApiError::Internal(_) => "internal",
+            _ => "other",
         }
     }
     assert_eq!(label(ApiError::NotFound("x".into())), "not_found");

--- a/crates/awaken-stores/Cargo.toml
+++ b/crates/awaken-stores/Cargo.toml
@@ -25,15 +25,15 @@ async-trait = { workspace = true }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], default-features = false, optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 async-nats = { version = "0.47", optional = true }
-metrics = { version = "0.24", optional = true }
-bytes = "1"
+metrics = { workspace = true, optional = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
-tempfile = "3"
+tempfile = { workspace = true }
 proptest = { workspace = true }
 futures = { workspace = true }
-testcontainers = "0.23"
+testcontainers = { workspace = true }
 
 [features]
 default = []

--- a/crates/awaken-stores/Cargo.toml
+++ b/crates/awaken-stores/Cargo.toml
@@ -22,7 +22,7 @@ futures = { workspace = true }
 async-trait = { workspace = true }
 
 # Optional backends
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "json"], default-features = false, optional = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "json"], optional = true }
 rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 async-nats = { version = "0.47", optional = true }
 metrics = { workspace = true, optional = true }

--- a/crates/awaken-stores/src/file.rs
+++ b/crates/awaken-stores/src/file.rs
@@ -1051,19 +1051,7 @@ fn owner_dir_name(owner: &ProfileOwner) -> String {
     }
 }
 
-/// Returns the current time in milliseconds since the UNIX epoch.
-///
-/// # Panics
-///
-/// Panics if the system clock is set before the UNIX epoch (1970-01-01).
-/// This is a truly exceptional condition that indicates a severely
-/// misconfigured system and cannot be meaningfully recovered from.
-fn current_millis() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_millis() as u64
-}
+use crate::current_millis;
 
 #[async_trait]
 impl ProfileStore for FileStore {

--- a/crates/awaken-stores/src/lib.rs
+++ b/crates/awaken-stores/src/lib.rs
@@ -11,6 +11,17 @@
 pub mod memory;
 pub mod memory_mailbox;
 
+/// Wall-clock time in milliseconds since the UNIX epoch.
+///
+/// Panics if the system clock is set before 1970 — a severely misconfigured
+/// system that cannot be meaningfully recovered from.
+pub(crate) fn current_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as u64
+}
+
 #[cfg(feature = "file")]
 pub mod file;
 

--- a/crates/awaken-stores/src/memory.rs
+++ b/crates/awaken-stores/src/memory.rs
@@ -380,12 +380,7 @@ impl ThreadRunStore for InMemoryStore {
 
 // ── ProfileStore ────────────────────────────────────────────────────
 
-fn current_millis() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("system clock before UNIX epoch")
-        .as_millis() as u64
-}
+use crate::current_millis;
 
 #[async_trait]
 impl ProfileStore for InMemoryStore {

--- a/crates/awaken-stores/src/nats_buffered_thread/flusher.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/flusher.rs
@@ -1097,12 +1097,7 @@ async fn flush_batch<T: ThreadRunStore + Send + Sync + 'static>(
     }
 }
 
-fn now_millis() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as u64)
-        .unwrap_or(0)
-}
+use super::recovery::now_millis;
 
 #[cfg(test)]
 mod tests {

--- a/crates/awaken-stores/src/nats_buffered_thread/hierarchy_claim.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/hierarchy_claim.rs
@@ -369,12 +369,7 @@ async fn renew(
     )))
 }
 
-fn now_millis() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as u64)
-        .unwrap_or(0)
-}
+use super::recovery::now_millis;
 
 #[cfg(test)]
 mod tests {

--- a/crates/awaken-stores/src/nats_buffered_thread/mod.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/mod.rs
@@ -126,13 +126,9 @@ impl HierarchyMutationTestHooks {
 
 pub struct NatsBufferedThreadStore<T: ThreadRunStore + Send + Sync + 'static> {
     pub(crate) inner: Arc<T>,
-    #[allow(dead_code)]
-    pub(crate) client: async_nats::Client,
     pub(crate) jetstream: async_nats::jetstream::Context,
     pub(crate) stream: async_nats::jetstream::stream::Stream,
     pub(crate) kv_hot: async_nats::jetstream::kv::Store,
-    #[allow(dead_code)]
-    pub(crate) consumer: async_nats::jetstream::consumer::PullConsumer,
     pub(crate) config: config::NatsBufferedThreadConfig,
     pub(crate) hierarchy_write_lock: tokio::sync::Mutex<()>,
     pub(crate) hierarchy_claim_options: hierarchy_claim::ClaimOptions,
@@ -210,11 +206,9 @@ impl<T: ThreadRunStore + Send + Sync + 'static> NatsBufferedThreadStore<T> {
 
         Ok(Self {
             inner,
-            client,
             jetstream,
             stream,
             kv_hot,
-            consumer,
             config,
             hierarchy_write_lock: tokio::sync::Mutex::new(()),
             hierarchy_claim_options: hierarchy_claim::ClaimOptions::default(),

--- a/crates/awaken-stores/src/nats_buffered_thread/recovery.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/recovery.rs
@@ -73,7 +73,7 @@ pub(crate) async fn settle_thread_states<T: ThreadRunStore + Send + Sync + 'stat
     Ok(states)
 }
 
-fn now_millis() -> u64 {
+pub(super) fn now_millis() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)

--- a/crates/awaken-stores/src/nats_buffered_thread/writer.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/writer.rs
@@ -193,9 +193,4 @@ async fn checkpoint_after_prepare<T: ThreadRunStore + Send + Sync + 'static>(
     Ok(())
 }
 
-fn now_millis() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_millis() as u64)
-        .unwrap_or(0)
-}
+use super::recovery::now_millis;

--- a/crates/awaken-stores/src/nats_mailbox/mod.rs
+++ b/crates/awaken-stores/src/nats_mailbox/mod.rs
@@ -57,15 +57,12 @@ pub fn __test_encode_dispatch(dispatch: &RunDispatch) -> Vec<u8> {
 }
 
 pub struct NatsMailboxStore {
-    #[allow(dead_code)]
     pub(crate) client: async_nats::Client,
     pub(crate) jetstream: async_nats::jetstream::Context,
     pub(crate) kv_dispatch: async_nats::jetstream::kv::Store,
     pub(crate) kv_epoch: async_nats::jetstream::kv::Store,
     pub(crate) kv_thread_index: async_nats::jetstream::kv::Store,
     pub(crate) consumer: async_nats::jetstream::consumer::PullConsumer,
-    #[allow(dead_code)]
-    pub(crate) stream_name: String,
     pub(crate) authoritative_scan_timeout: std::time::Duration,
     pub(crate) live_request_timeout: std::time::Duration,
     pub(crate) index: Arc<tokio::sync::RwLock<DispatchIndex>>,
@@ -166,7 +163,6 @@ impl NatsMailboxStore {
             kv_epoch,
             kv_thread_index,
             consumer,
-            stream_name: config.stream_name,
             authoritative_scan_timeout,
             live_request_timeout,
             index,

--- a/crates/awaken-stores/src/nats_mailbox/ops_write.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_write.rs
@@ -364,12 +364,7 @@ pub(super) async fn release_dedupe_lock(
     }
 }
 
-fn current_millis() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
+use super::sweeper::current_millis;
 
 pub(crate) async fn append_thread_index(
     store: &NatsMailboxStore,

--- a/crates/awaken-stores/src/nats_mailbox/sweeper.rs
+++ b/crates/awaken-stores/src/nats_mailbox/sweeper.rs
@@ -110,7 +110,7 @@ async fn publish(jetstream: &async_nats::jetstream::Context, dispatch: &RunDispa
     }
 }
 
-fn current_millis() -> u64 {
+pub(super) fn current_millis() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)

--- a/crates/awaken/tests/agent_loop.rs
+++ b/crates/awaken/tests/agent_loop.rs
@@ -1,9 +1,7 @@
 #![allow(missing_docs)]
 
 use async_trait::async_trait;
-use awaken::agent::state::{
-    ContextMessageStore, ContextThrottleState, PendingWorkKey, RunLifecycle, ToolCallStates,
-};
+use awaken::agent::state::{RunLifecycle, ToolCallStates};
 use awaken::contract::content::ContentBlock;
 use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::{NullEventSink, VecEventSink};
@@ -136,22 +134,7 @@ impl Tool for SuspendingTool {
 // Helpers
 // ---------------------------------------------------------------------------
 
-struct LoopStatePlugin;
-
-impl Plugin for LoopStatePlugin {
-    fn descriptor(&self) -> PluginDescriptor {
-        PluginDescriptor { name: "loop-state" }
-    }
-
-    fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-        registrar.register_key::<RunLifecycle>(StateKeyOptions::default())?;
-        registrar.register_key::<ToolCallStates>(StateKeyOptions::default())?;
-        registrar.register_key::<ContextThrottleState>(StateKeyOptions::default())?;
-        registrar.register_key::<ContextMessageStore>(StateKeyOptions::default())?;
-        registrar.register_key::<PendingWorkKey>(StateKeyOptions::default())?;
-        Ok(())
-    }
-}
+use awaken::loop_runner::LoopStatePlugin;
 
 fn make_runtime() -> PhaseRuntime {
     let store = StateStore::new();

--- a/crates/awaken/tests/handoff.rs
+++ b/crates/awaken/tests/handoff.rs
@@ -6,9 +6,6 @@
 //! - Changing active_hook_filter between phases via different specs
 
 use async_trait::async_trait;
-use awaken::agent::state::{
-    ContextMessageStore, ContextThrottleState, RunLifecycle, ToolCallStates,
-};
 use awaken::contract::active_agent::ActiveAgentIdKey;
 use awaken::registry::AgentSpec;
 use awaken::*;
@@ -88,17 +85,19 @@ impl PhaseHook for HandoffHook {
 // Plugin wrappers
 // ---------------------------------------------------------------------------
 
-struct LoopStatePlugin;
-impl Plugin for LoopStatePlugin {
+use awaken::loop_runner::LoopStatePlugin;
+
+/// Registers the handoff-specific ActiveAgentIdKey alongside the canonical
+/// LoopStatePlugin.
+struct ActiveAgentPlugin;
+impl Plugin for ActiveAgentPlugin {
     fn descriptor(&self) -> PluginDescriptor {
-        PluginDescriptor { name: "loop-state" }
+        PluginDescriptor {
+            name: "test-active-agent",
+        }
     }
     fn register(&self, r: &mut PluginRegistrar) -> Result<(), StateError> {
-        r.register_key::<RunLifecycle>(StateKeyOptions::default())?;
-        r.register_key::<ToolCallStates>(StateKeyOptions::default())?;
-        r.register_key::<ContextThrottleState>(StateKeyOptions::default())?;
         r.register_key::<ActiveAgentIdKey>(StateKeyOptions::default())?;
-        r.register_key::<ContextMessageStore>(StateKeyOptions::default())?;
         Ok(())
     }
 }
@@ -202,6 +201,7 @@ async fn hook_filtering_only_active_hook_filter_fire() {
 
     let runtime = PhaseRuntime::new(StateStore::new()).unwrap();
     runtime.store().install_plugin(LoopStatePlugin).unwrap();
+    runtime.store().install_plugin(ActiveAgentPlugin).unwrap();
 
     let tracker = Arc::new(MultiTrackerPlugin {
         trackers: vec![
@@ -237,6 +237,7 @@ async fn empty_active_hook_filter_runs_all_hooks() {
 
     let runtime = PhaseRuntime::new(StateStore::new()).unwrap();
     runtime.store().install_plugin(LoopStatePlugin).unwrap();
+    runtime.store().install_plugin(ActiveAgentPlugin).unwrap();
 
     let tracker = Arc::new(MultiTrackerPlugin {
         trackers: vec![
@@ -272,6 +273,7 @@ async fn config_values_accessible_in_hooks() {
 
     let runtime = PhaseRuntime::new(StateStore::new()).unwrap();
     runtime.store().install_plugin(LoopStatePlugin).unwrap();
+    runtime.store().install_plugin(ActiveAgentPlugin).unwrap();
 
     let tracker = Arc::new(SingleTrackerPlugin {
         id: "tracker",
@@ -311,6 +313,7 @@ async fn handoff_switches_spec_at_next_boundary() {
 
     let runtime = PhaseRuntime::new(StateStore::new()).unwrap();
     runtime.store().install_plugin(LoopStatePlugin).unwrap();
+    runtime.store().install_plugin(ActiveAgentPlugin).unwrap();
 
     let handoff_plugin = Arc::new(HandoffPlugin {
         target_agent: "reviewer".into(),
@@ -375,6 +378,7 @@ async fn deactivate_plugin_mid_run_via_configure() {
 
     let runtime = PhaseRuntime::new(StateStore::new()).unwrap();
     runtime.store().install_plugin(LoopStatePlugin).unwrap();
+    runtime.store().install_plugin(ActiveAgentPlugin).unwrap();
 
     let tracker = Arc::new(SingleTrackerPlugin {
         id: "tracker",

--- a/crates/awaken/tests/observability_e2e.rs
+++ b/crates/awaken/tests/observability_e2e.rs
@@ -5,9 +5,6 @@
 //! These tests use InMemorySink and require no external services.
 
 use async_trait::async_trait;
-use awaken::agent::state::{
-    ContextMessageStore, ContextThrottleState, RunLifecycle, ToolCallStates,
-};
 use awaken::contract::content::ContentBlock;
 use awaken::contract::event_sink::NullEventSink;
 use awaken::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
@@ -112,21 +109,7 @@ impl Tool for CalcTool {
 // Helpers
 // ---------------------------------------------------------------------------
 
-struct LoopStatePlugin;
-
-impl Plugin for LoopStatePlugin {
-    fn descriptor(&self) -> PluginDescriptor {
-        PluginDescriptor { name: "loop-state" }
-    }
-
-    fn register(&self, registrar: &mut PluginRegistrar) -> Result<(), StateError> {
-        registrar.register_key::<RunLifecycle>(StateKeyOptions::default())?;
-        registrar.register_key::<ToolCallStates>(StateKeyOptions::default())?;
-        registrar.register_key::<ContextThrottleState>(StateKeyOptions::default())?;
-        registrar.register_key::<ContextMessageStore>(StateKeyOptions::default())?;
-        Ok(())
-    }
-}
+use awaken::loop_runner::LoopStatePlugin;
 
 fn make_runtime() -> PhaseRuntime {
     let store = StateStore::new();

--- a/crates/awaken/tests/skill_permission_e2e.rs
+++ b/crates/awaken/tests/skill_permission_e2e.rs
@@ -21,9 +21,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use awaken::agent::state::{
-    ContextMessageStore, ContextThrottleState, RunLifecycle, ToolCallStates,
-};
 use awaken::contract::content::ContentBlock;
 use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::VecEventSink;
@@ -167,19 +164,7 @@ impl Tool for CountingWeatherTool {
 // Helpers
 // ---------------------------------------------------------------------------
 
-struct LoopStatePlugin;
-impl Plugin for LoopStatePlugin {
-    fn descriptor(&self) -> PluginDescriptor {
-        PluginDescriptor { name: "loop-state" }
-    }
-    fn register(&self, r: &mut PluginRegistrar) -> Result<(), StateError> {
-        r.register_key::<RunLifecycle>(StateKeyOptions::default())?;
-        r.register_key::<ToolCallStates>(StateKeyOptions::default())?;
-        r.register_key::<ContextThrottleState>(StateKeyOptions::default())?;
-        r.register_key::<ContextMessageStore>(StateKeyOptions::default())?;
-        Ok(())
-    }
-}
+use awaken::loop_runner::LoopStatePlugin;
 
 fn make_runtime() -> PhaseRuntime {
     let store = StateStore::new();

--- a/crates/awaken/tests/tool_executor.rs
+++ b/crates/awaken/tests/tool_executor.rs
@@ -4,9 +4,7 @@
 //! cross-hook state visibility, stop conditions, and phase interaction.
 
 use async_trait::async_trait;
-use awaken::agent::state::{
-    ContextThrottleState, RunLifecycle, SetInferenceOverride, ToolCallStates,
-};
+use awaken::agent::state::{RunLifecycle, SetInferenceOverride, ToolCallStates};
 use awaken::contract::content::ContentBlock;
 use awaken::contract::event::AgentEvent;
 use awaken::contract::event_sink::{NullEventSink, VecEventSink};
@@ -128,21 +126,7 @@ impl Tool for CountingTool {
 // Helpers
 // ---------------------------------------------------------------------------
 
-use awaken::agent::state::ContextMessageStore;
-
-struct LoopStatePlugin;
-impl Plugin for LoopStatePlugin {
-    fn descriptor(&self) -> PluginDescriptor {
-        PluginDescriptor { name: "loop-state" }
-    }
-    fn register(&self, r: &mut PluginRegistrar) -> Result<(), StateError> {
-        r.register_key::<RunLifecycle>(StateKeyOptions::default())?;
-        r.register_key::<ToolCallStates>(StateKeyOptions::default())?;
-        r.register_key::<ContextThrottleState>(StateKeyOptions::default())?;
-        r.register_key::<ContextMessageStore>(StateKeyOptions::default())?;
-        Ok(())
-    }
-}
+use awaken::loop_runner::LoopStatePlugin;
 
 fn make_runtime() -> PhaseRuntime {
     let store = StateStore::new();

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,12 +25,12 @@ serde_json = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal", "time"] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 uuid = { version = "1", features = ["v4"] }
-axum = { version = "0.7", default-features = false, features = ["http1", "json", "tokio"] }
-clap = { version = "4", features = ["derive", "env"] }
+axum = { workspace = true, features = ["http1", "json", "tokio"] }
+clap = { workspace = true }
 genai = { workspace = true }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { workspace = true, features = ["cors"] }
 
 [[example]]
 name = "generative_ui"

--- a/examples/ai-sdk-starter/agent/Cargo.toml
+++ b/examples/ai-sdk-starter/agent/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 awaken-examples = { path = "../.." }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
-clap = { version = "4", features = ["derive", "env"] }
+clap = { workspace = true }
 
 [[bin]]
 name = "ai-sdk-starter-agent"

--- a/examples/copilotkit-starter/agent/Cargo.toml
+++ b/examples/copilotkit-starter/agent/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 awaken-examples = { path = "../.." }
 tokio = { workspace = true, features = ["rt-multi-thread", "signal"] }
-clap = { version = "4", features = ["derive", "env"] }
+clap = { workspace = true }
 
 [[bin]]
 name = "copilotkit-starter-agent"

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -2,11 +2,9 @@ pub mod frontend_tools;
 mod generative_ui_config;
 pub mod generative_ui_tools;
 pub mod phase_logger;
-pub mod research;
 pub mod scripted_executor;
 pub mod state;
 pub mod tools;
-pub mod travel;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -58,18 +56,18 @@ use awaken_server::services::config_runtime::{
 };
 use awaken_stores::FileStore;
 
+use crate::research::tools::{
+    DeleteResourcesTool, ExtractResourcesTool, SearchTool, SetQuestionTool, WriteReportTool,
+};
 use crate::starter_backend::frontend_tools::FrontendToolPlugin;
 use crate::starter_backend::generative_ui_config::StarterPromptOverrides;
 use crate::starter_backend::generative_ui_tools::{SharedAgentResolver, StreamingGenerativeUiTool};
 use crate::starter_backend::phase_logger::PhaseLoggerPlugin;
-use crate::starter_backend::research::{
-    DeleteResourcesTool, ExtractResourcesTool, SearchTool, SetQuestionTool, WriteReportTool,
-};
 use crate::starter_backend::tools::{
     AppendNoteTool, AskUserQuestionTool, FailingTool, FinishTool, GetStockPriceTool,
     GetWeatherTool, ProgressDemoTool, ServerInfoTool, SetBackgroundColorTool,
 };
-use crate::starter_backend::travel::{
+use crate::travel::tools::{
     AddTripTool, DeleteTripTool, SearchPlacesTool, SelectTripTool, UpdateTripTool,
 };
 

--- a/examples/src/starter_backend/research.rs
+++ b/examples/src/starter_backend/research.rs
@@ -1,3 +1,0 @@
-pub use crate::research::tools::{
-    DeleteResourcesTool, ExtractResourcesTool, SearchTool, SetQuestionTool, WriteReportTool,
-};

--- a/examples/src/starter_backend/travel.rs
+++ b/examples/src/starter_backend/travel.rs
@@ -1,3 +1,0 @@
-pub use crate::travel::tools::{
-    AddTripTool, DeleteTripTool, SearchPlacesTool, SelectTripTool, UpdateTripTool,
-};


### PR DESCRIPTION
## Summary

Engineering-pass cleanup over the workspace: dedup, hoist, drop unused privates,
plus targeted public-API restorations and one CI flake fix surfaced during
review. **The PR is no longer pure no-behavior-change** — see API-Surface
Changes and Behavior Notes below.

**Diff against `main`**: 22 commits, 55 files, +412 / −567. History was
interactively rebased to fold review-fixup commits into their parents and
drop the matcher / RecipientRef delete-then-restore cycle (net change for
those items now lives in the single `chore(api): annotate retained public
surface` commit).

### Themes

- **Error consolidation** — `TraceAppError` and `ConfigRouteError` collapsed into the canonical `ApiError`.
- **Dead-code drop** — `wrap_builtin`, `_types_used` sentinel, `Nats*` dead-stored fields, `starter_backend` shim modules.
- **Workspace.dependencies hoist** — two rounds (5 + 7 packages: axum/tower/tower-http/sqlx/clap/mcp/tracing-subscriber + others). **No version bumps.**
- **Canonical `LoopStatePlugin`** — replaced 4 test-local copies with the shared one.
- **Constant hoisting** — `JSON_RPC_VERSION`, `MCP-Session-Id`, `MCP-Protocol-Version` into module roots.
- **Helper extraction** — `auth::strip_bearer_prefix` (ASCII case-insensitive on the scheme word, per RFC 6750 §2.1), `time::now_millis` in awaken-server; `current_millis` consolidated across awaken-stores.

## API-Surface Changes (not pure cleanup)

These are intentional adjustments — call out for SemVer / changelog awareness:

- **`awaken_server::ApiError` is now `#[non_exhaustive]`.** Downstream exhaustive matches must add a wildcard arm. Adopted to make future variant additions SemVer-compatible.
- **`awaken_server::ApiError::Unauthorized(String)` variant added.** Surfaced from existing auth paths through the canonical error pipeline (previously inline 401 responses).
- **`awaken_server::auth` module is `pub(crate)`.** Internal helper module; not part of the public surface.
- **Bearer scheme matching is now ASCII case-insensitive.** Previously only `"Bearer "` / `"bearer "` literals matched; now `"BEARER "`, `"bEaReR "`, etc. are accepted as RFC 6750 §2.1 specifies. Canonical-case callers are unaffected.
- **`awaken_ext_permission::matcher` is now `#[deprecated]`.** The shim still re-exports `pattern_matches`, `MatchResult`, `Specificity`, etc., but downstream code should migrate to importing from `awaken_tool_pattern` directly.

## API-Surface Stability (compatibility shims preserved)

These public items were initially proposed for removal but **kept** after review:

- **`awaken_ext_permission::matcher`** — kept as a deprecated re-export shim (see above).
- **`awaken_runtime::extensions::background::send_message_tool::RecipientRef`** — retained as the typed-request `pub enum`.
- **`awaken_server::services::trace_service::{list_traces, get_trace, pin_trace}`** — remain `pub async fn` for callers mounting these handlers directly.
- **`GET /v1/traces?since=...` error response shape** — preserved as `{ "error": "...", "detail": "..." }`.

## Behavior Notes

- `GET /v1/traces?limit=0` returns `400 Bad Request`. **Pre-existing** — introduced with the trace API in `d5fa88a3`, already on `main`. Flagged only because it surfaced during review of this PR; not a behavior change introduced here.

## CI / Flake Fix

- `crates/awaken-ext-mcp/tests/mcp_tests.rs::http_listener_response_404_resets_session_before_next_call` — polling window for session-generation reset bumped from 2s → 5s. The 2s window was tight under CI runner load and produced a one-shot flake on an earlier push; the 5s window matches a sibling waiter elsewhere in the same file and removes the time pressure without changing the assertion.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --locked` — green on the pre-rebase tip (`ad559c2`); awaiting fresh CI confirmation on the rebased tip (`5905f6c`)
- [x] `cargo test -p awaken-ext-mcp --test mcp_tests http_listener_response_404_resets_session_before_next_call` — green locally; CI Rust Tests confirmed the timeout bump fixed the flake
- [x] admin-console `npm run ci` — green (lefthook validates on push)
