### PR TITLE
docs(adr): 0.6.0 architecture ADRs

### DIFF
--- a/docs/adr/0034-server-cqrs-lite-event-infrastructure.md
+++ b/docs/adr/0034-server-cqrs-lite-event-infrastructure.md
@@ -1,0 +1,1014 @@
+# ADR-0034: Server CQRS-lite EventStore, ProtocolReplayLog, and Outbox
+
+- **Status**: ✅ Accepted
+- **Date**: 2026-05-20
+- **Depends on**: ADR-0012, ADR-0018, ADR-0019, ADR-0022, ADR-0030
+
+## Context
+
+Awaken already separates runtime execution from transport encoding:
+`AgentEvent` is the runtime stream, and protocol encoders turn that stream
+into AI SDK, AG-UI, A2A, MCP, or other wire formats. The server storage
+boundary is similarly state-oriented: `ThreadRunStore` owns current thread,
+message, run, waiting, and checkpoint state. ADR-0030 added `TraceStore`, but
+that store is observability-oriented: it records sampled metrics and spans, not
+the durable event ledger a protocol stream can replay exactly.
+
+Production server deployments need a different capability set:
+
+- Reconnectable event streams need a durable cursor and replay source.
+- Multi-protocol serving needs one canonical runtime event source rather than a
+  separate event log per protocol.
+- Multi-process deployments need reliable fanout to a different server process,
+  worker, webhook relay, evaluator, or scheduler.
+- Wire replay must remain stable across encoder upgrades; clients that already
+  saw a wire event must receive the same wire event after reconnect.
+- Debug and eval flows sometimes require full runtime deltas, while the default
+  server path must avoid writing every streamed token or partial tool argument
+  to storage.
+
+The server should not solve this by making `ThreadRunStore` event-sourced.
+Threads, messages, runs, waiting tickets, and checkpoints remain state
+aggregates. The missing piece is a CQRS-lite event infrastructure next to those
+aggregates:
+
+```text
+ThreadRunStore      current state and checkpoint truth
+EventStore          canonical event truth
+ProtocolReplayLog   protocol wire replay truth
+Outbox              cross-process delivery truth
+Protocol adapter    wire-event mapping
+```
+
+## Non-Goals
+
+- Replacing `ThreadRunStore` or changing threads/runs into pure event-sourced
+  aggregates.
+- Making `awaken-runtime` depend on a concrete storage backend.
+- Storing Anthropic, AI SDK, AG-UI, or other protocol wire events as the
+  canonical server truth.
+- Replacing `TraceStore` or OTLP observability. Trace data and event-ledger data
+  have different sampling, replay, and correctness contracts.
+- Providing a webhook-specific system. The outbox is a generic reliable delivery
+  primitive for any cross-process consumer.
+- Requiring protocol replay persistence to run as a separate service,
+  database, or deployment unit. `EventStore`, `ProtocolReplayLog`, and
+  `OutboxStore` are logical substrates that server processes may call through
+  traits directly.
+- Collapsing canonical event rows and protocol replay rows into one physical
+  table. Co-location is allowed, but row ownership remains separate.
+
+## Decision
+
+### D1: Introduce a protocol-neutral canonical event envelope
+
+`awaken-contract` defines a canonical event envelope that can carry runtime,
+domain, and control events without naming any protocol adapter:
+
+```text
+event_id
+scopes
+cursors_by_scope
+event_kind
+payload
+thread_id
+run_id
+causation_id
+correlation_id
+origin
+visibility
+schema_version
+created_at
+```
+
+Field semantics are part of the contract:
+
+| Field | Semantics |
+|---|---|
+| `event_id` | Stable canonical event identifier, shared by every scope index for the same event |
+| `scopes` | Non-empty set of scopes where the event is queryable |
+| `cursors_by_scope` | Per-scope cursor assigned during append; cursors from different scopes are not comparable |
+| `thread_id` | Optional denormalized routing field derived from the `Thread(...)` scope or payload |
+| `run_id` | Optional denormalized routing field derived from the `Run(...)` scope or payload |
+| `causation_id` | Immediate upstream canonical event id or external input id that directly caused this event; absent for root domain facts |
+| `correlation_id` | Request/run correlation key for tracing and diagnostics; when W3C trace context exists, this carries or references the trace id |
+| `origin` | Open, lower-kebab source label such as `native`, `server`, `ai-sdk`, `ag-ui`, `a2a`, `mcp`, or `extension:<id>` |
+| `visibility` | Protocol replay and redaction hint such as `public`, `internal`, `audit`, or `sensitive`; it is not an authorization decision |
+
+`scopes` is the query and ordering truth. The denormalized `thread_id` and
+`run_id` fields exist for routing, filtering, and operator readability. Append
+rejects events whose denormalized IDs contradict explicit scope membership.
+
+The canonical payload uses Awaken contract shapes or domain-specific envelopes,
+not wire events from downstream protocols. Sensitive values are either redacted
+or stored through a payload reference with an integrity hash; the event envelope
+must not become a raw credential store.
+
+### D2: Classify events by durability fidelity
+
+The server records different event families at different fidelity levels:
+
+| Class | Meaning | Default server persistence |
+|---|---|---|
+| `ObservedRuntimeEvent` | Streaming observations such as deltas or snapshots | Only in full-fidelity mode |
+| `CommittedRuntimeEvent` | Runtime events with stable replay semantics | Yes |
+| `DomainEvent` | State changes outside the runtime stream | Yes |
+| `ControlEvent` | External inputs that control execution | Yes |
+
+The default server mode is compacted: persist committed, domain, and control
+events; skip streaming deltas unless full-fidelity recording is enabled.
+
+The initial `AgentEvent` mapping is explicit so storage backends do not diverge:
+
+| `AgentEvent` variant | Fidelity class | Compacted persistence | Notes |
+|---|---|---:|---|
+| `RunStart` | `DomainEvent` | yes | Translated to canonical lifecycle facts such as `RunStarted` or `RunResumed`; no separate untyped run-start fact |
+| `RunFinish` | `DomainEvent` | yes | Translated by termination reason to canonical lifecycle facts; no separate untyped run-finish fact |
+| `TextDelta` | `ObservedRuntimeEvent` | no | Persist only in full-fidelity mode |
+| `ReasoningDelta` | `ObservedRuntimeEvent` | no | Persist only in full-fidelity mode |
+| `ReasoningEncryptedValue` | `ObservedRuntimeEvent` | no | Persist only in full-fidelity mode |
+| `ToolCallStart` | `ObservedRuntimeEvent` | no | Streaming detail for tool start |
+| `ToolCallDelta` | `ObservedRuntimeEvent` | no | Partial tool arguments |
+| `ToolCallReady` | `CommittedRuntimeEvent` | yes | Tool input is complete |
+| `ToolCallDone` | `CommittedRuntimeEvent` | yes | Tool result is complete |
+| `ToolCallStreamDelta` | `ObservedRuntimeEvent` | no | Persist only in full-fidelity mode |
+| `ToolCallResumed` | `ControlEvent` | yes | Resume marker for waiting work |
+| `ToolCallCancel` | `CommittedRuntimeEvent` | yes | Visible cancellation boundary |
+| `StreamReset` | `CommittedRuntimeEvent` | yes | Affects replay consistency |
+| `StepStart` | `ObservedRuntimeEvent` | no | Span/debug boundary, persisted only in full-fidelity mode |
+| `StepEnd` | `ObservedRuntimeEvent` | no | Step boundary, persisted only in full-fidelity mode |
+| `InferenceComplete` | `CommittedRuntimeEvent` | yes | Model request completion and usage |
+| `MessagesSnapshot` | `ObservedRuntimeEvent` | no | Full-fidelity/debug only |
+| `ActivitySnapshot` | `ObservedRuntimeEvent` | no | UI/debug observation |
+| `ActivityDelta` | `ObservedRuntimeEvent` | no | UI/debug observation |
+| `StateSnapshot` | `ObservedRuntimeEvent` | no | Internal/debug observation |
+| `StateDelta` | `ObservedRuntimeEvent` | no | Internal/debug observation |
+| `Error` | `CommittedRuntimeEvent` | yes | Maps to `ErrorRecorded`; may also cause `RunErrored` if it terminates the run |
+
+A committed event is a semantic boundary, not necessarily a run boundary. A
+single run may commit several messages, tool calls, tool results, and model
+request completions before `RunFinish`.
+
+### D3: Support three fidelity modes
+
+Server wiring exposes three durability modes:
+
+| Mode | Behavior |
+|---|---|
+| `Disabled` | No runtime event persistence; suitable for simple embedded usage |
+| `Compacted` | Persist committed, domain, and control events; server default |
+| `FullFidelity` | Persist observed runtime deltas and snapshots as well |
+
+This keeps the production default safe for storage throughput and first-token
+latency while preserving a high-detail mode for debug, incident replay, and
+eval evidence.
+
+Replay promises follow the fidelity mode. In full-fidelity mode, every live wire
+event that carries a replay cursor must first be stored as a protocol replay row.
+In compacted mode, only committed, domain, and control wire events are
+replayable. Observed deltas may still be emitted as live-only frames, but a
+live-only frame does not carry a protocol replay cursor and is not promised after
+reconnect. A protocol adapter must not expose a cursor for a wire event that was
+not written to `ProtocolReplayLog`. A live-only frame must not advance the
+client's durable `Last-Event-ID`. If a transport requires a transient frame id
+for local ordering, that id is transport-local and is not accepted as a
+`ProtocolReplayCursor`.
+
+### D4: Split EventStore traits by capability
+
+`awaken-contract` defines separate traits instead of one monolithic store:
+
+```text
+EventWriter      append
+EventReader      list, count
+EventSubscriber  subscribe
+EventStore       EventWriter + EventReader + EventSubscriber
+```
+
+The split keeps transaction coordination scoped to `EventWriter`, lets admin
+and replay tools depend only on `EventReader`, and allows a backend to provide
+live subscription via another component such as an outbox relay or message bus.
+
+### D5: Use opaque cursors and scoped ordering
+
+`EventCursor` is opaque on public surfaces. Callers may pass it back to
+`list` or `subscribe`; they must not decode it, compare it, or derive sequence
+numbers from it.
+
+The store guarantees total order only within an `EventScope`:
+
+```text
+Thread(thread_id)
+Run(run_id)
+```
+
+A canonical event may belong to several scopes. Append accepts a non-empty scope
+set and returns one cursor per scope:
+
+```text
+append(scopes, event, options) -> { event_id, cursors_by_scope }
+```
+
+Append options include `writer_id`, an optional idempotency key, and an
+optional expected prior cursor per scope. The idempotency identity is:
+
+```text
+writer_id + idempotency_key
+```
+
+Repeating the same identity with byte-identical append input returns the
+original `event_id` and cursors instead of creating a duplicate event. The
+append input equality basis is the scope set, `event_kind`, canonical payload
+hash, visibility, causation id, and correlation id. Reusing the same identity
+with a different equality basis returns `IdempotencyConflict`. Idempotency
+records have their own retention policy; after that retention expires, a retry
+may create a new event.
+
+Expected-cursor checks are backend-enforced guards for writers that need
+compare-and-append behavior. A mismatch fails the append without creating an
+event.
+
+The event body is stored once. Each scope receives an index row such as:
+
+```text
+event_scope_index(scope_type, scope_id, sequence, event_id)
+```
+
+`list(scope)` returns events indexed into that scope, ordered by that scope's
+sequence, without duplicating the same `event_id` inside the page. Scope
+membership is explicit. A child-thread runtime event commonly indexes into
+`Thread` and `Run` scopes at the same append.
+
+`Thread.resource_id` and `parent_thread_id` remain thread-store metadata for
+membership and hierarchy. They are not canonical `EventScope` families. A
+protocol that exposes a session/resource-wide ordered wire feed uses a
+ProtocolReplayLog `stream_id` for that feed instead of asking EventStore to
+produce cross-thread total order. Canonical EventStore readers that need a
+single-thread stream read `Thread(thread_id)`, and readers that need run-level
+diagnostics read `Run(run_id)`.
+
+The standard scope family is intentionally small. Current writers index at most
+one `Thread` and one `Run` scope for a single event. Adding another standard
+scope type changes write amplification, index shape, and replay semantics; it
+requires an ADR update or follow-up ADR.
+
+If server internals need ordered cursor comparison, that comparison is exposed
+as an internal helper tied to a scope. It is not a public cursor-format
+contract.
+
+### D6: Define subscription start semantics with a high-water mark
+
+Live subscription supports:
+
+```text
+FromStart
+FromCursor(cursor)
+FromNow
+```
+
+`FromNow` captures a high-water cursor atomically with subscription creation and
+returns it with the stream:
+
+```text
+SubscribeHandle { start_cursor, stream }
+```
+
+This prevents the race where a client lists the current tail, then subscribes,
+and an event lands between the two operations. Backends that cannot atomically
+subscribe and capture the high-water mark implement `FromNow` by capturing the
+high-water cursor in storage, attaching the live subscriber, replaying events
+after the high-water cursor that landed during attachment, and then continuing
+with live delivery.
+
+### D7: Connect runtime via DurableEventSink, not runtime API changes
+
+`awaken-runtime` does not need a new run API for this infrastructure. Compatible
+server wiring wraps the existing stream sink:
+
+```text
+AgentRuntime::run(request, DurableEventSink(inner_sink))
+```
+
+This is an additive durable path, not an immediate replacement for the existing
+live stream path. Existing server streams may continue to use:
+
+```text
+AgentEvent
+  -> ReconnectableEventSink
+  -> mpsc channel
+  -> wire_sse_relay
+  -> EventReplayBuffer
+  -> client
+```
+
+For each incoming runtime event, the wrapper:
+
+1. assigns the fidelity class,
+2. writes or buffers the canonical event according to the durability mode,
+3. emits to the inner live/protocol sink.
+
+The ordering is durable-first: append to `EventStore` before emitting to the
+live sink. If durable append succeeds and live emit fails, the client can
+reconnect and replay. If live emit succeeded before a failed durable append, the
+client would have observed an event that cannot be replayed; that ordering is
+forbidden.
+
+Durable append failures are explicit. ADR-0036 defines the fallible entry point
+as `CommitCoordinator::commit_checkpoint`, not `EventSink::emit`; runtime tee
+for durable variants stages drafts into a per-run buffer and surfaces append
+failures through the commit boundary. `EventSink::emit` therefore remains
+infallible for transient wire emission, where failure has no durable
+consequence to surface. Disabled mode does not install the durable wrapper.
+
+Existing suspension and reconnect behavior must remain in the stream path. A
+server that already uses a suspension-aware sink should wrap the durable sink
+inside that detection layer:
+
+```text
+SuspensionAwareSink
+  -> DurableEventSink
+      -> ReconnectableEventSink
+```
+
+Client-visible `AgentEvent`s authored by server or mailbox code must use the
+same sink path when durable wiring is enabled. Sending synthetic terminal or
+error events directly to the transport channel would let a client observe an
+event that `EventStore` cannot replay.
+
+In server production, the inner sink of `DurableEventSink` must not emit
+client-facing protocol wire events unless it first writes the corresponding
+`ProtocolReplayLog` row. The inner sink is either a non-client diagnostic/live
+cache or a protocol-projector-aware sink that enforces:
+
+```text
+canonical append -> protocol replay append -> wire emit
+```
+
+The forbidden production path is:
+
+```text
+canonical append -> client wire emit
+```
+
+`EventReplayBuffer` remains an in-process live cache for active-stream resume
+until a specific protocol moves to `ProtocolReplayLog`-backed replay. Its
+numeric SSE ids are not `ProtocolReplayCursor`s and must not be mixed with
+protocol replay cursors.
+
+### D7a: Allow non-runtime server writers
+
+Not every canonical event originates from `awaken-runtime`. Runtime events use:
+
+```text
+awaken-runtime -> DurableEventSink -> EventWriter
+```
+
+Server, control-plane, scheduler, evaluator, and protocol-adapter code may write
+canonical events directly through `EventWriter` and, when the same writer owns the
+client-visible wire event, write protocol replay rows directly through the
+protocol replay writer in the same transaction.
+
+Typical non-runtime sources include:
+
+| Source | Example canonical facts | Writer path |
+|---|---|---|
+| control-plane lifecycle | session created, session cancelled, run scheduled | domain transaction -> `EventWriter` |
+| external user input | user message accepted, tool result submitted | domain transaction -> `EventWriter` + optional inline protocol replay |
+| scheduler lifecycle | runtime bound, sandbox bound, reschedule requested | scheduler transaction -> `EventWriter` |
+| evaluator output | outcome recorded, eval completed | evaluator transaction -> `EventWriter` |
+| protocol adapter generated events | public lifecycle/status frames not emitted by runtime | adapter transaction -> `EventWriter` + `ProtocolReplayLog` |
+
+These writers must still obey the same invariants: canonical rows are not wire
+payloads, public wire events are replayable only after a `ProtocolReplayLog` row
+exists, and cross-process notifications go through `OutboxStore`.
+
+### D8: ProtocolReplayLog is the wire replay truth
+
+`EventStore` is the canonical domain/debug truth. `ProtocolReplayLog` is the wire
+replay truth for protocol streams. It is a logical component, not necessarily a
+separate service or database. The default Postgres implementation keeps it
+co-resident with `EventStore` in the same database but uses a separate
+`protocol_replay_log` table instead of mixing canonical and protocol rows in one
+table. This preserves separate ownership, retention, indexing, and constraints
+without adding another deployment component. A future event-service wrapper is an
+optional deployment evolution, not a requirement of this ADR.
+
+A protocol replay row stores the literal wire event emitted to a client:
+
+```text
+protocol_replay_id
+protocol
+protocol_version
+projector_version
+stream_id
+wire_event_id
+wire_event_type
+wire_payload_bytes
+wire_payload_json_optional
+source_event_ids
+source_event_cursors
+protocol_replay_cursor
+redaction_state
+expires_at
+created_at
+```
+
+If a protocol requires byte-exact replay, the log must store the serialized wire
+payload or complete wire frame as emitted (`wire_payload_bytes`). JSON/JSONB may
+be stored as an auxiliary debug or indexing representation, but JSONB alone is
+not a byte-stability guarantee because serialization details can change.
+
+Replay after reconnect reads stored protocol replay rows. It does not re-run the
+current projector against old canonical events, because projector changes would
+alter payloads or IDs clients already observed. `EventCursor` is used for
+canonical event replay; `ProtocolReplayCursor` and `wire_event_id` are used for
+protocol stream replay. Protocol clients do not see canonical cursors.
+
+Protocol replay rows are append-only. Projector upgrades affect newly written
+protocol replay rows.
+Older rows remain replayable with their stored payload. If a cursor refers to a
+protocol replay row that should still be within retention but is missing, the
+server surfaces an integrity error instead of silently re-running the projector.
+If the cursor is outside retention, the server returns a cursor-expired
+response.
+
+Redaction must preserve cursor continuity while a protocol replay row remains
+within retention. A redacted replay row returns a redacted or tombstone wire
+payload, or an explicit redacted response, instead of disappearing as a missing
+row. Removing the row entirely is allowed only through retention expiry.
+
+Protocol projector and SDK compatibility is forward-compatible by default: new
+wire formats should add fields rather than remove or reinterpret existing fields.
+Breaking wire changes require a protocol version bump or a distinct wire-event
+id namespace. Replay returns the stored payload as-is, including its
+`projector_version`; clients that reconnect to supported history must tolerate
+older projector versions for the advertised protocol version.
+
+Protocol projectors write independent protocol replay rows from the same canonical
+event. `ProtocolReplayLog` lists by `(stream_id, protocol, protocol_version)` and
+orders by `protocol_replay_cursor`. Different protocols may share
+`source_event_ids` while producing different `wire_event_id` values and payloads.
+
+Only protocol-visible wire events are written to `ProtocolReplayLog`. Internal
+lifecycle details, heartbeats, delivery attempts, metrics, and traces remain in
+canonical/internal stores or observability systems unless a protocol explicitly
+exposes them as public wire events.
+
+| Signal | `ProtocolReplayLog` |
+|---|---:|
+| public protocol event emitted to a client or webhook | yes |
+| runtime heartbeat | no |
+| sandbox heartbeat | no |
+| outbox retry / delivery attempt | no |
+| webhook delivery attempt | no |
+| trace span / metric sample | no |
+| internal scheduler diagnostic | no |
+
+### D9: Generate protocol replay inline or after canonical commit
+
+The canonical write path is the consistency boundary for server-owned
+control-plane and domain writes:
+
+```text
+BEGIN
+  update ThreadRunStore / config / domain state
+  append canonical EventStore row
+  insert canonical outbox row
+COMMIT
+```
+
+Runtime `AgentEvent` tee atomicity is defined by ADR-0036, which folds runtime
+tee writes for durable variants into the `CommitCoordinator::commit_checkpoint`
+transaction at checkpoint cadence. The pre-0036 exemption — runtime tee may
+append canonical events outside the `ThreadRunStore` transaction — is removed
+by ADR-0036 in a single hard cut; no non-atomic fallback coordinator exists.
+
+Protocol replay generation has two valid paths.
+
+Async projection is allowed when canonical and wire ownership are separate:
+
+```text
+canonical outbox -> protocol projector -> ProtocolReplayLog
+ProtocolReplayLog -> protocol-replay outbox -> protocol fanout
+```
+
+Inline generation is allowed when the writer owns both the canonical fact and the
+public wire event, such as gateway/control/scheduler events:
+
+```text
+BEGIN
+  update domain row
+  append canonical EventStore row
+  write ProtocolReplayLog row
+  enqueue canonical and/or protocol-replay outbox work
+COMMIT
+```
+
+Inline writers must store the protocol replay row before any client-visible wire
+emit. Async projectors must write the `ProtocolReplayLog` row and the
+protocol-replay outbox work in the same transaction before fanout. Therefore the
+common emission invariant is:
+
+```text
+canonical append -> protocol replay append -> wire emit
+```
+
+The default Postgres design uses one outbox table with a `lane` and `target`
+column, not separate schemas per consumer. The logical lanes are:
+
+| Lane | Written with | Typical target |
+|---|---|---|
+| `canonical` | canonical event transaction | protocol projector, evaluator, scheduler |
+| `protocol_replay` | protocol replay row transaction, or inline writer transaction | SSE fanout, webhook relay, protocol bus |
+
+An implementation may physically split lanes for operations, but the contract is
+one `OutboxStore` abstraction with lane and target routing.
+
+A protocol replay generation failure does not erase the canonical event in the
+async path; the protocol projector retries, records metrics, and exposes replay
+delay until the protocol replay row exists. In an inline writer transaction,
+`ProtocolReplayLog` append failure rolls back the transaction and the writer must
+not emit the public wire event.
+
+### D10: Use an outbox for every cross-process push
+
+Outbox is required whenever events must be pushed to a separate process:
+
+- another server replica serving a live stream,
+- webhook delivery,
+- evaluator workers,
+- scheduler workers,
+- message-bus consumers.
+
+The outbox uses at-least-once delivery. Consumers deduplicate by canonical
+`event_id` or protocol `wire_event_id`. Relay failures retry with backoff and
+move exhausted entries to a dead-letter state. Canonical consumers should read
+canonical events from `EventStore`; protocol fanout consumers should read
+protocol replay rows from `ProtocolReplayLog` so they never observe a canonical
+event before its wire protocol replay row exists.
+
+`MailboxStore` and `OutboxStore` are intentionally separate. `MailboxStore`
+delivers run work and control inputs to runtime workers. `OutboxStore` delivers
+notifications that committed canonical events or protocol replay rows are ready
+for independent consumers. A mailbox dispatch may cause canonical events, but
+protocol fanout and replay must not consume mailbox records as their event
+source.
+
+### D11: Add coarse lifecycle, tool, and mailbox events
+
+Existing streaming detail events are not enough to explain why a run is waiting
+or slow. The event model adds coarse state events:
+
+| Event | Trigger | Fidelity class |
+|---|---|---|
+| `RunQueued` | A durable dispatch record is created for a run | `DomainEvent` |
+| `RunSubmitted` | A dispatch is delivered to a runtime worker | `DomainEvent` |
+| `RunStarted` | Runtime execution begins | `DomainEvent` |
+| `RunSuspended` | The run persists a waiting state | `DomainEvent` |
+| `RunResumed` | A waiting run continues after a decision or input | `DomainEvent` |
+| `RunFinished` | The run reaches a normal terminal outcome | `DomainEvent` |
+| `RunCancelled` | An explicit cancel request stops the run | `DomainEvent` |
+| `RunInterrupted` | A user interrupt stops the current execution | `DomainEvent` |
+| `RunRescheduled` | Retry, lease, or backoff logic schedules another activation | `DomainEvent` |
+| `RunTerminated` | Platform policy ends the run without another activation | `DomainEvent` |
+| `RunErrored` | The run reaches a terminal error outcome | `DomainEvent` |
+| `ToolPermissionRequested` | Tool gate requests an approval decision | `DomainEvent` |
+| `ToolPermissionResolved` | Approval or denial is recorded | `ControlEvent` |
+| `ToolCallSuspended` | Tool execution waits for external input or callback | `DomainEvent` |
+| `ToolCallResumed` | A suspended tool receives the required input or callback | `ControlEvent` |
+| `ToolCallTimedOut` | Tool execution exceeds its configured deadline | `DomainEvent` |
+| `ToolCallCancelled` | Runtime or caller cancels the tool call | `DomainEvent` |
+| `ToolCallRejected` | Policy, quota, or permission denial prevents execution | `DomainEvent` |
+| `MailboxSubmitFailed` | The server cannot enqueue or deliver a dispatch | `DomainEvent` |
+| `MailboxDecisionReceived` | A decision or custom result is accepted by mailbox control | `ControlEvent` |
+| `MailboxResumeFailed` | A resume dispatch cannot be created or delivered | `DomainEvent` |
+| `MailboxTimeout` | A server-managed configurable wait deadline expires | `DomainEvent` |
+
+Compacted mode also needs committed message facts that are independent of token
+deltas. Message commits are emitted from message append or checkpoint
+boundaries, not reconstructed from `TextDelta` history:
+
+| Event | Trigger | Fidelity class |
+|---|---|---|
+| `MessageCommitted` | A stable message record is durably appended to the thread log; `message_kind` identifies assistant output, tool result, system/internal, or other producer categories | `DomainEvent` |
+| `ThreadMessagesCheckpointed` | A checkpoint records the message range made durable for a run | `DomainEvent` |
+
+These events do not replace `ToolCallStart`, `ToolCallDelta`, `ToolCallReady`,
+or `ToolCallDone`. They give operators and protocol adapters stable state
+boundaries for reconnect, diagnosis, and control surfaces.
+
+## Consistency contract
+
+EventStore implementations must guarantee:
+
+- total order within a single scope,
+- visibility to `list` and `subscribe` after a successful append,
+- no committed-event replay gap within a scope after append returns,
+- stable opaque cursors,
+- `FromCursor` replay that does not lose events,
+- retention behavior that returns explicit cursor-expired errors,
+- idempotent retry for successful appends that supplied an idempotency key.
+
+They may:
+
+- provide no total order across scopes,
+- batch writes,
+- skip observed runtime events in compacted mode,
+- use backend-specific subscription mechanisms,
+- lose pre-commit events on crash.
+
+## Failure mode decisions
+
+| Failure | Decision |
+|---|---|
+| EventStore append fails | ADR-0036 routes runtime tee through `CommitCoordinator::commit_checkpoint`; append failure rolls back the checkpoint transaction and the run is marked failed at the next dispatch. Inline writers see the failure synchronously |
+| Append idempotency identity reused with different input | Return `IdempotencyConflict`; do not append |
+| Append expected prior cursor mismatch | Return conflict; do not append; caller may retry after reading the current cursor |
+| Live sink fails after EventStore append | Accept; reconnect can replay from EventStore/ProtocolReplayLog |
+| Live sink emits before append succeeds | Forbidden ordering |
+| ProtocolReplayLog append fails in async projection | Keep canonical event; retry protocol replay generation; protocol replay is delayed |
+| ProtocolReplayLog append fails in inline writer transaction | Roll back the transaction; do not emit the public wire event |
+| Protocol replay row missing inside retention | Integrity error and metric; do not silently re-run the projector |
+| Protocol replay row redacted inside retention | Preserve cursor continuity with a redacted or tombstone wire payload, or an explicit redacted response |
+| Protocol replay cursor outside retention | Cursor expired / replay unavailable |
+| Outbox insert fails in canonical transaction | Roll back the transaction |
+| Outbox relay publish fails | Retry with backoff, then dead-letter |
+| Projector bug | Mark protocol replay generation failure, expose metric, keep canonical event unchanged |
+| Message bus or fanout outage | Outbox backlog grows; relay retries |
+| Storage backpressure | Compacted mode remains default; full-fidelity mode can be throttled or disabled |
+
+## Consistency boundaries
+
+| Boundary | Consistency |
+|---|---|
+| ThreadRunStore and canonical EventStore | Strong when written in the same backend transaction |
+| Canonical EventStore and canonical Outbox | Strong in the same backend transaction |
+| EventStore and ProtocolReplayLog | Strong when written inline in one transaction; eventually consistent when generated by async projector |
+| ProtocolReplayLog and client replay | Strong once protocol replay rows exist |
+| Outbox and message bus/webhook | Eventually consistent, at-least-once |
+| Cross-replica live visibility | Depends on outbox relay or message-bus tailing |
+| TraceStore and EventStore | Independent systems with no ordering guarantee |
+
+## Backend compatibility and consistency profiles
+
+The contract layer remains backend-agnostic. `ThreadRunStore`, `EventStore`,
+`ProtocolReplayLog`, and `OutboxStore` are separate traits and may be backed by
+different implementations in embedded or test usage. The server consistency
+contract is selected by deployment wiring, not by forcing every trait to share a
+concrete type.
+
+Server production wiring defines two consistency groups for the async projection
+path:
+
+```text
+Group A: ThreadRunStore + EventStore + canonical outbox lane
+Group B: ProtocolReplayLog + protocol-replay outbox lane
+```
+
+Inline protocol replay writers may combine Group A and Group B in one transaction
+when the writer owns domain state, canonical event, wire event, and outbox work.
+For strict replay and audit semantics, every used group must have one
+transactional backend boundary. The default Postgres server shape satisfies this
+by keeping the thread/run tables, canonical event tables, protocol replay table,
+and outbox table in the same database while preserving separate logical traits
+and tables.
+
+| Usage | Backend requirement | Semantics |
+|---|---|---|
+| Embedded or disabled event persistence | No shared backend required | Runtime streaming only; no durable replay promise |
+| Eventual-consistency server wiring | Mixed backends allowed | Requires idempotency, reconciliation, and integrity checks; cannot claim strong state/event/outbox atomicity |
+| Strict production server wiring | Group A and Group B each use one transactional backend boundary; inline writers may use one combined boundary | Strong state/event/outbox commit within each group; protocol replay is strong for inline rows and eventually consistent for async projection |
+
+Using different backends across a consistency group is allowed only as an
+explicit eventual-consistency choice. For example, pairing a NATS-buffered
+`ThreadRunStore` WAL with a direct Postgres `EventStore` does not provide a
+single atomic commit for thread checkpoint and canonical event append. A strict
+configuration should either use direct Postgres `ThreadRunStore` with Postgres
+`EventStore` and canonical outbox, or extend the WAL entry to carry both the
+thread checkpoint and canonical event draft so the flusher materializes them
+together. That WAL-based design is a separate backend design, not the default
+shape.
+
+`TraceStore` remains outside these consistency groups. It is observability
+storage with independent retention and failure semantics, not a substitute for
+canonical event or protocol replay storage.
+
+## Retention and capacity
+
+This ADR defines correctness semantics, not deployment quotas. EventStore,
+ProtocolReplayLog, and Outbox implementations must expose retention and capacity
+configuration separately for compacted events, full-fidelity observed events,
+protocol replay rows, and delivery attempts. Cursor-expired behavior is part of this
+ADR; concrete retention durations, storage budgets, and sizing guidance belong
+in operator documentation for each backend.
+
+## Delivery shape
+
+The compatible server slice should land as separable changes that do not change
+existing public constructor shapes or stream defaults:
+
+1. Contract shapes: event envelope, scopes, cursors, fidelity classes, and split
+   store traits.
+2. Shared conformance tests for EventStore behavior.
+3. `InMemoryEventStore` for tests and embedded use.
+4. AgentEvent-to-canonical normalizer with compacted mode filtering.
+5. `DurableEventSink` as an optional wrapper around existing live sinks.
+6. Server-authored client-visible events routed through the same sink path.
+7. `PostgresEventStore` for server use.
+8. Server list and stream-resume endpoints backed by EventStore cursors.
+
+Protocol replay and fanout build on the compatible slice:
+
+1. ProtocolReplayLog for stable wire replay.
+2. ProtocolReplayLog conformance tests.
+3. One protocol projector moved to ProtocolReplayLog-backed replay.
+4. Outbox relay for cross-process delivery.
+5. Coarse run, tool, and mailbox lifecycle events.
+6. Thread-group, context-compaction, memory/resource, and eval event families.
+
+ProtocolReplayLog conformance covers append-then-list by protocol stream,
+byte-stable payload replay, protocol-version isolation, `wire_event_id`
+uniqueness, missing rows inside retention as integrity errors, expired cursors
+as cursor-expired responses, and live-only frames never producing durable replay
+cursors.
+
+Initial wiring must be opt-in and builder-based. It must not add required fields
+to `AppState::new`, `Mailbox::new`, `ServerConfig`, or `EventSink`.
+
+Runtime transaction-scope changes are addressed by ADR-0036, which adds a
+`CommitCoordinator` abstraction at the contract layer and routes runtime tee
+through a checkpoint-batched commit boundary. The initial server wiring
+described above is unchanged; ADR-0036 layers the coordinator on top via the
+builder surface without touching `AppState::new`, `Mailbox::new`,
+`ServerConfig`, or `EventSink`.
+
+## Implementation notes
+
+### Draft vs persisted canonical events
+
+Canonical event types are storage contract types. They are not replacements for
+the runtime `AgentEvent` stream:
+
+```text
+AgentEvent / domain fact / control input
+        -> CanonicalEventDraft
+        -> EventStore.append(...)
+        -> CanonicalEvent
+        -> protocol projector
+        -> ProtocolReplayLog row
+```
+
+`AgentEvent` remains the awaken-runtime execution stream. It describes what the
+loop observed or completed during a run, and it can contain transient streaming
+details such as token deltas or partial tool arguments. It does not own durable
+identity, scoped replay cursors, idempotency, retention, or protocol replay
+semantics.
+
+`CanonicalEventDraft` is the EventStore write input. It represents a
+protocol-neutral fact that a writer wants to persist after classifying,
+normalizing, and assigning query scopes to a runtime, domain, or control event.
+The draft intentionally excludes store-assigned fields.
+
+`CanonicalEvent` is the EventStore output after a successful append. It is the
+same canonical fact with backend-assigned identity, per-scope cursors, and
+timestamp. Readers, subscribers, outbox consumers, and protocol projectors
+consume this persisted shape.
+
+Contract types should therefore separate caller input from store-assigned
+output:
+
+```text
+CanonicalEventDraft
+  scopes
+  event_kind
+  payload
+  causation_id
+  correlation_id
+  origin
+  visibility
+  schema_version
+
+CanonicalEvent
+  event_id
+  cursors_by_scope
+  created_at
+  plus the accepted draft fields
+```
+
+Writers submit drafts. Stores assign `event_id`, per-scope cursors, and
+`created_at` atomically during append. This avoids requiring producers to invent
+cursors before the backend has sequenced the event.
+
+For example, `AgentEvent::RunStart` is normalized into a
+`CanonicalEventDraft { event_kind: RunStarted, scopes: ..., payload: ... }`.
+After append, the returned `CanonicalEvent` carries the canonical `event_id`,
+the cursor for each indexed scope, and the accepted `RunStarted` payload.
+
+### Runtime event mapping into canonical lifecycle events
+
+Existing runtime stream variants should not create duplicate lifecycle facts.
+They map into canonical lifecycle events:
+
+```text
+AgentEvent::RunStart, initial activation        -> RunStarted
+AgentEvent::RunStart, after a waiting boundary  -> RunResumed
+AgentEvent::RunFinish(NaturalEnd)               -> RunFinished
+AgentEvent::RunFinish(BehaviorRequested)        -> RunFinished
+AgentEvent::RunFinish(Suspended)                -> RunSuspended
+AgentEvent::RunFinish(Cancelled)                -> RunCancelled
+AgentEvent::RunFinish(Error)                    -> RunErrored
+AgentEvent::RunFinish(Stopped / policy-denied)  -> RunTerminated
+AgentEvent::Error                               -> ErrorRecorded
+```
+
+The `RunFinish` mapping depends on `TerminationReason`. `AgentEvent::Error`
+records the error fact. If that same failure boundary also terminates the run,
+the normalizer may emit `RunErrored`, but it must avoid duplicate terminal facts
+for the same failure boundary. A protocol projector may still render
+protocol-specific status events, but the canonical event stream should not
+contain both an untyped `RunStart` fact and a second `RunStarted` fact for the
+same boundary.
+
+### Default Postgres physical shape
+
+The default implementation should keep canonical and protocol replay data in the same
+Postgres backend but in different tables:
+
+```text
+event                  canonical event body
+event_scope_index      canonical per-scope ordering
+protocol_replay_log    protocol wire replay rows
+outbox                 delivery work items
+```
+
+A minimal `protocol_replay_log` row contains:
+
+```text
+protocol_replay_id
+stream_id
+protocol
+protocol_version
+projector_version
+protocol_replay_seq
+protocol_replay_cursor
+wire_event_id
+wire_event_type
+wire_payload_bytes
+wire_payload_json_optional
+source_event_ids
+source_event_cursors
+redaction_state
+created_at
+expires_at
+```
+
+Recommended uniqueness constraints are `(stream_id, protocol,
+protocol_version, protocol_replay_seq)` and `(protocol, protocol_version,
+wire_event_id)`. A deployment may later split the table or backend for scale,
+but this ADR does not require that.
+
+### ProtocolReplayLog stream identity
+
+Protocol replay cursors are scoped to a protocol stream id, not to every
+canonical scope at once. A protocol replay row belongs to exactly one
+`(stream_id, protocol, protocol_version)` stream and receives one
+`protocol_replay_cursor` for that stream. Stream ids are protocol/server routing
+keys such as `thread:<thread_id>` or `session:<session_id>`; they are not
+canonical `EventScope` values.
+
+If a projector needs the same wire payload to appear in several protocol
+streams, it writes separate protocol replay rows. Each stream has its own
+cursor. Protocol clients must not infer ordering across different protocol
+replay streams.
+
+### Message commit payload shape
+
+Compacted mode needs a stable message fact independent of token deltas. The
+minimal payload shape is:
+
+```text
+MessageCommitted
+  thread_id
+  run_id
+  message_id
+  role
+  content_blocks
+  message_kind
+  parent_message_id
+  created_at
+```
+
+`message_kind` distinguishes assistant output, tool result, system/internal
+message, and other producer-specific message categories. Specialized names such
+as assistant-message or tool-result commits may exist as code-level helpers, but
+the default canonical fact is `MessageCommitted`. Protocol projectors must be
+able to produce final wire messages from the compacted message payload without
+reconstructing token deltas.
+
+## Protocol adapter behavior
+
+Adapters consume canonical events and protocol replay rows. Most adapters use
+asynchronous projection:
+
+```text
+Canonical EventStore -> protocol projector -> ProtocolReplayLog -> stream/list
+```
+
+Adapters that author both the canonical fact and the public wire event may write
+the protocol replay row inline and then stream/list from `ProtocolReplayLog`.
+
+AI SDK, AG-UI, A2A, MCP, and future compatibility protocols should not maintain
+their own canonical event stores. They may maintain protocol replay rows for
+wire replay. This keeps protocol-specific schemas out of core runtime and store
+contracts while allowing each adapter to preserve exact replay semantics.
+
+## Migration notes for existing server streams
+
+Existing server stream paths can migrate without replacing their current live
+broadcast mechanism immediately:
+
+1. Keep the existing `AgentEvent` live stream, `wire_sse_relay`, and
+   `EventReplayBuffer` path active.
+2. Write canonical events through `DurableEventSink` while continuing the
+   current stream path.
+3. Route server-authored client-visible `AgentEvent`s through the same durable
+   sink path.
+4. Compare EventStore replay with current stream/list output in tests.
+5. Switch canonical list/replay reads to EventStore.
+6. Add ProtocolReplayLog for one protocol's wire replay stability.
+7. Move additional protocol replay paths from in-process buffers to
+   ProtocolReplayLog one at a time.
+8. Keep the current in-process broadcast as a live cache for protocols that have
+   not moved to ProtocolReplayLog-backed replay.
+9. Replace cross-process fanout with outbox/message-bus delivery.
+10. Remove any protocol-specific event log once protocol replay is stable.
+
+## Consequences
+
+### Positive
+
+- Multiple protocol adapters share the same canonical event source.
+- Reconnect and replay semantics become backend-tested instead of
+  protocol-specific.
+- Crash recovery improves: committed events can be listed and projected after
+  process restart.
+- Multi-replica server deployments have a reliable fanout path.
+- Protocol adapters become thinner because durability, replay, and delivery
+  are server infrastructure concerns.
+- Debug and eval can opt into full-fidelity event capture without forcing that
+  cost onto the default server path.
+- TraceStore keeps observability semantics while EventStore owns replay
+  semantics; neither store has to impersonate the other.
+
+### Negative
+
+- The server architecture becomes more complex: EventStore, ProtocolReplayLog,
+  and Outbox have separate correctness contracts.
+- Protocol replay generation is eventually consistent with canonical event append
+  unless a deployment chooses inline protocol replay generation.
+- Full-fidelity mode can produce high write volume and needs explicit operator
+  controls.
+- Store implementations must pass conformance tests across cursor, retention,
+  and subscription behavior.
+- Multi-process delivery becomes at-least-once; consumers must deduplicate.
+
+## Alternatives considered
+
+### Alternative A: Make ThreadRunStore event-sourced
+
+Rejected. Threads, messages, run records, waiting tickets, and checkpoints are
+current-state aggregates in the existing architecture. Rebuilding them from an
+event stream would be a larger architectural change, would complicate runtime
+checkpointing, and is not needed to solve replay and fanout.
+
+### Alternative B: Store protocol wire events as the canonical truth
+
+Rejected. It would make the core store depend on individual protocol schemas and
+would duplicate the same runtime facts across adapters. It would also make
+cross-protocol replay and debug harder because the canonical representation
+would already be lossy and protocol-shaped.
+
+### Alternative C: Use TraceStore as EventStore
+
+Rejected. TraceStore is observability-focused, may be sampled, and has
+best-effort behavior. Runtime replay and stream recovery require a lossless
+committed-event contract for the scopes that are persisted.
+
+### Alternative D: Emit live events first, persist later
+
+Rejected. A client could observe an event that is absent from replay after
+reconnect. Durable-first ordering is required for stream correctness.
+
+### Alternative E: Re-run protocol projectors during replay
+
+Rejected. Projector upgrades can change wire payloads or IDs. ProtocolReplayLog
+keeps already-emitted wire events stable.
+
+### Alternative F: Store canonical events and protocol replay rows in one table
+
+Rejected for the default implementation. A single physical table with a
+`kind = canonical | protocol_replay` discriminator appears smaller but blurs two
+different truths: canonical facts and already-emitted protocol frames. The two
+row families have different schemas, indexes, retention policies, and integrity
+constraints. The default Postgres backend therefore uses the same database but
+separate tables.

--- a/docs/adr/0035-published-versioned-registry-and-runtime-pinning.md
+++ b/docs/adr/0035-published-versioned-registry-and-runtime-pinning.md
@@ -1,0 +1,976 @@
+# ADR-0035: Published Versioned Registry and Runtime Pinning
+
+- **Status**: Proposed
+- **Date**: 2026-05-21
+- **Depends on**: ADR-0010, ADR-0014, ADR-0018, ADR-0019, ADR-0025, ADR-0028, ADR-0034
+
+## Context
+
+Awaken already has a serializable registry model (`AgentSpec`,
+`ModelBindingSpec`, `ProviderSpec`, `ToolSpec`, `SkillSpec`), a `ConfigStore`
+for admin-managed JSON records, and a runtime `RegistrySnapshot` with a
+monotonic snapshot version. The server can rebuild a `RegistrySet` from
+`ConfigStore` and replace the runtime registry handle.
+
+That model is enough for live config updates, but it does not provide immutable
+published runtime-config versions. The `ConfigRecord.meta.revision` field is an
+editing-time compare-and-set value, not a runtime version. The
+`RegistrySnapshot::version` field is a whole-snapshot cache key, not a stable
+per-resource version. Audit-log restore can reapply an older payload, but it is
+not a versioned registry with current pointers, content hashes, archived
+runtime-config resources, atomic publication records, or run-pinned registry
+manifests.
+
+Production runtime behavior needs four separate concepts:
+
+```text
+ConfigStore              editing / draft / CAS revision
+VersionedRegistryStore   immutable published per-runtime-config versions
+RegistryPublication      atomic published graph snapshot
+RegistrySnapshot         in-memory runtime cache version
+```
+
+Runs also need repeatable resolution after resume, handoff, and delegation.
+The runtime should not query PostgreSQL or any other async store while resolving
+agents and tools on the hot path.
+
+## Non-goals
+
+- Introducing a direct SQL-backed `AgentSpecRegistry` as the runtime lookup
+  model.
+- Making `AgentSpecRegistry` async.
+- Putting workspace, organization, billing, quota, or hosted tenant isolation
+  into `awaken-runtime`.
+- Encoding protocol-specific fields, such as Anthropic AgentVersion payloads,
+  into `AgentSpec`, `VersionedRegistryStore`, or runtime loops.
+- Replacing `ThreadRunStore`, `MailboxStore`, `EventStore`,
+  `ProtocolReplayLog`, or `OutboxStore`.
+- Implementing downstream protocol surfaces, hosted tenant business policy,
+  credential lifecycle products, hosted sandbox fleets, resource data planes,
+  approval workflows, or billing-driven retention policy.
+
+## Decisions
+
+### D1: Separate editing revision, published version, publication, and snapshot version
+
+`ConfigStore` remains the admin editing store. It owns CRUD, draft state,
+seeded records, optimistic concurrency through `meta.revision`, audit restore,
+and UI editing workflows.
+
+`VersionedRegistryStore` is a new published-state store. It owns immutable
+per-runtime-config versions, current pointers, rollback-by-copy, archive
+markers, content-addressed no-op detection, and historical reads for pinned
+runs.
+
+`RegistryPublication` is the atomic published graph boundary. It records one
+publish operation's selected runtime-config versions across agents, skills,
+tools, models, providers, and plugin config. A current run materializer
+resolves the latest publication, not a set of independently observed resource
+current pointers.
+
+`RegistrySnapshot` remains the runtime in-memory cache. It is a synchronous
+`RegistrySet` plus a monotonic runtime cache version. It is not a persistence
+layer and does not replace per-resource versions or publication records.
+
+### D2: Add a generic store plus typed wrappers in `awaken-contract`
+
+The published registry applies to published runtime configuration resources,
+not only agents:
+
+- `agent`
+- `skill`
+- `tool`
+- `model`
+- `provider`
+- `plugin_config`
+
+The underlying store is kind-discriminated and serde-json based so one backend
+can atomically publish mixed resource kinds:
+
+```rust
+pub struct VersionRef {
+    pub kind: String,
+    pub id: String,
+    pub version: u64,
+}
+
+pub struct VersionedRecord<T> {
+    pub kind: String,
+    pub id: String,
+    pub version: u64,
+    pub content_hash: String,
+    pub value_schema_version: u32,
+    pub value: T,
+    pub canonical_json_bytes: Vec<u8>,
+    pub created_at_ms: u64,
+    pub metadata: serde_json::Value,
+}
+
+pub enum PublishOutcome<T> {
+    Created(VersionedRecord<T>),
+    Noop(VersionedRecord<T>),
+}
+
+pub struct VersionedResourceState {
+    pub scope_id: String,
+    pub kind: String,
+    pub id: String,
+    pub current_version: Option<u64>,
+    pub archived_at_ms: Option<u64>,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    pub metadata: serde_json::Value,
+}
+
+pub struct ConfigRevisionRef {
+    pub namespace: String,
+    pub id: String,
+    pub revision: u64,
+}
+
+pub struct RegistryPublication {
+    pub publication_id: String,
+    pub scope_id: String,
+    pub snapshot_version: u64,
+    pub entries: Vec<VersionRef>,
+    pub source_config_revisions: Vec<ConfigRevisionRef>,
+    pub created_by: Option<String>,
+    pub created_at_ms: u64,
+    pub metadata: serde_json::Value,
+}
+```
+
+The storage trait is asynchronous because it belongs to server/store layers:
+
+```rust
+#[async_trait::async_trait]
+pub trait VersionedRegistryStore: Send + Sync {
+    async fn resource_state(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+    ) -> Result<Option<VersionedResourceState>, VersionedRegistryError>;
+
+    async fn current(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+    ) -> Result<Option<VersionedRecord<serde_json::Value>>, VersionedRegistryError>;
+
+    async fn get(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+        version: u64,
+    ) -> Result<Option<VersionedRecord<serde_json::Value>>, VersionedRegistryError>;
+
+    async fn list_versions(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+    ) -> Result<Vec<VersionedRecord<serde_json::Value>>, VersionedRegistryError>;
+
+    async fn publish_resource(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+        value: serde_json::Value,
+        value_schema_version: u32,
+        metadata: serde_json::Value,
+    ) -> Result<PublishOutcome<serde_json::Value>, VersionedRegistryError>;
+
+    async fn rollback_resource(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+        to_version: u64,
+        metadata: serde_json::Value,
+    ) -> Result<VersionedRecord<serde_json::Value>, VersionedRegistryError>;
+
+    async fn archive_resource(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+    ) -> Result<(), VersionedRegistryError>;
+
+    async fn unarchive_resource(
+        &self,
+        scope_id: &str,
+        kind: &str,
+        id: &str,
+    ) -> Result<(), VersionedRegistryError>;
+
+    async fn create_publication(
+        &self,
+        scope_id: &str,
+        publication_id: &str,
+        entries: Vec<VersionRef>,
+        source_config_revisions: Vec<ConfigRevisionRef>,
+        created_by: Option<String>,
+        metadata: serde_json::Value,
+    ) -> Result<RegistryPublication, VersionedRegistryError>;
+
+    async fn latest_publication(
+        &self,
+        scope_id: &str,
+    ) -> Result<Option<RegistryPublication>, VersionedRegistryError>;
+
+    async fn get_publication(
+        &self,
+        scope_id: &str,
+        snapshot_version: u64,
+    ) -> Result<Option<RegistryPublication>, VersionedRegistryError>;
+
+    async fn pinned_manifest_for_publication(
+        &self,
+        scope_id: &str,
+        snapshot_version: u64,
+    ) -> Result<Option<PinnedRegistryManifest>, VersionedRegistryError>;
+
+    async fn latest_pinned_manifest(
+        &self,
+        scope_id: &str,
+    ) -> Result<Option<PinnedRegistryManifest>, VersionedRegistryError>;
+}
+```
+
+A typed wrapper binds `scope_id`, `kind`, and serde codecs for consumers that
+work with concrete Awaken specs:
+
+```rust
+pub struct TypedVersionedRegistry<T> {
+    pub store: std::sync::Arc<dyn VersionedRegistryStore>,
+    pub scope_id: String,
+    pub kind: String,
+    pub _phantom: std::marker::PhantomData<T>,
+}
+```
+
+`TypedVersionedRegistry<T>` delegates to `VersionedRegistryStore`, handles
+serde, resource-specific schema migration, and returns `VersionedRecord<T>`.
+Mixed-kind publish, publication history, and backend conformance tests use the
+untyped store directly. `create_publication` records a committed graph snapshot
+from already-published version references and validates that each referenced
+version exists in the same `scope_id`; higher-level server publish orchestration
+uses this store operation after publishing the selected resource versions.
+The default pinned-manifest helpers load the publication entries and attach the
+stored content hashes needed by `RunRecord.registry_manifest`.
+
+`awaken-runtime` must not depend on these traits for run execution. Runtime uses
+a materialized synchronous registry snapshot.
+
+### D2a: Published values carry schema evolution rules
+
+Published values must remain readable across Awaken upgrades. Every versioned
+record carries a `value_schema_version`; resource-specific codecs own any
+migration from older stored shapes into the current Rust type.
+
+For Awaken-owned published types such as `AgentSpec`, `SkillSpec`,
+`ModelBindingSpec`, and `ProviderSpec`:
+
+- adding fields requires `#[serde(default)]` or an equivalent defaulting codec,
+- deleting or renaming stored fields is forbidden unless a migration codec remains
+  available,
+- write-time validation may reject unknown fields, but read-time deserialization
+  of historical published values must be backward compatible,
+- incompatible schema changes require a new `value_schema_version` and an
+  explicit migration path, and
+- store and wrapper `get` operations must surface an incompatible-schema error
+  instead of silently returning `None` or drifting to the current version.
+
+This rule is required because pinned runs may resume from historical published
+bytes long after the process binary has been upgraded.
+
+### D2b: Published registries and registry manifests are not secret stores
+
+Published runtime configuration values and `RunRecord.registry_manifest` must not
+contain plaintext credentials or resolved secret material. `RedactedString` is
+safe for logs and debug output, but its JSON representation is still plaintext;
+it is not sufficient for immutable published registry storage.
+
+This ADR does not introduce a generic `SecretRef`, `SecretResolver`, vault,
+credential broker, or secret-lint subsystem. Awaken's contract-level invariant
+is narrower: published registry values, publication metadata, registry manifests,
+EventStore rows, and ProtocolReplayLog rows must not persist resolved plaintext
+secrets.
+
+If an Awaken-owned schema must name a credential before constructing a model or
+provider backend, it may carry a schema-owned opaque credential reference, such
+as:
+
+```rust
+pub struct OpaqueCredentialRef {
+    pub id: String,
+    pub kind: Option<String>,
+}
+```
+
+That reference is only a stable identifier. It is not a secret resolver contract
+and does not define a vault backend, KMS policy, OAuth lifecycle, credential
+sharing model, rotation workflow, hosted credential ACL, or audit UI. Resolving
+the reference into secret material belongs to the downstream provider factory,
+protocol adapter, deployment integration, or hosted product layer. Resolved
+secret values must not be written back into `VersionedRegistryStore`,
+`RegistryPublication`, `RunRecord.registry_manifest`, EventStore, or
+ProtocolReplayLog.
+
+Tool credentials, MCP OAuth tokens, GitHub clone tokens, file fetch tokens,
+memory mount tokens, sandbox capabilities, image pull credentials, webhook HMAC
+keys, and product credential resources are downstream concerns. They must not be
+modeled as Awaken registry secrets.
+
+Generic store implementations must not hard-code heuristic field-name scanning
+such as `*_token`, `*_key`, `client_secret`, `password`, or `*_credential` as a
+framework contract. Product-specific publish validators may enforce stricter
+linting for their own DTOs and credential schemas before values reach the
+published registry.
+
+### D3: Publish uses canonical JSON and content hash no-op detection
+
+Publishing converts the resource through its schema-specific canonical encoder,
+serializes the resulting JSON to canonical UTF-8 bytes, and computes
+`content_hash` as `sha256:<lowercase-hex>` over those bytes plus the explicit
+`value_schema_version` envelope. The hash input may include opaque credential
+reference identifiers when an Awaken-owned schema contains them, but it never
+includes resolved plaintext secret material.
+
+Awaken uses a stable canonical JSON profile:
+
+- object keys are sorted lexicographically using the JSON string order defined by
+  RFC 8785 JSON Canonicalization Scheme;
+- strings are emitted as UTF-8 JSON strings without Unicode normalization;
+- integers are preserved exactly;
+- non-finite floats are rejected; finite numbers follow the RFC 8785 JSON number
+  serialization rules;
+- the resource-specific canonical encoder normalizes missing optional/default
+  fields and explicit optional `null` values to the same canonical omission;
+  required `null` values remain distinct;
+- default-valued additive fields must not perturb the canonical bytes for older
+  published values; and
+- metadata, creation timestamps, version numbers, and publication identifiers are
+  not part of `content_hash`.
+
+Store implementations persist the canonical bytes produced by publish. JSONB may
+be stored as an auxiliary query/debug representation, but deserializing and
+re-serializing JSONB must not be the source of truth for hash verification.
+
+No-op detection compares the new hash only to the current version's hash for the
+same `(scope_id, kind, id)`. A matching current hash returns
+`PublishOutcome::Noop` and does not create a new version. A hash that matches an
+older historical version is still publishable as a new monotonic version when
+rollback-by-copy or publication semantics require it.
+
+Conformance tests must verify that memory, file, and PostgreSQL stores compute
+identical hashes for canonical-equivalent fixtures.
+
+### D4: Rollback publishes a new version instead of moving the pointer back
+
+Rollback does not set `current_version` to an older version. It copies the
+selected historical value and publishes that value as the next monotonic version
+with metadata such as:
+
+```json
+{ "restored_from": 3 }
+```
+
+This keeps versions append-only and makes every current pointer advance
+monotonically. Rollback may create a new version with the same `content_hash` as
+a historical version. Historical `content_hash` values therefore must not be
+unique within a resource.
+
+A server rollback operation may target either one resource or a
+`RegistryPublication`. Publication rollback copies every selected entry into a
+new publication transaction and records the source publication in metadata.
+
+### D5: Archive marks resources without deleting published history
+
+Archive sets an archived marker on the resource record and keeps all historical
+versions available. Archive state is per resource, not per version, and is
+exposed through `VersionedResourceState`.
+
+`current` may still return the current version of an archived resource for
+administrative and explicit-version use. Callers that need active-only behavior
+must call `resource_state` and check `archived_at_ms`.
+
+Default lifecycle semantics are:
+
+- latest-publication and current-version materialization reject archived
+  resources;
+- explicit version and pinned registry manifest materialization may load archived
+  historical versions;
+- `publish_resource` rejects an archived resource and must not implicitly
+  unarchive it;
+- `rollback_resource` rejects an archived resource and must not implicitly
+  unarchive it;
+- `archive_resource` is idempotent and does not move the current pointer;
+- `unarchive_resource` is an explicit administrative action that clears
+  `archived_at_ms` without creating a new version; and
+- a server restore flow that wants to republish an archived resource must make
+  the unarchive step explicit in audit metadata.
+
+Archive never physically deletes version rows and never invalidates a retained
+`RegistryPublication` or retained `RunRecord.registry_manifest` reference.
+
+### D6: Store implementations live in `awaken-stores`
+
+`awaken-stores` owns memory, file, and PostgreSQL implementations of
+`VersionedRegistryStore`.
+
+The default PostgreSQL shape uses generic resource, version, and publication
+tables:
+
+```sql
+awaken_registry_resources (
+  scope_id          text not null default 'default',
+  kind              text not null,
+  id                text not null,
+  current_version   bigint,
+  archived_at_ms    bigint,
+  created_at_ms     bigint not null,
+  updated_at_ms     bigint not null,
+  metadata_json      jsonb not null default '{}',
+  primary key (scope_id, kind, id)
+);
+
+awaken_registry_versions (
+  scope_id              text not null default 'default',
+  kind                  text not null,
+  id                    text not null,
+  version               bigint not null,
+  content_hash          text not null,
+  value_schema_version  int not null,
+  canonical_value_json  text not null,
+  value_json            jsonb not null,
+  metadata_json         jsonb not null default '{}',
+  created_at_ms         bigint not null,
+  primary key (scope_id, kind, id, version)
+);
+
+create index awaken_registry_versions_hash_idx
+  on awaken_registry_versions(scope_id, kind, id, content_hash);
+
+awaken_registry_publications (
+  scope_id                      text not null default 'default',
+  snapshot_version              bigint not null,
+  publication_id                text not null,
+  source_config_revisions_json  jsonb not null default '[]',
+  created_by                    text,
+  metadata_json                 jsonb not null default '{}',
+  created_at_ms                 bigint not null,
+  primary key (scope_id, snapshot_version),
+  unique (scope_id, publication_id)
+);
+
+awaken_registry_publication_entries (
+  scope_id          text not null default 'default',
+  snapshot_version  bigint not null,
+  kind              text not null,
+  id                text not null,
+  version           bigint not null,
+  content_hash      text not null,
+  primary key (scope_id, snapshot_version, kind, id),
+  foreign key (scope_id, snapshot_version)
+    references awaken_registry_publications(scope_id, snapshot_version),
+  foreign key (scope_id, kind, id, version)
+    references awaken_registry_versions(scope_id, kind, id, version)
+);
+```
+
+`content_hash` is intentionally indexed but not unique. No-op detection is a
+pointer comparison against the current version, not a historical uniqueness
+constraint.
+
+All resource version rows, resource current-pointer updates, publication rows,
+and publication entry rows for one publish operation are written in a single
+store transaction. A latest publication becomes visible only after that
+transaction commits.
+
+`scope_id` is a store/server partition key. OSS and local deployments use
+`scope_id = 'default'`. Hosted deployments map it to a workspace or equivalent
+tenant boundary. `awaken-runtime` does not interpret `scope_id`.
+
+### D7: Runtime resolution stays synchronous and snapshot-based
+
+`AgentSpecRegistry` remains synchronous:
+
+```rust
+fn get_agent(&self, id: &str) -> Option<AgentSpec>;
+fn agent_ids(&self) -> Vec<String>;
+```
+
+Runtime handoff, delegate resolution, and tool resolution must use an in-memory
+snapshot. They must not await a database read.
+
+`awaken-runtime` adds a pinned registry implementation:
+
+```text
+PinnedAgentSpecRegistry
+  - agent_id -> AgentSpec
+  - agent_id -> version metadata
+  - implements AgentSpecRegistry
+```
+
+The existing `MapAgentSpecRegistry` remains useful for unpinned and test
+registries.
+
+### D8: Server materializes frozen registry sets from publications or explicit pins
+
+`awaken-server` owns materialization from published versions into runtime
+registries. A `FrozenRegistryMaterializer` loads a root agent and every
+reachable published runtime-config resource needed by Awaken runtime resolution:
+
+1. root agent,
+2. delegate agents,
+3. referenced skills,
+4. model profiles,
+5. provider profiles,
+6. plugin config entries that participate in runtime resolution.
+
+The output is both:
+
+- a typed `PinnedRegistryManifest`, and
+- a frozen `RegistrySet` backed by synchronous registries.
+
+Server code persists the typed manifest in `RunRecord.registry_manifest` before
+runtime execution starts; `awaken-runtime` receives only the frozen
+`RegistrySet`.
+
+The materializer accepts one of these policies:
+
+- latest publication in a scope,
+- an explicit version for the root resource,
+- an explicit publication snapshot version,
+- an existing `RunRecord.registry_manifest` value.
+
+For latest-publication policy, the materializer resolves the latest
+`RegistryPublication` and uses that publication's entries as the candidate graph.
+It must not read independent per-resource current pointers in a way that can mix
+versions from different publish transactions. For explicit root-version policy,
+the materializer validates and freezes the reachable graph from that exact root.
+For existing-manifest policy, it reloads exactly the manifest entries.
+
+Before producing a frozen registry set, the materializer invokes the standard
+registry graph validator described in D11a. A materializer must not silently skip
+missing, archived, cross-scope, or cyclic references.
+
+### D9: `RunRecord.registry_manifest` persists registry pinning and verifies hashes on resume
+
+Registry pinning is stored as a concrete typed field on `RunRecord`, not as a
+multi-kind manifest envelope. This keeps the contract simple because Awaken has
+one run-level pinned registry payload here: `PinnedRegistryManifest`. This ADR
+must not introduce a generic `RunManifest { kind, payload }` or
+`RunManifestStore`.
+
+```rust
+pub struct RunRecord {
+    pub registry_manifest: Option<PinnedRegistryManifest>,
+}
+
+pub struct PinnedRegistryManifest {
+    pub publication_id: Option<String>,
+    pub registry_snapshot_version: Option<u64>,
+    pub entries: Vec<PinnedRegistryEntry>,
+}
+
+pub struct PinnedRegistryEntry {
+    pub kind: String,
+    pub id: String,
+    pub version: u64,
+    pub content_hash: String,
+}
+```
+
+When a manifest is produced from a `RegistryPublication`,
+`registry_snapshot_version` is the publication `snapshot_version` and
+`publication_id` records the publication identity. For explicitly pinned graphs,
+these fields may be absent while the entry list remains authoritative.
+
+Entries in `PinnedRegistryManifest` contain only published runtime-config
+versions needed by Awaken runtime resolution:
+
+```text
+agent
+skill
+tool
+model
+provider
+plugin_config
+```
+
+It does not contain session resources, files, memory stores, git repositories,
+vault credential lifecycle objects, image digests, mount plans, sandbox bindings,
+runtime tiers, workspace quota, billing data, or hosted tenancy policy. Those are
+downstream/session-manifest or hosted-layer concerns.
+
+The default storage shape follows the `ThreadRunStore` backend's `RunRecord`
+persistence. PostgreSQL backends may store `registry_manifest` as typed JSON on
+the run row or in a backend-specific run-record table, but they must not expose a
+generic `(run_id, kind, payload)` manifest table for this ADR. Backends that can
+transactionally create runs must persist the `RunRecord` and
+`registry_manifest` together or expose an equivalent all-or-nothing server
+operation.
+
+Run start writes `RunRecord.registry_manifest` before execution starts. Resume
+reads that field, materializes from the exact versions recorded there, and never
+falls back to the current published version. Delegate and handoff resolution must
+resolve only runtime-config resources present in the decoded registry manifest
+value. If a delegate or handoff target was not frozen into the manifest, resolution fails
+instead of reading the current published version.
+
+`PinnedRegistryEntry.content_hash` is an integrity check, not only audit
+metadata. Resume and manifest-based materialization reload each version's stored
+canonical bytes, recompute the hash using D3, and fail with an integrity error
+if the stored hash differs from the manifest entry. This requires stores to keep
+the canonical bytes written by publish and not rely on serde round-tripping as
+the hash source.
+
+Existing stored runs with `registry_manifest = None` are treated as legacy
+records. New server-created runs must write `RunRecord.registry_manifest` before
+execution starts.
+
+### D10: Agent IDs remain stable and version-free
+
+`AgentSpec.id` stays as the logical resource id:
+
+```text
+agent_xxx
+```
+
+The version is carried by the decoded `PinnedRegistryManifest`, not by appending
+a suffix to the runtime id. Server/materializer inputs may use current,
+publication, or explicit `VersionRef` selectors, but protocol-specific API
+selector syntax is owned by protocol adapters and does not enter this ADR.
+
+### D11: Config publish and version publish are separate server actions
+
+Admin CRUD writes `ConfigStore` and bumps `meta.revision`.
+
+Publishing loads `ConfigStore`, validates the full graph, publishes changed
+resources into `VersionedRegistryStore`, writes a `RegistryPublication`, builds a
+frozen `RegistrySet`, and calls `RegistryHandle::replace`.
+
+The resource version rows and the publication row must commit atomically. A
+run-start materializer using current policy observes the latest committed
+publication. It must never capture a manifest made from partially updated
+resource current pointers.
+
+Restore from audit log remains valid as an editing-store operation. Registry
+rollback is separate: it copies a previous published resource version or every
+entry in a previous publication into a new published version/publication.
+
+`RegistryHandle::replace` is a hot-swap for future resolution only. It affects
+new runs, admin previews, and unpinned current-version materialization. It does
+not mutate an active run's `PinnedAgentSpecRegistry`, stored
+`RunRecord.registry_manifest`, or already-resolved tool/delegate set. Resume
+materializes from the stored registry manifest, not from the latest current
+registry. This prevents admin publish from changing a run mid-flight.
+
+### D11a: Registry graph validation is a shared contract
+
+Publish and materialization use the same registry graph validator so
+`awaken-server`, protocol adapters, and hosted products do not implement
+conflicting reference semantics.
+
+The contract shape is:
+
+```rust
+pub enum VersionSelector {
+    LatestPublication { scope_id: String },
+    Publication { scope_id: String, snapshot_version: u64 },
+    Exact { scope_id: String, kind: String, id: String, version: u64 },
+    // A decoded `RunRecord.registry_manifest` value.
+    Manifest { scope_id: String, manifest: PinnedRegistryManifest },
+}
+
+pub struct RegistryGraphValidationRequest {
+    pub root: VersionSelector,
+    pub reference_policy: RegistryReferencePolicy,
+}
+
+pub enum RegistryReferencePolicy {
+    SameScopeOnly,
+}
+
+pub struct RegistryGraphValidationReport {
+    pub entries: Vec<PinnedRegistryEntry>,
+}
+
+#[async_trait::async_trait]
+pub trait RegistryGraphValidator: Send + Sync {
+    async fn validate(
+        &self,
+        request: RegistryGraphValidationRequest,
+    ) -> Result<RegistryGraphValidationReport, RegistryGraphValidationError>;
+}
+```
+
+Standard validation errors are stable contract variants:
+
+```rust
+pub enum RegistryGraphValidationError {
+    MissingResource { kind: String, id: String },
+    MissingVersion { kind: String, id: String, version: u64 },
+    ArchivedReference { kind: String, id: String, version: Option<u64> },
+    ContentHashMismatch {
+        kind: String,
+        id: String,
+        version: u64,
+        expected: String,
+        actual: String,
+    },
+    CycleDetected { path: Vec<VersionRef> },
+    InvalidReference { kind: String, id: String, reason: String },
+    Backend(String),
+}
+```
+
+The standard validator follows references from agents to delegate agents and
+model profiles, and from model profiles to provider profiles. Explicitly pinned
+`skill`, `tool`, and `plugin_config` entries are verified when present, but the
+core validator does not infer product-specific skill/plugin references that are
+not represented by Awaken runtime fields. Every reference resolves within the
+same `scope_id` as the selected publication, exact selector, or decoded registry payload.
+
+The validator rejects references that are missing, archived for new
+current-version materialization, outside the allowed scope policy, hash-mismatched,
+or cyclic. Explicit pinned historical references may load archived resources,
+matching D5.
+
+Principal ACL, quota, billing, rate limits, and protocol-specific field checks
+remain outside the core validator. Server or hosted layers run those checks
+before calling publish or materialization.
+
+### D12: Multi-agent dispatch stays in the existing delegation model
+
+Awaken keeps the current delegation architecture:
+
+- `AgentSpec.delegates`,
+- delegate tools resolved during registry resolution,
+- `AgentTool`,
+- `ExecutionBackend`,
+- local delegate execution,
+- A2A remote delegate execution,
+- parent run, thread, and tool-call lineage.
+
+No `MultiagentCoordinator` is introduced by this ADR. The added requirement is
+version enforcement through the decoded `RunRecord.registry_manifest`.
+
+### D13: Permission hard-deny is independent of registry pinning
+
+Regex and glob permission matching are already part of the permission rule
+model and remain outside the registry-versioning problem.
+
+This ADR does not require a new permission behavior to implement published
+registry versions, publications, registry manifests, or materialization. If
+Awaken needs a system-level hard prohibition that cannot be overridden by later
+rules, that change should land as a separate permission decision covering
+evaluator precedence, tool-list filtering, preview APIs, rule serialization,
+and skill elevation logic.
+
+Actor, workspace, and role-based policy resolution does not enter the core
+evaluator. A server-side resolver may map principal context to a
+`PermissionRuleset`, and the evaluator remains a pure rule calculator.
+
+### D14: PostgreSQL checkpoint and mailbox stores are `awaken-stores` concerns
+
+`StreamCheckpointStore` already belongs to `awaken-contract`; PostgreSQL
+persistence belongs in `awaken-stores`. The PostgreSQL implementation uses a
+run-keyed upsert table:
+
+```sql
+awaken_stream_checkpoints (
+  scope_id          text not null default 'default',
+  run_id            text not null,
+  thread_id         text not null,
+  upstream_model    text not null,
+  checkpoint_json   jsonb not null,
+  updated_at_ms     bigint not null,
+  primary key (scope_id, run_id)
+);
+```
+
+`MailboxStore` PostgreSQL persistence also belongs in `awaken-stores`. It must
+preserve the durable dispatch lifecycle, lease semantics, retry counters,
+interrupt epoch, dedupe behavior, and multi-worker claim safety. PostgreSQL
+claim queries use row locking with `FOR UPDATE SKIP LOCKED`.
+
+Redis can be added later as another store backend. It is not required for the
+runtime contract because NATS already covers real-time distributed dispatch.
+
+### D15: Outbox remains the cross-process event delivery primitive
+
+`OutboxStore` is defined by ADR-0034 and remains separate from `MailboxStore`.
+Mailbox dispatches deliver run work and control inputs. Outbox rows deliver
+notifications that canonical events or protocol replay rows are ready for
+independent consumers.
+
+ADR-0034 owns the reusable `OutboxRelay` library. A ready-to-run
+`awaken-outbox-relay` binary may wrap that library for generic lanes, but
+downstream products own lane policy, webhook payloads, HMAC, and retry business
+policy. Registry publish, materialization, and run pinning may enqueue outbox
+rows when they need cross-process notification, but the relay does not change
+registry versioning or run-pinning contracts and must not understand downstream
+webhook semantics.
+
+### D16: Sandbox lifecycle stays downstream
+
+Sandbox execution, lifecycle, resource mounts, image selection, runtime tier,
+warm pools, and deployment drivers are outside this ADR. They are not part of
+`awaken-runtime` and are not encoded in `PinnedRegistryManifest`.
+
+Awaken keeps only the generic `Tool` / `ToolRegistry` invocation boundary. A
+concrete tool implementation may call a downstream sandbox service, but sandbox
+binding, resource mounting, credential injection, and deployment policy remain in
+the protocol adapter or hosted product layer.
+
+### D17: Protocol adapters do not pollute core contracts
+
+Anthropic-compatible APIs, AI SDK, A2A, ACP, MCP, and future protocols belong
+in protocol adapter crates or `awaken-server/src/protocols/*`.
+
+Protocol adapters may translate protocol-specific agent selectors into a current,
+publication, or explicit `VersionRef` materializer input before runtime starts.
+This ADR does not define Anthropic request DTOs, JSON selector shapes, public
+version fields, beta headers, public event names, or public error schema.
+
+Protocol adapters may also map protocol permission policy payloads to
+`PermissionRuleset` and protocol outcome fields to generic Awaken eval/outcome
+metadata. Those fields do not enter `AgentSpec`, `VersionedRegistryStore`,
+`RegistrySnapshot`, `PinnedRegistryManifest`, or runtime loop code.
+
+### D18: Hosted tenancy stays above runtime
+
+Hosted concepts such as workspace, organization, user, quota, billing, and
+tenant isolation stay in `awaken-server` or hosted product code.
+
+`awaken-runtime` may carry opaque metadata such as `Thread.resource_id`, run
+metadata, and event metadata, but it does not enforce tenant policy.
+
+Server and store layers enforce hosted isolation by applying the principal's
+scope to every hosted query, using `scope_id` or an equivalent partition key.
+
+### D19: Registry retention preserves registry manifests and publications
+
+Version rows are immutable and retained by default. Store implementations may
+support physical purge, but purge is subject to registry retention policy and
+must never delete a version referenced by any retained
+`RunRecord.registry_manifest` or retained `RegistryPublication`.
+
+A retention policy is evaluated per scope and kind. It may combine rules such as:
+
+- keep the current version of every resource,
+- keep every version referenced by retained publications,
+- keep every version referenced by retained registry manifests,
+- keep the last `N` historical versions per resource, and
+- keep versions newer than a configured age.
+
+`awaken-contract` should expose a purge planning surface rather than deleting
+blindly:
+
+```rust
+pub struct RegistryRetentionPolicy {
+    pub keep_last_versions: Option<u64>,
+    pub keep_younger_than_ms: Option<u64>,
+}
+
+pub trait VersionedRegistryRetention {
+    async fn purge_eligible_versions(
+        &self,
+        scope_id: &str,
+        policy: RegistryRetentionPolicy,
+        dry_run: bool,
+    ) -> Result<Vec<VersionRef>, VersionedRegistryError>;
+}
+```
+
+Registry manifest retention follows `RunRecord` and thread retention. Registry
+stores use retained `RunRecord.registry_manifest` values as protection roots
+while planning version purge. Archive is not a purge operation and leaves history
+intact.
+
+### D20: Downstream products own protocol, hosted, workflow, and data-plane semantics
+
+This ADR keeps Awaken as a generic runtime and server substrate. Awaken owns
+stable contracts, storage primitives, materialization, integrity checks, and
+extension hooks. Downstream protocol adapters and hosted products own their
+public API shape, tenant policy, resource data plane, credential lifecycle, and
+deployment-specific control loops.
+
+Awaken framework code may expose generic hooks or opaque metadata for these
+concerns, but it must not encode their product semantics:
+
+| Area | Awaken provides | Downstream owns |
+|---|---|---|
+| Protocol APIs | `VersionRef`, `PinnedRegistryManifest`, `ProtocolReplayLog`, generic projector/fanout substrate | Anthropic or Managed Agents DTOs, routes, beta headers, public event names, public IDs, `Last-Event-ID` contract, and public error schema |
+| Hosted tenancy | `scope_id`, optional principal/auth hooks, metadata, same-scope defaults, access hook interfaces | workspace, organization, user, team, quota, billing, rate limit, tenant entitlement, sharing policy, and hosted administration UI |
+| ACL and policy resolution | `RegistryReferencePolicy`, `RegistryReferenceAccessHook`, pure permission evaluator inputs | role inheritance, team membership, public/private resource policy, cross-workspace sharing rules, approval UX, and policy editor behavior |
+| Secrets | the invariant that published registry values and registry manifests contain no plaintext secrets; optional schema-owned opaque credential references for model/provider backend construction | secret resolvers, vault schema, KMS policy, OAuth grant/refresh, GitHub tokens, MCP credentials, tool credentials, sandbox credential injection, rotation workflow, sharing policy, product-specific linting, and credential audit UI |
+| Resource data plane | optional opaque runtime-config references only when needed by runtime tools | memory-store contents, file blobs, git checkout contents, datasets, vector indexes, object storage, resource binding, and artifact lifecycle |
+| Sandbox/resource execution | `Tool` / `ToolRegistry` invocation boundary only; no sandbox or resource binding data in `PinnedRegistryManifest` | sandbox lifecycle, resource mounts, credential injection, Kubernetes fleets, warm pools, Cilium policy, Karpenter/autoscaling, image warmers, runtime classes, tenant network isolation, mount plans, runtime tiers, and hosted sandbox quota |
+| Publication workflow | `RegistryPublication`, `source_config_revisions`, `created_by`, and `metadata` | draft review, approval chains, staging or production promotion, release notes, rollout policy, and change-request workflow |
+| Resource kinds | standard runtime config kinds: agent, skill, tool, model, provider, plugin_config; extension kinds must remain runtime config | product-specific schemas such as environments, memory stores, vault credentials, dreams, outcome evaluations, sessions, workspace files, sandbox bindings, or git credential products |
+| Provider routing | model/provider profiles and optional server hooks | cost routing by plan, regional compliance routing, tenant provider quotas, vendor contract policy, and billing-tier fallback strategy |
+| Observability | trace hooks, generic span attributes, content hashes, and correlation IDs | hosted dashboards, billing analytics, usage reports, service-level reports, and tenant audit reports |
+| Retention | purge planning APIs and protection of retained publications/registry manifests | exact retention duration, legal hold, plan-based limits, billing-driven purge, and per-tenant version quotas |
+| Outcome and evaluation | generic run outcomes, eval hooks, or optional evaluator traits | Anthropic outcome evaluation fields, dream resources, official evaluation product schemas, and managed-agent completion criteria |
+
+When a downstream product needs an extension registry object to participate in
+Awaken's generic machinery, that object must still be runtime configuration.
+Product data-plane, session, resource binding, and sandbox payloads stay outside
+`PinnedRegistryManifest` and are interpreted only by the owning adapter or hosted
+layer.
+
+## Consequences
+
+- Runtime resolution remains fast and synchronous.
+- Published config can be rolled back without losing monotonic version history.
+- Current run materialization observes atomic publication snapshots instead of
+  partially updated resource pointers.
+- Run resume, handoff, and delegation can be made repeatable across config
+  changes and verified against stored content hashes.
+- Store implementations carry the complexity of immutable version persistence,
+  canonical bytes, publication history, and retention planning, while
+  `awaken-runtime` remains database-agnostic.
+- Protocol-specific compatibility layers can evolve without adding foreign
+  fields to core contracts.
+- Hosted deployments gain a clear boundary for scope enforcement without
+  embedding workspace semantics into runtime crates.
+- Product-specific API, tenant, workflow, credential, and data-plane behavior
+  remains outside Awaken framework code while still being able to use generic
+  hooks and registry manifests.
+
+## Rejected alternatives
+
+### Direct SQL AgentSpecRegistry
+
+Rejected. It would put async database reads on the runtime resolution path,
+weaken active-run consistency, and only solve agents while leaving skills,
+tools, models, providers, and plugin config without a common
+published-version model.
+
+### Reusing `ConfigRecord.meta.revision` as runtime version
+
+Rejected. `meta.revision` is an editing-time CAS value. It changes on every
+admin write and exists to reject stale writers. Runtime versions are immutable
+published artifacts and need stable historical reads, content hashes, archive
+state, atomic publications, and monotonic rollback-by-copy semantics.
+
+### Encoding versions into `AgentSpec.id`
+
+Rejected. Runtime ids should remain logical resource ids. Encoding versions in
+ids makes handoff, delegation, permissions, tracing, and UI references depend on
+string parsing instead of an explicit registry manifest value.
+
+### Materializing current runs from independent resource pointers
+
+Rejected. Reading `agent.current_version`, `skill.current_version`, and provider
+pointers independently can create a manifest that never existed as a published
+configuration. Current-policy materialization must use a committed
+`RegistryPublication`.

--- a/docs/adr/0036-runtime-commit-atomicity-and-event-buffer.md
+++ b/docs/adr/0036-runtime-commit-atomicity-and-event-buffer.md
@@ -1,0 +1,409 @@
+# ADR-0036: Runtime Commit Atomicity and Event Buffer
+
+- **Status**: 🚧 Proposed
+- **Date**: 2026-05-21
+- **Depends on**: ADR-0012, ADR-0018, ADR-0030, ADR-0034
+
+## Context
+
+ADR-0034 established the canonical `EventStore`, `ProtocolReplayLog`, and
+`Outbox` next to `ThreadRunStore`. Its D9 wrote the inline writer template:
+
+```text
+BEGIN
+  update ThreadRunStore / config / domain state
+  append canonical EventStore row
+  insert canonical outbox row
+COMMIT
+```
+
+That template applies to **server-side inline writers** — control plane,
+gateway, scheduler. ADR-0034 §739–742 and §481–484 explicitly excluded the
+runtime `AgentEvent` tee from this transaction:
+
+> Runtime `AgentEvent` tee writes may append canonical events outside the
+> `ThreadRunStore` checkpoint transaction until a future runtime transaction
+> ADR exists.
+
+The same deferral appears in §316–322 and in the failure mode table
+(§624): an `EventStore::append` failure can be recorded but not abort the
+run, because `EventSink::emit` is infallible.
+
+Two consequences leak into production:
+
+- A checkpoint can be durable while one or more of its events are missing
+  from the canonical store, leaving replay incomplete.
+- Phase code that wants to react to a failed canonical append has no
+  fallible entry point; it can only observe a diagnostic after the fact.
+
+This ADR closes both gaps by introducing a commit-atomicity boundary
+between `ThreadRunStore` and `EventStore` and a runtime-private event
+buffer that defers durable event drafts to that boundary. The atomicity
+guarantee is **checkpoint-batched**: every canonical event a phase
+produces between checkpoints is committed atomically with the
+`ThreadRunStore` writes for that checkpoint. The fallible sink contract
+ADR-0034 deferred is folded into the new commit entry point and is not
+issued as a separate ADR.
+
+## Non-Goals
+
+- Per-event atomicity. Canonical events are not committed one-by-one
+  with runtime state; they are batched at checkpoint boundaries.
+- Cross-backend two-phase commit. Mixed `ThreadRunStore` + `EventStore`
+  backends are rejected at builder time; no 2PC abstraction is added.
+- Changing the wire-emit ordering of streaming events. Transient
+  AgentEvents continue to reach clients before any canonical commit.
+- Re-shaping `AgentEvent` or `CanonicalEventDraft`. Both retain their
+  ADR-0034 shapes.
+- Cross-protocol `ProtocolReplayLog` schema constraints. Tracked
+  separately as a follow-up ADR.
+
+## Decisions
+
+### D1: Checkpoint-batched atomicity
+
+The atomicity unit is the **checkpoint**. A phase between two checkpoints
+may produce zero or more `CanonicalEventDraft` values; all of them, plus
+the `ThreadRunStore` writes for the next checkpoint, plus the outbox rows
+they imply, commit inside a single backend transaction. A crash before
+commit drops the entire batch; the next run dispatch replays from the
+last successful checkpoint.
+
+Per-phase or per-event atomicity is explicitly rejected. Per-phase
+requires re-aligning checkpoint cadence with phase boundaries and gains
+little durability for significant complexity. Per-event requires the
+runtime to hold backend-specific transaction handles, which collides with
+ADR-0034 D5.
+
+### D2: `CommitCoordinator` owns the cross-store transaction
+
+A new contract trait `CommitCoordinator` is introduced in
+`awaken-contract`. It is the only abstraction that observes both
+`ThreadRunStore` and `EventStore` writes. Conceptual shape:
+
+```rust
+pub trait CommitCoordinator: Send + Sync {
+    fn scope(&self) -> TransactionScopeId;
+
+    async fn commit_checkpoint(
+        &self,
+        plan: CheckpointCommitPlan,
+    ) -> Result<CheckpointCommitOutcome, CommitError>;
+}
+
+pub struct CheckpointCommitPlan {
+    pub checkpoint: ThreadRunCheckpointInputs, // ADR-0012 inputs
+    pub canonical_drafts: Vec<CanonicalEventDraft>,
+    pub outbox_rows: Vec<OutboxRow>,
+}
+```
+
+`ThreadRunStore` and `EventStore` contracts remain backend-agnostic and
+do not grow transaction parameters. The coordinator is the only crate
+that holds a concrete backend handle (`PgPool`, in-memory `Mutex`) and
+the only place where ordering of the three writes is encoded.
+
+Two production-shaped implementations are required by this ADR:
+
+- `PgCommitCoordinator` — opens a `BEGIN`, drives the `ThreadRunStore`
+  and `EventStore` writes through the same connection, inserts the
+  outbox rows, and commits. On any error inside the block, the
+  connection rolls back and the error propagates as `CommitError`.
+- `MemoryCommitCoordinator` — wraps the in-memory stores behind an
+  async `Mutex`. The mutex is held across the conceptual transaction so
+  that the multi-store update is atomic to other observers. A panic or
+  early-return inside the critical section reverts staged in-memory
+  buffers before the mutex is released; observers never see partial
+  state.
+
+No non-atomic fallback is provided. The only sanctioned coordinators
+are `PgCommitCoordinator` and `MemoryCommitCoordinator`. Removing the
+non-atomic path is a deliberate choice over a deprecation cycle: every
+caller that previously held a `ThreadRunStore` plus an `EventWriter`
+must switch to a `CommitCoordinator` in the same change set, and no
+production deployment can run in a silently non-atomic mode.
+
+### D3: Strict scope match at builder time
+
+Mixed-backend deployments — for example in-memory `ThreadRunStore` with
+Postgres `EventStore` — cannot share a transaction. They are rejected,
+not silently degraded. `TransactionScopeId` is an opaque equality marker
+exposed by every coordinator implementation. The `RuntimeBuilder` (and
+the equivalent `AppState`/`Mailbox` builders that own these stores)
+validate that the supplied coordinator can drive both stores it was
+constructed from before `build()` returns. A mismatch produces a build
+error whose message names both backends.
+
+`MemoryCommitCoordinator` reports a `Memory(instance_id)` scope keyed on
+the pair of underlying store instances it was constructed with. Two
+memory stores belonging to different test fixtures do not share scope
+even though both are in-process.
+
+This rule formalises ADR-0034 D5's "strong consistency when both writes
+share the same backend transaction" by making any other configuration
+unbuildable.
+
+### D4: Event durability is a typed property of `AgentEvent`
+
+`AgentEvent` gains a typed durability classification:
+
+```rust
+pub enum EventDurability {
+    Transient,
+    Durable,
+}
+
+impl AgentEvent {
+    pub fn durability(&self) -> EventDurability { /* match per variant */ }
+}
+```
+
+Transient variants (token deltas, partial tool arguments, phase-progress
+markers) are wire-only. The runtime tees them to subscribers and never
+stages them into the canonical buffer.
+
+Durable variants (message appended, tool call completed, run status
+changed, checkpoint reached, and other variants currently mapped to
+canonical kinds by ADR-0034 D8) are wire-tee'd immediately **and** staged
+as `CanonicalEventDraft` in the per-run `EventBuffer`. The buffer drains
+at the next checkpoint commit.
+
+The classification lives next to the enum, not at emission sites. Adding
+a new `AgentEvent` variant requires choosing its durability at definition
+time; the compiler enforces exhaustiveness.
+
+### D5: Wire-emit order remains live-first for runtime tee
+
+ADR-0034 D9 stated the inline writer invariant:
+
+```text
+canonical append -> protocol replay append -> wire emit
+```
+
+That invariant continues to hold for **inline writers** (control plane,
+gateway, scheduler). It does **not** apply to the runtime tee path. The
+runtime emits durable events on the live wire as soon as they are staged
+into the buffer; canonical commit happens later at checkpoint. The
+replay path remains canonical-first because the protocol projector reads
+canonical rows.
+
+This is sound under one explicit client-side invariant:
+
+> Canonical is the single source of truth. Any live wire event without a
+> corresponding canonical row on replay must be treated by the client as
+> "did not happen".
+
+Reconciling clients (admin UI, AI SDK replay, AG-UI replay, A2A
+adapters) must drop live-received durable events that fail to appear in
+canonical replay after reconnect. Protocol adapter documentation owns
+this contract. Transient events are exempt because they never enter
+canonical.
+
+### D6: Failure surface — fallible commit replaces fallible sink
+
+`CommitCoordinator::commit_checkpoint` is fallible. Any of these
+conditions returns `CommitError`:
+
+| Failure | `CommitError` variant |
+|---|---|
+| `ThreadRunStore` write failure | `StoreWrite(ThreadRunStoreError)` |
+| `EventStore::append` validation/idempotency/cursor conflict | `EventAppend(EventStoreError)` |
+| Outbox insert failure | `OutboxInsert(OutboxError)` |
+| Transaction commit failure (network, backend disconnect) | `Commit(BackendError)` |
+
+The runtime treats any `CommitError` as terminal for the current run:
+
+1. The run transitions to `Failed { reason: CheckpointCommitFailed { cause } }`
+   in in-memory state. No further `commit_checkpoint` is attempted for
+   this run; the in-memory failure is observed by the next dispatch.
+2. The `EventBuffer` is drained and discarded. Drafts staged but not
+   committed are gone; they will not be replayed.
+3. Live wire emit that has already occurred for the dropped drafts is
+   the client's reconciliation problem per D5.
+
+This subsumes ADR-0034's deferred "fallible sink" contract: the entry
+point is now `commit_checkpoint`, not `EventSink::emit`, so the
+infallible-emit limitation no longer applies. `EventSink::emit` remains
+infallible for transient wire emission, where failure has no durable
+consequence to surface.
+
+### D7: Dedup at existing layers, not at the buffer
+
+Buffer staging does not introduce a new idempotency mechanism. Two
+existing layers already cover the relevant cases:
+
+- `AgentEventNormalizer` (today `ScopedAgentEventNormalizer`) carries
+  per-variant dedup state for variants whose canonical mapping is
+  intrinsically once-per-run, such as `RunStart` → `RunStarted` /
+  `RunResumed` (started_runs set) and `RunFinish` → terminal kinds
+  (terminal_runs set). Re-emitting the same `AgentEvent` inside one
+  run does not yield duplicate canonical drafts for these variants.
+- `EventStore::append` enforces backend-level idempotency through
+  `AppendOptions::idempotency_key` (ADR-0034 D9,
+  `IdempotencyConflict`). A draft that survives staging and reaches
+  the coordinator is deduplicated by the canonical store on append.
+
+The buffer therefore passes drafts through unchanged. Hook retries
+that re-emit an `AgentEvent` for the same canonical fact will produce
+multiple staged drafts only when the normalizer admits multiple
+drafts; in that case the append-time idempotency key (assigned by the
+normalizer or the coordinator at flush) is the dedup boundary.
+
+### D8: Mandatory coordinator selection
+
+`RuntimeBuilder::build()` requires a `CommitCoordinator`. The previous
+`with_thread_run_store(…)` entry point is removed in the same change
+set that introduces the coordinator; all callers switch to
+`with_commit_coordinator(…)` at once.
+
+`AppState::new`, `Mailbox::new`, `ServerConfig`, and `EventSink` keep
+their existing signatures. Coordinator wiring is added through the
+builder surface only, satisfying ADR-0034 §735–736.
+
+There is no default coordinator. A `RuntimeBuilder` without a
+coordinator returns a build error naming the two sanctioned choices
+(`PgCommitCoordinator`, `MemoryCommitCoordinator`).
+
+### D9: `EventBuffer` placement and `DurableEventSink` reshape
+
+The buffer is a runtime-owned, per-run structure. A minimal `stage`
+trait (`CanonicalEventStager` or equivalent, exposing only
+`fn stage(&self, draft: CanonicalEventDraft)`) is defined in
+`awaken-contract`; the concrete buffer with `drain` capability lives
+in `awaken-runtime`.
+
+`DurableEventSink` is reshaped in place rather than retired:
+
+- The `writer: Arc<dyn EventWriter>` field is replaced by
+  `stager: Arc<dyn CanonicalEventStager>`.
+- `emit` is reordered to forward to the inner wire sink first
+  (live emission, satisfying D5), then normalize and stage drafts
+  into the buffer. The previous "durable-first" forwarding gate is
+  removed because durable persistence is no longer co-located with
+  wire emission.
+- `last_error` / `has_failed` are removed. Staging is infallible;
+  the only failure surface is `CommitCoordinator::commit_checkpoint`
+  per D6.
+
+`AgentEventNormalizer` remains the single source of truth for
+`AgentEvent` → `CanonicalEventDraft` mapping. Phase code and hooks
+**do not** stage drafts directly; they emit `AgentEvent` through the
+existing `EventSink` surface and the reshaped sink stages on their
+behalf. No new `PhaseContext` API is required.
+
+The buffer is drained inside `complete_step` / `persist_checkpoint`
+(`crates/awaken-runtime/src/loop_runner/checkpoint.rs`) when those
+functions call `coordinator.commit_checkpoint(plan)`. No hook or
+phase code observes `CommitCoordinator` or the buffer concrete type.
+
+Server-side inline writers (per ADR-0034 D9) do not go through this
+buffer. They call `CommitCoordinator::commit_checkpoint` directly
+with their own `CheckpointCommitPlan` built from the facts they are
+publishing.
+
+## Failure mode decisions
+
+| Failure | Decision |
+|---|---|
+| `EventStore::append` fails | `CommitError::EventAppend`; transaction rolls back; run marked `Failed` per D6 |
+| `ThreadRunStore` write fails | `CommitError::StoreWrite`; same handling |
+| Outbox insert fails | `CommitError::OutboxInsert`; same handling |
+| Transaction commit fails | `CommitError::Commit`; same handling |
+| Run suspends with drafts staged | Suspension is itself a checkpoint commit; drafts flush atomically with the waiting-ticket persistence. The buffer is empty across the suspension boundary |
+| Builder receives mismatched-scope stores | `RuntimeBuilder::build()` returns error naming both backends |
+| Duplicate `AgentEvent` re-emitted in one run | Normalizer dedup (e.g. `started_runs`) or backend `IdempotencyConflict` at flush handles it; buffer does not dedup |
+
+## Rollout
+
+The change set is a single hard cut, sequenced internally as ordered
+steps so each is independently reviewable but all land together:
+
+1. Land `CommitCoordinator`, `MemoryCommitCoordinator`, and
+   `PgCommitCoordinator` in `awaken-contract` / `awaken-stores`.
+2. Replace `RuntimeBuilder::with_thread_run_store` with
+   `with_commit_coordinator`. The old method is removed, not deprecated.
+3. Add the `EventBuffer` (and its `CanonicalEventStager` trait) and
+   wire it into `LoopRunner`. Reshape `DurableEventSink` in place:
+   replace its `EventWriter` field with a `CanonicalEventStager`,
+   flip `emit` to wire-first + stage, and remove `last_error` /
+   `has_failed`. No new `PhaseContext` API is added; phase code
+   continues to emit `AgentEvent` through the existing sink.
+4. Switch `complete_step` / `persist_checkpoint` to call
+   `coordinator.commit_checkpoint`. Direct
+   `ThreadRunStore::record_checkpoint` calls move into the coordinator.
+5. Convert every server-side construction site (`AppState`, `Mailbox`,
+   tests) to supply a `PgCommitCoordinator` or
+   `MemoryCommitCoordinator`. Build will not compile until all sites
+   are converted.
+
+## Testing
+
+| Test | Coordinator | Asserts |
+|---|---|---|
+| `memory_commit_atomicity` | `MemoryCommitCoordinator` | Injecting `EventStore::append` failure leaves checkpoint un-advanced and buffer drained |
+| `pg_commit_atomicity` | `PgCommitCoordinator` (testcontainer) | Same property under real Postgres transactions |
+| `scope_mismatch_rejected` | builder unit test | Memory `ThreadRunStore` + Postgres `EventStore` fails `build()` with both backend names in the error |
+| `phase_crash_replay` | `MemoryCommitCoordinator` | Panic mid-phase causes replay from the prior checkpoint; uncommitted durable drafts are absent on replay |
+| `transient_not_persisted` | `MemoryCommitCoordinator` | A transient `AgentEvent` reaches subscribers but produces no canonical row |
+| `normalizer_dedup_preserved` | `MemoryCommitCoordinator` | Re-emitting `RunStart` for the same run still produces one `RunStarted` canonical row (normalizer-level dedup survives the reshape) |
+
+Memory coordinator conformance lives alongside ADR-0034's existing
+`memory_event_store_conformance` suite.
+
+## Relation to ADR-0034
+
+- §316–322 (deferred fallible sink contract): superseded by D6. The
+  fallible entry point is `commit_checkpoint`, not `EventSink::emit`.
+- §481–484 (runtime tee outside `ThreadRunStore` transaction): superseded
+  by D1+D2. Runtime tee for durable variants now commits inside the
+  coordinator transaction at checkpoint cadence.
+- §624 (failure table row "EventStore append fails"): superseded by D6.
+- §738–742 ("future runtime transaction ADR"): satisfied by this ADR.
+- ADR-0034 D5 (backend-agnostic contract layer): preserved. Neither
+  `ThreadRunStore` nor `EventStore` grows transaction parameters; the
+  coordinator is the only backend-aware piece.
+- ADR-0034 D9 inline-writer invariant: unchanged. Runtime tee carves out
+  an explicit exception under D5 of this ADR, justified by the
+  reconciling-client invariant.
+
+## Alternatives considered
+
+### Alternative A: Per-event atomicity via runtime-held transaction
+
+Each `AgentEvent` would be committed in its own backend transaction held
+by the runtime. Rejected: violates ADR-0034 D5 by forcing the runtime to
+hold a concrete backend handle, and per-event transaction overhead is
+not justified by any observable consistency gain over checkpoint-batched
+atomicity.
+
+### Alternative B: Pass `&mut Tx` through both store traits
+
+`ThreadRunStore::begin() -> Tx` plus
+`EventStore::append_in_tx(&mut Tx, …)`. Rejected: the `Tx` associated
+type must be either backend-concrete (leaking `sqlx::Transaction` into
+the contract crate) or trait-object (downcast-heavy, poor async-trait
+ergonomics). Both options re-couple contracts to backends.
+
+### Alternative C: `ThreadRunStore` absorbs `EventStore`
+
+`ThreadRunStore::record_checkpoint(…, events: &[CanonicalEventDraft])`
+would internally write to the event table. Rejected: undoes ADR-0034
+D5's separation. `ThreadRunStore` would need to understand cursor
+allocation, scope rules, and replay constraints that belong to
+`EventStore`.
+
+### Alternative D: Cross-backend 2PC
+
+A `TwoPhaseParticipant` trait letting the coordinator drive prepare /
+commit across heterogeneous backends. Rejected: in-memory stores cannot
+genuinely 2PC; Rust ecosystem lacks a usable abstraction; the practical
+end state is identical to D3's "reject mismatched scope".
+
+### Alternative E: Best-effort with degradation warning
+
+Permit mismatched backends and log a degradation metric. Rejected in
+favour of D3 after weighing test ergonomics against the cost of carrying
+a silently-non-atomic production path. The strict-mode decision is in
+the brainstorming record; the trade-off is that test fixtures must use
+`MemoryCommitCoordinator` on both sides or a testcontainer Postgres
+instead of mixing memory and Postgres stores.

--- a/docs/adr/0037-0.6.0-design-overhaul-overview.md
+++ b/docs/adr/0037-0.6.0-design-overhaul-overview.md
@@ -1,0 +1,158 @@
+# ADR-0037: 0.6.0 Design Overhaul — Overview
+
+- **Status**: 🚧 Proposed
+- **Date**: 2026-05-22
+- **Sub-ADRs**: ADR-0038, ADR-0039, ADR-0040, ADR-0041
+- **Breaking**: yes (0.6.0)
+
+This index ties together four ADRs that make the runtime and server
+boundaries explicit.
+
+## Four boundaries
+
+| Boundary | What gets defined | Sub-ADR |
+|---|---|---|
+| **Transaction** | The only durable write entry for runtime tee events | ADR-0038 |
+| **Activation** | Owned run input, trace, and runtime wiring | ADR-0039 |
+| **Execution plan** | A resolved run plan and typed backend capability contract | ADR-0040 |
+| **Application composition** | Typed server module states and conditional route mounting | ADR-0041 |
+
+## Convergence map
+
+```text
+Symptom                                          → Boundary       → ADR
+────────────────────────────────────────────────  ──────────────   ────
+Runtime events can append outside checkpoint     → Transaction    → 0038
+Dual DurableEventSink / BufferedDurableEventSink → Transaction    → 0038
+RunRequest god-struct with optional wiring       → Activation     → 0039
+RunRequestSnapshot as an omission-based shape    → Activation     → 0039
+RunRegistryManifestResolver as a third resolver  → Execution plan → 0040
+AgentResolver / ExecutionResolver bifurcation    → Execution plan → 0040
+BackendCapabilities bool/enum mixture            → Execution plan → 0040
+AppState + APP_STATE_EXTRAS service locator      → Composition    → 0041
+```
+
+## Core principle
+
+0.6.0 is a breaking boundary cleanup. It does not claim source
+compatibility when the old surface would preserve a parallel concept.
+Migration wrappers are allowed only when they delegate into the new
+boundary and their limitations are explicit.
+
+## Direct deletions in 0.6.0
+
+| Removed | Replacement |
+|---|---|
+| `DurableEventSink::new(inner, writer, normalizer, mode)` | `DurableEventSink::new(inner, stager, normalizer, mode)` |
+| `BufferedDurableEventSink` | merged into reshaped `DurableEventSink` |
+| `runtime_event_capture` `if event_buffer / else` selector | one capture path; enabled capture requires coordinator + per-run buffer |
+| long-lived `RuntimeEventCaptureConfig { writer }` | capture policy plus per-dispatch `EventBuffer` |
+| `RunRequestExtras` JSON escape hatch | typed fields on `RunActivationSnapshot` |
+| old `RunRequest` public fields and builder chain | explicit `RunActivation` construction |
+| `LocalExecutionResolver` | `ResolvedRun<...>.execution = ExecutionPlan::Local { ... }` |
+| `RunRegistryManifestResolver` | registry materialization inside `Resolver::resolve` |
+| `ResolvedExecution::{Local, NonLocal}` | `ResolvedRun<Scope>` + `ExecutionPlan` |
+| `ExecutionResolver` | `Resolver` |
+| `BackendCapabilities::unsupported_*_features() -> Vec<&'static str>` | `BackendProfile::check(&BackendRequirements) -> CapabilityDecision` |
+| `BackendCapabilities.decisions / overrides / frontend_tools` bools | typed capability enums |
+| `AppState` and `AppState::with_*` service setters | `ServerState` module construction |
+| `APP_STATE_EXTRAS` | fields on typed module states |
+
+## Migration adapters and compatibility limits
+
+| Surface | 0.6.0 compatibility | Limit |
+|---|---|---|
+| `RunRequest` | **deleted outright**; no migration wrapper | callers construct `RunActivation` directly |
+| `RunRequestSnapshot` | legacy serde struct + conversion adapter for old stored records | new writes use `RunActivationSnapshot`; replay-safe writes require pinned scope |
+| `AgentResolver` | can be wrapped by `LocalRegistryResolver` | live-only root local runs; not valid for persistent server/mailbox execution |
+| `ExecutionResolver` | no source-compatible adapter | removed with `ResolvedExecution`; implement `Resolver` |
+| `AppState` | no type alias | callers construct `ServerState` modules explicitly |
+
+## Crate dependency shape
+
+```text
+awaken-contract
+  ├─ run contract types: RunIntent, RunInputSnapshot, RunTraceContext,
+  │  RunResolutionScope, RunActivationSnapshot
+  ├─ event contract types: AgentEvent, CanonicalEventDraft,
+  │  CanonicalEventStager
+  └─ capability contract types shared by runtime/server
+
+awaken-runtime
+  ├─ owns RunActivation, RunControl, RunExecutionWiring
+  ├─ owns concrete EventBuffer with drain()
+  ├─ implements DurableEventSink wiring against CanonicalEventStager
+  ├─ defines Resolver, ResolvedRun<Scope>, ExecutionPlan, BackendProfile
+  └─ pins persistent submits and runs resolved plans via run_replayable/run_live
+
+awaken-stores
+  └─ implements CommitCoordinator and transaction-scoped store primitives
+
+awaken-server
+  ├─ mints per-run EventBuffer and passes the same Arc to sink + activation
+  ├─ requires ResolvedRun<ReplayableScope> for persistent mailbox paths
+  └─ composes ServerState modules into axum routers
+```
+
+`awaken-contract` never depends on `awaken-runtime`. The concrete buffer
+therefore cannot be named by `DurableEventSink`; only the stage-only port is
+visible across that crate boundary.
+
+## Dependency chain
+
+```text
+ADR-0038 (Transaction)
+    defines: CommitCoordinator is the only runtime durable write entry;
+             CanonicalEventStager is stage-only;
+             committed server facts attach to checkpoint plans and advisory
+             server facts use outbox publication.
+    ↓
+ADR-0039 (Activation)
+    defines: owned RunActivation; runtime wiring carries Arc<EventBuffer>;
+             snapshots require persisted input and pinned registry scope;
+             execution receives a resolved plan and durable queues store only
+             the snapshot.
+    ↓
+ADR-0040 (Execution plan)
+    defines: Resolver returns ResolvedRunPlan;
+             persistent paths require ResolvedRun<ReplayableScope>;
+             BackendRequirements are derived from activation features.
+    ↓
+ADR-0041 (Composition)
+    defines: ServerState modules and route-bound module state;
+             persistent server paths compose the earlier boundaries.
+```
+
+## Cross-ADR invariants
+
+- Runtime canonical event capture is either disabled or built with a
+  coordinator and a single shared `Arc<EventBuffer>`.
+- `RunActivation` is owned. It carries thread context by `Arc`, not by
+  reference, across async dispatch.
+- Persisted `RunActivationSnapshot` stores a pinned manifest, not `Live`.
+- Persistent submit resolution pins registry scope for the snapshot; dispatch
+  resolution rebuilds live handles and passes a resolved plan to execution.
+  Durable queues do not store live execution handles.
+- Backend capability requirements are derived from activation features and
+  checked against the resolved backend profile.
+- Resolution happens at dispatch entry for root runs and inside the runtime
+  for sub-runs (delegate / handoff). Sub-runs spawned from a replayable root
+  must themselves be replayable; the runtime fails the parent run on a
+  scope mismatch rather than silently downgrading.
+- Legacy `AgentResolver` adapters are live-only and rejected by persistent
+  server/mailbox paths.
+- Handlers extract module state or a purpose-specific service state, never
+  the full `ServerState`.
+
+## What this does not do
+
+- It does not add a config-store transaction coordinator. Config/audit
+  atomicity with config writes requires a separate design; ADR-0038 only
+  defines runtime checkpoint and server canonical event publication tiers.
+- It does not decompose `MailboxStore` into queue/signal/live-channel
+  traits.
+- It does not consolidate read-side traits. `ThreadReader`, `RunReader`,
+  and `EventReader` remain separate because different server modules need
+  different read surfaces.
+- It does not keep source-compatible aliases for surfaces whose old methods
+  would preserve the removed boundary.

--- a/docs/adr/0038-runtime-commit-boundary.md
+++ b/docs/adr/0038-runtime-commit-boundary.md
@@ -1,0 +1,303 @@
+# ADR-0038: Runtime Commit Boundary — Single Durable Write Entry
+
+- **Status**: 🚧 Proposed
+- **Date**: 2026-05-22
+- **Depends on**: ADR-0034, ADR-0036
+- **Updates**: ADR-0034 D7/D9, ADR-0036 D8/D9
+- **Breaking**: yes (0.6.0)
+
+## Context
+
+ADR-0036 introduced `CommitCoordinator` as the cross-store atomic write
+boundary for `ThreadRunStore + EventStore + OutboxStore`. The rollout
+landed the coordinator and event buffer, but left a legacy inline append
+branch in `runtime_event_capture`:
+
+```rust
+// runtime_event_capture.rs (current)
+if let Some(buffer) = event_buffer {
+    Arc::new(BufferedDurableEventSink::new(/* coordinator-bound */))
+} else {
+    Arc::new(DurableEventSink::new(inner, capture.writer, /* legacy inline */))
+}
+```
+
+That shape has two failure modes:
+
+- A deployment can wire `runtime_event_capture` without a coordinator and
+  silently append canonical runtime events outside the matching
+  `ThreadRunStore` checkpoint transaction.
+- Two sink wrappers (`DurableEventSink`, `BufferedDurableEventSink`) encode
+  the same runtime tee concept with different ordering and error behavior.
+
+`runtime_event_capture` also writes mailbox-authored events such as
+`RunRescheduled` and `MailboxResumeFailed`. Those are not runtime tee
+facts. They are server canonical facts with their own consistency tier.
+Mixing runtime tee, server canonical events, and diagnostics behind one
+`writer` field makes the durability contract ambiguous.
+
+## Decision
+
+Runtime tee persistence has one durable write entry:
+`CommitCoordinator::commit_checkpoint`. A reshaped `DurableEventSink`
+forwards live events, normalizes them, and stages canonical drafts. It
+never appends to `EventStore` itself. Server-authored canonical events and
+diagnostics use distinct publisher types.
+
+### D1: Reshape `DurableEventSink` (no `writer` field)
+
+```rust
+pub struct DurableEventSink {
+    inner: Arc<dyn EventSink>,
+    stager: Arc<dyn CanonicalEventStager>,
+    normalizer: Arc<dyn AgentEventNormalizer>,
+    mode: RuntimeEventDurability,
+}
+
+impl DurableEventSink {
+    pub fn new(
+        inner: Arc<dyn EventSink>,
+        stager: Arc<dyn CanonicalEventStager>,
+        normalizer: Arc<dyn AgentEventNormalizer>,
+        mode: RuntimeEventDurability,
+    ) -> Self { /* ... */ }
+}
+
+#[async_trait]
+impl EventSink for DurableEventSink {
+    async fn emit(&self, event: AgentEvent) {
+        // 1. forward the live event to `inner`;
+        // 2. normalize into zero or more CanonicalEventDrafts;
+        // 3. stage each selected draft through CanonicalEventStager.
+    }
+}
+```
+
+0.6.0 deletes the legacy constructor
+`DurableEventSink::new(inner, writer, normalizer, mode)`. It also deletes
+`BufferedDurableEventSink`; its live-first staging behavior is folded into
+`DurableEventSink`.
+
+`RuntimeEventDurability` remains the selection policy for which normalized
+fidelity classes are staged:
+
+| Mode | Runtime capture config | Stager required | Effect |
+|---|---|---:|---|
+| `Disabled` | Not installed | No | The composition root returns the live sink unchanged. |
+| `Compacted` | Installed | Yes | Stage committed/domain facts; skip observed token deltas. |
+| `FullFidelity` | Installed | Yes | Stage every normalizable runtime tee fact. |
+
+There is no no-op stager in the persistent capture path. `Disabled` means
+no durable runtime wrapper is constructed.
+
+### D2: `CanonicalEventStager` is a narrow crate-boundary port
+
+`DurableEventSink` stays in `awaken-contract` because it owns the
+contract-level mapping from `AgentEvent` to `CanonicalEventDraft`. The
+concrete `EventBuffer` stays in `awaken-runtime` because it owns runtime
+checkpoint lifecycle (`drain`, buffer disposal, and per-dispatch sharing).
+That split avoids both unwanted dependencies:
+
+- `awaken-contract` must not depend on `awaken-runtime` to name
+  `EventBuffer`.
+- The runtime checkpoint code must not expose `drain` through a public
+  contract trait that arbitrary emitters can call.
+
+The contract-facing port is intentionally stage-only:
+
+```rust
+/// Crate-boundary port for runtime event staging. A single runtime
+/// implementation is expected; this trait exists to keep contract types
+/// from depending on the runtime-owned EventBuffer.
+pub trait CanonicalEventStager: Send + Sync {
+    fn stage(&self, draft: CanonicalEventDraft);
+}
+```
+
+`EventBuffer` is the expected runtime implementation, but the trait is not
+introduced for substitutability. It is a one-method boundary that lets a
+contract-level sink write into runtime-owned staging without making the
+buffer type part of the contract crate.
+
+### D3: Explicit buffer sharing and drain ownership
+
+The composition root constructs one concrete `Arc<EventBuffer>` per run
+activation when runtime event capture is enabled. That same allocation is
+passed through two different views:
+
+```rust
+let buffer: Arc<EventBuffer> = Arc::new(EventBuffer::new());
+let stager: Arc<dyn CanonicalEventStager> = buffer.clone();
+let sink = Arc::new(DurableEventSink::new(live_sink, stager, normalizer, mode));
+let activation = activation.with_event_buffer(buffer);
+```
+
+Only runtime checkpoint code receives the concrete `Arc<EventBuffer>` and
+therefore can call `drain()`. The sink receives only
+`Arc<dyn CanonicalEventStager>` and can only call `stage(...)`. A runtime
+activation with capture enabled is invalid unless both views reference the
+same `Arc<EventBuffer>`.
+
+### D4: Server canonical events are not runtime tee sinks
+
+Server-authored events use two explicit APIs. The committed tier is
+attached to the same checkpoint plan that writes the state transition:
+
+```rust
+pub struct ServerCanonicalEvent {
+    pub draft: CanonicalEventDraft,
+    pub options: AppendOptions,
+}
+
+impl CheckpointCommitPlan {
+    pub fn with_server_events(
+        self,
+        events: Vec<ServerCanonicalEvent>,
+    ) -> Self { /* append in the coordinator transaction */ }
+}
+```
+
+The enqueued/advisory tier is a long-lived module dependency:
+
+```rust
+#[async_trait]
+pub trait OutboxServerEventPublisher: Send + Sync {
+    async fn publish(
+        &self,
+        draft: CanonicalEventDraft,
+        options: AppendOptions,
+    ) -> Result<ServerEventPublishOutcome, EventPublishError>;
+}
+
+pub enum ServerEventPublishOutcome {
+    Enqueued { dedupe_key: String },
+}
+
+pub enum EventPublishError {
+    Validation(String),
+    Enqueue(OutboxError),
+    Serialization(String),
+}
+```
+
+Committed publication does not have a separate async `publish` call: the
+coordinator appends `ServerCanonicalEvent` entries inside
+`CommitCoordinator::commit_checkpoint`, and failures surface as
+`CommitError` for the whole checkpoint. Enqueued publication failures return
+`EventPublishError`; the caller must either propagate the error when the
+event gates correctness or log-and-continue for advisory notifications.
+
+ADR-0038 does **not** create a config-store transaction boundary. Config
+admin/audit events that must be atomic with `ConfigStore` mutation remain
+outside this ADR unless their storage backend exposes a future config
+transaction boundary. Until then they use the enqueued/advisory tier or a
+future config transaction ADR.
+
+### D5: `DiagnosticEventPublisher` for telemetry
+
+```rust
+pub trait DiagnosticEventPublisher: Send + Sync {
+    /// Fire-and-forget. Failures are logged and never affect replay.
+    fn record(&self, event: DiagnosticEvent);
+}
+```
+
+Diagnostic events are non-transactional, not replayed as canonical events,
+and have their own schema and retention policy.
+
+### D6: Runtime event capture has one composition path
+
+```rust
+fn wrap_runtime_event_sink(
+    &self,
+    inner: Arc<dyn EventSink>,
+    /* thread/run/correlation context */,
+    stager: Arc<dyn CanonicalEventStager>,
+) -> Arc<dyn EventSink> {
+    Arc::new(DurableEventSink::new(inner, stager, normalizer, capture.mode))
+}
+```
+
+`Mailbox::with_runtime_event_capture(writer, mode, origin)` is deleted.
+The replacement `with_runtime_event_capture(mode, origin)` only records
+capture policy and origin. At dispatch time, if capture is enabled, the
+mailbox/runtime mints the per-run `EventBuffer` described in D3.
+
+`executor.has_commit_coordinator()` is a construction precondition for
+enabled runtime event capture. A mailbox or server state that enables
+capture with an executor that lacks a coordinator is rejected at build time.
+There is no runtime fallback to inline append.
+
+### D7: Checkpoint writes become coordinator-owned
+
+`ThreadRunStore::checkpoint` is no longer a general runtime/server write
+entry. Store implementations still need an internal primitive that the
+coordinator can call, but production runtime/server code writes through
+`CommitCoordinator::commit_checkpoint`.
+
+This supersedes ADR-0036 D8's build-time pairing check as the primary
+write-boundary guarantee. The D8 check may remain as a defensive migration
+error, but the steady-state contract is compile-time access to the write
+primitive only through coordinator-owned internals.
+
+0.6.0 enforces this by API shape rather than by a grep allowlist:
+
+- read paths use read-side traits (`ThreadReader`, `RunReader`, or
+  read-only adapters over existing stores);
+- the checkpoint write primitive is moved behind a sealed/internal trait
+  implemented by store crates and consumed by coordinator implementations;
+- `ThreadRunStore::checkpoint` remains only for store conformance tests
+  and downstream compatibility during the 0.6 line, is deprecated, and is
+  not re-exported from server/runtime composition surfaces.
+
+A CI grep may exist as a supplemental guard, but it is not the primary
+contract. Renaming files must not be able to bypass the boundary.
+
+## Migration
+
+- Delete:
+  - `DurableEventSink::new(inner, writer, normalizer, mode)`.
+  - `BufferedDurableEventSink`.
+  - the `runtime_event_capture` `if event_buffer / else` selector.
+  - `Mailbox::with_runtime_event_capture(writer, mode, origin)`.
+- Add:
+  - `DurableEventSink::new(inner, stager, normalizer, mode)`.
+  - runtime-owned `EventBuffer` with `drain()` not exposed by
+    `CanonicalEventStager`.
+  - `CheckpointCommitPlan::with_server_events(...)` for committed server facts.
+  - `OutboxServerEventPublisher` and `DiagnosticEventPublisher`.
+  - `Mailbox::with_runtime_event_capture(mode, origin)`.
+- Migrate mailbox/thread-run state transitions that currently call
+  `.checkpoint(...)` to `CommitCoordinator::commit_checkpoint` with
+  attached server canonical drafts when atomic publication is required.
+- Migrate advisory mailbox lifecycle fanout to `OutboxServerEventPublisher`.
+
+## Risks
+
+- Deleting inline runtime append before wiring committed server events into
+  checkpoint plans and advisory events into the outbox publisher would leave
+  mailbox lifecycle events without a canonical path. The runtime tee reshape
+  and server event API changes land in the same change set.
+- Backends without coordinator-backed checkpoint commits can only publish
+  advisory server-authored events through the outbox. They must not document
+  those events as atomic with run/thread state changes.
+
+## Test Plan
+
+1. Building runtime event capture without a coordinator returns a build
+   error.
+2. A staged runtime event is not visible from `EventStore::list` if the
+   checkpoint commit fails.
+3. The same `Arc<EventBuffer>` is shared between `DurableEventSink` staging
+   and runtime checkpoint draining.
+4. Server canonical facts attached through `CheckpointCommitPlan` roll back
+   with the checkpoint; advisory outbox publication reports `Enqueued` or an
+   `EventPublishError`.
+5. Runtime/server production crates do not call the checkpoint write
+   primitive directly.
+
+## Non-Goals
+
+- Adding a config-store transaction coordinator.
+- Refactoring outbox dispatch or protocol projector internals beyond the
+  publisher boundary defined here.

--- a/docs/adr/0039-run-activation-layering.md
+++ b/docs/adr/0039-run-activation-layering.md
@@ -1,0 +1,384 @@
+# ADR-0039: `RunActivation` — Replacing the `RunRequest` God-Struct
+
+- **Status**: 🚧 Proposed
+- **Date**: 2026-05-22
+- **Depends on**: ADR-0011, ADR-0038
+- **Updates**: ADR-0011 D3/D6, ADR-0022 D3
+- **Breaking**: yes (0.6.0)
+
+## Context
+
+`RunRequest` has accumulated 20+ optional public fields that mix four
+concerns:
+
+| Concern | Example fields |
+|---|---|
+| User intent | `messages`, `agent_id`, `thread_id`, `overrides`, `frontend_tools` |
+| Dispatch / transport | `origin`, `adapter`, `dispatch_id`, `session_id`, `transport_request_id` |
+| Run identity hints | `continue_run_id`, `run_id_hint`, `dispatch_id_hint` |
+| Runtime wiring | `event_buffer`, `registry_manifest`, `pinned_registry_set` |
+
+`RunRequestSnapshot` lives in `awaken-contract`, while executable
+`RunRequest` lives in `awaken-runtime`. Runtime-only handles leak into a
+public request object, and the persisted projection is defined by fields
+that were omitted rather than by fields that are safe to replay.
+
+## Decision
+
+Replace `RunRequest` with an owned `RunActivation` split into
+contract-layer data and runtime-layer execution resources. The activation
+is owned so it can cross `.await`, be queued by mailbox dispatch, and move
+between tasks without borrowing stack-local context.
+
+### D1: Contract-layer types
+
+In `awaken-contract::contract::run`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunIntent {
+    pub agent_id: Option<String>,
+    pub thread_id: String,
+    pub kind: RunKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RunKind {
+    /// Start a new run for a new user or system intent.
+    NewIntent,
+    /// Resume the same durable run that is waiting for human/tool input.
+    HitlResume { run_id: String },
+    /// Start a fresh activation using a previous run as continuation context.
+    ContinuationFromRun { run_id: String },
+}
+```
+
+The names are intentionally explicit. `HitlResume` is the same durable run
+being re-dispatched after an interrupt or decision. `ContinuationFromRun`
+creates a new activation whose prompt/state is derived from an earlier run;
+it is not the HITL resume path.
+
+Runtime input may contain message bodies, but persisted input never does:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RunInput {
+    NewMessages(Vec<Message>),
+    AlreadyPersisted(RunInputSnapshot),
+}
+
+/// Durable projection of the thread message slice consumed by a run.
+/// Shape intentionally mirrors existing RunMessageInput.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunInputSnapshot {
+    pub thread_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub range: Option<MessageSeqRange>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trigger_message_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected_message_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_policy: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compacted_snapshot_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunOptions {
+    pub overrides: Option<InferenceOverride>,
+    pub frontend_tools: Vec<ToolDescriptor>,
+}
+```
+
+`MessageSeqRange` is the existing thread-log watermark. ADR-0039 does not
+introduce a new `MessageWatermark` type.
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunTraceContext {
+    pub parent_run_id: Option<String>,
+    pub parent_thread_id: Option<String>,
+    pub origin: RunOrigin,
+    pub adapter: AdapterKind,
+    pub run_mode: RunMode,
+    pub dispatch_id: Option<String>,
+    pub session_id: Option<String>,
+    pub transport_request_id: Option<String>,
+    pub correlation_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RunResolutionScope {
+    Live,
+    Pinned(PinnedRegistryManifest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunActivationSnapshot {
+    pub intent: RunIntent,
+    pub input: RunInputSnapshot,
+    pub options: RunOptions,
+    pub trace: RunTraceContext,
+    pub resolution_scope: PinnedRegistryManifest,
+}
+```
+
+A persisted snapshot is replay-safe by construction: its
+`resolution_scope` is the exact pinned manifest, not `Live`.
+
+### D2: Runtime-layer type is owned
+
+In `awaken-runtime::run`:
+
+```rust
+pub struct RunActivation {
+    pub intent: RunIntent,
+    pub input: RunInput,
+    pub options: RunOptions,
+    pub trace: RunTraceContext,
+    /// Requested scope. Persistent snapshots use the resolved pinned manifest
+    /// supplied by ADR-0040, not this field directly.
+    pub resolution_scope: RunResolutionScope,
+    pub control: RunControl,
+    /// Event capture + thread-context fast-path. Orthogonal to user
+    /// intent and trace metadata.
+    pub capture: CaptureWiring,
+    /// Submit-side persistence facts the runtime must honour for
+    /// idempotency and id stability.
+    pub persistence: PersistenceHints,
+    /// Pinned resolver objects inherited from the parent for sub-run
+    /// scope continuity.
+    pub inherited: ResolverInheritance,
+}
+
+pub struct RunControl {
+    pub cancellation_token: Option<CancellationToken>,
+    pub decision_rx: Option<mpsc::UnboundedReceiver<Vec<(String, ToolCallResume)>>>,
+    /// Owned inbox pair. The activation must hold the `sender` half so
+    /// background tasks and extensions can deliver messages into this
+    /// run; a bare `InboxReceiver` is not enough.
+    pub inbox: Option<RunInbox>,
+    pub seeded_decisions: Vec<(String, ToolCallResume)>,
+}
+
+pub struct RunInbox {
+    pub sender: InboxSender,
+    pub receiver: InboxReceiver,
+}
+
+pub struct CaptureWiring {
+    /// Canonical event capture buffer. `None` means capture is disabled
+    /// for this activation; persistent runs always carry `Some`.
+    pub event_buffer: Option<Arc<EventBuffer>>,
+    /// Optional caller-side fast path; absent means the runtime loads
+    /// thread context from the store.
+    pub thread_context_cache: Option<Arc<ThreadContextSnapshot>>,
+}
+
+pub struct PersistenceHints {
+    /// True when the activation continues a prior run (resume / handoff).
+    pub is_continuation: bool,
+    /// Set by submit paths that have already appended new messages to the
+    /// thread log; prevents the runtime from re-persisting `NewMessages`.
+    pub messages_already_persisted: bool,
+    /// Mailbox-allocated identifiers that the runtime must adopt instead
+    /// of minting new ones (preserves the dispatch ↔ run ↔ event chain).
+    pub run_id_hint: Option<String>,
+    pub dispatch_id_hint: Option<String>,
+}
+
+pub struct ResolverInheritance {
+    /// Frozen resolver objects inherited from a pinned root run. Sub-runs
+    /// use this to resolve against the same registry the parent ran under,
+    /// independent of the live registry snapshot.
+    pub pinned_registry_set: Option<RegistrySet>,
+}
+```
+
+No lifetime parameter appears on `RunActivation`. The mailbox can enqueue
+and later dispatch the activation without extending stack borrows.
+`ThreadContextSnapshot` is either absent or owned through `Arc`.
+
+`capture.event_buffer == None` means canonical runtime capture is
+disabled for this activation. It does not mean the runtime lacks a
+coordinator; ADR-0038 requires persistent runtime execution to be wired
+through `CommitCoordinator`.
+
+The three split structs each represent a distinct boundary participation
+— **event capture**, **persistence idempotency / id injection**, and
+**sub-run resolver inheritance** — instead of a single
+`RunExecutionWiring` god-struct with seven mixed-intent fields. Each
+consumer can take the sub-struct it cares about (capture sinks see
+`CaptureWiring`; mailbox submit sees `PersistenceHints`; nested
+resolution sees `ResolverInheritance`) so the type signature reveals
+which boundary is participating.
+
+### D3: Snapshot creation happens after message persistence
+
+`RunActivation::snapshot` does not infer durable input references from
+message bodies and does not mutate `RunActivation::resolution_scope`. The
+caller must first append `RunInput::NewMessages` to the thread message log,
+resolve a replayable run plan through ADR-0040, and pass both durable
+results explicitly:
+
+```rust
+impl RunActivation {
+    pub fn snapshot(
+        &self,
+        persisted_input: RunInputSnapshot,
+        pinned_manifest: PinnedRegistryManifest,
+    ) -> RunActivationSnapshot {
+        RunActivationSnapshot {
+            intent: self.intent.clone(),
+            input: persisted_input,
+            options: self.options.clone(),
+            trace: self.trace.clone(),
+            resolution_scope: pinned_manifest,
+        }
+    }
+}
+```
+
+Runtime may provide a convenience helper that extracts the manifest from
+`ResolvedRun<ReplayableScope>`, but the snapshot API itself takes the
+manifest directly so the Live → Pinned transition is explicit.
+
+Mailbox/server submit paths own the order:
+
+1. normalize and append new messages to the thread log;
+2. build the `RunInputSnapshot` from the assigned `MessageSeqRange` and
+   trigger message ids;
+3. resolve `RunActivation` through ADR-0040 with
+   `ResolutionPolicy::PersistentServer` and require
+   `ResolvedRun<ReplayableScope>`;
+4. pass `plan.scope.manifest` into `snapshot(...)`;
+5. persist `RunActivationSnapshot` on the `RunRecord`;
+6. discard the live execution handles from this pre-dispatch resolution
+   unless the run is executed immediately in the same task.
+
+Embedded non-persistent callers may run with `RunResolutionScope::Live`,
+but they cannot produce a replay-safe snapshot because they do not have a
+`PinnedRegistryManifest`.
+
+### D4: Runtime execution receives a resolved plan
+
+`AgentRuntime` execution takes a resolved plan instead of resolving
+implicitly inside `run_*`. A resolved plan contains live handles
+(`LlmExecutor`, backend instances, plugin environment) and is not durable
+queue data. Durable queues store only `RunActivationSnapshot`, including
+the pinned manifest from D3, never `ResolvedRunPlan`.
+
+Persistent server/mailbox flows therefore have two resolution moments:
+
+1. submit-time resolution pins the registry scope so the run record is
+   replay-safe; only `plan.scope.manifest` is persisted;
+2. dispatch-time resolution rebuilds live execution handles from that
+   pinned scope, and the resulting plan is passed to `run_replayable`.
+
+Immediate non-queued execution may reuse the fresh plan from submit-time
+resolution if no durable queue boundary is crossed. The execution entry
+points take both the owned activation and a resolved plan:
+
+```rust
+impl AgentRuntime {
+    pub async fn resolve_activation(
+        &self,
+        activation: &RunActivation,
+        policy: ResolutionPolicy,
+    ) -> Result<ResolvedRunPlan, ResolveError>;
+
+    pub async fn run_replayable(
+        &self,
+        activation: RunActivation,
+        plan: ResolvedRun<ReplayableScope>,
+        live_sink: Arc<dyn EventSink>,
+    ) -> Result<RunOutcome, RuntimeError>;
+
+    pub async fn run_live(
+        &self,
+        activation: RunActivation,
+        plan: ResolvedRunPlan,
+        live_sink: Arc<dyn EventSink>,
+    ) -> Result<RunOutcome, RuntimeError>;
+}
+```
+
+Mailbox/server persistent dispatch calls `resolve_activation(...,
+ResolutionPolicy::PersistentServer)` against the snapshot's pinned scope and
+rejects `ResolvedRunPlan::LiveOnly` before any execution side effect.
+Embedded callers may call `run_live` with a live-only plan.
+
+`AgentRuntime` holds an `Arc<dyn Resolver>` because `resolve_activation` is
+the same entry used for root dispatch and for sub-run resolution mid-execution
+(`ResolutionTarget::Delegate`, `ResolutionTarget::Handoff` — see ADR-0040 D7).
+Holding the resolver on the runtime does not weaken the dispatch-entry
+contract: persistent paths still reject `LiveOnly` plans at every resolution
+moment, root or nested, by the same type boundary.
+
+`live_sink` is the live emission destination. If canonical runtime capture
+is enabled, the composition root wraps `live_sink` in ADR-0038's
+`DurableEventSink` before execution. The wrapped sink and
+`activation.wiring.event_buffer` must reference the same concrete
+`EventBuffer` allocation.
+
+### D5: `RunRequestExtras` is deleted
+
+`RunRequestExtras` was a JSON escape hatch for fields that did not fit the
+snapshot schema. With typed `RunIntent`, `RunInputSnapshot`, `RunOptions`,
+`RunTraceContext`, and `RunResolutionScope`, every field has an explicit
+home. `RunRequestExtras` is removed in 0.6.0.
+
+### D6: `RunRequest` is deleted
+
+0.6.0 is source-breaking. The `RunRequest` god-struct is deleted outright;
+no migration wrapper is retained. Callers construct `RunActivation`
+directly. Keeping a `#[deprecated]` shell would preserve a parallel request
+model in the public surface for no real callers; deleting it is simpler
+than maintaining a wrapper that delegates straight into the new boundary.
+
+`RunRequestSnapshot` remains as a legacy serde struct for one release. It
+keeps the old wire fields, including `request_extras`, and implements
+`TryFrom<RunRequestSnapshot> for RunActivationSnapshot` once the caller has
+provided persisted input and pinned registry data. It is **not** a type alias
+to `RunActivationSnapshot`, because old JSON would not match the new field
+shape. New writes use `RunActivationSnapshot`.
+
+## Migration
+
+| 0.5.x | 0.6.0 |
+|---|---|
+| `RunRequest::new(thread_id, messages).with_agent_id(a).with_dispatch_id(d)` | construct `RunActivation { intent, input, options, trace, resolution_scope, control, wiring }` |
+| `continue_run_id` for HITL resume | `RunKind::HitlResume { run_id }` |
+| `continue_run_id` for continuation context | `RunKind::ContinuationFromRun { run_id }` |
+| `RunRequestExtras` | typed fields on `RunActivationSnapshot` |
+| `RunRequestSnapshot` | legacy serde struct + `TryFrom` adapter; new writes use `RunActivationSnapshot` |
+| `runtime.run(request, sink)` | `resolve_activation(...)` then `run_replayable(...)` or `run_live(...)` |
+
+## Risks
+
+- Every request construction site changes at 0.6.0. The benefit is that
+  runtime-only handles no longer leak into persisted/public request data.
+- The `RunKind` rename forces callers to choose HITL resume vs continuation
+  explicitly; ambiguous old uses of `continue_run_id` must be inspected.
+
+## Test Plan
+
+1. `RunActivation` can be moved across async tasks without lifetime bounds.
+2. Snapshot creation requires caller-supplied `RunInputSnapshot` and
+   `PinnedRegistryManifest`; attempting to snapshot raw `NewMessages` or
+   `Live` scope without a manifest is impossible through the API.
+3. Persistent dispatch rejects `ResolvedRunPlan::LiveOnly` before execution.
+4. Old `RunRequestSnapshot` fixtures deserialize through the legacy struct
+   and convert to `RunActivationSnapshot` only after pinned manifest input is
+   provided.
+5. The sink wrapper and activation wiring share the same `EventBuffer` when
+   runtime capture is enabled.
+6. Durable mailbox records persist the pinned manifest but never serialize or
+   cache `ResolvedRunPlan` live handles.
+
+## Non-Goals
+
+- Splitting `RunOutcome`.
+- Replacing `MessageSeqRange` or `RunMessageInput`; ADR-0039 reuses the
+  existing message-log reference model.

--- a/docs/adr/0040-resolver-resolved-run.md
+++ b/docs/adr/0040-resolver-resolved-run.md
@@ -1,0 +1,445 @@
+# ADR-0040: `Resolver` + `ResolvedRun` + Typed Backend Capabilities
+
+- **Status**: 🚧 Proposed
+- **Date**: 2026-05-22
+- **Depends on**: ADR-0010, ADR-0035, ADR-0039
+- **Updates**: ADR-0010 D4/D8/D9, ADR-0011 D2/D6, ADR-0035 runtime pinning
+- **Breaking**: yes (0.6.0)
+
+## Context
+
+Three resolver-shaped concepts overlap today:
+
+```text
+AgentResolver::resolve(id) -> ResolvedAgent
+ExecutionResolver::resolve_execution(id) -> ResolvedExecution::{Local | NonLocal}
+RunRegistryManifestResolver::manifest_for_run(agent_id) -> PinnedRegistryManifest
+```
+
+Backend capability reporting is also mixed. Some dimensions are typed
+(`cancellation`, `continuation`, `waits`, `transcript`, `output`) while
+`decisions`, `overrides`, and `frontend_tools` are bools and unsupported
+feature errors are returned as `Vec<&'static str>`.
+
+The result is a fragmented setup path: runtime code resolves an agent,
+asks another resolver whether execution is local or remote, asks mailbox
+which registry version to pin, and then performs a separate capability
+check.
+
+## Decision
+
+Collapse run materialisation into one async `Resolver` that returns a
+`ResolvedRunPlan`. The plan is the complete execution plan, including live
+execution handles. Capability requirements are derived from the activation
+by runtime code, not supplied manually by external callers.
+
+### D1: Single async `Resolver` trait
+
+`Resolver`, `ResolutionRequest`, `ResolvedRunPlan`, `ResolvedRun`, and
+`BackendProfile` live in `awaken-runtime`. Server code already depends on
+runtime and calls this surface at dispatch time; `awaken-contract` only owns
+the serializable run and event contract types.
+
+```rust
+#[async_trait]
+pub trait Resolver: Send + Sync {
+    async fn resolve(
+        &self,
+        request: ResolutionRequest,
+    ) -> Result<ResolvedRunPlan, ResolveError>;
+}
+```
+
+Spec-only reads are not a second method on `Resolver`. They use a separate
+read-side trait or existing registry interface:
+
+```rust
+#[async_trait]
+pub trait AgentSpecLookup: Send + Sync {
+    async fn resolve_spec(&self, agent_id: &str) -> Result<AgentSpec, ResolveError>;
+}
+```
+
+This keeps the execution-planning trait from gaining a method whose
+"must not materialize execution state" rule cannot be enforced by the
+signature. Implementations that can provide both traits may do so, but
+callers choose the narrower trait when they only need a spec.
+
+### D2: `ResolutionRequest` is a projection of `RunActivation`
+
+`Resolver` does not receive the full activation. Runtime builds a
+projection that contains identity, registry scope, and run features from
+which backend requirements are derived:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ResolutionRequest {
+    pub target: ResolutionTarget,
+    pub resolution_scope: RunResolutionScope,
+    pub overrides: Option<InferenceOverride>,
+    pub frontend_tools: Vec<ToolDescriptor>,
+    pub features: RunFeatureSet,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RunFeatureSet {
+    pub has_seeded_decisions: bool,
+    pub has_live_decision_channel: bool,
+    pub has_overrides: bool,
+    pub has_frontend_tools: bool,
+    pub is_human_resume: bool,
+    pub is_continuation: bool,
+    pub requested_persistence: PersistenceRequirement,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolutionPolicy {
+    PersistentServer,
+    LiveOnlyEmbedded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistenceRequirement {
+    NotRequired,
+    CheckpointRequired,
+}
+
+impl Default for PersistenceRequirement {
+    fn default() -> Self { Self::NotRequired }
+}
+
+impl From<ResolutionPolicy> for PersistenceRequirement {
+    fn from(policy: ResolutionPolicy) -> Self {
+        match policy {
+            ResolutionPolicy::PersistentServer => Self::CheckpointRequired,
+            ResolutionPolicy::LiveOnlyEmbedded => Self::NotRequired,
+        }
+    }
+}
+
+impl RunFeatureSet {
+    pub fn from_activation(activation: &RunActivation, policy: ResolutionPolicy) -> Self {
+        Self {
+            has_seeded_decisions: !activation.control.seeded_decisions.is_empty(),
+            has_live_decision_channel: activation.control.decision_rx.is_some(),
+            has_overrides: activation.options.overrides.is_some(),
+            has_frontend_tools: !activation.options.frontend_tools.is_empty(),
+            is_human_resume: matches!(&activation.intent.kind, RunKind::HitlResume { .. }),
+            is_continuation: matches!(
+                &activation.intent.kind,
+                RunKind::ContinuationFromRun { .. },
+            ),
+            requested_persistence: PersistenceRequirement::from(policy),
+        }
+    }
+}
+
+pub enum ResolutionTarget {
+    Root { agent_id: String, thread_id: String },
+    Delegate { agent_id: String, parent_run: RunIdentity, persistence: DelegatePersistence },
+    Handoff { agent_id: String, from_agent: String, transcript_ref: HandoffTranscriptRef },
+}
+```
+
+The mapping from activation to features is fixed:
+
+| Feature | Source |
+|---|---|
+| `has_seeded_decisions` | `!activation.control.seeded_decisions.is_empty()` |
+| `has_live_decision_channel` | `activation.control.decision_rx.is_some()` |
+| `has_overrides` | `activation.options.overrides.is_some()` |
+| `has_frontend_tools` | `!activation.options.frontend_tools.is_empty()` |
+| `is_human_resume` | `RunKind::HitlResume` |
+| `is_continuation` | `RunKind::ContinuationFromRun` |
+| `requested_persistence` | `ResolutionPolicy::PersistentServer` → `CheckpointRequired`; `LiveOnlyEmbedded` → `NotRequired` |
+
+`BackendRequirements` is derived from `RunFeatureSet` by a deterministic
+runtime function:
+
+```rust
+impl BackendRequirements {
+    pub fn from_features(features: &RunFeatureSet) -> Self { /* ... */ }
+}
+```
+
+`PersistenceRequirement::CheckpointRequired` maps to
+`Some(PersistenceCapability::Checkpoint)`; profile checking treats stronger
+profiles such as `CrossSession` as satisfying that requirement.
+`NotRequired` maps to no persistence requirement.
+
+External callers do not hand-write requirements before resolution.
+`ResolutionPolicy::PersistentServer` is selected by persistent
+mailbox/server submit and dispatch paths; `ResolutionPolicy::LiveOnlyEmbedded`
+is selected by embedded live-only calls.
+A resolver may use the derived requirements to choose among candidate
+backends. After resolution, the runtime recomputes the same requirements and
+checks `plan.backend_profile.check(&requirements)` as a defensive invariant
+before execution. A mismatch is reported as a resolve/capability error and
+no execution side effect has started.
+
+For persistent submits, `RunResolutionScope::Live` means "materialize a
+pinned registry snapshot now"; `RunResolutionScope::Pinned(manifest)` means
+"resolve against this exact pinned snapshot." The durable queue stores only
+that pinned snapshot. Dispatch resolves again from the pinned scope to
+recreate live handles.
+
+### D3: Replayability is encoded in the returned plan
+
+A resolved run is either replayable or live-only:
+
+```rust
+pub enum ResolvedRunPlan {
+    Replayable(ResolvedRun<ReplayableScope>),
+    LiveOnly(ResolvedRun<LiveOnlyScope>),
+}
+
+pub struct ReplayableScope {
+    pub manifest: PinnedRegistryManifest,
+}
+
+pub struct LiveOnlyScope;
+
+pub struct ResolvedRun<S> {
+    pub agent_spec: AgentSpec,
+    pub role: ExecutionRole,
+    pub execution: ExecutionPlan,
+    pub model: ResolvedModelBinding,
+    pub tools: Vec<ResolvedTool>,
+    pub overrides: Option<InferenceOverride>,
+    pub backend_profile: BackendProfile,
+    pub requirements: BackendRequirements,
+    pub scope: S,
+}
+```
+
+Server/mailbox persistent execution accepts only
+`ResolvedRun<ReplayableScope>`. Embedded non-persistent execution may use
+`LiveOnly`. This replaces prose-only "server runs must be pinned" rules
+with a type boundary.
+
+### D4: `ResolvedRun` contains live execution handles
+
+`ResolvedRun` is not just serializable metadata. It includes everything the
+runtime needs to dispatch:
+
+```rust
+pub enum ExecutionPlan {
+    Local {
+        env: ExecutionEnv,
+        llm_executor: Arc<dyn LlmExecutor>,
+        tool_executor: Arc<dyn ToolExecutor>,
+        context_summarizer: Option<Arc<dyn ContextSummarizer>>,
+        background_manager: Option<Arc<BackgroundTaskManager>>,
+        stream_checkpoint_store: Option<Arc<dyn StreamCheckpointStore>>,
+    },
+    Remote {
+        backend_id: String,
+        endpoint: RemoteEndpoint,
+        backend: Arc<dyn ExecutionBackend>,
+    },
+}
+```
+
+This preserves the execution information carried today by
+`ResolvedAgent` and `ResolvedBackendAgent`. Downstream execution no longer
+reassembles a plan from agent spec, backend registry, and runtime globals.
+
+### D5: Typed backend profile and multi-mismatch decisions
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendProfile {
+    pub cancellation: CancellationCapability,
+    pub continuation: ContinuationCapability,
+    pub decisions: DecisionCapability,
+    pub overrides: OverrideCapability,
+    pub frontend_tools: FrontendToolCapability,
+    pub persistence: PersistenceCapability,
+    pub waits: WaitCapability,
+    pub transcript: TranscriptCapability,
+    pub output: OutputCapability,
+}
+
+pub enum DecisionCapability { None, LiveOnly, DurableResume, LiveAndDurable }
+pub enum OverrideCapability { None, InferenceParams, ModelAndParams }
+pub enum FrontendToolCapability { None, DescriptorsOnly, Executable }
+pub enum PersistenceCapability { Ephemeral, Checkpoint, CrossSession }
+
+pub struct BackendRequirements {
+    pub cancellation: Option<CancellationCapability>,
+    pub continuation: Option<ContinuationCapability>,
+    pub decisions: Option<DecisionCapability>,
+    pub overrides: Option<OverrideCapability>,
+    pub frontend_tools: Option<FrontendToolCapability>,
+    pub persistence: Option<PersistenceCapability>,
+    pub waits: Option<WaitCapability>,
+    pub transcript: Option<TranscriptCapability>,
+    pub output: Option<OutputCapability>,
+}
+
+pub enum CapabilityDecision {
+    Supported,
+    Unsupported(Vec<CapabilityMismatch>),
+}
+```
+
+The new profile keeps the existing typed dimensions (`waits`,
+`transcript`, `output`) while replacing bool-only dimensions with typed
+capabilities. `BackendProfile::check(&BackendRequirements)` returns all
+mismatches in one result.
+
+`BackendProfile::full_local()` has a fixed contract:
+
+| Capability | `full_local()` value |
+|---|---|
+| `cancellation` | `CooperativeToken` |
+| `continuation` | `InProcessState` |
+| `decisions` | `LiveAndDurable` |
+| `overrides` | `ModelAndParams` |
+| `frontend_tools` | `Executable` |
+| `persistence` | `Checkpoint` |
+| `waits` | `InputAndAuth` |
+| `transcript` | `FullTranscript` |
+| `output` | `TextAndArtifacts` |
+
+### D6: 0.6.0 removals and migration adapters
+
+0.6.0 removes these internal bridges:
+
+- `LocalExecutionResolver`.
+- `RunRegistryManifestResolver`.
+- `ResolvedExecution::{Local, NonLocal}`.
+- `BackendCapabilities::unsupported_*_features() -> Vec<&'static str>`.
+- `BackendCapabilities` bool fields `decisions`, `overrides`, and
+  `frontend_tools`.
+
+`ExecutionResolver` cannot remain source-compatible because its return type
+is deleted. It is removed with `ResolvedExecution`.
+
+`AgentResolver` is user-facing enough to get a narrow adapter for embedded
+or test code:
+
+```rust
+pub struct LocalRegistryResolver<R: AgentResolver> { /* ... */ }
+
+#[async_trait]
+impl<R: AgentResolver + 'static> Resolver for LocalRegistryResolver<R> {
+    async fn resolve(&self, req: ResolutionRequest) -> Result<ResolvedRunPlan, ResolveError> {
+        let ResolutionTarget::Root { agent_id, .. } = &req.target else {
+            return Err(ResolveError::UnsupportedTarget(
+                "legacy AgentResolver adapter supports root local resolution only".into(),
+            ));
+        };
+        if matches!(req.resolution_scope, RunResolutionScope::Pinned(_)) {
+            return Err(ResolveError::UnsupportedPersistence(
+                "legacy AgentResolver adapter cannot materialize pinned registry scopes".into(),
+            ));
+        }
+        let agent = self.inner.resolve(agent_id)?;
+        Ok(ResolvedRunPlan::LiveOnly(ResolvedRun {
+            agent_spec: (*agent.spec).clone(),
+            role: ExecutionRole::Root,
+            execution: ExecutionPlan::from_resolved_agent(agent),
+            backend_profile: BackendProfile::full_local(),
+            requirements: BackendRequirements::from_features(&req.features),
+            scope: LiveOnlyScope,
+            /* ... */
+        }))
+    }
+}
+```
+
+The adapter is explicitly live-only. Persistent server/mailbox paths reject
+it because they require `ResolvedRun<ReplayableScope>`.
+
+### D7: Nested resolution for delegate / handoff
+
+Root resolution happens at the dispatch entry (mailbox/server submit and
+dispatch, embedded `run_*` call). Sub-runs spawned mid-execution
+(`ResolutionTarget::Delegate`, `ResolutionTarget::Handoff`) cannot be
+enumerated upfront, so `AgentRuntime` keeps an `Arc<dyn Resolver>` and calls
+it during execution:
+
+```rust
+pub struct AgentRuntime {
+    resolver: Arc<dyn Resolver>,
+    /* other fields */
+}
+```
+
+Nested resolution is **not** a back-door around the dispatch-entry contract.
+The scope of a sub-run is constrained by the root's scope:
+
+| Root plan scope | Allowed sub-run plan scope | On `LiveOnly` return |
+|---|---|---|
+| `ReplayableScope` | `ReplayableScope` only | runtime fails the parent run with `ResolveError::NestedScopeMismatch` |
+| `LiveOnlyScope` | either | accept and continue |
+
+The runtime constructs the nested `ResolutionRequest` with
+`resolution_scope` inherited from the root (the root's
+`PinnedRegistryManifest` for replayable runs, `Live` for live-only) and the
+appropriate `ResolutionTarget::{Delegate, Handoff}`. Sub-run
+`RunFeatureSet` is derived from the sub-run's own `RunActivation` (not the
+root's), via the same `RunFeatureSet::from_activation` function.
+
+`Resolver::resolve` itself does not know whether a request is root or
+nested — that distinction lives in `ResolutionTarget`. Resolvers that
+cannot honor `Delegate` or `Handoff` return
+`ResolveError::UnsupportedTarget`, which the runtime surfaces as a normal
+tool/spawn error rather than as a top-level dispatch failure.
+
+This keeps the dispatch-entry rule ("persistent paths reject `LiveOnly`")
+intact: the runtime enforces it for sub-runs the same way the dispatcher
+enforces it for the root, using the same type boundary.
+
+## Migration
+
+| 0.5.x | 0.6.0 |
+|---|---|
+| `impl AgentResolver for MyResolver` | implement `Resolver`, or wrap with `LocalRegistryResolver` for live-only embedded use |
+| `impl ExecutionResolver for MyResolver` | implement `Resolver` directly |
+| `LocalExecutionResolver::new(agent_resolver)` | `LocalRegistryResolver::new(agent_resolver)` for live-only root runs |
+| `RunRegistryManifestResolver` | manifest materialization inside `Resolver::resolve` |
+| `resolver.resolve_execution("agent")?` | `resolver.resolve(activation.resolution_request()).await?` |
+| `caps.unsupported_root_features(req)` | derive `BackendRequirements`, then `profile.check(&requirements)` |
+| `caps.decisions = true` | `profile.decisions = DecisionCapability::LiveAndDurable` |
+
+## Risks
+
+- `ResolvedRun` is richer than `ResolvedExecution`; test construction needs
+  builders.
+- Legacy `AgentResolver` fixtures that need persistence must migrate to
+  real `Resolver` implementations because the adapter cannot pin registries.
+
+## Test Plan
+
+1. `RunFeatureSet::from_activation` derives every feature from the owned
+   activation plus `ResolutionPolicy`; callers cannot hand-write
+   persistence requirements.
+2. `BackendRequirements::from_features` derives decisions, overrides,
+   frontend tools, continuation, waits, transcript, output, and persistence
+   requirements from activation features.
+3. `BackendProfile::full_local()` matches the fixed capability table and
+   `BackendProfile::check` returns every mismatch, not only the first.
+4. A server/mailbox path rejects `ResolvedRunPlan::LiveOnly` before
+   persistence or execution.
+5. `LocalRegistryResolver` succeeds only for root live local runs and
+   fails for delegate, handoff, remote, or pinned requests.
+6. `ResolvedRun<ReplayableScope>` contains the live handles needed by local
+   and remote execution without a second registry lookup.
+7. Runtime validation fails before execution side effects when a resolver
+   returns a plan whose profile does not satisfy derived requirements.
+8. Persistent submit with `RunResolutionScope::Live` materializes a pinned
+   registry snapshot, and dispatch with `RunResolutionScope::Pinned`
+   resolves against exactly that pinned snapshot.
+9. A delegate/handoff spawned from a `ReplayableScope` parent run that
+   resolves to `LiveOnly` fails the parent run with
+   `ResolveError::NestedScopeMismatch`; the same spawn from a `LiveOnly`
+   parent run is accepted.
+
+## Non-Goals
+
+- Per-tool capability negotiation. The current requirements cover run-level
+  capabilities; per-tool flags can be added without changing the resolver
+  boundary.
+- Streaming resolution. `resolve` is a one-shot setup call.

--- a/docs/adr/0041-server-state-modules.md
+++ b/docs/adr/0041-server-state-modules.md
@@ -1,0 +1,305 @@
+# ADR-0041: `ServerState` Modules — Replacing the `AppState` Service Locator
+
+- **Status**: 🚧 Proposed
+- **Date**: 2026-05-22
+- **Depends on**: ADR-0038, ADR-0039, ADR-0040
+- **Updates**: ADR-0023 server composition, ADR-0034 server event wiring
+- **Breaking**: yes (0.6.0, server crate)
+
+## Context
+
+`AppState` carries required runtime state plus many optional dependencies.
+A second registry, `APP_STATE_EXTRAS`, stores services that did not fit the
+public struct shape: admin config, audit config, runtime stats, audit log,
+trace store, event store, eval store, construction time, and credential
+broker. Handlers discover these dependencies through accessors at runtime,
+not through axum state types.
+
+This makes route availability and handler dependencies implicit. Tests also
+need global extra-state setup before exercising handlers that rely on those
+services.
+
+## Decision
+
+Replace `AppState` with typed `ServerState` modules. Each optional vertical
+is represented by a module state, and routers for optional verticals are
+mounted only when that module exists. Handlers extract concrete module
+state, never `Option<...>` and never the whole `ServerState`.
+
+### D1: Module decomposition and field ownership
+
+```rust
+pub struct ServerState {
+    pub run: RunModuleState,
+    pub config: Option<ConfigModuleState>,
+    pub events: Option<EventModuleState>,
+    pub eval: Option<EvalModuleState>,
+    pub trace: Option<TraceModuleState>,
+    pub protocol: Option<ProtocolModuleState>,
+    pub admin: AdminModuleState,
+    pub server_config: ServerConfig,
+}
+
+#[derive(Clone)]
+pub struct RunModuleState {
+    pub runtime: Arc<AgentRuntime>,
+    pub mailbox: Arc<Mailbox>,
+    pub resolver: Arc<dyn AgentResolver>,
+    /// Single thread/run store handle. Reads happen directly; writes go
+    /// through ADR-0038's `CommitCoordinator`, so the coordinator boundary
+    /// — not a parallel read-only trait — is what keeps modules from
+    /// performing ad hoc durable writes.
+    pub store: Arc<dyn ThreadRunStore>,
+    pub credential_broker: Arc<dyn CredentialBroker>,
+    pub runtime_stats: Option<Arc<RuntimeStatsRegistry>>,
+}
+
+#[derive(Clone)]
+pub struct ConfigModuleState {
+    pub config_store: Arc<dyn ConfigStore>,
+    pub runtime_manager: Arc<ConfigRuntimeManager>,
+    pub audit_log: Option<Arc<AuditLogger>>,
+    pub skill_catalog_provider: Option<Arc<dyn SkillCatalogProvider>>,
+}
+
+#[derive(Clone)]
+pub struct EventModuleState {
+    /// Single canonical event handle. `EventStore` is itself the trait
+    /// composition `EventWriter + EventReader + EventLookup + EventSubscriber`,
+    /// so handlers that need any of those surfaces extract them through
+    /// this one field. Protocol replay logs, outbox publishers, and
+    /// fanout publishers are constructed independently against the same
+    /// underlying store and wired where they are used (mailbox capture,
+    /// protocol projectors); they do not flow through this module state.
+    pub event_store: Arc<dyn EventStore>,
+}
+
+#[derive(Clone)]
+pub struct EvalModuleState {
+    pub eval_run_store: Arc<dyn EvalRunStore>,
+}
+
+#[derive(Clone)]
+pub struct TraceModuleState {
+    pub trace_store: Arc<dyn TraceStore>,
+}
+
+#[derive(Clone)]
+pub struct ProtocolModuleState {
+    pub replay_buffers: ReplayBufferMap,
+    pub mcp_http: Arc<McpHttpState>,
+}
+
+#[derive(Clone)]
+pub struct AdminModuleState {
+    pub admin_api_config: AdminApiConfig,
+    pub audit_log_config: AuditLogConfig,
+    pub started_at: Instant,
+}
+```
+
+`APP_STATE_EXTRAS` is deleted. Its fields move as follows:
+
+| Existing source | New owner |
+|---|---|
+| `admin_api_config`, `audit_log_config`, `started_at` | `AdminModuleState` |
+| `runtime_stats`, `credential_broker` | `RunModuleState` |
+| `audit_log`, `skill_catalog_provider` | `ConfigModuleState` |
+| `trace_store` | `TraceModuleState` |
+| `event_store` (composed reader/writer/lookup/subscriber) | `EventModuleState` |
+| `eval_run_store` | `EvalModuleState` |
+| `replay_buffers`, `mcp_http` | `ProtocolModuleState` |
+
+### D2: Router composition with concrete module state
+
+Module route builders are typed over their own state. They are converted to
+`Router<()>` with `.with_state(...)` before being nested into the top-level
+router:
+
+```rust
+pub fn run_routes() -> Router<RunModuleState> { /* handlers use State<RunModuleState> */ }
+pub fn config_routes() -> Router<ConfigModuleState> { /* ... */ }
+pub fn event_routes() -> Router<EventModuleState> { /* ... */ }
+
+pub fn build_router(state: ServerState) -> Router {
+    let mut router: Router = run_routes()
+        .with_state(state.run.clone());
+
+    if let Some(config) = state.config.clone() {
+        router = router.nest("/v1/config", config_routes().with_state(config));
+    }
+
+    if let Some(events) = state.events.clone() {
+        router = router.nest("/v1/events", event_routes().with_state(events));
+    }
+
+    if let Some(trace) = state.trace.clone() {
+        router = router.nest("/v1/traces", trace_routes().with_state(trace));
+    }
+
+    if let Some(eval) = state.eval.clone() {
+        router = router.nest("/v1/eval", eval_routes().with_state(eval));
+    }
+
+    if let Some(protocol) = state.protocol.clone() {
+        router = router
+            .nest("/v1/mcp", mcp_routes().with_state(protocol.clone()))
+            .nest("/v1/a2a", a2a_routes().with_state(protocol.clone()))
+            .nest("/v1/ai-sdk", ai_sdk_routes().with_state(protocol));
+    }
+
+    router
+}
+```
+
+`eval_routes()` in this example covers eval-store surfaces that need only
+`EvalModuleState`. Eval execution routes that also need run/config state
+use the service-state pattern in D3.
+
+A route that needs two modules gets a combined state at the composition
+root:
+
+```rust
+#[derive(Clone)]
+pub struct ConfigRunModuleState {
+    pub run: RunModuleState,
+    pub config: ConfigModuleState,
+}
+
+pub fn config_run_routes() -> Router<ConfigRunModuleState> { /* ... */ }
+
+if let Some(config) = state.config.clone() {
+    let combined = ConfigRunModuleState { run: state.run.clone(), config };
+    router = router.nest(
+        "/v1/config-run",
+        config_run_routes().with_state(combined),
+    );
+}
+```
+
+This is the required axum pattern: no `Router<S>` with optional state is
+nested into the top-level router.
+
+### D3: Cross-module operation rule
+
+Combined states are allowed for one- or two-module handlers. If an operation
+needs three or more modules, or if a vertical requires another module to do
+real work, the composition root builds a purpose-specific service and mounts
+a router whose handlers extract that service state. Module states must not
+embed other module states; otherwise top-level modules can drift and point at
+different `Arc` instances.
+
+```rust
+#[derive(Clone)]
+pub struct EvalExecutionService {
+    pub run: RunModuleState,
+    pub eval: EvalModuleState,
+    pub config: ConfigModuleState,
+    pub trace: Option<TraceModuleState>,
+    pub events: Option<EventModuleState>,
+}
+
+pub fn eval_execution_routes() -> Router<EvalExecutionService> { /* ... */ }
+
+if let (Some(eval), Some(config)) = (state.eval.clone(), state.config.clone()) {
+    let service = EvalExecutionService {
+        run: state.run.clone(),
+        eval,
+        config,
+        trace: state.trace.clone(),
+        events: state.events.clone(),
+    };
+    router = router.nest("/v1/eval/run", eval_execution_routes().with_state(service));
+}
+```
+
+Handlers do not assemble tuples from `ServerState` and do not extract
+`ServerState`. The required dependency set remains visible at the route
+boundary.
+
+### D4: Optional routes change absent-module behavior
+
+If a module is absent, its routes are absent and axum returns 404. This is
+a 0.6.0 API behavior change from handlers that were always mounted and
+returned 503 for missing optional stores. Admin exposure flags are still
+checked, but route mounting requires both:
+
+1. the exposure flag permits the surface; and
+2. the module state is present.
+
+A configured module with a disabled exposure flag is not mounted. An enabled
+exposure flag with no module is also not mounted.
+
+Client upgrade behavior is explicit:
+
+| Absent module | Route families that are absent and return 404 |
+|---|---|
+| `config` | `/v1/config/*`, config-backed agent/tool/model/provider admin routes, config-backed eval execution routes |
+| `events` | `/v1/threads/:id/events*`, `/v1/runs/:id/events*` |
+| `trace` | `/v1/traces*` |
+| `eval` | `/v1/eval/*` |
+| `protocol` | `/v1/mcp/*`, `/v1/a2a/*`, `/v1/ai-sdk/*` |
+
+Deployments that need capability discovery expose an admin-protected
+`GET /v1/system/modules` response listing which modules are mounted. Clients
+that previously probed optional handlers by expecting 503 should switch to
+that endpoint or deployment configuration.
+
+### D5: `AppState` is removed, not aliased
+
+`AppState` is not type-aliased to `ServerState`; an alias would preserve
+only the name while silently breaking all old constructor and `with_*`
+methods. 0.6.0 is source-breaking and requires callers to construct
+`ServerState` explicitly:
+
+```rust
+impl ServerState {
+    pub fn new(run: RunModuleState, server_config: ServerConfig) -> Self { /* ... */ }
+    pub fn with_config(mut self, cfg: ConfigModuleState) -> Self { /* ... */ }
+    pub fn with_events(mut self, events: EventModuleState) -> Self { /* ... */ }
+    pub fn with_eval(mut self, eval: EvalModuleState) -> Self { /* ... */ }
+    pub fn with_trace(mut self, trace: TraceModuleState) -> Self { /* ... */ }
+    pub fn with_protocol(mut self, protocol: ProtocolModuleState) -> Self { /* ... */ }
+}
+```
+
+The old `AppState::with_config_store(...)`, `with_event_store(...)`,
+`with_trace_store(...)`, and similar scattered setters are deleted.
+
+## Migration
+
+| 0.5.x | 0.6.0 |
+|---|---|
+| `AppState::new(...).with_config_store(cs)` | `ServerState::new(run, cfg).with_config(ConfigModuleState { config_store: cs, ... })` |
+| `state.event_store()` returning `Option` | handlers extract `State<EventModuleState>` |
+| `APP_STATE_EXTRAS` | explicit fields on module states |
+| always-mounted optional routes returning 503 | module-gated routes returning 404 when absent |
+| handler extracts `State<AppState>` | handler extracts one module state or purpose-specific service state |
+
+## Risks
+
+- Tests must construct relevant module states explicitly.
+- Clients that used 503 from absent optional handlers as capability probing
+  must switch to route discovery or documented deployment configuration.
+- Cross-module services need names and ownership at route boundaries, not
+  ad hoc extraction inside handlers.
+
+## Test Plan
+
+1. A `ServerState` with only `run` mounts only run-level routes.
+2. A state with `events` mounts event routes whose handlers receive
+   `EventModuleState` directly.
+3. `APP_STATE_EXTRAS` has no matches in server code.
+4. A two-module route compiles with a combined state pre-bound through
+   `.with_state(combined)` before nesting.
+5. Eval/protocol module states do not embed config/event module states;
+   cross-module eval/protocol operations use purpose-specific service state.
+6. A three-module operation is represented by a purpose-specific service
+   state, not `ServerState` extraction.
+7. Absent optional modules return 404 for the documented route families and
+   appear absent from `/v1/system/modules`.
+
+## Non-Goals
+
+- Splitting `ServerConfig` into per-module configs.
+- Multi-tenant module isolation.


### PR DESCRIPTION
Stack entry 1/8.\n\nScope:\n- ADR/docs only for the 0.6.0 design boundaries.\n\nValidation:\n- cargo check --workspace\n- pre-push validate passed.