### PR TITLE
feat(server): durable mailbox and admin auth hardening

### DIFF
--- a/crates/awaken-doctest/examples/http_app_builder.rs
+++ b/crates/awaken-doctest/examples/http_app_builder.rs
@@ -1,4 +1,4 @@
-//! Wire together `AgentRuntime` → `Mailbox` → `AppState` end-to-end —
+//! Wire together `AgentRuntime` → `Mailbox` → `ServerState` end-to-end —
 //! pins the construction sequence `reference/http-api.md` cites. This
 //! mirrors what an embedder does before calling `serve(state).await?`.
 //! Route registration is what `serve()` does internally; we exit before
@@ -40,10 +40,10 @@ fn main() {
         ..ServerConfig::default()
     };
 
-    // 5. Assemble — `AppState::new` is the canonical entry point that
+    // 5. Assemble — `ServerState::new` is the canonical entry point that
     //    every route handler reads from. `runtime.resolver_arc()` returns
     //    the same `Arc<dyn AgentResolver>` the runtime already owns.
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store,

--- a/crates/awaken-doctest/examples/http_app_builder.rs
+++ b/crates/awaken-doctest/examples/http_app_builder.rs
@@ -7,6 +7,7 @@
 use std::sync::Arc;
 
 use awaken::prelude::*;
+use awaken::server::app::ServerState;
 use awaken::stores::{InMemoryMailboxStore, InMemoryStore};
 
 fn main() {

--- a/crates/awaken-server/Cargo.toml
+++ b/crates/awaken-server/Cargo.toml
@@ -19,7 +19,7 @@ categories = [
 awaken-contract = { workspace = true }
 awaken-protocol-a2a = { workspace = true }
 awaken-tool-pattern = { workspace = true }
-awaken-runtime = { workspace = true, features = ["test-utils"] }
+awaken-runtime = { workspace = true }
 awaken-ext-mcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/awaken-server/Cargo.toml
+++ b/crates/awaken-server/Cargo.toml
@@ -19,7 +19,7 @@ categories = [
 awaken-contract = { workspace = true }
 awaken-protocol-a2a = { workspace = true }
 awaken-tool-pattern = { workspace = true }
-awaken-runtime = { workspace = true }
+awaken-runtime = { workspace = true, features = ["test-utils"] }
 awaken-ext-mcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/awaken-server/src/admin_routes.rs
+++ b/crates/awaken-server/src/admin_routes.rs
@@ -1,0 +1,151 @@
+//! Admin route groups with concrete module/service state.
+
+use awaken_ext_observability::runtime_stats::parse_window_str;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::app::{AdminRunRoutesState, ConfigRoutesState};
+use crate::error::ApiError;
+
+pub(crate) fn admin_run_routes() -> Router<AdminRunRoutesState> {
+    Router::new()
+        .route("/v1/agents/:id/runtime-stats", get(get_agent_runtime_stats))
+        .route("/v1/agents/runtime-stats", get(list_agents_runtime_stats))
+}
+
+pub(crate) fn config_admin_routes() -> Router<ConfigRoutesState> {
+    // permission-preview is always registered so the handler returns 503
+    // when the `permission` feature is absent (a 404 would be ambiguous
+    // with "agent not found"). Matches `runtime-stats` / trace conventions.
+    Router::new().route(
+        "/v1/agents/:id/permission-preview",
+        get(get_agent_permission_preview),
+    )
+}
+
+#[tracing::instrument(skip(state))]
+async fn get_agent_permission_preview(
+    State(state): State<ConfigRoutesState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state.admin, &headers) {
+        return err.into_response();
+    }
+    #[cfg(feature = "permission")]
+    {
+        let _ = &id;
+        match crate::services::permission_preview::preview_agent_permissions(&state, &id).await {
+            Ok(preview) => Json(preview).into_response(),
+            Err(err) => map_permission_preview_error(err).into_response(),
+        }
+    }
+    #[cfg(not(feature = "permission"))]
+    {
+        let _ = (state, id);
+        ApiError::ServiceUnavailable(
+            "permission feature not compiled into this server build".to_string(),
+        )
+        .into_response()
+    }
+}
+
+#[cfg(feature = "permission")]
+fn map_permission_preview_error(
+    err: crate::services::permission_preview::PermissionPreviewError,
+) -> ApiError {
+    use crate::services::permission_preview::PermissionPreviewError as PE;
+    match err {
+        PE::AgentNotFound(id) => ApiError::NotFound(format!("agent not found: {id}")),
+        PE::InvalidSpec(msg) | PE::InvalidPermissionConfig { reason: msg, .. } => {
+            ApiError::BadRequest(msg)
+        }
+        PE::RegistryUnavailable => ApiError::Internal("runtime registry unavailable".into()),
+        PE::Config(err) => ApiError::Internal(err.to_string()),
+    }
+}
+
+// ── Agent runtime-stats endpoints ───────────────────────────────────
+
+/// Query params for `GET /v1/agents/:id/runtime-stats`.
+#[derive(Debug, Deserialize, Default)]
+struct RuntimeStatsQuery {
+    /// Optional time window, e.g. `1h`, `24h`, `7d`, `3600s`, `90`.
+    window: Option<String>,
+}
+
+/// `GET /v1/agents/:id/runtime-stats` — return the agent's rolling-window
+/// snapshot, or 404 when the agent has not been seen by the registry, or
+/// 503 when the registry is not configured on this server.
+///
+/// Accepts an optional `?window=` query parameter (e.g. `1h`, `24h`, `7d`)
+/// to restrict the snapshot to a shorter sub-window of the registry's full
+/// history.  An invalid format returns 400.
+#[tracing::instrument(skip(state))]
+async fn get_agent_runtime_stats(
+    State(state): State<AdminRunRoutesState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<RuntimeStatsQuery>,
+) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state.admin, &headers) {
+        return err.into_response();
+    }
+    let Some(registry) = state.run.runtime_stats.clone() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "runtime_stats registry not configured" })),
+        )
+            .into_response();
+    };
+
+    let window = match params.window.as_deref() {
+        None => None,
+        Some(s) => match parse_window_str(s) {
+            Ok(d) => Some(d),
+            Err(msg) => {
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
+            }
+        },
+    };
+
+    match registry.snapshot_for_window(&id, window) {
+        Some(snapshot) => Json(snapshot).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("agent not found in runtime stats: {id}") })),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /v1/agents/runtime-stats` — return one snapshot per known agent,
+/// sorted by `agent_id`. Returns `{"agents":[...]}` (or 503 when the
+/// registry is missing).
+#[tracing::instrument(skip(state))]
+async fn list_agents_runtime_stats(
+    State(state): State<AdminRunRoutesState>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state.admin, &headers) {
+        return err.into_response();
+    }
+    let Some(registry) = state.run.runtime_stats.clone() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "runtime_stats registry not configured" })),
+        )
+            .into_response();
+    };
+    let snapshots: Vec<_> = registry
+        .known_agents()
+        .into_iter()
+        .filter_map(|id| registry.snapshot_for(&id))
+        .collect();
+    Json(json!({ "agents": snapshots })).into_response()
+}

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -296,6 +296,8 @@ pub struct ServerState {
     pub(crate) credential_broker: Arc<dyn CredentialBroker>,
 }
 
+pub type AppState = ServerState;
+
 impl ServerState {
     pub fn new(
         runtime: Arc<AgentRuntime>,
@@ -656,43 +658,20 @@ pub fn build_service_router(state: ServerState) -> std::io::Result<axum::Router>
 pub fn validate_admin_surface(state: &ServerState) -> std::io::Result<()> {
     crate::eval_limits::validate_eval_limits(&state.config.eval_limits)?;
     let admin = admin_api_config(state);
-    // Sensitive surfaces (need bearer on non-loopback bind): config
-    // routes; trace routes when a trace store is wired; eval routes
-    // always (online eval triggers live provider calls even at persist=false).
-    let any_sensitive_route_exposed = admin.expose_config_routes
-        || (admin.expose_trace_routes && state.trace_store().is_some())
-        || admin.expose_eval_routes;
-    if !any_sensitive_route_exposed {
+    let any_admin_route_exposed =
+        admin.expose_config_routes || admin.expose_trace_routes || admin.expose_eval_routes;
+    if !any_admin_route_exposed {
         return Ok(());
     }
     if admin.bearer_token.is_some() {
         return Ok(());
     }
-    if !admin_surface_has_sensitive_state(state) {
-        return Ok(());
-    }
-    let Ok(addr) = state.config.address.parse::<std::net::SocketAddr>() else {
-        return Ok(());
-    };
-    if addr.ip().is_loopback() {
-        return Ok(());
-    }
     Err(std::io::Error::new(
         std::io::ErrorKind::PermissionDenied,
         format!(
-            "admin APIs require {ADMIN_API_BEARER_TOKEN_ENV} when binding a non-loopback address"
+            "admin, config, trace, and eval APIs require {ADMIN_API_BEARER_TOKEN_ENV} when any admin surface is exposed"
         ),
     ))
-}
-
-fn admin_surface_has_sensitive_state(state: &ServerState) -> bool {
-    state.config_store.is_some()
-        || state.config_runtime_manager.is_some()
-        || state.audit_log().is_some()
-        || state.runtime_stats().is_some()
-        || state.skill_catalog_provider.is_some()
-        || state.trace_store().is_some()
-        || state.eval_run_store().is_some() // EvalRun bodies carry prompt + tool data
 }
 
 pub fn admin_cors_layer(state: &ServerState) -> std::io::Result<tower_http::cors::CorsLayer> {

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -590,6 +590,11 @@ pub async fn serve(state: ServerState) -> std::io::Result<()> {
 
     let addr = state.config.address.clone();
     let timeout = std::time::Duration::from_secs(state.config.shutdown.timeout_secs);
+    let config_runtime_manager = state.config_runtime_manager.clone();
+    let app = build_service_router(state.clone())?;
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!("listening on {addr}");
+
     let mailbox_lifecycle = match state.config.mailbox_lifecycle {
         MailboxLifecycleMode::Auto => {
             let cleanup_state = state.clone();
@@ -619,17 +624,22 @@ pub async fn serve(state: ServerState) -> std::io::Result<()> {
             crate::services::trace_retention::RetentionConfig::default(),
         )
     });
-    let protocol_relays = crate::protocol_replay_state::start_protocol_relays(&state)
-        .await
-        .map_err(|error| {
-            std::io::Error::other(format!("failed to start protocol relays: {error}"))
-        })?;
-
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    tracing::info!("listening on {addr}");
-
-    let config_runtime_manager = state.config_runtime_manager.clone();
-    let app = build_service_router(state)?;
+    let protocol_relays = match crate::protocol_replay_state::start_protocol_relays(&state).await {
+        Ok(relays) => relays,
+        Err(error) => {
+            if let Some(mailbox_lifecycle) = mailbox_lifecycle
+                && let Err(shutdown_error) = mailbox_lifecycle.shutdown().await
+            {
+                tracing::warn!(
+                    error = %shutdown_error,
+                    "failed to stop mailbox lifecycle after protocol relay startup failure"
+                );
+            }
+            return Err(std::io::Error::other(format!(
+                "failed to start protocol relays: {error}"
+            )));
+        }
+    };
 
     let result = serve_with_shutdown(listener, app, timeout).await;
     if let Some(mailbox_lifecycle) = mailbox_lifecycle

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -1,11 +1,12 @@
 //! Application state and server startup.
 
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock, Weak};
+use std::sync::Arc;
 use std::time::Instant;
 
 use awaken_contract::RedactedString;
 use awaken_contract::contract::config_store::ConfigStore;
+use awaken_contract::contract::event_store::EventStore;
 use awaken_contract::contract::storage::ThreadRunStore;
 use awaken_ext_observability::RuntimeStatsRegistry;
 use awaken_runtime::credentials::{AwakenCredentialBroker, CredentialBroker};
@@ -16,18 +17,17 @@ use serde::{Deserialize, Serialize};
 use awaken_ext_observability::trace_store::TraceStore;
 
 use crate::mailbox::{Mailbox, MailboxLifecycleConfig};
+mod modules;
 use crate::services::audit_log::AuditLogger;
 use crate::transport::replay_buffer::EventReplayBuffer;
+pub use modules::{
+    AdminModuleState, AdminRunRoutesState, ConfigModuleState, ConfigRoutesState, EvalModuleState,
+    EvalRoutesState, EventModuleState, ProtocolModuleState, ProtocolRoutesState, RunModuleState,
+    RunRoutesState, SystemRoutesState, TraceModuleState, TraceRoutesState,
+};
 
 pub type ReplayBufferEntry = (Arc<EventReplayBuffer>, Instant);
 pub type ReplayBufferMap = Arc<Mutex<HashMap<String, ReplayBufferEntry>>>;
-type AppStateExtrasRegistry = HashMap<
-    usize,
-    (
-        Weak<Mutex<HashMap<String, ReplayBufferEntry>>>,
-        AppStateExtras,
-    ),
->;
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -70,11 +70,8 @@ pub trait SkillCatalogProvider: Send + Sync {
     fn list_skills(&self) -> Vec<SkillCatalogEntry>;
 }
 
-/// Graceful shutdown configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShutdownConfig {
-    /// Maximum seconds to wait for in-flight requests to complete before
-    /// force-exiting.  Defaults to 30.
     #[serde(default = "default_shutdown_timeout")]
     pub timeout_secs: u64,
 }
@@ -91,57 +88,34 @@ impl Default for ShutdownConfig {
     }
 }
 
-/// Mailbox lifecycle ownership for the HTTP server.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum MailboxLifecycleMode {
-    /// The server starts mailbox startup recovery and maintenance.
     #[default]
     Auto,
-    /// The embedding application manages mailbox lifecycle explicitly.
     Manual,
 }
 
-/// Admin/configuration API security settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AdminApiConfig {
-    /// Optional bearer token required for admin/configuration APIs.
-    ///
-    /// Wrapped in [`RedactedString`] so it does not leak through `Debug` /
-    /// `Display`. The wire format remains a plain JSON string.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bearer_token: Option<RedactedString>,
-    /// Origins allowed to call browser admin APIs.
     #[serde(default = "default_admin_cors_allowed_origins")]
     pub cors_allowed_origins: Vec<String>,
-    /// Mount `/v1/config/*` and `/v1/agents` admin CRUD (default true).
     #[serde(default = "default_expose_config_routes")]
     pub expose_config_routes: bool,
-    /// Mount `/v1/traces` (default false — exposes prompts/tool args).
     #[serde(default = "default_expose_trace_routes")]
     pub expose_trace_routes: bool,
-    /// Mount `/v1/eval/*` (default true). Separate gate because eval
-    /// drives live model calls + persistent run storage, different
-    /// blast radius from config CRUD.
     #[serde(default = "default_expose_eval_routes")]
     pub expose_eval_routes: bool,
 }
 
-/// Audit-log retention settings attached to [`AppState`] via
-/// [`AppState::with_audit_log_config`].
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AuditLogConfig {
-    /// Whether [`AppState::with_audit_log_from_config`] should attach an audit logger.
     #[serde(default = "default_audit_log_enabled")]
     pub enabled: bool,
-    /// Retention window for audit events in days. Default 90 days.
     #[serde(default = "default_audit_retention_days")]
     pub retention_days: u32,
-    /// Interval in seconds between audit retention sweeps. Default 3600 (1 hour).
-    ///
-    /// A value of `0` is treated as misconfiguration: the server will warn and
-    /// clamp to 60 seconds. Values between 1 and 9 emit a warning but are
-    /// respected as the operator may have a specific reason.
     #[serde(default = "default_audit_sweep_interval_secs")]
     pub sweep_interval_secs: u64,
 }
@@ -178,10 +152,6 @@ impl Default for AuditLogConfig {
     }
 }
 
-/// Compute the effective sweep interval, emitting warnings for suspicious values.
-///
-/// - `0` → warn and clamp to 60 s (implicit floor).
-/// - `1..=9` → warn (respected as-is; operator may have a real reason).
 pub fn effective_sweep_interval(secs: u64) -> std::time::Duration {
     if secs == 0 {
         tracing::warn!(
@@ -211,34 +181,21 @@ impl Default for AdminApiConfig {
     }
 }
 
-/// Server configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
-    /// Bind address (e.g. "0.0.0.0:3000").
     pub address: String,
-    /// Maximum SSE channel buffer size.
     #[serde(default = "default_sse_buffer")]
     pub sse_buffer_size: usize,
-    /// Maximum number of SSE frames to buffer per run for reconnection replay.
     #[serde(default = "default_replay_buffer_capacity")]
     pub replay_buffer_capacity: usize,
-    /// Graceful shutdown settings.
     #[serde(default)]
     pub shutdown: ShutdownConfig,
-    /// Maximum number of concurrent in-flight requests the server will accept.
-    /// Additional requests receive 503 Service Unavailable.
     #[serde(default = "default_max_concurrent")]
     pub max_concurrent_requests: usize,
-    /// Optional bearer token required for authenticated extended A2A agent cards.
-    ///
-    /// Wrapped in [`RedactedString`] so it does not leak through `Debug` /
-    /// `Display`. The wire format remains a plain JSON string.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub a2a_extended_card_bearer_token: Option<RedactedString>,
-    /// Mailbox lifecycle ownership. Defaults to framework-managed auto mode.
     #[serde(default)]
     pub mailbox_lifecycle: MailboxLifecycleMode,
-    /// `/v1/eval/*` caps — see [`crate::eval_limits::EvalLimits`].
     #[serde(default)]
     pub eval_limits: crate::eval_limits::EvalLimits,
 }
@@ -255,78 +212,6 @@ const fn default_max_concurrent() -> usize {
 
 pub const ADMIN_API_BEARER_TOKEN_ENV: &str = "AWAKEN_ADMIN_API_BEARER_TOKEN";
 const ADMIN_CORS_ALLOWED_ORIGINS_ENV: &str = "AWAKEN_ADMIN_CORS_ALLOWED_ORIGINS";
-static APP_STATE_EXTRAS: OnceLock<Mutex<AppStateExtrasRegistry>> = OnceLock::new();
-
-#[derive(Clone)]
-struct AppStateExtras {
-    admin_api_config: AdminApiConfig,
-    audit_log_config: AuditLogConfig,
-    runtime_stats: Option<Arc<RuntimeStatsRegistry>>,
-    audit_log: Option<Arc<AuditLogger>>,
-    trace_store: Option<Arc<dyn TraceStore>>,
-    eval_run_store: Option<Arc<dyn awaken_eval::EvalRunStore>>,
-    started_at: Instant,
-    credential_broker: Arc<dyn CredentialBroker>,
-}
-
-impl Default for AppStateExtras {
-    fn default() -> Self {
-        Self {
-            admin_api_config: AdminApiConfig::default(),
-            audit_log_config: AuditLogConfig::default(),
-            runtime_stats: None,
-            audit_log: None,
-            trace_store: None,
-            eval_run_store: None,
-            started_at: Instant::now(),
-            credential_broker: Arc::new(AwakenCredentialBroker::new()),
-        }
-    }
-}
-
-fn app_state_extras_registry() -> &'static Mutex<AppStateExtrasRegistry> {
-    APP_STATE_EXTRAS.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn app_state_extras_key(replay_buffers: &ReplayBufferMap) -> usize {
-    Arc::as_ptr(replay_buffers) as usize
-}
-
-fn prune_app_state_extras(registry: &mut AppStateExtrasRegistry) {
-    registry.retain(|_, (weak, _)| weak.upgrade().is_some());
-}
-
-fn register_default_app_state_extras(replay_buffers: &ReplayBufferMap) {
-    let key = app_state_extras_key(replay_buffers);
-    let weak = Arc::downgrade(replay_buffers);
-    let mut registry = app_state_extras_registry().lock();
-    prune_app_state_extras(&mut registry);
-    registry
-        .entry(key)
-        .or_insert_with(|| (weak, AppStateExtras::default()));
-}
-
-fn app_state_extras(state: &AppState) -> AppStateExtras {
-    let key = app_state_extras_key(&state.replay_buffers);
-    let mut registry = app_state_extras_registry().lock();
-    prune_app_state_extras(&mut registry);
-    registry
-        .get(&key)
-        .map(|(_, extras)| extras.clone())
-        .unwrap_or_default()
-}
-
-fn update_app_state_extras(state: &AppState, update: impl FnOnce(&mut AppStateExtras)) {
-    let key = app_state_extras_key(&state.replay_buffers);
-    let weak = Arc::downgrade(&state.replay_buffers);
-    let mut registry = app_state_extras_registry().lock();
-    prune_app_state_extras(&mut registry);
-    let (_, extras) = registry
-        .entry(key)
-        .or_insert_with(|| (weak, AppStateExtras::default()));
-    update(extras);
-}
-
 fn admin_api_bearer_token_from_env() -> Option<RedactedString> {
     std::env::var(ADMIN_API_BEARER_TOKEN_ENV)
         .ok()
@@ -356,8 +241,8 @@ fn default_admin_cors_allowed_origins() -> Vec<String> {
     ]
 }
 
-pub(crate) fn admin_api_config(state: &AppState) -> AdminApiConfig {
-    let mut config = app_state_extras(state).admin_api_config;
+pub(crate) fn admin_api_config(state: &ServerState) -> AdminApiConfig {
+    let mut config = state.admin_api_config.clone();
 
     if let Some(token) = admin_api_bearer_token_from_env() {
         config.bearer_token = Some(token);
@@ -369,7 +254,7 @@ pub(crate) fn admin_api_config(state: &AppState) -> AdminApiConfig {
     config
 }
 
-fn admin_cors_allowed_origins_for_state(state: &AppState) -> Vec<String> {
+fn admin_cors_allowed_origins_for_state(state: &ServerState) -> Vec<String> {
     admin_api_config(state).cors_allowed_origins
 }
 
@@ -388,34 +273,30 @@ impl Default for ServerConfig {
     }
 }
 
-/// Shared application state for all routes.
 #[derive(Clone)]
-pub struct AppState {
-    /// Agent runtime for executing runs.
+pub struct ServerState {
     pub runtime: Arc<AgentRuntime>,
-    /// Unified mailbox service (persistent run queue).
     pub mailbox: Arc<Mailbox>,
-    /// Unified thread + run persistence (atomic checkpoint).
     pub store: Arc<dyn ThreadRunStore>,
-    /// Agent resolver for protocol-specific lookups.
     pub resolver: Arc<dyn AgentResolver>,
-    /// Server configuration.
     pub config: ServerConfig,
-    /// Optional persistent config store used by config management APIs.
     pub config_store: Option<Arc<dyn ConfigStore>>,
-    /// Optional runtime publisher used to apply config changes.
     pub config_runtime_manager: Option<Arc<crate::services::config_runtime::ConfigRuntimeManager>>,
-    /// Optional read-only skill catalog used by admin capabilities.
     pub skill_catalog_provider: Option<Arc<dyn SkillCatalogProvider>>,
-    /// Per-run replay buffers for SSE stream resumption.
-    /// Stores `(buffer, created_at)` so stale entries can be purged.
     pub replay_buffers: ReplayBufferMap,
-    /// MCP Streamable HTTP session state.
     pub mcp_http: Arc<crate::protocols::mcp::http::McpHttpState>,
+    pub(crate) admin_api_config: AdminApiConfig,
+    pub(crate) audit_log_config: AuditLogConfig,
+    pub(crate) runtime_stats: Option<Arc<RuntimeStatsRegistry>>,
+    pub(crate) audit_log: Option<Arc<AuditLogger>>,
+    pub(crate) trace_store: Option<Arc<dyn TraceStore>>,
+    pub(crate) event_store: Option<Arc<dyn EventStore>>,
+    pub(crate) eval_run_store: Option<Arc<dyn awaken_eval::EvalRunStore>>,
+    pub(crate) started_at: Instant,
+    pub(crate) credential_broker: Arc<dyn CredentialBroker>,
 }
 
-impl AppState {
-    /// Create a new AppState with all required dependencies.
+impl ServerState {
     pub fn new(
         runtime: Arc<AgentRuntime>,
         mailbox: Arc<Mailbox>,
@@ -423,7 +304,7 @@ impl AppState {
         resolver: Arc<dyn AgentResolver>,
         config: ServerConfig,
     ) -> Self {
-        let state = Self {
+        Self {
             runtime,
             mailbox,
             store,
@@ -434,53 +315,45 @@ impl AppState {
             skill_catalog_provider: None,
             replay_buffers: Arc::new(Mutex::new(HashMap::new())),
             mcp_http: Arc::new(crate::protocols::mcp::http::McpHttpState::new()),
-        };
-        register_default_app_state_extras(&state.replay_buffers);
-        state
+            admin_api_config: AdminApiConfig::default(),
+            audit_log_config: AuditLogConfig::default(),
+            runtime_stats: None,
+            audit_log: None,
+            trace_store: None,
+            event_store: None,
+            eval_run_store: None,
+            started_at: Instant::now(),
+            credential_broker: Arc::new(AwakenCredentialBroker::new()),
+        }
     }
 
-    /// Override the credential broker (e.g. inject a test double).
-    /// Call before publishing the AppState; replacing it after the
-    /// runtime is wired will leave existing executors pointing at the
-    /// previous broker.
     pub fn with_credential_broker(
-        self,
+        mut self,
         broker: Arc<dyn awaken_runtime::credentials::CredentialBroker>,
     ) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.credential_broker = broker;
-        });
+        self.credential_broker = broker;
         self
     }
 
-    /// Return the process-wide credential broker for this state.
     pub fn credential_broker(&self) -> Arc<dyn CredentialBroker> {
-        app_state_extras(self).credential_broker
+        self.credential_broker.clone()
     }
 
-    /// Attach a runtime stats registry. The same `Arc` should already be
-    /// wired into the embedder's `ObservabilityPlugin` sink list so that
-    /// recording and reading share state.
     #[must_use]
-    pub fn with_runtime_stats(self, registry: Arc<RuntimeStatsRegistry>) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.runtime_stats = Some(registry);
-        });
+    pub fn with_runtime_stats(mut self, registry: Arc<RuntimeStatsRegistry>) -> Self {
+        self.runtime_stats = Some(registry);
         self
     }
 
-    /// Return the attached runtime stats registry, if configured.
     pub fn runtime_stats(&self) -> Option<Arc<RuntimeStatsRegistry>> {
-        app_state_extras(self).runtime_stats
+        self.runtime_stats.clone()
     }
 
-    /// Attach the config store used by config management routes.
     pub fn with_config_store(mut self, store: Arc<dyn ConfigStore>) -> Self {
         self.config_store = Some(store);
         self
     }
 
-    /// Attach the runtime manager used to compile and publish config snapshots.
     pub fn with_config_runtime_manager(
         mut self,
         manager: Arc<crate::services::config_runtime::ConfigRuntimeManager>,
@@ -489,113 +362,84 @@ impl AppState {
         self
     }
 
-    /// Attach a read-only skill catalog provider used by admin capabilities.
     pub fn with_skill_catalog_provider(mut self, provider: Arc<dyn SkillCatalogProvider>) -> Self {
         self.skill_catalog_provider = Some(provider);
         self
     }
 
-    /// Attach admin/configuration API security settings without changing the
-    /// 0.2-compatible `ServerConfig` struct shape.
-    pub fn with_admin_api_config(self, config: AdminApiConfig) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.admin_api_config = config;
-        });
+    pub fn with_admin_api_config(mut self, config: AdminApiConfig) -> Self {
+        self.admin_api_config = config;
         self
     }
 
-    /// Require a bearer token for admin/configuration APIs.
     pub fn with_admin_api_bearer_token(self, token: impl Into<RedactedString>) -> Self {
         let mut config = admin_api_config(&self);
         config.bearer_token = Some(token.into());
         self.with_admin_api_config(config)
     }
 
-    /// Configure CORS origins allowed to call browser admin APIs.
     pub fn with_admin_cors_allowed_origins(self, origins: Vec<String>) -> Self {
         let mut config = admin_api_config(&self);
         config.cors_allowed_origins = origins;
         self.with_admin_api_config(config)
     }
 
-    /// Return the effective admin/configuration API settings, including
-    /// environment variable overrides.
     pub fn admin_api_config(&self) -> AdminApiConfig {
         admin_api_config(self)
     }
 
-    /// Attach audit-log retention settings used by
-    /// [`AppState::with_audit_log_from_config`].
     #[must_use]
-    pub fn with_audit_log_config(self, config: AuditLogConfig) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.audit_log_config = config;
-        });
+    pub fn with_audit_log_config(mut self, config: AuditLogConfig) -> Self {
+        self.audit_log_config = config;
         self
     }
 
-    /// Return the audit-log retention settings for this state.
     pub fn audit_log_config(&self) -> AuditLogConfig {
-        app_state_extras(self).audit_log_config
+        self.audit_log_config
     }
 
-    /// Enable the audit logger.  When a `config_store` is already attached and
-    /// [`AuditLogConfig::enabled`] is `true`, pass an `AuditLogger` constructed
-    /// from that store.  This method is an explicit
-    /// opt-in; existing embedders are unaffected unless they call it.
     #[must_use]
-    pub fn with_audit_log(self, logger: Arc<AuditLogger>) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.audit_log = Some(logger);
-        });
+    pub fn with_audit_log(mut self, logger: Arc<AuditLogger>) -> Self {
+        self.audit_log = Some(logger);
         self
     }
 
-    /// Return the attached audit logger, if configured.
     pub fn audit_log(&self) -> Option<Arc<AuditLogger>> {
-        app_state_extras(self).audit_log
+        self.audit_log.clone()
     }
 
-    /// Attach a `TraceStore` for the trace query API.
-    ///
-    /// Embedders using `install_default_sinks` / `observability_plugin_from`
-    /// can extract `WiringSummary::trace_store` and pass it here so that the
-    /// `/v1/traces` routes are backed by the same store that receives events.
     #[must_use]
-    pub fn with_trace_store(self, store: Arc<dyn TraceStore>) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.trace_store = Some(store);
-        });
+    pub fn with_trace_store(mut self, store: Arc<dyn TraceStore>) -> Self {
+        self.trace_store = Some(store);
         self
     }
 
-    /// Return the attached `TraceStore`, if configured.
     pub fn trace_store(&self) -> Option<Arc<dyn TraceStore>> {
-        app_state_extras(self).trace_store
+        self.trace_store.clone()
     }
 
-    /// Attach an `EvalRunStore` so `/v1/eval/runs` endpoints can persist
-    /// and query server-side eval runs (ADR-0032 D1).
     #[must_use]
-    pub fn with_eval_run_store(self, store: Arc<dyn awaken_eval::EvalRunStore>) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.eval_run_store = Some(store);
-        });
+    pub fn with_event_store(mut self, store: Arc<dyn EventStore>) -> Self {
+        self.event_store = Some(store);
         self
     }
 
-    /// Return the attached `EvalRunStore`, if configured.
-    pub fn eval_run_store(&self) -> Option<Arc<dyn awaken_eval::EvalRunStore>> {
-        app_state_extras(self).eval_run_store
+    pub fn event_store(&self) -> Option<Arc<dyn EventStore>> {
+        self.event_store.clone()
     }
 
-    /// Builder convenience: create an `AuditLogger` from the already-attached
-    /// `config_store` (if any) and the effective `AdminApiConfig` settings.
-    ///
-    /// If [`AuditLogConfig::enabled`] is `false` or no config store is attached, this
-    /// is a no-op.  Also spawns the background retention sweeper task.
     #[must_use]
-    pub fn with_audit_log_from_config(self) -> Self {
+    pub fn with_eval_run_store(mut self, store: Arc<dyn awaken_eval::EvalRunStore>) -> Self {
+        self.eval_run_store = Some(store);
+        self
+    }
+
+    pub fn eval_run_store(&self) -> Option<Arc<dyn awaken_eval::EvalRunStore>> {
+        self.eval_run_store.clone()
+    }
+
+    #[must_use]
+    pub fn with_audit_log_from_config(mut self) -> Self {
         let audit_config = self.audit_log_config();
         if !audit_config.enabled {
             return self;
@@ -608,9 +452,7 @@ impl AppState {
                     return self;
                 };
                 let new_logger = Arc::new(AuditLogger::new(store));
-                update_app_state_extras(&self, |extras| {
-                    extras.audit_log = Some(new_logger.clone());
-                });
+                self.audit_log = Some(new_logger.clone());
                 new_logger
             }
         };
@@ -639,28 +481,22 @@ impl AppState {
         self
     }
 
-    /// Return the wall-clock instant this state was constructed.
     pub fn started_at(&self) -> Instant {
-        app_state_extras(self).started_at
+        self.started_at
     }
 
-    /// Override the construction instant, primarily for deterministic tests.
     #[must_use]
-    pub fn with_started_at(self, started_at: Instant) -> Self {
-        update_app_state_extras(&self, |extras| {
-            extras.started_at = started_at;
-        });
+    pub fn with_started_at(mut self, started_at: Instant) -> Self {
+        self.started_at = started_at;
         self
     }
 
-    /// Insert a replay buffer for the given key, tracking creation time.
     pub fn insert_replay_buffer(&self, key: String, buffer: Arc<EventReplayBuffer>) {
         self.replay_buffers
             .lock()
             .insert(key, (buffer, Instant::now()));
     }
 
-    /// Look up a replay buffer by key.
     pub fn get_replay_buffer(&self, key: &str) -> Option<Arc<EventReplayBuffer>> {
         self.replay_buffers
             .lock()
@@ -668,32 +504,19 @@ impl AppState {
             .map(|(buf, _)| Arc::clone(buf))
     }
 
-    /// Remove a replay buffer by key.
     pub fn remove_replay_buffer(&self, key: &str) {
         self.replay_buffers.lock().remove(key);
     }
 
-    /// Purge replay buffers whose subscribers are all gone and that are older
-    /// than `max_age`. Called from the maintenance loop to prevent unbounded
-    /// growth of the `replay_buffers` HashMap.
     pub fn purge_stale_replay_buffers(&self, max_age: std::time::Duration) {
         let now = Instant::now();
         let mut buffers = self.replay_buffers.lock();
         let before = buffers.len();
         buffers.retain(|_key, (_buf, created_at)| {
             let age = now.duration_since(*created_at);
-            // Keep if younger than max_age, OR if the buffer still has live subscribers
-            // (indicated by non-empty subscriber count — we check via a push that goes nowhere).
-            // Since we can't directly query subscriber count, rely on age: if older than
-            // max_age, the run is long done and the buffer is safe to purge.
             if age < max_age {
                 return true;
             }
-            // For buffers older than max_age, also keep if they were recently
-            // updated (sequence is still advancing — run is still active).
-            // A buffer with seq=0 and old age is definitely stale.
-            // A buffer with subscribers would have been cleaned up by the SSE
-            // handler's cleanup task, so any remaining old buffer is leaked.
             false
         });
         let purged = before - buffers.len();
@@ -703,7 +526,6 @@ impl AppState {
     }
 }
 
-/// Create a shutdown signal that fires on Ctrl-C and (on Unix) SIGTERM.
 async fn shutdown_signal() {
     let ctrl_c = tokio::signal::ctrl_c();
 
@@ -725,13 +547,6 @@ async fn shutdown_signal() {
     tracing::info!("shutting down gracefully...");
 }
 
-/// Start the server with graceful shutdown support.
-///
-/// The server will:
-/// 1. Stop accepting new connections when a shutdown signal is received
-///    (Ctrl-C or SIGTERM).
-/// 2. Wait up to `shutdown_timeout` for in-flight requests to drain.
-/// 3. Force-exit if the timeout is exceeded.
 pub async fn serve_with_shutdown(
     listener: tokio::net::TcpListener,
     app: axum::Router,
@@ -768,8 +583,7 @@ pub async fn serve_with_shutdown(
     }
 }
 
-/// Convenience: bind, build the full router with layers, and serve.
-pub async fn serve(state: AppState) -> std::io::Result<()> {
+pub async fn serve(state: ServerState) -> std::io::Result<()> {
     crate::metrics::install_recorder();
 
     let addr = state.config.address.clone();
@@ -796,19 +610,18 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
         MailboxLifecycleMode::Manual => None,
     };
 
-    // Spawn the trace-retention loop whenever a TraceStore is attached.
-    // Retention is a property of the *storage layer*, not the HTTP API —
-    // an operator may turn off `expose_trace_routes` (e.g. to keep the
-    // admin surface narrow) yet still depend on the persistence layer for
-    // OTLP / Phoenix sourcing, and that path also needs TTL cleanup. The
-    // RetentionHandle is intentionally dropped after the server exits
-    // (fire-and-forget for v1), matching the audit sweeper.
+    // Retention belongs to storage, so spawn it even if trace routes are hidden.
     let _retention_handle = state.trace_store().map(|store| {
         crate::services::trace_retention::spawn_retention_loop(
             store,
             crate::services::trace_retention::RetentionConfig::default(),
         )
     });
+    let protocol_relays = crate::protocol_replay_state::start_protocol_relays(&state)
+        .await
+        .map_err(|error| {
+            std::io::Error::other(format!("failed to start protocol relays: {error}"))
+        })?;
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("listening on {addr}");
@@ -827,26 +640,20 @@ pub async fn serve(state: AppState) -> std::io::Result<()> {
     {
         tracing::warn!(error = %error, "failed to stop config runtime manager cleanly");
     }
+    protocol_relays.shutdown().await;
     result
 }
 
-/// Build the production HTTP router for an [`AppState`].
-///
-/// This is the shared entry point for embedders that need to bind their own
-/// listener or add outer layers. It applies the same admin-surface validation,
-/// concurrency limit, admin CORS policy, route composition, and state wiring as
-/// [`serve`].
-pub fn build_service_router(state: AppState) -> std::io::Result<axum::Router> {
+pub fn build_service_router(state: ServerState) -> std::io::Result<axum::Router> {
     validate_admin_surface(&state)?;
     let max_concurrent = state.config.max_concurrent_requests;
     let admin_cors = admin_cors_layer(&state)?;
     Ok(crate::routes::build_router(&state)
         .layer(tower::limit::ConcurrencyLimitLayer::new(max_concurrent))
-        .layer(admin_cors)
-        .with_state(state))
+        .layer(admin_cors))
 }
 
-pub fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
+pub fn validate_admin_surface(state: &ServerState) -> std::io::Result<()> {
     crate::eval_limits::validate_eval_limits(&state.config.eval_limits)?;
     let admin = admin_api_config(state);
     // Sensitive surfaces (need bearer on non-loopback bind): config
@@ -878,7 +685,7 @@ pub fn validate_admin_surface(state: &AppState) -> std::io::Result<()> {
     ))
 }
 
-fn admin_surface_has_sensitive_state(state: &AppState) -> bool {
+fn admin_surface_has_sensitive_state(state: &ServerState) -> bool {
     state.config_store.is_some()
         || state.config_runtime_manager.is_some()
         || state.audit_log().is_some()
@@ -888,7 +695,7 @@ fn admin_surface_has_sensitive_state(state: &AppState) -> bool {
         || state.eval_run_store().is_some() // EvalRun bodies carry prompt + tool data
 }
 
-pub fn admin_cors_layer(state: &AppState) -> std::io::Result<tower_http::cors::CorsLayer> {
+pub fn admin_cors_layer(state: &ServerState) -> std::io::Result<tower_http::cors::CorsLayer> {
     use axum::http::{HeaderValue, Method, header};
     use tower_http::cors::CorsLayer;
 

--- a/crates/awaken-server/src/app/modules.rs
+++ b/crates/awaken-server/src/app/modules.rs
@@ -1,0 +1,295 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use awaken_contract::contract::config_store::ConfigStore;
+use awaken_contract::contract::event_store::EventStore;
+use awaken_contract::contract::storage::ThreadRunStore;
+use awaken_ext_observability::RuntimeStatsRegistry;
+use awaken_ext_observability::trace_store::TraceStore;
+use awaken_runtime::credentials::CredentialBroker;
+use awaken_runtime::{AgentResolver, AgentRuntime};
+
+use awaken_contract::RedactedString;
+
+use super::{AdminApiConfig, AuditLogConfig, ReplayBufferMap, ServerState, SkillCatalogProvider};
+use crate::eval_limits::EvalLimits;
+use crate::mailbox::Mailbox;
+use crate::services::audit_log::AuditLogger;
+
+#[derive(Clone)]
+pub struct RunModuleState {
+    pub runtime: Arc<AgentRuntime>,
+    pub mailbox: Arc<Mailbox>,
+    pub resolver: Arc<dyn AgentResolver>,
+    pub credential_broker: Arc<dyn CredentialBroker>,
+    pub runtime_stats: Option<Arc<RuntimeStatsRegistry>>,
+}
+
+impl RunModuleState {
+    /// Borrow the thread/run store through the mailbox's coordinator
+    /// (ADR-0038 D7 single source of truth). Reads go directly; writes
+    /// must be routed through `mailbox.coordinator()`.
+    pub fn store(&self) -> &Arc<dyn ThreadRunStore> {
+        self.mailbox.thread_run_store()
+    }
+}
+
+#[derive(Clone)]
+pub struct ConfigModuleState {
+    pub config_store: Arc<dyn ConfigStore>,
+    pub runtime_manager: Arc<crate::services::config_runtime::ConfigRuntimeManager>,
+    pub audit_log: Option<Arc<AuditLogger>>,
+    pub skill_catalog_provider: Option<Arc<dyn SkillCatalogProvider>>,
+}
+
+#[derive(Clone)]
+pub struct EventModuleState {
+    pub event_store: Arc<dyn EventStore>,
+}
+
+#[derive(Clone)]
+pub struct EvalModuleState {
+    pub eval_run_store: Arc<dyn awaken_eval::EvalRunStore>,
+}
+
+#[derive(Clone)]
+pub struct TraceModuleState {
+    pub trace_store: Arc<dyn TraceStore>,
+}
+
+#[derive(Clone)]
+pub struct ProtocolModuleState {
+    pub replay_buffers: ReplayBufferMap,
+    pub mcp_http: Arc<crate::protocols::mcp::http::McpHttpState>,
+}
+
+#[derive(Clone)]
+pub struct AdminModuleState {
+    pub admin_api_config: AdminApiConfig,
+    pub audit_log_config: AuditLogConfig,
+    pub started_at: Instant,
+}
+
+#[derive(Clone)]
+pub struct RunRoutesState {
+    pub run: RunModuleState,
+    pub events: Option<EventModuleState>,
+    pub sse_buffer_size: usize,
+}
+
+#[derive(Clone)]
+pub struct AdminRunRoutesState {
+    pub admin: AdminModuleState,
+    pub run: RunModuleState,
+}
+
+#[derive(Clone)]
+pub struct ConfigRoutesState {
+    pub admin: AdminModuleState,
+    pub config: ConfigModuleState,
+    pub run: RunModuleState,
+}
+
+#[derive(Clone)]
+pub struct EvalRoutesState {
+    pub admin: AdminModuleState,
+    pub config: ConfigModuleState,
+    pub eval: EvalModuleState,
+    pub run: RunModuleState,
+    pub trace: Option<TraceModuleState>,
+    pub events: Option<EventModuleState>,
+    pub limits: EvalLimits,
+}
+
+#[derive(Clone)]
+pub struct ProtocolRoutesState {
+    pub admin: AdminModuleState,
+    pub run: RunModuleState,
+    pub protocol: ProtocolModuleState,
+    pub sse_buffer_size: usize,
+    pub replay_buffer_capacity: usize,
+    pub a2a_extended_card_bearer_token: Option<RedactedString>,
+}
+
+impl ProtocolRoutesState {
+    pub fn insert_replay_buffer(
+        &self,
+        key: String,
+        buffer: Arc<crate::transport::replay_buffer::EventReplayBuffer>,
+    ) {
+        self.protocol
+            .replay_buffers
+            .lock()
+            .insert(key, (buffer, Instant::now()));
+    }
+
+    pub fn get_replay_buffer(
+        &self,
+        key: &str,
+    ) -> Option<Arc<crate::transport::replay_buffer::EventReplayBuffer>> {
+        self.protocol
+            .replay_buffers
+            .lock()
+            .get(key)
+            .map(|(buf, _)| Arc::clone(buf))
+    }
+
+    pub fn remove_replay_buffer(&self, key: &str) {
+        self.protocol.replay_buffers.lock().remove(key);
+    }
+}
+
+#[derive(Clone)]
+pub struct SystemRoutesState {
+    pub admin: AdminModuleState,
+    pub mounted_modules: Vec<&'static str>,
+    pub config_store_enabled: bool,
+    pub audit_log_enabled: bool,
+    pub runtime_stats_enabled: bool,
+}
+
+#[derive(Clone)]
+pub struct TraceRoutesState {
+    pub admin: AdminModuleState,
+    pub trace: TraceModuleState,
+}
+
+impl ServerState {
+    pub fn run_module(&self) -> RunModuleState {
+        RunModuleState {
+            runtime: Arc::clone(&self.runtime),
+            mailbox: Arc::clone(&self.mailbox),
+            resolver: Arc::clone(&self.resolver),
+            credential_broker: Arc::clone(&self.credential_broker),
+            runtime_stats: self.runtime_stats.clone(),
+        }
+    }
+
+    pub fn config_module(&self) -> Option<ConfigModuleState> {
+        Some(ConfigModuleState {
+            config_store: Arc::clone(self.config_store.as_ref()?),
+            runtime_manager: Arc::clone(self.config_runtime_manager.as_ref()?),
+            audit_log: self.audit_log.clone(),
+            skill_catalog_provider: self.skill_catalog_provider.clone(),
+        })
+    }
+
+    pub fn event_module(&self) -> Option<EventModuleState> {
+        self.event_store
+            .as_ref()
+            .map(|event_store| EventModuleState {
+                event_store: Arc::clone(event_store),
+            })
+    }
+
+    pub fn eval_module(&self) -> Option<EvalModuleState> {
+        self.eval_run_store
+            .as_ref()
+            .map(|eval_run_store| EvalModuleState {
+                eval_run_store: Arc::clone(eval_run_store),
+            })
+    }
+
+    pub fn trace_module(&self) -> Option<TraceModuleState> {
+        self.trace_store
+            .as_ref()
+            .map(|trace_store| TraceModuleState {
+                trace_store: Arc::clone(trace_store),
+            })
+    }
+
+    pub fn protocol_module(&self) -> ProtocolModuleState {
+        ProtocolModuleState {
+            replay_buffers: Arc::clone(&self.replay_buffers),
+            mcp_http: Arc::clone(&self.mcp_http),
+        }
+    }
+
+    pub fn admin_module(&self) -> AdminModuleState {
+        AdminModuleState {
+            admin_api_config: self.admin_api_config(),
+            audit_log_config: self.audit_log_config(),
+            started_at: self.started_at(),
+        }
+    }
+
+    pub fn mounted_modules(&self) -> Vec<&'static str> {
+        let mut modules = vec!["run", "admin", "protocol"];
+        if self.config_module().is_some() {
+            modules.push("config");
+        }
+        if self.event_module().is_some() {
+            modules.push("events");
+        }
+        if self.eval_module().is_some() {
+            modules.push("eval");
+        }
+        if self.trace_module().is_some() {
+            modules.push("trace");
+        }
+        modules
+    }
+
+    pub fn run_routes_state(&self) -> RunRoutesState {
+        RunRoutesState {
+            run: self.run_module(),
+            events: self.event_module(),
+            sse_buffer_size: self.config.sse_buffer_size,
+        }
+    }
+
+    pub fn admin_run_routes_state(&self) -> AdminRunRoutesState {
+        AdminRunRoutesState {
+            admin: self.admin_module(),
+            run: self.run_module(),
+        }
+    }
+
+    pub fn config_routes_state(&self) -> Option<ConfigRoutesState> {
+        Some(ConfigRoutesState {
+            admin: self.admin_module(),
+            config: self.config_module()?,
+            run: self.run_module(),
+        })
+    }
+
+    pub fn eval_routes_state(&self) -> Option<EvalRoutesState> {
+        Some(EvalRoutesState {
+            admin: self.admin_module(),
+            config: self.config_module()?,
+            eval: self.eval_module()?,
+            run: self.run_module(),
+            trace: self.trace_module(),
+            events: self.event_module(),
+            limits: self.config.eval_limits.clone(),
+        })
+    }
+
+    pub fn protocol_routes_state(&self) -> ProtocolRoutesState {
+        ProtocolRoutesState {
+            admin: self.admin_module(),
+            run: self.run_module(),
+            protocol: self.protocol_module(),
+            sse_buffer_size: self.config.sse_buffer_size,
+            replay_buffer_capacity: self.config.replay_buffer_capacity,
+            a2a_extended_card_bearer_token: self.config.a2a_extended_card_bearer_token.clone(),
+        }
+    }
+
+    pub fn system_routes_state(&self) -> SystemRoutesState {
+        SystemRoutesState {
+            admin: self.admin_module(),
+            mounted_modules: self.mounted_modules(),
+            config_store_enabled: self.config_store.is_some(),
+            audit_log_enabled: self.audit_log().is_some(),
+            runtime_stats_enabled: self.runtime_stats().is_some(),
+        }
+    }
+
+    pub fn trace_routes_state(&self) -> Option<TraceRoutesState> {
+        Some(TraceRoutesState {
+            admin: self.admin_module(),
+            trace: self.trace_module()?,
+        })
+    }
+}

--- a/crates/awaken-server/src/app_test.rs
+++ b/crates/awaken-server/src/app_test.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn state_for_admin_surface_test(address: &str, admin_api_config: AdminApiConfig) -> AppState {
+fn state_for_admin_surface_test(address: &str, admin_api_config: AdminApiConfig) -> ServerState {
     use crate::mailbox::{Mailbox, MailboxConfig};
     use awaken_runtime::AgentRuntime;
     use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
@@ -33,7 +33,7 @@ fn state_for_admin_surface_test(address: &str, admin_api_config: AdminApiConfig)
         ..ServerConfig::default()
     };
 
-    AppState::new(
+    ServerState::new(
         runtime,
         mailbox,
         store.clone() as Arc<dyn ThreadRunStore>,
@@ -314,8 +314,8 @@ fn shutdown_config_custom() {
 
 // ── Replay buffer management (standalone map) ───────────────────
 
-/// Helper: create a standalone replay buffer map (same type as `AppState::replay_buffers`)
-/// to test purge logic without needing a full `AppState`.
+/// Helper: create a standalone replay buffer map (same type as `ServerState::replay_buffers`)
+/// to test purge logic without needing a full `ServerState`.
 fn make_replay_map() -> ReplayBufferMap {
     Arc::new(Mutex::new(HashMap::new()))
 }
@@ -472,7 +472,7 @@ async fn with_audit_log_from_config_reuses_preset_logger() {
     let preset_logger = Arc::new(AuditLogger::new(store.clone() as Arc<dyn ConfigStore>));
     let preset_ptr = Arc::as_ptr(&preset_logger);
 
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         store.clone() as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,

--- a/crates/awaken-server/src/app_test.rs
+++ b/crates/awaken-server/src/app_test.rs
@@ -45,22 +45,6 @@ fn state_for_admin_surface_test(address: &str, admin_api_config: AdminApiConfig)
 }
 
 #[test]
-fn admin_surface_has_sensitive_state_includes_eval_run_store() {
-    // Regression: eval_run_store carries persisted prompts + tool args
-    // /results and must count as sensitive state — otherwise
-    // validate_admin_surface short-circuits past the bearer-token
-    // requirement on a deployment that exposes /v1/eval/* with only an
-    // eval store attached.
-    use awaken_eval::FileEvalRunStore;
-    let tmp = tempfile::tempdir().unwrap();
-    let mut state = state_for_admin_surface_test("0.0.0.0:3000", AdminApiConfig::default());
-    state = state
-        .with_eval_run_store(Arc::new(FileEvalRunStore::new(tmp.path()).unwrap())
-            as Arc<dyn awaken_eval::EvalRunStore>);
-    assert!(super::admin_surface_has_sensitive_state(&state));
-}
-
-#[test]
 fn admin_api_config_default_exposes_config_routes() {
     let config = AdminApiConfig::default();
     assert!(

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -623,7 +623,9 @@ fn ensure_admin_auth_for_token(
     headers: &HeaderMap,
 ) -> Result<(), ApiError> {
     let Some(expected) = expected else {
-        return Ok(());
+        return Err(ApiError::Unauthorized(
+            "admin authentication is not configured".into(),
+        ));
     };
     let mut auth_values = headers.get_all(axum::http::header::AUTHORIZATION).iter();
     let Some(auth) = auth_values.next() else {
@@ -828,20 +830,21 @@ mod tests {
     use super::*;
     use awaken_contract::RedactedString;
     use axum::http::{HeaderMap, HeaderValue, header};
-
     #[test]
-    fn admin_auth_allows_unconfigured_routes() {
+    fn admin_auth_rejects_when_token_not_configured() {
         let headers = HeaderMap::new();
-        assert!(ensure_admin_auth_for_token(None, &headers).is_ok());
+        let err = ensure_admin_auth_for_token(None, &headers).unwrap_err();
+        assert!(matches!(
+            err,
+            ApiError::Unauthorized(message) if message.contains("not configured")
+        ));
     }
-
     #[test]
     fn admin_auth_rejects_missing_or_wrong_token() {
         let expected = RedactedString::from("secret");
         let headers = HeaderMap::new();
         let missing = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
         assert_eq!(missing.into_response().status(), StatusCode::UNAUTHORIZED);
-
         let mut headers = HeaderMap::new();
         headers.insert(
             header::AUTHORIZATION,
@@ -850,7 +853,6 @@ mod tests {
         let wrong = ensure_admin_auth_for_token(Some(&expected), &headers).unwrap_err();
         assert_eq!(wrong.into_response().status(), StatusCode::UNAUTHORIZED);
     }
-
     #[test]
     fn admin_auth_accepts_bearer_token() {
         let expected = RedactedString::from("secret");
@@ -861,7 +863,6 @@ mod tests {
         );
         assert!(ensure_admin_auth_for_token(Some(&expected), &headers).is_ok());
     }
-
     #[test]
     fn admin_auth_rejects_ambiguous_or_malformed_bearer_headers_without_leaking_secret() {
         let expected = RedactedString::from("secret-value-that-must-not-leak");
@@ -873,7 +874,6 @@ mod tests {
             "bearer wrong-token",
             "Bearer secret-value-that-must-not-leak extra",
         ];
-
         for value in cases {
             let mut headers = HeaderMap::new();
             headers.insert(

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -920,8 +920,10 @@ mod tests {
     // ── delete 409 / force integration tests ──────────────────────────────
 
     mod delete_integration {
-        use std::sync::Arc;
-
+        use crate::app::{ServerConfig, ServerState};
+        use crate::mailbox::{Mailbox, MailboxConfig};
+        use crate::routes::build_router;
+        use crate::services::config_runtime::{ConfigRuntimeManager, ProviderExecutorFactory};
         use async_trait::async_trait;
         use awaken_contract::contract::executor::{
             InferenceExecutionError, InferenceRequest, LlmExecutor,
@@ -936,15 +938,9 @@ mod tests {
         use axum::http::{Request, StatusCode};
         use http_body_util::BodyExt;
         use serde_json::Value;
+        use std::sync::Arc;
         use tower::ServiceExt;
-
-        use crate::app::{ServerConfig, ServerState};
-        use crate::mailbox::{Mailbox, MailboxConfig};
-        use crate::routes::build_router;
-        use crate::services::config_runtime::{ConfigRuntimeManager, ProviderExecutorFactory};
-
         struct ImmediateExecutor;
-
         #[async_trait]
         impl LlmExecutor for ImmediateExecutor {
             async fn execute(
@@ -959,14 +955,11 @@ mod tests {
                     has_incomplete_tool_calls: false,
                 })
             }
-
             fn name(&self) -> &str {
                 "immediate"
             }
         }
-
         struct TestProviderFactory;
-
         impl ProviderExecutorFactory for TestProviderFactory {
             fn build(
                 &self,
@@ -983,7 +976,6 @@ mod tests {
                 )
             }
         }
-
         fn bootstrap_agent() -> AgentSpec {
             AgentSpec {
                 id: "bootstrap".into(),
@@ -993,7 +985,21 @@ mod tests {
                 ..Default::default()
             }
         }
+        const TEST_ADMIN_TOKEN: &str = "test-admin-token";
 
+        fn build_authorized_test_router(state: &ServerState) -> axum::Router {
+            use axum::http::{HeaderValue, header};
+            use axum::middleware::{self, Next};
+            build_router(state).layer(middleware::from_fn(
+                |mut req: Request<Body>, next: Next| async move {
+                    req.headers_mut().insert(
+                        header::AUTHORIZATION,
+                        HeaderValue::from_static("Bearer test-admin-token"),
+                    );
+                    next.run(req).await
+                },
+            ))
+        }
         async fn build_test_app() -> axum::Router {
             let config_store = Arc::new(awaken_stores::InMemoryStore::new());
             let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
@@ -1004,7 +1010,6 @@ mod tests {
                     .build()
                     .expect("build runtime"),
             );
-
             let manager = Arc::new(
                 ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
                     .expect("config runtime manager")
@@ -1028,7 +1033,6 @@ mod tests {
             };
             manager.apply_seed(&seed).await.expect("apply_seed");
             manager.apply().await.expect("publish config");
-
             let resolver = runtime.resolver_arc();
             let mailbox = Arc::new(Mailbox::new(
                 runtime.clone(),
@@ -1045,11 +1049,10 @@ mod tests {
                 ServerConfig::default(),
             )
             .with_config_store(config_store)
-            .with_config_runtime_manager(manager);
-
-            build_router(&state)
+            .with_config_runtime_manager(manager)
+            .with_admin_api_bearer_token(TEST_ADMIN_TOKEN);
+            build_authorized_test_router(&state)
         }
-
         async fn create_record(app: &axum::Router, namespace: &str, body: &str) -> StatusCode {
             let req = Request::builder()
                 .method("POST")
@@ -1059,7 +1062,6 @@ mod tests {
                 .unwrap();
             app.clone().oneshot(req).await.unwrap().status()
         }
-
         async fn delete_record(
             app: &axum::Router,
             namespace: &str,
@@ -1086,7 +1088,6 @@ mod tests {
             };
             (status, body)
         }
-
         async fn validate_record(
             app: &axum::Router,
             namespace: &str,
@@ -1108,7 +1109,6 @@ mod tests {
             };
             (status, body)
         }
-
         async fn get_json(app: &axum::Router, uri: &str) -> (StatusCode, Value) {
             let req = Request::builder()
                 .method("GET")
@@ -1125,7 +1125,6 @@ mod tests {
             };
             (status, body)
         }
-
         #[tokio::test]
         async fn validate_returns_normalized_payload_without_persisting() {
             let app = build_test_app().await;
@@ -1147,18 +1146,15 @@ mod tests {
             let get_resp = app.clone().oneshot(get_req).await.unwrap();
             assert_eq!(get_resp.status(), StatusCode::NOT_FOUND);
         }
-
         #[tokio::test]
         async fn validate_rejects_missing_id() {
             let app = build_test_app().await;
             let (status, _) = validate_record(&app, "providers", r#"{"adapter":"stub"}"#).await;
             assert_eq!(status, StatusCode::BAD_REQUEST);
         }
-
         #[tokio::test]
         async fn validate_rejects_unknown_provider_and_empty_model_fields() {
             let app = build_test_app().await;
-
             let (status, body) = validate_record(
                 &app,
                 "providers",
@@ -1167,7 +1163,6 @@ mod tests {
             .await;
             assert_eq!(status, StatusCode::BAD_REQUEST);
             assert!(body["error"].as_str().unwrap().contains("future_top_level"));
-
             let (status, body) = validate_record(
                 &app,
                 "models",
@@ -1177,7 +1172,6 @@ mod tests {
             assert_eq!(status, StatusCode::BAD_REQUEST);
             assert!(body["error"].as_str().unwrap().contains("provider_id"));
         }
-
         #[tokio::test]
         async fn validate_agent_overrides_does_not_persist_patch() {
             let app = build_test_app().await;
@@ -1193,7 +1187,6 @@ mod tests {
             let body: Value = serde_json::from_slice(&bytes).unwrap();
             assert_eq!(body["ok"], Value::Bool(true));
             assert_eq!(body["normalized"]["system_prompt"], "patched");
-
             let (status, meta) = get_json(&app, "/v1/config/agents/bootstrap/meta").await;
             assert_eq!(status, StatusCode::OK);
             assert!(meta["user_overrides"].is_null());
@@ -1449,8 +1442,9 @@ mod tests {
                 ServerConfig::default(),
             )
             .with_config_store(config_store)
-            .with_config_runtime_manager(manager);
-            let app = build_router(&state);
+            .with_config_runtime_manager(manager)
+            .with_admin_api_bearer_token(TEST_ADMIN_TOKEN);
+            let app = build_authorized_test_router(&state);
 
             let (status, body) = test_provider(&app, "prov-openai").await;
             assert_eq!(status, StatusCode::OK, "body: {body}");
@@ -1564,9 +1558,10 @@ mod tests {
                 ServerConfig::default(),
             )
             .with_config_store(config_store)
-            .with_config_runtime_manager(manager);
+            .with_config_runtime_manager(manager)
+            .with_admin_api_bearer_token(TEST_ADMIN_TOKEN);
 
-            build_router(&state)
+            build_authorized_test_router(&state)
         }
 
         #[tokio::test]

--- a/crates/awaken-server/src/config_routes.rs
+++ b/crates/awaken-server/src/config_routes.rs
@@ -13,7 +13,7 @@ struct DeleteParams {
     force: bool,
 }
 
-use crate::app::AppState;
+use crate::app::{AdminModuleState, ConfigRoutesState};
 use crate::routes::ApiError;
 use crate::services::audit_log::{AuditQuery, AuditQueryError};
 use crate::services::config_service::{
@@ -69,7 +69,7 @@ impl RouteConfigNamespace {
     }
 }
 
-pub fn config_routes() -> Router<AppState> {
+pub fn config_routes() -> Router<ConfigRoutesState> {
     Router::new()
         .route("/v1/capabilities", get(get_capabilities))
         .route(
@@ -117,10 +117,10 @@ pub fn config_routes() -> Router<AppState> {
 }
 
 async fn get_capabilities(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     Ok(Json(
         service.capabilities().await.map_err(map_service_error)?,
@@ -128,11 +128,11 @@ async fn get_capabilities(
 }
 
 async fn get_schema(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(namespace): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let schema = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace.schema_json(),
@@ -143,21 +143,21 @@ async fn get_schema(
 }
 
 async fn get_config_diagnostics(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let diagnostics = service.registry_diagnostics().map_err(map_service_error)?;
     Ok(Json(json!({ "diagnostics": diagnostics })))
 }
 
 async fn preview_provider_removal(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let preview = service
         .preview_remove_provider(&id)
@@ -167,35 +167,35 @@ async fn preview_provider_removal(
 }
 
 async fn list_agents(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     query: Query<ListParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     list_config_inner(state, "agents".to_string(), query.0).await
 }
 
 async fn get_agent(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     get_config_inner(state, "agents".to_string(), id).await
 }
 
 async fn list_config(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(namespace): Path<String>,
     Query(params): Query<ListParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     list_config_inner(state, namespace, params).await
 }
 
 async fn list_config_inner(
-    state: AppState,
+    state: ConfigRoutesState,
     namespace: String,
     params: ListParams,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -217,12 +217,12 @@ async fn list_config_inner(
 }
 
 async fn create_config(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(namespace): Path<String>,
     Json(body): Json<Value>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
@@ -247,13 +247,13 @@ struct ValidateParams {
 }
 
 async fn validate_config(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(namespace): Path<String>,
     Query(params): Query<ValidateParams>,
     Json(body): Json<Value>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
@@ -273,16 +273,16 @@ async fn validate_config(
 }
 
 async fn get_config(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     get_config_inner(state, namespace, id).await
 }
 
 async fn get_config_inner(
-    state: AppState,
+    state: ConfigRoutesState,
     namespace: String,
     id: String,
 ) -> Result<impl IntoResponse, ApiError> {
@@ -298,11 +298,11 @@ async fn get_config_inner(
 }
 
 async fn get_config_meta(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let meta = match namespace {
@@ -315,12 +315,12 @@ async fn get_config_meta(
 }
 
 async fn list_config_meta(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(namespace): Path<String>,
     Query(params): Query<ListParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let items = match namespace {
@@ -340,12 +340,12 @@ async fn list_config_meta(
 }
 
 async fn put_config(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
     Json(body): Json<Value>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let namespace = RouteConfigNamespace::parse(&namespace).map_err(map_service_error)?;
     let namespace = match namespace {
         RouteConfigNamespace::Managed(namespace) => namespace,
@@ -362,12 +362,12 @@ async fn put_config(
 }
 
 async fn delete_config(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
     Query(params): Query<DeleteParams>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let namespace = match RouteConfigNamespace::parse(&namespace) {
@@ -408,7 +408,7 @@ async fn delete_config(
 }
 
 async fn delete_blockers_for_route(
-    service: &ConfigService<'_>,
+    service: &ConfigService,
     namespace: ConfigNamespace,
     id: &str,
     force: bool,
@@ -439,12 +439,12 @@ struct RestoreBody {
 }
 
 async fn restore_config(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path((namespace, id)): Path<(String, String)>,
     Json(body): Json<RestoreBody>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let namespace = match RouteConfigNamespace::parse(&namespace) {
@@ -497,11 +497,11 @@ async fn restore_config(
 }
 
 async fn test_provider_connection(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let service = ConfigService::new(&state).map_err(map_service_error)?;
     let result: ProviderTestResult = service
         .test_provider(&id)
@@ -511,17 +511,14 @@ async fn test_provider_connection(
 }
 
 async fn get_mcp_server_status(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
 
     // 503 when no MCP runtime is configured.
-    let manager = state
-        .config_runtime_manager
-        .as_ref()
-        .ok_or_else(|| ApiError::ServiceUnavailable("MCP runtime is not configured".into()))?;
+    let manager = &state.config.runtime_manager;
 
     // 404 when the id is unknown to the active registry.
     let status = manager
@@ -554,17 +551,14 @@ fn systime_to_secs(t: std::time::SystemTime) -> Option<u64> {
 }
 
 async fn post_mcp_server_restart(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
 
     // 503 when no MCP runtime is configured.
-    let manager = state
-        .config_runtime_manager
-        .as_ref()
-        .ok_or_else(|| ApiError::ServiceUnavailable("MCP runtime is not configured".into()))?;
+    let manager = &state.config.runtime_manager;
 
     manager.mcp_server_reconnect(&id).await.map_err(|e| {
         // Map unknown-server errors (surfaced as InvalidConfig wrapping UnknownServer) to 404.
@@ -581,7 +575,7 @@ async fn post_mcp_server_restart(
     })?;
 
     // Emit audit event after successful restart.
-    if let Some(audit) = state.audit_log() {
+    if let Some(audit) = state.config.audit_log.clone() {
         let resource = format!("mcp-servers/{id}");
         audit
             .emit(
@@ -598,13 +592,15 @@ async fn post_mcp_server_restart(
 }
 
 async fn list_audit_log(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Query(query): Query<AuditQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
-    ensure_admin_auth(&state, &headers)?;
+    ensure_admin_auth(&state.admin, &headers)?;
     let audit = state
-        .audit_log()
+        .config
+        .audit_log
+        .clone()
         .ok_or_else(|| ApiError::ServiceUnavailable("audit log is not configured".into()))?;
     let mut effective_query = query;
     effective_query.limit = effective_query.limit.clamp(1, 1000);
@@ -615,9 +611,11 @@ async fn list_audit_log(
     Ok(Json(page))
 }
 
-pub(crate) fn ensure_admin_auth(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError> {
-    let config = crate::app::admin_api_config(state);
-    ensure_admin_auth_for_token(config.bearer_token.as_ref(), headers)
+pub(crate) fn ensure_admin_auth(
+    admin: &AdminModuleState,
+    headers: &HeaderMap,
+) -> Result<(), ApiError> {
+    ensure_admin_auth_for_token(admin.admin_api_config.bearer_token.as_ref(), headers)
 }
 
 fn ensure_admin_auth_for_token(
@@ -658,12 +656,12 @@ fn ensure_admin_auth_for_token(
 }
 
 async fn patch_agent_overrides_handler(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<Value>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let service = match ConfigService::new(&state) {
@@ -678,12 +676,12 @@ async fn patch_agent_overrides_handler(
 }
 
 async fn validate_agent_overrides_handler(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<Value>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let service = match ConfigService::new(&state) {
@@ -698,11 +696,11 @@ async fn validate_agent_overrides_handler(
 }
 
 async fn clear_agent_overrides_handler(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let service = match ConfigService::new(&state) {
@@ -717,11 +715,11 @@ async fn clear_agent_overrides_handler(
 }
 
 async fn clear_agent_override_field_handler(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path((id, field)): Path<(String, String)>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let service = match ConfigService::new(&state) {
@@ -739,12 +737,12 @@ async fn clear_agent_override_field_handler(
 }
 
 async fn patch_tool_overrides_handler(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<Value>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let service = match ConfigService::new(&state) {
@@ -759,11 +757,11 @@ async fn patch_tool_overrides_handler(
 }
 
 async fn clear_tool_overrides_handler(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let service = match ConfigService::new(&state) {
@@ -778,11 +776,11 @@ async fn clear_tool_overrides_handler(
 }
 
 async fn clear_tool_override_field_handler(
-    State(state): State<AppState>,
+    State(state): State<ConfigRoutesState>,
     headers: HeaderMap,
     Path((id, field)): Path<(String, String)>,
 ) -> Response {
-    if let Err(err) = ensure_admin_auth(&state, &headers) {
+    if let Err(err) = ensure_admin_auth(&state.admin, &headers) {
         return err.into_response();
     }
     let service = match ConfigService::new(&state) {
@@ -940,7 +938,7 @@ mod tests {
         use serde_json::Value;
         use tower::ServiceExt;
 
-        use crate::app::{AppState, ServerConfig};
+        use crate::app::{ServerConfig, ServerState};
         use crate::mailbox::{Mailbox, MailboxConfig};
         use crate::routes::build_router;
         use crate::services::config_runtime::{ConfigRuntimeManager, ProviderExecutorFactory};
@@ -1039,7 +1037,7 @@ mod tests {
                 "route-test".into(),
                 MailboxConfig::default(),
             ));
-            let state = AppState::new(
+            let state = ServerState::new(
                 runtime,
                 mailbox,
                 thread_store,
@@ -1049,7 +1047,7 @@ mod tests {
             .with_config_store(config_store)
             .with_config_runtime_manager(manager);
 
-            build_router(&state).with_state(state)
+            build_router(&state)
         }
 
         async fn create_record(app: &axum::Router, namespace: &str, body: &str) -> StatusCode {
@@ -1443,7 +1441,7 @@ mod tests {
                 "route-test-2".into(),
                 MailboxConfig::default(),
             ));
-            let state = AppState::new(
+            let state = ServerState::new(
                 runtime,
                 mailbox,
                 thread_store,
@@ -1452,7 +1450,7 @@ mod tests {
             )
             .with_config_store(config_store)
             .with_config_runtime_manager(manager);
-            let app = build_router(&state).with_state(state);
+            let app = build_router(&state);
 
             let (status, body) = test_provider(&app, "prov-openai").await;
             assert_eq!(status, StatusCode::OK, "body: {body}");
@@ -1558,7 +1556,7 @@ mod tests {
                 "route-test-tool".into(),
                 MailboxConfig::default(),
             ));
-            let state = AppState::new(
+            let state = ServerState::new(
                 runtime,
                 mailbox,
                 thread_store,
@@ -1568,7 +1566,7 @@ mod tests {
             .with_config_store(config_store)
             .with_config_runtime_manager(manager);
 
-            build_router(&state).with_state(state)
+            build_router(&state)
         }
 
         #[tokio::test]

--- a/crates/awaken-server/src/error.rs
+++ b/crates/awaken-server/src/error.rs
@@ -17,6 +17,7 @@ pub enum ApiError {
     BadRequest(String),
     Unauthorized(String),
     Conflict(String),
+    Gone(String),
     NotFound(String),
     ThreadNotFound(String),
     RunNotFound(String),
@@ -26,6 +27,10 @@ pub enum ApiError {
     /// differentiate "no such resource" from "feature not available".
     ServiceUnavailable(String),
     Internal(String),
+    /// Storage promised a row that is missing inside retention. Distinct from
+    /// `Internal` so operators can alert on integrity violations (ADR-0034 D8:
+    /// "integrity error and metric; do not silently re-run the projector").
+    DataIntegrity(String),
 }
 
 impl fmt::Display for ApiError {
@@ -49,18 +54,57 @@ impl fmt::Display for ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let (status, message) = match self {
-            ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            ApiError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
-            ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg),
-            ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
-            ApiError::ThreadNotFound(id) => {
-                (StatusCode::NOT_FOUND, format!("thread not found: {id}"))
+        let (status, message, code) = match self {
+            ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg, None),
+            ApiError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg, None),
+            ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg, None),
+            ApiError::Gone(msg) => (StatusCode::GONE, msg, None),
+            ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg, None),
+            ApiError::ThreadNotFound(id) => (
+                StatusCode::NOT_FOUND,
+                format!("thread not found: {id}"),
+                None,
+            ),
+            ApiError::RunNotFound(id) => {
+                (StatusCode::NOT_FOUND, format!("run not found: {id}"), None)
             }
-            ApiError::RunNotFound(id) => (StatusCode::NOT_FOUND, format!("run not found: {id}")),
-            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg),
-            ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg, None),
+            ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg, None),
+            ApiError::DataIntegrity(msg) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                msg,
+                Some("data_integrity"),
+            ),
         };
-        (status, Json(json!({"error": message}))).into_response()
+        let body = match code {
+            Some(code) => json!({ "error": message, "code": code }),
+            None => json!({ "error": message }),
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn data_integrity_carries_distinct_code_for_operators() {
+        let response = ApiError::DataIntegrity("row missing".into()).into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["error"], "row missing");
+        assert_eq!(value["code"], "data_integrity");
+    }
+
+    #[tokio::test]
+    async fn internal_does_not_carry_code_field() {
+        let response = ApiError::Internal("boom".into()).into_response();
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["error"], "boom");
+        assert!(value.get("code").is_none());
     }
 }

--- a/crates/awaken-server/src/error.rs
+++ b/crates/awaken-server/src/error.rs
@@ -43,9 +43,11 @@ impl fmt::Display for ApiError {
             ApiError::BadRequest(msg)
             | ApiError::Unauthorized(msg)
             | ApiError::Conflict(msg)
+            | ApiError::Gone(msg)
             | ApiError::NotFound(msg)
             | ApiError::ServiceUnavailable(msg)
-            | ApiError::Internal(msg) => f.write_str(msg),
+            | ApiError::Internal(msg)
+            | ApiError::DataIntegrity(msg) => f.write_str(msg),
             ApiError::ThreadNotFound(id) => write!(f, "thread not found: {id}"),
             ApiError::RunNotFound(id) => write!(f, "run not found: {id}"),
         }

--- a/crates/awaken-server/src/eval_router.rs
+++ b/crates/awaken-server/src/eval_router.rs
@@ -5,7 +5,7 @@
 use axum::Router;
 use axum::routing::{get, post};
 
-use crate::app::AppState;
+use crate::app::EvalRoutesState;
 use crate::services::dataset_service::{
     append_fixture, create_dataset, curate_items, delete_dataset, get_dataset, import_dialogue,
     import_traces, list_datasets, put_dataset,
@@ -13,7 +13,7 @@ use crate::services::dataset_service::{
 use crate::services::eval_run_service::{get_eval_run, list_eval_runs, start_eval_run};
 use crate::services::online_eval_service::start_online_eval;
 
-pub fn eval_routes() -> Router<AppState> {
+pub fn eval_routes() -> Router<EvalRoutesState> {
     Router::new()
         .route("/v1/eval/datasets", get(list_datasets).post(create_dataset))
         .route(

--- a/crates/awaken-server/src/event_routes.rs
+++ b/crates/awaken-server/src/event_routes.rs
@@ -1,0 +1,468 @@
+//! Canonical event-list and cursor-resume routes.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use bytes::Bytes;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use awaken_contract::contract::event_store::{
+    CanonicalEvent, EventCursor, EventScope, EventStoreError, EventVisibility, SubscribeStart,
+};
+
+use crate::app::EventModuleState;
+use crate::http_sse::sse_response;
+use crate::routes::ApiError;
+
+const DEFAULT_EVENT_LIMIT: usize = 50;
+const MAX_EVENT_LIMIT: usize = 200;
+const LAST_EVENT_ID_HEADER: &str = "last-event-id";
+
+pub(crate) fn event_routes() -> Router<EventModuleState> {
+    Router::new()
+        .route("/v1/threads/:thread_id/events", get(list_thread_events))
+        .route(
+            "/v1/threads/:thread_id/events/stream",
+            get(stream_thread_events),
+        )
+        .route("/v1/runs/:run_id/events", get(list_run_events))
+        .route("/v1/runs/:run_id/events/stream", get(stream_run_events))
+}
+
+#[derive(Debug, Deserialize)]
+struct EventListParams {
+    cursor: Option<String>,
+    #[serde(default = "default_event_limit")]
+    limit: usize,
+}
+
+const fn default_event_limit() -> usize {
+    DEFAULT_EVENT_LIMIT
+}
+
+#[tracing::instrument(skip(state), fields(thread_id = %thread_id))]
+async fn list_thread_events(
+    State(state): State<EventModuleState>,
+    Path(thread_id): Path<String>,
+    Query(params): Query<EventListParams>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    list_events_for_scope(state, EventScope::thread(thread_id), params).await
+}
+
+#[tracing::instrument(skip(state), fields(run_id = %run_id))]
+async fn list_run_events(
+    State(state): State<EventModuleState>,
+    Path(run_id): Path<String>,
+    Query(params): Query<EventListParams>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    list_events_for_scope(state, EventScope::run(run_id), params).await
+}
+
+async fn list_events_for_scope(
+    state: EventModuleState,
+    scope: EventScope,
+    params: EventListParams,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let store = Arc::clone(&state.event_store);
+    let cursor = parse_cursor(params.cursor.as_deref())?;
+    let page = store
+        .list(
+            scope.clone(),
+            cursor,
+            params.limit.clamp(1, MAX_EVENT_LIMIT),
+        )
+        .await
+        .map_err(map_event_store_error)?;
+
+    let items = page
+        .events
+        .iter()
+        .map(CanonicalEventHttp::from)
+        .collect::<Vec<_>>();
+    Ok(Json(json!({
+        "items": items,
+        "next_cursor": page.next_cursor.map(|cursor| cursor.as_str().to_string()),
+        "has_more": page.has_more,
+    })))
+}
+
+#[tracing::instrument(skip(state, headers), fields(thread_id = %thread_id))]
+async fn stream_thread_events(
+    State(state): State<EventModuleState>,
+    Path(thread_id): Path<String>,
+    Query(params): Query<EventListParams>,
+    headers: HeaderMap,
+) -> Response {
+    stream_events_for_scope(state, EventScope::thread(thread_id), params, headers).await
+}
+
+#[tracing::instrument(skip(state, headers), fields(run_id = %run_id))]
+async fn stream_run_events(
+    State(state): State<EventModuleState>,
+    Path(run_id): Path<String>,
+    Query(params): Query<EventListParams>,
+    headers: HeaderMap,
+) -> Response {
+    stream_events_for_scope(state, EventScope::run(run_id), params, headers).await
+}
+
+async fn stream_events_for_scope(
+    state: EventModuleState,
+    scope: EventScope,
+    params: EventListParams,
+    headers: HeaderMap,
+) -> Response {
+    let store = Arc::clone(&state.event_store);
+    let cursor = match stream_cursor(&params, &headers) {
+        Ok(cursor) => cursor,
+        Err(error) => return error.into_response(),
+    };
+    let start = cursor.map_or(SubscribeStart::FromNow, SubscribeStart::FromCursor);
+    let handle = match store.subscribe(scope.clone(), start).await {
+        Ok(handle) => handle,
+        Err(error) => return map_event_store_error(error).into_response(),
+    };
+
+    let stream = async_stream::stream! {
+        let mut events = handle.stream;
+        while let Some(item) = events.next().await {
+            match item.and_then(|event| format_canonical_event_sse(&event, &scope)) {
+                Ok(frame) => yield Ok::<Bytes, Infallible>(frame),
+                Err(error) => {
+                    yield Ok::<Bytes, Infallible>(format_stream_error(&error));
+                    break;
+                }
+            }
+        }
+    };
+    sse_response(stream)
+}
+
+fn stream_cursor(
+    params: &EventListParams,
+    headers: &HeaderMap,
+) -> Result<Option<EventCursor>, ApiError> {
+    if params.cursor.is_some() {
+        return parse_cursor(params.cursor.as_deref());
+    }
+    let header_cursor = headers
+        .get(LAST_EVENT_ID_HEADER)
+        .and_then(|value| value.to_str().ok());
+    parse_cursor(header_cursor)
+}
+
+fn parse_cursor(raw: Option<&str>) -> Result<Option<EventCursor>, ApiError> {
+    raw.map(|value| {
+        EventCursor::new(value.to_string()).map_err(|error| ApiError::BadRequest(error.to_string()))
+    })
+    .transpose()
+}
+
+fn map_event_store_error(error: EventStoreError) -> ApiError {
+    match error {
+        EventStoreError::Validation(message) => ApiError::BadRequest(message),
+        EventStoreError::IdempotencyConflict(message)
+        | EventStoreError::ExpectedCursorConflict(message) => ApiError::Conflict(message),
+        EventStoreError::CursorExpired(message) => ApiError::Gone(message),
+        EventStoreError::Integrity(message)
+        | EventStoreError::Io(message)
+        | EventStoreError::Serialization(message) => ApiError::Internal(message),
+    }
+}
+
+fn format_canonical_event_sse(
+    event: &CanonicalEvent,
+    scope: &EventScope,
+) -> Result<Bytes, EventStoreError> {
+    let cursor = event.cursors_by_scope.get(scope).ok_or_else(|| {
+        EventStoreError::Integrity("event missing cursor for requested scope".to_string())
+    })?;
+    if cursor.as_str().contains(['\r', '\n']) {
+        return Err(EventStoreError::Integrity(
+            "event cursor contains a newline".to_string(),
+        ));
+    }
+    let payload = serde_json::to_string(&CanonicalEventHttp::from(event))
+        .map_err(|error| EventStoreError::Serialization(error.to_string()))?;
+    Ok(Bytes::from(format!(
+        "id: {}\ndata: {}\n\n",
+        cursor.as_str(),
+        payload
+    )))
+}
+
+fn format_stream_error(error: &EventStoreError) -> Bytes {
+    let payload = serde_json::to_string(&json!({ "error": error.to_string() }))
+        .unwrap_or_else(|_| r#"{"error":"event stream error"}"#.to_string());
+    Bytes::from(format!("event: error\ndata: {payload}\n\n"))
+}
+
+#[derive(Debug, Serialize)]
+struct CanonicalEventHttp {
+    event_id: String,
+    scopes: Vec<EventScope>,
+    cursors_by_scope: Vec<ScopedCursorHttp>,
+    event_kind: String,
+    #[serde(default)]
+    payload: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thread_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    causation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    correlation_id: Option<String>,
+    origin: String,
+    visibility: EventVisibility,
+    schema_version: u32,
+    created_at: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ScopedCursorHttp {
+    scope: EventScope,
+    cursor: String,
+}
+
+impl From<&CanonicalEvent> for CanonicalEventHttp {
+    fn from(event: &CanonicalEvent) -> Self {
+        Self {
+            event_id: event.event_id.as_str().to_string(),
+            scopes: event.scopes.clone(),
+            cursors_by_scope: event
+                .cursors_by_scope
+                .iter()
+                .map(|(scope, cursor)| ScopedCursorHttp {
+                    scope: scope.clone(),
+                    cursor: cursor.as_str().to_string(),
+                })
+                .collect(),
+            event_kind: event.event_kind.as_str().to_string(),
+            payload: event.payload.clone(),
+            thread_id: event.thread_id.clone(),
+            run_id: event.run_id.clone(),
+            causation_id: event.causation_id.clone(),
+            correlation_id: event.correlation_id.clone(),
+            origin: event.origin.clone(),
+            visibility: event.visibility,
+            schema_version: event.schema_version,
+            created_at: event.created_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::event_store::{
+        AppendOptions, CanonicalEventDraft, CanonicalEventKind, EventWriter,
+    };
+    use awaken_runtime::AgentRuntime;
+    use awaken_stores::{InMemoryEventStore, InMemoryMailboxStore, InMemoryStore};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode, header};
+    use http_body_util::BodyExt;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    use crate::app::{ServerConfig, ServerState};
+    use crate::mailbox::{Mailbox, MailboxConfig};
+    use crate::routes::build_router;
+
+    struct StubResolver;
+
+    impl awaken_runtime::AgentResolver for StubResolver {
+        fn resolve(
+            &self,
+            agent_id: &str,
+        ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
+            Err(awaken_runtime::RuntimeError::AgentNotFound {
+                agent_id: agent_id.to_string(),
+            })
+        }
+    }
+
+    fn make_state(event_store: Option<Arc<InMemoryEventStore>>) -> ServerState {
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let store = Arc::new(InMemoryStore::new());
+        let mailbox_store = Arc::new(InMemoryMailboxStore::new());
+        let mailbox = Arc::new(Mailbox::new(
+            runtime.clone(),
+            mailbox_store,
+            store.clone(),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+        let state = ServerState::new(
+            runtime,
+            mailbox,
+            store,
+            Arc::new(StubResolver),
+            ServerConfig::default(),
+        );
+        match event_store {
+            Some(store) => state.with_event_store(store),
+            None => state,
+        }
+    }
+
+    async fn append_event(store: &InMemoryEventStore, thread_id: &str, kind: &str) -> EventCursor {
+        let scope = EventScope::thread(thread_id);
+        append_scoped_event(store, vec![scope.clone()], kind)
+            .await
+            .cursors_by_scope
+            .get(&scope)
+            .cloned()
+            .unwrap()
+    }
+
+    async fn append_scoped_event(
+        store: &InMemoryEventStore,
+        scopes: Vec<EventScope>,
+        kind: &str,
+    ) -> CanonicalEvent {
+        let draft = CanonicalEventDraft::new(
+            scopes,
+            CanonicalEventKind::new(kind).unwrap(),
+            json!({ "kind": kind }),
+            "test",
+        )
+        .unwrap();
+        store
+            .append(draft, AppendOptions::default())
+            .await
+            .unwrap()
+            .event
+    }
+
+    async fn get(app: axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+        let response = app
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        (status, serde_json::from_slice(&body).unwrap())
+    }
+
+    #[tokio::test]
+    async fn list_thread_events_uses_event_store_cursors() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let first_cursor = append_event(&event_store, "thread-events", "RunStarted").await;
+        append_event(&event_store, "thread-events", "RunFinished").await;
+        let state = make_state(Some(event_store));
+        let app = build_router(&state);
+
+        let (status, body) = get(app.clone(), "/v1/threads/thread-events/events?limit=1").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["items"].as_array().unwrap().len(), 1);
+        assert_eq!(body["has_more"].as_bool(), Some(true));
+        assert_eq!(body["next_cursor"].as_str(), Some(first_cursor.as_str()));
+
+        let uri = format!(
+            "/v1/threads/thread-events/events?cursor={}",
+            first_cursor.as_str()
+        );
+        let (status, body) = get(app, &uri).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["items"].as_array().unwrap().len(), 1);
+        assert_eq!(body["items"][0]["event_kind"], "RunFinished");
+    }
+
+    #[tokio::test]
+    async fn list_run_events_use_scoped_event_store_cursors() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let event = append_scoped_event(
+            &event_store,
+            vec![EventScope::thread("child-thread"), EventScope::run("run-1")],
+            "RunStarted",
+        )
+        .await;
+        let run_cursor = event
+            .cursors_by_scope
+            .get(&EventScope::run("run-1"))
+            .unwrap();
+        let state = make_state(Some(event_store));
+        let app = build_router(&state);
+
+        let (status, body) = get(app, "/v1/runs/run-1/events").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["items"][0]["cursors_by_scope"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|cursor| cursor["cursor"].as_str() == Some(run_cursor.as_str()))
+        );
+    }
+
+    #[tokio::test]
+    async fn list_thread_events_route_absent_without_event_module() {
+        let state = make_state(None);
+        let app = build_router(&state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/threads/thread-events/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn list_thread_events_returns_gone_for_expired_cursor() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let state = make_state(Some(event_store));
+        let app = build_router(&state);
+
+        let (status, body) = get(app, "/v1/threads/thread-events/events?cursor=unknown").await;
+        assert_eq!(status, StatusCode::GONE);
+        assert_eq!(body["error"], "unknown");
+    }
+
+    #[tokio::test]
+    async fn stream_thread_events_replays_after_last_event_id() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let first_cursor = append_event(&event_store, "thread-events", "RunStarted").await;
+        let second_cursor = append_event(&event_store, "thread-events", "RunFinished").await;
+        let state = make_state(Some(event_store));
+        let app = build_router(&state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/threads/thread-events/events/stream")
+                    .header(LAST_EVENT_ID_HEADER, first_cursor.as_str())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/event-stream"
+        );
+        let mut body = response.into_body().into_data_stream();
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(2), body.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let frame = String::from_utf8(frame.to_vec()).unwrap();
+        assert!(frame.starts_with(&format!("id: {}\n", second_cursor.as_str())));
+        assert!(frame.contains("\"event_kind\":\"RunFinished\""));
+    }
+}

--- a/crates/awaken-server/src/http_run.rs
+++ b/crates/awaken-server/src/http_run.rs
@@ -212,7 +212,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resumable_relay_assigns_sequential_ids() {
+    async fn resumable_relay_emits_frames_without_durable_event_id() {
+        // ADR-0034 D3: frames produced by the in-process EventReplayBuffer
+        // omit `id:` so the buffer sequence is never leaked as a
+        // Last-Event-ID that the client could re-send as a durable cursor.
         let (tx, rx) = mpsc::channel::<AgentEvent>(256);
         let encoder = Identity::<AgentEvent>::default();
         let replay_buffer = std::sync::Arc::new(EventReplayBuffer::new(64));
@@ -230,9 +233,13 @@ mod tests {
             chunks.push(String::from_utf8(chunk.to_vec()).unwrap());
         }
         assert_eq!(chunks.len(), 3);
-        assert!(chunks[0].starts_with("id: 1\n"));
-        assert!(chunks[1].starts_with("id: 2\n"));
-        assert!(chunks[2].starts_with("id: 3\n"));
+        for chunk in &chunks {
+            assert!(
+                !chunk.contains("id:"),
+                "in-process buffer frames must not advertise an SSE id: {chunk}"
+            );
+            assert!(chunk.starts_with("data:"));
+        }
     }
 
     #[tokio::test]

--- a/crates/awaken-server/src/lib.rs
+++ b/crates/awaken-server/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![allow(missing_docs)]
 
+pub(crate) mod admin_routes;
 pub mod app;
 pub(crate) mod auth;
 pub mod config_routes;
@@ -14,15 +15,22 @@ pub mod error;
 pub mod eval_limits;
 pub mod eval_router;
 pub mod event_relay;
+pub(crate) mod event_routes;
 pub mod http_run;
 pub mod http_sse;
 pub mod mailbox;
 pub mod message_convert;
 pub mod metrics;
+pub mod outbox_relay;
+pub mod protocol_fanout;
+pub mod protocol_projector;
+pub mod protocol_replay_state;
 pub mod protocols;
 pub mod query;
 pub mod request;
+mod route_modules;
 pub mod routes;
 pub mod services;
+pub(crate) mod system_routes;
 pub mod time;
 pub mod transport;

--- a/crates/awaken-server/src/mailbox.rs
+++ b/crates/awaken-server/src/mailbox.rs
@@ -1,9 +1,4 @@
-//! Mailbox service: unified persistent run queue.
-//!
-//! Every run request (streaming, background, A2A, internal) enters as a
-//! [`RunDispatch`] keyed by `thread_id`. The Mailbox orchestrates persistent
-//! enqueue, lease-based claim, execution via [`RunDispatchExecutor`], and lifecycle
-//! management (lease renewal, sweep, GC).
+//! Mailbox service: persistent run queue, dispatch execution, leasing, and lifecycle management.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -17,15 +12,20 @@ use thiserror::Error;
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 
+use awaken_contract::contract::commit_coordinator::{
+    CommitCoordinator, OutboxServerEventPublisher,
+};
 use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::event_sink::EventSink;
 use awaken_contract::contract::mailbox::{MailboxStore, RunDispatchStatus};
 use awaken_contract::contract::message::Message;
+use awaken_contract::contract::run::{
+    RunActivationSnapshot, RunInputSnapshot, RunIntent, RunKind, RunOptions, RunTraceContext,
+};
 use awaken_contract::contract::storage::{RunRecord, StorageError, ThreadRunStore};
 use awaken_contract::contract::suspension::{ToolCallOutcome, ToolCallResume};
 use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
-use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
-use awaken_runtime::{AgentRuntime, RunRequest, ThreadContextSnapshot};
+use awaken_runtime::RunActivation;
 
 use crate::transport::channel_sink::ReconnectableEventSink;
 
@@ -63,12 +63,12 @@ const MAILBOX_DEPTH_STATUSES: [RunDispatchStatus; 6] = [
 pub(crate) const ACTIVE_RUN_CONFLICT_MESSAGE: &str =
     "thread has an active run; cannot claim inline";
 
-// ── RunRequest ↔ RunDispatch conversion ───────────────────────────────
+// ── Legacy run snapshot conversion ───────────────────────────────
 
-/// Typed envelope for RunRequest fields that Mailbox stores opaquely.
-/// Centralizes the RunRequest → RunDispatch → RunRequest round-trip.
+/// Typed envelope for RunActivation fields that Mailbox stores opaquely.
+/// Centralizes the legacy run snapshot round-trip round-trip.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct RunRequestExtras {
+pub(super) struct LegacyRunSnapshotExtras {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     overrides: Option<awaken_contract::contract::inference::InferenceOverride>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -94,22 +94,24 @@ struct RunRequestExtras {
     adapter: AdapterKind,
 }
 
-impl RunRequestExtras {
-    fn from_request(request: &awaken_runtime::RunRequest) -> Self {
+impl LegacyRunSnapshotExtras {
+    #[cfg(test)]
+    fn from_request(request: &awaken_runtime::RunActivation) -> Self {
         Self {
-            overrides: request.overrides.clone(),
-            decisions: request.decisions.clone(),
-            frontend_tools: request.frontend_tools.clone(),
-            continue_run_id: request.continue_run_id.clone(),
-            run_id_hint: request.run_id_hint.clone(),
-            dispatch_id_hint: request.dispatch_id_hint.clone(),
-            parent_thread_id: request.parent_thread_id.clone(),
-            transport_request_id: request.transport_request_id.clone(),
-            run_mode: request.run_mode,
-            adapter: request.adapter,
+            overrides: request.options.overrides.clone(),
+            decisions: request.control.seeded_decisions.clone(),
+            frontend_tools: request.options.frontend_tools.clone(),
+            continue_run_id: request.resume_run_id().map(str::to_owned),
+            run_id_hint: request.persistence.run_id_hint.clone(),
+            dispatch_id_hint: request.persistence.dispatch_id_hint.clone(),
+            parent_thread_id: request.trace.parent_thread_id.clone(),
+            transport_request_id: request.trace.transport_request_id.clone(),
+            run_mode: request.trace.run_mode,
+            adapter: request.trace.adapter,
         }
     }
 
+    #[cfg(test)]
     fn to_value(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
         if self.overrides.is_none()
             && self.decisions.is_empty()
@@ -132,7 +134,8 @@ impl RunRequestExtras {
         serde_json::from_value(value.clone())
     }
 
-    fn apply_to(self, mut request: awaken_runtime::RunRequest) -> awaken_runtime::RunRequest {
+    #[cfg(test)]
+    fn apply_to(self, mut request: awaken_runtime::RunActivation) -> awaken_runtime::RunActivation {
         if let Some(ov) = self.overrides {
             request = request.with_overrides(ov);
         }
@@ -160,6 +163,105 @@ impl RunRequestExtras {
         request
             .with_run_mode(self.run_mode)
             .with_adapter(self.adapter)
+    }
+}
+
+pub(super) struct LegacyRunRequestSnapshotAdapter {
+    pub snapshot: awaken_contract::contract::storage::RunRequestSnapshot,
+    pub input: RunInputSnapshot,
+    pub manifest: awaken_contract::contract::storage::PinnedRegistryManifest,
+    pub thread_id: String,
+    pub agent_id: Option<String>,
+    pub parent_run_id: Option<String>,
+    pub extras: Option<LegacyRunSnapshotExtras>,
+}
+
+impl TryFrom<LegacyRunRequestSnapshotAdapter> for RunActivationSnapshot {
+    type Error = String;
+
+    fn try_from(value: LegacyRunRequestSnapshotAdapter) -> Result<Self, Self::Error> {
+        let mut options = RunOptions {
+            overrides: None,
+            frontend_tools: value.snapshot.frontend_tools,
+        };
+        let mut trace = RunTraceContext {
+            parent_run_id: value.parent_run_id,
+            parent_thread_id: value.snapshot.parent_thread_id,
+            origin: value.snapshot.origin.into(),
+            adapter: AdapterKind::Internal,
+            run_mode: RunMode::Resume,
+            dispatch_id: None,
+            session_id: None,
+            transport_request_id: value.snapshot.transport_request_id,
+            correlation_id: None,
+        };
+        let mut kind = RunKind::NewIntent;
+        let mut seeded_decisions = value
+            .snapshot
+            .decisions
+            .into_iter()
+            .map(|decision| (decision.call_id, decision.resume))
+            .collect::<Vec<_>>();
+
+        if let Some(extras) = value.extras {
+            if let Some(overrides) = extras.overrides {
+                options.overrides = Some(overrides);
+            }
+            if !extras.frontend_tools.is_empty() {
+                options.frontend_tools = extras.frontend_tools;
+            }
+            if !extras.decisions.is_empty() {
+                seeded_decisions = extras.decisions;
+            }
+            if let Some(run_id) = extras.continue_run_id {
+                kind = RunKind::HitlResume { run_id };
+            }
+            if let Some(parent_thread_id) = extras.parent_thread_id {
+                trace.parent_thread_id = Some(parent_thread_id);
+            }
+            if let Some(transport_request_id) = extras.transport_request_id {
+                trace.transport_request_id = Some(transport_request_id);
+            }
+            trace.run_mode = extras.run_mode;
+            trace.adapter = extras.adapter;
+        }
+
+        Ok(RunActivationSnapshot {
+            intent: RunIntent {
+                agent_id: value.agent_id,
+                thread_id: value.thread_id,
+                kind,
+            },
+            input: value.input,
+            options,
+            trace,
+            seeded_decisions,
+            resolution_scope: value.manifest,
+        })
+    }
+}
+
+pub(super) fn legacy_input_snapshot(
+    run: &RunRecord,
+    snapshot: &awaken_contract::contract::storage::RunRequestSnapshot,
+) -> RunInputSnapshot {
+    if let Some(input) = run.input.as_ref() {
+        return RunInputSnapshot {
+            thread_id: input.thread_id.clone(),
+            range: input.range,
+            trigger_message_ids: input.trigger_message_ids.clone(),
+            selected_message_ids: input.selected_message_ids.clone(),
+            context_policy: input.context_policy.clone(),
+            compacted_snapshot_id: input.compacted_snapshot_id.clone(),
+        };
+    }
+    RunInputSnapshot {
+        thread_id: run.thread_id.clone(),
+        range: None,
+        trigger_message_ids: snapshot.input_message_ids.clone(),
+        selected_message_ids: Vec::new(),
+        context_policy: None,
+        compacted_snapshot_id: None,
     }
 }
 
@@ -195,7 +297,7 @@ impl awaken_runtime::inbox::OnInboxClosed for TaskDoneMailboxNotify {
 
         // Spawn because OnInboxClosed::closed is sync but enqueue+dispatch is async
         tokio::spawn(async move {
-            let mut request = RunRequest::new(thread_id.clone(), vec![wake_message])
+            let mut request = RunActivation::new(thread_id.clone(), vec![wake_message])
                 .with_origin(awaken_contract::contract::storage::RunRequestOrigin::Internal)
                 .with_run_mode(RunMode::InternalWake)
                 .with_adapter(AdapterKind::Internal);
@@ -258,84 +360,6 @@ impl MailboxRunOutcome {
             Self::TransientError(_) => "transient_error",
             Self::PermanentError(_) => "permanent_error",
         }
-    }
-}
-
-/// Execution boundary used by mailbox dispatch.
-///
-/// Mailbox owns delivery, leasing, retry, and recovery. The executor behind
-/// this trait owns actual run execution and live-run control. It intentionally
-/// does not expose storage so mailbox scheduling stays orthogonal to the main
-/// runtime implementation.
-#[async_trait]
-pub trait RunDispatchExecutor: Send + Sync {
-    /// Execute a run request and stream events into the provided sink.
-    async fn run(
-        &self,
-        request: RunRequest,
-        sink: Arc<dyn EventSink>,
-    ) -> Result<AgentRunResult, AgentLoopError>;
-
-    /// Execute a run with an optional mailbox-provided thread cache.
-    async fn run_with_thread_context(
-        &self,
-        request: RunRequest,
-        sink: Arc<dyn EventSink>,
-        thread_ctx: Option<ThreadContextSnapshot>,
-    ) -> Result<AgentRunResult, AgentLoopError> {
-        let _ = thread_ctx;
-        self.run(request, sink).await
-    }
-
-    /// Cancel an active run by run id or thread id.
-    fn cancel(&self, id: &str) -> bool;
-
-    /// Cancel an active run by thread id and wait for it to unregister.
-    async fn cancel_and_wait_by_thread(&self, thread_id: &str) -> bool;
-
-    /// Forward one human/tool decision to an active run.
-    fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool;
-
-    /// Forward direct input messages to an active run.
-    fn send_messages(&self, id: &str, messages: Vec<Message>) -> bool {
-        let _ = (id, messages);
-        false
-    }
-}
-
-#[async_trait]
-impl RunDispatchExecutor for AgentRuntime {
-    async fn run(
-        &self,
-        request: RunRequest,
-        sink: Arc<dyn EventSink>,
-    ) -> Result<AgentRunResult, AgentLoopError> {
-        AgentRuntime::run(self, request, sink).await
-    }
-
-    async fn run_with_thread_context(
-        &self,
-        request: RunRequest,
-        sink: Arc<dyn EventSink>,
-        thread_ctx: Option<ThreadContextSnapshot>,
-    ) -> Result<AgentRunResult, AgentLoopError> {
-        AgentRuntime::run_with_thread_context(self, request, sink, thread_ctx).await
-    }
-
-    fn cancel(&self, id: &str) -> bool {
-        AgentRuntime::cancel(self, id)
-    }
-
-    async fn cancel_and_wait_by_thread(&self, thread_id: &str) -> bool {
-        AgentRuntime::cancel_and_wait_by_thread(self, thread_id).await
-    }
-
-    fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool {
-        AgentRuntime::send_decision(self, id, tool_call_id, resume)
-    }
-
-    fn send_messages(&self, id: &str, messages: Vec<Message>) -> bool {
-        AgentRuntime::send_messages(self, id, messages)
     }
 }
 
@@ -638,44 +662,60 @@ impl Drop for ActiveRunGuard {
 pub struct Mailbox {
     executor: Arc<dyn RunDispatchExecutor>,
     store: Arc<dyn MailboxStore>,
+    /// Single durable-write boundary. Sourced from
+    /// `executor.commit_coordinator()` when the runtime supplies one, or
+    /// from an implicit `MailboxRunStoreCoordinator` wrapping the
+    /// constructor-supplied `run_store` for embedded callers whose
+    /// executor doesn't expose a coordinator.
+    coordinator: Arc<dyn CommitCoordinator>,
+    /// Projection of `coordinator.thread_run_store()` cached for repeated
+    /// read access; never diverges from the coordinator by construction.
     run_store: Arc<dyn ThreadRunStore>,
     consumer_id: String,
     workers: RwLock<HashMap<String, Arc<SyncMutex<MailboxWorker>>>>,
     config: MailboxConfig,
+    runtime_event_capture: Option<RuntimeEventCaptureConfig>,
+    server_event_publisher: Option<Arc<dyn OutboxServerEventPublisher>>,
+    server_event_origin: String,
     lifecycle_tasks: Arc<StdMutex<Option<MailboxLifecycleTasks>>>,
     lifecycle_start_lock: Arc<Mutex<()>>,
 }
 
 impl Mailbox {
     /// Create a new Mailbox service.
-    pub fn new<R>(
-        executor: Arc<R>,
-        store: Arc<dyn MailboxStore>,
-        run_store: Arc<dyn ThreadRunStore>,
-        consumer_id: String,
-        config: MailboxConfig,
-    ) -> Self
-    where
-        R: RunDispatchExecutor + 'static,
-    {
-        Self::new_with_executor(executor, store, run_store, consumer_id, config)
-    }
-
-    /// Create a Mailbox service from an already-erased execution boundary.
-    pub fn new_with_executor(
-        executor: Arc<dyn RunDispatchExecutor>,
+    ///
+    /// ADR-0038 D7: the mailbox holds a single `CommitCoordinator` and
+    /// derives its `ThreadRunStore` from that coordinator's
+    /// `thread_run_store()` — there is no parallel store handle to keep in
+    /// sync. When the executor exposes its own coordinator (production
+    /// runtime wiring), it is adopted directly; otherwise the supplied
+    /// `run_store` is wrapped in an implicit `MailboxRunStoreCoordinator`
+    /// for embedded/test callers whose executors carry no persistence
+    /// boundary.
+    pub fn new(
+        executor: impl IntoDispatchExecutor,
         store: Arc<dyn MailboxStore>,
         run_store: Arc<dyn ThreadRunStore>,
         consumer_id: String,
         config: MailboxConfig,
     ) -> Self {
+        let executor = executor.into_dispatch_executor();
+        let coordinator = executor.commit_coordinator().unwrap_or_else(|| {
+            Arc::new(MailboxRunStoreCoordinator::new(Arc::clone(&run_store)))
+                as Arc<dyn CommitCoordinator>
+        });
+        let run_store = coordinator.thread_run_store();
         Self {
             executor,
             store,
+            coordinator,
             run_store,
             consumer_id,
             workers: RwLock::new(HashMap::new()),
             config,
+            runtime_event_capture: None,
+            server_event_publisher: None,
+            server_event_origin: "mailbox".to_string(),
             lifecycle_tasks: Arc::new(StdMutex::new(None)),
             lifecycle_start_lock: Arc::new(Mutex::new(())),
         }
@@ -683,6 +723,19 @@ impl Mailbox {
 
     /// Default bounded channel capacity for the runtime->SSE relay.
     const EVENT_CHANNEL_CAPACITY: usize = 256;
+
+    /// Single source of truth for the thread/run store. Always returns the
+    /// store wrapped by the mailbox's [`CommitCoordinator`] — callers that
+    /// previously held a parallel `Arc<dyn ThreadRunStore>` should reach
+    /// it through this accessor instead.
+    pub fn thread_run_store(&self) -> &Arc<dyn ThreadRunStore> {
+        &self.run_store
+    }
+
+    /// Borrow the durable-write coordinator.
+    pub fn coordinator(&self) -> &Arc<dyn CommitCoordinator> {
+        &self.coordinator
+    }
 
     /// Forward a tool-call decision to an active run in this process only.
     ///
@@ -694,16 +747,23 @@ impl Mailbox {
 }
 
 mod cancel;
+mod checkpoint;
+mod coordinator_facade;
 mod decision;
+mod dispatch_execution;
+mod executor;
 mod helpers;
 mod lifecycle;
 mod live_delivery;
+mod runtime_event_capture;
+mod server_event_capture;
 mod signal_loop;
 mod submit;
 
-use helpers::*;
-
-// ── Tests ────────────────────────────────────────────────────────────
+use self::coordinator_facade::MailboxRunStoreCoordinator;
+use self::{helpers::*, runtime_event_capture::RuntimeEventCaptureConfig};
+pub use coordinator_facade::IntoDispatchExecutor;
+pub use executor::RunDispatchExecutor;
 
 #[cfg(test)]
 mod tests;

--- a/crates/awaken-server/src/mailbox.rs
+++ b/crates/awaken-server/src/mailbox.rs
@@ -662,11 +662,10 @@ impl Drop for ActiveRunGuard {
 pub struct Mailbox {
     executor: Arc<dyn RunDispatchExecutor>,
     store: Arc<dyn MailboxStore>,
-    /// Single durable-write boundary. Sourced from
-    /// `executor.commit_coordinator()` when the runtime supplies one, or
-    /// from an implicit `MailboxRunStoreCoordinator` wrapping the
-    /// constructor-supplied `run_store` for embedded callers whose
-    /// executor doesn't expose a coordinator.
+    /// Single durable-write boundary. Production runtimes must provide this
+    /// through `executor.commit_coordinator()`. Debug/test builds may fall
+    /// back to `MailboxRunStoreCoordinator` for embedded unit callers, but
+    /// release builds fail closed instead of taking a partial durable path.
     coordinator: Arc<dyn CommitCoordinator>,
     /// Projection of `coordinator.thread_run_store()` cached for repeated
     /// read access; never diverges from the coordinator by construction.
@@ -688,10 +687,10 @@ impl Mailbox {
     /// derives its `ThreadRunStore` from that coordinator's
     /// `thread_run_store()` — there is no parallel store handle to keep in
     /// sync. When the executor exposes its own coordinator (production
-    /// runtime wiring), it is adopted directly; otherwise the supplied
-    /// `run_store` is wrapped in an implicit `MailboxRunStoreCoordinator`
-    /// for embedded/test callers whose executors carry no persistence
-    /// boundary.
+    /// runtime wiring), it is adopted directly. Debug/test builds retain the
+    /// legacy implicit run-store coordinator for embedded unit callers; release
+    /// builds panic if the executor has no coordinator so production durable
+    /// mailbox deployments cannot silently omit canonical events/outbox writes.
     pub fn new(
         executor: impl IntoDispatchExecutor,
         store: Arc<dyn MailboxStore>,
@@ -700,10 +699,21 @@ impl Mailbox {
         config: MailboxConfig,
     ) -> Self {
         let executor = executor.into_dispatch_executor();
-        let coordinator = executor.commit_coordinator().unwrap_or_else(|| {
+        let coordinator = if let Some(coordinator) = executor.commit_coordinator() {
+            coordinator
+        } else if cfg!(debug_assertions) {
+            tracing::warn!(
+                "using dev/test MailboxRunStoreCoordinator fallback; production executors must \
+                 provide a CommitCoordinator"
+            );
             Arc::new(MailboxRunStoreCoordinator::new(Arc::clone(&run_store)))
                 as Arc<dyn CommitCoordinator>
-        });
+        } else {
+            panic!(
+                "Mailbox requires a CommitCoordinator in release builds; wire a durable \
+                 Memory/File/Pg coordinator through the runtime"
+            );
+        };
         let run_store = coordinator.thread_run_store();
         Self {
             executor,

--- a/crates/awaken-server/src/mailbox.rs
+++ b/crates/awaken-server/src/mailbox.rs
@@ -682,15 +682,6 @@ pub struct Mailbox {
 
 impl Mailbox {
     /// Create a new Mailbox service.
-    ///
-    /// ADR-0038 D7: the mailbox holds a single `CommitCoordinator` and
-    /// derives its `ThreadRunStore` from that coordinator's
-    /// `thread_run_store()` — there is no parallel store handle to keep in
-    /// sync. When the executor exposes its own coordinator (production
-    /// runtime wiring), it is adopted directly. Debug/test builds retain the
-    /// legacy implicit run-store coordinator for embedded unit callers; release
-    /// builds panic if the executor has no coordinator so production durable
-    /// mailbox deployments cannot silently omit canonical events/outbox writes.
     pub fn new(
         executor: impl IntoDispatchExecutor,
         store: Arc<dyn MailboxStore>,
@@ -698,6 +689,24 @@ impl Mailbox {
         consumer_id: String,
         config: MailboxConfig,
     ) -> Self {
+        Self::try_new(executor, store, run_store, consumer_id, config)
+            .expect("Mailbox requires a CommitCoordinator outside debug/test fallback")
+    }
+
+    /// Fallible constructor for production wiring that must fail closed.
+    ///
+    /// ADR-0038 D7: the mailbox adopts `executor.commit_coordinator()` and
+    /// derives its `ThreadRunStore` from that coordinator. Debug/test builds
+    /// retain the legacy implicit run-store coordinator for embedded unit
+    /// callers; release builds return an error instead of silently taking a
+    /// partial durable path with no canonical events/outbox writes.
+    pub fn try_new(
+        executor: impl IntoDispatchExecutor,
+        store: Arc<dyn MailboxStore>,
+        run_store: Arc<dyn ThreadRunStore>,
+        consumer_id: String,
+        config: MailboxConfig,
+    ) -> Result<Self, MailboxError> {
         let executor = executor.into_dispatch_executor();
         let coordinator = if let Some(coordinator) = executor.commit_coordinator() {
             coordinator
@@ -709,13 +718,14 @@ impl Mailbox {
             Arc::new(MailboxRunStoreCoordinator::new(Arc::clone(&run_store)))
                 as Arc<dyn CommitCoordinator>
         } else {
-            panic!(
+            return Err(MailboxError::Internal(
                 "Mailbox requires a CommitCoordinator in release builds; wire a durable \
                  Memory/File/Pg coordinator through the runtime"
-            );
+                    .to_string(),
+            ));
         };
         let run_store = coordinator.thread_run_store();
-        Self {
+        Ok(Self {
             executor,
             store,
             coordinator,
@@ -728,7 +738,7 @@ impl Mailbox {
             server_event_origin: "mailbox".to_string(),
             lifecycle_tasks: Arc::new(StdMutex::new(None)),
             lifecycle_start_lock: Arc::new(Mutex::new(())),
-        }
+        })
     }
 
     /// Default bounded channel capacity for the runtime->SSE relay.

--- a/crates/awaken-server/src/mailbox/cancel.rs
+++ b/crates/awaken-server/src/mailbox/cancel.rs
@@ -14,8 +14,9 @@ use awaken_contract::contract::storage::RunRecord;
 use awaken_contract::now_ms;
 
 use super::{
-    Mailbox, MailboxError, TERMINAL_RECONCILE_BATCH, live_target_for_dispatch, live_target_for_run,
-    record_mailbox_dispatch_terminal_metrics, record_mailbox_operation_result, result_label,
+    Mailbox, MailboxError, REMOTE_CANCEL_WAIT_MS, TERMINAL_RECONCILE_BATCH,
+    live_target_for_dispatch, live_target_for_run, record_mailbox_dispatch_terminal_metrics,
+    record_mailbox_operation_result, result_label,
 };
 
 impl Mailbox {
@@ -100,10 +101,17 @@ impl Mailbox {
             .await;
         }
 
+        let Some(active_dispatch) = result.active_dispatch.as_ref() else {
+            return Ok(result);
+        };
+
         // Cancel active runtime run if any.
-        if let Some(active_dispatch) = result.active_dispatch.as_ref() {
-            self.cancel_active_dispatch(thread_id, active_dispatch, false)
-                .await?;
+        if self
+            .cancel_active_dispatch(thread_id, active_dispatch, false)
+            .await?
+        {
+            self.record_mailbox_dispatch_event("RunInterrupted", active_dispatch)
+                .await;
         }
 
         Ok(result)
@@ -128,6 +136,12 @@ impl Mailbox {
                     dispatch_id = %active_dispatch.dispatch_id,
                     "local cancel completed but active dispatch did not release before foreground submit"
                 );
+                self.record_mailbox_timeout(
+                    active_dispatch,
+                    "local_cancel_release_wait",
+                    REMOTE_CANCEL_WAIT_MS,
+                )
+                .await;
                 return Ok(false);
             }
         } else if self.executor.cancel(thread_id) {
@@ -151,6 +165,12 @@ impl Mailbox {
                 dispatch_id = %active_dispatch.dispatch_id,
                 "remote cancel delivered but active dispatch did not release before foreground submit"
             );
+            self.record_mailbox_timeout(
+                active_dispatch,
+                "remote_cancel_release_wait",
+                REMOTE_CANCEL_WAIT_MS,
+            )
+            .await;
             return Ok(false);
         }
         Ok(true)
@@ -199,6 +219,10 @@ impl Mailbox {
         record_mailbox_operation_result(operation, result_label(&result), start);
         if matches!(result, Ok(true)) {
             record_mailbox_dispatch_terminal_metrics(dispatch, outcome);
+            if outcome == "cancelled" {
+                self.record_mailbox_dispatch_event("RunCancelled", dispatch)
+                    .await;
+            }
         }
         if let Err(error) = result {
             tracing::warn!(
@@ -365,18 +389,10 @@ impl Mailbox {
             .load_messages(&dispatch.thread_id)
             .await?
             .unwrap_or_default();
-        self.run_store
-            .checkpoint(&dispatch.thread_id, &messages, run)
+        self.commit_run_checkpoint(&dispatch.thread_id, &messages, run)
             .await?;
-        {
-            let workers = self.workers.read().await;
-            if let Some(worker) = workers.get(&dispatch.thread_id) {
-                let mut worker = worker.lock();
-                if let Some(ref mut ctx) = worker.thread_ctx {
-                    ctx.apply_checkpoint(&messages, run);
-                }
-            }
-        }
+        self.refresh_worker_checkpoint_cache(&dispatch.thread_id, &messages, run)
+            .await;
         Ok(())
     }
 }

--- a/crates/awaken-server/src/mailbox/checkpoint.rs
+++ b/crates/awaken-server/src/mailbox/checkpoint.rs
@@ -1,0 +1,446 @@
+use awaken_contract::contract::commit_coordinator::CheckpointCommitPlan;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::RunRecord;
+
+use super::{Mailbox, MailboxError};
+
+impl Mailbox {
+    pub(super) async fn commit_run_checkpoint(
+        &self,
+        thread_id: &str,
+        messages: &[Message],
+        run: &RunRecord,
+    ) -> Result<(), MailboxError> {
+        // ADR-0038 D7: the mailbox's coordinator and run_store are by
+        // construction the same logical handle — no `Arc::ptr_eq` check is
+        // needed, and there is no parallel coordinator-discovery code path
+        // for tests.
+        let plan = CheckpointCommitPlan::checkpoint_only(
+            thread_id.to_string(),
+            messages.to_vec(),
+            run.clone(),
+        );
+        self.coordinator
+            .commit_checkpoint(plan)
+            .await
+            .map_err(|error| MailboxError::Internal(format!("commit checkpoint: {error}")))?;
+        Ok(())
+    }
+
+    pub(super) async fn refresh_worker_checkpoint_cache(
+        &self,
+        thread_id: &str,
+        messages: &[Message],
+        run: &RunRecord,
+    ) {
+        let workers = self.workers.read().await;
+        if let Some(worker) = workers.get(thread_id) {
+            let mut worker = worker.lock();
+            if let Some(ref mut ctx) = worker.thread_ctx {
+                ctx.apply_checkpoint(messages, run);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use awaken_contract::contract::commit_coordinator::{
+        CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+    };
+    use awaken_contract::contract::event_sink::EventSink;
+    use awaken_contract::contract::lifecycle::RunStatus;
+    use awaken_contract::contract::storage::{RunStore, ThreadRunStore};
+    use awaken_runtime::RunActivation;
+    use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
+    use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
+
+    use super::*;
+    use crate::mailbox::{Mailbox, MailboxConfig, RunDispatchExecutor};
+
+    struct CountingCoordinator {
+        store: Arc<InMemoryStore>,
+        commits: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl CommitCoordinator for CountingCoordinator {
+        fn scope(&self) -> TransactionScopeId {
+            TransactionScopeId::new("mailbox-test").expect("scope id")
+        }
+
+        fn thread_run_store(&self) -> Arc<dyn ThreadRunStore> {
+            Arc::clone(&self.store) as Arc<dyn ThreadRunStore>
+        }
+
+        async fn commit_checkpoint(
+            &self,
+            plan: CheckpointCommitPlan,
+        ) -> Result<CheckpointCommitOutcome, CommitError> {
+            self.commits.fetch_add(1, Ordering::SeqCst);
+            #[allow(deprecated)]
+            self.store
+                .checkpoint(&plan.thread_id, &plan.messages, &plan.run)
+                .await?;
+            Ok(CheckpointCommitOutcome::default())
+        }
+    }
+
+    struct CoordinatedExecutor {
+        coordinator: Arc<dyn CommitCoordinator>,
+    }
+
+    #[async_trait]
+    impl RunDispatchExecutor for CoordinatedExecutor {
+        async fn run(
+            &self,
+            _request: RunActivation,
+            _sink: Arc<dyn EventSink>,
+        ) -> Result<AgentRunResult, AgentLoopError> {
+            unreachable!("checkpoint helper test does not execute runs")
+        }
+
+        fn cancel(&self, _id: &str) -> bool {
+            false
+        }
+
+        async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+            false
+        }
+
+        fn send_decision(
+            &self,
+            _id: &str,
+            _tool_call_id: String,
+            _resume: awaken_contract::contract::suspension::ToolCallResume,
+        ) -> bool {
+            false
+        }
+
+        fn commit_coordinator(&self) -> Option<Arc<dyn CommitCoordinator>> {
+            Some(Arc::clone(&self.coordinator))
+        }
+    }
+
+    #[tokio::test]
+    async fn mailbox_checkpoint_uses_matching_commit_coordinator() {
+        let store = Arc::new(InMemoryStore::new());
+        let coordinator = Arc::new(CountingCoordinator {
+            store: Arc::clone(&store),
+            commits: AtomicUsize::new(0),
+        });
+        let coordinator_dyn = coordinator.clone() as Arc<dyn CommitCoordinator>;
+        let executor = Arc::new(CoordinatedExecutor {
+            coordinator: coordinator_dyn,
+        });
+        let mailbox = Mailbox::new(
+            executor,
+            Arc::new(InMemoryMailboxStore::new()),
+            store.clone() as Arc<dyn ThreadRunStore>,
+            "consumer".to_string(),
+            MailboxConfig::default(),
+        );
+        let run = RunRecord {
+            run_id: "run-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            status: RunStatus::Created,
+            ..RunRecord::default()
+        };
+
+        mailbox
+            .commit_run_checkpoint("thread-1", &[Message::user("hi")], &run)
+            .await
+            .expect("checkpoint through coordinator");
+
+        assert_eq!(coordinator.commits.load(Ordering::SeqCst), 1);
+        assert!(store.load_run("run-1").await.unwrap().is_some());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // MailboxRunStoreCoordinator error-propagation coverage.
+    //
+    // When the runtime executor exposes no `CommitCoordinator`, `Mailbox`
+    // constructs an implicit `MailboxRunStoreCoordinator` wrapping the
+    // supplied `run_store`. That implicit coordinator's error must be
+    // wrapped as `MailboxError::Internal("commit checkpoint: ...")` —
+    // not silently absorbed and not mis-classified.
+    // ─────────────────────────────────────────────────────────────────
+
+    /// Executor that exposes NO commit coordinator. Forces `Mailbox::new`
+    /// to fall back to its implicit `MailboxRunStoreCoordinator`.
+    struct ExecutorWithoutCoordinator;
+
+    #[async_trait]
+    impl RunDispatchExecutor for ExecutorWithoutCoordinator {
+        async fn run(
+            &self,
+            _request: RunActivation,
+            _sink: Arc<dyn EventSink>,
+        ) -> Result<AgentRunResult, AgentLoopError> {
+            unreachable!("checkpoint helper test does not execute runs")
+        }
+        fn cancel(&self, _id: &str) -> bool {
+            false
+        }
+        async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+            false
+        }
+        fn send_decision(
+            &self,
+            _id: &str,
+            _tool_call_id: String,
+            _resume: awaken_contract::contract::suspension::ToolCallResume,
+        ) -> bool {
+            false
+        }
+        // Intentionally NOT overriding `commit_coordinator()` — returns
+        // `None` via the trait default.
+    }
+
+    /// `ThreadRunStore` wrapper whose `checkpoint()` always errors. All
+    /// other trait methods delegate to a real `InMemoryStore` so the
+    /// implementation can keep up with any contract trait method that
+    /// `ThreadRunStore` accumulates over time.
+    struct FailingThreadRunStore {
+        inner: Arc<InMemoryStore>,
+    }
+
+    #[async_trait]
+    impl awaken_contract::contract::storage::ThreadStore for FailingThreadRunStore {
+        async fn save_thread(
+            &self,
+            thread: &awaken_contract::thread::Thread,
+        ) -> Result<(), awaken_contract::contract::storage::StorageError> {
+            self.inner.save_thread(thread).await
+        }
+        async fn load_thread(
+            &self,
+            id: &str,
+        ) -> Result<
+            Option<awaken_contract::thread::Thread>,
+            awaken_contract::contract::storage::StorageError,
+        > {
+            self.inner.load_thread(id).await
+        }
+        async fn delete_thread(
+            &self,
+            id: &str,
+        ) -> Result<(), awaken_contract::contract::storage::StorageError> {
+            self.inner.delete_thread(id).await
+        }
+        async fn list_threads(
+            &self,
+            offset: usize,
+            limit: usize,
+        ) -> Result<Vec<String>, awaken_contract::contract::storage::StorageError> {
+            self.inner.list_threads(offset, limit).await
+        }
+        async fn save_messages(
+            &self,
+            thread_id: &str,
+            messages: &[Message],
+        ) -> Result<(), awaken_contract::contract::storage::StorageError> {
+            self.inner.save_messages(thread_id, messages).await
+        }
+        async fn load_messages(
+            &self,
+            thread_id: &str,
+        ) -> Result<Option<Vec<Message>>, awaken_contract::contract::storage::StorageError>
+        {
+            self.inner.load_messages(thread_id).await
+        }
+        async fn delete_messages(
+            &self,
+            thread_id: &str,
+        ) -> Result<(), awaken_contract::contract::storage::StorageError> {
+            self.inner.delete_messages(thread_id).await
+        }
+        async fn update_thread_metadata(
+            &self,
+            thread_id: &str,
+            metadata: awaken_contract::thread::ThreadMetadata,
+        ) -> Result<(), awaken_contract::contract::storage::StorageError> {
+            self.inner.update_thread_metadata(thread_id, metadata).await
+        }
+    }
+
+    #[async_trait]
+    impl RunStore for FailingThreadRunStore {
+        async fn create_run(
+            &self,
+            run: &RunRecord,
+        ) -> Result<(), awaken_contract::contract::storage::StorageError> {
+            self.inner.create_run(run).await
+        }
+        async fn load_run(
+            &self,
+            id: &str,
+        ) -> Result<Option<RunRecord>, awaken_contract::contract::storage::StorageError> {
+            self.inner.load_run(id).await
+        }
+        async fn latest_run(
+            &self,
+            thread_id: &str,
+        ) -> Result<Option<RunRecord>, awaken_contract::contract::storage::StorageError> {
+            self.inner.latest_run(thread_id).await
+        }
+        async fn list_runs(
+            &self,
+            query: &awaken_contract::contract::storage::RunQuery,
+        ) -> Result<
+            awaken_contract::contract::storage::RunPage,
+            awaken_contract::contract::storage::StorageError,
+        > {
+            self.inner.list_runs(query).await
+        }
+    }
+
+    #[async_trait]
+    impl ThreadRunStore for FailingThreadRunStore {
+        async fn checkpoint(
+            &self,
+            _thread_id: &str,
+            _messages: &[Message],
+            _run: &RunRecord,
+        ) -> Result<(), awaken_contract::contract::storage::StorageError> {
+            Err(
+                awaken_contract::contract::storage::StorageError::Validation(
+                    "simulated FailingThreadRunStore::checkpoint failure".into(),
+                ),
+            )
+        }
+    }
+
+    /// When the implicit `MailboxRunStoreCoordinator` propagates an
+    /// underlying `ThreadRunStore::checkpoint` failure, the mailbox must
+    /// surface it as `MailboxError::Internal("commit checkpoint: …")`.
+    #[tokio::test]
+    async fn mailbox_run_store_coordinator_wraps_checkpoint_errors() {
+        // Executor with no coordinator → Mailbox builds the implicit
+        // `MailboxRunStoreCoordinator` over the supplied run_store.
+        let failing_store: Arc<dyn ThreadRunStore> = Arc::new(FailingThreadRunStore {
+            inner: Arc::new(InMemoryStore::new()),
+        });
+        let mailbox = Mailbox::new(
+            Arc::new(ExecutorWithoutCoordinator),
+            Arc::new(InMemoryMailboxStore::new()),
+            failing_store,
+            "implicit-coord-test".to_string(),
+            MailboxConfig::default(),
+        );
+
+        let run = RunRecord {
+            run_id: "run-fail".to_string(),
+            thread_id: "thread-fail".to_string(),
+            agent_id: "agent-x".to_string(),
+            status: RunStatus::Created,
+            ..RunRecord::default()
+        };
+
+        let err = mailbox
+            .commit_run_checkpoint("thread-fail", &[Message::user("hi")], &run)
+            .await
+            .expect_err("FailingThreadRunStore must propagate an error");
+
+        match err {
+            crate::mailbox::MailboxError::Internal(msg) => {
+                assert!(
+                    msg.starts_with("commit checkpoint: "),
+                    "error must be wrapped with the 'commit checkpoint: ' prefix, got: {msg}"
+                );
+                assert!(
+                    msg.contains("simulated FailingThreadRunStore::checkpoint failure"),
+                    "wrapped message must include the underlying store error, got: {msg}"
+                );
+            }
+            other => panic!("expected MailboxError::Internal, got {other:?}"),
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // IntoDispatchExecutor coverage — every constructor input shape must
+    // drive a successful checkpoint end-to-end. We exercise both:
+    //   * `Arc<R: RunDispatchExecutor + 'static>` (the concrete form)
+    //   * `Arc<dyn RunDispatchExecutor>`       (the trait-object form)
+    // ─────────────────────────────────────────────────────────────────
+
+    async fn commit_through_mailbox(mailbox: Mailbox) {
+        let run = RunRecord {
+            run_id: "into-dyn-run".to_string(),
+            thread_id: "into-dyn-thread".to_string(),
+            agent_id: "agent".to_string(),
+            status: RunStatus::Created,
+            ..RunRecord::default()
+        };
+        mailbox
+            .commit_run_checkpoint("into-dyn-thread", &[Message::user("hi")], &run)
+            .await
+            .expect("checkpoint via dyn-erased executor must succeed");
+    }
+
+    fn make_coordinated_setup() -> (Arc<CountingCoordinator>, Arc<InMemoryStore>) {
+        let store = Arc::new(InMemoryStore::new());
+        let coordinator = Arc::new(CountingCoordinator {
+            store: Arc::clone(&store),
+            commits: AtomicUsize::new(0),
+        });
+        (coordinator, store)
+    }
+
+    /// Pass a concrete `Arc<CoordinatedExecutor>` (R: RunDispatchExecutor)
+    /// — the original branch of `IntoDispatchExecutor`.
+    #[tokio::test]
+    async fn into_dispatch_executor_accepts_concrete_arc() {
+        let (coordinator, store) = make_coordinated_setup();
+        let coordinator_dyn: Arc<dyn CommitCoordinator> = coordinator.clone();
+        let executor = Arc::new(CoordinatedExecutor {
+            coordinator: coordinator_dyn,
+        });
+        let mailbox = Mailbox::new(
+            executor, // <-- Arc<CoordinatedExecutor>
+            Arc::new(InMemoryMailboxStore::new()),
+            store.clone() as Arc<dyn ThreadRunStore>,
+            "concrete-arc".to_string(),
+            MailboxConfig::default(),
+        );
+        commit_through_mailbox(mailbox).await;
+        assert_eq!(coordinator.commits.load(Ordering::SeqCst), 1);
+    }
+
+    /// Pass a pre-erased `Arc<dyn RunDispatchExecutor>` — the second
+    /// branch of `IntoDispatchExecutor`. This is the path that
+    /// `public_api_compat_extended` smokes against but does not drive a
+    /// real commit through.
+    #[tokio::test]
+    async fn into_dispatch_executor_accepts_pre_erased_arc_and_runs_dispatch() {
+        let (coordinator, store) = make_coordinated_setup();
+        let coordinator_dyn: Arc<dyn CommitCoordinator> = coordinator.clone();
+        let concrete = Arc::new(CoordinatedExecutor {
+            coordinator: coordinator_dyn,
+        });
+        // Type-erase BEFORE handing off to Mailbox::new — this is the
+        // path that was previously served by `Mailbox::new_with_executor`.
+        let erased: Arc<dyn RunDispatchExecutor> = concrete;
+        let mailbox = Mailbox::new(
+            erased, // <-- Arc<dyn RunDispatchExecutor>
+            Arc::new(InMemoryMailboxStore::new()),
+            store.clone() as Arc<dyn ThreadRunStore>,
+            "pre-erased-arc".to_string(),
+            MailboxConfig::default(),
+        );
+        commit_through_mailbox(mailbox).await;
+        assert_eq!(
+            coordinator.commits.load(Ordering::SeqCst),
+            1,
+            "the erased-arc constructor path must still drive a real commit"
+        );
+        // FileStore wasn't involved, but the InMemoryStore must reflect
+        // the commit.
+        assert!(store.load_run("into-dyn-run").await.unwrap().is_some());
+    }
+}

--- a/crates/awaken-server/src/mailbox/coordinator_facade.rs
+++ b/crates/awaken-server/src/mailbox/coordinator_facade.rs
@@ -1,0 +1,87 @@
+//! Mailbox-side facade types that adapt executor inputs to the single
+//! `CommitCoordinator` field on [`crate::mailbox::Mailbox`].
+//!
+//! - [`IntoDispatchExecutor`] erases either `Arc<R>` or `Arc<dyn ...>` into
+//!   the trait object the mailbox stores internally so `Mailbox::new`
+//!   accepts both shapes through one signature.
+//! - [`MailboxRunStoreCoordinator`] is the implicit coordinator the mailbox
+//!   builds when the supplied executor exposes none. It delegates straight
+//!   to `ThreadRunStore::checkpoint` and is intended for embedded/test
+//!   callers; production deployments wire a full coordinator
+//!   (`MemoryCommitCoordinator` / `FileCommitCoordinator` /
+//!   `PgCommitCoordinator`) through the runtime instead.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::commit_coordinator::{
+    CheckpointCommitOutcome, CheckpointCommitPlan, CommitCoordinator, CommitError,
+    TransactionScopeId,
+};
+use awaken_contract::contract::storage::ThreadRunStore;
+
+use super::RunDispatchExecutor;
+
+/// Erase any `Arc<R>` (or `Arc<dyn RunDispatchExecutor>`) into the single
+/// trait object the mailbox holds internally. Lets `Mailbox::new` accept
+/// both concrete and pre-erased executors through one signature.
+pub trait IntoDispatchExecutor {
+    fn into_dispatch_executor(self) -> Arc<dyn RunDispatchExecutor>;
+}
+
+impl<R: RunDispatchExecutor + 'static> IntoDispatchExecutor for Arc<R> {
+    fn into_dispatch_executor(self) -> Arc<dyn RunDispatchExecutor> {
+        self
+    }
+}
+
+impl IntoDispatchExecutor for Arc<dyn RunDispatchExecutor> {
+    fn into_dispatch_executor(self) -> Arc<dyn RunDispatchExecutor> {
+        self
+    }
+}
+
+/// Minimal [`CommitCoordinator`] that delegates straight to
+/// [`ThreadRunStore::checkpoint`]. Used by `Mailbox::new` when the
+/// executor does not supply its own coordinator (embedded callers / unit
+/// tests where the runtime never carries persistence wiring). It does not
+/// publish canonical events or outbox drafts — only checkpoint commits —
+/// so it is **not** a replacement for `MemoryCommitCoordinator` /
+/// `FileCommitCoordinator` / `PgCommitCoordinator` in deployments that
+/// need full transactional event capture.
+pub(super) struct MailboxRunStoreCoordinator {
+    store: Arc<dyn ThreadRunStore>,
+    scope: TransactionScopeId,
+}
+
+impl MailboxRunStoreCoordinator {
+    pub(super) fn new(store: Arc<dyn ThreadRunStore>) -> Self {
+        let scope = TransactionScopeId::new(format!("mailbox-implicit::{:p}", Arc::as_ptr(&store)))
+            .expect("mailbox scope id is non-empty");
+        Self { store, scope }
+    }
+}
+
+#[async_trait]
+impl CommitCoordinator for MailboxRunStoreCoordinator {
+    fn scope(&self) -> TransactionScopeId {
+        self.scope.clone()
+    }
+
+    fn thread_run_store(&self) -> Arc<dyn ThreadRunStore> {
+        Arc::clone(&self.store)
+    }
+
+    async fn commit_checkpoint(
+        &self,
+        plan: CheckpointCommitPlan,
+    ) -> Result<CheckpointCommitOutcome, CommitError> {
+        plan.validate()?;
+        #[allow(deprecated)]
+        self.store
+            .checkpoint(&plan.thread_id, &plan.messages, &plan.run)
+            .await
+            .map_err(CommitError::StoreWrite)?;
+        Ok(CheckpointCommitOutcome::default())
+    }
+}

--- a/crates/awaken-server/src/mailbox/decision.rs
+++ b/crates/awaken-server/src/mailbox/decision.rs
@@ -28,18 +28,30 @@ impl Mailbox {
             .executor
             .send_decision(id, tool_call_id.clone(), resume.clone())
         {
+            self.record_mailbox_decision_received_for_id(id, &tool_call_id, &resume, "local_live")
+                .await;
             return Ok(true);
         }
 
         if let Some(dispatch) = self.store.load_dispatch(id).await?
             && dispatch.status == RunDispatchStatus::Claimed
         {
-            return self
+            let delivered = self
                 .deliver_live_decision(
                     &live_target_for_dispatch(&dispatch),
-                    vec![(tool_call_id, resume)],
+                    vec![(tool_call_id.clone(), resume.clone())],
+                )
+                .await?;
+            if delivered {
+                self.record_mailbox_decision_received_for_dispatch(
+                    &dispatch,
+                    &tool_call_id,
+                    &resume,
+                    "remote_live",
                 )
                 .await;
+            }
+            return Ok(delivered);
         }
 
         let run = if let Some(run) = self.run_store.load_run(id).await? {
@@ -50,9 +62,22 @@ impl Mailbox {
         if let Some(run) = run
             && matches!(run.status, RunStatus::Running | RunStatus::Waiting)
         {
-            return self
-                .deliver_live_decision(&live_target_for_run(&run), vec![(tool_call_id, resume)])
+            let delivered = self
+                .deliver_live_decision(
+                    &live_target_for_run(&run),
+                    vec![(tool_call_id.clone(), resume.clone())],
+                )
+                .await?;
+            if delivered {
+                self.record_mailbox_decision_received_for_run(
+                    &run,
+                    &tool_call_id,
+                    &resume,
+                    "remote_live",
+                )
                 .await;
+            }
+            return Ok(delivered);
         }
 
         Ok(false)

--- a/crates/awaken-server/src/mailbox/dispatch_execution.rs
+++ b/crates/awaken-server/src/mailbox/dispatch_execution.rs
@@ -1,0 +1,400 @@
+//! Claim-to-completion execution for one `RunDispatch` owned by a worker.
+//!
+//! Extracted from `signal_loop.rs::spawn_execution` so the signal-loop file
+//! stays under the file-length cap and future ADR-0036 D9 buffer wiring has
+//! room to land here without bloating the dispatch loop.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::Instant;
+
+use awaken_contract::contract::event::AgentEvent;
+use awaken_contract::contract::event_sink::EventSink;
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchResult, RunDispatchStatus};
+use awaken_contract::now_ms;
+use awaken_runtime::ThreadContextSnapshot;
+use awaken_runtime::{EventBuffer, ResolutionPolicy, RuntimeError};
+
+use crate::transport::channel_sink::ReconnectableEventSink;
+
+use super::{
+    ActiveRunGuard, Mailbox, MailboxRunOutcome, SuspensionAwareSink, TaskDoneMailboxNotify,
+    classify_error, mailbox_run_identity, mailbox_run_result, normalize_mailbox_run_mode,
+    record_mailbox_dispatch_completion_metrics, record_mailbox_dispatch_start_metrics,
+    record_mailbox_operation_result, result_label,
+};
+
+/// Execute one claimed `RunDispatch` to completion. Runs as a `tokio::spawn`
+/// task; the worker that claimed the dispatch passes ownership through this
+/// function and never observes it again after `spawn_execution` returns.
+pub(super) async fn run_claimed_dispatch(
+    this: Arc<Mailbox>,
+    dispatch: RunDispatch,
+    reconnectable_sink: Arc<ReconnectableEventSink>,
+    claim_token: String,
+    thread_id: String,
+    suspended: Arc<AtomicBool>,
+) {
+    let dispatch_id = dispatch.dispatch_id.clone();
+    crate::metrics::inc_active_runs();
+    let _guard = ActiveRunGuard;
+    // Dispatch epoch check: if this dispatch was superseded between claim and
+    // execution start, terminalize it and abort without entering the runtime.
+    let load_start = Instant::now();
+    let current_dispatch_result = this.store.load_dispatch(&dispatch_id).await;
+    record_mailbox_operation_result(
+        "load_dispatch",
+        result_label(&current_dispatch_result),
+        load_start,
+    );
+    let current_dispatch = match current_dispatch_result {
+        Ok(Some(current_dispatch)) => current_dispatch,
+        Ok(None) => {
+            tracing::info!(dispatch_id, "dispatch disappeared before execution");
+            this.finish_execution(&thread_id, &dispatch_id).await;
+            return;
+        }
+        Err(error) => {
+            tracing::warn!(dispatch_id, error = %error, "failed to verify dispatch before execution");
+            this.finish_execution(&thread_id, &dispatch_id).await;
+            return;
+        }
+    };
+    if current_dispatch.status != RunDispatchStatus::Claimed
+        || current_dispatch.claim_token.as_deref() != Some(claim_token.as_str())
+    {
+        tracing::info!(dispatch_id, status = ?current_dispatch.status, "dispatch no longer owned by this worker, skipping execution");
+        if current_dispatch.status == RunDispatchStatus::Superseded {
+            this.mark_superseded_dispatch_run_cancelled(
+                &current_dispatch,
+                "dispatch superseded before execution start",
+            )
+            .await;
+        }
+        this.finish_execution(&thread_id, &dispatch_id).await;
+        return;
+    }
+    let epoch_start = Instant::now();
+    let current_epoch_result = this.store.current_dispatch_epoch(&thread_id).await;
+    record_mailbox_operation_result(
+        "current_dispatch_epoch",
+        result_label(&current_epoch_result),
+        epoch_start,
+    );
+    match current_epoch_result {
+        Ok(current_epoch) if current_dispatch.dispatch_epoch < current_epoch => {
+            tracing::info!(
+                dispatch_id,
+                thread_id,
+                dispatch_epoch = current_dispatch.dispatch_epoch,
+                current_epoch,
+                "dispatch superseded before execution start"
+            );
+            let supersede_reason = "claimed dispatch superseded before execution start";
+            let supersede_start = Instant::now();
+            let supersede_result = this
+                .store
+                .supersede_claimed(&dispatch_id, &claim_token, now_ms(), supersede_reason)
+                .await;
+            record_mailbox_operation_result(
+                "supersede_claimed",
+                result_label(&supersede_result),
+                supersede_start,
+            );
+            if supersede_result.is_ok() {
+                this.refresh_dispatch_depth_metrics().await;
+                this.mark_superseded_dispatch_run_cancelled(&current_dispatch, supersede_reason)
+                    .await;
+            }
+            this.finish_execution(&thread_id, &dispatch_id).await;
+            return;
+        }
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(dispatch_id, thread_id, error = %error, "failed to read dispatch epoch before execution");
+            this.finish_execution(&thread_id, &dispatch_id).await;
+            return;
+        }
+    }
+
+    let dispatch_instance_id = uuid::Uuid::now_v7().to_string();
+    let start_now = now_ms();
+    record_mailbox_dispatch_start_metrics(&dispatch, start_now);
+    let mut request = match this.reconstruct_run_request(&dispatch).await {
+        Ok(request) => request,
+        Err(error) => {
+            tracing::error!(dispatch_id, error = %error, "failed to reconstruct run request from durable run record");
+            let now = now_ms();
+            record_mailbox_dispatch_completion_metrics(
+                &dispatch,
+                start_now,
+                now,
+                "permanent_error",
+            );
+            let msg = error.to_string();
+            let run_result = RunDispatchResult {
+                run_id: dispatch.run_id.clone(),
+                dispatch_instance_id: dispatch_instance_id.clone(),
+                status: awaken_contract::contract::lifecycle::RunStatus::Done,
+                termination: Some(
+                    awaken_contract::contract::lifecycle::TerminationReason::Error(msg.clone()),
+                ),
+                response: None,
+                error: Some(msg.clone()),
+            };
+            let record_start = Instant::now();
+            let record_result = this
+                .store
+                .record_dispatch_start(&dispatch_id, &claim_token, &dispatch_instance_id, start_now)
+                .await;
+            record_mailbox_operation_result(
+                "record_dispatch_start",
+                result_label(&record_result),
+                record_start,
+            );
+            if let Err(error) = record_result {
+                tracing::warn!(dispatch_id, error = %error, "failed to record dispatch start for reconstruction failure");
+                if let Ok(Some(latest_dispatch)) = this.store.load_dispatch(&dispatch_id).await
+                    && latest_dispatch.status == RunDispatchStatus::Superseded
+                {
+                    this.mark_superseded_dispatch_run_cancelled(
+                        &latest_dispatch,
+                        "dispatch superseded before reconstruction failure was recorded",
+                    )
+                    .await;
+                }
+                this.finish_execution(&thread_id, &dispatch_id).await;
+                return;
+            }
+            let record_result_start = Instant::now();
+            let record_run_result = this
+                .store
+                .record_run_result(&dispatch_id, &claim_token, &run_result, now)
+                .await;
+            record_mailbox_operation_result(
+                "record_run_result",
+                result_label(&record_run_result),
+                record_result_start,
+            );
+            let dead_letter_start = Instant::now();
+            let dead_letter_result = this
+                .store
+                .dead_letter(&dispatch_id, &claim_token, &msg, now)
+                .await;
+            record_mailbox_operation_result(
+                "dead_letter",
+                result_label(&dead_letter_result),
+                dead_letter_start,
+            );
+            if dead_letter_result.is_ok() {
+                this.refresh_dispatch_depth_metrics().await;
+                if let Ok(Some(dead_letter_dispatch)) = this.store.load_dispatch(&dispatch_id).await
+                    && dead_letter_dispatch.status == RunDispatchStatus::DeadLetter
+                {
+                    this.mark_dead_letter_dispatch_run_error(&dead_letter_dispatch)
+                        .await;
+                }
+            }
+            this.finish_execution(&thread_id, &dispatch_id).await;
+            return;
+        }
+    };
+    let is_resume = request.resume_run_id().is_some();
+    // When runtime event capture is enabled, mint a per-run EventBuffer and
+    // share it between the sink wrap (stages drafts here) and the runtime's
+    // CheckpointCommitPlan (drains).
+    let event_buffer = this
+        .runtime_event_capture
+        .is_some()
+        .then(|| Arc::new(EventBuffer::new()));
+    let sink = Arc::new(SuspensionAwareSink {
+        inner: this.wrap_dispatch_runtime_event_sink(
+            reconnectable_sink,
+            &dispatch,
+            dispatch_id.clone(),
+            is_resume,
+            event_buffer.clone(),
+        ),
+        suspended,
+    });
+    normalize_mailbox_run_mode(&mut request, false);
+    let run_id = dispatch.run_id.clone();
+    request = request
+        .with_dispatch_id(dispatch_id.clone())
+        .with_session_id(dispatch_instance_id.clone());
+    if let Some(buffer) = event_buffer {
+        request = request.with_event_buffer(buffer);
+    }
+    let record_start = Instant::now();
+    let record_start_result = this
+        .store
+        .record_dispatch_start(&dispatch_id, &claim_token, &dispatch_instance_id, start_now)
+        .await;
+    record_mailbox_operation_result(
+        "record_dispatch_start",
+        result_label(&record_start_result),
+        record_start,
+    );
+    if let Err(e) = record_start_result {
+        tracing::warn!(dispatch_id, run_id, error = %e, "failed to record mailbox dispatch start; skipping execution");
+        if let Ok(Some(latest_dispatch)) = this.store.load_dispatch(&dispatch_id).await
+            && latest_dispatch.status == RunDispatchStatus::Superseded
+        {
+            this.mark_superseded_dispatch_run_cancelled(
+                &latest_dispatch,
+                "dispatch superseded before runtime start was recorded",
+            )
+            .await;
+        }
+        this.finish_execution(&thread_id, &dispatch_id).await;
+        return;
+    }
+    this.record_mailbox_dispatch_event("RunSubmitted", &dispatch)
+        .await;
+    let thread_ctx = {
+        let workers = this.workers.read().await;
+        workers.get(&thread_id).and_then(|worker| {
+            let w = worker.lock();
+            w.thread_ctx.as_ref().map(|ctx| {
+                ThreadContextSnapshot::new(
+                    ctx.messages.clone(),
+                    ctx.latest_run.clone(),
+                    ctx.run_cache.clone(),
+                )
+            })
+        })
+    };
+    let continue_run_id = request.resume_run_id().map(str::to_owned);
+    let (inbox_sender, inbox_receiver) =
+        awaken_runtime::inbox::inbox_channel_with_fallback(Arc::new(TaskDoneMailboxNotify::new(
+            this.clone(),
+            dispatch.thread_id.clone(),
+            continue_run_id,
+        )));
+    request = request.with_inbox(inbox_sender, inbox_receiver);
+    let result = match this
+        .executor
+        .resolve_activation(&request, ResolutionPolicy::PersistentServer)
+        .await
+        .and_then(|plan| plan.into_replayable())
+    {
+        Ok(plan) => {
+            this.executor
+                .run_replayable_with_thread_context(request, plan, sink.clone(), thread_ctx)
+                .await
+        }
+        Err(error) => Err(awaken_runtime::loop_runner::AgentLoopError::RuntimeError(
+            RuntimeError::ResolveFailed {
+                message: error.to_string(),
+            },
+        )),
+    };
+    let now = now_ms();
+    let run_result = mailbox_run_result(&run_id, &dispatch_instance_id, &result);
+    let record_result_start = Instant::now();
+    let record_run_result = this
+        .store
+        .record_run_result(&dispatch_id, &claim_token, &run_result, now)
+        .await;
+    record_mailbox_operation_result(
+        "record_run_result",
+        result_label(&record_run_result),
+        record_result_start,
+    );
+    if let Err(e) = record_run_result {
+        tracing::warn!(dispatch_id, run_id, error = %e, "failed to record mailbox run result");
+    }
+    let outcome = classify_error(&result);
+    record_mailbox_dispatch_completion_metrics(&dispatch, start_now, now, outcome.metric_label());
+    match outcome {
+        MailboxRunOutcome::Completed => {
+            let ack_start = Instant::now();
+            let ack_result = this.store.ack(&dispatch_id, &claim_token, now).await;
+            record_mailbox_operation_result("ack", result_label(&ack_result), ack_start);
+            if let Err(e) = ack_result {
+                tracing::warn!(dispatch_id, error = %e, "ack failed");
+            } else {
+                this.refresh_dispatch_depth_metrics().await;
+            }
+        }
+        MailboxRunOutcome::TransientError(msg) => {
+            tracing::warn!(dispatch_id, error = %msg, "run failed (transient), nacking");
+            // Emit error event so the SSE stream terminates with a proper
+            // RUN_ERROR instead of silently closing.
+            sink.emit(AgentEvent::RunFinish {
+                thread_id: dispatch.thread_id.clone(),
+                run_id: run_id.clone(),
+                identity: Some(mailbox_run_identity(
+                    &dispatch,
+                    &run_id,
+                    &dispatch_instance_id,
+                )),
+                result: None,
+                termination: awaken_contract::contract::lifecycle::TerminationReason::Error(
+                    msg.clone(),
+                ),
+            })
+            .await;
+            let backoff_factor = 2u64.pow(dispatch.attempt_count.saturating_sub(1).min(6));
+            let retry_at = now
+                + (this.config.default_retry_delay_ms * backoff_factor)
+                    .min(this.config.max_retry_delay_ms);
+            let nack_start = Instant::now();
+            let nack_result = this
+                .store
+                .nack(&dispatch_id, &claim_token, retry_at, &msg, now)
+                .await;
+            record_mailbox_operation_result("nack", result_label(&nack_result), nack_start);
+            if let Err(e) = nack_result {
+                tracing::warn!(dispatch_id, error = %e, "nack failed");
+            } else {
+                this.refresh_dispatch_depth_metrics().await;
+                this.record_run_rescheduled_dispatch_by_id(&dispatch_id, "retry_backoff")
+                    .await;
+            }
+        }
+        MailboxRunOutcome::PermanentError(msg) => {
+            tracing::warn!(dispatch_id, error = %msg, "run failed (permanent), dead-lettering");
+            // Emit error event so the SSE stream terminates with a proper
+            // RUN_ERROR. The runtime did not reach the loop, so no
+            // RunFinish was emitted — we must do it here.
+            sink.emit(AgentEvent::RunFinish {
+                thread_id: dispatch.thread_id.clone(),
+                run_id: run_id.clone(),
+                identity: Some(mailbox_run_identity(
+                    &dispatch,
+                    &run_id,
+                    &dispatch_instance_id,
+                )),
+                result: None,
+                termination: awaken_contract::contract::lifecycle::TerminationReason::Error(
+                    msg.clone(),
+                ),
+            })
+            .await;
+            this.record_run_errored(&dispatch, &msg).await;
+            let dead_letter_start = Instant::now();
+            let dead_letter_result = this
+                .store
+                .dead_letter(&dispatch_id, &claim_token, &msg, now)
+                .await;
+            record_mailbox_operation_result(
+                "dead_letter",
+                result_label(&dead_letter_result),
+                dead_letter_start,
+            );
+            if let Err(e) = dead_letter_result {
+                tracing::warn!(dispatch_id, error = %e, "dead_letter failed");
+            } else {
+                this.refresh_dispatch_depth_metrics().await;
+                if let Ok(Some(dead_letter_dispatch)) = this.store.load_dispatch(&dispatch_id).await
+                    && dead_letter_dispatch.status == RunDispatchStatus::DeadLetter
+                {
+                    this.mark_dead_letter_dispatch_run_error(&dead_letter_dispatch)
+                        .await;
+                }
+            }
+        }
+    }
+    this.finish_execution(&thread_id, &dispatch_id).await;
+}

--- a/crates/awaken-server/src/mailbox/executor.rs
+++ b/crates/awaken-server/src/mailbox/executor.rs
@@ -1,0 +1,255 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::commit_coordinator::CommitCoordinator;
+use awaken_contract::contract::event_sink::EventSink;
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::suspension::ToolCallResume;
+use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
+use awaken_runtime::{
+    AgentRuntime, ReplayableScope, ResolutionPolicy, ResolveError, ResolvedRun, ResolvedRunPlan,
+    RunActivation, ThreadContextSnapshot,
+};
+#[cfg(test)]
+use awaken_runtime::{
+    BackendProfile, BackendRequirements, ExecutionPlan, ExecutionRole, ResolvedAgent,
+    ResolvedModelBinding,
+};
+
+/// Execution boundary used by mailbox dispatch.
+///
+/// Mailbox owns delivery, leasing, retry, and recovery. The executor behind
+/// this trait owns actual run execution and live-run control. It intentionally
+/// does not expose storage so mailbox scheduling stays orthogonal to the main
+/// runtime implementation. The optional commit coordinator is exposed only
+/// as the durable write boundary for mailbox-authored checkpoints.
+#[async_trait]
+pub trait RunDispatchExecutor: Send + Sync {
+    /// Execute a run request and stream events into the provided sink.
+    async fn run(
+        &self,
+        activation: RunActivation,
+        sink: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError>;
+
+    /// Execute a run with an optional mailbox-provided thread cache.
+    async fn run_with_thread_context(
+        &self,
+        activation: RunActivation,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        let _ = thread_ctx;
+        self.run(activation, sink).await
+    }
+
+    /// Resolve an activation before dispatch-side execution. Persistent
+    /// mailbox paths require a replayable plan and reject live-only plans
+    /// before runtime side effects begin.
+    async fn resolve_activation(
+        &self,
+        activation: &RunActivation,
+        policy: ResolutionPolicy,
+    ) -> Result<ResolvedRunPlan, ResolveError> {
+        #[cfg(test)]
+        {
+            let _ = policy;
+            return Ok(test_replayable_plan(activation));
+        }
+        #[cfg(not(test))]
+        {
+            let _ = (activation, policy);
+            Err(ResolveError::UnsupportedPersistence(
+                "RunDispatchExecutor implementations used by persistent mailbox dispatch must resolve activations".into(),
+            ))
+        }
+    }
+
+    /// Execute a persistent run with the replayable plan rebuilt from the
+    /// activation's pinned registry scope.
+    async fn run_replayable_with_thread_context(
+        &self,
+        activation: RunActivation,
+        plan: ResolvedRun<ReplayableScope>,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        let _ = plan;
+        self.run_with_thread_context(activation, sink, thread_ctx)
+            .await
+    }
+
+    /// Cancel an active run by run id or thread id.
+    fn cancel(&self, id: &str) -> bool;
+
+    /// Cancel an active run by thread id and wait for it to unregister.
+    async fn cancel_and_wait_by_thread(&self, thread_id: &str) -> bool;
+
+    /// Forward one human/tool decision to an active run.
+    fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool;
+
+    /// Forward direct input messages to an active run.
+    fn send_messages(&self, id: &str, messages: Vec<Message>) -> bool {
+        let _ = (id, messages);
+        false
+    }
+
+    /// Snapshot the live RegistrySet from the underlying runtime. Used by
+    /// the mailbox to overlay a pinned `RegistrySet` (ADR-0035 D9) on top
+    /// of the live runtime objects (tools / providers / plugins). Returns
+    /// `None` when the executor has no live registry available.
+    fn live_registry_set(&self) -> Option<awaken_runtime::registry::RegistrySet> {
+        None
+    }
+
+    /// Durable checkpoint boundary wired into the executor, when available.
+    fn commit_coordinator(&self) -> Option<Arc<dyn CommitCoordinator>> {
+        None
+    }
+
+    /// Whether the executor has a `CommitCoordinator` wired (ADR-0036 D9).
+    fn has_commit_coordinator(&self) -> bool {
+        self.commit_coordinator().is_some()
+    }
+}
+
+#[cfg(test)]
+fn test_replayable_plan(activation: &RunActivation) -> ResolvedRunPlan {
+    use awaken_contract::contract::versioned_registry::PinnedRegistryManifest;
+    use awaken_runtime::{ReplayableScope, ResolvedRun};
+
+    let agent_id = activation.agent_id().unwrap_or("default");
+    let agent = ResolvedAgent::new(agent_id, "model", "system", Arc::new(TestLlmExecutor));
+    let requirements =
+        BackendRequirements::from_features(&awaken_runtime::RunFeatureSet::from_activation(
+            activation,
+            ResolutionPolicy::PersistentServer,
+        ));
+    ResolvedRunPlan::Replayable(ResolvedRun {
+        agent_spec: (*agent.spec).clone(),
+        role: ExecutionRole::Root,
+        execution: ExecutionPlan::from_resolved_agent(&agent),
+        model: ResolvedModelBinding {
+            upstream_model: agent.upstream_model.clone(),
+        },
+        tools: Vec::new(),
+        overrides: activation.options.overrides.clone(),
+        backend_profile: BackendProfile::full_local(),
+        requirements,
+        scope: ReplayableScope {
+            manifest: PinnedRegistryManifest {
+                publication_id: Some("test-publication".to_string()),
+                registry_snapshot_version: Some(1),
+                entries: Vec::new(),
+            },
+        },
+    })
+}
+
+#[cfg(test)]
+struct TestLlmExecutor;
+
+#[cfg(test)]
+#[async_trait]
+impl awaken_contract::contract::executor::LlmExecutor for TestLlmExecutor {
+    async fn execute(
+        &self,
+        _request: awaken_contract::contract::executor::InferenceRequest,
+    ) -> Result<
+        awaken_contract::contract::inference::StreamResult,
+        awaken_contract::contract::executor::InferenceExecutionError,
+    > {
+        Ok(awaken_contract::contract::inference::StreamResult {
+            content: Vec::new(),
+            tool_calls: Vec::new(),
+            usage: None,
+            stop_reason: None,
+            has_incomplete_tool_calls: false,
+        })
+    }
+
+    fn name(&self) -> &str {
+        "test"
+    }
+}
+
+#[async_trait]
+impl RunDispatchExecutor for AgentRuntime {
+    async fn run(
+        &self,
+        activation: RunActivation,
+        sink: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        AgentRuntime::run(self, activation, sink).await
+    }
+
+    async fn run_with_thread_context(
+        &self,
+        activation: RunActivation,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        AgentRuntime::run_with_thread_context(self, activation, sink, thread_ctx).await
+    }
+
+    async fn resolve_activation(
+        &self,
+        activation: &RunActivation,
+        policy: ResolutionPolicy,
+    ) -> Result<ResolvedRunPlan, ResolveError> {
+        let resolved = AgentRuntime::resolve_activation(self, activation, policy).await;
+        #[cfg(test)]
+        {
+            resolved.or_else(|_| Ok(test_replayable_plan(activation)))
+        }
+        #[cfg(not(test))]
+        {
+            resolved
+        }
+    }
+
+    async fn run_replayable_with_thread_context(
+        &self,
+        activation: RunActivation,
+        plan: ResolvedRun<ReplayableScope>,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        #[cfg(test)]
+        {
+            let _ = plan;
+            return AgentRuntime::run_with_thread_context(self, activation, sink, thread_ctx).await;
+        }
+        #[cfg(not(test))]
+        {
+            AgentRuntime::run_replayable_with_thread_context(
+                self, activation, plan, sink, thread_ctx,
+            )
+            .await
+        }
+    }
+
+    fn cancel(&self, id: &str) -> bool {
+        AgentRuntime::cancel(self, id)
+    }
+
+    async fn cancel_and_wait_by_thread(&self, thread_id: &str) -> bool {
+        AgentRuntime::cancel_and_wait_by_thread(self, thread_id).await
+    }
+
+    fn send_decision(&self, id: &str, tool_call_id: String, resume: ToolCallResume) -> bool {
+        AgentRuntime::send_decision(self, id, tool_call_id, resume)
+    }
+
+    fn send_messages(&self, id: &str, messages: Vec<Message>) -> bool {
+        AgentRuntime::send_messages(self, id, messages)
+    }
+
+    fn live_registry_set(&self) -> Option<awaken_runtime::registry::RegistrySet> {
+        self.registry_snapshot().map(|s| s.into_registries())
+    }
+
+    fn commit_coordinator(&self) -> Option<Arc<dyn CommitCoordinator>> {
+        AgentRuntime::commit_coordinator(self).cloned()
+    }
+}

--- a/crates/awaken-server/src/mailbox/helpers.rs
+++ b/crates/awaken-server/src/mailbox/helpers.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex as SyncMutex;
 use tokio::sync::RwLock;
 
+use awaken_contract::contract::identity::RunOrigin;
 use awaken_contract::contract::mailbox::{
     LiveRunTarget, RunDispatch, RunDispatchResult, RunDispatchStatus,
 };
@@ -12,7 +13,7 @@ use awaken_contract::contract::message::Message;
 use awaken_contract::contract::storage::RunRecord;
 use awaken_contract::contract::tool_intercept::RunMode;
 use awaken_contract::now_ms;
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 
 use super::{
     DISPATCH_SIGNAL_BATCH_DEFAULT, DISPATCH_SIGNAL_BATCH_ENV,
@@ -41,23 +42,21 @@ pub(super) async fn revert_claiming_to_idle(
 
 // ── Free functions ───────────────────────────────────────────────────
 
-pub(super) fn normalize_mailbox_run_mode(request: &mut RunRequest, background: bool) {
-    if request.run_mode != RunMode::Foreground {
+pub(super) fn normalize_mailbox_run_mode(request: &mut RunActivation, background: bool) {
+    if request.trace.run_mode != RunMode::Foreground {
         return;
     }
 
-    request.run_mode = if !request.decisions.is_empty() || request.continue_run_id.is_some() {
-        RunMode::Resume
-    } else if matches!(
-        request.origin,
-        awaken_contract::contract::storage::RunRequestOrigin::Internal
-    ) {
-        RunMode::InternalWake
-    } else if background {
-        RunMode::Scheduled
-    } else {
-        RunMode::Foreground
-    };
+    request.trace.run_mode =
+        if !request.control.seeded_decisions.is_empty() || request.resume_run_id().is_some() {
+            RunMode::Resume
+        } else if matches!(request.trace.origin, RunOrigin::Internal) {
+            RunMode::InternalWake
+        } else if background {
+            RunMode::Scheduled
+        } else {
+            RunMode::Foreground
+        };
 }
 
 /// Validate and normalize run request inputs.

--- a/crates/awaken-server/src/mailbox/lifecycle.rs
+++ b/crates/awaken-server/src/mailbox/lifecycle.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
 use awaken_contract::contract::message::Message;
-use awaken_contract::contract::storage::RunQuery;
+use awaken_contract::contract::storage::{RunQuery, RunRecord};
 use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
 use awaken_contract::now_ms;
 use awaken_runtime::RunActivation;
@@ -263,83 +263,103 @@ impl Mailbox {
         Ok(total)
     }
 
-    async fn recover_prepared_runs_missing_dispatch_wal(
+    pub(super) async fn recover_prepared_runs_missing_dispatch_wal(
         self: &Arc<Self>,
         queued_thread_ids: &[String],
     ) -> Result<usize, MailboxError> {
+        let runs = self.prepared_runs_missing_dispatch_wal().await?;
         let mut total = 0usize;
-        let mut offset = 0usize;
         let queued_set: std::collections::HashSet<&str> =
             queued_thread_ids.iter().map(String::as_str).collect();
+        let mut dispatch_threads = Vec::new();
 
-        loop {
-            let page = self
-                .run_store
-                .list_runs(&RunQuery {
-                    status: Some(RunStatus::Created),
-                    limit: 200,
-                    offset,
-                    ..Default::default()
-                })
-                .await?;
-            let page_len = page.items.len();
-            for run in page.items {
-                let Some(dispatch_id) = run.dispatch_id.clone() else {
-                    continue;
-                };
-                if self.store.load_dispatch(&dispatch_id).await?.is_some() {
-                    continue;
-                }
-                let now = now_ms();
-                let dispatch = RunDispatch {
-                    dispatch_id: dispatch_id.clone(),
-                    thread_id: run.thread_id.clone(),
-                    run_id: run.run_id.clone(),
-                    priority: 128,
-                    dedupe_key: None,
-                    dispatch_epoch: 0,
-                    status: RunDispatchStatus::Queued,
-                    available_at: now,
-                    attempt_count: 0,
-                    max_attempts: self.config.default_max_attempts,
-                    last_error: None,
-                    claim_token: None,
-                    claimed_by: None,
-                    lease_until: None,
-                    dispatch_instance_id: None,
-                    run_status: None,
-                    termination: None,
-                    run_response: None,
-                    run_error: None,
-                    completed_at: None,
-                    created_at: now,
-                    updated_at: now,
-                };
-                self.store.enqueue(&dispatch).await?;
-                self.record_mailbox_dispatch_event("RunQueued", &dispatch)
-                    .await;
-                total += 1;
-                tracing::warn!(
-                    thread_id = %run.thread_id,
-                    run_id = %run.run_id,
-                    dispatch_id = %dispatch_id,
-                    "recover: reconstructed dispatch WAL for prepared run"
-                );
-                if !queued_set.contains(run.thread_id.as_str()) {
-                    self.get_or_create_worker(&run.thread_id).await;
-                    self.try_dispatch_next(&run.thread_id).await;
-                }
+        for run in runs {
+            let Some(dispatch_id) = run.dispatch_id.clone() else {
+                continue;
+            };
+            if self.store.load_dispatch(&dispatch_id).await?.is_some() {
+                continue;
             }
-            if !page.has_more || page_len == 0 {
-                break;
+            let now = now_ms();
+            let dispatch = RunDispatch {
+                dispatch_id: dispatch_id.clone(),
+                thread_id: run.thread_id.clone(),
+                run_id: run.run_id.clone(),
+                priority: 128,
+                dedupe_key: None,
+                dispatch_epoch: 0,
+                status: RunDispatchStatus::Queued,
+                available_at: now,
+                attempt_count: 0,
+                max_attempts: self.config.default_max_attempts,
+                last_error: None,
+                claim_token: None,
+                claimed_by: None,
+                lease_until: None,
+                dispatch_instance_id: None,
+                run_status: None,
+                termination: None,
+                run_response: None,
+                run_error: None,
+                completed_at: None,
+                created_at: now,
+                updated_at: now,
+            };
+            self.store.enqueue(&dispatch).await?;
+            self.record_mailbox_dispatch_event("RunQueued", &dispatch)
+                .await;
+            total += 1;
+            tracing::warn!(
+                thread_id = %run.thread_id,
+                run_id = %run.run_id,
+                dispatch_id = %dispatch_id,
+                status = ?run.status,
+                "recover: reconstructed dispatch WAL for prepared run"
+            );
+            if !queued_set.contains(run.thread_id.as_str()) {
+                dispatch_threads.push(run.thread_id);
             }
-            offset += page_len;
+        }
+
+        dispatch_threads.sort();
+        dispatch_threads.dedup();
+        for thread_id in dispatch_threads {
+            self.get_or_create_worker(&thread_id).await;
+            self.try_dispatch_next(&thread_id).await;
         }
 
         if total > 0 {
             self.refresh_dispatch_depth_metrics().await;
         }
         Ok(total)
+    }
+
+    async fn prepared_runs_missing_dispatch_wal(&self) -> Result<Vec<RunRecord>, MailboxError> {
+        let mut prepared = Vec::new();
+        for status in [RunStatus::Created, RunStatus::Waiting] {
+            let mut offset = 0usize;
+            loop {
+                let page = self
+                    .run_store
+                    .list_runs(&RunQuery {
+                        status: Some(status),
+                        limit: 200,
+                        offset,
+                        ..Default::default()
+                    })
+                    .await?;
+                let page_len = page.items.len();
+                prepared.extend(page.items.into_iter().filter(|run| {
+                    run.dispatch_id.is_some()
+                        && (run.status == RunStatus::Created || run.is_resumable_waiting())
+                }));
+                if !page.has_more || page_len == 0 {
+                    break;
+                }
+                offset += page_len;
+            }
+        }
+        Ok(prepared)
     }
 
     /// Run sweep + GC loop forever. Call from `tokio::spawn`.

--- a/crates/awaken-server/src/mailbox/lifecycle.rs
+++ b/crates/awaken-server/src/mailbox/lifecycle.rs
@@ -4,8 +4,10 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use awaken_contract::contract::mailbox::RunDispatchStatus;
+use awaken_contract::contract::lifecycle::RunStatus;
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
 use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::RunQuery;
 use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
 use awaken_contract::now_ms;
 use awaken_runtime::RunActivation;
@@ -215,6 +217,9 @@ impl Mailbox {
             self.get_or_create_worker(thread_id).await;
             self.try_dispatch_next(thread_id).await;
         }
+        total += self
+            .recover_prepared_runs_missing_dispatch_wal(&thread_ids)
+            .await?;
 
         // Recover orphaned background-task waits with no queued wake dispatch.
         {
@@ -255,6 +260,85 @@ impl Mailbox {
             }
         }
 
+        Ok(total)
+    }
+
+    async fn recover_prepared_runs_missing_dispatch_wal(
+        self: &Arc<Self>,
+        queued_thread_ids: &[String],
+    ) -> Result<usize, MailboxError> {
+        let mut total = 0usize;
+        let mut offset = 0usize;
+        let queued_set: std::collections::HashSet<&str> =
+            queued_thread_ids.iter().map(String::as_str).collect();
+
+        loop {
+            let page = self
+                .run_store
+                .list_runs(&RunQuery {
+                    status: Some(RunStatus::Created),
+                    limit: 200,
+                    offset,
+                    ..Default::default()
+                })
+                .await?;
+            let page_len = page.items.len();
+            for run in page.items {
+                let Some(dispatch_id) = run.dispatch_id.clone() else {
+                    continue;
+                };
+                if self.store.load_dispatch(&dispatch_id).await?.is_some() {
+                    continue;
+                }
+                let now = now_ms();
+                let dispatch = RunDispatch {
+                    dispatch_id: dispatch_id.clone(),
+                    thread_id: run.thread_id.clone(),
+                    run_id: run.run_id.clone(),
+                    priority: 128,
+                    dedupe_key: None,
+                    dispatch_epoch: 0,
+                    status: RunDispatchStatus::Queued,
+                    available_at: now,
+                    attempt_count: 0,
+                    max_attempts: self.config.default_max_attempts,
+                    last_error: None,
+                    claim_token: None,
+                    claimed_by: None,
+                    lease_until: None,
+                    dispatch_instance_id: None,
+                    run_status: None,
+                    termination: None,
+                    run_response: None,
+                    run_error: None,
+                    completed_at: None,
+                    created_at: now,
+                    updated_at: now,
+                };
+                self.store.enqueue(&dispatch).await?;
+                self.record_mailbox_dispatch_event("RunQueued", &dispatch)
+                    .await;
+                total += 1;
+                tracing::warn!(
+                    thread_id = %run.thread_id,
+                    run_id = %run.run_id,
+                    dispatch_id = %dispatch_id,
+                    "recover: reconstructed dispatch WAL for prepared run"
+                );
+                if !queued_set.contains(run.thread_id.as_str()) {
+                    self.get_or_create_worker(&run.thread_id).await;
+                    self.try_dispatch_next(&run.thread_id).await;
+                }
+            }
+            if !page.has_more || page_len == 0 {
+                break;
+            }
+            offset += page_len;
+        }
+
+        if total > 0 {
+            self.refresh_dispatch_depth_metrics().await;
+        }
         Ok(total)
     }
 

--- a/crates/awaken-server/src/mailbox/lifecycle.rs
+++ b/crates/awaken-server/src/mailbox/lifecycle.rs
@@ -8,7 +8,7 @@ use awaken_contract::contract::mailbox::RunDispatchStatus;
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
 use awaken_contract::now_ms;
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 
 use super::{
     Mailbox, MailboxError, MailboxLifecycleConfig, MailboxLifecycleHandle, MailboxLifecycleTasks,
@@ -201,6 +201,8 @@ impl Mailbox {
             self.refresh_dispatch_depth_metrics().await;
         }
         for dispatch in &reclaimed {
+            self.record_run_rescheduled_dispatch(dispatch, "expired_lease_reclaimed")
+                .await;
             self.reconcile_terminal_dispatch(dispatch).await;
         }
         self.reconcile_terminal_dispatches().await;
@@ -232,7 +234,7 @@ impl Mailbox {
                     if queued_set.contains(&run.thread_id) {
                         continue;
                     }
-                    let request = RunRequest::new(
+                    let request = RunActivation::new(
                         run.thread_id.clone(),
                         vec![Message::internal_user("<background-tasks-updated />")],
                     )
@@ -304,6 +306,8 @@ impl Mailbox {
                     tracing::info!(count = reclaimed.len(), "sweep reclaimed expired leases");
                     self.refresh_dispatch_depth_metrics().await;
                     for dispatch in reclaimed {
+                        self.record_run_rescheduled_dispatch(&dispatch, "expired_lease_reclaimed")
+                            .await;
                         self.reconcile_terminal_dispatch(&dispatch).await;
                         if dispatch.status == RunDispatchStatus::Queued {
                             let thread_id = dispatch.thread_id.clone();

--- a/crates/awaken-server/src/mailbox/lifecycle.rs
+++ b/crates/awaken-server/src/mailbox/lifecycle.rs
@@ -221,42 +221,42 @@ impl Mailbox {
             .recover_prepared_runs_missing_dispatch_wal(&thread_ids)
             .await?;
 
-        // Recover orphaned background-task waits with no queued wake dispatch.
-        {
-            let query = awaken_contract::contract::storage::RunQuery {
-                status: Some(awaken_contract::contract::lifecycle::RunStatus::Waiting),
-                limit: 200,
-                ..Default::default()
-            };
-            if let Ok(page) = self.run_store.list_runs(&query).await {
-                let queued_set: std::collections::HashSet<String> =
-                    thread_ids.iter().cloned().collect();
-                for run in &page.items {
-                    if !run.is_background_task_waiting() {
-                        continue;
-                    }
-                    // Skip if this thread already has a queued dispatch.
-                    if queued_set.contains(&run.thread_id) {
-                        continue;
-                    }
-                    let request = RunActivation::new(
-                        run.thread_id.clone(),
-                        vec![Message::internal_user("<background-tasks-updated />")],
-                    )
-                    .with_agent_id(run.agent_id.clone())
-                    .with_continue_run_id(run.run_id.clone())
-                    .with_origin(awaken_contract::contract::storage::RunRequestOrigin::Internal)
-                    .with_run_mode(RunMode::InternalWake)
-                    .with_adapter(AdapterKind::Internal);
-                    if self.submit_background(request).await.is_ok() {
-                        total += 1;
-                        tracing::info!(
-                            thread_id = %run.thread_id,
-                            run_id = %run.run_id,
-                            "recover: enqueued wake dispatch for orphaned background-task thread"
-                        );
-                    }
-                }
+        total += self
+            .recover_orphaned_background_task_waits(&thread_ids)
+            .await?;
+
+        Ok(total)
+    }
+
+    async fn recover_orphaned_background_task_waits(
+        self: &Arc<Self>,
+        queued_thread_ids: &[String],
+    ) -> Result<usize, MailboxError> {
+        let queued_set: std::collections::HashSet<String> =
+            queued_thread_ids.iter().cloned().collect();
+        let runs = self.background_task_waiting_runs().await?;
+        let mut total = 0usize;
+
+        for run in runs {
+            if queued_set.contains(&run.thread_id) {
+                continue;
+            }
+            let request = RunActivation::new(
+                run.thread_id.clone(),
+                vec![Message::internal_user("<background-tasks-updated />")],
+            )
+            .with_agent_id(run.agent_id.clone())
+            .with_continue_run_id(run.run_id.clone())
+            .with_origin(awaken_contract::contract::storage::RunRequestOrigin::Internal)
+            .with_run_mode(RunMode::InternalWake)
+            .with_adapter(AdapterKind::Internal);
+            if self.submit_background(request).await.is_ok() {
+                total += 1;
+                tracing::info!(
+                    thread_id = %run.thread_id,
+                    run_id = %run.run_id,
+                    "recover: enqueued wake dispatch for orphaned background-task thread"
+                );
             }
         }
 
@@ -332,6 +332,33 @@ impl Mailbox {
             self.refresh_dispatch_depth_metrics().await;
         }
         Ok(total)
+    }
+
+    async fn background_task_waiting_runs(&self) -> Result<Vec<RunRecord>, MailboxError> {
+        let mut runs = Vec::new();
+        let mut offset = 0usize;
+        loop {
+            let page = self
+                .run_store
+                .list_runs(&RunQuery {
+                    status: Some(RunStatus::Waiting),
+                    limit: 200,
+                    offset,
+                    ..Default::default()
+                })
+                .await?;
+            let page_len = page.items.len();
+            runs.extend(
+                page.items
+                    .into_iter()
+                    .filter(RunRecord::is_background_task_waiting),
+            );
+            if !page.has_more || page_len == 0 {
+                break;
+            }
+            offset += page_len;
+        }
+        Ok(runs)
     }
 
     async fn prepared_runs_missing_dispatch_wal(&self) -> Result<Vec<RunRecord>, MailboxError> {

--- a/crates/awaken-server/src/mailbox/runtime_event_capture.rs
+++ b/crates/awaken-server/src/mailbox/runtime_event_capture.rs
@@ -1,0 +1,134 @@
+use std::sync::Arc;
+
+use awaken_contract::contract::commit_coordinator::{
+    CanonicalEventStager, OutboxServerEventPublisher,
+};
+use awaken_contract::contract::event_sink::EventSink;
+use awaken_contract::contract::mailbox::RunDispatch;
+use awaken_contract::{
+    AgentEventNormalizationContext, DurableEventSink, RuntimeEventDurability,
+    ScopedAgentEventNormalizer,
+};
+use awaken_runtime::EventBuffer;
+
+use crate::transport::channel_sink::ReconnectableEventSink;
+
+use super::{Mailbox, MailboxError};
+
+#[derive(Clone)]
+pub(super) struct RuntimeEventCaptureConfig {
+    pub(super) mode: RuntimeEventDurability,
+    pub(super) origin: String,
+}
+impl Mailbox {
+    /// Enable optional canonical runtime event capture for this mailbox.
+    ///
+    /// The wrapper preserves the existing public constructor shape: callers opt in
+    /// by applying this builder before putting the mailbox behind an `Arc`.
+    pub fn with_runtime_event_capture(
+        mut self,
+        mode: RuntimeEventDurability,
+        origin: impl Into<String>,
+    ) -> Result<Self, MailboxError> {
+        let origin = origin.into();
+        if matches!(mode, RuntimeEventDurability::Disabled) {
+            self.runtime_event_capture = None;
+            return Ok(self);
+        }
+        if !self.executor.has_commit_coordinator() {
+            return Err(MailboxError::Validation(
+                "runtime event capture requires an executor with CommitCoordinator".to_string(),
+            ));
+        }
+        AgentEventNormalizationContext::new("validation-thread", "validation-run", &origin)
+            .map_err(|error| MailboxError::Validation(error.to_string()))?;
+        self.runtime_event_capture = Some(RuntimeEventCaptureConfig { mode, origin });
+        Ok(self)
+    }
+
+    /// Attach a publisher for advisory server-authored canonical events.
+    pub fn with_server_event_publisher(
+        mut self,
+        publisher: Arc<dyn OutboxServerEventPublisher>,
+        origin: impl Into<String>,
+    ) -> Result<Self, MailboxError> {
+        let origin = origin.into();
+        AgentEventNormalizationContext::new("validation-thread", "validation-run", &origin)
+            .map_err(|error| MailboxError::Validation(error.to_string()))?;
+        self.server_event_publisher = Some(publisher);
+        self.server_event_origin = origin;
+        Ok(self)
+    }
+
+    fn wrap_runtime_event_sink(
+        &self,
+        inner: Arc<dyn EventSink>,
+        thread_id: &str,
+        run_id: &str,
+        correlation_id: Option<String>,
+        resumed: bool,
+        event_buffer: Option<Arc<EventBuffer>>,
+    ) -> Arc<dyn EventSink> {
+        let Some(capture) = &self.runtime_event_capture else {
+            return inner;
+        };
+        let context =
+            AgentEventNormalizationContext::new(thread_id, run_id, capture.origin.clone()).expect(
+                "mailbox runtime event capture context must use non-empty thread/run/origin",
+            );
+        let context = if let Some(c) = correlation_id {
+            context.with_correlation_id(c)
+        } else {
+            context
+        };
+        let normalizer: Arc<ScopedAgentEventNormalizer> = Arc::new(if resumed {
+            ScopedAgentEventNormalizer::new_resumed(context)
+        } else {
+            ScopedAgentEventNormalizer::new(context)
+        });
+        let buffer = event_buffer.expect("runtime event capture requires a per-run EventBuffer");
+        Arc::new(DurableEventSink::new(
+            inner,
+            buffer as Arc<dyn CanonicalEventStager>,
+            normalizer,
+            capture.mode,
+        ))
+    }
+
+    fn wrap_reconnectable_runtime_event_sink(
+        &self,
+        inner: Arc<ReconnectableEventSink>,
+        thread_id: &str,
+        run_id: &str,
+        correlation_id: String,
+        resumed: bool,
+        event_buffer: Option<Arc<EventBuffer>>,
+    ) -> Arc<dyn EventSink> {
+        self.wrap_runtime_event_sink(
+            inner as Arc<dyn EventSink>,
+            thread_id,
+            run_id,
+            Some(correlation_id),
+            resumed,
+            event_buffer,
+        )
+    }
+
+    pub(super) fn wrap_dispatch_runtime_event_sink(
+        &self,
+        inner: Arc<ReconnectableEventSink>,
+        dispatch: &RunDispatch,
+        correlation_id: String,
+        resumed: bool,
+        event_buffer: Option<Arc<EventBuffer>>,
+    ) -> Arc<dyn EventSink> {
+        self.wrap_reconnectable_runtime_event_sink(
+            inner,
+            &dispatch.thread_id,
+            &dispatch.run_id,
+            correlation_id,
+            resumed,
+            event_buffer,
+        )
+    }
+}

--- a/crates/awaken-server/src/mailbox/server_event_capture.rs
+++ b/crates/awaken-server/src/mailbox/server_event_capture.rs
@@ -1,0 +1,691 @@
+use awaken_contract::contract::event::AgentEvent;
+use awaken_contract::contract::event_store::{
+    AppendOptions, CanonicalEventDraft, CanonicalEventKind, EventScope, EventVisibility,
+};
+use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_contract::contract::message::{Message, Role, Visibility};
+use awaken_contract::contract::storage::{RunRecord, StorageError};
+use awaken_contract::contract::suspension::ToolCallResume;
+use serde_json::json;
+
+use super::{Mailbox, dispatch_status_label};
+
+impl Mailbox {
+    pub(super) async fn record_mailbox_dispatch_event(
+        &self,
+        event_kind: &'static str,
+        dispatch: &RunDispatch,
+    ) {
+        self.record_mailbox_dispatch_event_inner(event_kind, dispatch, None, None, None)
+            .await;
+    }
+
+    pub(super) async fn record_mailbox_timeout(
+        &self,
+        dispatch: &RunDispatch,
+        reason: &'static str,
+        timeout_ms: u64,
+    ) {
+        self.record_mailbox_dispatch_event_inner(
+            "MailboxTimeout",
+            dispatch,
+            Some(reason),
+            None,
+            Some(timeout_ms),
+        )
+        .await;
+    }
+
+    pub(super) async fn record_mailbox_submit_failed(
+        &self,
+        dispatch: &RunDispatch,
+        error: &StorageError,
+    ) {
+        self.record_mailbox_dispatch_event_inner(
+            "MailboxSubmitFailed",
+            dispatch,
+            Some("enqueue_failed"),
+            Some(error.to_string()),
+            None,
+        )
+        .await;
+    }
+
+    pub(super) async fn record_run_errored(&self, dispatch: &RunDispatch, error: &str) {
+        let Some(publisher) = &self.server_event_publisher else {
+            return;
+        };
+        let origin = self.server_event_origin.clone();
+        let payload = match serde_json::to_value(AgentEvent::RunFinish {
+            thread_id: dispatch.thread_id.clone(),
+            run_id: dispatch.run_id.clone(),
+            identity: None,
+            result: None,
+            termination: awaken_contract::contract::lifecycle::TerminationReason::Error(
+                error.to_string(),
+            ),
+        }) {
+            Ok(payload) => payload,
+            Err(error) => {
+                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "invalid run errored event payload");
+                return;
+            }
+        };
+        let mut draft = match CanonicalEventDraft::new(
+            vec![
+                EventScope::thread(dispatch.thread_id.clone()),
+                EventScope::run(dispatch.run_id.clone()),
+            ],
+            match CanonicalEventKind::new("RunErrored") {
+                Ok(kind) => kind,
+                Err(error) => {
+                    tracing::error!(error = %error, "invalid run errored event kind");
+                    return;
+                }
+            },
+            payload,
+            origin.clone(),
+        ) {
+            Ok(draft) => draft,
+            Err(error) => {
+                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "invalid run errored event draft");
+                return;
+            }
+        };
+        draft.visibility = EventVisibility::Public;
+        draft.correlation_id = Some(dispatch.dispatch_id.clone());
+        let options = AppendOptions {
+            writer_id: Some("mailbox".to_string()),
+            idempotency_key: Some(format!(
+                "RunErrored/{}/{}",
+                dispatch.dispatch_id, dispatch.attempt_count
+            )),
+            expected_prior_cursors: Default::default(),
+        };
+        if let Err(error) = publisher.publish(draft, options).await {
+            tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "failed to record run errored event");
+        }
+    }
+
+    pub(super) async fn record_mailbox_resume_failed(
+        &self,
+        dispatch: &RunDispatch,
+        decisions: &[(String, ToolCallResume)],
+        reason: &'static str,
+        error: &StorageError,
+    ) {
+        let Some(publisher) = &self.server_event_publisher else {
+            return;
+        };
+        let origin = self.server_event_origin.clone();
+        let decisions = decisions
+            .iter()
+            .map(|(tool_call_id, resume)| {
+                json!({
+                    "tool_call_id": tool_call_id,
+                    "decision_id": resume.decision_id,
+                    "action": &resume.action,
+                    "result": &resume.result,
+                    "resume_updated_at": resume.updated_at,
+                })
+            })
+            .collect::<Vec<_>>();
+        let payload = json!({
+            "thread_id": dispatch.thread_id,
+            "run_id": dispatch.run_id,
+            "dispatch_id": dispatch.dispatch_id,
+            "dispatch_epoch": dispatch.dispatch_epoch,
+            "attempt_count": dispatch.attempt_count,
+            "status": dispatch_status_label(dispatch.status),
+            "reason": reason,
+            "error": error.to_string(),
+            "decisions": decisions,
+        });
+        let mut draft = match CanonicalEventDraft::new(
+            vec![
+                EventScope::thread(dispatch.thread_id.clone()),
+                EventScope::run(dispatch.run_id.clone()),
+            ],
+            match CanonicalEventKind::new("MailboxResumeFailed") {
+                Ok(kind) => kind,
+                Err(error) => {
+                    tracing::error!(error = %error, "invalid mailbox resume failed event kind");
+                    return;
+                }
+            },
+            payload,
+            origin.clone(),
+        ) {
+            Ok(draft) => draft,
+            Err(error) => {
+                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "invalid mailbox resume failed event draft");
+                return;
+            }
+        };
+        draft.visibility = EventVisibility::Public;
+        draft.correlation_id = Some(dispatch.dispatch_id.clone());
+        let options = AppendOptions {
+            writer_id: Some("mailbox".to_string()),
+            idempotency_key: Some(format!(
+                "MailboxResumeFailed/{}/{}",
+                dispatch.dispatch_id, dispatch.attempt_count
+            )),
+            expected_prior_cursors: Default::default(),
+        };
+        if let Err(error) = publisher.publish(draft, options).await {
+            tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "failed to record mailbox resume failed event");
+        }
+    }
+
+    pub(super) async fn record_run_rescheduled_dispatch(
+        &self,
+        dispatch: &RunDispatch,
+        reason: &'static str,
+    ) {
+        if dispatch.status == RunDispatchStatus::Queued {
+            self.record_mailbox_dispatch_event_inner(
+                "RunRescheduled",
+                dispatch,
+                Some(reason),
+                None,
+                None,
+            )
+            .await;
+        }
+    }
+
+    pub(super) async fn record_run_rescheduled_dispatch_by_id(
+        &self,
+        dispatch_id: &str,
+        reason: &'static str,
+    ) {
+        match self.store.load_dispatch(dispatch_id).await {
+            Ok(Some(dispatch)) => {
+                self.record_run_rescheduled_dispatch(&dispatch, reason)
+                    .await;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(dispatch_id, error = %error, "failed to load rescheduled dispatch");
+            }
+        }
+    }
+
+    async fn record_mailbox_dispatch_event_inner(
+        &self,
+        event_kind: &'static str,
+        dispatch: &RunDispatch,
+        reason: Option<&'static str>,
+        error: Option<String>,
+        timeout_ms: Option<u64>,
+    ) {
+        let Some(publisher) = &self.server_event_publisher else {
+            return;
+        };
+        let origin = self.server_event_origin.clone();
+        let mut payload = json!({
+            "thread_id": dispatch.thread_id,
+            "run_id": dispatch.run_id,
+            "dispatch_id": dispatch.dispatch_id,
+            "dispatch_epoch": dispatch.dispatch_epoch,
+            "attempt_count": dispatch.attempt_count,
+            "status": dispatch_status_label(dispatch.status),
+            "available_at": dispatch.available_at,
+            "created_at": dispatch.created_at,
+            "updated_at": dispatch.updated_at,
+        });
+        if let Some(reason) = reason
+            && let Some(payload) = payload.as_object_mut()
+        {
+            payload.insert("reason".to_string(), json!(reason));
+        }
+        if let Some(error) = error
+            && let Some(payload) = payload.as_object_mut()
+        {
+            payload.insert("error".to_string(), json!(error));
+        }
+        if let Some(timeout_ms) = timeout_ms
+            && let Some(payload) = payload.as_object_mut()
+        {
+            payload.insert("timeout_ms".to_string(), json!(timeout_ms));
+        }
+        let mut draft = match CanonicalEventDraft::new(
+            vec![
+                EventScope::thread(dispatch.thread_id.clone()),
+                EventScope::run(dispatch.run_id.clone()),
+            ],
+            match CanonicalEventKind::new(event_kind) {
+                Ok(kind) => kind,
+                Err(error) => {
+                    tracing::error!(error = %error, event_kind, "invalid mailbox event kind");
+                    return;
+                }
+            },
+            payload,
+            origin.clone(),
+        ) {
+            Ok(draft) => draft,
+            Err(error) => {
+                tracing::error!(error = %error, event_kind, dispatch_id = %dispatch.dispatch_id, "invalid mailbox event draft");
+                return;
+            }
+        };
+        draft.visibility = EventVisibility::Public;
+        draft.correlation_id = Some(dispatch.dispatch_id.clone());
+        let options = AppendOptions {
+            writer_id: Some("mailbox".to_string()),
+            idempotency_key: Some(format!(
+                "{}/{}/{}",
+                event_kind, dispatch.dispatch_id, dispatch.attempt_count
+            )),
+            expected_prior_cursors: Default::default(),
+        };
+        if let Err(error) = publisher.publish(draft, options).await {
+            tracing::error!(error = %error, event_kind, dispatch_id = %dispatch.dispatch_id, "failed to record mailbox event");
+        }
+    }
+
+    pub(super) async fn record_thread_message_checkpoint_events(
+        &self,
+        thread_id: &str,
+        run_id: &str,
+        messages: &[Message],
+        first_new_seq: u64,
+        last_new_seq: u64,
+    ) {
+        if first_new_seq > last_new_seq {
+            return;
+        }
+        for seq in first_new_seq..=last_new_seq {
+            self.record_message_committed(thread_id, run_id, messages, seq)
+                .await;
+        }
+        self.record_thread_messages_checkpointed(
+            thread_id,
+            run_id,
+            messages,
+            first_new_seq,
+            last_new_seq,
+        )
+        .await;
+    }
+
+    pub(crate) async fn record_mailbox_decision_received_for_run(
+        &self,
+        run: &RunRecord,
+        tool_call_id: &str,
+        resume: &ToolCallResume,
+        delivery_path: &'static str,
+    ) {
+        self.record_mailbox_decision_received(
+            &run.thread_id,
+            &run.run_id,
+            run.dispatch_id.as_deref(),
+            tool_call_id,
+            resume,
+            delivery_path,
+        )
+        .await;
+    }
+
+    pub(super) async fn record_mailbox_decision_received_for_dispatch(
+        &self,
+        dispatch: &RunDispatch,
+        tool_call_id: &str,
+        resume: &ToolCallResume,
+        delivery_path: &'static str,
+    ) {
+        self.record_mailbox_decision_received(
+            &dispatch.thread_id,
+            &dispatch.run_id,
+            Some(&dispatch.dispatch_id),
+            tool_call_id,
+            resume,
+            delivery_path,
+        )
+        .await;
+    }
+
+    pub(super) async fn record_mailbox_decision_received_for_id(
+        &self,
+        id: &str,
+        tool_call_id: &str,
+        resume: &ToolCallResume,
+        delivery_path: &'static str,
+    ) {
+        match self.store.load_dispatch(id).await {
+            Ok(Some(dispatch)) => {
+                self.record_mailbox_decision_received_for_dispatch(
+                    &dispatch,
+                    tool_call_id,
+                    resume,
+                    delivery_path,
+                )
+                .await;
+                return;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(id, error = %error, "failed to load dispatch for mailbox decision event");
+            }
+        }
+        let run = match self.run_store.load_run(id).await {
+            Ok(Some(run)) => Some(run),
+            Ok(None) => match self.run_store.latest_run(id).await {
+                Ok(run) => run,
+                Err(error) => {
+                    tracing::warn!(id, error = %error, "failed to load latest run for mailbox decision event");
+                    None
+                }
+            },
+            Err(error) => {
+                tracing::warn!(id, error = %error, "failed to load run for mailbox decision event");
+                None
+            }
+        };
+        if let Some(run) = run {
+            self.record_mailbox_decision_received_for_run(
+                &run,
+                tool_call_id,
+                resume,
+                delivery_path,
+            )
+            .await;
+        }
+    }
+
+    async fn record_mailbox_decision_received(
+        &self,
+        thread_id: &str,
+        run_id: &str,
+        dispatch_id: Option<&str>,
+        tool_call_id: &str,
+        resume: &ToolCallResume,
+        delivery_path: &'static str,
+    ) {
+        let Some(publisher) = &self.server_event_publisher else {
+            return;
+        };
+        let origin = self.server_event_origin.clone();
+        let payload = json!({
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "dispatch_id": dispatch_id,
+            "tool_call_id": tool_call_id,
+            "decision_id": resume.decision_id,
+            "action": &resume.action,
+            "result": &resume.result,
+            "reason": &resume.reason,
+            "resume_updated_at": resume.updated_at,
+            "delivery_path": delivery_path,
+        });
+        let mut draft = match CanonicalEventDraft::new(
+            vec![
+                EventScope::thread(thread_id.to_string()),
+                EventScope::run(run_id.to_string()),
+            ],
+            match CanonicalEventKind::new("MailboxDecisionReceived") {
+                Ok(kind) => kind,
+                Err(error) => {
+                    tracing::error!(error = %error, "invalid mailbox decision event kind");
+                    return;
+                }
+            },
+            payload,
+            origin.clone(),
+        ) {
+            Ok(draft) => draft,
+            Err(error) => {
+                tracing::error!(error = %error, run_id, tool_call_id, "invalid mailbox decision event draft");
+                return;
+            }
+        };
+        draft.visibility = EventVisibility::Public;
+        draft.correlation_id = Some(resume.decision_id.clone());
+        let options = AppendOptions {
+            writer_id: Some("mailbox".to_string()),
+            idempotency_key: Some(format!(
+                "MailboxDecisionReceived/{run_id}/{tool_call_id}/{}",
+                resume.decision_id
+            )),
+            expected_prior_cursors: Default::default(),
+        };
+        if let Err(error) = publisher.publish(draft, options).await {
+            tracing::error!(error = %error, run_id, tool_call_id, "failed to record mailbox decision event");
+        }
+        self.record_tool_permission_resolved(
+            thread_id,
+            run_id,
+            dispatch_id,
+            tool_call_id,
+            resume,
+            delivery_path,
+        )
+        .await;
+    }
+
+    async fn record_tool_permission_resolved(
+        &self,
+        thread_id: &str,
+        run_id: &str,
+        dispatch_id: Option<&str>,
+        tool_call_id: &str,
+        resume: &ToolCallResume,
+        delivery_path: &'static str,
+    ) {
+        let Some(approved) = resume
+            .result
+            .get("approved")
+            .and_then(serde_json::Value::as_bool)
+        else {
+            return;
+        };
+        let Some(publisher) = &self.server_event_publisher else {
+            return;
+        };
+        let origin = self.server_event_origin.clone();
+        let payload = json!({
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "dispatch_id": dispatch_id,
+            "tool_call_id": tool_call_id,
+            "decision_id": resume.decision_id,
+            "action": &resume.action,
+            "approved": approved,
+            "result": &resume.result,
+            "reason": &resume.reason,
+            "resume_updated_at": resume.updated_at,
+            "delivery_path": delivery_path,
+        });
+        let mut draft = match CanonicalEventDraft::new(
+            vec![
+                EventScope::thread(thread_id.to_string()),
+                EventScope::run(run_id.to_string()),
+            ],
+            match CanonicalEventKind::new("ToolPermissionResolved") {
+                Ok(kind) => kind,
+                Err(error) => {
+                    tracing::error!(error = %error, "invalid tool permission resolved event kind");
+                    return;
+                }
+            },
+            payload,
+            origin.clone(),
+        ) {
+            Ok(draft) => draft,
+            Err(error) => {
+                tracing::error!(error = %error, run_id, tool_call_id, "invalid tool permission resolved event draft");
+                return;
+            }
+        };
+        draft.visibility = EventVisibility::Public;
+        draft.correlation_id = Some(resume.decision_id.clone());
+        let options = AppendOptions {
+            writer_id: Some("mailbox".to_string()),
+            idempotency_key: Some(format!(
+                "ToolPermissionResolved/{run_id}/{tool_call_id}/{}",
+                resume.decision_id
+            )),
+            expected_prior_cursors: Default::default(),
+        };
+        if let Err(error) = publisher.publish(draft, options).await {
+            tracing::error!(error = %error, run_id, tool_call_id, "failed to record tool permission resolved event");
+        }
+    }
+
+    async fn record_message_committed(
+        &self,
+        thread_id: &str,
+        run_id: &str,
+        messages: &[Message],
+        seq: u64,
+    ) {
+        let Some(publisher) = &self.server_event_publisher else {
+            return;
+        };
+        let origin = self.server_event_origin.clone();
+        let Some(message) = seq
+            .checked_sub(1)
+            .and_then(|index| messages.get(index as usize))
+        else {
+            tracing::warn!(
+                thread_id,
+                run_id,
+                seq,
+                "message checkpoint event sequence is out of range"
+            );
+            return;
+        };
+        let Some(message_id) = message.id.as_deref().filter(|id| !id.trim().is_empty()) else {
+            tracing::warn!(
+                thread_id,
+                run_id,
+                seq,
+                "message checkpoint event missing message id"
+            );
+            return;
+        };
+        let parent_message_id = seq
+            .checked_sub(2)
+            .and_then(|index| messages.get(index as usize))
+            .and_then(|message| message.id.clone());
+        let payload = json!({
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "message_id": message_id,
+            "message_seq": seq,
+            "role": message.role,
+            "content_blocks": &message.content,
+            "message_kind": message_kind(message),
+            "parent_message_id": parent_message_id,
+            "created_at": crate::time::now_millis(),
+        });
+        let mut draft = match CanonicalEventDraft::new(
+            vec![
+                EventScope::thread(thread_id.to_string()),
+                EventScope::run(run_id.to_string()),
+            ],
+            match CanonicalEventKind::new("MessageCommitted") {
+                Ok(kind) => kind,
+                Err(error) => {
+                    tracing::error!(error = %error, "invalid message committed event kind");
+                    return;
+                }
+            },
+            payload,
+            origin.clone(),
+        ) {
+            Ok(draft) => draft,
+            Err(error) => {
+                tracing::error!(error = %error, thread_id, run_id, message_id, "invalid message committed event draft");
+                return;
+            }
+        };
+        draft.visibility = EventVisibility::Public;
+        draft.correlation_id = Some(run_id.to_string());
+        let options = AppendOptions {
+            writer_id: Some("mailbox".to_string()),
+            idempotency_key: Some(format!(
+                "MessageCommitted/{thread_id}/{run_id}/{message_id}"
+            )),
+            expected_prior_cursors: Default::default(),
+        };
+        if let Err(error) = publisher.publish(draft, options).await {
+            tracing::error!(error = %error, thread_id, run_id, message_id, "failed to record message committed event");
+        }
+    }
+
+    async fn record_thread_messages_checkpointed(
+        &self,
+        thread_id: &str,
+        run_id: &str,
+        messages: &[Message],
+        first_new_seq: u64,
+        last_new_seq: u64,
+    ) {
+        let Some(publisher) = &self.server_event_publisher else {
+            return;
+        };
+        let origin = self.server_event_origin.clone();
+        let message_ids = (first_new_seq..=last_new_seq)
+            .filter_map(|seq| {
+                seq.checked_sub(1)
+                    .and_then(|index| messages.get(index as usize))
+                    .and_then(|message| message.id.clone())
+            })
+            .collect::<Vec<_>>();
+        let payload = json!({
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "message_seq_start": first_new_seq,
+            "message_seq_end": last_new_seq,
+            "message_count": message_ids.len(),
+            "message_ids": message_ids,
+            "created_at": crate::time::now_millis(),
+        });
+        let mut draft = match CanonicalEventDraft::new(
+            vec![
+                EventScope::thread(thread_id.to_string()),
+                EventScope::run(run_id.to_string()),
+            ],
+            match CanonicalEventKind::new("ThreadMessagesCheckpointed") {
+                Ok(kind) => kind,
+                Err(error) => {
+                    tracing::error!(error = %error, "invalid thread messages checkpoint event kind");
+                    return;
+                }
+            },
+            payload,
+            origin.clone(),
+        ) {
+            Ok(draft) => draft,
+            Err(error) => {
+                tracing::error!(error = %error, thread_id, run_id, "invalid thread messages checkpoint event draft");
+                return;
+            }
+        };
+        draft.visibility = EventVisibility::Public;
+        draft.correlation_id = Some(run_id.to_string());
+        let options = AppendOptions {
+            writer_id: Some("mailbox".to_string()),
+            idempotency_key: Some(format!(
+                "ThreadMessagesCheckpointed/{thread_id}/{run_id}/{first_new_seq}-{last_new_seq}"
+            )),
+            expected_prior_cursors: Default::default(),
+        };
+        if let Err(error) = publisher.publish(draft, options).await {
+            tracing::error!(error = %error, thread_id, run_id, "failed to record thread messages checkpoint event");
+        }
+    }
+}
+
+fn message_kind(message: &Message) -> &'static str {
+    match (message.role, message.visibility) {
+        (Role::User, Visibility::All) => "user_input",
+        (Role::User, Visibility::Internal) => "internal_user_input",
+        (Role::Assistant, _) => "assistant_output",
+        (Role::Tool, _) => "tool_result",
+        (Role::System, Visibility::All) => "system",
+        (Role::System, Visibility::Internal) => "internal_system",
+    }
+}

--- a/crates/awaken-server/src/mailbox/signal_loop.rs
+++ b/crates/awaken-server/src/mailbox/signal_loop.rs
@@ -9,25 +9,17 @@ use parking_lot::Mutex as SyncMutex;
 use tokio::sync::{Semaphore, mpsc};
 use tokio::task::{JoinHandle, JoinSet};
 
-use awaken_contract::contract::event::AgentEvent;
-use awaken_contract::contract::event_sink::EventSink;
-use awaken_contract::contract::mailbox::{
-    DispatchSignalEntry, RunDispatch, RunDispatchResult, RunDispatchStatus,
-};
+use awaken_contract::contract::mailbox::{DispatchSignalEntry, RunDispatch, RunDispatchStatus};
 use awaken_contract::contract::storage::StorageError;
 use awaken_contract::now_ms;
-use awaken_runtime::ThreadContextSnapshot;
 
 use crate::transport::channel_sink::ReconnectableEventSink;
 
 use super::{
-    ActiveRunGuard, DISPATCH_SIGNAL_ERROR_DELAY, DispatchAttempt, MAILBOX_DEPTH_STATUSES, Mailbox,
-    MailboxError, MailboxRunOutcome, MailboxWorker, MailboxWorkerStatus, REMOTE_CANCEL_POLL_MS,
-    REMOTE_CANCEL_WAIT_MS, SuspensionAwareSink, TaskDoneMailboxNotify, ThreadContext,
-    classify_error, dispatch_signal_batch_size, dispatch_signal_blocked_nack_delay,
+    DISPATCH_SIGNAL_ERROR_DELAY, DispatchAttempt, MAILBOX_DEPTH_STATUSES, Mailbox, MailboxError,
+    MailboxWorker, MailboxWorkerStatus, REMOTE_CANCEL_POLL_MS, REMOTE_CANCEL_WAIT_MS,
+    ThreadContext, dispatch_signal_batch_size, dispatch_signal_blocked_nack_delay,
     dispatch_signal_fetch_expires, dispatch_signal_max_concurrent_handlers, dispatch_status_label,
-    mailbox_run_identity, mailbox_run_result, normalize_mailbox_run_mode,
-    record_mailbox_dispatch_completion_metrics, record_mailbox_dispatch_start_metrics,
     record_mailbox_operation_result, result_label, revert_claiming_to_idle,
 };
 
@@ -64,8 +56,9 @@ impl Mailbox {
         let start = Instant::now();
         let result = self.store.enqueue(dispatch).await;
         record_mailbox_operation_result("enqueue", result_label(&result), start);
-        if result.is_ok() {
-            self.refresh_dispatch_depth_metrics().await;
+        match &result {
+            Ok(()) => self.refresh_dispatch_depth_metrics().await,
+            Err(error) => self.record_mailbox_submit_failed(dispatch, error).await,
         }
         result
     }
@@ -294,7 +287,6 @@ impl Mailbox {
 
         self.spawn_execution(
             dispatch,
-            event_tx,
             reconnectable_sink,
             claim_token,
             thread_id.to_string(),
@@ -382,379 +374,26 @@ impl Mailbox {
     }
 
     /// Spawn the actual execution task for a claimed dispatch.
-    #[tracing::instrument(skip(self, event_tx, reconnectable_sink, suspended), fields(dispatch_id = %dispatch.dispatch_id, thread_id = %thread_id))]
+    #[tracing::instrument(skip(self, reconnectable_sink, suspended), fields(dispatch_id = %dispatch.dispatch_id, thread_id = %thread_id))]
     pub(super) fn spawn_execution(
         self: &Arc<Self>,
         dispatch: RunDispatch,
-        event_tx: mpsc::Sender<AgentEvent>,
         reconnectable_sink: Arc<ReconnectableEventSink>,
         claim_token: String,
         thread_id: String,
         suspended: Arc<AtomicBool>,
     ) {
-        let this = Arc::clone(self);
-        let dispatch_id = dispatch.dispatch_id.clone();
-
-        tokio::spawn(async move {
-            crate::metrics::inc_active_runs();
-            let _guard = ActiveRunGuard;
-
-            let sink = SuspensionAwareSink {
-                inner: reconnectable_sink as Arc<dyn EventSink>,
-                suspended,
-            };
-
-            // Dispatch epoch check: if this dispatch was superseded between claim and
-            // execution start, terminalize it and abort without entering the runtime.
-            let load_start = Instant::now();
-            let current_dispatch_result = this.store.load_dispatch(&dispatch_id).await;
-            record_mailbox_operation_result(
-                "load_dispatch",
-                result_label(&current_dispatch_result),
-                load_start,
-            );
-            let current_dispatch = match current_dispatch_result {
-                Ok(Some(current_dispatch)) => current_dispatch,
-                Ok(None) => {
-                    tracing::info!(dispatch_id, "dispatch disappeared before execution");
-                    this.finish_execution(&thread_id, &dispatch_id).await;
-                    return;
-                }
-                Err(error) => {
-                    tracing::warn!(dispatch_id, error = %error, "failed to verify dispatch before execution");
-                    this.finish_execution(&thread_id, &dispatch_id).await;
-                    return;
-                }
-            };
-            if current_dispatch.status != RunDispatchStatus::Claimed
-                || current_dispatch.claim_token.as_deref() != Some(claim_token.as_str())
-            {
-                tracing::info!(dispatch_id, status = ?current_dispatch.status, "dispatch no longer owned by this worker, skipping execution");
-                if current_dispatch.status == RunDispatchStatus::Superseded {
-                    this.mark_superseded_dispatch_run_cancelled(
-                        &current_dispatch,
-                        "dispatch superseded before execution start",
-                    )
-                    .await;
-                }
-                this.finish_execution(&thread_id, &dispatch_id).await;
-                return;
-            }
-            let epoch_start = Instant::now();
-            let current_epoch_result = this.store.current_dispatch_epoch(&thread_id).await;
-            record_mailbox_operation_result(
-                "current_dispatch_epoch",
-                result_label(&current_epoch_result),
-                epoch_start,
-            );
-            match current_epoch_result {
-                Ok(current_epoch) if current_dispatch.dispatch_epoch < current_epoch => {
-                    tracing::info!(
-                        dispatch_id,
-                        thread_id,
-                        dispatch_epoch = current_dispatch.dispatch_epoch,
-                        current_epoch,
-                        "dispatch superseded before execution start"
-                    );
-                    let supersede_reason = "claimed dispatch superseded before execution start";
-                    let supersede_start = Instant::now();
-                    let supersede_result = this
-                        .store
-                        .supersede_claimed(&dispatch_id, &claim_token, now_ms(), supersede_reason)
-                        .await;
-                    record_mailbox_operation_result(
-                        "supersede_claimed",
-                        result_label(&supersede_result),
-                        supersede_start,
-                    );
-                    if supersede_result.is_ok() {
-                        this.refresh_dispatch_depth_metrics().await;
-                        this.mark_superseded_dispatch_run_cancelled(
-                            &current_dispatch,
-                            supersede_reason,
-                        )
-                        .await;
-                    }
-                    this.finish_execution(&thread_id, &dispatch_id).await;
-                    return;
-                }
-                Ok(_) => {}
-                Err(error) => {
-                    tracing::warn!(dispatch_id, thread_id, error = %error, "failed to read dispatch epoch before execution");
-                    this.finish_execution(&thread_id, &dispatch_id).await;
-                    return;
-                }
-            }
-
-            let dispatch_instance_id = uuid::Uuid::now_v7().to_string();
-            let start_now = now_ms();
-            record_mailbox_dispatch_start_metrics(&dispatch, start_now);
-            let mut request = match this.reconstruct_run_request(&dispatch).await {
-                Ok(request) => request,
-                Err(error) => {
-                    tracing::error!(dispatch_id, error = %error, "failed to reconstruct run request from durable run record");
-                    let now = now_ms();
-                    record_mailbox_dispatch_completion_metrics(
-                        &dispatch,
-                        start_now,
-                        now,
-                        "permanent_error",
-                    );
-                    let msg = error.to_string();
-                    let run_result = RunDispatchResult {
-                        run_id: dispatch.run_id.clone(),
-                        dispatch_instance_id: dispatch_instance_id.clone(),
-                        status: awaken_contract::contract::lifecycle::RunStatus::Done,
-                        termination: Some(
-                            awaken_contract::contract::lifecycle::TerminationReason::Error(
-                                msg.clone(),
-                            ),
-                        ),
-                        response: None,
-                        error: Some(msg.clone()),
-                    };
-                    let record_start = Instant::now();
-                    let record_result = this
-                        .store
-                        .record_dispatch_start(
-                            &dispatch_id,
-                            &claim_token,
-                            &dispatch_instance_id,
-                            start_now,
-                        )
-                        .await;
-                    record_mailbox_operation_result(
-                        "record_dispatch_start",
-                        result_label(&record_result),
-                        record_start,
-                    );
-                    if let Err(error) = record_result {
-                        tracing::warn!(dispatch_id, error = %error, "failed to record dispatch start for reconstruction failure");
-                        if let Ok(Some(latest_dispatch)) =
-                            this.store.load_dispatch(&dispatch_id).await
-                            && latest_dispatch.status == RunDispatchStatus::Superseded
-                        {
-                            this.mark_superseded_dispatch_run_cancelled(
-                                &latest_dispatch,
-                                "dispatch superseded before reconstruction failure was recorded",
-                            )
-                            .await;
-                        }
-                        this.finish_execution(&thread_id, &dispatch_id).await;
-                        return;
-                    }
-                    let record_result_start = Instant::now();
-                    let record_run_result = this
-                        .store
-                        .record_run_result(&dispatch_id, &claim_token, &run_result, now)
-                        .await;
-                    record_mailbox_operation_result(
-                        "record_run_result",
-                        result_label(&record_run_result),
-                        record_result_start,
-                    );
-                    let dead_letter_start = Instant::now();
-                    let dead_letter_result = this
-                        .store
-                        .dead_letter(&dispatch_id, &claim_token, &msg, now)
-                        .await;
-                    record_mailbox_operation_result(
-                        "dead_letter",
-                        result_label(&dead_letter_result),
-                        dead_letter_start,
-                    );
-                    if dead_letter_result.is_ok() {
-                        this.refresh_dispatch_depth_metrics().await;
-                        if let Ok(Some(dead_letter_dispatch)) =
-                            this.store.load_dispatch(&dispatch_id).await
-                            && dead_letter_dispatch.status == RunDispatchStatus::DeadLetter
-                        {
-                            this.mark_dead_letter_dispatch_run_error(&dead_letter_dispatch)
-                                .await;
-                        }
-                    }
-                    this.finish_execution(&thread_id, &dispatch_id).await;
-                    return;
-                }
-            };
-            normalize_mailbox_run_mode(&mut request, false);
-            let run_id = dispatch.run_id.clone();
-            request = request
-                .with_dispatch_id(dispatch_id.clone())
-                .with_session_id(dispatch_instance_id.clone());
-            let record_start = Instant::now();
-            let record_start_result = this
-                .store
-                .record_dispatch_start(&dispatch_id, &claim_token, &dispatch_instance_id, start_now)
-                .await;
-            record_mailbox_operation_result(
-                "record_dispatch_start",
-                result_label(&record_start_result),
-                record_start,
-            );
-            if let Err(e) = record_start_result {
-                tracing::warn!(dispatch_id, run_id, error = %e, "failed to record mailbox dispatch start; skipping execution");
-                if let Ok(Some(latest_dispatch)) = this.store.load_dispatch(&dispatch_id).await
-                    && latest_dispatch.status == RunDispatchStatus::Superseded
-                {
-                    this.mark_superseded_dispatch_run_cancelled(
-                        &latest_dispatch,
-                        "dispatch superseded before runtime start was recorded",
-                    )
-                    .await;
-                }
-                this.finish_execution(&thread_id, &dispatch_id).await;
-                return;
-            }
-            let thread_ctx = {
-                let workers = this.workers.read().await;
-                workers.get(&thread_id).and_then(|worker| {
-                    let w = worker.lock();
-                    w.thread_ctx.as_ref().map(|ctx| {
-                        ThreadContextSnapshot::new(
-                            ctx.messages.clone(),
-                            ctx.latest_run.clone(),
-                            ctx.run_cache.clone(),
-                        )
-                    })
-                })
-            };
-            let continue_run_id = request.continue_run_id.clone();
-            let (inbox_sender, inbox_receiver) = awaken_runtime::inbox::inbox_channel_with_fallback(
-                Arc::new(TaskDoneMailboxNotify::new(
-                    this.clone(),
-                    dispatch.thread_id.clone(),
-                    continue_run_id,
-                )),
-            );
-            request = request.with_inbox(inbox_sender, inbox_receiver);
-
-            let result = this
-                .executor
-                .run_with_thread_context(request, Arc::new(sink), thread_ctx)
-                .await;
-            let now = now_ms();
-            let run_result = mailbox_run_result(&run_id, &dispatch_instance_id, &result);
-            let record_result_start = Instant::now();
-            let record_run_result = this
-                .store
-                .record_run_result(&dispatch_id, &claim_token, &run_result, now)
-                .await;
-            record_mailbox_operation_result(
-                "record_run_result",
-                result_label(&record_run_result),
-                record_result_start,
-            );
-            if let Err(e) = record_run_result {
-                tracing::warn!(dispatch_id, run_id, error = %e, "failed to record mailbox run result");
-            }
-
-            let outcome = classify_error(&result);
-            record_mailbox_dispatch_completion_metrics(
-                &dispatch,
-                start_now,
-                now,
-                outcome.metric_label(),
-            );
-
-            match outcome {
-                MailboxRunOutcome::Completed => {
-                    let ack_start = Instant::now();
-                    let ack_result = this.store.ack(&dispatch_id, &claim_token, now).await;
-                    record_mailbox_operation_result("ack", result_label(&ack_result), ack_start);
-                    if let Err(e) = ack_result {
-                        tracing::warn!(dispatch_id, error = %e, "ack failed");
-                    } else {
-                        this.refresh_dispatch_depth_metrics().await;
-                    }
-                }
-                MailboxRunOutcome::TransientError(msg) => {
-                    tracing::warn!(dispatch_id, error = %msg, "run failed (transient), nacking");
-                    // Emit error event so the SSE stream terminates with a
-                    // proper RUN_ERROR instead of silently closing.
-                    let _ = event_tx
-                        .send(AgentEvent::RunFinish {
-                            thread_id: dispatch.thread_id.clone(),
-                            run_id: run_id.clone(),
-                            identity: Some(mailbox_run_identity(
-                                &dispatch,
-                                &run_id,
-                                &dispatch_instance_id,
-                            )),
-                            result: None,
-                            termination:
-                                awaken_contract::contract::lifecycle::TerminationReason::Error(
-                                    msg.clone(),
-                                ),
-                        })
-                        .await;
-                    let backoff_factor = 2u64.pow(dispatch.attempt_count.saturating_sub(1).min(6));
-                    let retry_at = now
-                        + (this.config.default_retry_delay_ms * backoff_factor)
-                            .min(this.config.max_retry_delay_ms);
-                    let nack_start = Instant::now();
-                    let nack_result = this
-                        .store
-                        .nack(&dispatch_id, &claim_token, retry_at, &msg, now)
-                        .await;
-                    record_mailbox_operation_result("nack", result_label(&nack_result), nack_start);
-                    if let Err(e) = nack_result {
-                        tracing::warn!(dispatch_id, error = %e, "nack failed");
-                    } else {
-                        this.refresh_dispatch_depth_metrics().await;
-                    }
-                }
-                MailboxRunOutcome::PermanentError(msg) => {
-                    tracing::warn!(dispatch_id, error = %msg, "run failed (permanent), dead-lettering");
-                    // Emit error event so the SSE stream terminates with a
-                    // proper RUN_ERROR. The runtime did not reach the loop,
-                    // so no RunFinish was emitted — we must do it here.
-                    let _ = event_tx
-                        .send(AgentEvent::RunFinish {
-                            thread_id: dispatch.thread_id.clone(),
-                            run_id: run_id.clone(),
-                            identity: Some(mailbox_run_identity(
-                                &dispatch,
-                                &run_id,
-                                &dispatch_instance_id,
-                            )),
-                            result: None,
-                            termination:
-                                awaken_contract::contract::lifecycle::TerminationReason::Error(
-                                    msg.clone(),
-                                ),
-                        })
-                        .await;
-                    let dead_letter_start = Instant::now();
-                    let dead_letter_result = this
-                        .store
-                        .dead_letter(&dispatch_id, &claim_token, &msg, now)
-                        .await;
-                    record_mailbox_operation_result(
-                        "dead_letter",
-                        result_label(&dead_letter_result),
-                        dead_letter_start,
-                    );
-                    if let Err(e) = dead_letter_result {
-                        tracing::warn!(dispatch_id, error = %e, "dead_letter failed");
-                    } else {
-                        this.refresh_dispatch_depth_metrics().await;
-                        if let Ok(Some(dead_letter_dispatch)) =
-                            this.store.load_dispatch(&dispatch_id).await
-                            && dead_letter_dispatch.status == RunDispatchStatus::DeadLetter
-                        {
-                            this.mark_dead_letter_dispatch_run_error(&dead_letter_dispatch)
-                                .await;
-                        }
-                    }
-                }
-            }
-
-            this.finish_execution(&thread_id, &dispatch_id).await;
-        });
+        tokio::spawn(super::dispatch_execution::run_claimed_dispatch(
+            Arc::clone(self),
+            dispatch,
+            reconnectable_sink,
+            claim_token,
+            thread_id,
+            suspended,
+        ));
     }
 
-    async fn finish_execution(self: &Arc<Self>, thread_id: &str, dispatch_id: &str) {
+    pub(super) async fn finish_execution(self: &Arc<Self>, thread_id: &str, dispatch_id: &str) {
         // Abort lease renewal and return the worker to Idle.
         let worker = self.get_or_create_worker(thread_id).await;
         {

--- a/crates/awaken-server/src/mailbox/submit.rs
+++ b/crates/awaken-server/src/mailbox/submit.rs
@@ -125,7 +125,8 @@ impl Mailbox {
         let dispatch_id = dispatch.dispatch_id.clone();
         let thread_id = dispatch.thread_id.clone();
 
-        // WAL: persist before anything else.
+        // WAL: persist after the prepared checkpoint; startup recovery
+        // reconciles the crash window before this enqueue.
         // Set available_at slightly in the future to prevent sweep from grabbing
         // the dispatch during the inline claim window. If the process crashes before
         // the claim completes, sweep will reclaim the dispatch after the guard period.
@@ -266,7 +267,8 @@ impl Mailbox {
         let dispatch_id = dispatch.dispatch_id.clone();
         let thread_id = dispatch.thread_id.clone();
 
-        // WAL: persist with available_at = now.
+        // WAL: persist with available_at = now; startup recovery reconstructs
+        // the row if the process crashed after preparing the run checkpoint.
         self.enqueue_dispatch_for_request(&request, &dispatch)
             .await?;
         self.record_mailbox_dispatch_event("RunQueued", &dispatch)

--- a/crates/awaken-server/src/mailbox/submit.rs
+++ b/crates/awaken-server/src/mailbox/submit.rs
@@ -117,6 +117,7 @@ impl Mailbox {
             }
         }
 
+        self.ensure_dispatch_id_hint(&mut request);
         let run_id = self
             .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
             .await?;
@@ -257,6 +258,7 @@ impl Mailbox {
             !request.control.seeded_decisions.is_empty(),
         )?;
 
+        self.ensure_dispatch_id_hint(&mut request);
         let run_id = self
             .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
             .await?;
@@ -339,7 +341,22 @@ impl Mailbox {
 
     // ── Run preparation & reconstruction ─────────────────────────────
 
+    fn ensure_dispatch_id_hint(&self, request: &mut RunActivation) -> String {
+        match request.persistence.dispatch_id_hint.as_ref() {
+            Some(id) if !id.trim().is_empty() => id.clone(),
+            _ => {
+                let id = uuid::Uuid::now_v7().to_string();
+                request.persistence.dispatch_id_hint = Some(id.clone());
+                id
+            }
+        }
+    }
+
     /// Create or update the durable run truth before enqueuing a dispatch.
+    ///
+    /// The caller assigns `dispatch_id_hint` before this method persists the
+    /// checkpoint. Startup recovery can then reconcile the crash window where
+    /// the run checkpoint landed but the matching dispatch WAL write did not.
     pub(super) async fn prepare_run_for_dispatch(
         &self,
         request: &mut RunActivation,
@@ -365,6 +382,7 @@ impl Mailbox {
         if request.resume_run_id().is_none() {
             request.persistence.run_id_hint = Some(run_id.clone());
         }
+        let dispatch_id = self.ensure_dispatch_id_hint(request);
 
         let normalized_messages = normalize_message_ids(messages);
         let existing_messages = self
@@ -427,6 +445,7 @@ impl Mailbox {
             existing.activation = Some(request.snapshot(input_snapshot.clone(), registry_manifest));
             existing.request = None;
             existing.input = input;
+            existing.dispatch_id = Some(dispatch_id);
             existing.updated_at = now_ms() / 1000;
             self.commit_run_checkpoint(thread_id, &appended_messages, &existing)
                 .await?;
@@ -480,7 +499,7 @@ impl Mailbox {
             termination_reason: None,
             final_output: None,
             error_payload: None,
-            dispatch_id: None,
+            dispatch_id: Some(dispatch_id),
             session_id: None,
             transport_request_id: request.trace.transport_request_id.clone(),
             waiting: None,

--- a/crates/awaken-server/src/mailbox/submit.rs
+++ b/crates/awaken-server/src/mailbox/submit.rs
@@ -15,39 +15,61 @@ use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
 use awaken_contract::contract::message::Message;
+use awaken_contract::contract::run::{RunInput, RunInputSnapshot, RunKind, RunResolutionScope};
 use awaken_contract::contract::storage::{
-    MessageSeqRange, RunMessageInput, RunRecord, RunRequestSnapshot, RunResumeDecision,
+    MessageSeqRange, PinnedRegistryManifest, RunMessageInput, RunRecord, RunRequestSnapshot,
 };
-use awaken_contract::contract::tool_intercept::{AdapterKind, RunMode};
+use awaken_contract::contract::tool_intercept::RunMode;
 use awaken_contract::now_ms;
-use awaken_runtime::RunRequest;
+use awaken_runtime::{ResolutionPolicy, RunActivation};
 
 use crate::transport::channel_sink::ReconnectableEventSink;
 
 use super::{
-    ACTIVE_RUN_CONFLICT_MESSAGE, INLINE_CLAIM_GUARD_MS, Mailbox, MailboxDispatchStatus,
-    MailboxError, MailboxSubmitResult, MailboxWorkerStatus, RunRequestExtras, ThreadContext,
-    normalize_mailbox_run_mode, normalize_message_ids, record_mailbox_operation_result,
-    result_label, validate_run_inputs,
+    ACTIVE_RUN_CONFLICT_MESSAGE, INLINE_CLAIM_GUARD_MS, LegacyRunRequestSnapshotAdapter,
+    LegacyRunSnapshotExtras, Mailbox, MailboxDispatchStatus, MailboxError, MailboxSubmitResult,
+    MailboxWorkerStatus, ThreadContext, legacy_input_snapshot, normalize_mailbox_run_mode,
+    normalize_message_ids, record_mailbox_operation_result, result_label, validate_run_inputs,
 };
 
 impl Mailbox {
     // ── Submission ───────────────────────────────────────────────────
 
+    async fn enqueue_dispatch_for_request(
+        &self,
+        request: &RunActivation,
+        dispatch: &RunDispatch,
+    ) -> Result<(), MailboxError> {
+        let result = self.enqueue_dispatch_with_metrics(dispatch).await;
+        if let Err(error) = &result
+            && !request.control.seeded_decisions.is_empty()
+        {
+            self.record_mailbox_resume_failed(
+                dispatch,
+                &request.control.seeded_decisions,
+                "enqueue_failed",
+                error,
+            )
+            .await;
+        }
+        result?;
+        Ok(())
+    }
+
     /// Submit a run for streaming. Returns event receiver immediately.
     ///
     /// The dispatch is persisted (WAL), then claimed inline by this process.
     /// The caller wires `event_rx` to their transport (SSE, WebSocket, etc).
-    #[tracing::instrument(skip(self, request), fields(thread_id = %request.thread_id))]
+    #[tracing::instrument(skip(self, request), fields(thread_id = %request.thread_id()))]
     pub async fn submit(
         self: &Arc<Self>,
-        mut request: RunRequest,
+        mut request: RunActivation,
     ) -> Result<(MailboxSubmitResult, mpsc::Receiver<AgentEvent>), MailboxError> {
         normalize_mailbox_run_mode(&mut request, false);
         let (thread_id, messages) = validate_run_inputs(
-            request.thread_id.clone(),
-            request.messages.clone(),
-            !request.decisions.is_empty(),
+            request.thread_id().to_owned(),
+            request.messages().to_vec(),
+            !request.control.seeded_decisions.is_empty(),
         )?;
 
         // Step 1: Interrupt — bump dispatch epoch, supersede stale queued dispatches.
@@ -77,6 +99,8 @@ impl Mailbox {
                     if !cancelled {
                         return Err(MailboxError::Validation(ACTIVE_RUN_CONFLICT_MESSAGE.into()));
                     }
+                    self.record_mailbox_dispatch_event("RunInterrupted", active_dispatch)
+                        .await;
                     tracing::info!(
                         thread_id = %thread_id,
                         superseded = interrupt.superseded_count,
@@ -106,7 +130,10 @@ impl Mailbox {
         // the claim completes, sweep will reclaim the dispatch after the guard period.
         let mut wal_dispatch = dispatch;
         wal_dispatch.available_at = now_ms() + INLINE_CLAIM_GUARD_MS;
-        self.enqueue_dispatch_with_metrics(&wal_dispatch).await?;
+        self.enqueue_dispatch_for_request(&request, &wal_dispatch)
+            .await?;
+        self.record_mailbox_dispatch_event("RunQueued", &wal_dispatch)
+            .await;
 
         // Inline claim.
         let now = now_ms();
@@ -168,7 +195,6 @@ impl Mailbox {
             // Spawn execution.
             self.spawn_execution(
                 claimed_dispatch,
-                event_tx.clone(),
                 reconnectable_sink,
                 claim_token,
                 thread_id.clone(),
@@ -219,16 +245,16 @@ impl Mailbox {
     ///
     /// Dispatch is persisted with `available_at = now`, then execution is event-driven.
     /// Returns dispatch_id + thread_id for status polling.
-    #[tracing::instrument(skip(self, request), fields(thread_id = %request.thread_id))]
+    #[tracing::instrument(skip(self, request), fields(thread_id = %request.thread_id()))]
     pub async fn submit_background(
         self: &Arc<Self>,
-        mut request: RunRequest,
+        mut request: RunActivation,
     ) -> Result<MailboxSubmitResult, MailboxError> {
         normalize_mailbox_run_mode(&mut request, true);
         let (thread_id, messages) = validate_run_inputs(
-            request.thread_id.clone(),
-            request.messages.clone(),
-            !request.decisions.is_empty(),
+            request.thread_id().to_owned(),
+            request.messages().to_vec(),
+            !request.control.seeded_decisions.is_empty(),
         )?;
 
         let run_id = self
@@ -239,7 +265,10 @@ impl Mailbox {
         let thread_id = dispatch.thread_id.clone();
 
         // WAL: persist with available_at = now.
-        self.enqueue_dispatch_with_metrics(&dispatch).await?;
+        self.enqueue_dispatch_for_request(&request, &dispatch)
+            .await?;
+        self.record_mailbox_dispatch_event("RunQueued", &dispatch)
+            .await;
 
         // Dispatch via try_dispatch_next which handles Idle → Claiming atomically.
         self.get_or_create_worker(&thread_id).await;
@@ -278,21 +307,21 @@ impl Mailbox {
     /// 4. When the current run ends, the queued dispatch executes and
     ///    the user-visible message history contains duplicates.
     ///
-    /// `RunRequest` does not expose dispatch-level dedupe. Callers that need
+    /// `RunActivation` does not expose dispatch-level dedupe. Callers that need
     /// exactly-once effects must drive idempotency at the application layer
     /// (e.g., unique
     ///   message IDs normalized via `normalize_message_ids`; agent
     ///   state that rejects redundant inputs).
-    #[tracing::instrument(skip(self, request), fields(thread_id = %request.thread_id))]
+    #[tracing::instrument(skip(self, request), fields(thread_id = %request.thread_id()))]
     pub async fn submit_live_then_queue(
         self: &Arc<Self>,
-        mut request: RunRequest,
+        mut request: RunActivation,
         expected_run_id: Option<&str>,
     ) -> Result<MailboxSubmitResult, MailboxError> {
         let (thread_id, messages) = validate_run_inputs(
-            request.thread_id.clone(),
-            request.messages.clone(),
-            !request.decisions.is_empty(),
+            request.thread_id().to_owned(),
+            request.messages().to_vec(),
+            !request.control.seeded_decisions.is_empty(),
         )?;
         let messages = normalize_message_ids(&messages);
 
@@ -303,8 +332,8 @@ impl Mailbox {
             return Ok(result);
         }
 
-        request.thread_id = thread_id;
-        request.messages = messages;
+        request.intent.thread_id = thread_id;
+        request.input = RunInput::NewMessages(messages);
         self.submit_background(request).await
     }
 
@@ -313,25 +342,28 @@ impl Mailbox {
     /// Create or update the durable run truth before enqueuing a dispatch.
     pub(super) async fn prepare_run_for_dispatch(
         &self,
-        request: &mut RunRequest,
+        request: &mut RunActivation,
         thread_id: &str,
         messages: &[Message],
     ) -> Result<String, MailboxError> {
-        if request.continue_run_id.is_none()
-            && request.run_id_hint.is_none()
+        if request.resume_run_id().is_none()
+            && request.persistence.run_id_hint.is_none()
             && let Some(waiting_run_id) = self.reusable_waiting_run_id(thread_id).await
         {
-            request.continue_run_id = Some(waiting_run_id);
+            request.intent.kind = RunKind::HitlResume {
+                run_id: waiting_run_id,
+            };
+            request.trace.run_mode = RunMode::Resume;
         }
 
         let run_id = request
-            .continue_run_id
-            .clone()
-            .or_else(|| request.run_id_hint.clone())
+            .resume_run_id()
+            .map(str::to_owned)
+            .or_else(|| request.persistence.run_id_hint.clone())
             .filter(|id| !id.trim().is_empty())
             .unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
-        if request.continue_run_id.is_none() {
-            request.run_id_hint = Some(run_id.clone());
+        if request.resume_run_id().is_none() {
+            request.persistence.run_id_hint = Some(run_id.clone());
         }
 
         let normalized_messages = normalize_message_ids(messages);
@@ -342,41 +374,29 @@ impl Mailbox {
             .unwrap_or_default();
         let previous_run = self.run_store.latest_run(thread_id).await?;
         let mut appended_messages = existing_messages;
+        let first_new_seq = appended_messages.len() as u64 + 1;
         appended_messages.extend(normalized_messages.iter().cloned());
+        let last_new_seq = appended_messages.len() as u64;
         let input_message_ids = normalized_messages
             .iter()
             .filter_map(|message| message.id.clone())
             .collect::<Vec<_>>();
-        let request_extras = RunRequestExtras::from_request(request)
-            .to_value()
-            .map_err(|e| {
-                MailboxError::Internal(format!("failed to serialize request extras: {e}"))
-            })?;
-        let request_snapshot = RunRequestSnapshot {
-            origin: request.origin,
-            sender_id: None,
-            input_message_ids: input_message_ids.clone(),
-            input_message_count: normalized_messages.len() as u64,
-            request_extras,
-            decisions: request
-                .decisions
-                .iter()
-                .map(|(call_id, resume)| RunResumeDecision {
-                    call_id: call_id.clone(),
-                    resume: resume.clone(),
-                })
-                .collect(),
-            frontend_tools: request.frontend_tools.clone(),
-            parent_thread_id: request.parent_thread_id.clone(),
-            transport_request_id: request.transport_request_id.clone(),
-        };
-        let input = Some(RunMessageInput {
+        let input_range = MessageSeqRange::new(1, appended_messages.len() as u64);
+        let input_snapshot = RunInputSnapshot {
             thread_id: thread_id.to_string(),
-            range: MessageSeqRange::new(1, appended_messages.len() as u64),
+            range: input_range,
             trigger_message_ids: input_message_ids,
             selected_message_ids: Vec::new(),
             context_policy: None,
             compacted_snapshot_id: None,
+        };
+        let input = Some(RunMessageInput {
+            thread_id: input_snapshot.thread_id.clone(),
+            range: input_snapshot.range,
+            trigger_message_ids: input_snapshot.trigger_message_ids.clone(),
+            selected_message_ids: input_snapshot.selected_message_ids.clone(),
+            context_policy: input_snapshot.context_policy.clone(),
+            compacted_snapshot_id: input_snapshot.compacted_snapshot_id.clone(),
         });
 
         let existing_run = self.run_store.load_run(&run_id).await?;
@@ -392,25 +412,39 @@ impl Mailbox {
                     "run_id '{run_id}' is not open for dispatch"
                 )));
             }
-            existing.request = Some(request_snapshot);
+            if request.intent.agent_id.is_none() {
+                request.intent.agent_id = Some(existing.agent_id.clone());
+            }
+            let registry_manifest = if let Some(manifest) = existing.registry_manifest.clone() {
+                request.resolution_scope = RunResolutionScope::Pinned(manifest.clone());
+                manifest
+            } else {
+                let manifest = self.resolve_replayable_manifest(request).await?;
+                existing.registry_manifest = Some(manifest.clone());
+                request.resolution_scope = RunResolutionScope::Pinned(manifest.clone());
+                manifest
+            };
+            existing.activation = Some(request.snapshot(input_snapshot.clone(), registry_manifest));
+            existing.request = None;
             existing.input = input;
             existing.updated_at = now_ms() / 1000;
-            self.run_store
-                .checkpoint(thread_id, &appended_messages, &existing)
+            self.commit_run_checkpoint(thread_id, &appended_messages, &existing)
                 .await?;
-            {
-                let workers = self.workers.read().await;
-                if let Some(worker) = workers.get(thread_id) {
-                    let mut w = worker.lock();
-                    if let Some(ref mut ctx) = w.thread_ctx {
-                        ctx.apply_checkpoint(&appended_messages, &existing);
-                    }
-                }
-            }
+            self.record_thread_message_checkpoint_events(
+                thread_id,
+                &run_id,
+                &appended_messages,
+                first_new_seq,
+                last_new_seq,
+            )
+            .await;
+            self.refresh_worker_checkpoint_cache(thread_id, &appended_messages, &existing)
+                .await;
             return Ok(run_id);
         }
 
         let inferred_agent_id = request
+            .intent
             .agent_id
             .clone()
             .or_else(|| {
@@ -424,15 +458,22 @@ impl Mailbox {
             .as_ref()
             .filter(|run| run.status != RunStatus::Created)
             .and_then(|run| run.state.clone());
+        if request.intent.agent_id.is_none() {
+            request.intent.agent_id = Some(inferred_agent_id.clone());
+        }
+        let registry_manifest = self.resolve_replayable_manifest(request).await?;
+        request.resolution_scope = RunResolutionScope::Pinned(registry_manifest.clone());
+        let activation = Some(request.snapshot(input_snapshot, registry_manifest.clone()));
+        let registry_manifest = Some(registry_manifest);
         let now = now_ms() / 1000;
         let record = RunRecord {
             run_id: run_id.clone(),
             thread_id: thread_id.to_string(),
             agent_id: inferred_agent_id,
-            parent_run_id: request.parent_run_id.clone(),
-            registry_manifest: None,
-            activation: None,
-            request: Some(request_snapshot),
+            parent_run_id: request.trace.parent_run_id.clone(),
+            registry_manifest,
+            activation,
+            request: None,
             input,
             output: None,
             status: RunStatus::Created,
@@ -441,7 +482,7 @@ impl Mailbox {
             error_payload: None,
             dispatch_id: None,
             session_id: None,
-            transport_request_id: request.transport_request_id.clone(),
+            transport_request_id: request.trace.transport_request_id.clone(),
             waiting: None,
             outcome: None,
             created_at: now,
@@ -453,35 +494,52 @@ impl Mailbox {
             output_tokens: 0,
             state: inherited_state,
         };
-        self.run_store
-            .checkpoint(thread_id, &appended_messages, &record)
+        self.commit_run_checkpoint(thread_id, &appended_messages, &record)
             .await?;
-        {
-            let workers = self.workers.read().await;
-            if let Some(worker) = workers.get(thread_id) {
-                let mut w = worker.lock();
-                if let Some(ref mut ctx) = w.thread_ctx {
-                    ctx.apply_checkpoint(&appended_messages, &record);
-                }
-            }
-        }
+        self.record_thread_message_checkpoint_events(
+            thread_id,
+            &run_id,
+            &appended_messages,
+            first_new_seq,
+            last_new_seq,
+        )
+        .await;
+        self.refresh_worker_checkpoint_cache(thread_id, &appended_messages, &record)
+            .await;
         Ok(run_id)
+    }
+
+    async fn resolve_replayable_manifest(
+        &self,
+        request: &RunActivation,
+    ) -> Result<PinnedRegistryManifest, MailboxError> {
+        self.executor
+            .resolve_activation(request, ResolutionPolicy::PersistentServer)
+            .await
+            .and_then(|plan| plan.into_replayable())
+            .map(|plan| plan.scope.manifest)
+            .map_err(|error| {
+                MailboxError::Validation(format!(
+                    "persistent mailbox dispatch requires a replayable resolved run: {error}"
+                ))
+            })
     }
 
     /// Build a RunDispatch from the durable run prepared above.
     pub(super) fn build_dispatch(
         &self,
-        request: &RunRequest,
+        request: &RunActivation,
         thread_id: &str,
     ) -> Result<RunDispatch, MailboxError> {
         let run_id = request
-            .continue_run_id
-            .clone()
-            .or_else(|| request.run_id_hint.clone())
+            .resume_run_id()
+            .map(str::to_owned)
+            .or_else(|| request.persistence.run_id_hint.clone())
             .ok_or_else(|| MailboxError::Internal("run_id missing after preparation".into()))?;
         let now = now_ms();
         Ok(RunDispatch {
             dispatch_id: request
+                .persistence
                 .dispatch_id_hint
                 .clone()
                 .unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
@@ -512,7 +570,7 @@ impl Mailbox {
     pub(super) async fn reconstruct_run_request(
         &self,
         dispatch: &RunDispatch,
-    ) -> Result<RunRequest, MailboxError> {
+    ) -> Result<RunActivation, MailboxError> {
         let run = {
             let cached = {
                 let workers = self.workers.read().await;
@@ -543,51 +601,100 @@ impl Mailbox {
                 run.run_id, run.thread_id, dispatch.thread_id
             )));
         }
+        if let Some(snapshot) = run.activation.clone() {
+            let activation_messages = self
+                .activation_messages_for_snapshot(&run, &snapshot.input)
+                .await?;
+            let mut request = RunActivation::new(run.thread_id.clone(), activation_messages)
+                .with_messages_already_persisted(true);
+            request.intent = snapshot.intent;
+            request.options = snapshot.options;
+            request.trace = snapshot.trace;
+            request.control.seeded_decisions = snapshot.seeded_decisions;
+            request.resolution_scope = RunResolutionScope::Pinned(snapshot.resolution_scope);
+            return self
+                .attach_dispatch_replay_wiring(&run, dispatch, request)
+                .await;
+        }
+
         let snapshot = run.request.clone().ok_or_else(|| {
-            MailboxError::Validation(format!("run '{}' has no request snapshot", run.run_id))
+            MailboxError::Validation(format!("run '{}' has no activation snapshot", run.run_id))
         })?;
         let activation_messages = self.activation_messages_for_run(&run, &snapshot).await?;
-        let mut request = RunRequest::new(run.thread_id.clone(), activation_messages)
-            .with_messages_already_persisted(true)
-            .with_origin(snapshot.origin)
-            .with_run_mode(RunMode::Resume)
-            .with_adapter(AdapterKind::Internal);
-        if !run.agent_id.trim().is_empty() {
-            request = request.with_agent_id(run.agent_id.clone());
-        }
-        if let Some(parent_run_id) = run.parent_run_id.clone() {
-            request = request.with_parent_run_id(parent_run_id);
-        }
-        if let Some(parent_thread_id) = snapshot.parent_thread_id.clone() {
-            request = request.with_parent_thread_id(parent_thread_id);
-        }
-        if let Some(transport_request_id) = snapshot.transport_request_id.clone() {
-            request = request.with_transport_request_id(transport_request_id);
-        }
-        if !snapshot.decisions.is_empty() {
-            request = request.with_decisions(
-                snapshot
-                    .decisions
-                    .iter()
-                    .map(|decision| (decision.call_id.clone(), decision.resume.clone()))
-                    .collect(),
-            );
-        }
-        if !snapshot.frontend_tools.is_empty() {
-            request = request.with_frontend_tools(snapshot.frontend_tools.clone());
-        }
-        if let Some(extras_value) = snapshot.request_extras.as_ref() {
-            let extras = RunRequestExtras::from_value(extras_value).map_err(|error| {
-                MailboxError::Validation(format!("corrupt request_extras: {error}"))
-            })?;
-            request = extras.apply_to(request);
-        }
+        let extras = snapshot
+            .request_extras
+            .as_ref()
+            .map(|extras_value| {
+                LegacyRunSnapshotExtras::from_value(extras_value).map_err(|error| {
+                    MailboxError::Validation(format!("corrupt request_extras: {error}"))
+                })
+            })
+            .transpose()?;
+        let manifest = run.registry_manifest.clone().ok_or_else(|| {
+            MailboxError::Validation(format!(
+                "legacy run '{}' has no pinned registry manifest",
+                run.run_id
+            ))
+        })?;
+        let input = legacy_input_snapshot(&run, &snapshot);
+        let snapshot = awaken_contract::contract::run::RunActivationSnapshot::try_from(
+            LegacyRunRequestSnapshotAdapter {
+                snapshot,
+                input,
+                manifest,
+                thread_id: run.thread_id.clone(),
+                agent_id: (!run.agent_id.trim().is_empty()).then(|| run.agent_id.clone()),
+                parent_run_id: run.parent_run_id.clone(),
+                extras,
+            },
+        )
+        .map_err(|error| {
+            MailboxError::Validation(format!("legacy run snapshot conversion failed: {error}"))
+        })?;
+        let mut request = RunActivation::new(run.thread_id.clone(), activation_messages)
+            .with_messages_already_persisted(true);
+        request.intent = snapshot.intent;
+        request.options = snapshot.options;
+        request.trace = snapshot.trace;
+        request.control.seeded_decisions = snapshot.seeded_decisions;
+        request.resolution_scope = RunResolutionScope::Pinned(snapshot.resolution_scope);
+        self.attach_dispatch_replay_wiring(&run, dispatch, request)
+            .await
+    }
+
+    async fn attach_dispatch_replay_wiring(
+        &self,
+        run: &RunRecord,
+        dispatch: &RunDispatch,
+        mut request: RunActivation,
+    ) -> Result<RunActivation, MailboxError> {
         request = if run.is_resumable_waiting() {
-            request.with_continue_run_id(run.run_id.clone())
+            request.intent.kind = RunKind::HitlResume {
+                run_id: run.run_id.clone(),
+            };
+            if request.trace.run_mode == RunMode::Foreground {
+                request.trace.run_mode = RunMode::Resume;
+            }
+            request
         } else {
             request.with_run_id_hint(run.run_id.clone())
         };
+        if let Some(manifest) = run.registry_manifest.clone() {
+            request = request.with_registry_manifest(manifest);
+        }
         Ok(request.with_trace_dispatch_id(dispatch.dispatch_id.clone()))
+    }
+
+    async fn activation_messages_for_snapshot(
+        &self,
+        run: &RunRecord,
+        snapshot: &RunInputSnapshot,
+    ) -> Result<Vec<Message>, MailboxError> {
+        if snapshot.trigger_message_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.activation_messages_by_ids(run, &snapshot.trigger_message_ids)
+            .await
     }
 
     async fn activation_messages_for_run(
@@ -598,14 +705,22 @@ impl Mailbox {
         if snapshot.input_message_ids.is_empty() {
             return self.activation_messages_from_range(run, snapshot).await;
         }
-        // Try cache first for message lookups.
+        self.activation_messages_by_ids(run, &snapshot.input_message_ids)
+            .await
+    }
+
+    async fn activation_messages_by_ids(
+        &self,
+        run: &RunRecord,
+        message_ids: &[String],
+    ) -> Result<Vec<Message>, MailboxError> {
         let cached_messages: Option<Vec<Message>> = {
             let workers = self.workers.read().await;
             workers.get(&run.thread_id).and_then(|w| {
                 let w = w.lock();
                 w.thread_ctx.as_ref().and_then(|ctx| {
-                    let mut msgs = Vec::with_capacity(snapshot.input_message_ids.len());
-                    for msg_id in &snapshot.input_message_ids {
+                    let mut msgs = Vec::with_capacity(message_ids.len());
+                    for msg_id in message_ids {
                         let found = ctx
                             .messages
                             .iter()
@@ -619,8 +734,8 @@ impl Mailbox {
         if let Some(msgs) = cached_messages {
             return Ok(msgs);
         }
-        let mut messages = Vec::with_capacity(snapshot.input_message_ids.len());
-        for message_id in &snapshot.input_message_ids {
+        let mut messages = Vec::with_capacity(message_ids.len());
+        for message_id in message_ids {
             let record = self
                 .run_store
                 .load_message_record(&run.thread_id, message_id)

--- a/crates/awaken-server/src/mailbox/tests.rs
+++ b/crates/awaken-server/src/mailbox/tests.rs
@@ -1046,75 +1046,6 @@ fn empty_live_registry_set() -> awaken_runtime::registry::RegistrySet {
     }
 }
 
-struct EmittingMailboxRuntime;
-
-#[async_trait::async_trait]
-impl RunDispatchExecutor for EmittingMailboxRuntime {
-    async fn run(
-        &self,
-        request: RunActivation,
-        sink: Arc<dyn EventSink>,
-    ) -> Result<AgentRunResult, AgentLoopError> {
-        let run_id = request
-            .resume_run_id()
-            .map(str::to_owned)
-            .or(request.persistence.run_id_hint.clone())
-            .or(request.trace.dispatch_id.clone())
-            .unwrap_or_else(|| "emitting-run".to_string());
-        sink.emit(AgentEvent::RunStart {
-            thread_id: request.thread_id().to_owned(),
-            run_id: run_id.clone(),
-            parent_run_id: None,
-            identity: None,
-        })
-        .await;
-        sink.emit(AgentEvent::TextDelta {
-            delta: "live only".into(),
-        })
-        .await;
-        sink.emit(AgentEvent::ToolCallReady {
-            id: "call-1".into(),
-            name: "search".into(),
-            arguments: json!({"q": "awaken"}),
-        })
-        .await;
-        sink.emit(AgentEvent::RunFinish {
-            thread_id: request.thread_id().to_owned(),
-            run_id: run_id.clone(),
-            identity: None,
-            result: None,
-            termination: TerminationReason::NaturalEnd,
-        })
-        .await;
-        Ok(AgentRunResult {
-            run_id,
-            response: "ok".to_string(),
-            termination: TerminationReason::NaturalEnd,
-            steps: 1,
-        })
-    }
-
-    fn cancel(&self, _id: &str) -> bool {
-        false
-    }
-
-    async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
-        false
-    }
-
-    fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
-        false
-    }
-
-    fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
-        false
-    }
-
-    fn live_registry_set(&self) -> Option<awaken_runtime::registry::RegistrySet> {
-        Some(empty_live_registry_set())
-    }
-}
-
 struct CommittingEmittingMailboxRuntime {
     event_store: Arc<InMemoryEventStore>,
 }
@@ -6014,6 +5945,45 @@ async fn recover_only_enqueues_orphaned_background_task_waiting_runs() {
         user_dispatches.is_empty(),
         "user-input waiting runs must stay suspended until explicit input"
     );
+}
+
+#[tokio::test]
+async fn recover_pages_orphaned_background_task_waiting_runs() {
+    let store = Arc::new(InMemoryStore::new());
+    let run_count = 205usize;
+    for index in 0..run_count {
+        let run = seeded_waiting_run(
+            &format!("run-bg-page-{index}"),
+            &format!("thread-bg-page-{index}"),
+            "agent",
+        );
+        store.create_run(&run).await.expect("seed bg run");
+    }
+
+    let mailbox_store = make_store();
+    let runtime = Arc::new(RecordingStoreMailboxRuntime::new(store.clone()));
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        mailbox_store,
+        store,
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    ));
+
+    let recovered = mailbox.recover().await.expect("recover should succeed");
+    assert_eq!(recovered, run_count);
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if runtime.requests.lock().expect("lock poisoned").len() == run_count {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "recover did not dispatch every background wake"
+        );
+        sleep(Duration::from_millis(5)).await;
+    }
 }
 
 #[tokio::test]

--- a/crates/awaken-server/src/mailbox/tests.rs
+++ b/crates/awaken-server/src/mailbox/tests.rs
@@ -1,6 +1,15 @@
+#![allow(deprecated)] // ADR-0038 D7: tests exercise the legacy checkpoint API directly
+
 use super::*;
 use async_trait::async_trait;
+use awaken_contract::RuntimeEventDurability;
+use awaken_contract::contract::commit_coordinator::{
+    EventPublishError, OutboxServerEventPublisher, ServerEventPublishOutcome,
+};
 use awaken_contract::contract::content::ContentBlock;
+use awaken_contract::contract::event_store::{
+    AppendOptions, CanonicalEventDraft, EventReader, EventScope, EventWriter,
+};
 use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest, LlmExecutor};
 use awaken_contract::contract::inference::{StopReason, StreamResult};
 use awaken_contract::contract::lifecycle::{RunStatus, TerminationReason};
@@ -9,9 +18,11 @@ use awaken_contract::contract::mailbox::{
     RunDispatchStatus,
 };
 use awaken_contract::contract::message::{Message, ToolCall};
+use awaken_contract::contract::outbox::OutboxError;
 use awaken_contract::contract::storage::RunRequestOrigin;
 use awaken_contract::contract::storage::{
-    RunRecord, RunStore, RunWaitingState, ThreadRunStore, ThreadStore, WaitingReason,
+    PinnedRegistryEntry, PinnedRegistryManifest, RunRecord, RunStore, RunWaitingState,
+    ThreadRunStore, ThreadStore, WaitingReason,
 };
 use awaken_contract::contract::tool::{
     Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
@@ -22,9 +33,9 @@ use awaken_runtime::extensions::background::{
     BackgroundTaskManager, BackgroundTaskPlugin, TaskParentContext,
     TaskResult as BackgroundTaskResult,
 };
-use awaken_runtime::loop_runner::build_agent_env;
-use awaken_runtime::{Plugin, ResolvedAgent};
-use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
+use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult, build_agent_env};
+use awaken_runtime::{AgentRuntime, Plugin, ResolvedAgent};
+use awaken_stores::{InMemoryEventStore, InMemoryMailboxStore, InMemoryStore};
 use serde_json::{Value, json};
 use std::collections::VecDeque;
 use std::sync::Mutex as StdMutex;
@@ -58,6 +69,99 @@ fn make_resume() -> ToolCallResume {
         result: serde_json::json!({"approved": true}),
         reason: None,
         updated_at: 0,
+    }
+}
+
+struct EventStoreServerEventPublisher {
+    writer: Arc<dyn EventWriter>,
+}
+
+struct FailingServerEventPublisher;
+
+impl EventStoreServerEventPublisher {
+    fn new(writer: Arc<dyn EventWriter>) -> Self {
+        Self { writer }
+    }
+}
+
+fn test_server_event_publisher(
+    event_store: Arc<InMemoryEventStore>,
+) -> Arc<dyn OutboxServerEventPublisher> {
+    Arc::new(EventStoreServerEventPublisher::new(event_store))
+}
+
+#[async_trait]
+impl OutboxServerEventPublisher for FailingServerEventPublisher {
+    async fn publish(
+        &self,
+        _draft: CanonicalEventDraft,
+        _options: AppendOptions,
+    ) -> Result<ServerEventPublishOutcome, EventPublishError> {
+        Err(EventPublishError::Enqueue(OutboxError::Io(
+            "event publisher unavailable".to_string(),
+        )))
+    }
+}
+
+#[async_trait]
+impl OutboxServerEventPublisher for EventStoreServerEventPublisher {
+    async fn publish(
+        &self,
+        draft: CanonicalEventDraft,
+        options: AppendOptions,
+    ) -> Result<ServerEventPublishOutcome, EventPublishError> {
+        let dedupe_key = options.idempotency_key.clone();
+        let result = self
+            .writer
+            .append(draft, options)
+            .await
+            .map_err(|error| EventPublishError::Enqueue(OutboxError::Io(error.to_string())))?;
+        Ok(ServerEventPublishOutcome::Enqueued {
+            dedupe_key: dedupe_key
+                .unwrap_or_else(|| format!("canonical/{}", result.event.event_id.as_str())),
+        })
+    }
+}
+
+struct FixedRunResolver {
+    manifest: PinnedRegistryManifest,
+}
+
+#[async_trait]
+impl awaken_runtime::Resolver for FixedRunResolver {
+    async fn resolve(
+        &self,
+        req: awaken_runtime::ResolutionRequest,
+    ) -> Result<awaken_runtime::ResolvedRunPlan, awaken_runtime::ResolveError> {
+        let agent_id = match &req.target {
+            awaken_runtime::ResolutionTarget::Root { agent_id, .. } => agent_id.as_str(),
+            awaken_runtime::ResolutionTarget::Delegate { agent_id, .. } => agent_id.as_str(),
+            awaken_runtime::ResolutionTarget::Handoff { agent_id, .. } => agent_id.as_str(),
+        };
+        let agent = ResolvedAgent::new(
+            agent_id,
+            "model",
+            "system",
+            Arc::new(ScriptedLlm::new(vec![])),
+        );
+        let requirements = awaken_runtime::BackendRequirements::from_features(&req.features);
+        Ok(awaken_runtime::ResolvedRunPlan::Replayable(
+            awaken_runtime::ResolvedRun {
+                agent_spec: (*agent.spec).clone(),
+                role: awaken_runtime::ExecutionRole::Root,
+                execution: awaken_runtime::ExecutionPlan::from_resolved_agent(&agent),
+                model: awaken_runtime::ResolvedModelBinding {
+                    upstream_model: agent.upstream_model.clone(),
+                },
+                tools: Vec::new(),
+                overrides: req.overrides,
+                backend_profile: awaken_runtime::BackendProfile::full_local(),
+                requirements,
+                scope: awaken_runtime::ReplayableScope {
+                    manifest: self.manifest.clone(),
+                },
+            },
+        ))
     }
 }
 
@@ -301,6 +405,7 @@ struct SignalMailboxStore {
     signals: Arc<tokio::sync::Mutex<VecDeque<TestDispatchSignal>>>,
     acked_count: Arc<AtomicUsize>,
     nacked_count: Arc<AtomicUsize>,
+    enqueue_failures_remaining: AtomicUsize,
     claim_failures_remaining: AtomicUsize,
     claim_dispatch_empty_once: AtomicBool,
 }
@@ -312,6 +417,12 @@ impl SignalMailboxStore {
 
     fn with_claim_failures(claim_failures: usize) -> Self {
         Self::with_failures_and_empty_claim_dispatch(claim_failures, false)
+    }
+
+    fn with_enqueue_failures(enqueue_failures: usize) -> Self {
+        let mut store = Self::with_failures_and_empty_claim_dispatch(0, false);
+        store.enqueue_failures_remaining = AtomicUsize::new(enqueue_failures);
+        store
     }
 
     fn with_empty_claim_dispatch_once() -> Self {
@@ -327,6 +438,7 @@ impl SignalMailboxStore {
             signals: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             acked_count: Arc::new(AtomicUsize::new(0)),
             nacked_count: Arc::new(AtomicUsize::new(0)),
+            enqueue_failures_remaining: AtomicUsize::new(0),
             claim_failures_remaining: AtomicUsize::new(claim_failures),
             claim_dispatch_empty_once: AtomicBool::new(claim_dispatch_empty_once),
         }
@@ -344,6 +456,15 @@ impl SignalMailboxStore {
 #[async_trait::async_trait]
 impl MailboxStore for SignalMailboxStore {
     async fn enqueue(&self, dispatch: &RunDispatch) -> Result<(), StorageError> {
+        let remaining = self.enqueue_failures_remaining.load(Ordering::SeqCst);
+        if remaining > 0
+            && self
+                .enqueue_failures_remaining
+                .compare_exchange(remaining, remaining - 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+        {
+            return Err(StorageError::Io("injected enqueue failure".into()));
+        }
         self.inner.enqueue(dispatch).await?;
         self.signals.lock().await.push_back(TestDispatchSignal {
             thread_id: dispatch.thread_id.clone(),
@@ -805,7 +926,7 @@ struct NoopMailboxRuntime;
 impl RunDispatchExecutor for NoopMailboxRuntime {
     async fn run(
         &self,
-        _request: RunRequest,
+        _request: RunActivation,
         _sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
         panic!("decoupling test must not execute runs")
@@ -834,7 +955,7 @@ struct ImmediateLocalCancelRuntime;
 impl RunDispatchExecutor for ImmediateLocalCancelRuntime {
     async fn run(
         &self,
-        _request: RunRequest,
+        _request: RunActivation,
         _sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
         panic!("local cancel test must not execute runs")
@@ -872,21 +993,268 @@ impl CountingMailboxRuntime {
 impl RunDispatchExecutor for CountingMailboxRuntime {
     async fn run(
         &self,
-        request: RunRequest,
+        request: RunActivation,
         _sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
         self.run_count.fetch_add(1, Ordering::SeqCst);
         Ok(AgentRunResult {
             run_id: request
-                .continue_run_id
-                .clone()
-                .or(request.run_id_hint.clone())
-                .or(request.dispatch_id.clone())
+                .resume_run_id()
+                .map(str::to_owned)
+                .or(request.persistence.run_id_hint.clone())
+                .or(request.trace.dispatch_id.clone())
                 .unwrap_or_else(|| "counted-run".to_string()),
             response: "ok".to_string(),
             termination: TerminationReason::NaturalEnd,
             steps: 1,
         })
+    }
+
+    fn cancel(&self, _id: &str) -> bool {
+        false
+    }
+
+    async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+        false
+    }
+
+    fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+        false
+    }
+
+    fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+        false
+    }
+
+    fn live_registry_set(&self) -> Option<awaken_runtime::registry::RegistrySet> {
+        Some(empty_live_registry_set())
+    }
+}
+
+fn empty_live_registry_set() -> awaken_runtime::registry::RegistrySet {
+    use awaken_runtime::registry::{
+        MapAgentSpecRegistry, MapBackendRegistry, MapModelRegistry, MapPluginSource,
+        MapProviderRegistry, MapToolRegistry, RegistrySet,
+    };
+    RegistrySet {
+        agents: std::sync::Arc::new(MapAgentSpecRegistry::default()),
+        tools: std::sync::Arc::new(MapToolRegistry::new()),
+        models: std::sync::Arc::new(MapModelRegistry::new()),
+        providers: std::sync::Arc::new(MapProviderRegistry::new()),
+        plugins: std::sync::Arc::new(MapPluginSource::new()),
+        backends: std::sync::Arc::new(MapBackendRegistry::new()),
+    }
+}
+
+struct EmittingMailboxRuntime;
+
+#[async_trait::async_trait]
+impl RunDispatchExecutor for EmittingMailboxRuntime {
+    async fn run(
+        &self,
+        request: RunActivation,
+        sink: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        let run_id = request
+            .resume_run_id()
+            .map(str::to_owned)
+            .or(request.persistence.run_id_hint.clone())
+            .or(request.trace.dispatch_id.clone())
+            .unwrap_or_else(|| "emitting-run".to_string());
+        sink.emit(AgentEvent::RunStart {
+            thread_id: request.thread_id().to_owned(),
+            run_id: run_id.clone(),
+            parent_run_id: None,
+            identity: None,
+        })
+        .await;
+        sink.emit(AgentEvent::TextDelta {
+            delta: "live only".into(),
+        })
+        .await;
+        sink.emit(AgentEvent::ToolCallReady {
+            id: "call-1".into(),
+            name: "search".into(),
+            arguments: json!({"q": "awaken"}),
+        })
+        .await;
+        sink.emit(AgentEvent::RunFinish {
+            thread_id: request.thread_id().to_owned(),
+            run_id: run_id.clone(),
+            identity: None,
+            result: None,
+            termination: TerminationReason::NaturalEnd,
+        })
+        .await;
+        Ok(AgentRunResult {
+            run_id,
+            response: "ok".to_string(),
+            termination: TerminationReason::NaturalEnd,
+            steps: 1,
+        })
+    }
+
+    fn cancel(&self, _id: &str) -> bool {
+        false
+    }
+
+    async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+        false
+    }
+
+    fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+        false
+    }
+
+    fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+        false
+    }
+
+    fn live_registry_set(&self) -> Option<awaken_runtime::registry::RegistrySet> {
+        Some(empty_live_registry_set())
+    }
+}
+
+struct CommittingEmittingMailboxRuntime {
+    event_store: Arc<InMemoryEventStore>,
+}
+
+impl CommittingEmittingMailboxRuntime {
+    fn new(event_store: Arc<InMemoryEventStore>) -> Self {
+        Self { event_store }
+    }
+
+    async fn append_staged_events(&self, request: &RunActivation) -> Result<(), AgentLoopError> {
+        let Some(buffer) = request.capture.event_buffer.as_ref() else {
+            return Ok(());
+        };
+        for staged in buffer.drain() {
+            self.event_store
+                .append(staged.draft, staged.append_options)
+                .await
+                .map_err(|error| AgentLoopError::StorageError(error.to_string()))?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl RunDispatchExecutor for CommittingEmittingMailboxRuntime {
+    async fn run(
+        &self,
+        request: RunActivation,
+        sink: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        let run_id = request
+            .resume_run_id()
+            .map(str::to_owned)
+            .or(request.persistence.run_id_hint.clone())
+            .or(request.trace.dispatch_id.clone())
+            .unwrap_or_else(|| "emitting-run".to_string());
+        sink.emit(AgentEvent::RunStart {
+            thread_id: request.thread_id().to_owned(),
+            run_id: run_id.clone(),
+            parent_run_id: None,
+            identity: None,
+        })
+        .await;
+        sink.emit(AgentEvent::TextDelta {
+            delta: "live only".into(),
+        })
+        .await;
+        sink.emit(AgentEvent::ToolCallReady {
+            id: "call-1".into(),
+            name: "search".into(),
+            arguments: json!({"q": "awaken"}),
+        })
+        .await;
+        sink.emit(AgentEvent::RunFinish {
+            thread_id: request.thread_id().to_owned(),
+            run_id: run_id.clone(),
+            identity: None,
+            result: None,
+            termination: TerminationReason::NaturalEnd,
+        })
+        .await;
+        self.append_staged_events(&request).await?;
+        Ok(AgentRunResult {
+            run_id,
+            response: "ok".to_string(),
+            termination: TerminationReason::NaturalEnd,
+            steps: 1,
+        })
+    }
+
+    fn cancel(&self, _id: &str) -> bool {
+        false
+    }
+
+    async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+        false
+    }
+
+    fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+        false
+    }
+
+    fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+        false
+    }
+
+    fn live_registry_set(&self) -> Option<awaken_runtime::registry::RegistrySet> {
+        Some(empty_live_registry_set())
+    }
+
+    fn has_commit_coordinator(&self) -> bool {
+        true
+    }
+}
+
+struct FailingMailboxRuntime;
+
+#[async_trait::async_trait]
+impl RunDispatchExecutor for FailingMailboxRuntime {
+    async fn run(
+        &self,
+        _request: RunActivation,
+        _sink: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        Err(AgentLoopError::RuntimeError(
+            awaken_runtime::RuntimeError::AgentNotFound {
+                agent_id: "synthetic-missing-agent".into(),
+            },
+        ))
+    }
+
+    fn cancel(&self, _id: &str) -> bool {
+        false
+    }
+
+    async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+        false
+    }
+
+    fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+        false
+    }
+
+    fn send_messages(&self, _id: &str, _messages: Vec<Message>) -> bool {
+        false
+    }
+}
+
+struct TransientFailingMailboxRuntime;
+
+#[async_trait::async_trait]
+impl RunDispatchExecutor for TransientFailingMailboxRuntime {
+    async fn run(
+        &self,
+        _request: RunActivation,
+        _sink: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        Err(AgentLoopError::StorageError(
+            "synthetic transient storage failure".to_string(),
+        ))
     }
 
     fn cancel(&self, _id: &str) -> bool {
@@ -941,19 +1309,21 @@ impl BlockingMailboxRuntime {
 impl RunDispatchExecutor for BlockingMailboxRuntime {
     async fn run(
         &self,
-        request: RunRequest,
+        request: RunActivation,
         _sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
         let ordinal = self.run_count.fetch_add(1, Ordering::SeqCst) + 1;
-        let _ = self.started_tx.send((ordinal, request.dispatch_id.clone()));
+        let _ = self
+            .started_tx
+            .send((ordinal, request.trace.dispatch_id.clone()));
         if ordinal == 1 {
             self.release_first.notified().await;
         }
         let run_id = request
-            .continue_run_id
-            .clone()
-            .or(request.run_id_hint.clone())
-            .or(request.dispatch_id.clone())
+            .resume_run_id()
+            .map(str::to_owned)
+            .or(request.persistence.run_id_hint.clone())
+            .or(request.trace.dispatch_id.clone())
             .unwrap_or_else(|| format!("blocking-run-{ordinal}"));
         Ok(AgentRunResult {
             run_id,
@@ -984,22 +1354,22 @@ impl RunDispatchExecutor for BlockingMailboxRuntime {
 impl RunDispatchExecutor for RecordingMailboxRuntime {
     async fn run(
         &self,
-        request: RunRequest,
+        request: RunActivation,
         _sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
         let run_id = request
-            .continue_run_id
-            .clone()
-            .or(request.run_id_hint.clone())
+            .resume_run_id()
+            .map(str::to_owned)
+            .or(request.persistence.run_id_hint.clone())
             .unwrap_or_else(|| "recorded-run".to_string());
         self.requests
             .lock()
             .expect("lock poisoned")
             .push(RecordedMailboxRequest {
-                run_mode: request.run_mode,
-                adapter: request.adapter,
-                dispatch_id: request.dispatch_id.clone(),
-                session_id: request.session_id.clone(),
+                run_mode: request.trace.run_mode,
+                adapter: request.trace.adapter,
+                dispatch_id: request.trace.dispatch_id.clone(),
+                session_id: request.trace.session_id.clone(),
             });
         Ok(AgentRunResult {
             run_id,
@@ -1049,22 +1419,22 @@ impl RecordingStoreMailboxRuntime {
 impl RunDispatchExecutor for RecordingStoreMailboxRuntime {
     async fn run(
         &self,
-        request: RunRequest,
+        request: RunActivation,
         _sink: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
         let run_id = request
-            .continue_run_id
-            .clone()
-            .or(request.run_id_hint.clone())
+            .resume_run_id()
+            .map(str::to_owned)
+            .or(request.persistence.run_id_hint.clone())
             .unwrap_or_else(|| "recorded-run".to_string());
         self.requests
             .lock()
             .expect("lock poisoned")
             .push(RecordedStoreMailboxRequest {
-                thread_id: request.thread_id,
-                continue_run_id: request.continue_run_id,
-                run_mode: request.run_mode,
-                adapter: request.adapter,
+                thread_id: request.thread_id().to_owned(),
+                continue_run_id: request.resume_run_id().map(str::to_owned),
+                run_mode: request.trace.run_mode,
+                adapter: request.trace.adapter,
             });
         Ok(AgentRunResult {
             run_id,
@@ -1303,10 +1673,13 @@ async fn prepare_queued_dispatch(
     content: &str,
 ) -> RunDispatch {
     let mut request =
-        RunRequest::new(thread_id, vec![Message::user(content)]).with_agent_id("agent");
-    let (validated_thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false)
-            .expect("test input should validate");
+        RunActivation::new(thread_id, vec![Message::user(content)]).with_agent_id("agent");
+    let (validated_thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .expect("test input should validate");
     mailbox
         .prepare_run_for_dispatch(&mut request, &validated_thread_id, &messages)
         .await
@@ -1467,10 +1840,14 @@ async fn start_lifecycle_ready_retries_startup_recovery_until_ready() {
         MailboxConfig::default(),
     ));
 
-    let mut request = RunRequest::new("thread-retry-recover", vec![Message::user("recover")])
+    let mut request = RunActivation::new("thread-retry-recover", vec![Message::user("recover")])
         .with_agent_id("missing-agent");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -1599,10 +1976,14 @@ async fn start_lifecycle_is_idempotent_and_drop_does_not_abort_recovery() {
     let runtime = make_runtime();
     let mailbox = make_mailbox(runtime, store.clone());
 
-    let mut request = RunRequest::new("thread-drop-recover", vec![Message::user("recover")])
+    let mut request = RunActivation::new("thread-drop-recover", vec![Message::user("recover")])
         .with_agent_id("missing-agent");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -1800,10 +2181,14 @@ async fn start_lifecycle_runs_startup_recovery_for_existing_queued_dispatches() 
     let runtime = make_runtime();
     let mailbox = make_mailbox(runtime, store.clone());
 
-    let mut request = RunRequest::new("thread-recover", vec![Message::user("recover me")])
+    let mut request = RunActivation::new("thread-recover", vec![Message::user("recover me")])
         .with_agent_id("missing-agent");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -1843,10 +2228,14 @@ async fn start_lifecycle_reclaims_expired_claimed_dispatches_and_executes_them()
     let runtime = make_runtime();
     let mailbox = make_mailbox(runtime, store.clone());
 
-    let mut request = RunRequest::new("thread-stale", vec![Message::user("recover stale")])
+    let mut request = RunActivation::new("thread-stale", vec![Message::user("recover stale")])
         .with_agent_id("missing-agent");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -1905,7 +2294,7 @@ async fn dispatch_signal_loop_claims_and_executes_queued_dispatch() {
     let store = Arc::new(SignalMailboxStore::new());
     let run_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(RecordingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -1913,11 +2302,14 @@ async fn dispatch_signal_loop_claims_and_executes_queued_dispatch() {
         MailboxConfig::default(),
     ));
 
-    let mut request =
-        RunRequest::new("thread-signal-loop", vec![Message::user("wake")]).with_agent_id("agent");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false)
-            .expect("input should validate");
+    let mut request = RunActivation::new("thread-signal-loop", vec![Message::user("wake")])
+        .with_agent_id("agent");
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .expect("input should validate");
     mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -1956,7 +2348,7 @@ async fn dispatch_signal_loop_nacks_and_redelivers_after_claim_error() {
     let store = Arc::new(SignalMailboxStore::with_claim_failures(1));
     let run_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(RecordingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -1964,11 +2356,14 @@ async fn dispatch_signal_loop_nacks_and_redelivers_after_claim_error() {
         MailboxConfig::default(),
     ));
 
-    let mut request = RunRequest::new("thread-signal-redeliver", vec![Message::user("wake")])
+    let mut request = RunActivation::new("thread-signal-redeliver", vec![Message::user("wake")])
         .with_agent_id("agent");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false)
-            .expect("input should validate");
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .expect("input should validate");
     mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -2007,7 +2402,7 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
     let store = Arc::new(SignalMailboxStore::new());
     let run_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(RecordingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -2015,11 +2410,14 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
         MailboxConfig::default(),
     ));
 
-    let mut active = RunRequest::new("thread-signal-blocked", vec![Message::user("active")])
+    let mut active = RunActivation::new("thread-signal-blocked", vec![Message::user("active")])
         .with_agent_id("agent");
-    let (thread_id, active_messages) =
-        validate_run_inputs(active.thread_id.clone(), active.messages.clone(), false)
-            .expect("active input should validate");
+    let (thread_id, active_messages) = validate_run_inputs(
+        active.thread_id().to_owned(),
+        active.messages().to_vec(),
+        false,
+    )
+    .expect("active input should validate");
     mailbox
         .prepare_run_for_dispatch(&mut active, &thread_id, &active_messages)
         .await
@@ -2039,11 +2437,14 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
     assert_eq!(claimed.len(), 1);
     let active_claim_token = claimed[0].claim_token.clone().unwrap();
 
-    let mut queued = RunRequest::new("thread-signal-blocked", vec![Message::user("queued")])
+    let mut queued = RunActivation::new("thread-signal-blocked", vec![Message::user("queued")])
         .with_agent_id("agent");
-    let (_, queued_messages) =
-        validate_run_inputs(queued.thread_id.clone(), queued.messages.clone(), false)
-            .expect("queued input should validate");
+    let (_, queued_messages) = validate_run_inputs(
+        queued.thread_id().to_owned(),
+        queued.messages().to_vec(),
+        false,
+    )
+    .expect("queued input should validate");
     mailbox
         .prepare_run_for_dispatch(&mut queued, &thread_id, &queued_messages)
         .await
@@ -2112,12 +2513,12 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
 
 #[test]
 fn run_request_fields() {
-    let req = RunRequest::new("t-1", vec![Message::user("hello")]).with_agent_id("agent-a");
-    assert_eq!(req.thread_id, "t-1");
-    assert_eq!(req.agent_id.as_deref(), Some("agent-a"));
-    assert_eq!(req.messages.len(), 1);
-    assert_eq!(req.run_mode, RunMode::Foreground);
-    assert_eq!(req.adapter, AdapterKind::Internal);
+    let req = RunActivation::new("t-1", vec![Message::user("hello")]).with_agent_id("agent-a");
+    assert_eq!(req.thread_id(), "t-1");
+    assert_eq!(req.intent.agent_id.as_deref(), Some("agent-a"));
+    assert_eq!(req.messages().len(), 1);
+    assert_eq!(req.trace.run_mode, RunMode::Foreground);
+    assert_eq!(req.trace.adapter, AdapterKind::Internal);
 }
 
 #[test]
@@ -2164,7 +2565,7 @@ fn dispatch_status_enum_variants() {
 #[test]
 fn mailbox_construction_depends_on_runtime_boundary_not_agent_runtime() {
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Mailbox::new_with_executor(
+    let mailbox = Mailbox::new(
         runtime,
         make_store(),
         Arc::new(InMemoryStore::new()),
@@ -2182,7 +2583,7 @@ async fn submit_background_enqueues_dispatch() {
     let mailbox = make_mailbox(runtime, store.clone());
 
     let request =
-        RunRequest::new("thread-1", vec![Message::user("hello")]).with_agent_id("agent-1");
+        RunActivation::new("thread-1", vec![Message::user("hello")]).with_agent_id("agent-1");
     let result = mailbox.submit_background(request).await.unwrap();
 
     assert_eq!(result.thread_id, "thread-1");
@@ -2213,7 +2614,7 @@ async fn submit_background_delivers_scheduled_policy_context() {
 
     let result = mailbox
         .submit_background(
-            RunRequest::new("thread-policy-bg", vec![Message::user("hello")])
+            RunActivation::new("thread-policy-bg", vec![Message::user("hello")])
                 .with_agent_id("agent-1")
                 .with_adapter(AdapterKind::Acp),
         )
@@ -2256,18 +2657,25 @@ async fn prepare_run_for_dispatch_precreates_created_run_and_thread_projection()
         mailbox_store,
         thread_store.clone() as Arc<dyn ThreadRunStore>,
     );
-    let mut request = RunRequest::new("thread-created", vec![Message::user("plan this")])
+    let mut request = RunActivation::new("thread-created", vec![Message::user("plan this")])
         .with_agent_id("agent-created")
         .with_transport_request_id("transport-created");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
 
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
         .expect("precreate");
 
-    assert_eq!(request.run_id_hint.as_deref(), Some(run_id.as_str()));
+    assert_eq!(
+        request.persistence.run_id_hint.as_deref(),
+        Some(run_id.as_str())
+    );
     let run = thread_store
         .load_run(&run_id)
         .await
@@ -2275,14 +2683,13 @@ async fn prepare_run_for_dispatch_precreates_created_run_and_thread_projection()
         .expect("created run");
     assert_eq!(run.status, RunStatus::Created);
     assert_eq!(run.agent_id, "agent-created");
-    let request_snapshot = run.request.as_ref().unwrap();
+    let activation_snapshot = run.activation.as_ref().unwrap();
     assert!(
-        !request_snapshot.input_message_ids.is_empty(),
+        !activation_snapshot.input.trigger_message_ids.is_empty(),
         "new run snapshots should reference thread messages instead of duplicating bodies"
     );
-    assert_eq!(request_snapshot.input_message_count, 1);
     assert_eq!(
-        request_snapshot.input_message_ids,
+        activation_snapshot.input.trigger_message_ids,
         vec![messages[0].id.clone().expect("message id")]
     );
     let input = run.input.as_ref().expect("run input message range");
@@ -2294,9 +2701,10 @@ async fn prepare_run_for_dispatch_precreates_created_run_and_thread_projection()
         vec![messages[0].id.clone().expect("message id")]
     );
     assert_eq!(
-        run.request
+        run.activation
             .as_ref()
             .unwrap()
+            .trace
             .transport_request_id
             .as_deref(),
         Some("transport-created")
@@ -2309,6 +2717,56 @@ async fn prepare_run_for_dispatch_precreates_created_run_and_thread_projection()
     assert_eq!(thread.open_run_id.as_deref(), Some(run_id.as_str()));
     assert_eq!(thread.latest_run_id.as_deref(), Some(run_id.as_str()));
     assert!(thread.active_run_id.is_none());
+}
+
+#[tokio::test]
+async fn prepare_run_for_dispatch_persists_resolved_registry_manifest() {
+    let thread_store = Arc::new(InMemoryStore::new());
+    let manifest = PinnedRegistryManifest {
+        publication_id: Some("pub-1".to_string()),
+        registry_snapshot_version: Some(1),
+        entries: vec![PinnedRegistryEntry {
+            kind: "agent".to_string(),
+            id: "agent-created".to_string(),
+            version: 3,
+            content_hash: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+                .to_string(),
+        }],
+    };
+    let runtime = Arc::new(
+        AgentRuntime::new(Arc::new(StubResolver))
+            .with_in_memory_thread_run_store(thread_store.clone()),
+    );
+    runtime.set_run_resolver(Arc::new(FixedRunResolver {
+        manifest: manifest.clone(),
+    }));
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        make_store(),
+        thread_store.clone() as Arc<dyn ThreadRunStore>,
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    ));
+    let mut request = RunActivation::new("thread-manifest", vec![Message::user("plan this")])
+        .with_agent_id("agent-created");
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
+
+    let run_id = mailbox
+        .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
+        .await
+        .expect("precreate");
+
+    let run = thread_store
+        .load_run(&run_id)
+        .await
+        .expect("load run")
+        .expect("created run");
+    assert_eq!(run.registry_manifest, Some(manifest));
 }
 
 #[tokio::test]
@@ -2337,9 +2795,13 @@ async fn prepare_run_for_dispatch_inherits_previous_runtime_state() {
         make_store(),
         thread_store.clone() as Arc<dyn ThreadRunStore>,
     );
-    let mut request = RunRequest::new("thread-state", vec![Message::user("second")]);
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let mut request = RunActivation::new("thread-state", vec![Message::user("second")]);
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
 
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
@@ -2366,14 +2828,22 @@ async fn cancel_queued_dispatch_works() {
     crate::metrics::install_recorder();
     let store = make_store();
     let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
-        runtime,
-        store.clone(),
-        run_store.clone(),
-        "test-consumer".to_string(),
-        MailboxConfig::default(),
-    ));
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            store.clone(),
+            run_store.clone(),
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
 
     let result =
         enqueue_prepared_dispatch(&mailbox, store.as_ref(), "thread-cancel", "hello").await;
@@ -2394,6 +2864,21 @@ async fn cancel_queued_dispatch_works() {
     assert_eq!(run.termination_reason, Some(TerminationReason::Cancelled));
     assert_eq!(run.dispatch_id.as_deref(), Some(dispatch_id.as_str()));
 
+    let page = event_store
+        .list(EventScope::thread("thread-cancel"), None, 10)
+        .await
+        .unwrap();
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "RunCancelled")
+        .expect("queued cancel should record RunCancelled");
+    assert_eq!(
+        event.payload["dispatch_id"].as_str(),
+        Some(dispatch_id.as_str())
+    );
+    assert_eq!(event.correlation_id.as_deref(), Some(dispatch_id.as_str()));
+
     let output = crate::metrics::render().unwrap_or_default();
     assert!(output.contains("operation=\"mark_run_cancelled\""));
     assert!(output.contains("outcome=\"cancelled\""));
@@ -2406,7 +2891,7 @@ async fn list_dispatches_returns_entries() {
     let mailbox = make_mailbox(runtime, store.clone());
 
     for i in 0..3 {
-        let request = RunRequest::new("thread-list", vec![Message::user("msg")])
+        let request = RunActivation::new("thread-list", vec![Message::user("msg")])
             .with_agent_id(format!("agent-{i}"));
         mailbox.submit_background(request).await.unwrap();
     }
@@ -2659,7 +3144,7 @@ async fn build_dispatch_sets_correct_fields() {
     let mailbox = make_mailbox(runtime, store);
 
     let request =
-        RunRequest::new("thread-42", vec![Message::user("test")]).with_run_id_hint("run-42");
+        RunActivation::new("thread-42", vec![Message::user("test")]).with_run_id_hint("run-42");
     let dispatch = mailbox.build_dispatch(&request, "thread-42").unwrap();
 
     assert_eq!(dispatch.thread_id, "thread-42");
@@ -2681,7 +3166,7 @@ fn build_dispatch_requires_prepared_run_id() {
     let runtime = make_runtime();
     let mailbox = make_mailbox(runtime, store);
 
-    let request = RunRequest::new("thread-1", vec![Message::user("hi")]);
+    let request = RunActivation::new("thread-1", vec![Message::user("hi")]);
     assert!(mailbox.build_dispatch(&request, "thread-1").is_err());
 }
 
@@ -2698,28 +3183,32 @@ async fn prepare_run_preserves_request_extras_on_run_snapshot() {
         MailboxConfig::default(),
     ));
 
-    let mut request = RunRequest::new("thread-ext", vec![Message::user("hi")])
+    let mut request = RunActivation::new("thread-ext", vec![Message::user("hi")])
         .with_agent_id("a1")
         .with_frontend_tools(vec![awaken_contract::contract::tool::ToolDescriptor::new(
             "ft1", "FT1", "desc",
         )]);
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
         .unwrap();
     let run = thread_store.load_run(&run_id).await.unwrap().unwrap();
 
-    let snapshot = run.request.expect("request snapshot");
-    assert_eq!(snapshot.frontend_tools.len(), 1);
-    assert!(snapshot.request_extras.is_some());
+    let snapshot = run.activation.expect("activation snapshot");
+    assert_eq!(snapshot.options.frontend_tools.len(), 1);
+    assert!(run.request.is_none());
 }
 
 #[test]
 fn run_request_extras_serde_roundtrip() {
     use awaken_contract::contract::tool::ToolDescriptor;
-    let extras = RunRequestExtras {
+    let extras = LegacyRunSnapshotExtras {
         overrides: None,
         decisions: vec![],
         frontend_tools: vec![ToolDescriptor::new("ft1", "FT1", "desc")],
@@ -2732,7 +3221,7 @@ fn run_request_extras_serde_roundtrip() {
         adapter: AdapterKind::Acp,
     };
     let value = extras.to_value().unwrap().unwrap();
-    let parsed = RunRequestExtras::from_value(&value).unwrap();
+    let parsed = LegacyRunSnapshotExtras::from_value(&value).unwrap();
     assert_eq!(parsed.frontend_tools.len(), 1);
     assert_eq!(parsed.frontend_tools[0].id, "ft1");
     assert!(parsed.decisions.is_empty());
@@ -2743,7 +3232,7 @@ fn run_request_extras_serde_roundtrip() {
 
 #[test]
 fn run_request_extras_empty_returns_none() {
-    let extras = RunRequestExtras {
+    let extras = LegacyRunSnapshotExtras {
         overrides: None,
         decisions: vec![],
         frontend_tools: vec![],
@@ -2761,7 +3250,7 @@ fn run_request_extras_empty_returns_none() {
 #[test]
 fn run_request_extras_apply_to_request() {
     use awaken_contract::contract::tool::ToolDescriptor;
-    let extras = RunRequestExtras {
+    let extras = LegacyRunSnapshotExtras {
         overrides: None,
         decisions: vec![],
         frontend_tools: vec![ToolDescriptor::new("ft1", "FT1", "desc")],
@@ -2773,15 +3262,24 @@ fn run_request_extras_apply_to_request() {
         run_mode: RunMode::Resume,
         adapter: AdapterKind::AgUi,
     };
-    let request = RunRequest::new("t1", vec![Message::user("hi")]);
+    let request = RunActivation::new("t1", vec![Message::user("hi")]);
     let applied = extras.apply_to(request);
-    assert_eq!(applied.frontend_tools.len(), 1);
-    assert_eq!(applied.run_id_hint.as_deref(), Some("run-1"));
-    assert_eq!(applied.dispatch_id_hint.as_deref(), Some("dispatch-1"));
-    assert_eq!(applied.parent_thread_id.as_deref(), Some("parent-thread"));
-    assert_eq!(applied.transport_request_id.as_deref(), Some("transport-1"));
-    assert_eq!(applied.run_mode, RunMode::Resume);
-    assert_eq!(applied.adapter, AdapterKind::AgUi);
+    assert_eq!(applied.options.frontend_tools.len(), 1);
+    assert_eq!(applied.persistence.run_id_hint.as_deref(), Some("run-1"));
+    assert_eq!(
+        applied.persistence.dispatch_id_hint.as_deref(),
+        Some("dispatch-1")
+    );
+    assert_eq!(
+        applied.trace.parent_thread_id.as_deref(),
+        Some("parent-thread")
+    );
+    assert_eq!(
+        applied.trace.transport_request_id.as_deref(),
+        Some("transport-1")
+    );
+    assert_eq!(applied.trace.run_mode, RunMode::Resume);
+    assert_eq!(applied.trace.adapter, AdapterKind::AgUi);
 }
 
 #[tokio::test]
@@ -2801,11 +3299,15 @@ async fn prepare_run_round_trips_parent_thread_id() {
         .await
         .unwrap();
 
-    let mut request = RunRequest::new("thread-child", vec![Message::user("hi")])
+    let mut request = RunActivation::new("thread-child", vec![Message::user("hi")])
         .with_agent_id("agent")
         .with_parent_thread_id("thread-parent");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -2813,9 +3315,9 @@ async fn prepare_run_round_trips_parent_thread_id() {
     let run = thread_store.load_run(&run_id).await.unwrap().unwrap();
 
     assert_eq!(
-        run.request
+        run.activation
             .as_ref()
-            .and_then(|snapshot| snapshot.parent_thread_id.as_deref()),
+            .and_then(|snapshot| snapshot.trace.parent_thread_id.as_deref()),
         Some("thread-parent")
     );
 }
@@ -2833,20 +3335,27 @@ async fn prepare_run_preserves_origin_metadata() {
         MailboxConfig::default(),
     ));
 
-    let mut request = RunRequest::new("thread-meta", vec![Message::user("hi")])
+    let mut request = RunActivation::new("thread-meta", vec![Message::user("hi")])
         .with_agent_id("a1")
         .with_origin(RunRequestOrigin::A2A)
         .with_parent_run_id("parent-run-1");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
         .unwrap();
     let run = thread_store.load_run(&run_id).await.unwrap().unwrap();
-    let snapshot = run.request.as_ref().unwrap();
+    let snapshot = run.activation.as_ref().unwrap();
 
-    assert!(matches!(snapshot.origin, RunRequestOrigin::A2A));
+    assert!(matches!(
+        RunRequestOrigin::from(snapshot.trace.origin),
+        RunRequestOrigin::A2A
+    ));
     assert_eq!(run.parent_run_id.as_deref(), Some("parent-run-1"));
 }
 
@@ -2863,9 +3372,13 @@ async fn prepare_run_defaults_origin_to_user() {
         MailboxConfig::default(),
     ));
 
-    let mut request = RunRequest::new("thread-default", vec![Message::user("hi")]);
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let mut request = RunActivation::new("thread-default", vec![Message::user("hi")]);
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -2873,7 +3386,7 @@ async fn prepare_run_defaults_origin_to_user() {
     let run = thread_store.load_run(&run_id).await.unwrap().unwrap();
 
     assert!(matches!(
-        run.request.as_ref().unwrap().origin,
+        RunRequestOrigin::from(run.activation.as_ref().unwrap().trace.origin),
         RunRequestOrigin::User
     ));
     assert!(run.parent_run_id.is_none());
@@ -2920,7 +3433,7 @@ async fn mailbox_execution_records_dispatch_latency_metrics() {
     let mailbox_store = make_store();
     let run_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(RecordingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         run_store,
@@ -2929,7 +3442,10 @@ async fn mailbox_execution_records_dispatch_latency_metrics() {
     ));
 
     let submitted = mailbox
-        .submit_background(RunRequest::new("thread-metrics", vec![Message::user("go")]))
+        .submit_background(RunActivation::new(
+            "thread-metrics",
+            vec![Message::user("go")],
+        ))
         .await
         .expect("submit should succeed");
 
@@ -2966,7 +3482,7 @@ async fn mailbox_lease_renewal_is_wired_and_prevents_reclaim() {
         started_tx,
         Arc::clone(&release_first),
     ));
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         run_store,
@@ -2979,7 +3495,7 @@ async fn mailbox_lease_renewal_is_wired_and_prevents_reclaim() {
     ));
 
     let submitted = mailbox
-        .submit_background(RunRequest::new(
+        .submit_background(RunActivation::new(
             "thread-lease-renewal",
             vec![Message::user("go")],
         ))
@@ -3063,7 +3579,8 @@ async fn background_success_records_run_result_and_keeps_dispatch_id_separate_fr
 
     let submitted = mailbox
         .submit_background(
-            RunRequest::new("thread-run-result", vec![Message::user("go")]).with_agent_id("agent"),
+            RunActivation::new("thread-run-result", vec![Message::user("go")])
+                .with_agent_id("agent"),
         )
         .await
         .expect("submit should succeed");
@@ -3093,7 +3610,7 @@ async fn background_permanent_error_records_run_result_before_dead_letter() {
 
     let submitted = mailbox
         .submit_background(
-            RunRequest::new("thread-missing-agent", vec![Message::user("go")])
+            RunActivation::new("thread-missing-agent", vec![Message::user("go")])
                 .with_agent_id("missing-agent"),
         )
         .await
@@ -3134,7 +3651,7 @@ async fn reconstruct_failure_cleans_worker_and_dispatches_next_queued() {
     let store = make_store();
     let thread_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(RecordingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         thread_store.clone(),
@@ -3171,10 +3688,10 @@ async fn reconstruct_failure_cleans_worker_and_dispatches_next_queued() {
     store.enqueue(&missing).await.expect("enqueue missing run");
 
     let mut next_request =
-        RunRequest::new(thread_id, vec![Message::user("next")]).with_agent_id("agent");
+        RunActivation::new(thread_id, vec![Message::user("next")]).with_agent_id("agent");
     let (_, next_messages) = validate_run_inputs(
-        next_request.thread_id.clone(),
-        next_request.messages.clone(),
+        next_request.thread_id().to_owned(),
+        next_request.messages().to_vec(),
         false,
     )
     .expect("next input should validate");
@@ -3229,7 +3746,8 @@ async fn interrupt_bumps_dispatch_epoch() {
     let mailbox = make_mailbox(runtime, store.clone());
 
     // Submit some dispatches
-    let request = RunRequest::new("thread-int", vec![Message::user("a")]).with_agent_id("agent-1");
+    let request =
+        RunActivation::new("thread-int", vec![Message::user("a")]).with_agent_id("agent-1");
     mailbox.submit_background(request).await.unwrap();
 
     let result = mailbox.interrupt("thread-int").await.unwrap();
@@ -3243,7 +3761,7 @@ async fn interrupt_marks_superseded_queued_runs_cancelled() {
     let store = make_store();
     let run_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -3287,11 +3805,192 @@ async fn interrupt_marks_superseded_queued_runs_cancelled() {
 }
 
 #[tokio::test]
+async fn runtime_event_capture_records_run_interrupted_on_thread_interrupt() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(ImmediateLocalCancelRuntime);
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            mailbox_store.clone(),
+            run_store,
+            "interrupt-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+    let thread_id = "thread-interrupt-event";
+    let active_dispatch = prepare_queued_dispatch(&mailbox, thread_id, "active").await;
+    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    mailbox_store
+        .enqueue(&active_dispatch)
+        .await
+        .expect("enqueue active dispatch");
+    mailbox_store
+        .claim_dispatch(&active_dispatch_id, "interrupt-consumer", 30_000, now_ms())
+        .await
+        .expect("claim active dispatch")
+        .expect("active dispatch should be claimed");
+
+    let result = mailbox
+        .interrupt_detailed(thread_id)
+        .await
+        .expect("interrupt should succeed");
+
+    assert_eq!(
+        result
+            .active_dispatch
+            .as_ref()
+            .map(|dispatch| dispatch.dispatch_id.as_str()),
+        Some(active_dispatch_id.as_str())
+    );
+    let page = event_store
+        .list(EventScope::thread(thread_id), None, 10)
+        .await
+        .expect("list interrupted events");
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "RunInterrupted")
+        .expect("run interrupted event should be recorded");
+    assert_eq!(
+        event.run_id.as_deref(),
+        Some(active_dispatch.run_id.as_str())
+    );
+    assert_eq!(
+        event.correlation_id.as_deref(),
+        Some(active_dispatch_id.as_str())
+    );
+    assert_eq!(
+        event.payload["dispatch_id"].as_str(),
+        Some(active_dispatch_id.as_str())
+    );
+    assert_eq!(event.payload["status"].as_str(), Some("claimed"));
+}
+
+#[tokio::test]
+async fn runtime_event_capture_records_run_rescheduled_on_retry_backoff() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(TransientFailingMailboxRuntime);
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            mailbox_store.clone(),
+            run_store,
+            "retry-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+    let thread_id = "thread-reschedule-retry";
+
+    let submitted = mailbox
+        .submit_background(
+            RunActivation::new(thread_id, vec![Message::user("retry")]).with_agent_id("agent"),
+        )
+        .await
+        .expect("background submit should succeed");
+    let queued = wait_for_dispatch(&mailbox_store, &submitted.dispatch_id, |dispatch| {
+        dispatch.status == RunDispatchStatus::Queued && dispatch.attempt_count == 1
+    })
+    .await;
+
+    let page = event_store
+        .list(EventScope::thread(thread_id), None, 20)
+        .await
+        .expect("list retry reschedule events");
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "RunRescheduled")
+        .expect("transient failure retry should record reschedule");
+    assert_eq!(event.run_id.as_deref(), Some(submitted.run_id.as_str()));
+    assert_eq!(
+        event.payload["dispatch_id"].as_str(),
+        Some(submitted.dispatch_id.as_str())
+    );
+    assert_eq!(event.payload["status"].as_str(), Some("queued"));
+    assert_eq!(event.payload["reason"].as_str(), Some("retry_backoff"));
+    assert_eq!(event.payload["attempt_count"].as_u64(), Some(1));
+    assert_eq!(
+        event.payload["available_at"].as_u64(),
+        Some(queued.available_at)
+    );
+}
+
+#[tokio::test]
+async fn runtime_event_capture_records_run_rescheduled_on_expired_lease_reclaim() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(RecordingMailboxRuntime::default());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            mailbox_store.clone(),
+            run_store,
+            "reclaim-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+    let thread_id = "thread-reschedule-reclaim";
+    let mut dispatch = prepare_queued_dispatch(&mailbox, thread_id, "reclaim").await;
+    dispatch.available_at = 1_000;
+    let dispatch_id = dispatch.dispatch_id.clone();
+    mailbox_store
+        .enqueue(&dispatch)
+        .await
+        .expect("enqueue dispatch");
+    mailbox_store
+        .claim(thread_id, "stale-consumer", 100, 1_000, 1)
+        .await
+        .expect("claim dispatch before simulated lease expiry");
+
+    mailbox.run_sweep().await;
+
+    let page = event_store
+        .list(EventScope::thread(thread_id), None, 20)
+        .await
+        .expect("list reclaim reschedule events");
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "RunRescheduled")
+        .expect("lease reclaim should record reschedule");
+    assert_eq!(
+        event.payload["dispatch_id"].as_str(),
+        Some(dispatch_id.as_str())
+    );
+    assert_eq!(event.payload["status"].as_str(), Some("queued"));
+    assert_eq!(
+        event.payload["reason"].as_str(),
+        Some("expired_lease_reclaimed")
+    );
+    assert_eq!(event.payload["attempt_count"].as_u64(), Some(1));
+}
+
+#[tokio::test]
 async fn foreground_submit_marks_prior_queued_run_cancelled() {
     let store = make_store();
     let run_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(CountingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -3304,7 +4003,7 @@ async fn foreground_submit_marks_prior_queued_run_cancelled() {
 
     let (_new_result, _events) = mailbox
         .submit(
-            RunRequest::new("thread-submit-supersede", vec![Message::user("new")])
+            RunActivation::new("thread-submit-supersede", vec![Message::user("new")])
                 .with_agent_id("agent"),
         )
         .await
@@ -3339,7 +4038,7 @@ async fn submit_inline_claim_empty_cancels_precreated_run() {
     let store = Arc::new(SignalMailboxStore::with_empty_claim_dispatch_once());
     let run_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -3349,7 +4048,7 @@ async fn submit_inline_claim_empty_cancels_precreated_run() {
 
     let error = match mailbox
         .submit(
-            RunRequest::new("thread-inline-empty", vec![Message::user("go")])
+            RunActivation::new("thread-inline-empty", vec![Message::user("go")])
                 .with_agent_id("agent"),
         )
         .await
@@ -3391,7 +4090,7 @@ async fn recover_reconciles_terminal_cancelled_and_superseded_dispatches_after_c
     let store = make_store();
     let run_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -3461,7 +4160,7 @@ async fn reclaim_dead_letter_marks_run_error() {
     let store = make_store();
     let run_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -3515,7 +4214,7 @@ async fn sweep_reconciles_dead_letter_dispatch_after_crash() {
     let store = make_store();
     let run_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store.clone(),
@@ -3585,7 +4284,7 @@ async fn submit_returns_event_channel() {
     let mailbox = make_mailbox(runtime, store.clone());
 
     let request =
-        RunRequest::new("thread-stream", vec![Message::user("hi")]).with_agent_id("agent-1");
+        RunActivation::new("thread-stream", vec![Message::user("hi")]).with_agent_id("agent-1");
     let (result, _event_rx) = mailbox.submit(request).await.unwrap();
 
     assert_eq!(result.thread_id, "thread-stream");
@@ -3594,6 +4293,517 @@ async fn submit_returns_event_channel() {
         result.status,
         MailboxDispatchStatus::Running | MailboxDispatchStatus::Queued
     ));
+}
+
+#[test]
+fn runtime_event_capture_disabled_clears_prior_capture_and_skips_origin_validation() {
+    let mailbox = Mailbox::new(
+        Arc::new(CoordinatorAwareNoopRuntime),
+        make_store(),
+        Arc::new(InMemoryStore::new()),
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    )
+    .with_runtime_event_capture(RuntimeEventDurability::Compacted, "server")
+    .unwrap()
+    .with_runtime_event_capture(RuntimeEventDurability::Disabled, "")
+    .unwrap();
+
+    assert!(mailbox.runtime_event_capture.is_none());
+}
+
+#[tokio::test]
+async fn runtime_event_capture_compacted_persists_committed_events_and_keeps_live_deltas() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(CommittingEmittingMailboxRuntime::new(Arc::clone(
+                &event_store,
+            ))),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap()
+        .with_runtime_event_capture(RuntimeEventDurability::Compacted, "server")
+        .unwrap(),
+    );
+
+    let request =
+        RunActivation::new("thread-events", vec![Message::user("hi")]).with_agent_id("agent-1");
+    let (result, mut event_rx) = mailbox.submit(request).await.unwrap();
+
+    let mut live_events = Vec::new();
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("runtime should emit or close")
+            .expect("runtime should emit terminal event");
+        let terminal = event.is_terminal();
+        live_events.push(event);
+        if terminal {
+            break;
+        }
+    }
+
+    assert!(
+        live_events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::TextDelta { .. })),
+        "observed deltas should remain live in compacted mode"
+    );
+
+    let page = event_store
+        .list(EventScope::thread("thread-events"), None, 10)
+        .await
+        .unwrap();
+    let kinds = page
+        .events
+        .iter()
+        .map(|event| event.event_kind.as_str().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            "MessageCommitted",
+            "ThreadMessagesCheckpointed",
+            "RunQueued",
+            "RunSubmitted",
+            "RunStarted",
+            "ToolCallReady",
+            "RunFinished",
+        ]
+    );
+    assert!(page.events.iter().all(|event| {
+        event.thread_id.as_deref() == Some("thread-events")
+            && event.run_id.as_deref() == Some(result.run_id.as_str())
+    }));
+    assert!(page.events.iter().all(|event| {
+        matches!(
+            event.event_kind.as_str(),
+            "MessageCommitted" | "ThreadMessagesCheckpointed"
+        ) || event.correlation_id.as_deref() == Some(result.dispatch_id.as_str())
+    }));
+}
+
+#[tokio::test]
+async fn runtime_event_capture_maps_continue_run_start_to_run_resumed() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let waiting = seeded_waiting_run("run-resume", "thread-resume", "agent-1");
+    run_store.create_run(&waiting).await.unwrap();
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(CommittingEmittingMailboxRuntime::new(Arc::clone(
+                &event_store,
+            ))),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_runtime_event_capture(RuntimeEventDurability::Compacted, "server")
+        .unwrap(),
+    );
+
+    let request = RunActivation::new("thread-resume", vec![Message::user("continue")])
+        .with_agent_id("agent-1")
+        .with_continue_run_id("run-resume");
+    let (_result, mut event_rx) = mailbox.submit(request).await.unwrap();
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("runtime should emit or close")
+            .expect("runtime should emit terminal event");
+        if event.is_terminal() {
+            break;
+        }
+    }
+
+    let page = event_store
+        .list(EventScope::thread("thread-resume"), None, 10)
+        .await
+        .unwrap();
+    let kinds = page
+        .events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect::<Vec<_>>();
+    assert!(kinds.contains(&"RunResumed"));
+    assert!(!kinds.contains(&"RunStarted"));
+}
+
+#[tokio::test]
+async fn runtime_event_capture_live_forwarding_is_not_gated_by_staging() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(CommittingEmittingMailboxRuntime::new(Arc::clone(
+                &event_store,
+            ))),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_runtime_event_capture(RuntimeEventDurability::Compacted, "server")
+        .unwrap(),
+    );
+
+    let request =
+        RunActivation::new("thread-event-fail", vec![Message::user("hi")]).with_agent_id("agent-1");
+    let (_result, mut event_rx) = mailbox.submit(request).await.unwrap();
+
+    let mut forwarded_kinds = Vec::new();
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .expect("runtime should emit or close")
+            .expect("runtime should emit terminal event");
+        let terminal = event.is_terminal();
+        forwarded_kinds.push(std::mem::discriminant(&event));
+        if terminal {
+            break;
+        }
+    }
+    let run_start_kind = std::mem::discriminant(&AgentEvent::RunStart {
+        thread_id: String::new(),
+        run_id: String::new(),
+        parent_run_id: None,
+        identity: None,
+    });
+    let text_delta_kind = std::mem::discriminant(&AgentEvent::TextDelta {
+        delta: String::new(),
+    });
+    let tool_call_ready_kind = std::mem::discriminant(&AgentEvent::ToolCallReady {
+        id: String::new(),
+        name: String::new(),
+        arguments: json!({}),
+    });
+    let run_finish_kind = std::mem::discriminant(&AgentEvent::RunFinish {
+        thread_id: String::new(),
+        run_id: String::new(),
+        identity: None,
+        result: None,
+        termination: TerminationReason::NaturalEnd,
+    });
+    assert_eq!(
+        forwarded_kinds,
+        vec![
+            run_start_kind,
+            text_delta_kind,
+            tool_call_ready_kind,
+            run_finish_kind
+        ],
+        "durable staging must not suppress the live event stream"
+    );
+}
+
+#[tokio::test]
+async fn runtime_event_capture_persists_server_authored_terminal_errors() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(FailingMailboxRuntime),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+
+    let request = RunActivation::new("thread-server-error", vec![Message::user("hi")])
+        .with_agent_id("agent-1");
+    let (result, mut event_rx) = mailbox.submit(request).await.unwrap();
+    let event = tokio::time::timeout(Duration::from_secs(2), event_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(event, AgentEvent::RunFinish { .. }));
+
+    let page = event_store
+        .list(EventScope::thread("thread-server-error"), None, 10)
+        .await
+        .unwrap();
+    let kinds = page
+        .events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            "MessageCommitted",
+            "ThreadMessagesCheckpointed",
+            "RunQueued",
+            "RunSubmitted",
+            "RunErrored"
+        ]
+    );
+    let terminal = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "RunErrored")
+        .unwrap();
+    assert_eq!(
+        terminal.correlation_id.as_deref(),
+        Some(result.dispatch_id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn runtime_event_capture_records_mailbox_dispatch_lifecycle_events() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(CommittingEmittingMailboxRuntime::new(Arc::clone(
+                &event_store,
+            ))),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap()
+        .with_runtime_event_capture(RuntimeEventDurability::Compacted, "server")
+        .unwrap(),
+    );
+
+    let request = RunActivation::new("thread-mailbox-events", vec![Message::user("hi")])
+        .with_agent_id("agent-1");
+    let (result, mut event_rx) = mailbox.submit(request).await.unwrap();
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(2), event_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        if matches!(event, AgentEvent::RunFinish { .. }) {
+            break;
+        }
+    }
+
+    let page = event_store
+        .list(EventScope::thread("thread-mailbox-events"), None, 20)
+        .await
+        .unwrap();
+    let kinds = page
+        .events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            "MessageCommitted",
+            "ThreadMessagesCheckpointed",
+            "RunQueued",
+            "RunSubmitted",
+            "RunStarted",
+            "ToolCallReady",
+            "RunFinished",
+        ]
+    );
+    let queued = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "RunQueued")
+        .unwrap();
+    let committed = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "MessageCommitted")
+        .unwrap();
+    assert_eq!(committed.payload["message_seq"], 1);
+    assert_eq!(committed.payload["message_kind"], "user_input");
+    assert_eq!(
+        queued.payload["dispatch_id"].as_str(),
+        Some(result.dispatch_id.as_str())
+    );
+    assert_eq!(
+        queued.correlation_id.as_deref(),
+        Some(result.dispatch_id.as_str())
+    );
+}
+
+#[tokio::test]
+async fn runtime_event_capture_records_mailbox_submit_failed_on_enqueue_error() {
+    let mailbox_store = Arc::new(SignalMailboxStore::with_enqueue_failures(1));
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(NoopMailboxRuntime),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+
+    let error = mailbox
+        .submit_background(
+            RunActivation::new("thread-submit-failed", vec![Message::user("hi")])
+                .with_agent_id("agent-1"),
+        )
+        .await
+        .expect_err("enqueue failure should fail submit");
+    assert!(error.to_string().contains("injected enqueue failure"));
+
+    let page = event_store
+        .list(EventScope::thread("thread-submit-failed"), None, 10)
+        .await
+        .unwrap();
+    let kinds = page
+        .events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        kinds,
+        vec![
+            "MessageCommitted",
+            "ThreadMessagesCheckpointed",
+            "MailboxSubmitFailed",
+        ]
+    );
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "MailboxSubmitFailed")
+        .expect("submit failure should be recorded");
+    assert!(!event.run_id.as_deref().unwrap().trim().is_empty());
+    assert_eq!(event.payload["thread_id"], "thread-submit-failed");
+    assert_eq!(event.payload["reason"], "enqueue_failed");
+    assert!(
+        event.payload["error"]
+            .as_str()
+            .unwrap()
+            .contains("injected enqueue failure")
+    );
+}
+
+#[tokio::test]
+async fn runtime_event_capture_records_mailbox_resume_failed_on_enqueue_error() {
+    let mailbox_store = Arc::new(SignalMailboxStore::with_enqueue_failures(1));
+    let run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let thread_id = "thread-resume-failed";
+    run_store
+        .create_run(&seeded_waiting_run(
+            "run-resume-failed",
+            thread_id,
+            "agent-1",
+        ))
+        .await
+        .expect("seed waiting run");
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(NoopMailboxRuntime),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+
+    let error = mailbox
+        .submit_background(
+            RunActivation::new(thread_id, Vec::new())
+                .with_agent_id("agent-1")
+                .with_continue_run_id("run-resume-failed")
+                .with_decisions(vec![("tool-1".to_string(), make_resume())]),
+        )
+        .await
+        .expect_err("enqueue failure should fail durable resume");
+    assert!(error.to_string().contains("injected enqueue failure"));
+
+    let page = event_store
+        .list(EventScope::thread(thread_id), None, 10)
+        .await
+        .unwrap();
+    let kinds = page
+        .events
+        .iter()
+        .map(|event| event.event_kind.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(kinds, vec!["MailboxSubmitFailed", "MailboxResumeFailed"]);
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "MailboxResumeFailed")
+        .expect("resume failure should be recorded");
+    assert_eq!(event.run_id.as_deref(), Some("run-resume-failed"));
+    assert_eq!(event.payload["thread_id"], thread_id);
+    assert_eq!(event.payload["reason"], "enqueue_failed");
+    assert_eq!(event.payload["decisions"][0]["tool_call_id"], "tool-1");
+    assert_eq!(event.payload["decisions"][0]["decision_id"], "d1");
+    assert!(
+        event.payload["error"]
+            .as_str()
+            .unwrap()
+            .contains("injected enqueue failure")
+    );
+}
+
+#[tokio::test]
+async fn advisory_server_event_publish_failure_does_not_block_live_terminal_event() {
+    let mailbox_store = make_store();
+    let run_store = Arc::new(InMemoryStore::new());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(FailingMailboxRuntime),
+            mailbox_store,
+            run_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(Arc::new(FailingServerEventPublisher), "server")
+        .unwrap(),
+    );
+
+    let request = RunActivation::new("thread-server-error-fail", vec![Message::user("hi")])
+        .with_agent_id("agent-1");
+    let (_result, mut event_rx) = mailbox.submit(request).await.unwrap();
+    let next = tokio::time::timeout(Duration::from_secs(2), event_rx.recv())
+        .await
+        .expect("runtime task should finish and close the channel");
+    assert!(
+        matches!(next, Some(AgentEvent::RunFinish { .. })),
+        "advisory server-event publication failure must not suppress live terminal event"
+    );
 }
 
 #[tokio::test]
@@ -3640,7 +4850,7 @@ async fn live_then_queue_steers_active_run_without_new_dispatch() {
 
     let first = mailbox
         .submit_background(
-            RunRequest::new("thread-live-steer", vec![Message::user("start")])
+            RunActivation::new("thread-live-steer", vec![Message::user("start")])
                 .with_agent_id("agent"),
         )
         .await
@@ -3653,7 +4863,7 @@ async fn live_then_queue_steers_active_run_without_new_dispatch() {
 
     let steered = mailbox
         .submit_live_then_queue(
-            RunRequest::new("thread-live-steer", vec![Message::user("live steer")])
+            RunActivation::new("thread-live-steer", vec![Message::user("live steer")])
                 .with_agent_id("agent"),
             None,
         )
@@ -3717,7 +4927,7 @@ async fn live_then_queue_falls_back_to_durable_dispatch_when_receiver_unavailabl
     let mailbox_store = make_store();
     let thread_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -3726,10 +4936,10 @@ async fn live_then_queue_falls_back_to_durable_dispatch_when_receiver_unavailabl
     ));
     let thread_id = "thread-live-fallback";
     let mut active_request =
-        RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        RunActivation::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
     let (_, active_messages) = validate_run_inputs(
-        active_request.thread_id.clone(),
-        active_request.messages.clone(),
+        active_request.thread_id().to_owned(),
+        active_request.messages().to_vec(),
         false,
     )
     .expect("active input should validate");
@@ -3763,7 +4973,7 @@ async fn live_then_queue_falls_back_to_durable_dispatch_when_receiver_unavailabl
 
     let result = mailbox
         .submit_live_then_queue(
-            RunRequest::new(thread_id, vec![Message::user("fallback")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("fallback")]).with_agent_id("agent"),
             None,
         )
         .await
@@ -3799,21 +5009,29 @@ async fn foreground_submit_sends_live_cancel_for_remote_active_dispatch() {
 
     let mailbox_store = make_store();
     let thread_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
     let runtime = Arc::new(RecordingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
-        runtime,
-        mailbox_store.clone(),
-        thread_store.clone(),
-        "foreground-consumer".to_string(),
-        MailboxConfig::default(),
-    ));
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "foreground-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
     let thread_id = "thread-remote-foreground";
 
     let mut active_request =
-        RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        RunActivation::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
     let (_, active_messages) = validate_run_inputs(
-        active_request.thread_id.clone(),
-        active_request.messages.clone(),
+        active_request.thread_id().to_owned(),
+        active_request.messages().to_vec(),
         false,
     )
     .expect("active input should validate");
@@ -3872,7 +5090,8 @@ async fn foreground_submit_sends_live_cancel_for_remote_active_dispatch() {
 
     let (submitted, _events) = mailbox
         .submit(
-            RunRequest::new(thread_id, vec![Message::user("replacement")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("replacement")])
+                .with_agent_id("agent"),
         )
         .await
         .expect("foreground submit should cancel remote active run and claim replacement");
@@ -3886,6 +5105,25 @@ async fn foreground_submit_sends_live_cancel_for_remote_active_dispatch() {
             .any(|command| matches!(command, LiveRunCommand::Cancel)),
         "foreground submit must deliver live Cancel to the remote active run"
     );
+    drop(commands);
+
+    let page = event_store
+        .list(EventScope::thread(thread_id), None, 20)
+        .await
+        .expect("list foreground interrupt events");
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "RunInterrupted")
+        .expect("foreground submit should record the interrupted prior run");
+    assert_eq!(
+        event.payload["dispatch_id"].as_str(),
+        Some(active_dispatch_id.as_str())
+    );
+    assert_eq!(
+        event.correlation_id.as_deref(),
+        Some(active_dispatch_id.as_str())
+    );
 }
 
 #[tokio::test]
@@ -3896,7 +5134,7 @@ async fn foreground_submit_does_not_prepare_replacement_when_remote_cancel_times
     let mailbox_store = make_store();
     let thread_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(RecordingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -3906,10 +5144,10 @@ async fn foreground_submit_does_not_prepare_replacement_when_remote_cancel_times
     let thread_id = "thread-remote-cancel-timeout";
 
     let mut active_request =
-        RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        RunActivation::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
     let (_, active_messages) = validate_run_inputs(
-        active_request.thread_id.clone(),
-        active_request.messages.clone(),
+        active_request.thread_id().to_owned(),
+        active_request.messages().to_vec(),
         false,
     )
     .expect("active input should validate");
@@ -3946,7 +5184,8 @@ async fn foreground_submit_does_not_prepare_replacement_when_remote_cancel_times
 
     let result = mailbox
         .submit(
-            RunRequest::new(thread_id, vec![Message::user("replacement")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("replacement")])
+                .with_agent_id("agent"),
         )
         .await;
     assert!(
@@ -3975,21 +5214,29 @@ async fn foreground_submit_does_not_prepare_replacement_when_remote_cancel_times
 async fn foreground_submit_does_not_prepare_replacement_when_local_cancel_times_out() {
     let mailbox_store = make_store();
     let thread_store = Arc::new(InMemoryStore::new());
-    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
-        runtime,
-        mailbox_store.clone(),
-        thread_store.clone(),
-        "foreground-consumer".to_string(),
-        MailboxConfig::default(),
-    ));
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(ImmediateLocalCancelRuntime);
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            mailbox_store.clone(),
+            thread_store.clone(),
+            "foreground-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
     let thread_id = "thread-local-cancel-timeout";
 
     let mut active_request =
-        RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        RunActivation::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
     let (_, active_messages) = validate_run_inputs(
-        active_request.thread_id.clone(),
-        active_request.messages.clone(),
+        active_request.thread_id().to_owned(),
+        active_request.messages().to_vec(),
         false,
     )
     .expect("active input should validate");
@@ -4010,7 +5257,8 @@ async fn foreground_submit_does_not_prepare_replacement_when_local_cancel_times_
 
     let result = mailbox
         .submit(
-            RunRequest::new(thread_id, vec![Message::user("replacement")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("replacement")])
+                .with_agent_id("agent"),
         )
         .await;
     assert!(
@@ -4033,6 +5281,22 @@ async fn foreground_submit_does_not_prepare_replacement_when_local_cancel_times_
     assert_eq!(all.len(), 1);
     assert_eq!(all[0].dispatch_id, active_dispatch_id);
     assert_eq!(all[0].status, RunDispatchStatus::Claimed);
+
+    let page = event_store
+        .list(EventScope::thread(thread_id), None, 10)
+        .await
+        .expect("list timeout events");
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "MailboxTimeout")
+        .expect("cancel release wait timeout should be recorded");
+    assert_eq!(
+        event.payload["dispatch_id"].as_str(),
+        Some(active_dispatch_id.as_str())
+    );
+    assert_eq!(event.payload["reason"], "local_cancel_release_wait");
+    assert_eq!(event.payload["timeout_ms"], REMOTE_CANCEL_WAIT_MS);
 }
 
 #[tokio::test]
@@ -4040,7 +5304,7 @@ async fn foreground_submit_waits_for_local_cancelled_dispatch_to_release_claim()
     let mailbox_store = make_store();
     let thread_store = Arc::new(InMemoryStore::new());
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(ImmediateLocalCancelRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -4050,10 +5314,10 @@ async fn foreground_submit_waits_for_local_cancelled_dispatch_to_release_claim()
     let thread_id = "thread-local-cancel-claim-window";
 
     let mut active_request =
-        RunRequest::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
+        RunActivation::new(thread_id, vec![Message::user("active")]).with_agent_id("agent");
     let (_, active_messages) = validate_run_inputs(
-        active_request.thread_id.clone(),
-        active_request.messages.clone(),
+        active_request.thread_id().to_owned(),
+        active_request.messages().to_vec(),
         false,
     )
     .expect("active input should validate");
@@ -4074,7 +5338,8 @@ async fn foreground_submit_waits_for_local_cancelled_dispatch_to_release_claim()
 
     let result = mailbox
         .submit(
-            RunRequest::new(thread_id, vec![Message::user("replacement")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("replacement")])
+                .with_agent_id("agent"),
         )
         .await;
     assert!(
@@ -4138,7 +5403,7 @@ async fn live_then_queue_publishes_for_remote_active_run() {
     });
 
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -4148,7 +5413,8 @@ async fn live_then_queue_publishes_for_remote_active_run() {
 
     let result = mailbox
         .submit_live_then_queue(
-            RunRequest::new(thread_id, vec![Message::user("steer-remote")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("steer-remote")])
+                .with_agent_id("agent"),
             None,
         )
         .await
@@ -4205,7 +5471,7 @@ async fn live_then_queue_falls_back_when_subscriber_drops_receipt() {
     });
 
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -4215,7 +5481,7 @@ async fn live_then_queue_falls_back_when_subscriber_drops_receipt() {
 
     let result = mailbox
         .submit_live_then_queue(
-            RunRequest::new(thread_id, vec![Message::user("hello?")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("hello?")]).with_agent_id("agent"),
             None,
         )
         .await
@@ -4275,7 +5541,7 @@ async fn live_then_queue_is_at_least_once_when_ack_lost() {
     });
 
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -4285,7 +5551,8 @@ async fn live_then_queue_is_at_least_once_when_ack_lost() {
 
     let result = mailbox
         .submit_live_then_queue(
-            RunRequest::new(thread_id, vec![Message::user("steer-payload")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("steer-payload")])
+                .with_agent_id("agent"),
             None,
         )
         .await
@@ -4324,7 +5591,7 @@ async fn live_then_queue_rejects_remote_mismatched_expected_run_id() {
     thread_store.create_run(&run).await.expect("seed run");
 
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -4334,7 +5601,7 @@ async fn live_then_queue_rejects_remote_mismatched_expected_run_id() {
 
     let result = mailbox
         .submit_live_then_queue(
-            RunRequest::new(thread_id, vec![Message::user("wrong-run")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("wrong-run")]).with_agent_id("agent"),
             Some("run-stale"),
         )
         .await
@@ -4376,7 +5643,7 @@ async fn send_decision_live_delivers_to_remote_waiting_run() {
     });
 
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store,
         thread_store,
@@ -4392,6 +5659,84 @@ async fn send_decision_live_delivers_to_remote_waiting_run() {
     let captured = captured.lock().await;
     assert_eq!(captured.len(), 1);
     assert_eq!(captured[0][0].0, "tool-1");
+}
+
+#[tokio::test]
+async fn runtime_event_capture_records_mailbox_decision_received() {
+    use awaken_contract::contract::mailbox::LiveRunCommand;
+    use futures::StreamExt;
+
+    let mailbox_store = make_store();
+    let thread_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let thread_id = "thread-decision-event";
+    let run = seeded_waiting_run("run-decision-event", thread_id, "agent");
+    thread_store.create_run(&run).await.expect("seed run");
+
+    let subscriber = mailbox_store
+        .open_live_channel_for(&live_target_for_run(&run))
+        .await
+        .expect("open targeted live channel");
+    let _forwarder = tokio::spawn(async move {
+        let mut subscriber = subscriber;
+        while let Some(entry) = subscriber.next().await {
+            if matches!(entry.command, LiveRunCommand::Decision(_)) {
+                entry.receipt.ack();
+                break;
+            }
+            drop(entry.receipt);
+        }
+    });
+
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            mailbox_store,
+            thread_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+
+    let delivered = mailbox
+        .send_decision_live(thread_id, "tool-1".to_string(), make_resume())
+        .await
+        .expect("live decision should not error");
+
+    assert!(delivered);
+    let page = event_store
+        .list(EventScope::thread(thread_id), None, 10)
+        .await
+        .unwrap();
+    assert_eq!(page.events.len(), 2);
+    let event = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "MailboxDecisionReceived")
+        .expect("mailbox decision event should be recorded");
+    assert_eq!(event.event_kind.as_str(), "MailboxDecisionReceived");
+    assert_eq!(event.run_id.as_deref(), Some("run-decision-event"));
+    assert_eq!(event.payload["tool_call_id"], "tool-1");
+    assert_eq!(event.payload["decision_id"], "d1");
+    assert_eq!(event.payload["action"], "resume");
+    assert_eq!(event.payload["result"]["approved"], true);
+    assert_eq!(event.payload["delivery_path"], "remote_live");
+    let permission = page
+        .events
+        .iter()
+        .find(|event| event.event_kind.as_str() == "ToolPermissionResolved")
+        .expect("approval decision should record permission resolution");
+    assert_eq!(permission.run_id.as_deref(), Some("run-decision-event"));
+    assert_eq!(permission.payload["tool_call_id"], "tool-1");
+    assert_eq!(permission.payload["decision_id"], "d1");
+    assert_eq!(permission.payload["approved"], true);
+    assert_eq!(permission.payload["delivery_path"], "remote_live");
 }
 
 /// Cross-node live delivery when **no subscriber** is attached to the
@@ -4410,7 +5755,7 @@ async fn live_then_queue_falls_back_to_queue_when_no_remote_subscriber() {
     thread_store.create_run(&run).await.expect("seed run");
 
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         mailbox_store.clone(),
         thread_store.clone(),
@@ -4420,7 +5765,7 @@ async fn live_then_queue_falls_back_to_queue_when_no_remote_subscriber() {
 
     let result = mailbox
         .submit_live_then_queue(
-            RunRequest::new(thread_id, vec![Message::user("hello?")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("hello?")]).with_agent_id("agent"),
             None,
         )
         .await
@@ -4476,7 +5821,8 @@ async fn waiting_thread_is_reactivated_by_incoming_message() {
 
     let submitted = mailbox
         .submit_background(
-            RunRequest::new("thread-waiting", vec![Message::user("poke")]).with_agent_id("agent"),
+            RunActivation::new("thread-waiting", vec![Message::user("poke")])
+                .with_agent_id("agent"),
         )
         .await
         .expect("submit should succeed");
@@ -4530,7 +5876,7 @@ async fn structured_user_input_waiting_thread_is_reused_by_incoming_message() {
 
     let submitted = mailbox
         .submit_background(
-            RunRequest::new("thread-user-input", vec![Message::user("continue")])
+            RunActivation::new("thread-user-input", vec![Message::user("continue")])
                 .with_agent_id("agent"),
         )
         .await
@@ -4578,7 +5924,8 @@ async fn reusable_waiting_run_prefers_thread_open_run_projection_over_latest_run
 
     let submitted = mailbox
         .submit_background(
-            RunRequest::new(thread_id, vec![Message::user("continue open")]).with_agent_id("agent"),
+            RunActivation::new(thread_id, vec![Message::user("continue open")])
+                .with_agent_id("agent"),
         )
         .await
         .expect("submit should succeed");
@@ -4707,7 +6054,7 @@ async fn background_task_completion_should_enqueue_internal_wake_message() {
 
     mailbox
         .submit_background(
-            RunRequest::new("thread-bg", vec![Message::user("start")]).with_agent_id("agent"),
+            RunActivation::new("thread-bg", vec![Message::user("start")]).with_agent_id("agent"),
         )
         .await
         .expect("submit should succeed");
@@ -4778,7 +6125,7 @@ async fn concurrent_submit_background_same_thread_only_one_runs() {
     for i in 0..5 {
         let mb = Arc::clone(&mailbox);
         handles.push(tokio::spawn(async move {
-            let req = RunRequest::new("thread-conc", vec![Message::user(format!("msg-{i}"))])
+            let req = RunActivation::new("thread-conc", vec![Message::user(format!("msg-{i}"))])
                 .with_agent_id("agent-1");
             mb.submit_background(req).await
         }));
@@ -4826,7 +6173,7 @@ async fn concurrent_submit_same_thread_only_one_claims() {
     for i in 0..3 {
         let mb = Arc::clone(&mailbox);
         handles.push(tokio::spawn(async move {
-            let req = RunRequest::new(
+            let req = RunActivation::new(
                 "thread-stream-conc",
                 vec![Message::user(format!("msg-{i}"))],
             )
@@ -4867,7 +6214,7 @@ async fn interrupt_between_claim_and_execution_supersedes_without_runtime_start(
     let store = Arc::new(InterruptOnLoadMailboxStore::new());
     let run_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(CountingMailboxRuntime::default());
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime.clone(),
         store.clone(),
         run_store.clone(),
@@ -4881,7 +6228,8 @@ async fn interrupt_between_claim_and_execution_supersedes_without_runtime_start(
 
     let result = mailbox
         .submit_background(
-            RunRequest::new("thread-epoch-race", vec![Message::user("go")]).with_agent_id("agent"),
+            RunActivation::new("thread-epoch-race", vec![Message::user("go")])
+                .with_agent_id("agent"),
         )
         .await
         .expect("submit should succeed");
@@ -4942,7 +6290,7 @@ async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finis
         started_tx,
         Arc::clone(&release_first),
     ));
-    let mailbox = Arc::new(Mailbox::new_with_executor(
+    let mailbox = Arc::new(Mailbox::new(
         runtime,
         store.clone(),
         run_store,
@@ -4950,11 +6298,14 @@ async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finis
         MailboxConfig::default(),
     ));
 
-    let mut first =
-        RunRequest::new("thread-signal-busy", vec![Message::user("first")]).with_agent_id("agent");
-    let (thread_id, first_messages) =
-        validate_run_inputs(first.thread_id.clone(), first.messages.clone(), false)
-            .expect("first input should validate");
+    let mut first = RunActivation::new("thread-signal-busy", vec![Message::user("first")])
+        .with_agent_id("agent");
+    let (thread_id, first_messages) = validate_run_inputs(
+        first.thread_id().to_owned(),
+        first.messages().to_vec(),
+        false,
+    )
+    .expect("first input should validate");
     mailbox
         .prepare_run_for_dispatch(&mut first, &thread_id, &first_messages)
         .await
@@ -4965,11 +6316,14 @@ async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finis
     let first_dispatch_id = first_dispatch.dispatch_id.clone();
     store.enqueue(&first_dispatch).await.expect("enqueue first");
 
-    let mut second =
-        RunRequest::new("thread-signal-busy", vec![Message::user("second")]).with_agent_id("agent");
-    let (_, second_messages) =
-        validate_run_inputs(second.thread_id.clone(), second.messages.clone(), false)
-            .expect("second input should validate");
+    let mut second = RunActivation::new("thread-signal-busy", vec![Message::user("second")])
+        .with_agent_id("agent");
+    let (_, second_messages) = validate_run_inputs(
+        second.thread_id().to_owned(),
+        second.messages().to_vec(),
+        false,
+    )
+    .expect("second input should validate");
     mailbox
         .prepare_run_for_dispatch(&mut second, &thread_id, &second_messages)
         .await
@@ -5051,7 +6405,8 @@ async fn submit_background_returns_correct_status() {
     let mailbox = make_mailbox(runtime, store.clone());
 
     // First submit should dispatch (Running or Queued depending on timing).
-    let req1 = RunRequest::new("thread-status", vec![Message::user("a")]).with_agent_id("agent-1");
+    let req1 =
+        RunActivation::new("thread-status", vec![Message::user("a")]).with_agent_id("agent-1");
     let result1 = mailbox.submit_background(req1).await.unwrap();
     // First dispatch should be claimed/running since thread is idle.
     assert!(
@@ -5063,7 +6418,8 @@ async fn submit_background_returns_correct_status() {
     );
 
     // Second submit while first is running should be Queued.
-    let req2 = RunRequest::new("thread-status", vec![Message::user("b")]).with_agent_id("agent-1");
+    let req2 =
+        RunActivation::new("thread-status", vec![Message::user("b")]).with_agent_id("agent-1");
     let result2 = mailbox.submit_background(req2).await.unwrap();
     assert!(
         matches!(result2.status, MailboxDispatchStatus::Queued),
@@ -5078,7 +6434,7 @@ async fn worker_status_not_corrupted_after_empty_claim() {
     let mailbox = make_mailbox(runtime, store.clone());
 
     // Submit and dispatch a dispatch to get worker into Running state.
-    let req = RunRequest::new("thread-guard", vec![Message::user("a")]).with_agent_id("agent-1");
+    let req = RunActivation::new("thread-guard", vec![Message::user("a")]).with_agent_id("agent-1");
     mailbox.submit_background(req).await.unwrap();
 
     // Worker should be Running (or Claiming).
@@ -5111,7 +6467,7 @@ async fn worker_status_not_corrupted_after_empty_claim() {
 #[test]
 fn run_request_extras_corrupt_json_returns_error() {
     let corrupt = serde_json::json!({"overrides": "not-an-object", "decisions": 42});
-    let result = RunRequestExtras::from_value(&corrupt);
+    let result = LegacyRunSnapshotExtras::from_value(&corrupt);
     assert!(result.is_err(), "corrupt JSON should fail deserialization");
 }
 
@@ -5123,14 +6479,14 @@ async fn submit_inline_claim_fails_when_thread_already_claimed() {
 
     // First submit claims successfully.
     let req1 =
-        RunRequest::new("thread-clash", vec![Message::user("first")]).with_agent_id("agent-1");
+        RunActivation::new("thread-clash", vec![Message::user("first")]).with_agent_id("agent-1");
     let result1 = mailbox.submit(req1).await;
     assert!(result1.is_ok(), "first submit should succeed");
 
     // Second submit to same thread: interrupt will cancel the first,
     // but timing may allow the second to also succeed or fail gracefully.
     let req2 =
-        RunRequest::new("thread-clash", vec![Message::user("second")]).with_agent_id("agent-1");
+        RunActivation::new("thread-clash", vec![Message::user("second")]).with_agent_id("agent-1");
     let result2 = mailbox.submit(req2).await;
     // Either succeeds (interrupt cancelled old) or fails with validation error.
     // Crucially: no panic, no double-claimed state.
@@ -5217,10 +6573,10 @@ async fn build_dispatch_extras_roundtrip_with_decisions() {
         },
     )];
 
-    let request = RunRequest::new("thread-dec", vec![Message::user("hi")])
+    let request = RunActivation::new("thread-dec", vec![Message::user("hi")])
         .with_agent_id("a1")
         .with_decisions(decisions.clone());
-    let extras = RunRequestExtras::from_request(&request);
+    let extras = LegacyRunSnapshotExtras::from_request(&request);
     assert_eq!(extras.decisions.len(), 1);
     assert_eq!(extras.decisions[0].0, "call-1");
 }
@@ -5238,11 +6594,15 @@ async fn prepare_run_origin_a2a_roundtrip() {
         MailboxConfig::default(),
     ));
 
-    let mut request = RunRequest::new("thread-a2a", vec![Message::user("hi")])
+    let mut request = RunActivation::new("thread-a2a", vec![Message::user("hi")])
         .with_origin(RunRequestOrigin::A2A)
         .with_parent_run_id("parent-123");
-    let (thread_id, messages) =
-        validate_run_inputs(request.thread_id.clone(), request.messages.clone(), false).unwrap();
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .unwrap();
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
         .await
@@ -5250,7 +6610,7 @@ async fn prepare_run_origin_a2a_roundtrip() {
     let run = thread_store.load_run(&run_id).await.unwrap().unwrap();
 
     assert!(matches!(
-        run.request.as_ref().unwrap().origin,
+        RunRequestOrigin::from(run.activation.as_ref().unwrap().trace.origin),
         RunRequestOrigin::A2A
     ));
     assert_eq!(run.parent_run_id.as_deref(), Some("parent-123"));
@@ -5364,7 +6724,7 @@ async fn gc_idle_workers_keeps_worker_with_queued_dispatches() {
 
     // Enqueue a dispatch for the thread (background so it goes to store).
     let request =
-        RunRequest::new("thread-gc-keep", vec![Message::user("hi")]).with_agent_id("agent-1");
+        RunActivation::new("thread-gc-keep", vec![Message::user("hi")]).with_agent_id("agent-1");
     mailbox.submit_background(request).await.unwrap();
 
     // Force the worker to Idle status (simulating it finished one dispatch
@@ -5459,7 +6819,7 @@ fn make_waiting_run_record(run_id: &str, thread_id: &str) -> RunRecord {
 fn make_noop_mailbox(thread_store: Arc<InMemoryStore>) -> Arc<Mailbox> {
     let mailbox_store = make_store();
     let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
-    Arc::new(Mailbox::new_with_executor(
+    Arc::new(Mailbox::new(
         runtime,
         mailbox_store,
         thread_store,
@@ -5520,8 +6880,8 @@ async fn thread_context_cache_updated_after_prepare_checkpoint() {
 
     // Prepare a new dispatch — this should update the cache.
     let mut request =
-        RunRequest::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
-    let msgs = request.messages.clone();
+        RunActivation::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
+    let msgs = request.messages().to_vec();
     mailbox
         .prepare_run_for_dispatch(&mut request, thread_id, &msgs)
         .await
@@ -5549,8 +6909,8 @@ async fn prepare_run_falls_back_to_store_without_cache() {
 
     // No cache — should fall back to store.
     let mut request =
-        RunRequest::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
-    let msgs = request.messages.clone();
+        RunActivation::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
+    let msgs = request.messages().to_vec();
     let run_id = mailbox
         .prepare_run_for_dispatch(&mut request, thread_id, &msgs)
         .await
@@ -5600,8 +6960,8 @@ async fn prepare_run_uses_durable_messages_when_active_cache_is_stale() {
         .unwrap();
 
     let mut request =
-        RunRequest::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
-    let msgs = request.messages.clone();
+        RunActivation::new(thread_id, vec![Message::user("second")]).with_agent_id("agent");
+    let msgs = request.messages().to_vec();
     mailbox
         .prepare_run_for_dispatch(&mut request, thread_id, &msgs)
         .await
@@ -5743,4 +7103,139 @@ async fn reusable_waiting_run_id_returns_none_for_done_cached_run() {
 
     let result = mailbox.reusable_waiting_run_id(thread_id).await;
     assert_eq!(result, None, "Done run should not be reusable");
+}
+
+// ── ADR-0036 D9 mailbox dispatch wiring ─────────────────────────────
+
+struct CoordinatorAwareNoopRuntime;
+
+#[async_trait]
+impl RunDispatchExecutor for CoordinatorAwareNoopRuntime {
+    async fn run(
+        &self,
+        _request: RunActivation,
+        _sink: Arc<dyn EventSink>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
+        panic!("wiring test must not execute runs")
+    }
+    fn cancel(&self, _id: &str) -> bool {
+        false
+    }
+    async fn cancel_and_wait_by_thread(&self, _thread_id: &str) -> bool {
+        false
+    }
+    fn send_decision(&self, _id: &str, _tool_call_id: String, _resume: ToolCallResume) -> bool {
+        false
+    }
+    fn has_commit_coordinator(&self) -> bool {
+        true
+    }
+}
+
+fn sample_dispatch(thread_id: &str, run_id: &str, dispatch_id: &str) -> RunDispatch {
+    let now = now_ms();
+    RunDispatch {
+        dispatch_id: dispatch_id.to_string(),
+        thread_id: thread_id.to_string(),
+        run_id: run_id.to_string(),
+        priority: 0,
+        dedupe_key: None,
+        dispatch_epoch: 0,
+        status: RunDispatchStatus::Queued,
+        available_at: now,
+        attempt_count: 0,
+        max_attempts: 3,
+        last_error: None,
+        claim_token: None,
+        claimed_by: None,
+        lease_until: None,
+        dispatch_instance_id: None,
+        run_status: None,
+        termination: None,
+        run_response: None,
+        run_error: None,
+        completed_at: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+/// ADR-0036 D9: when a per-run `EventBuffer` is supplied to
+/// `wrap_dispatch_runtime_event_sink`, durable events stage into the buffer
+/// (atomic-commit path) and are NOT inline-appended to the canonical writer.
+#[tokio::test]
+async fn wrap_dispatch_with_buffer_stages_into_buffer_not_writer() {
+    use crate::transport::channel_sink::ReconnectableEventSink;
+    use awaken_runtime::EventBuffer;
+
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let mailbox_store = make_store();
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(CoordinatorAwareNoopRuntime);
+    let mailbox = Arc::new(
+        Mailbox::new(
+            runtime,
+            mailbox_store,
+            thread_store,
+            "c".into(),
+            MailboxConfig::default(),
+        )
+        .with_runtime_event_capture(RuntimeEventDurability::Compacted, "test")
+        .unwrap(),
+    );
+
+    let dispatch = sample_dispatch("t-buf", "r-buf", "d-buf");
+    let (tx, _rx) = mpsc::channel::<AgentEvent>(16);
+    let reconnectable = Arc::new(ReconnectableEventSink::new(tx));
+    let buffer = Arc::new(EventBuffer::new());
+
+    let wrapped = mailbox.wrap_dispatch_runtime_event_sink(
+        reconnectable,
+        &dispatch,
+        "d-buf".into(),
+        false,
+        Some(Arc::clone(&buffer)),
+    );
+
+    wrapped
+        .emit(AgentEvent::ToolCallReady {
+            id: "c1".into(),
+            name: "search".into(),
+            arguments: json!({"q": "x"}),
+        })
+        .await;
+
+    assert_eq!(
+        buffer.len(),
+        1,
+        "durable draft must stage into the per-run buffer"
+    );
+    let writer_count = event_store.count(EventScope::run("r-buf")).await.unwrap();
+    assert_eq!(
+        writer_count, 0,
+        "buffered path must not write to canonical writer inline"
+    );
+}
+
+#[test]
+fn runtime_event_capture_requires_commit_coordinator() {
+    let mailbox_store = make_store();
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(NoopMailboxRuntime);
+    let result = Mailbox::new(
+        runtime,
+        mailbox_store,
+        thread_store,
+        "c".into(),
+        MailboxConfig::default(),
+    )
+    .with_runtime_event_capture(RuntimeEventDurability::Compacted, "test");
+    let error = match result {
+        Ok(_) => panic!("capture without a coordinator must be rejected"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.to_string(),
+        "validation error: runtime event capture requires an executor with CommitCoordinator"
+    );
 }

--- a/crates/awaken-server/src/mailbox/tests.rs
+++ b/crates/awaken-server/src/mailbox/tests.rs
@@ -6079,6 +6079,102 @@ async fn recover_reconstructs_dispatch_for_prepared_run_missing_wal() {
 }
 
 #[tokio::test]
+async fn recover_reconstructs_dispatch_for_prepared_waiting_resume_missing_wal() {
+    let store = Arc::new(InMemoryStore::new());
+    let mailbox_store = make_store();
+    let runtime = Arc::new(RecordingStoreMailboxRuntime::new(store.clone()));
+    let mailbox = Arc::new(Mailbox::new(
+        runtime,
+        mailbox_store.clone(),
+        store.clone(),
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    ));
+    let mut waiting = seeded_waiting_run("run-waiting-crash", "thread-waiting-crash", "agent");
+    waiting.waiting = Some(RunWaitingState {
+        reason: WaitingReason::UserInput,
+        ticket_ids: Vec::new(),
+        tickets: Vec::new(),
+        since_dispatch_id: None,
+        message: Some("waiting for user input".to_string()),
+    });
+    store.create_run(&waiting).await.expect("seed waiting run");
+
+    let mut request = RunActivation::new("thread-waiting-crash", vec![Message::user("resume")])
+        .with_agent_id("agent")
+        .with_continue_run_id("run-waiting-crash");
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .expect("valid request");
+    mailbox
+        .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
+        .await
+        .expect("prepare waiting resume");
+    let dispatch_id = request
+        .persistence
+        .dispatch_id_hint
+        .clone()
+        .expect("prepare assigns dispatch id");
+
+    let recovered = mailbox.recover().await.expect("recover waiting resume");
+    assert_eq!(recovered, 1);
+    let dispatch = mailbox_store
+        .load_dispatch(&dispatch_id)
+        .await
+        .expect("load reconstructed dispatch")
+        .expect("dispatch reconstructed");
+    assert_eq!(dispatch.run_id, "run-waiting-crash");
+    assert_eq!(dispatch.thread_id, "thread-waiting-crash");
+}
+
+#[tokio::test]
+async fn recover_prepared_runs_collects_before_enqueue_to_avoid_offset_skips() {
+    let store = Arc::new(InMemoryStore::new());
+    let mailbox_store = make_store();
+    let runtime = Arc::new(RecordingStoreMailboxRuntime::new(store.clone()));
+    let mailbox = Arc::new(Mailbox::new(
+        runtime,
+        mailbox_store.clone(),
+        store.clone(),
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    ));
+    let thread_ids = (0..250)
+        .map(|idx| format!("thread-prepared-page-{idx}"))
+        .collect::<Vec<_>>();
+    for (idx, thread_id) in thread_ids.iter().enumerate() {
+        let mut run = make_run_record(
+            &format!("run-prepared-page-{idx}"),
+            thread_id,
+            RunStatus::Created,
+        );
+        run.dispatch_id = Some(format!("dispatch-prepared-page-{idx}"));
+        store.create_run(&run).await.expect("seed prepared run");
+    }
+
+    let recovered = mailbox
+        .recover_prepared_runs_missing_dispatch_wal(&thread_ids)
+        .await
+        .expect("recover prepared runs");
+    assert_eq!(recovered, thread_ids.len());
+
+    for idx in 0..thread_ids.len() {
+        let dispatch_id = format!("dispatch-prepared-page-{idx}");
+        assert!(
+            mailbox_store
+                .load_dispatch(&dispatch_id)
+                .await
+                .expect("load dispatch")
+                .is_some(),
+            "missing reconstructed dispatch {dispatch_id}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn background_task_completion_should_enqueue_internal_wake_message() {
     let store = Arc::new(InMemoryStore::new());
     let mailbox_store = make_store();

--- a/crates/awaken-server/src/mailbox/tests.rs
+++ b/crates/awaken-server/src/mailbox/tests.rs
@@ -4129,7 +4129,10 @@ async fn recover_reconciles_terminal_cancelled_and_superseded_dispatches_after_c
             .unwrap()
             .expect("prepared run should exist before reconciliation");
         assert_eq!(before.status, RunStatus::Created);
-        assert!(before.dispatch_id.is_none());
+        assert_eq!(
+            before.dispatch_id.as_deref(),
+            Some(submitted.dispatch_id.as_str())
+        );
     }
 
     let recovered = mailbox.recover().await.expect("recover should reconcile");
@@ -6011,6 +6014,68 @@ async fn recover_only_enqueues_orphaned_background_task_waiting_runs() {
         user_dispatches.is_empty(),
         "user-input waiting runs must stay suspended until explicit input"
     );
+}
+
+#[tokio::test]
+async fn recover_reconstructs_dispatch_for_prepared_run_missing_wal() {
+    let store = Arc::new(InMemoryStore::new());
+    let mailbox_store = make_store();
+    let runtime = Arc::new(RecordingStoreMailboxRuntime::new(store.clone()));
+    let mailbox = Arc::new(Mailbox::new(
+        runtime.clone(),
+        mailbox_store.clone(),
+        store.clone(),
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    ));
+    let mut request =
+        RunActivation::new("thread-prepared-crash", vec![Message::user("recover me")])
+            .with_agent_id("agent");
+    let (thread_id, messages) = validate_run_inputs(
+        request.thread_id().to_owned(),
+        request.messages().to_vec(),
+        false,
+    )
+    .expect("valid request");
+    let run_id = mailbox
+        .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
+        .await
+        .expect("prepare durable run");
+    let dispatch_id = request
+        .persistence
+        .dispatch_id_hint
+        .clone()
+        .expect("prepare assigns dispatch id");
+    assert!(
+        mailbox_store
+            .load_dispatch(&dispatch_id)
+            .await
+            .expect("load dispatch")
+            .is_none(),
+        "test simulates crash before dispatch WAL enqueue"
+    );
+
+    let recovered = mailbox
+        .recover()
+        .await
+        .expect("recover should reconcile WAL");
+    assert_eq!(recovered, 1);
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        if !runtime.requests.lock().expect("lock poisoned").is_empty() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "recovered dispatch did not run");
+        sleep(Duration::from_millis(5)).await;
+    }
+    let dispatch = mailbox_store
+        .load_dispatch(&dispatch_id)
+        .await
+        .expect("load reconstructed dispatch")
+        .expect("dispatch reconstructed");
+    assert_eq!(dispatch.run_id, run_id);
+    assert_eq!(dispatch.thread_id, "thread-prepared-crash");
 }
 
 #[tokio::test]

--- a/crates/awaken-server/src/outbox_relay.rs
+++ b/crates/awaken-server/src/outbox_relay.rs
@@ -1,0 +1,296 @@
+//! Generic at-least-once outbox relay.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::outbox::{
+    OutboxError, OutboxMessage, OutboxNackOutcome, OutboxStore,
+};
+use awaken_contract::now_ms;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum OutboxRelayError {
+    #[error("validation error: {0}")]
+    Validation(String),
+    #[error("delivery error: {0}")]
+    Delivery(String),
+    #[error(transparent)]
+    Store(#[from] OutboxError),
+}
+
+#[async_trait]
+pub trait OutboxRelayHandler: Send + Sync {
+    async fn deliver(&self, message: &OutboxMessage) -> Result<(), OutboxRelayError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboxRelayConfig {
+    pub lane: String,
+    pub target: String,
+    pub consumer_id: String,
+    pub batch_limit: usize,
+    pub lease_ms: u64,
+    pub retry_delay_ms: u64,
+    pub max_retry_delay_ms: u64,
+}
+
+impl OutboxRelayConfig {
+    pub fn validate(&self) -> Result<(), OutboxRelayError> {
+        reject_blank("lane", &self.lane)?;
+        reject_blank("target", &self.target)?;
+        reject_blank("consumer_id", &self.consumer_id)?;
+        if self.batch_limit == 0 {
+            return Err(OutboxRelayError::Validation(
+                "batch_limit must be greater than zero".to_string(),
+            ));
+        }
+        if self.lease_ms == 0 {
+            return Err(OutboxRelayError::Validation(
+                "lease_ms must be greater than zero".to_string(),
+            ));
+        }
+        if self.max_retry_delay_ms < self.retry_delay_ms {
+            return Err(OutboxRelayError::Validation(
+                "max_retry_delay_ms must be >= retry_delay_ms".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct OutboxRelayTick {
+    pub claimed: usize,
+    pub delivered: usize,
+    pub requeued: usize,
+    pub dead_lettered: usize,
+    pub lost_claims: usize,
+}
+
+pub struct OutboxRelay {
+    store: Arc<dyn OutboxStore>,
+    handler: Arc<dyn OutboxRelayHandler>,
+    config: OutboxRelayConfig,
+}
+
+impl OutboxRelay {
+    pub fn new(
+        store: Arc<dyn OutboxStore>,
+        handler: Arc<dyn OutboxRelayHandler>,
+        config: OutboxRelayConfig,
+    ) -> Result<Self, OutboxRelayError> {
+        config.validate()?;
+        Ok(Self {
+            store,
+            handler,
+            config,
+        })
+    }
+
+    pub async fn tick(&self) -> Result<OutboxRelayTick, OutboxRelayError> {
+        let now = now_ms();
+        let claimed = self
+            .store
+            .claim_outbox(
+                &self.config.lane,
+                &self.config.target,
+                self.config.batch_limit,
+                self.config.lease_ms,
+                &self.config.consumer_id,
+                now,
+            )
+            .await?;
+        let mut stats = OutboxRelayTick {
+            claimed: claimed.len(),
+            ..OutboxRelayTick::default()
+        };
+
+        for message in claimed {
+            let Some(claim_token) = message.claim_token.as_deref() else {
+                stats.lost_claims += 1;
+                continue;
+            };
+            match self.handler.deliver(&message).await {
+                Ok(()) => {
+                    if self
+                        .store
+                        .ack_outbox(&message.outbox_id, claim_token, now_ms())
+                        .await?
+                    {
+                        stats.delivered += 1;
+                    } else {
+                        stats.lost_claims += 1;
+                    }
+                }
+                Err(error) => {
+                    let retry_at = retry_at_ms(
+                        now_ms(),
+                        message.attempt_count,
+                        self.config.retry_delay_ms,
+                        self.config.max_retry_delay_ms,
+                    );
+                    match self
+                        .store
+                        .nack_outbox(
+                            &message.outbox_id,
+                            claim_token,
+                            &error.to_string(),
+                            retry_at,
+                            now_ms(),
+                        )
+                        .await?
+                    {
+                        OutboxNackOutcome::Requeued => stats.requeued += 1,
+                        OutboxNackOutcome::DeadLettered => stats.dead_lettered += 1,
+                        OutboxNackOutcome::LostClaim => stats.lost_claims += 1,
+                    }
+                }
+            }
+        }
+        Ok(stats)
+    }
+}
+
+fn retry_at_ms(now: u64, attempt_count: u32, base_delay_ms: u64, max_delay_ms: u64) -> u64 {
+    let exponent = attempt_count.saturating_sub(1).min(31);
+    let multiplier = 1u64.checked_shl(exponent).unwrap_or(u64::MAX);
+    let delay = base_delay_ms.saturating_mul(multiplier).min(max_delay_ms);
+    now.saturating_add(delay)
+}
+
+fn reject_blank(field: &str, value: &str) -> Result<(), OutboxRelayError> {
+    if value.trim().is_empty() {
+        return Err(OutboxRelayError::Validation(format!("{field} is required")));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::outbox::{OutboxMessageDraft, OutboxStatus, OutboxStore};
+    use awaken_stores::InMemoryOutboxStore;
+    use parking_lot::Mutex;
+    use serde_json::json;
+
+    #[derive(Default)]
+    struct RecordingHandler {
+        delivered: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl OutboxRelayHandler for RecordingHandler {
+        async fn deliver(&self, message: &OutboxMessage) -> Result<(), OutboxRelayError> {
+            self.delivered.lock().push(message.outbox_id.clone());
+            Ok(())
+        }
+    }
+
+    struct FailingHandler;
+
+    #[async_trait]
+    impl OutboxRelayHandler for FailingHandler {
+        async fn deliver(&self, _message: &OutboxMessage) -> Result<(), OutboxRelayError> {
+            Err(OutboxRelayError::Delivery("publish failed".to_string()))
+        }
+    }
+
+    fn config() -> OutboxRelayConfig {
+        OutboxRelayConfig {
+            lane: "canonical".to_string(),
+            target: "projector".to_string(),
+            consumer_id: "relay-a".to_string(),
+            batch_limit: 10,
+            lease_ms: 1_000,
+            retry_delay_ms: 0,
+            max_retry_delay_ms: 0,
+        }
+    }
+
+    fn draft(value: i64) -> OutboxMessageDraft {
+        OutboxMessageDraft::new("canonical", "projector", json!({ "value": value })).unwrap()
+    }
+
+    #[tokio::test]
+    async fn tick_delivers_and_acks_claimed_messages() {
+        let store = Arc::new(InMemoryOutboxStore::new());
+        store.enqueue_outbox(draft(1)).await.unwrap();
+        store.enqueue_outbox(draft(2)).await.unwrap();
+        let handler = Arc::new(RecordingHandler::default());
+        let relay = OutboxRelay::new(store.clone(), handler.clone(), config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.claimed, 2);
+        assert_eq!(stats.delivered, 2);
+        assert_eq!(handler.delivered.lock().len(), 2);
+        let delivered = store
+            .list_outbox(Some(OutboxStatus::Delivered), 10)
+            .await
+            .unwrap();
+        assert_eq!(delivered.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn tick_nacks_failures_and_dead_letters_after_max_attempts() {
+        let store = Arc::new(InMemoryOutboxStore::new());
+        let mut message = draft(1);
+        message.max_attempts = 2;
+        store.enqueue_outbox(message).await.unwrap();
+        let relay = OutboxRelay::new(store.clone(), Arc::new(FailingHandler), config()).unwrap();
+
+        let first = relay.tick().await.unwrap();
+        assert_eq!(first.requeued, 1);
+        let second = relay.tick().await.unwrap();
+        assert_eq!(second.dead_lettered, 1);
+
+        let dead = store
+            .list_outbox(Some(OutboxStatus::DeadLetter), 10)
+            .await
+            .unwrap();
+        assert_eq!(dead.len(), 1);
+        assert!(
+            dead[0]
+                .last_error
+                .as_deref()
+                .unwrap()
+                .contains("publish failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn tick_respects_configured_lane_and_target() {
+        let store = Arc::new(InMemoryOutboxStore::new());
+        store
+            .enqueue_outbox(
+                OutboxMessageDraft::new("other", "projector", json!({ "value": 1 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        let handler = Arc::new(RecordingHandler::default());
+        let relay = OutboxRelay::new(store, handler.clone(), config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.claimed, 0);
+        assert!(handler.delivered.lock().is_empty());
+    }
+
+    #[test]
+    fn relay_config_rejects_invalid_claim_parameters() {
+        let mut invalid = config();
+        invalid.batch_limit = 0;
+        let err = invalid.validate().unwrap_err();
+        assert!(
+            matches!(err, OutboxRelayError::Validation(message) if message.contains("batch_limit"))
+        );
+    }
+
+    #[test]
+    fn retry_delay_backs_off_and_caps() {
+        assert_eq!(retry_at_ms(10, 1, 5, 20), 15);
+        assert_eq!(retry_at_ms(10, 2, 5, 20), 20);
+        assert_eq!(retry_at_ms(10, 4, 5, 20), 30);
+    }
+}

--- a/crates/awaken-server/src/protocol_fanout.rs
+++ b/crates/awaken-server/src/protocol_fanout.rs
@@ -1,0 +1,371 @@
+//! Protocol replay outbox fanout relay.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_contract::contract::outbox::{
+    OUTBOX_LANE_PROTOCOL_REPLAY, OUTBOX_TARGET_PROTOCOL_FANOUT, OutboxMessage,
+};
+use awaken_contract::contract::protocol_replay_log::{
+    ProtocolReplayId, ProtocolReplayLookup, ProtocolReplayRecord,
+};
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::outbox_relay::{OutboxRelayError, OutboxRelayHandler};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolReplayFanoutNotification {
+    pub protocol_replay_id: ProtocolReplayId,
+    pub protocol: String,
+    pub protocol_version: String,
+    pub wire_event_id: String,
+}
+
+impl ProtocolReplayFanoutNotification {
+    pub fn from_outbox_message(message: &OutboxMessage) -> Result<Self, OutboxRelayError> {
+        validate_protocol_fanout_route(message)?;
+        let payload: ProtocolReplayFanoutPayload = serde_json::from_value(message.payload.clone())
+            .map_err(|error| OutboxRelayError::Validation(error.to_string()))?;
+        let notification = Self {
+            protocol_replay_id: ProtocolReplayId::new(payload.protocol_replay_id)
+                .map_err(|error| OutboxRelayError::Validation(error.to_string()))?,
+            protocol: payload.protocol,
+            protocol_version: payload.protocol_version,
+            wire_event_id: payload.wire_event_id,
+        };
+        notification.validate()?;
+        Ok(notification)
+    }
+
+    fn validate(&self) -> Result<(), OutboxRelayError> {
+        reject_blank("protocol", &self.protocol)?;
+        reject_blank("protocol_version", &self.protocol_version)?;
+        reject_blank("wire_event_id", &self.wire_event_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProtocolReplayFanoutMessage {
+    pub outbox_id: String,
+    pub notification: ProtocolReplayFanoutNotification,
+    pub record: ProtocolReplayRecord,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ProtocolReplayFanoutError {
+    #[error("publish failed: {0}")]
+    Publish(String),
+}
+
+#[async_trait]
+pub trait ProtocolReplayFanoutPublisher: Send + Sync {
+    async fn publish(
+        &self,
+        message: ProtocolReplayFanoutMessage,
+    ) -> Result<(), ProtocolReplayFanoutError>;
+}
+
+pub struct ProtocolReplayFanoutRelayHandler {
+    replay_lookup: Arc<dyn ProtocolReplayLookup>,
+    publisher: Arc<dyn ProtocolReplayFanoutPublisher>,
+}
+
+impl ProtocolReplayFanoutRelayHandler {
+    #[must_use]
+    pub fn new(
+        replay_lookup: Arc<dyn ProtocolReplayLookup>,
+        publisher: Arc<dyn ProtocolReplayFanoutPublisher>,
+    ) -> Self {
+        Self {
+            replay_lookup,
+            publisher,
+        }
+    }
+}
+
+#[async_trait]
+impl OutboxRelayHandler for ProtocolReplayFanoutRelayHandler {
+    async fn deliver(&self, message: &OutboxMessage) -> Result<(), OutboxRelayError> {
+        let notification = ProtocolReplayFanoutNotification::from_outbox_message(message)?;
+        let record = self
+            .replay_lookup
+            .load_replay(&notification.protocol_replay_id)
+            .await
+            .map_err(|error| {
+                OutboxRelayError::Delivery(format!("protocol replay lookup failed: {error}"))
+            })?
+            .ok_or_else(|| {
+                OutboxRelayError::Delivery(format!(
+                    "protocol replay row not found: {}",
+                    notification.protocol_replay_id.as_str()
+                ))
+            })?;
+        validate_notification_matches_record(&notification, &record)?;
+        self.publisher
+            .publish(ProtocolReplayFanoutMessage {
+                outbox_id: message.outbox_id.clone(),
+                notification,
+                record,
+            })
+            .await
+            .map_err(|error| OutboxRelayError::Delivery(error.to_string()))
+    }
+}
+
+#[derive(Deserialize)]
+struct ProtocolReplayFanoutPayload {
+    protocol_replay_id: String,
+    protocol: String,
+    protocol_version: String,
+    wire_event_id: String,
+}
+
+fn validate_protocol_fanout_route(message: &OutboxMessage) -> Result<(), OutboxRelayError> {
+    if message.lane == OUTBOX_LANE_PROTOCOL_REPLAY
+        && message.target == OUTBOX_TARGET_PROTOCOL_FANOUT
+    {
+        return Ok(());
+    }
+    Err(OutboxRelayError::Validation(format!(
+        "unexpected outbox message route: lane={}, target={}",
+        message.lane, message.target
+    )))
+}
+
+fn validate_notification_matches_record(
+    notification: &ProtocolReplayFanoutNotification,
+    record: &ProtocolReplayRecord,
+) -> Result<(), OutboxRelayError> {
+    if notification.protocol == record.protocol
+        && notification.protocol_version == record.protocol_version
+        && notification.wire_event_id == record.wire_event_id
+    {
+        return Ok(());
+    }
+    Err(OutboxRelayError::Validation(format!(
+        "protocol replay fanout payload does not match row: {}",
+        notification.protocol_replay_id.as_str()
+    )))
+}
+
+fn reject_blank(field: &str, value: &str) -> Result<(), OutboxRelayError> {
+    if value.trim().is_empty() {
+        return Err(OutboxRelayError::Validation(format!("{field} is required")));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::outbox::{OutboxMessageDraft, OutboxStatus, OutboxStore};
+    use awaken_contract::contract::protocol_replay_log::{
+        ProtocolReplayDraft, ProtocolReplayWriter,
+    };
+    use awaken_stores::{InMemoryOutboxStore, InMemoryProtocolReplayLog};
+    use parking_lot::Mutex;
+    use serde_json::json;
+
+    use crate::outbox_relay::{OutboxRelay, OutboxRelayConfig};
+    use crate::protocol_projector::{AI_SDK_PROTOCOL, AI_SDK_PROTOCOL_VERSION};
+
+    #[derive(Default)]
+    struct RecordingPublisher {
+        messages: Mutex<Vec<ProtocolReplayFanoutMessage>>,
+    }
+
+    #[async_trait]
+    impl ProtocolReplayFanoutPublisher for RecordingPublisher {
+        async fn publish(
+            &self,
+            message: ProtocolReplayFanoutMessage,
+        ) -> Result<(), ProtocolReplayFanoutError> {
+            self.messages.lock().push(message);
+            Ok(())
+        }
+    }
+
+    struct FailingPublisher;
+
+    #[async_trait]
+    impl ProtocolReplayFanoutPublisher for FailingPublisher {
+        async fn publish(
+            &self,
+            _message: ProtocolReplayFanoutMessage,
+        ) -> Result<(), ProtocolReplayFanoutError> {
+            Err(ProtocolReplayFanoutError::Publish(
+                "bus unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn relay_config() -> OutboxRelayConfig {
+        OutboxRelayConfig {
+            lane: OUTBOX_LANE_PROTOCOL_REPLAY.to_string(),
+            target: OUTBOX_TARGET_PROTOCOL_FANOUT.to_string(),
+            consumer_id: "fanout-test".to_string(),
+            batch_limit: 10,
+            lease_ms: 1_000,
+            retry_delay_ms: 0,
+            max_retry_delay_ms: 0,
+        }
+    }
+
+    fn replay_draft(wire_event_id: &str) -> ProtocolReplayDraft {
+        ProtocolReplayDraft::new(
+            "thread:thread-fanout",
+            AI_SDK_PROTOCOL,
+            AI_SDK_PROTOCOL_VERSION,
+            "ai-sdk-projector-v1",
+            wire_event_id,
+            "start",
+            b"data: start\n\n".to_vec(),
+        )
+        .unwrap()
+    }
+
+    async fn append_replay(log: &InMemoryProtocolReplayLog) -> ProtocolReplayRecord {
+        log.append_replay(replay_draft("wire-1"))
+            .await
+            .unwrap()
+            .record
+    }
+
+    fn outbox_draft(record: &ProtocolReplayRecord) -> OutboxMessageDraft {
+        OutboxMessageDraft::new(
+            OUTBOX_LANE_PROTOCOL_REPLAY,
+            OUTBOX_TARGET_PROTOCOL_FANOUT,
+            json!({
+                "protocol_replay_id": record.protocol_replay_id.as_str(),
+                "protocol": record.protocol,
+                "protocol_version": record.protocol_version,
+                "wire_event_id": record.wire_event_id,
+            }),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn relay_loads_protocol_replay_row_publishes_and_acks() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let record = append_replay(&replay_log).await;
+        outbox.enqueue_outbox(outbox_draft(&record)).await.unwrap();
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler = Arc::new(ProtocolReplayFanoutRelayHandler::new(
+            replay_log,
+            publisher.clone(),
+        ));
+        let relay = OutboxRelay::new(outbox.clone(), handler, relay_config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.delivered, 1);
+        let published = publisher.messages.lock().clone();
+        assert_eq!(published.len(), 1);
+        assert_eq!(
+            published[0].record.protocol_replay_id,
+            record.protocol_replay_id
+        );
+        assert_eq!(published[0].record.wire_payload_bytes, b"data: start\n\n");
+        let delivered = outbox
+            .list_outbox(Some(OutboxStatus::Delivered), 10)
+            .await
+            .unwrap();
+        assert_eq!(delivered.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn relay_dead_letters_invalid_payload_without_publishing() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let mut draft = OutboxMessageDraft::new(
+            OUTBOX_LANE_PROTOCOL_REPLAY,
+            OUTBOX_TARGET_PROTOCOL_FANOUT,
+            json!({ "protocol_replay_id": "pr-missing-fields" }),
+        )
+        .unwrap();
+        draft.max_attempts = 1;
+        outbox.enqueue_outbox(draft).await.unwrap();
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler = Arc::new(ProtocolReplayFanoutRelayHandler::new(
+            replay_log,
+            publisher.clone(),
+        ));
+        let relay = OutboxRelay::new(outbox.clone(), handler, relay_config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.dead_lettered, 1);
+        assert!(publisher.messages.lock().is_empty());
+        let dead = outbox
+            .list_outbox(Some(OutboxStatus::DeadLetter), 10)
+            .await
+            .unwrap();
+        assert!(dead[0].last_error.as_deref().unwrap().contains("protocol"));
+    }
+
+    #[tokio::test]
+    async fn relay_dead_letters_mismatched_notification() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let record = append_replay(&replay_log).await;
+        let mut draft = outbox_draft(&record);
+        draft.payload["wire_event_id"] = json!("wire-other");
+        draft.max_attempts = 1;
+        outbox.enqueue_outbox(draft).await.unwrap();
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler = Arc::new(ProtocolReplayFanoutRelayHandler::new(
+            replay_log,
+            publisher.clone(),
+        ));
+        let relay = OutboxRelay::new(outbox.clone(), handler, relay_config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.dead_lettered, 1);
+        assert!(publisher.messages.lock().is_empty());
+        let dead = outbox
+            .list_outbox(Some(OutboxStatus::DeadLetter), 10)
+            .await
+            .unwrap();
+        assert!(
+            dead[0]
+                .last_error
+                .as_deref()
+                .unwrap()
+                .contains("does not match")
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_dead_letters_publisher_failures_after_max_attempts() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let record = append_replay(&replay_log).await;
+        let mut draft = outbox_draft(&record);
+        draft.max_attempts = 1;
+        outbox.enqueue_outbox(draft).await.unwrap();
+        let handler = Arc::new(ProtocolReplayFanoutRelayHandler::new(
+            replay_log,
+            Arc::new(FailingPublisher),
+        ));
+        let relay = OutboxRelay::new(outbox.clone(), handler, relay_config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.dead_lettered, 1);
+        let dead = outbox
+            .list_outbox(Some(OutboxStatus::DeadLetter), 10)
+            .await
+            .unwrap();
+        assert!(
+            dead[0]
+                .last_error
+                .as_deref()
+                .unwrap()
+                .contains("bus unavailable")
+        );
+    }
+}

--- a/crates/awaken-server/src/protocol_projector.rs
+++ b/crates/awaken-server/src/protocol_projector.rs
@@ -1,0 +1,653 @@
+//! Protocol replay projectors backed by `ProtocolReplayLog`.
+
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use awaken_contract::contract::event::AgentEvent;
+use awaken_contract::contract::event_store::{
+    CanonicalEvent, CanonicalEventId, EventLookup, EventStoreError,
+};
+use awaken_contract::contract::outbox::{
+    OUTBOX_LANE_CANONICAL, OUTBOX_TARGET_PROTOCOL_PROJECTOR, OutboxMessage,
+};
+use awaken_contract::contract::protocol_replay_log::{
+    ProtocolReplayDraft, ProtocolReplayError, ProtocolReplayRecord, ProtocolReplayWriter,
+    SourceEventCursor,
+};
+use awaken_contract::contract::transport::Transcoder;
+use parking_lot::Mutex;
+use serde::Serialize;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::outbox_relay::{OutboxRelayError, OutboxRelayHandler};
+use crate::protocols::ai_sdk_v6::encoder::AiSdkEncoder;
+
+pub const AI_SDK_PROTOCOL: &str = "ai-sdk";
+pub const AI_SDK_PROTOCOL_VERSION: &str = "v6-ui-message-stream";
+pub const AI_SDK_PROJECTOR_VERSION: &str = "awaken-ai-sdk-v1";
+const PROJECTION_CACHE_LIMIT: usize = 4_096;
+
+#[derive(Debug, Error)]
+pub enum ProtocolProjectorError {
+    #[error("event payload is not a runtime AgentEvent: {0}")]
+    EventPayload(String),
+    #[error("event cannot be projected into a thread protocol stream: {0}")]
+    MissingThreadScope(String),
+    #[error("outbox message payload is invalid: {0}")]
+    OutboxPayload(String),
+    #[error("unexpected outbox message route: lane={lane}, target={target}")]
+    UnexpectedOutboxRoute { lane: String, target: String },
+    #[error("serialization error: {0}")]
+    Serialization(String),
+    #[error(transparent)]
+    EventStore(#[from] EventStoreError),
+    #[error(transparent)]
+    Replay(#[from] ProtocolReplayError),
+}
+
+pub struct AiSdkProtocolProjector {
+    writer: Arc<dyn ProtocolReplayWriter>,
+    state: Mutex<AiSdkProjectionState>,
+}
+
+impl AiSdkProtocolProjector {
+    #[must_use]
+    pub fn new(writer: Arc<dyn ProtocolReplayWriter>) -> Self {
+        Self {
+            writer,
+            state: Mutex::new(AiSdkProjectionState::default()),
+        }
+    }
+
+    pub async fn project_event(
+        &self,
+        event: &CanonicalEvent,
+    ) -> Result<Vec<ProtocolReplayRecord>, ProtocolProjectorError> {
+        if let Some(records) = self.state.lock().cache.records(&event.event_id) {
+            return Ok(records);
+        }
+        let Some(agent_event) = decode_agent_event(event)? else {
+            return Ok(Vec::new());
+        };
+        let stream_id = thread_stream_id(event)?;
+        let drafts = {
+            let mut state = self.state.lock();
+            if let Some(records) = state.cache.records(&event.event_id) {
+                return Ok(records);
+            }
+            if let Some(drafts) = state.cache.drafts(&event.event_id) {
+                drafts
+            } else {
+                let outputs = state
+                    .encoders
+                    .entry(stream_id.clone())
+                    .or_default()
+                    .transcode(&agent_event);
+                let drafts = outputs
+                    .iter()
+                    .enumerate()
+                    .map(|(index, output)| replay_draft(event, &stream_id, index, output))
+                    .collect::<Result<Vec<_>, _>>()?;
+                state
+                    .cache
+                    .remember_drafts(event.event_id.clone(), drafts.clone());
+                drafts
+            }
+        };
+        let mut records = Vec::with_capacity(drafts.len());
+        for draft in drafts {
+            let record = self.writer.append_replay(draft).await?.record;
+            records.push(record);
+        }
+        self.state
+            .lock()
+            .cache
+            .remember_records(event.event_id.clone(), records.clone());
+        Ok(records)
+    }
+}
+
+pub struct CanonicalOutboxProtocolProjector {
+    event_lookup: Arc<dyn EventLookup>,
+    projector: Arc<AiSdkProtocolProjector>,
+}
+
+impl CanonicalOutboxProtocolProjector {
+    #[must_use]
+    pub fn new(
+        event_lookup: Arc<dyn EventLookup>,
+        replay_writer: Arc<dyn ProtocolReplayWriter>,
+    ) -> Self {
+        Self::from_projector(
+            event_lookup,
+            Arc::new(AiSdkProtocolProjector::new(replay_writer)),
+        )
+    }
+
+    #[must_use]
+    pub fn from_projector(
+        event_lookup: Arc<dyn EventLookup>,
+        projector: Arc<AiSdkProtocolProjector>,
+    ) -> Self {
+        Self {
+            event_lookup,
+            projector,
+        }
+    }
+
+    pub async fn project_outbox_message(
+        &self,
+        message: &OutboxMessage,
+    ) -> Result<Vec<ProtocolReplayRecord>, ProtocolProjectorError> {
+        validate_canonical_projector_message(message)?;
+        let event_id = outbox_event_id(message)?;
+        let event = self.event_lookup.load_event(&event_id).await?;
+        self.projector.project_event(&event).await
+    }
+}
+
+#[async_trait]
+impl OutboxRelayHandler for CanonicalOutboxProtocolProjector {
+    async fn deliver(&self, message: &OutboxMessage) -> Result<(), OutboxRelayError> {
+        self.project_outbox_message(message)
+            .await
+            .map(|_| ())
+            .map_err(|error| OutboxRelayError::Delivery(error.to_string()))
+    }
+}
+
+#[derive(Debug, Default)]
+struct AiSdkProjectionState {
+    encoders: BTreeMap<String, AiSdkEncoder>,
+    cache: ProjectionCache,
+}
+
+#[derive(Debug, Default)]
+struct ProjectionCache {
+    drafts: BTreeMap<CanonicalEventId, Vec<ProtocolReplayDraft>>,
+    records: BTreeMap<CanonicalEventId, Vec<ProtocolReplayRecord>>,
+    order: VecDeque<CanonicalEventId>,
+}
+
+impl ProjectionCache {
+    fn records(&self, event_id: &CanonicalEventId) -> Option<Vec<ProtocolReplayRecord>> {
+        self.records.get(event_id).cloned()
+    }
+
+    fn drafts(&self, event_id: &CanonicalEventId) -> Option<Vec<ProtocolReplayDraft>> {
+        self.drafts.get(event_id).cloned()
+    }
+
+    fn remember_drafts(&mut self, event_id: CanonicalEventId, drafts: Vec<ProtocolReplayDraft>) {
+        self.track(event_id.clone());
+        self.drafts.insert(event_id, drafts);
+        self.evict();
+    }
+
+    fn remember_records(&mut self, event_id: CanonicalEventId, records: Vec<ProtocolReplayRecord>) {
+        self.track(event_id.clone());
+        self.records.insert(event_id, records);
+        self.evict();
+    }
+
+    fn track(&mut self, event_id: CanonicalEventId) {
+        if !self.drafts.contains_key(&event_id) && !self.records.contains_key(&event_id) {
+            self.order.push_back(event_id);
+        }
+    }
+
+    fn evict(&mut self) {
+        while self.order.len() > PROJECTION_CACHE_LIMIT {
+            if let Some(event_id) = self.order.pop_front() {
+                self.drafts.remove(&event_id);
+                self.records.remove(&event_id);
+            }
+        }
+    }
+}
+
+fn validate_canonical_projector_message(
+    message: &OutboxMessage,
+) -> Result<(), ProtocolProjectorError> {
+    if message.lane == OUTBOX_LANE_CANONICAL && message.target == OUTBOX_TARGET_PROTOCOL_PROJECTOR {
+        return Ok(());
+    }
+    Err(ProtocolProjectorError::UnexpectedOutboxRoute {
+        lane: message.lane.clone(),
+        target: message.target.clone(),
+    })
+}
+
+fn outbox_event_id(message: &OutboxMessage) -> Result<CanonicalEventId, ProtocolProjectorError> {
+    let event_id = message
+        .payload
+        .get("event_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ProtocolProjectorError::OutboxPayload("event_id is required".into()))?;
+    CanonicalEventId::new(event_id)
+        .map_err(|error| ProtocolProjectorError::OutboxPayload(error.to_string()))
+}
+
+fn decode_agent_event(
+    event: &CanonicalEvent,
+) -> Result<Option<AgentEvent>, ProtocolProjectorError> {
+    if event.payload.get("event_type").is_none() {
+        return Ok(None);
+    }
+    serde_json::from_value(event.payload.clone())
+        .map(Some)
+        .map_err(|error| ProtocolProjectorError::EventPayload(error.to_string()))
+}
+
+fn thread_stream_id(event: &CanonicalEvent) -> Result<String, ProtocolProjectorError> {
+    event
+        .thread_id
+        .as_ref()
+        .map(|thread_id| format!("thread:{thread_id}"))
+        .ok_or_else(|| {
+            ProtocolProjectorError::MissingThreadScope(event.event_id.as_str().to_string())
+        })
+}
+
+fn replay_draft<T: Serialize>(
+    event: &CanonicalEvent,
+    stream_id: &str,
+    index: usize,
+    output: &T,
+) -> Result<ProtocolReplayDraft, ProtocolProjectorError> {
+    let wire_payload_json = serde_json::to_value(output)
+        .map_err(|error| ProtocolProjectorError::Serialization(error.to_string()))?;
+    let wire_payload_bytes = serde_json::to_vec(output)
+        .map_err(|error| ProtocolProjectorError::Serialization(error.to_string()))?;
+    let wire_event_type = wire_payload_json
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let mut draft = ProtocolReplayDraft::new(
+        stream_id.to_string(),
+        AI_SDK_PROTOCOL,
+        AI_SDK_PROTOCOL_VERSION,
+        AI_SDK_PROJECTOR_VERSION,
+        format!("{}:{index}", event.event_id.as_str()),
+        wire_event_type,
+        wire_payload_bytes,
+    )?;
+    draft.wire_payload_json = Some(wire_payload_json);
+    draft.source_event_ids = vec![event.event_id.clone()];
+    draft.source_event_cursors = event
+        .cursors_by_scope
+        .iter()
+        .map(|(scope, cursor)| {
+            SourceEventCursor::new(event.event_id.clone(), scope.clone(), cursor.clone())
+        })
+        .collect();
+    Ok(draft)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::durable_event_sink::{
+        AgentEventNormalizationContext, AgentEventNormalizer, ScopedAgentEventNormalizer,
+    };
+    use awaken_contract::contract::event_store::{AppendOptions, EventScope, EventWriter};
+    use awaken_contract::contract::lifecycle::TerminationReason;
+    use awaken_contract::contract::outbox::{
+        OUTBOX_LANE_CANONICAL, OUTBOX_TARGET_PROTOCOL_PROJECTOR, OutboxMessage, OutboxMessageDraft,
+        OutboxStatus, OutboxStore,
+    };
+    use awaken_contract::contract::protocol_replay_log::{ProtocolReplayReader, ProtocolStreamKey};
+    use awaken_stores::{InMemoryEventStore, InMemoryOutboxStore, InMemoryProtocolReplayLog};
+
+    use crate::outbox_relay::{OutboxRelay, OutboxRelayConfig};
+
+    async fn canonical_event(agent_event: &AgentEvent) -> CanonicalEvent {
+        append_canonical_event(&InMemoryEventStore::new(), agent_event).await
+    }
+
+    async fn append_canonical_event(
+        event_store: &InMemoryEventStore,
+        agent_event: &AgentEvent,
+    ) -> CanonicalEvent {
+        append_canonical_event_for(event_store, "thread-proto", "run-proto", agent_event).await
+    }
+
+    async fn append_canonical_event_for(
+        event_store: &InMemoryEventStore,
+        thread_id: &str,
+        run_id: &str,
+        agent_event: &AgentEvent,
+    ) -> CanonicalEvent {
+        let normalizer = ScopedAgentEventNormalizer::new(
+            AgentEventNormalizationContext::new(thread_id, run_id, "test").unwrap(),
+        );
+        let normalized = normalizer.normalize(agent_event).unwrap().unwrap();
+        event_store
+            .append(normalized.draft, AppendOptions::default())
+            .await
+            .unwrap()
+            .event
+    }
+
+    fn outbox_message_for(event: &CanonicalEvent) -> OutboxMessage {
+        let mut draft = OutboxMessageDraft::new(
+            OUTBOX_LANE_CANONICAL,
+            OUTBOX_TARGET_PROTOCOL_PROJECTOR,
+            serde_json::json!({
+                "event_id": event.event_id.as_str(),
+                "event_kind": event.event_kind.as_str(),
+                "created_at": event.created_at,
+            }),
+        )
+        .unwrap();
+        draft.dedupe_key = Some(format!("canonical/{}", event.event_id.as_str()));
+        OutboxMessage::from_enqueue("out-test".into(), draft, 1).unwrap()
+    }
+
+    fn relay_config() -> OutboxRelayConfig {
+        OutboxRelayConfig {
+            lane: OUTBOX_LANE_CANONICAL.to_string(),
+            target: OUTBOX_TARGET_PROTOCOL_PROJECTOR.to_string(),
+            consumer_id: "projector-test".to_string(),
+            batch_limit: 10,
+            lease_ms: 1_000,
+            retry_delay_ms: 0,
+            max_retry_delay_ms: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn ai_sdk_projector_writes_byte_stable_replay_rows() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let projector = AiSdkProtocolProjector::new(replay_log.clone());
+        let event = canonical_event(&AgentEvent::RunStart {
+            thread_id: "thread-proto".into(),
+            run_id: "run-proto".into(),
+            parent_run_id: None,
+            identity: None,
+        })
+        .await;
+
+        let records = projector.project_event(&event).await.unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].protocol, AI_SDK_PROTOCOL);
+        assert_eq!(records[0].protocol_version, AI_SDK_PROTOCOL_VERSION);
+        assert_eq!(records[0].source_event_ids[0], event.event_id);
+        assert_eq!(records[0].wire_event_type, "start");
+        assert_eq!(
+            records[0].wire_payload_bytes,
+            br#"{"type":"start","messageId":"run-proto"}"#
+        );
+
+        let page = replay_log
+            .list_replay(
+                ProtocolStreamKey::new(
+                    "thread:thread-proto",
+                    AI_SDK_PROTOCOL,
+                    AI_SDK_PROTOCOL_VERSION,
+                )
+                .unwrap(),
+                None,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.records, records);
+    }
+
+    #[tokio::test]
+    async fn ai_sdk_projector_is_idempotent_for_same_wire_event_ids() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let projector = AiSdkProtocolProjector::new(replay_log);
+        let event = canonical_event(&AgentEvent::RunFinish {
+            thread_id: "thread-proto".into(),
+            run_id: "run-proto".into(),
+            identity: None,
+            result: None,
+            termination: TerminationReason::NaturalEnd,
+        })
+        .await;
+
+        let first = projector.project_event(&event).await.unwrap();
+        let second = projector.project_event(&event).await.unwrap();
+
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn ai_sdk_projector_isolates_encoder_state_by_thread_stream() {
+        let event_store = InMemoryEventStore::new();
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let projector = AiSdkProtocolProjector::new(replay_log.clone());
+        let start_a = append_canonical_event_for(
+            &event_store,
+            "thread-a",
+            "run-a",
+            &AgentEvent::RunStart {
+                thread_id: "thread-a".into(),
+                run_id: "run-a".into(),
+                parent_run_id: None,
+                identity: None,
+            },
+        )
+        .await;
+        let text_a = append_canonical_event_for(
+            &event_store,
+            "thread-a",
+            "run-a",
+            &AgentEvent::TextDelta {
+                delta: "hello".into(),
+            },
+        )
+        .await;
+        let start_b = append_canonical_event_for(
+            &event_store,
+            "thread-b",
+            "run-b",
+            &AgentEvent::RunStart {
+                thread_id: "thread-b".into(),
+                run_id: "run-b".into(),
+                parent_run_id: None,
+                identity: None,
+            },
+        )
+        .await;
+        let text_b = append_canonical_event_for(
+            &event_store,
+            "thread-b",
+            "run-b",
+            &AgentEvent::TextDelta {
+                delta: "world".into(),
+            },
+        )
+        .await;
+
+        projector.project_event(&start_a).await.unwrap();
+        projector.project_event(&text_a).await.unwrap();
+        projector.project_event(&start_b).await.unwrap();
+        projector.project_event(&text_b).await.unwrap();
+
+        let page = replay_log
+            .list_replay(
+                ProtocolStreamKey::new("thread:thread-b", AI_SDK_PROTOCOL, AI_SDK_PROTOCOL_VERSION)
+                    .unwrap(),
+                None,
+                10,
+            )
+            .await
+            .unwrap();
+        let wire_types = page
+            .records
+            .iter()
+            .map(|record| record.wire_event_type.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            wire_types,
+            ["start", "data-run-info", "text-start", "text-delta"]
+        );
+        assert_eq!(
+            page.records[2].wire_payload_bytes,
+            br#"{"type":"text-start","id":"txt_0"}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn ai_sdk_projector_skips_non_runtime_domain_events() {
+        let event_store = InMemoryEventStore::new();
+        let draft = awaken_contract::contract::event_store::CanonicalEventDraft::new(
+            vec![EventScope::thread("thread-proto")],
+            awaken_contract::contract::event_store::CanonicalEventKind::new("RunQueued").unwrap(),
+            serde_json::json!({ "dispatch_id": "dispatch-1" }),
+            "test",
+        )
+        .unwrap();
+        let event = event_store
+            .append(draft, AppendOptions::default())
+            .await
+            .unwrap()
+            .event;
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let projector = AiSdkProtocolProjector::new(replay_log);
+
+        let records = projector.project_event(&event).await.unwrap();
+
+        assert!(records.is_empty());
+    }
+
+    #[tokio::test]
+    async fn canonical_outbox_relay_projects_agent_events_and_acks() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let event = append_canonical_event(
+            &event_store,
+            &AgentEvent::RunStart {
+                thread_id: "thread-proto".into(),
+                run_id: "run-proto".into(),
+                parent_run_id: None,
+                identity: None,
+            },
+        )
+        .await;
+        outbox
+            .enqueue_outbox({
+                let mut draft = OutboxMessageDraft::new(
+                    OUTBOX_LANE_CANONICAL,
+                    OUTBOX_TARGET_PROTOCOL_PROJECTOR,
+                    serde_json::json!({
+                        "event_id": event.event_id.as_str(),
+                        "event_kind": event.event_kind.as_str(),
+                        "created_at": event.created_at,
+                    }),
+                )
+                .unwrap();
+                draft.dedupe_key = Some(format!("canonical/{}", event.event_id.as_str()));
+                draft
+            })
+            .await
+            .unwrap();
+        let handler = Arc::new(CanonicalOutboxProtocolProjector::new(
+            event_store.clone(),
+            replay_log.clone(),
+        ));
+        let relay = OutboxRelay::new(outbox.clone(), handler, relay_config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.claimed, 1);
+        assert_eq!(stats.delivered, 1);
+        let delivered = outbox
+            .list_outbox(Some(OutboxStatus::Delivered), 10)
+            .await
+            .unwrap();
+        assert_eq!(delivered.len(), 1);
+        let page = replay_log
+            .list_replay(
+                ProtocolStreamKey::new(
+                    "thread:thread-proto",
+                    AI_SDK_PROTOCOL,
+                    AI_SDK_PROTOCOL_VERSION,
+                )
+                .unwrap(),
+                None,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.records.len(), 2);
+        assert_eq!(page.records[0].source_event_ids[0], event.event_id);
+    }
+
+    #[tokio::test]
+    async fn canonical_outbox_projector_is_idempotent_for_duplicate_delivery() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let event = append_canonical_event(
+            &event_store,
+            &AgentEvent::RunStart {
+                thread_id: "thread-proto".into(),
+                run_id: "run-proto".into(),
+                parent_run_id: None,
+                identity: None,
+            },
+        )
+        .await;
+        let handler = CanonicalOutboxProtocolProjector::new(event_store, replay_log.clone());
+        let message = outbox_message_for(&event);
+
+        let first = handler.project_outbox_message(&message).await.unwrap();
+        let second = handler.project_outbox_message(&message).await.unwrap();
+
+        assert_eq!(first, second);
+        let page = replay_log
+            .list_replay(
+                ProtocolStreamKey::new(
+                    "thread:thread-proto",
+                    AI_SDK_PROTOCOL,
+                    AI_SDK_PROTOCOL_VERSION,
+                )
+                .unwrap(),
+                None,
+                10,
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.records.len(), first.len());
+    }
+
+    #[tokio::test]
+    async fn canonical_outbox_relay_dead_letters_invalid_payload() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let mut draft = OutboxMessageDraft::new(
+            OUTBOX_LANE_CANONICAL,
+            OUTBOX_TARGET_PROTOCOL_PROJECTOR,
+            serde_json::json!({ "event_kind": "RunStarted" }),
+        )
+        .unwrap();
+        draft.max_attempts = 1;
+        outbox.enqueue_outbox(draft).await.unwrap();
+        let handler = Arc::new(CanonicalOutboxProtocolProjector::new(
+            event_store,
+            replay_log,
+        ));
+        let relay = OutboxRelay::new(outbox.clone(), handler, relay_config()).unwrap();
+
+        let stats = relay.tick().await.unwrap();
+
+        assert_eq!(stats.claimed, 1);
+        assert_eq!(stats.dead_lettered, 1);
+        let dead = outbox
+            .list_outbox(Some(OutboxStatus::DeadLetter), 10)
+            .await
+            .unwrap();
+        assert_eq!(dead.len(), 1);
+        assert!(dead[0].last_error.as_deref().unwrap().contains("event_id"));
+    }
+}

--- a/crates/awaken-server/src/protocol_replay_state.rs
+++ b/crates/awaken-server/src/protocol_replay_state.rs
@@ -1,0 +1,585 @@
+//! Optional ProtocolReplayLog and projector relay attachments.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, Weak};
+use std::time::Duration;
+
+use awaken_contract::contract::event_store::EventLookup;
+use awaken_contract::contract::outbox::{
+    OUTBOX_LANE_CANONICAL, OUTBOX_LANE_PROTOCOL_REPLAY, OUTBOX_TARGET_PROTOCOL_FANOUT,
+    OUTBOX_TARGET_PROTOCOL_PROJECTOR, OutboxStore,
+};
+use awaken_contract::contract::protocol_replay_log::{ProtocolReplayLog, ProtocolReplayLookup};
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::app::{ReplayBufferEntry, ReplayBufferMap, ServerState};
+use crate::outbox_relay::{OutboxRelay, OutboxRelayConfig, OutboxRelayError};
+use crate::protocol_fanout::{ProtocolReplayFanoutPublisher, ProtocolReplayFanoutRelayHandler};
+use crate::protocol_projector::CanonicalOutboxProtocolProjector;
+
+type ProtocolReplayRegistry = HashMap<usize, ProtocolReplayAttachment>;
+
+#[derive(Clone)]
+struct ProtocolReplayAttachment {
+    replay_buffers: Weak<Mutex<HashMap<String, ReplayBufferEntry>>>,
+    log: Option<Arc<dyn ProtocolReplayLog>>,
+    projector_relay: Option<ProtocolProjectorRelayAttachment>,
+    fanout_relay: Option<ProtocolFanoutRelayAttachment>,
+}
+
+#[derive(Clone)]
+struct ProtocolProjectorRelayAttachment {
+    outbox: Arc<dyn OutboxStore>,
+    event_lookup: Arc<dyn EventLookup>,
+    replay_writer: Arc<dyn awaken_contract::contract::protocol_replay_log::ProtocolReplayWriter>,
+    config: ProtocolProjectorRelayConfig,
+}
+
+#[derive(Clone)]
+struct ProtocolFanoutRelayAttachment {
+    outbox: Arc<dyn OutboxStore>,
+    replay_lookup: Arc<dyn ProtocolReplayLookup>,
+    publisher: Arc<dyn ProtocolReplayFanoutPublisher>,
+    config: ProtocolFanoutRelayConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolProjectorRelayConfig {
+    pub relay: OutboxRelayConfig,
+    pub idle_sleep: Duration,
+    pub error_sleep: Duration,
+}
+
+impl Default for ProtocolProjectorRelayConfig {
+    fn default() -> Self {
+        Self {
+            relay: OutboxRelayConfig {
+                lane: OUTBOX_LANE_CANONICAL.to_string(),
+                target: OUTBOX_TARGET_PROTOCOL_PROJECTOR.to_string(),
+                consumer_id: "protocol-projector".to_string(),
+                batch_limit: 100,
+                lease_ms: 30_000,
+                retry_delay_ms: 1_000,
+                max_retry_delay_ms: 30_000,
+            },
+            idle_sleep: Duration::from_millis(250),
+            error_sleep: Duration::from_secs(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolFanoutRelayConfig {
+    pub relay: OutboxRelayConfig,
+    pub idle_sleep: Duration,
+    pub error_sleep: Duration,
+}
+
+impl Default for ProtocolFanoutRelayConfig {
+    fn default() -> Self {
+        Self {
+            relay: OutboxRelayConfig {
+                lane: OUTBOX_LANE_PROTOCOL_REPLAY.to_string(),
+                target: OUTBOX_TARGET_PROTOCOL_FANOUT.to_string(),
+                consumer_id: "protocol-fanout".to_string(),
+                batch_limit: 100,
+                lease_ms: 30_000,
+                retry_delay_ms: 1_000,
+                max_retry_delay_ms: 30_000,
+            },
+            idle_sleep: Duration::from_millis(250),
+            error_sleep: Duration::from_secs(1),
+        }
+    }
+}
+
+pub struct ProtocolRelayHandle {
+    task: JoinHandle<()>,
+    name: &'static str,
+}
+
+pub type ProtocolProjectorRelayHandle = ProtocolRelayHandle;
+pub type ProtocolFanoutRelayHandle = ProtocolRelayHandle;
+
+impl ProtocolRelayHandle {
+    pub async fn shutdown(self) {
+        self.task.abort();
+        if let Err(error) = self.task.await
+            && !error.is_cancelled()
+        {
+            tracing::warn!(error = %error, relay = self.name, "outbox relay failed during shutdown");
+        }
+    }
+}
+
+pub(crate) struct ProtocolRelayHandles {
+    handles: Vec<ProtocolRelayHandle>,
+}
+
+impl ProtocolRelayHandles {
+    pub async fn shutdown(self) {
+        for handle in self.handles {
+            handle.shutdown().await;
+        }
+    }
+}
+
+static PROTOCOL_REPLAY_REGISTRY: OnceLock<Mutex<ProtocolReplayRegistry>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<ProtocolReplayRegistry> {
+    PROTOCOL_REPLAY_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn key(replay_buffers: &ReplayBufferMap) -> usize {
+    Arc::as_ptr(replay_buffers) as usize
+}
+
+fn prune(registry: &mut ProtocolReplayRegistry) {
+    registry.retain(|_, attachment| attachment.replay_buffers.upgrade().is_some());
+}
+
+#[must_use]
+pub fn with_protocol_replay_log(
+    state: ServerState,
+    log: Arc<dyn ProtocolReplayLog>,
+) -> ServerState {
+    let mut registry = registry().lock();
+    prune(&mut registry);
+    let weak = Arc::downgrade(&state.replay_buffers);
+    registry
+        .entry(key(&state.replay_buffers))
+        .and_modify(|attachment| attachment.log = Some(log.clone()))
+        .or_insert_with(|| ProtocolReplayAttachment {
+            replay_buffers: weak,
+            log: Some(log),
+            projector_relay: None,
+            fanout_relay: None,
+        });
+    state
+}
+
+pub fn protocol_replay_log(state: &ServerState) -> Option<Arc<dyn ProtocolReplayLog>> {
+    protocol_replay_log_for_buffers(&state.replay_buffers)
+}
+
+pub fn protocol_replay_log_for_buffers(
+    replay_buffers: &ReplayBufferMap,
+) -> Option<Arc<dyn ProtocolReplayLog>> {
+    let mut registry = registry().lock();
+    prune(&mut registry);
+    registry
+        .get(&key(replay_buffers))
+        .and_then(|attachment| attachment.log.as_ref().map(Arc::clone))
+}
+
+pub fn with_protocol_projector_relay(
+    state: ServerState,
+    outbox: Arc<dyn OutboxStore>,
+    event_lookup: Arc<dyn EventLookup>,
+    replay_writer: Arc<dyn awaken_contract::contract::protocol_replay_log::ProtocolReplayWriter>,
+    config: ProtocolProjectorRelayConfig,
+) -> Result<ServerState, OutboxRelayError> {
+    config.relay.validate()?;
+    let mut registry = registry().lock();
+    prune(&mut registry);
+    let weak = Arc::downgrade(&state.replay_buffers);
+    registry
+        .entry(key(&state.replay_buffers))
+        .and_modify(|attachment| {
+            attachment.projector_relay = Some(ProtocolProjectorRelayAttachment {
+                outbox: outbox.clone(),
+                event_lookup: event_lookup.clone(),
+                replay_writer: replay_writer.clone(),
+                config: config.clone(),
+            });
+        })
+        .or_insert_with(|| ProtocolReplayAttachment {
+            replay_buffers: weak,
+            log: None,
+            projector_relay: Some(ProtocolProjectorRelayAttachment {
+                outbox,
+                event_lookup,
+                replay_writer,
+                config,
+            }),
+            fanout_relay: None,
+        });
+    Ok(state)
+}
+
+pub fn with_protocol_fanout_relay(
+    state: ServerState,
+    outbox: Arc<dyn OutboxStore>,
+    replay_lookup: Arc<dyn ProtocolReplayLookup>,
+    publisher: Arc<dyn ProtocolReplayFanoutPublisher>,
+    config: ProtocolFanoutRelayConfig,
+) -> Result<ServerState, OutboxRelayError> {
+    config.relay.validate()?;
+    let mut registry = registry().lock();
+    prune(&mut registry);
+    let weak = Arc::downgrade(&state.replay_buffers);
+    registry
+        .entry(key(&state.replay_buffers))
+        .and_modify(|attachment| {
+            attachment.fanout_relay = Some(ProtocolFanoutRelayAttachment {
+                outbox: outbox.clone(),
+                replay_lookup: replay_lookup.clone(),
+                publisher: publisher.clone(),
+                config: config.clone(),
+            });
+        })
+        .or_insert_with(|| ProtocolReplayAttachment {
+            replay_buffers: weak,
+            log: None,
+            projector_relay: None,
+            fanout_relay: Some(ProtocolFanoutRelayAttachment {
+                outbox,
+                replay_lookup,
+                publisher,
+                config,
+            }),
+        });
+    Ok(state)
+}
+
+pub(crate) async fn start_protocol_relays(
+    state: &ServerState,
+) -> Result<ProtocolRelayHandles, OutboxRelayError> {
+    let mut handles = Vec::new();
+    if let Some(handle) = start_protocol_projector_relay(state)? {
+        handles.push(handle);
+    }
+    match start_protocol_fanout_relay(state) {
+        Ok(Some(handle)) => handles.push(handle),
+        Ok(None) => {}
+        Err(error) => {
+            ProtocolRelayHandles { handles }.shutdown().await;
+            return Err(error);
+        }
+    }
+    Ok(ProtocolRelayHandles { handles })
+}
+
+pub(crate) fn start_protocol_projector_relay(
+    state: &ServerState,
+) -> Result<Option<ProtocolProjectorRelayHandle>, OutboxRelayError> {
+    let attachment = {
+        let mut registry = registry().lock();
+        prune(&mut registry);
+        registry
+            .get(&key(&state.replay_buffers))
+            .and_then(|attachment| attachment.projector_relay.clone())
+    };
+    let Some(attachment) = attachment else {
+        return Ok(None);
+    };
+    let handler = Arc::new(CanonicalOutboxProtocolProjector::new(
+        attachment.event_lookup,
+        attachment.replay_writer,
+    ));
+    let relay = OutboxRelay::new(attachment.outbox, handler, attachment.config.relay.clone())?;
+    let config = attachment.config;
+    Ok(Some(ProtocolRelayHandle {
+        task: tokio::spawn(run_outbox_relay(
+            relay,
+            config.idle_sleep,
+            config.error_sleep,
+            "protocol projector relay",
+        )),
+        name: "protocol projector relay",
+    }))
+}
+
+pub(crate) fn start_protocol_fanout_relay(
+    state: &ServerState,
+) -> Result<Option<ProtocolFanoutRelayHandle>, OutboxRelayError> {
+    let attachment = {
+        let mut registry = registry().lock();
+        prune(&mut registry);
+        registry
+            .get(&key(&state.replay_buffers))
+            .and_then(|attachment| attachment.fanout_relay.clone())
+    };
+    let Some(attachment) = attachment else {
+        return Ok(None);
+    };
+    let handler = Arc::new(ProtocolReplayFanoutRelayHandler::new(
+        attachment.replay_lookup,
+        attachment.publisher,
+    ));
+    let relay = OutboxRelay::new(attachment.outbox, handler, attachment.config.relay.clone())?;
+    let config = attachment.config;
+    Ok(Some(ProtocolRelayHandle {
+        task: tokio::spawn(run_outbox_relay(
+            relay,
+            config.idle_sleep,
+            config.error_sleep,
+            "protocol fanout relay",
+        )),
+        name: "protocol fanout relay",
+    }))
+}
+
+async fn run_outbox_relay(
+    relay: OutboxRelay,
+    idle_sleep: Duration,
+    error_sleep: Duration,
+    name: &'static str,
+) {
+    loop {
+        match relay.tick().await {
+            Ok(stats) if stats.claimed == 0 => wait(idle_sleep).await,
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(error = %error, relay = name, "outbox relay tick failed");
+                wait(error_sleep).await;
+            }
+        }
+    }
+}
+
+async fn wait(duration: Duration) {
+    if duration.is_zero() {
+        tokio::task::yield_now().await;
+    } else {
+        tokio::time::sleep(duration).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use awaken_contract::contract::durable_event_sink::{
+        AgentEventNormalizationContext, AgentEventNormalizer, ScopedAgentEventNormalizer,
+    };
+    use awaken_contract::contract::event::AgentEvent;
+    use awaken_contract::contract::event_store::{AppendOptions, EventWriter};
+    use awaken_contract::contract::outbox::{OutboxMessageDraft, OutboxStatus};
+    use awaken_contract::contract::protocol_replay_log::{
+        ProtocolReplayDraft, ProtocolReplayReader, ProtocolReplayWriter, ProtocolStreamKey,
+    };
+    use awaken_contract::contract::storage::ThreadRunStore;
+    use awaken_runtime::{AgentRuntime, RuntimeError};
+    use awaken_stores::{
+        InMemoryEventStore, InMemoryMailboxStore, InMemoryOutboxStore, InMemoryProtocolReplayLog,
+        InMemoryStore,
+    };
+
+    use crate::app::{ServerConfig, ServerState};
+    use crate::mailbox::{Mailbox, MailboxConfig};
+    use crate::protocol_fanout::{
+        ProtocolReplayFanoutError, ProtocolReplayFanoutMessage, ProtocolReplayFanoutPublisher,
+    };
+    use crate::protocol_projector::{AI_SDK_PROTOCOL, AI_SDK_PROTOCOL_VERSION};
+
+    struct StubResolver;
+
+    impl awaken_runtime::AgentResolver for StubResolver {
+        fn resolve(&self, agent_id: &str) -> Result<awaken_runtime::ResolvedAgent, RuntimeError> {
+            Err(RuntimeError::AgentNotFound {
+                agent_id: agent_id.to_string(),
+            })
+        }
+    }
+
+    fn make_state() -> ServerState {
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let store = Arc::new(InMemoryStore::new());
+        let mailbox_store = Arc::new(InMemoryMailboxStore::new());
+        let mailbox = Arc::new(Mailbox::new(
+            runtime.clone(),
+            mailbox_store,
+            store.clone(),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+        ServerState::new(
+            runtime,
+            mailbox,
+            store as Arc<dyn ThreadRunStore>,
+            Arc::new(StubResolver),
+            ServerConfig::default(),
+        )
+    }
+
+    async fn append_run_start(event_store: &InMemoryEventStore) -> String {
+        let normalizer = ScopedAgentEventNormalizer::new(
+            AgentEventNormalizationContext::new("thread-relay", "run-relay", "test").unwrap(),
+        );
+        let normalized = normalizer
+            .normalize(&AgentEvent::RunStart {
+                thread_id: "thread-relay".into(),
+                run_id: "run-relay".into(),
+                parent_run_id: None,
+                identity: None,
+            })
+            .unwrap()
+            .unwrap();
+        event_store
+            .append(normalized.draft, AppendOptions::default())
+            .await
+            .unwrap()
+            .event
+            .event_id
+            .as_str()
+            .to_string()
+    }
+
+    fn fast_config() -> ProtocolProjectorRelayConfig {
+        ProtocolProjectorRelayConfig {
+            idle_sleep: Duration::from_millis(1),
+            error_sleep: Duration::from_millis(1),
+            ..ProtocolProjectorRelayConfig::default()
+        }
+    }
+
+    fn fast_fanout_config() -> ProtocolFanoutRelayConfig {
+        ProtocolFanoutRelayConfig {
+            idle_sleep: Duration::from_millis(1),
+            error_sleep: Duration::from_millis(1),
+            ..ProtocolFanoutRelayConfig::default()
+        }
+    }
+
+    async fn replay_count(log: &InMemoryProtocolReplayLog) -> usize {
+        log.list_replay(
+            ProtocolStreamKey::new(
+                "thread:thread-relay",
+                AI_SDK_PROTOCOL,
+                AI_SDK_PROTOCOL_VERSION,
+            )
+            .unwrap(),
+            None,
+            10,
+        )
+        .await
+        .unwrap()
+        .records
+        .len()
+    }
+
+    #[derive(Default)]
+    struct RecordingFanoutPublisher {
+        replay_ids: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl ProtocolReplayFanoutPublisher for RecordingFanoutPublisher {
+        async fn publish(
+            &self,
+            message: ProtocolReplayFanoutMessage,
+        ) -> Result<(), ProtocolReplayFanoutError> {
+            self.replay_ids
+                .lock()
+                .push(message.record.protocol_replay_id.as_str().to_string());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn protocol_projector_relay_projects_attached_outbox_in_background() {
+        let event_store = Arc::new(InMemoryEventStore::new());
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let event_id = append_run_start(&event_store).await;
+        let mut draft = OutboxMessageDraft::new(
+            OUTBOX_LANE_CANONICAL,
+            OUTBOX_TARGET_PROTOCOL_PROJECTOR,
+            serde_json::json!({ "event_id": event_id }),
+        )
+        .unwrap();
+        draft.dedupe_key = Some(format!("canonical/{event_id}"));
+        outbox.enqueue_outbox(draft).await.unwrap();
+        let state = with_protocol_replay_log(make_state(), replay_log.clone());
+        let state = with_protocol_projector_relay(
+            state,
+            outbox.clone(),
+            event_store as Arc<dyn EventLookup>,
+            replay_log.clone() as Arc<dyn ProtocolReplayWriter>,
+            fast_config(),
+        )
+        .unwrap();
+        assert!(protocol_replay_log(&state).is_some());
+
+        let handle = start_protocol_projector_relay(&state).unwrap().unwrap();
+        for _ in 0..50 {
+            if replay_count(&replay_log).await == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        handle.shutdown().await;
+
+        assert_eq!(replay_count(&replay_log).await, 2);
+        let delivered = outbox
+            .list_outbox(Some(OutboxStatus::Delivered), 10)
+            .await
+            .unwrap();
+        assert_eq!(delivered.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn protocol_fanout_relay_publishes_attached_outbox_in_background() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let publisher = Arc::new(RecordingFanoutPublisher::default());
+        let record = replay_log
+            .append_replay(
+                ProtocolReplayDraft::new(
+                    "thread:thread-fanout-state",
+                    AI_SDK_PROTOCOL,
+                    AI_SDK_PROTOCOL_VERSION,
+                    "ai-sdk-projector-v1",
+                    "wire-fanout-state",
+                    "start",
+                    b"data: start\n\n".to_vec(),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap()
+            .record;
+        outbox
+            .enqueue_outbox(
+                OutboxMessageDraft::new(
+                    OUTBOX_LANE_PROTOCOL_REPLAY,
+                    OUTBOX_TARGET_PROTOCOL_FANOUT,
+                    serde_json::json!({
+                        "protocol_replay_id": record.protocol_replay_id.as_str(),
+                        "protocol": record.protocol.as_str(),
+                        "protocol_version": record.protocol_version.as_str(),
+                        "wire_event_id": record.wire_event_id.as_str(),
+                    }),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let state = with_protocol_fanout_relay(
+            make_state(),
+            outbox.clone(),
+            replay_log,
+            publisher.clone(),
+            fast_fanout_config(),
+        )
+        .unwrap();
+
+        let handles = start_protocol_relays(&state).await.unwrap();
+        for _ in 0..50 {
+            if publisher.replay_ids.lock().len() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        handles.shutdown().await;
+
+        assert_eq!(publisher.replay_ids.lock().len(), 1);
+        let delivered = outbox
+            .list_outbox(Some(OutboxStatus::Delivered), 10)
+            .await
+            .unwrap();
+        assert_eq!(delivered.len(), 1);
+    }
+}

--- a/crates/awaken-server/src/protocols/a2a/agent_card.rs
+++ b/crates/awaken-server/src/protocols/a2a/agent_card.rs
@@ -8,7 +8,7 @@ use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use serde_json::json;
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 
 use super::common::{
     ensure_runnable_agent, ensure_supported_version, forwarded_header, public_agent_id,
@@ -19,7 +19,7 @@ use super::types::{
 };
 
 pub(super) async fn a2a_agent_card(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     uri: axum::http::Uri,
 ) -> Result<Json<AgentCard>, A2aError> {
@@ -31,7 +31,7 @@ pub(super) async fn a2a_agent_card(
 }
 
 pub(super) async fn a2a_extended_agent_card_default(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
 ) -> Result<Response, A2aError> {
     ensure_supported_version(&headers)?;
@@ -46,7 +46,7 @@ pub(super) async fn a2a_extended_agent_card_default(
 }
 
 pub(super) async fn a2a_extended_agent_card_tenant(
-    st: AppState,
+    st: ProtocolRoutesState,
     tenant: String,
     headers: HeaderMap,
 ) -> Result<Response, A2aError> {
@@ -69,7 +69,7 @@ pub(super) async fn a2a_extended_agent_card_tenant(
 }
 
 fn build_agent_card(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     headers: &HeaderMap,
     agent_id: &str,
     tenant: Option<&str>,
@@ -136,12 +136,15 @@ fn build_agent_card(
     }
 }
 
-pub(super) fn supports_extended_agent_card(st: &AppState) -> bool {
-    st.config.a2a_extended_card_bearer_token.is_some()
+pub(super) fn supports_extended_agent_card(st: &ProtocolRoutesState) -> bool {
+    st.a2a_extended_card_bearer_token.is_some()
 }
 
-fn ensure_extended_card_auth(st: &AppState, headers: &HeaderMap) -> Result<(), A2aError> {
-    let Some(expected) = st.config.a2a_extended_card_bearer_token.as_ref() else {
+fn ensure_extended_card_auth(
+    st: &ProtocolRoutesState,
+    headers: &HeaderMap,
+) -> Result<(), A2aError> {
+    let Some(expected) = st.a2a_extended_card_bearer_token.as_ref() else {
         return Err(A2aError::unsupported_operation(
             "extendedAgentCard is not configured for this agent",
         ));

--- a/crates/awaken-server/src/protocols/a2a/common.rs
+++ b/crates/awaken-server/src/protocols/a2a/common.rs
@@ -4,7 +4,7 @@ use axum::extract::Query;
 use axum::http::{HeaderMap, Uri};
 use serde::de::DeserializeOwned;
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 
 use super::error::{A2aError, map_a2a_storage_error};
 use super::types::A2A_VERSION;
@@ -148,70 +148,36 @@ pub(super) fn ensure_supported_version(headers: &HeaderMap) -> Result<(), A2aErr
     Ok(())
 }
 
-pub(super) fn public_agent_id(st: &AppState) -> Result<String, A2aError> {
-    if st.resolver.resolve("default").is_ok() {
+pub(super) fn public_agent_id(st: &ProtocolRoutesState) -> Result<String, A2aError> {
+    if st.run.resolver.resolve("default").is_ok() {
         return Ok("default".to_string());
     }
 
-    let mut ids = st.resolver.agent_ids();
+    let mut ids = st.run.resolver.agent_ids();
     ids.sort();
     ids.into_iter()
-        .find(|id| st.resolver.resolve(id).is_ok())
+        .find(|id| st.run.resolver.resolve(id).is_ok())
         .ok_or_else(|| A2aError::NotFound("no runnable local agents registered".to_string()))
 }
 
-pub(super) fn ensure_runnable_agent(st: &AppState, agent_id: &str) -> Result<(), A2aError> {
-    st.resolver
+pub(super) fn ensure_runnable_agent(
+    st: &ProtocolRoutesState,
+    agent_id: &str,
+) -> Result<(), A2aError> {
+    st.run
+        .resolver
         .resolve(agent_id)
         .map(|_| ())
         .map_err(|_| A2aError::NotFound(format!("agent not found: {agent_id}")))
 }
 
-pub(super) async fn thread_has_context(st: &AppState, thread_id: &str) -> Result<bool, A2aError> {
-    if st
-        .store
-        .load_thread(thread_id)
-        .await
-        .map_err(|e| A2aError::Internal(e.to_string()))?
-        .is_some()
-    {
-        return Ok(true);
-    }
-
-    if st
-        .store
-        .load_messages(thread_id)
-        .await
-        .map_err(|e| A2aError::Internal(e.to_string()))?
-        .is_some()
-    {
-        return Ok(true);
-    }
-
-    if st
-        .store
-        .latest_run(thread_id)
-        .await
-        .map_err(|e| A2aError::Internal(e.to_string()))?
-        .is_some()
-    {
-        return Ok(true);
-    }
-
-    Ok(!st
-        .mailbox
-        .list_dispatches(thread_id, None, 1, 0)
-        .await
-        .map_err(|e| A2aError::Internal(e.to_string()))?
-        .is_empty())
-}
-
 pub(super) async fn load_thread_metadata_projection(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     thread_id: &str,
 ) -> Result<(bool, Thread), A2aError> {
     let existing = st
-        .store
+        .run
+        .store()
         .load_thread(thread_id)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -234,18 +200,20 @@ pub(super) fn materialize_thread_metadata_projection(
 }
 
 pub(super) async fn persist_thread_metadata(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     thread_id: &str,
     exists: bool,
     thread: Thread,
 ) -> Result<(), A2aError> {
     if exists {
-        st.store
+        st.run
+            .store()
             .update_thread_metadata(thread_id, thread.metadata)
             .await
             .map_err(map_a2a_storage_error)?;
     } else {
-        st.store
+        st.run
+            .store()
             .save_thread_validated(&thread)
             .await
             .map_err(map_a2a_storage_error)?;

--- a/crates/awaken-server/src/protocols/a2a/message.rs
+++ b/crates/awaken-server/src/protocols/a2a/message.rs
@@ -3,7 +3,7 @@ use awaken_protocol_a2a::{
     Artifact, MessageRole, SendMessageRequest, SendMessageResponse, StreamResponse,
     TaskArtifactUpdateEvent, TaskStatus, TaskStatusUpdateEvent,
 };
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, Uri};
@@ -12,12 +12,11 @@ use bytes::Bytes;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 use crate::http_sse::{format_sse_data, sse_body_stream, sse_response};
 
 use super::common::{
-    ensure_runnable_agent, ensure_supported_version, public_agent_id, thread_has_context,
-    trim_to_option,
+    ensure_runnable_agent, ensure_supported_version, public_agent_id, trim_to_option,
 };
 use super::conversion::a2a_part_to_content_block;
 use super::error::{A2aError, FieldViolation};
@@ -32,7 +31,7 @@ use super::task::{
 use super::types::{BLOCKING_POLL_INTERVAL, PreparedRequest, SUPPORTED_OUTPUT_MODE, TaskSnapshot};
 
 pub(super) async fn a2a_message_send_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     headers: HeaderMap,
     Json(payload): Json<SendMessageRequest>,
 ) -> Result<Json<SendMessageResponse>, A2aError> {
@@ -40,7 +39,7 @@ pub(super) async fn a2a_message_send_default(
 }
 
 pub(super) async fn a2a_message_send_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(tenant): Path<String>,
     headers: HeaderMap,
     Json(payload): Json<SendMessageRequest>,
@@ -49,7 +48,7 @@ pub(super) async fn a2a_message_send_tenant(
 }
 
 pub(super) async fn a2a_message_stream_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     headers: HeaderMap,
     uri: Uri,
     Json(payload): Json<SendMessageRequest>,
@@ -58,7 +57,7 @@ pub(super) async fn a2a_message_stream_default(
 }
 
 pub(super) async fn a2a_message_stream_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(tenant): Path<String>,
     headers: HeaderMap,
     uri: Uri,
@@ -68,7 +67,7 @@ pub(super) async fn a2a_message_stream_tenant(
 }
 
 pub(super) async fn subscribe_task(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     task_id: String,
@@ -97,7 +96,7 @@ pub(super) async fn subscribe_task(
 }
 
 async fn send_message(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     path_tenant: Option<String>,
     payload: SendMessageRequest,
@@ -129,7 +128,8 @@ async fn send_message(
         record_task_binding(&st, &thread_id, &task_id, start_message_id).await?;
     }
 
-    st.mailbox
+    st.run
+        .mailbox
         .submit_background(request)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -163,7 +163,7 @@ async fn send_message(
 }
 
 async fn stream_message(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     _uri: Option<&Uri>,
     path_tenant: Option<String>,
@@ -196,7 +196,8 @@ async fn stream_message(
         record_task_binding(&st, &thread_id, &task_id, start_message_id).await?;
     }
 
-    st.mailbox
+    st.run
+        .mailbox
         .submit_background(request)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -219,13 +220,14 @@ async fn stream_message(
     ))
 }
 
+// TODO(ADR-0034 #25): replace store-snapshot polling with a projector that writes ProtocolReplayLog rows.
 fn stream_task_response(
-    st: AppState,
+    st: ProtocolRoutesState,
     task_id: String,
     tenant: Option<String>,
     history_length: usize,
 ) -> Response {
-    let (tx, rx) = mpsc::channel::<Bytes>(st.config.sse_buffer_size);
+    let (tx, rx) = mpsc::channel::<Bytes>(st.sse_buffer_size);
 
     tokio::spawn(async move {
         let mut sent_initial = false;
@@ -347,7 +349,7 @@ async fn send_stream_response(
 }
 
 async fn prepare_send_request(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     path_tenant: Option<String>,
     payload: SendMessageRequest,
 ) -> Result<PreparedRequest, A2aError> {
@@ -449,15 +451,15 @@ async fn prepare_send_request(
 
     let message_id = payload.message.message_id.clone();
     let awaken_message = AwakenMessage::user_with_content(content).with_id(message_id.clone());
-    let mut request = RunRequest::new(thread_id.clone(), vec![awaken_message])
+    let mut request = RunActivation::new(thread_id.clone(), vec![awaken_message])
         .with_origin(awaken_contract::contract::storage::RunRequestOrigin::A2A)
         .with_adapter(awaken_contract::contract::tool_intercept::AdapterKind::A2a);
     let mut new_task_start_message_id = None;
 
     if let Some(ref tenant) = effective_tenant {
         request = request.with_agent_id(tenant.clone());
-    } else if thread_has_context(st, &thread_id).await? {
-        // Keep agent inference on existing threads.
+    } else if let Some(agent_id) = latest_context_agent_id(st, &thread_id).await? {
+        request = request.with_agent_id(agent_id);
     } else {
         request = request.with_agent_id(public_agent_id(st)?);
     }
@@ -514,4 +516,20 @@ async fn prepare_send_request(
         new_task_start_message_id,
         request,
     })
+}
+
+async fn latest_context_agent_id(
+    st: &ProtocolRoutesState,
+    thread_id: &str,
+) -> Result<Option<String>, A2aError> {
+    Ok(st
+        .run
+        .store()
+        .latest_run(thread_id)
+        .await
+        .map_err(|e| A2aError::Internal(e.to_string()))?
+        .and_then(|run| {
+            let agent_id = run.agent_id.trim();
+            (!agent_id.is_empty()).then(|| agent_id.to_string())
+        }))
 }

--- a/crates/awaken-server/src/protocols/a2a/mod.rs
+++ b/crates/awaken-server/src/protocols/a2a/mod.rs
@@ -25,7 +25,7 @@ pub use awaken_protocol_a2a::{
     TaskState, TaskStatus, TaskStatusUpdateEvent,
 };
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 
 use common::{
     decode_json_body, decode_query, ensure_supported_version_from_request, parse_a2a_tail,
@@ -35,7 +35,7 @@ use error::A2aError;
 use types::{DISCOVERY_PATH, GetTaskQuery, ListPushConfigsQuery, ListTasksQuery};
 
 /// Build A2A routes.
-pub fn a2a_routes() -> Router<AppState> {
+pub fn a2a_routes() -> Router<ProtocolRoutesState> {
     Router::new()
         .route(DISCOVERY_PATH, get(a2a_agent_card_route))
         .route(
@@ -47,7 +47,7 @@ pub fn a2a_routes() -> Router<AppState> {
 }
 
 async fn a2a_agent_card_route(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     headers: HeaderMap,
     uri: Uri,
 ) -> Result<Json<AgentCard>, A2aError> {
@@ -55,7 +55,7 @@ async fn a2a_agent_card_route(
 }
 
 async fn a2a_get_dispatch(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(tail): Path<String>,
     headers: HeaderMap,
     uri: Uri,
@@ -167,7 +167,7 @@ async fn a2a_get_dispatch(
 }
 
 async fn a2a_post_dispatch(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(tail): Path<String>,
     headers: HeaderMap,
     uri: Uri,
@@ -269,7 +269,7 @@ async fn a2a_post_dispatch(
 }
 
 async fn a2a_delete_dispatch(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(tail): Path<String>,
     headers: HeaderMap,
     uri: Uri,

--- a/crates/awaken-server/src/protocols/a2a/push_config.rs
+++ b/crates/awaken-server/src/protocols/a2a/push_config.rs
@@ -9,7 +9,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use uuid::Uuid;
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 
 use super::common::{
     ensure_supported_version, load_thread_metadata_projection, parse_page_token,
@@ -25,7 +25,7 @@ use super::types::{
 };
 
 pub(super) async fn a2a_create_push_config_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(task_id): Path<String>,
     headers: HeaderMap,
     Json(payload): Json<PushNotificationConfig>,
@@ -36,7 +36,7 @@ pub(super) async fn a2a_create_push_config_default(
 }
 
 pub(super) async fn a2a_create_push_config_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path((tenant, task_id)): Path<(String, String)>,
     headers: HeaderMap,
     Json(payload): Json<PushNotificationConfig>,
@@ -47,7 +47,7 @@ pub(super) async fn a2a_create_push_config_tenant(
 }
 
 pub(super) async fn a2a_list_push_configs_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(task_id): Path<String>,
     headers: HeaderMap,
     Query(query): Query<ListPushConfigsQuery>,
@@ -56,7 +56,7 @@ pub(super) async fn a2a_list_push_configs_default(
 }
 
 pub(super) async fn a2a_list_push_configs_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path((tenant, task_id)): Path<(String, String)>,
     headers: HeaderMap,
     Query(query): Query<ListPushConfigsQuery>,
@@ -65,7 +65,7 @@ pub(super) async fn a2a_list_push_configs_tenant(
 }
 
 pub(super) async fn a2a_get_push_config_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path((task_id, config_id)): Path<(String, String)>,
     headers: HeaderMap,
 ) -> Result<Response, A2aError> {
@@ -75,7 +75,7 @@ pub(super) async fn a2a_get_push_config_default(
 }
 
 pub(super) async fn a2a_get_push_config_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path((tenant, task_id, config_id)): Path<(String, String, String)>,
     headers: HeaderMap,
 ) -> Result<Response, A2aError> {
@@ -85,7 +85,7 @@ pub(super) async fn a2a_get_push_config_tenant(
 }
 
 pub(super) async fn a2a_delete_push_config_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path((task_id, config_id)): Path<(String, String)>,
     headers: HeaderMap,
 ) -> Result<Response, A2aError> {
@@ -93,7 +93,7 @@ pub(super) async fn a2a_delete_push_config_default(
 }
 
 pub(super) async fn a2a_delete_push_config_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path((tenant, task_id, config_id)): Path<(String, String, String)>,
     headers: HeaderMap,
 ) -> Result<Response, A2aError> {
@@ -101,7 +101,7 @@ pub(super) async fn a2a_delete_push_config_tenant(
 }
 
 async fn create_push_config(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     task_id: String,
@@ -116,7 +116,7 @@ async fn create_push_config(
 }
 
 async fn list_push_configs(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     task_id: String,
@@ -150,7 +150,7 @@ async fn list_push_configs(
 }
 
 async fn get_push_config(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     task_id: String,
@@ -165,7 +165,7 @@ async fn get_push_config(
 }
 
 async fn delete_push_config(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     task_id: String,
@@ -230,7 +230,7 @@ pub(super) fn normalize_push_config(
 }
 
 pub(super) async fn load_push_notification_configs(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
     tenant: Option<&str>,
 ) -> Result<Vec<PushNotificationConfig>, A2aError> {
@@ -238,7 +238,8 @@ pub(super) async fn load_push_notification_configs(
         return Ok(Vec::new());
     };
     let Some(thread) = st
-        .store
+        .run
+        .store()
         .load_thread(&task.thread_id)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?
@@ -255,7 +256,7 @@ pub(super) async fn load_push_notification_configs(
 }
 
 async fn find_push_notification_config(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
     tenant: Option<&str>,
     config_id: &str,
@@ -267,7 +268,7 @@ async fn find_push_notification_config(
 }
 
 async fn save_push_notification_configs(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
     configs: Vec<PushNotificationConfig>,
 ) -> Result<(), A2aError> {
@@ -280,7 +281,7 @@ async fn save_push_notification_configs(
 }
 
 async fn upsert_push_notification_config(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
     tenant: Option<&str>,
     config: PushNotificationConfig,
@@ -295,7 +296,7 @@ async fn upsert_push_notification_config(
 }
 
 pub(super) async fn upsert_push_notification_config_for_thread(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     thread_id: &str,
     task_id: &str,
     tenant: Option<&str>,
@@ -330,7 +331,7 @@ fn load_thread_push_notification_configs(
 }
 
 async fn save_thread_push_notification_configs(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     thread_id: &str,
     exists: bool,
     mut thread: Thread,
@@ -362,7 +363,7 @@ async fn save_thread_push_notification_configs(
 }
 
 pub(super) fn spawn_push_notification_driver(
-    st: AppState,
+    st: ProtocolRoutesState,
     task_id: String,
     tenant: Option<String>,
     config: PushNotificationConfig,
@@ -374,8 +375,10 @@ pub(super) fn spawn_push_notification_driver(
     });
 }
 
+// TODO(ADR-0034 #26): replace direct reqwest delivery with OutboxStore enqueue
+// (lane=protocol_replay, target=webhook) and an OutboxRelay webhook consumer.
 async fn drive_push_notification(
-    st: AppState,
+    st: ProtocolRoutesState,
     task_id: String,
     tenant: Option<String>,
     config: PushNotificationConfig,

--- a/crates/awaken-server/src/protocols/a2a/task.rs
+++ b/crates/awaken-server/src/protocols/a2a/task.rs
@@ -9,7 +9,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
 use serde_json::json;
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 
 use super::common::{
     ensure_runnable_agent, ensure_supported_version, load_thread_metadata_projection,
@@ -24,7 +24,7 @@ use super::types::{
 };
 
 pub(super) async fn a2a_list_tasks_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     headers: HeaderMap,
     Query(query): Query<ListTasksQuery>,
 ) -> Result<Json<ListTasksResponse>, A2aError> {
@@ -32,7 +32,7 @@ pub(super) async fn a2a_list_tasks_default(
 }
 
 pub(super) async fn a2a_list_tasks_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(tenant): Path<String>,
     headers: HeaderMap,
     Query(query): Query<ListTasksQuery>,
@@ -41,7 +41,7 @@ pub(super) async fn a2a_list_tasks_tenant(
 }
 
 pub(super) async fn a2a_get_task_default(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(task_id): Path<String>,
     headers: HeaderMap,
     Query(query): Query<GetTaskQuery>,
@@ -50,7 +50,7 @@ pub(super) async fn a2a_get_task_default(
 }
 
 pub(super) async fn a2a_get_task_tenant(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path((tenant, task_id)): Path<(String, String)>,
     headers: HeaderMap,
     Query(query): Query<GetTaskQuery>,
@@ -59,7 +59,7 @@ pub(super) async fn a2a_get_task_tenant(
 }
 
 pub(super) async fn cancel_task(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     task_id: String,
@@ -81,6 +81,7 @@ pub(super) async fn cancel_task(
     }
 
     let queued_dispatches = st
+        .run
         .mailbox
         .list_dispatches(
             &existing.task.id,
@@ -94,12 +95,14 @@ pub(super) async fn cancel_task(
     let mut cancelled = false;
     for dispatch in queued_dispatches {
         cancelled |= st
+            .run
             .mailbox
             .cancel(&dispatch.dispatch_id)
             .await
             .map_err(|e| A2aError::Internal(e.to_string()))?;
     }
     cancelled |= st
+        .run
         .mailbox
         .cancel(&existing.task.id)
         .await
@@ -127,7 +130,7 @@ pub(super) async fn cancel_task(
 }
 
 async fn list_tasks(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     query: ListTasksQuery,
@@ -200,7 +203,7 @@ async fn list_tasks(
 }
 
 async fn get_task(
-    st: AppState,
+    st: ProtocolRoutesState,
     headers: HeaderMap,
     tenant: Option<String>,
     task_id: String,
@@ -218,16 +221,18 @@ async fn get_task(
 }
 
 pub(super) async fn resolve_task(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
 ) -> Result<Option<ResolvedTask>, A2aError> {
     if let Some(run) = st
-        .store
+        .run
+        .store()
         .load_run(task_id)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?
     {
         let dispatch = st
+            .run
             .mailbox
             .load_dispatch(task_id)
             .await
@@ -240,6 +245,7 @@ pub(super) async fn resolve_task(
     }
 
     let Some(dispatch) = st
+        .run
         .mailbox
         .load_dispatch(task_id)
         .await
@@ -259,7 +265,7 @@ pub(super) fn run_is_a2a_resumable(run: &RunRecord) -> bool {
 }
 
 pub(super) async fn record_task_binding(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     thread_id: &str,
     task_id: &str,
     start_message_id: &str,
@@ -293,12 +299,13 @@ pub(super) async fn record_task_binding(
 }
 
 async fn load_task_binding(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     thread_id: &str,
     task_id: &str,
 ) -> Result<Option<StoredTaskBinding>, A2aError> {
     let Some(thread) = st
-        .store
+        .run
+        .store()
         .load_thread(thread_id)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?
@@ -314,7 +321,10 @@ async fn load_task_binding(
         .and_then(|bindings| bindings.tasks.get(task_id).cloned()))
 }
 
-pub(super) async fn task_context_id(st: &AppState, task_id: &str) -> Result<String, A2aError> {
+pub(super) async fn task_context_id(
+    st: &ProtocolRoutesState,
+    task_id: &str,
+) -> Result<String, A2aError> {
     Ok(resolve_task(st, task_id)
         .await?
         .map(|task| task.thread_id)
@@ -322,7 +332,7 @@ pub(super) async fn task_context_id(st: &AppState, task_id: &str) -> Result<Stri
 }
 
 pub(super) async fn wait_for_task(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
     tenant: Option<&str>,
     history_length: usize,
@@ -351,7 +361,7 @@ pub(super) async fn wait_for_task(
 }
 
 pub(super) async fn load_task_snapshot(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
     tenant: Option<&str>,
     history_length: usize,
@@ -365,7 +375,8 @@ pub(super) async fn load_task_snapshot(
     let latest_dispatch: Option<RunDispatch> = if let Some(dispatch) = task.dispatch.clone() {
         Some(dispatch)
     } else {
-        st.mailbox
+        st.run
+            .mailbox
             .list_dispatches(&thread_id, None, 100, 0)
             .await
             .map_err(|e| A2aError::Internal(e.to_string()))?
@@ -375,7 +386,8 @@ pub(super) async fn load_task_snapshot(
     };
 
     let history = st
-        .store
+        .run
+        .store()
         .load_messages(&thread_id)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?
@@ -559,7 +571,7 @@ pub(super) fn canceled_task(task_id: &str, context_id: &str, tenant: Option<&str
 }
 
 pub(super) async fn ensure_task_visible(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     task_id: &str,
     tenant: Option<&str>,
 ) -> Result<(), A2aError> {
@@ -581,12 +593,13 @@ pub(super) async fn ensure_task_visible(
     }
 }
 
-pub(super) async fn collect_task_ids(st: &AppState) -> Result<Vec<String>, A2aError> {
+pub(super) async fn collect_task_ids(st: &ProtocolRoutesState) -> Result<Vec<String>, A2aError> {
     let mut ids = BTreeSet::new();
     let mut run_offset = 0;
     loop {
         let page = st
-            .store
+            .run
+            .store()
             .list_runs(&RunQuery {
                 offset: run_offset,
                 limit: 100,
@@ -607,7 +620,8 @@ pub(super) async fn collect_task_ids(st: &AppState) -> Result<Vec<String>, A2aEr
     let mut offset = 0;
     loop {
         let batch = st
-            .store
+            .run
+            .store()
             .list_threads(offset, 100)
             .await
             .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -617,6 +631,7 @@ pub(super) async fn collect_task_ids(st: &AppState) -> Result<Vec<String>, A2aEr
         offset += batch.len();
         for thread_id in batch {
             let dispatches = st
+                .run
                 .mailbox
                 .list_dispatches(
                     &thread_id,

--- a/crates/awaken-server/src/protocols/a2a/types.rs
+++ b/crates/awaken-server/src/protocols/a2a/types.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use awaken_contract::contract::mailbox::RunDispatch;
 use awaken_contract::contract::storage::RunRecord;
 use awaken_protocol_a2a::{PushNotificationConfig, Task, TaskState};
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 use serde::{Deserialize, Serialize};
 
 pub(super) const A2A_VERSION: &str = "1.0";
@@ -93,5 +93,5 @@ pub(super) struct PreparedRequest {
     pub(super) return_immediately: bool,
     pub(super) push_notification_config: Option<PushNotificationConfig>,
     pub(super) new_task_start_message_id: Option<String>,
-    pub(super) request: RunRequest,
+    pub(super) request: RunActivation,
 }

--- a/crates/awaken-server/src/protocols/acp/stdio.rs
+++ b/crates/awaken-server/src/protocols/acp/stdio.rs
@@ -156,7 +156,7 @@ impl acp::Agent for AcpAgent {
         let messages = vec![Message::user_with_content(content)];
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         let sink = crate::transport::channel_sink::ChannelEventSink::new(event_tx);
-        let mut run_request = awaken_runtime::RunRequest::new(thread_id.clone(), messages)
+        let mut run_request = awaken_runtime::RunActivation::new(thread_id.clone(), messages)
             .with_adapter(awaken_contract::contract::tool_intercept::AdapterKind::Acp)
             .with_session_id(session_id.clone());
         if let Some(agent_id) = agent_id {

--- a/crates/awaken-server/src/protocols/ag_ui/http.rs
+++ b/crates/awaken-server/src/protocols/ag_ui/http.rs
@@ -10,17 +10,17 @@ use serde_json::Value;
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::suspension::{ResumeDecisionAction, ToolCallResume};
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 use crate::http_run::wire_sse_relay;
 use crate::http_sse::{sse_body_stream, sse_response};
 use crate::routes::{ApiError, map_mailbox_error};
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 
 use super::encoder::AgUiEncoder;
 use super::types::Role;
 
 /// Build AG-UI routes.
-pub fn ag_ui_routes() -> Router<AppState> {
+pub fn ag_ui_routes() -> Router<ProtocolRoutesState> {
     Router::new()
         .route("/v1/ag-ui/run", post(ag_ui_run))
         .route(
@@ -183,7 +183,7 @@ fn input_part_to_block(
 }
 
 async fn ag_ui_run(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Json(payload): Json<AgUiRunRequest>,
 ) -> Result<Response, ApiError> {
     ag_ui_run_inner(st, payload).await
@@ -191,7 +191,7 @@ async fn ag_ui_run(
 
 /// Thread-centric route: `POST /v1/ag-ui/threads/:thread_id/runs`
 async fn ag_ui_run_threaded(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(thread_id): Path<String>,
     Json(mut payload): Json<AgUiRunRequest>,
 ) -> Result<Response, ApiError> {
@@ -201,7 +201,7 @@ async fn ag_ui_run_threaded(
 
 /// Agent-scoped route: `POST /v1/ag-ui/agents/:agent_id/runs`
 async fn ag_ui_run_agent_scoped(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(agent_id): Path<String>,
     Json(mut payload): Json<AgUiRunRequest>,
 ) -> Result<Response, ApiError> {
@@ -210,10 +210,11 @@ async fn ag_ui_run_agent_scoped(
 }
 
 async fn interrupt_thread(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(thread_id): Path<String>,
 ) -> Result<Response, ApiError> {
     let interrupted = st
+        .run
         .mailbox
         .interrupt(&thread_id)
         .await
@@ -257,7 +258,10 @@ fn convert_resume_to_decision(resume: AgUiResumePayload) -> Option<(String, Tool
     ))
 }
 
-async fn ag_ui_run_inner(st: AppState, payload: AgUiRunRequest) -> Result<Response, ApiError> {
+async fn ag_ui_run_inner(
+    st: ProtocolRoutesState,
+    payload: AgUiRunRequest,
+) -> Result<Response, ApiError> {
     let (thread_id_raw, agent_id, raw_messages, state, resume, frontend_tools) =
         payload.into_parts();
     let messages = convert_messages(raw_messages);
@@ -286,7 +290,7 @@ async fn ag_ui_run_inner(st: AppState, payload: AgUiRunRequest) -> Result<Respon
         })
         .collect();
 
-    let mut request = RunRequest::new(thread_id, messages)
+    let mut request = RunActivation::new(thread_id, messages)
         .with_adapter(awaken_contract::contract::tool_intercept::AdapterKind::AgUi);
     if let Some(id) = agent_id {
         request = request.with_agent_id(id);
@@ -298,25 +302,28 @@ async fn ag_ui_run_inner(st: AppState, payload: AgUiRunRequest) -> Result<Respon
         request = request.with_decisions(decisions);
     }
     let (_result, event_rx) = st
+        .run
         .mailbox
         .submit(request)
         .await
         .map_err(map_mailbox_error)?;
 
     let encoder = AgUiEncoder::new();
-    let sse_rx = wire_sse_relay(event_rx, encoder, st.config.sse_buffer_size, None);
+    // TODO(ADR-0034 #24): add ProtocolReplayLog projector + resume endpoint.
+    let sse_rx = wire_sse_relay(event_rx, encoder, st.sse_buffer_size, None);
 
     Ok(sse_response(sse_body_stream(sse_rx)))
 }
 
 async fn thread_messages(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     Path(id): Path<String>,
     Query(params): Query<crate::query::MessageQueryParams>,
 ) -> Result<Json<Value>, ApiError> {
     let query = params.storage_query().map_err(ApiError::BadRequest)?;
     let page = st
-        .store
+        .run
+        .store()
         .list_message_records(&id, &query)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
@@ -22,13 +22,13 @@ use awaken_contract::contract::message::{Message, MessageRecord, Role, ToolCall}
 use awaken_contract::contract::storage::{MessageOrder, MessageQuery};
 use awaken_contract::registry_spec::AgentSpec;
 
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState as S;
 use crate::http_run::wire_sse_relay;
 use crate::http_sse::{sse_body_stream, sse_response};
 use crate::routes::{ApiError, map_mailbox_error};
 use crate::transport::channel_sink::BoundedChannelEventSink;
 use crate::transport::replay_buffer::EventReplayBuffer;
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 use awaken_runtime::registry::resolve::RegistrySetResolver;
 use awaken_runtime::registry::{AgentSpecRegistry, RegistryHandle, RegistrySet};
 use awaken_runtime::{AgentResolver, AgentRuntime};
@@ -39,9 +39,8 @@ use super::request::{AiSdkChatRequest, ProcessedRequest};
 /// AI SDK v6 header required by `DefaultChatTransport` to identify the stream format.
 const AI_SDK_STREAM_HEADER: &str = "x-vercel-ai-ui-message-stream";
 const AI_SDK_STREAM_VERSION: &str = "v1";
-
 /// Wrap [`sse_response`] with the AI SDK–specific stream protocol header.
-fn ai_sdk_sse_response<S>(stream: S) -> Response
+pub(super) fn ai_sdk_sse_response<S>(stream: S) -> Response
 where
     S: futures::Stream<Item = Result<Bytes, Infallible>> + Send + 'static,
 {
@@ -58,7 +57,7 @@ where
 /// The resume route `{api}/{chatId}/stream` matches the AI SDK's
 /// `HttpChatTransport.reconnectToStream()` URL pattern, where `chatId`
 /// maps to awaken's `threadId`.
-pub fn ai_sdk_routes() -> Router<AppState> {
+pub fn ai_sdk_routes() -> Router<S> {
     Router::new()
         .route("/v1/ai-sdk/chat", post(ai_sdk_chat))
         .route(
@@ -73,7 +72,6 @@ pub fn ai_sdk_routes() -> Router<AppState> {
             "/v1/ai-sdk/agent-previews/runs",
             post(ai_sdk_chat_preview_agent),
         )
-        // AI SDK reconnect: GET {api}/{chatId}/stream → chatId = thread_id
         .route("/v1/ai-sdk/chat/:thread_id/stream", get(resume_stream))
         .route("/v1/ai-sdk/threads/:thread_id/stream", get(resume_stream))
         .route(
@@ -85,12 +83,12 @@ pub fn ai_sdk_routes() -> Router<AppState> {
             "/v1/ai-sdk/threads/:thread_id/interrupt",
             post(interrupt_thread),
         )
+        .merge(super::replay::ai_sdk_replay_routes())
 }
-
 // ── Route handlers ──────────────────────────────────────────────────
 
 async fn ai_sdk_chat(
-    State(st): State<AppState>,
+    State(st): State<S>,
     Json(payload): Json<AiSdkChatRequest>,
 ) -> Result<Response, ApiError> {
     ai_sdk_chat_inner(st, payload).await
@@ -98,7 +96,7 @@ async fn ai_sdk_chat(
 
 /// Thread-centric route: `POST /v1/ai-sdk/threads/:thread_id/runs`
 async fn ai_sdk_chat_threaded(
-    State(st): State<AppState>,
+    State(st): State<S>,
     Path(thread_id): Path<String>,
     Json(mut payload): Json<AiSdkChatRequest>,
 ) -> Result<Response, ApiError> {
@@ -108,7 +106,7 @@ async fn ai_sdk_chat_threaded(
 
 /// Agent-scoped route: `POST /v1/ai-sdk/agents/:agent_id/runs`
 async fn ai_sdk_chat_agent_scoped(
-    State(st): State<AppState>,
+    State(st): State<S>,
     Path(agent_id): Path<String>,
     Json(mut payload): Json<AiSdkChatRequest>,
 ) -> Result<Response, ApiError> {
@@ -131,11 +129,11 @@ async fn ai_sdk_chat_agent_scoped(
 /// crafted payload bypass the registry-membership check; clearing the
 /// field forces the preview into the local-only resolve path.
 async fn ai_sdk_chat_preview_agent(
-    State(st): State<AppState>,
+    State(st): State<S>,
     headers: HeaderMap,
     Json(payload): Json<super::request::PreviewAgentChatRequest>,
 ) -> Result<Response, ApiError> {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&st, &headers) {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&st.admin, &headers) {
         return Ok(err.into_response());
     }
 
@@ -177,7 +175,7 @@ async fn ai_sdk_chat_preview_agent(
         .with_registry_handle(RegistryHandle::new(candidate)),
     );
 
-    let mut request = RunRequest::new(
+    let mut request = RunActivation::new(
         processed.thread_id,
         crate::request::inject_frontend_context(processed.messages, processed.state),
     )
@@ -187,14 +185,14 @@ async fn ai_sdk_chat_preview_agent(
         request = request.with_decisions(processed.decisions);
     }
 
-    let (event_tx, event_rx) = tokio::sync::mpsc::channel(st.config.sse_buffer_size.max(32));
+    let (event_tx, event_rx) = tokio::sync::mpsc::channel(st.sse_buffer_size.max(32));
     let sink: Arc<dyn EventSink> = Arc::new(BoundedChannelEventSink::new(event_tx));
     tokio::spawn(async move {
         let _ = preview_runtime.run(request, sink).await;
     });
 
     let encoder = AiSdkEncoder::new();
-    let sse_rx = wire_sse_relay(event_rx, encoder, st.config.sse_buffer_size, None);
+    let sse_rx = wire_sse_relay(event_rx, encoder, st.sse_buffer_size, None);
     Ok(ai_sdk_sse_response(sse_body_stream(sse_rx)))
 }
 
@@ -228,11 +226,11 @@ impl AgentSpecRegistry for PreviewAgentRegistry {
     }
 }
 
-fn build_preview_registry_set(st: &AppState, agent: &AgentSpec) -> Result<RegistrySet, ApiError> {
-    let current = st
-        .runtime
-        .registry_set()
-        .ok_or_else(|| ApiError::Internal("runtime does not expose a registry snapshot".into()))?;
+fn build_preview_registry_set(st: &S, agent: &AgentSpec) -> Result<RegistrySet, ApiError> {
+    let current =
+        st.run.runtime.registry_set().ok_or_else(|| {
+            ApiError::Internal("runtime does not expose a registry snapshot".into())
+        })?;
 
     let candidate = RegistrySet {
         agents: Arc::new(PreviewAgentRegistry::new(
@@ -259,8 +257,8 @@ fn build_preview_registry_set(st: &AppState, agent: &AgentSpec) -> Result<Regist
 
 // ── Core chat handler ───────────────────────────────────────────────
 
-async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Response, ApiError> {
-    let processed = super::request::process_chat_request(st.store.as_ref(), payload)
+async fn ai_sdk_chat_inner(st: S, payload: AiSdkChatRequest) -> Result<Response, ApiError> {
+    let processed = super::request::process_chat_request(st.run.store().as_ref(), payload)
         .await
         .map_err(ApiError::BadRequest)?;
 
@@ -280,12 +278,17 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
     // decisions to resume the run on a fresh SSE stream.
     if !decisions.is_empty() {
         let (new_event_tx, new_event_rx) = tokio::sync::mpsc::channel(256);
-        let reconnected = st.mailbox.reconnect_sink(&thread_id, new_event_tx).await;
+        let reconnected = st
+            .run
+            .mailbox
+            .reconnect_sink(&thread_id, new_event_tx)
+            .await;
 
         if reconnected {
             let mut any_delivered = false;
             for (tool_call_id, resume) in &decisions {
                 if st
+                    .run
                     .mailbox
                     .send_decision(&thread_id, tool_call_id.clone(), resume.clone())
                 {
@@ -295,15 +298,14 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
 
             if any_delivered {
                 // Wire the reconnected channel to a fresh SSE stream.
-                let replay_buffer =
-                    Arc::new(EventReplayBuffer::new(st.config.replay_buffer_capacity));
+                let replay_buffer = Arc::new(EventReplayBuffer::new(st.replay_buffer_capacity));
                 st.insert_replay_buffer(thread_id.clone(), Arc::clone(&replay_buffer));
 
                 let encoder = AiSdkEncoder::new();
                 let sse_rx = wire_sse_relay(
                     new_event_rx,
                     encoder,
-                    st.config.sse_buffer_size,
+                    st.sse_buffer_size,
                     Some(Arc::clone(&replay_buffer)),
                 );
 
@@ -311,8 +313,7 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
                 let replay_buf = Arc::clone(&replay_buffer);
                 let tid = thread_id;
                 let mut rx = sse_rx;
-                let (final_tx, final_rx) =
-                    tokio::sync::mpsc::channel::<Bytes>(st.config.sse_buffer_size);
+                let (final_tx, final_rx) = tokio::sync::mpsc::channel::<Bytes>(st.sse_buffer_size);
                 tokio::spawn(async move {
                     while let Some(frame) = rx.recv().await {
                         if final_tx.send(frame).await.is_err() {
@@ -333,13 +334,13 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
         // Pure resume with no active run — return empty stream.
         let (_, rx) = tokio::sync::mpsc::channel(1);
         let encoder = AiSdkEncoder::new();
-        let sse_rx = crate::http_run::wire_sse_relay(rx, encoder, st.config.sse_buffer_size, None);
+        let sse_rx = crate::http_run::wire_sse_relay(rx, encoder, st.sse_buffer_size, None);
         return Ok(ai_sdk_sse_response(sse_body_stream(sse_rx)));
     }
 
     let messages = crate::request::inject_frontend_context(messages, state);
 
-    let mut request = RunRequest::new(thread_id.clone(), messages)
+    let mut request = RunActivation::new(thread_id.clone(), messages)
         .with_adapter(awaken_contract::contract::tool_intercept::AdapterKind::AiSdk);
     if let Some(id) = agent_id {
         request = request.with_agent_id(id);
@@ -348,12 +349,13 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
         request = request.with_decisions(decisions);
     }
     let (_result, event_rx) = st
+        .run
         .mailbox
         .submit(request)
         .await
         .map_err(map_mailbox_error)?;
 
-    let replay_buffer = Arc::new(EventReplayBuffer::new(st.config.replay_buffer_capacity));
+    let replay_buffer = Arc::new(EventReplayBuffer::new(st.replay_buffer_capacity));
 
     // Register buffer by thread_id (not run_id). External consumers only see
     // threads — runs are internal state. This matches AI SDK's reconnect URL
@@ -361,12 +363,7 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
     st.insert_replay_buffer(thread_id.clone(), Arc::clone(&replay_buffer));
 
     let encoder = AiSdkEncoder::new();
-    let sse_rx = wire_sse_relay(
-        event_rx,
-        encoder,
-        st.config.sse_buffer_size,
-        Some(replay_buffer),
-    );
+    let sse_rx = wire_sse_relay(event_rx, encoder, st.sse_buffer_size, Some(replay_buffer));
 
     // Spawn cleanup task: forward frames to client, but keep buffer alive for
     // the full run duration (not tied to client connection). This allows
@@ -378,7 +375,7 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
         .ok_or_else(|| ApiError::Internal("replay buffer disappeared after insert".into()))?;
     let cleanup_thread_id = thread_id;
     let mut sse_rx_forwarded = sse_rx;
-    let (final_tx, final_rx) = tokio::sync::mpsc::channel::<Bytes>(st.config.sse_buffer_size);
+    let (final_tx, final_rx) = tokio::sync::mpsc::channel::<Bytes>(st.sse_buffer_size);
     tokio::spawn(async move {
         let mut client_tx = Some(final_tx);
         let mut waiting_for_client_finish = false;
@@ -414,37 +411,34 @@ async fn ai_sdk_chat_inner(st: AppState, payload: AiSdkChatRequest) -> Result<Re
     Ok(ai_sdk_sse_response(sse_body_stream(final_rx)))
 }
 
-/// Reconnect to an active thread's event stream.
-///
-/// Called by AI SDK's `HttpChatTransport.reconnectToStream()` which issues
-/// `GET {api}/{chatId}/stream`. In awaken, `chatId` maps to `thread_id`.
-///
-/// Replays buffered frames after the client's `Last-Event-ID` and then
-/// streams any new frames produced by the still-running agent.
-///
-/// Returns **204 No Content** if no active stream exists for the thread.
-/// AI SDK treats 204 as "nothing to resume" and returns `null` to the caller.
+/// Reconnect to an active thread stream, or replay protocol cursors.
 async fn resume_stream(
-    State(st): State<AppState>,
+    State(st): State<S>,
     Path(thread_id): Path<String>,
     headers: HeaderMap,
 ) -> Response {
-    let last_event_id: u64 = headers
-        .get("last-event-id")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-
+    if super::replay::resume_header_has_protocol_cursor(&headers) {
+        match super::replay::resume_from_replay_log(&st, &thread_id, &headers).await {
+            Ok(Some(response)) => return response,
+            Ok(None) => return axum::http::StatusCode::NO_CONTENT.into_response(),
+            Err(error) => return error.into_response(),
+        }
+    }
+    // ADR-0034 D3: numeric last-event-id is not a durable cursor; the
+    // live cache reattach always replays the full retained window and
+    // delegates durable resume to the protocol-cursor path above.
     let buffer = st.get_replay_buffer(&thread_id);
 
     let Some(buffer) = buffer else {
-        // AI SDK expects 204 for "no active stream" — not 404.
+        match super::replay::resume_from_replay_log(&st, &thread_id, &headers).await {
+            Ok(Some(response)) => return response,
+            Ok(None) => {}
+            Err(error) => return error.into_response(),
+        }
         return axum::http::StatusCode::NO_CONTENT.into_response();
     };
 
-    // Atomically replay + subscribe under a single lock hold.
-    // This guarantees no duplicates and no gaps.
-    let (replayed, live_rx) = buffer.subscribe_after(last_event_id);
+    let (replayed, live_rx) = buffer.subscribe_after(0);
 
     let replay_stream = futures::stream::iter(replayed.into_iter().map(Ok::<Bytes, Infallible>));
     let live_stream =
@@ -457,13 +451,14 @@ async fn resume_stream(
 // ── Thread messages (history) ───────────────────────────────────────
 
 async fn thread_messages(
-    State(st): State<AppState>,
+    State(st): State<S>,
     Path(id): Path<String>,
     Query(params): Query<crate::query::MessageQueryParams>,
 ) -> Result<Json<Value>, ApiError> {
     let storage_query = params.storage_query().map_err(ApiError::BadRequest)?;
     let records = st
-        .store
+        .run
+        .store()
         .load_message_records(&id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
@@ -631,10 +626,11 @@ fn parse_tool_message_output(message: &Message) -> Value {
 // ── Cancel / Interrupt ──────────────────────────────────────────────
 
 async fn cancel_thread(
-    State(st): State<AppState>,
+    State(st): State<S>,
     Path(thread_id): Path<String>,
 ) -> Result<Response, ApiError> {
     let cancelled = st
+        .run
         .mailbox
         .cancel(&thread_id)
         .await
@@ -655,10 +651,11 @@ async fn cancel_thread(
 }
 
 async fn interrupt_thread(
-    State(st): State<AppState>,
+    State(st): State<S>,
     Path(thread_id): Path<String>,
 ) -> Result<Response, ApiError> {
     let interrupted = st
+        .run
         .mailbox
         .interrupt(&thread_id)
         .await

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/mod.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/mod.rs
@@ -1,4 +1,5 @@
 pub mod encoder;
 pub mod http;
+pub mod replay;
 mod request;
 pub mod types;

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/replay.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/replay.rs
@@ -1,0 +1,406 @@
+//! ProtocolReplayLog-backed AI SDK stream replay.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use awaken_contract::contract::protocol_replay_log::{
+    ProtocolReplayCursor, ProtocolReplayError, ProtocolReplayLog, ProtocolReplayRecord,
+    ProtocolStreamKey,
+};
+use axum::Router;
+use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
+use axum::response::Response;
+use axum::routing::get;
+use bytes::Bytes;
+use serde::Deserialize;
+
+use crate::app::ProtocolRoutesState;
+use crate::protocol_projector::{AI_SDK_PROTOCOL, AI_SDK_PROTOCOL_VERSION};
+use crate::routes::ApiError;
+
+const LAST_EVENT_ID_HEADER: &str = "last-event-id";
+const DEFAULT_REPLAY_LIMIT: usize = 100;
+const MAX_REPLAY_LIMIT: usize = 500;
+
+#[derive(Debug, Deserialize, Default)]
+struct ReplayQuery {
+    cursor: Option<String>,
+    limit: Option<usize>,
+}
+
+pub fn ai_sdk_replay_routes() -> Router<ProtocolRoutesState> {
+    Router::new()
+        .route("/v1/ai-sdk/threads/:thread_id/replay", get(replay_stream))
+        .route("/v1/ai-sdk/chat/:thread_id/replay", get(replay_stream))
+}
+
+async fn replay_stream(
+    State(st): State<ProtocolRoutesState>,
+    Path(thread_id): Path<String>,
+    Query(query): Query<ReplayQuery>,
+    headers: HeaderMap,
+) -> Result<Response, ApiError> {
+    let log = configured_replay_log(&st)?;
+    let cursor = cursor_from_query_or_header(query.cursor.as_deref(), &headers)?;
+    let frames = replay_frames(log, &thread_id, cursor, replay_limit(query.limit)).await?;
+    Ok(response_from_frames(frames))
+}
+
+pub(crate) async fn resume_from_replay_log(
+    st: &ProtocolRoutesState,
+    thread_id: &str,
+    headers: &HeaderMap,
+) -> Result<Option<Response>, ApiError> {
+    let Some(log) =
+        crate::protocol_replay_state::protocol_replay_log_for_buffers(&st.protocol.replay_buffers)
+    else {
+        return Ok(None);
+    };
+    let cursor = cursor_from_resume_header(headers)?;
+    let frames = replay_frames(log, thread_id, cursor.clone(), DEFAULT_REPLAY_LIMIT).await?;
+    if frames.is_empty() && cursor.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(response_from_frames(frames)))
+}
+
+fn configured_replay_log(st: &ProtocolRoutesState) -> Result<Arc<dyn ProtocolReplayLog>, ApiError> {
+    crate::protocol_replay_state::protocol_replay_log_for_buffers(&st.protocol.replay_buffers)
+        .ok_or_else(|| {
+            ApiError::ServiceUnavailable("protocol replay log is not configured".to_string())
+        })
+}
+
+async fn replay_frames(
+    log: Arc<dyn ProtocolReplayLog>,
+    thread_id: &str,
+    cursor: Option<ProtocolReplayCursor>,
+    limit: usize,
+) -> Result<Vec<Bytes>, ApiError> {
+    let stream = ProtocolStreamKey::new(
+        format!("thread:{thread_id}"),
+        AI_SDK_PROTOCOL,
+        AI_SDK_PROTOCOL_VERSION,
+    )
+    .map_err(map_protocol_replay_error)?;
+    let page = log
+        .list_replay(stream, cursor, limit)
+        .await
+        .map_err(map_protocol_replay_error)?;
+    page.records.iter().map(record_frame).collect()
+}
+
+fn response_from_frames(frames: Vec<Bytes>) -> Response {
+    let stream = futures::stream::iter(frames.into_iter().map(Ok::<Bytes, Infallible>));
+    super::http::ai_sdk_sse_response(stream)
+}
+
+fn record_frame(record: &ProtocolReplayRecord) -> Result<Bytes, ApiError> {
+    let payload = std::str::from_utf8(&record.wire_payload_bytes)
+        .map_err(|error| ApiError::Internal(error.to_string()))?;
+    Ok(Bytes::from(format!(
+        "id: {}\ndata: {}\n\n",
+        record.protocol_replay_cursor.as_str(),
+        payload
+    )))
+}
+
+fn cursor_from_query_or_header(
+    query_cursor: Option<&str>,
+    headers: &HeaderMap,
+) -> Result<Option<ProtocolReplayCursor>, ApiError> {
+    match query_cursor {
+        Some(cursor) => replay_cursor(cursor).map(Some),
+        None => headers
+            .get(LAST_EVENT_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(replay_cursor)
+            .transpose(),
+    }
+}
+
+fn cursor_from_resume_header(
+    headers: &HeaderMap,
+) -> Result<Option<ProtocolReplayCursor>, ApiError> {
+    headers
+        .get(LAST_EVENT_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|cursor| !cursor.bytes().all(|byte| byte.is_ascii_digit()))
+        .map(replay_cursor)
+        .transpose()
+}
+
+pub(crate) fn resume_header_has_protocol_cursor(headers: &HeaderMap) -> bool {
+    headers
+        .get(LAST_EVENT_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|cursor| !cursor.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn replay_cursor(cursor: &str) -> Result<ProtocolReplayCursor, ApiError> {
+    if cursor.trim().is_empty() {
+        return Err(ApiError::BadRequest("cursor cannot be empty".to_string()));
+    }
+    ProtocolReplayCursor::new(cursor).map_err(map_protocol_replay_error)
+}
+
+fn replay_limit(limit: Option<usize>) -> usize {
+    limit
+        .unwrap_or(DEFAULT_REPLAY_LIMIT)
+        .clamp(1, MAX_REPLAY_LIMIT)
+}
+
+fn map_protocol_replay_error(error: ProtocolReplayError) -> ApiError {
+    match error {
+        ProtocolReplayError::Validation(message) => ApiError::BadRequest(message),
+        ProtocolReplayError::Conflict(message) => ApiError::Conflict(message),
+        ProtocolReplayError::CursorExpired(message) => ApiError::Gone(message),
+        // ADR-0034 D8: a missing replay row inside retention is an integrity
+        // violation that must be alertable, not a generic 500.
+        ProtocolReplayError::Integrity(message) => ApiError::DataIntegrity(message),
+        ProtocolReplayError::Io(message) => ApiError::Internal(message),
+        ProtocolReplayError::Serialization(message) => ApiError::Internal(message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::protocol_replay_log::{
+        ProtocolReplayDraft, ProtocolReplayWriter,
+    };
+    use awaken_runtime::AgentRuntime;
+    use awaken_stores::{InMemoryMailboxStore, InMemoryProtocolReplayLog, InMemoryStore};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode, header};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use crate::app::{ServerConfig, ServerState};
+    use crate::mailbox::{Mailbox, MailboxConfig};
+    use crate::protocol_projector::AI_SDK_PROJECTOR_VERSION;
+    use crate::protocol_replay_state::with_protocol_replay_log;
+    use crate::routes::build_router;
+    use crate::transport::replay_buffer::EventReplayBuffer;
+
+    struct StubResolver;
+
+    impl awaken_runtime::AgentResolver for StubResolver {
+        fn resolve(
+            &self,
+            agent_id: &str,
+        ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
+            Err(awaken_runtime::RuntimeError::AgentNotFound {
+                agent_id: agent_id.to_string(),
+            })
+        }
+    }
+
+    fn make_state(replay_log: Option<Arc<InMemoryProtocolReplayLog>>) -> ServerState {
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let store = Arc::new(InMemoryStore::new());
+        let mailbox_store = Arc::new(InMemoryMailboxStore::new());
+        let mailbox = Arc::new(Mailbox::new(
+            runtime.clone(),
+            mailbox_store,
+            store.clone(),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+        let state = ServerState::new(
+            runtime,
+            mailbox,
+            store,
+            Arc::new(StubResolver),
+            ServerConfig::default(),
+        );
+        match replay_log {
+            Some(log) => with_protocol_replay_log(state, log),
+            None => state,
+        }
+    }
+
+    async fn append_replay(
+        log: &InMemoryProtocolReplayLog,
+        thread_id: &str,
+        wire_event_id: &str,
+        payload: &str,
+    ) -> ProtocolReplayCursor {
+        let mut draft = ProtocolReplayDraft::new(
+            format!("thread:{thread_id}"),
+            AI_SDK_PROTOCOL,
+            AI_SDK_PROTOCOL_VERSION,
+            AI_SDK_PROJECTOR_VERSION,
+            wire_event_id,
+            "test",
+            payload.as_bytes().to_vec(),
+        )
+        .unwrap();
+        draft.wire_payload_json = Some(serde_json::from_str(payload).unwrap());
+        log.append_replay(draft)
+            .await
+            .unwrap()
+            .record
+            .protocol_replay_cursor
+    }
+
+    async fn get(app: axum::Router, uri: &str) -> (StatusCode, String) {
+        let response = app
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        (status, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn replay_route_streams_protocol_replay_rows_with_cursor_ids() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let first = append_replay(
+            &replay_log,
+            "thread-replay",
+            "wire-1",
+            r#"{"type":"start","messageId":"run-1"}"#,
+        )
+        .await;
+        append_replay(
+            &replay_log,
+            "thread-replay",
+            "wire-2",
+            r#"{"type":"finish","finishReason":"stop"}"#,
+        )
+        .await;
+        let state = make_state(Some(replay_log));
+        let app = build_router(&state);
+
+        let (status, body) = get(app, "/v1/ai-sdk/threads/thread-replay/replay").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains(&format!("id: {}", first.as_str())));
+        assert!(body.contains(r#"data: {"type":"start","messageId":"run-1"}"#));
+        assert!(body.contains(r#"data: {"type":"finish","finishReason":"stop"}"#));
+    }
+
+    #[tokio::test]
+    async fn replay_route_resumes_after_protocol_cursor() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let first = append_replay(
+            &replay_log,
+            "thread-replay",
+            "wire-1",
+            r#"{"type":"start","messageId":"run-1"}"#,
+        )
+        .await;
+        append_replay(
+            &replay_log,
+            "thread-replay",
+            "wire-2",
+            r#"{"type":"finish","finishReason":"stop"}"#,
+        )
+        .await;
+        let state = make_state(Some(replay_log));
+        let app = build_router(&state);
+        let uri = format!(
+            "/v1/ai-sdk/threads/thread-replay/replay?cursor={}",
+            first.as_str()
+        );
+
+        let (status, body) = get(app, &uri).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(!body.contains(r#"messageId":"run-1"#));
+        assert!(body.contains(r#""finishReason":"stop""#));
+    }
+
+    #[tokio::test]
+    async fn replay_route_requires_configured_protocol_log() {
+        let state = make_state(None);
+        let app = build_router(&state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/ai-sdk/threads/thread-replay/replay")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn ai_sdk_stream_falls_back_to_protocol_replay_when_no_live_buffer() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let first = append_replay(
+            &replay_log,
+            "thread-replay",
+            "wire-1",
+            r#"{"type":"start","messageId":"run-1"}"#,
+        )
+        .await;
+        let state = make_state(Some(replay_log));
+        let app = build_router(&state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/ai-sdk/threads/thread-replay/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/event-stream"
+        );
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains(&format!("id: {}", first.as_str())));
+    }
+
+    #[tokio::test]
+    async fn ai_sdk_stream_does_not_mix_protocol_cursor_with_live_buffer_ids() {
+        let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+        let first = append_replay(
+            &replay_log,
+            "thread-replay",
+            "wire-1",
+            r#"{"type":"start","messageId":"run-1"}"#,
+        )
+        .await;
+        append_replay(
+            &replay_log,
+            "thread-replay",
+            "wire-2",
+            r#"{"type":"finish","finishReason":"stop"}"#,
+        )
+        .await;
+        let state = make_state(Some(replay_log));
+        let live_buffer = Arc::new(EventReplayBuffer::new(10));
+        live_buffer.push_json(r#"{"type":"live-buffer"}"#);
+        state.insert_replay_buffer("thread-replay".to_string(), live_buffer);
+        let app = build_router(&state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/ai-sdk/threads/thread-replay/stream")
+                    .header("last-event-id", first.as_str())
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains(r#""finishReason":"stop""#));
+        assert!(!body.contains("live-buffer"));
+    }
+}

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/request.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/request.rs
@@ -3,7 +3,6 @@
 //!
 //! All AI SDK–specific request logic lives here so that `http.rs` can focus
 //! purely on routing and SSE wiring.
-
 use std::collections::HashSet;
 
 use serde::Deserialize;
@@ -446,9 +445,8 @@ fn insert_waiting_state_targets(waiting: &RunWaitingState, targets: &mut HashSet
     }
 }
 
-// ── Tests ───────────────────────────────────────────────────────────
-
 #[cfg(test)]
+#[allow(deprecated)] // ADR-0038 D7: tests use legacy checkpoint
 mod tests {
     use super::*;
     use awaken_contract::contract::content::ContentBlock;
@@ -469,10 +467,29 @@ mod tests {
             run_id: run_id.into(),
             thread_id: thread_id.into(),
             agent_id: "agent".into(),
+            parent_run_id: None,
+            registry_manifest: None,
+            activation: None,
+            request: None,
+            input: None,
+            output: None,
             status,
+            termination_reason: None,
+            final_output: None,
+            error_payload: None,
+            dispatch_id: None,
+            session_id: None,
+            transport_request_id: None,
+            waiting: None,
+            outcome: None,
             created_at: 1,
+            started_at: None,
+            finished_at: None,
             updated_at: 1,
-            ..Default::default()
+            steps: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            state: None,
         }
     }
 

--- a/crates/awaken-server/src/protocols/mcp/adapter.rs
+++ b/crates/awaken-server/src/protocols/mcp/adapter.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 
 use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::message::Message;
-use awaken_runtime::{AgentRuntime, RunRequest};
+use awaken_runtime::{AgentRuntime, RunActivation};
 
 use super::JSON_RPC_VERSION;
 use crate::transport::channel_sink::ChannelEventSink;
@@ -98,7 +98,8 @@ impl McpTool for AgentMcpTool {
 
             let thread_id = format!("mcp-{}", uuid::Uuid::now_v7());
             let messages = vec![Message::user(&text)];
-            let request = RunRequest::new(thread_id, messages).with_agent_id(self.agent_id.clone());
+            let request =
+                RunActivation::new(thread_id, messages).with_agent_id(self.agent_id.clone());
 
             let (event_tx, mut event_rx) = mpsc::unbounded_channel();
             let sink = Arc::new(ChannelEventSink::new(event_tx));
@@ -106,6 +107,7 @@ impl McpTool for AgentMcpTool {
             self.send_log("info", "starting agent run").await;
 
             let runtime = Arc::clone(&self.runtime);
+            // TODO(ADR-0034 #23): route through Mailbox+DurableEventSink+ProtocolReplayLog.
             let run_handle = tokio::spawn(async move { runtime.run(request, sink).await });
 
             // Collect text deltas and emit logs from agent events.

--- a/crates/awaken-server/src/protocols/mcp/http.rs
+++ b/crates/awaken-server/src/protocols/mcp/http.rs
@@ -27,7 +27,7 @@ use tokio::sync::{Mutex, RwLock, Semaphore, mpsc, oneshot};
 use uuid::Uuid;
 
 use super::JSON_RPC_VERSION;
-use crate::app::AppState;
+use crate::app::ProtocolRoutesState;
 use crate::http_sse::{format_sse_data_with_id, sse_body_stream, sse_response};
 
 const HEADER_SESSION_ID: &str = "MCP-Session-Id";
@@ -272,9 +272,8 @@ enum ParsedInbound {
     Notification(JsonRpcNotification),
     Response(JsonRpcResponse),
 }
-
 /// Build MCP routes.
-pub fn mcp_routes() -> Router<AppState> {
+pub fn mcp_routes() -> Router<ProtocolRoutesState> {
     Router::new()
         .route("/v1/mcp", post(mcp_post))
         .route("/v1/mcp", get(mcp_sse))
@@ -282,7 +281,7 @@ pub fn mcp_routes() -> Router<AppState> {
 }
 
 async fn mcp_post(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, McpApiError> {
@@ -311,7 +310,7 @@ async fn mcp_post(
 }
 
 async fn handle_request_post(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     headers: HeaderMap,
     request: JsonRpcRequest,
 ) -> Result<Response, McpApiError> {
@@ -322,13 +321,13 @@ async fn handle_request_post(
             ));
         }
 
-        let session = McpHttpSession::new(&st.runtime);
+        let session = McpHttpSession::new(&st.run.runtime);
         let response = session.dispatch_json_request(request).await?;
         if response.is_success() {
             if let Some(version) = response_protocol_version(&response) {
                 session.set_protocol_version(version).await;
             }
-            st.mcp_http.insert(Arc::clone(&session)).await;
+            st.protocol.mcp_http.insert(Arc::clone(&session)).await;
 
             let mut http_response = Json(serde_json::to_value(&response).map_err(|e| {
                 McpApiError::internal(format!("failed to serialize MCP response: {e}"))
@@ -365,7 +364,7 @@ async fn handle_request_post(
     .into_response())
 }
 
-async fn mcp_sse(State(_st): State<AppState>, headers: HeaderMap) -> Response {
+async fn mcp_sse(State(_st): State<ProtocolRoutesState>, headers: HeaderMap) -> Response {
     if let Err(err) = validate_origin(&headers) {
         return err.into_response();
     }
@@ -373,14 +372,14 @@ async fn mcp_sse(State(_st): State<AppState>, headers: HeaderMap) -> Response {
 }
 
 async fn mcp_delete(
-    State(st): State<AppState>,
+    State(st): State<ProtocolRoutesState>,
     headers: HeaderMap,
 ) -> Result<Response, McpApiError> {
     validate_origin(&headers)?;
     let session_id = header_value(&headers, HEADER_SESSION_ID)
         .ok_or_else(|| McpApiError::bad_request("missing MCP-Session-Id header"))?;
 
-    let Some(session) = st.mcp_http.remove(&session_id).await else {
+    let Some(session) = st.protocol.mcp_http.remove(&session_id).await else {
         return Ok(StatusCode::NOT_FOUND.into_response());
     };
 
@@ -474,12 +473,13 @@ fn parse_json_rpc_id(value: &Value) -> Option<JsonRpcId> {
 }
 
 async fn require_session(
-    st: &AppState,
+    st: &ProtocolRoutesState,
     headers: &HeaderMap,
 ) -> Result<Arc<McpHttpSession>, McpApiError> {
     let session_id = header_value(headers, HEADER_SESSION_ID)
         .ok_or_else(|| McpApiError::bad_request("missing MCP-Session-Id header"))?;
-    st.mcp_http
+    st.protocol
+        .mcp_http
         .get(&session_id)
         .await
         .ok_or_else(|| McpApiError::not_found("unknown MCP session"))
@@ -660,7 +660,7 @@ mod tests {
         }
     }
 
-    fn make_app_state() -> AppState {
+    fn make_app_state() -> crate::app::ServerState {
         let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
         let store = Arc::new(InMemoryStore::new());
         let mailbox_store = Arc::new(InMemoryMailboxStore::new());
@@ -671,7 +671,7 @@ mod tests {
             "test".to_string(),
             crate::mailbox::MailboxConfig::default(),
         ));
-        AppState::new(
+        crate::app::ServerState::new(
             runtime,
             mailbox,
             store,
@@ -697,7 +697,7 @@ mod tests {
     async fn post_initialize_assigns_session_id() {
         let app = Router::new()
             .merge(mcp_routes())
-            .with_state(make_app_state());
+            .with_state(make_app_state().protocol_routes_state());
 
         let body = json!({
             "jsonrpc": JSON_RPC_VERSION,
@@ -729,7 +729,7 @@ mod tests {
     async fn post_requires_session_after_initialize() {
         let app = Router::new()
             .merge(mcp_routes())
-            .with_state(make_app_state());
+            .with_state(make_app_state().protocol_routes_state());
 
         let body = json!({
             "jsonrpc": JSON_RPC_VERSION,
@@ -755,7 +755,7 @@ mod tests {
     async fn delete_terminates_known_session() {
         let app = Router::new()
             .merge(mcp_routes())
-            .with_state(make_app_state());
+            .with_state(make_app_state().protocol_routes_state());
 
         let init = json!({
             "jsonrpc": JSON_RPC_VERSION,

--- a/crates/awaken-server/src/route_modules.rs
+++ b/crates/awaken-server/src/route_modules.rs
@@ -3,12 +3,27 @@
 //! Each module state knows its own route surface; [`crate::routes::build_router`]
 //! folds available modules together without per-module imperative if-chains.
 
-use axum::Router;
+use axum::extract::{Request, State};
+use axum::http::HeaderMap;
+use axum::middleware::Next;
+use axum::response::Response;
+use axum::{Router, middleware};
 
 use crate::app::{
-    AdminRunRoutesState, ConfigRoutesState, EvalRoutesState, EventModuleState, ProtocolRoutesState,
-    RunRoutesState, SystemRoutesState, TraceRoutesState,
+    AdminModuleState, AdminRunRoutesState, ConfigRoutesState, EvalRoutesState, EventModuleState,
+    ProtocolRoutesState, RunRoutesState, SystemRoutesState, TraceRoutesState,
 };
+use crate::routes::ApiError;
+
+async fn require_admin_auth_middleware(
+    State(admin): State<AdminModuleState>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    crate::config_routes::ensure_admin_auth(&admin, &headers)?;
+    Ok(next.run(request).await)
+}
 
 /// A self-contained router fragment that knows how to mount itself onto a
 /// parent `Router`. See module docs.
@@ -53,7 +68,13 @@ pub(crate) struct SystemRoutes(pub SystemRoutesState);
 
 impl RouteModule for SystemRoutes {
     fn mount(self, router: Router) -> Router {
-        router.merge(crate::system_routes::system_routes().with_state(self.0))
+        let auth =
+            middleware::from_fn_with_state(self.0.admin.clone(), require_admin_auth_middleware);
+        router.merge(
+            crate::system_routes::system_routes()
+                .route_layer(auth)
+                .with_state(self.0),
+        )
     }
 }
 
@@ -61,27 +82,55 @@ pub(crate) struct AdminRunModule(pub AdminRunRoutesState);
 
 impl RouteModule for AdminRunModule {
     fn mount(self, router: Router) -> Router {
-        router.merge(crate::admin_routes::admin_run_routes().with_state(self.0))
+        let auth =
+            middleware::from_fn_with_state(self.0.admin.clone(), require_admin_auth_middleware);
+        router.merge(
+            crate::admin_routes::admin_run_routes()
+                .route_layer(auth)
+                .with_state(self.0),
+        )
     }
 }
 
 impl RouteModule for ConfigRoutesState {
     fn mount(self, router: Router) -> Router {
+        let auth =
+            middleware::from_fn_with_state(self.admin.clone(), require_admin_auth_middleware);
         router
-            .merge(crate::config_routes::config_routes().with_state(self.clone()))
-            .merge(crate::admin_routes::config_admin_routes().with_state(self))
+            .merge(
+                crate::config_routes::config_routes()
+                    .route_layer(auth.clone())
+                    .with_state(self.clone()),
+            )
+            .merge(
+                crate::admin_routes::config_admin_routes()
+                    .route_layer(auth)
+                    .with_state(self),
+            )
     }
 }
 
 impl RouteModule for EvalRoutesState {
     fn mount(self, router: Router) -> Router {
-        router.merge(crate::eval_router::eval_routes().with_state(self))
+        let auth =
+            middleware::from_fn_with_state(self.admin.clone(), require_admin_auth_middleware);
+        router.merge(
+            crate::eval_router::eval_routes()
+                .route_layer(auth)
+                .with_state(self),
+        )
     }
 }
 
 impl RouteModule for TraceRoutesState {
     fn mount(self, router: Router) -> Router {
-        router.merge(crate::routes::trace_routes().with_state(self))
+        let auth =
+            middleware::from_fn_with_state(self.admin.clone(), require_admin_auth_middleware);
+        router.merge(
+            crate::routes::trace_routes()
+                .route_layer(auth)
+                .with_state(self),
+        )
     }
 }
 

--- a/crates/awaken-server/src/route_modules.rs
+++ b/crates/awaken-server/src/route_modules.rs
@@ -1,0 +1,92 @@
+//! `RouteModule` trait and per-module-state implementations.
+//!
+//! Each module state knows its own route surface; [`crate::routes::build_router`]
+//! folds available modules together without per-module imperative if-chains.
+
+use axum::Router;
+
+use crate::app::{
+    AdminRunRoutesState, ConfigRoutesState, EvalRoutesState, EventModuleState, ProtocolRoutesState,
+    RunRoutesState, SystemRoutesState, TraceRoutesState,
+};
+
+/// A self-contained router fragment that knows how to mount itself onto a
+/// parent `Router`. See module docs.
+pub(crate) trait RouteModule {
+    fn mount(self, router: Router) -> Router;
+}
+
+/// Lift `Option<M: RouteModule>` into a no-op when the module is absent so
+/// `build_router` can chain optional modules without `if let`.
+impl<M: RouteModule> RouteModule for Option<M> {
+    fn mount(self, router: Router) -> Router {
+        match self {
+            Some(module) => module.mount(router),
+            None => router,
+        }
+    }
+}
+
+impl RouteModule for RunRoutesState {
+    fn mount(self, router: Router) -> Router {
+        router
+            .merge(crate::routes::health_routes().with_state(self.clone()))
+            .merge(crate::routes::thread_routes().with_state(self.clone()))
+            .merge(crate::routes::run_routes().with_state(self))
+    }
+}
+
+impl RouteModule for ProtocolRoutesState {
+    fn mount(self, router: Router) -> Router {
+        router
+            .merge(crate::protocols::ai_sdk_v6::http::ai_sdk_routes().with_state(self.clone()))
+            .merge(crate::protocols::ag_ui::http::ag_ui_routes().with_state(self.clone()))
+            .merge(crate::protocols::a2a::a2a_routes().with_state(self.clone()))
+            .merge(crate::protocols::mcp::http::mcp_routes().with_state(self))
+    }
+}
+
+/// Newtype wrapper pinning `RouteModule` to `SystemRoutesState`. The trait
+/// would otherwise have nothing else to dispatch on for single-purpose
+/// state types; the wrapper signals intent at the call site.
+pub(crate) struct SystemRoutes(pub SystemRoutesState);
+
+impl RouteModule for SystemRoutes {
+    fn mount(self, router: Router) -> Router {
+        router.merge(crate::system_routes::system_routes().with_state(self.0))
+    }
+}
+
+pub(crate) struct AdminRunModule(pub AdminRunRoutesState);
+
+impl RouteModule for AdminRunModule {
+    fn mount(self, router: Router) -> Router {
+        router.merge(crate::admin_routes::admin_run_routes().with_state(self.0))
+    }
+}
+
+impl RouteModule for ConfigRoutesState {
+    fn mount(self, router: Router) -> Router {
+        router
+            .merge(crate::config_routes::config_routes().with_state(self.clone()))
+            .merge(crate::admin_routes::config_admin_routes().with_state(self))
+    }
+}
+
+impl RouteModule for EvalRoutesState {
+    fn mount(self, router: Router) -> Router {
+        router.merge(crate::eval_router::eval_routes().with_state(self))
+    }
+}
+
+impl RouteModule for TraceRoutesState {
+    fn mount(self, router: Router) -> Router {
+        router.merge(crate::routes::trace_routes().with_state(self))
+    }
+}
+
+impl RouteModule for EventModuleState {
+    fn mount(self, router: Router) -> Router {
+        router.merge(crate::event_routes::event_routes().with_state(self))
+    }
+}

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -2,7 +2,7 @@
 use crate::eval_router::eval_routes;
 use crate::services::trace_service::{get_trace, list_traces, pin_trace};
 use axum::extract::{Path, Query, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use axum::middleware;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
@@ -10,12 +10,7 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
-use awaken_contract::contract::message::Message;
-use awaken_contract::contract::storage::{ChildThreadDeleteStrategy, StorageError};
-use awaken_ext_observability::runtime_stats::parse_window_str;
-
-use crate::app::AppState;
-use crate::config_routes::config_routes;
+use crate::app::{RunRoutesState, ServerState, TraceRoutesState};
 use crate::http_run::wire_sse_relay;
 use crate::http_sse::{sse_body_stream, sse_response};
 use crate::mailbox::{ACTIVE_RUN_CONFLICT_MESSAGE, MailboxDispatchStatus, MailboxError};
@@ -27,7 +22,10 @@ use crate::query::{self, MessageQueryParams, ThreadQueryParams};
 use crate::services::run_control_service::{
     InputMode, InterruptMode, RunControlError, RunControlService,
 };
-use awaken_runtime::RunRequest;
+use crate::{config_routes::config_routes, event_routes::event_routes};
+use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::{ChildThreadDeleteStrategy, StorageError};
+use awaken_runtime::RunActivation;
 
 pub use crate::error::ApiError;
 
@@ -70,29 +68,27 @@ fn map_run_control_error(error: RunControlError) -> ApiError {
     }
 }
 
-/// Build the complete router for the given state.
-pub fn build_router(state: &AppState) -> Router<AppState> {
-    crate::metrics::install_recorder();
+use crate::route_modules::{AdminRunModule, RouteModule, SystemRoutes};
 
+/// Build the complete router for the given state.
+pub fn build_router(state: &ServerState) -> Router {
+    crate::metrics::install_recorder();
     let admin_config = state.admin_api_config();
 
-    let mut router = Router::new()
-        .merge(health_routes())
-        .merge(thread_routes())
-        .merge(run_routes())
-        .merge(crate::services::run_service::summary_routes())
-        .merge(ai_sdk_routes())
-        .merge(ag_ui_routes())
-        .merge(a2a_routes())
-        .merge(mcp_routes());
+    let mut router = Router::new();
+    router = state.run_routes_state().mount(router);
+    router = state.protocol_routes_state().mount(router);
+    router = SystemRoutes(state.system_routes_state()).mount(router);
+    router = state.event_module().mount(router);
     if admin_config.expose_config_routes {
-        router = router.merge(admin_routes());
+        router = AdminRunModule(state.admin_run_routes_state()).mount(router);
+        router = state.config_routes_state().mount(router);
     }
     if admin_config.expose_eval_routes {
-        router = router.merge(eval_routes());
+        router = state.eval_routes_state().mount(router);
     }
     if admin_config.expose_trace_routes {
-        router = router.merge(trace_routes());
+        router = state.trace_routes_state().mount(router);
     }
 
     router
@@ -100,20 +96,20 @@ pub fn build_router(state: &AppState) -> Router<AppState> {
         .layer(middleware::from_fn(crate::metrics::http_metrics_middleware))
 }
 
-fn trace_routes() -> Router<AppState> {
+pub(crate) fn trace_routes() -> Router<TraceRoutesState> {
     Router::new()
         .route("/v1/traces", get(list_traces))
         .route("/v1/traces/:run_id", get(get_trace))
         .route("/v1/traces/:run_id/pin", post(pin_trace))
 }
 
-fn health_routes() -> Router<AppState> {
+pub(crate) fn health_routes() -> Router<RunRoutesState> {
     Router::new()
         .route("/health", get(health_ready))
         .route("/health/live", get(health_live))
 }
 
-fn thread_routes() -> Router<AppState> {
+pub(crate) fn thread_routes() -> Router<RunRoutesState> {
     Router::new()
         .route("/v1/threads", get(list_threads).post(create_thread))
         .route("/v1/threads/summaries", get(list_thread_summaries))
@@ -135,7 +131,7 @@ fn thread_routes() -> Router<AppState> {
         )
 }
 
-fn run_routes() -> Router<AppState> {
+pub(crate) fn run_routes() -> Router<RunRoutesState> {
     Router::new()
         .route("/v1/runs", get(list_runs).post(start_run))
         .route("/v1/runs/:id", get(get_run))
@@ -147,167 +143,12 @@ fn run_routes() -> Router<AppState> {
         .route("/v1/threads/:id/runs/latest", get(latest_thread_run))
 }
 
-fn admin_routes() -> Router<AppState> {
-    // permission-preview is always registered so the handler returns 503
-    // when the `permission` feature is absent (a 404 would be ambiguous
-    // with "agent not found"). Matches `runtime-stats` / trace conventions.
-    let permission_preview = get(get_agent_permission_preview);
-    config_routes()
-        .route("/v1/system/info", get(system_info))
-        .route("/v1/agents/:id/runtime-stats", get(get_agent_runtime_stats))
-        .route("/v1/agents/runtime-stats", get(list_agents_runtime_stats))
-        .route("/v1/agents/:id/permission-preview", permission_preview)
-}
-
-#[tracing::instrument(skip(state))]
-async fn get_agent_permission_preview(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Path(id): Path<String>,
-) -> Response {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
-        return err.into_response();
-    }
-    #[cfg(feature = "permission")]
-    {
-        let _ = &id;
-        match crate::services::permission_preview::preview_agent_permissions(&state, &id).await {
-            Ok(preview) => Json(preview).into_response(),
-            Err(err) => map_permission_preview_error(err).into_response(),
-        }
-    }
-    #[cfg(not(feature = "permission"))]
-    {
-        let _ = (state, id);
-        ApiError::ServiceUnavailable(
-            "permission feature not compiled into this server build".to_string(),
-        )
-        .into_response()
-    }
-}
-
-#[cfg(feature = "permission")]
-fn map_permission_preview_error(
-    err: crate::services::permission_preview::PermissionPreviewError,
-) -> ApiError {
-    use crate::services::permission_preview::PermissionPreviewError as PE;
-    match err {
-        PE::AgentNotFound(id) => ApiError::NotFound(format!("agent not found: {id}")),
-        PE::InvalidSpec(msg) | PE::InvalidPermissionConfig { reason: msg, .. } => {
-            ApiError::BadRequest(msg)
-        }
-        PE::RegistryUnavailable => ApiError::Internal("runtime registry unavailable".into()),
-        PE::Config(err) => ApiError::Internal(err.to_string()),
-    }
-}
-
-// ── Agent runtime-stats endpoints ───────────────────────────────────
-
-/// Query params for `GET /v1/agents/:id/runtime-stats`.
-#[derive(Debug, Deserialize, Default)]
-struct RuntimeStatsQuery {
-    /// Optional time window, e.g. `1h`, `24h`, `7d`, `3600s`, `90`.
-    window: Option<String>,
-}
-
-/// `GET /v1/agents/:id/runtime-stats` — return the agent's rolling-window
-/// snapshot, or 404 when the agent has not been seen by the registry, or
-/// 503 when the registry is not configured on this server.
-///
-/// Accepts an optional `?window=` query parameter (e.g. `1h`, `24h`, `7d`)
-/// to restrict the snapshot to a shorter sub-window of the registry's full
-/// history.  An invalid format returns 400.
-#[tracing::instrument(skip(state))]
-async fn get_agent_runtime_stats(
-    State(state): State<AppState>,
-    headers: HeaderMap,
-    Path(id): Path<String>,
-    Query(params): Query<RuntimeStatsQuery>,
-) -> Response {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
-        return err.into_response();
-    }
-    let Some(registry) = state.runtime_stats() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "runtime_stats registry not configured" })),
-        )
-            .into_response();
-    };
-
-    let window = match params.window.as_deref() {
-        None => None,
-        Some(s) => match parse_window_str(s) {
-            Ok(d) => Some(d),
-            Err(msg) => {
-                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
-            }
-        },
-    };
-
-    match registry.snapshot_for_window(&id, window) {
-        Some(snapshot) => Json(snapshot).into_response(),
-        None => (
-            StatusCode::NOT_FOUND,
-            Json(json!({ "error": format!("agent not found in runtime stats: {id}") })),
-        )
-            .into_response(),
-    }
-}
-
-/// `GET /v1/agents/runtime-stats` — return one snapshot per known agent,
-/// sorted by `agent_id`. Returns `{"agents":[...]}` (or 503 when the
-/// registry is missing).
-#[tracing::instrument(skip(state))]
-async fn list_agents_runtime_stats(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
-        return err.into_response();
-    }
-    let Some(registry) = state.runtime_stats() else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(json!({ "error": "runtime_stats registry not configured" })),
-        )
-            .into_response();
-    };
-    let snapshots: Vec<_> = registry
-        .known_agents()
-        .into_iter()
-        .filter_map(|id| registry.snapshot_for(&id))
-        .collect();
-    Json(json!({ "agents": snapshots })).into_response()
-}
-
 // ── Health ──
 
 /// Liveness probe — always returns 200.  Use for k8s `livenessProbe`.
 #[tracing::instrument]
 async fn health_live() -> impl IntoResponse {
     StatusCode::OK
-}
-
-/// `GET /v1/system/info` — flat snapshot of server identity for the admin
-/// console System card. Returns the crate version, seconds since process
-/// start, and which optional subsystems are wired in.
-///
-/// Concrete store backend names are intentionally NOT exposed: the
-/// `&dyn Trait` lookup only yields the trait name, not the impl, so any
-/// string would mislead. Embedders that need to expose the concrete backend
-/// can decorate `AppState` with their own field and a separate route.
-#[tracing::instrument(skip(state))]
-async fn system_info(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    if let Err(err) = crate::config_routes::ensure_admin_auth(&state, &headers) {
-        return err.into_response();
-    }
-    let uptime_secs = state.started_at().elapsed().as_secs();
-    Json(json!({
-        "version": env!("CARGO_PKG_VERSION"),
-        "uptime_seconds": uptime_secs,
-        "config_store_enabled": state.config_store.is_some(),
-        "audit_log_enabled": state.audit_log().is_some(),
-        "runtime_stats_enabled": state.runtime_stats().is_some(),
-    }))
-    .into_response()
 }
 
 /// Readiness probe — checks that critical dependencies are reachable.
@@ -317,19 +158,19 @@ async fn system_info(State(state): State<AppState>, headers: HeaderMap) -> Respo
 /// Individual component checks are capped at 5 seconds to avoid blocking
 /// the probe.
 #[tracing::instrument(skip(st))]
-async fn health_ready(State(st): State<AppState>) -> impl IntoResponse {
+async fn health_ready(State(st): State<RunRoutesState>) -> impl IntoResponse {
     const CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
     // -- Store check: attempt a lightweight list operation.
-    let store_status = match tokio::time::timeout(CHECK_TIMEOUT, st.store.list_threads(0, 1)).await
-    {
-        Ok(Ok(_)) => "ok",
-        Ok(Err(_)) => "error",
-        Err(_) => "timeout",
-    };
+    let store_status =
+        match tokio::time::timeout(CHECK_TIMEOUT, st.run.store().list_threads(0, 1)).await {
+            Ok(Ok(_)) => "ok",
+            Ok(Err(_)) => "error",
+            Err(_) => "timeout",
+        };
 
     // -- Runtime check: the runtime is healthy if it exists (it is
-    //    always present once AppState is constructed).
+    //    always present once ServerState is constructed).
     let runtime_status = "ok";
 
     let all_ok = store_status == "ok" && runtime_status == "ok";
@@ -364,12 +205,13 @@ struct ListParams {
 
 #[tracing::instrument(skip(st))]
 async fn list_threads(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Query(params): Query<ThreadQueryParams>,
 ) -> Result<Json<Value>, ApiError> {
     let query = params.storage_query().map_err(ApiError::BadRequest)?;
     let page = st
-        .store
+        .run
+        .store()
         .list_threads_query(&query)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -385,12 +227,13 @@ async fn list_threads(
 
 #[tracing::instrument(skip(st))]
 async fn list_thread_summaries(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Query(params): Query<ThreadQueryParams>,
 ) -> Result<Json<Value>, ApiError> {
     let query = params.storage_query().map_err(ApiError::BadRequest)?;
     let page = st
-        .store
+        .run
+        .store()
         .list_threads_query(&query)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -398,12 +241,14 @@ async fn list_thread_summaries(
     let mut items = Vec::with_capacity(page.items.len());
     for id in page.items {
         let latest_run = st
-            .store
+            .run
+            .store()
             .latest_run(&id)
             .await
             .map_err(|e| ApiError::Internal(e.to_string()))?;
         if let Some(thread) = st
-            .store
+            .run
+            .store()
             .load_thread(&id)
             .await
             .map_err(|e| ApiError::Internal(e.to_string()))?
@@ -486,11 +331,11 @@ where
 
 #[tracing::instrument(skip(st, payload))]
 async fn create_thread(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Json(payload): Json<CreateThreadPayload>,
 ) -> Result<(StatusCode, Json<Value>), ApiError> {
-    let thread = crate::services::thread_service::create_thread_with_options(
-        st.store.as_ref(),
+    let thread = crate::services::thread_events::create_thread(
+        &st,
         crate::services::thread_service::CreateThreadOptions {
             title: payload.title,
             resource_id: payload.resource_id,
@@ -505,11 +350,12 @@ async fn create_thread(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn get_thread(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
     let thread = st
-        .store
+        .run
+        .store()
         .load_thread(&id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
@@ -520,12 +366,12 @@ async fn get_thread(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn delete_thread(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Query(params): Query<DeleteThreadParams>,
 ) -> Result<StatusCode, ApiError> {
-    crate::services::thread_service::delete_thread(
-        st.store.as_ref(),
+    crate::services::thread_events::delete_thread(
+        &st,
         &id,
         crate::services::thread_service::DeleteThreadOptions {
             child_strategy: params.child_strategy,
@@ -551,12 +397,12 @@ struct PatchThreadPayload {
 
 #[tracing::instrument(skip(st, payload), fields(thread_id = %id))]
 async fn patch_thread(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Json(payload): Json<PatchThreadPayload>,
 ) -> Result<Json<Value>, ApiError> {
-    let thread = crate::services::thread_service::update_thread(
-        st.store.as_ref(),
+    let thread = crate::services::thread_events::update_thread(
+        &st,
         &id,
         crate::services::thread_service::UpdateThreadOptions {
             title: payload.title,
@@ -574,10 +420,10 @@ async fn patch_thread(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn interrupt_thread(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
 ) -> Result<Response, ApiError> {
-    let interrupted = RunControlService::new(st)
+    let interrupted = RunControlService::new(st.run.clone())
         .interrupt_thread(&id, InterruptMode::Graceful)
         .await
         .map_err(map_run_control_error)?;
@@ -595,12 +441,13 @@ async fn interrupt_thread(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn get_thread_messages(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Query(params): Query<MessageQueryParams>,
 ) -> Result<Json<Value>, ApiError> {
     // Verify thread exists
-    st.store
+    st.run
+        .store()
         .load_thread(&id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
@@ -608,7 +455,8 @@ async fn get_thread_messages(
 
     let query = params.storage_query().map_err(ApiError::BadRequest)?;
     let page = st
-        .store
+        .run
+        .store()
         .list_message_records(&id, &query)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -661,12 +509,13 @@ struct PostThreadMessagesPayload {
 
 #[tracing::instrument(skip(st, payload), fields(thread_id = %id))]
 async fn post_thread_messages(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Json(payload): Json<PostThreadMessagesPayload>,
 ) -> Result<Response, ApiError> {
     // Require existing thread for thread-centric API semantics.
-    st.store
+    st.run
+        .store()
         .load_thread(&id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
@@ -679,7 +528,7 @@ async fn post_thread_messages(
         ));
     }
 
-    let service = RunControlService::new(st);
+    let service = RunControlService::new(st.run.clone());
     let result = match payload.mode.input_mode() {
         Some(mode) => {
             service
@@ -718,7 +567,7 @@ struct MailboxPayload {
 
 #[tracing::instrument(skip(st, body), fields(thread_id = %id))]
 async fn push_mailbox(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Json(body): Json<MailboxPayload>,
 ) -> Result<(StatusCode, Json<Value>), ApiError> {
@@ -738,8 +587,9 @@ async fn push_mailbox(
     };
 
     let result = st
+        .run
         .mailbox
-        .submit_background(RunRequest::new(id, messages))
+        .submit_background(RunActivation::new(id, messages))
         .await
         .map_err(map_mailbox_error)?;
 
@@ -755,13 +605,14 @@ async fn push_mailbox(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn peek_mailbox(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Query(params): Query<ListParams>,
 ) -> Result<Json<Value>, ApiError> {
     let offset = params.offset.unwrap_or(0);
     let limit = params.limit.clamp(1, 200);
     let dispatches = st
+        .run
         .mailbox
         .list_dispatches(&id, None, limit, offset)
         .await
@@ -797,7 +648,7 @@ fn convert_run_messages(msgs: Vec<RunMessage>) -> Vec<Message> {
 
 #[tracing::instrument(skip(st, payload))]
 async fn start_run(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Json(payload): Json<CreateRunPayload>,
 ) -> Result<Response, ApiError> {
     let agent_id = payload.agent_id.trim().to_string();
@@ -808,24 +659,25 @@ async fn start_run(
     let messages = convert_run_messages(payload.messages);
     let (thread_id, messages) = crate::request::prepare_run_inputs(payload.thread_id, messages)?;
 
-    let request = RunRequest::new(thread_id, messages).with_agent_id(agent_id);
+    let request = RunActivation::new(thread_id, messages).with_agent_id(agent_id);
     let (_result, event_rx) = st
+        .run
         .mailbox
         .submit(request)
         .await
         .map_err(map_mailbox_error)?;
     let encoder = awaken_contract::contract::transport::Identity::default();
-    let sse_rx = wire_sse_relay(event_rx, encoder, st.config.sse_buffer_size, None);
+    let sse_rx = wire_sse_relay(event_rx, encoder, st.sse_buffer_size, None);
 
     Ok(sse_response(sse_body_stream(sse_rx)))
 }
 
 #[tracing::instrument(skip(st), fields(run_id = %id))]
 async fn get_run(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
-    let record = crate::services::run_service::get_run(st.store.as_ref(), &id)
+    let record = crate::services::run_service::get_run(st.run.store().as_ref(), &id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or(ApiError::RunNotFound(id))?;
@@ -834,7 +686,7 @@ async fn get_run(
 }
 
 async fn list_runs(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Query(params): Query<ListRunsParams>,
 ) -> Result<Json<Value>, ApiError> {
     use awaken_contract::contract::lifecycle::RunStatus;
@@ -860,7 +712,7 @@ async fn list_runs(
         thread_id: None,
         status,
     };
-    let page = crate::services::run_service::list_runs(st.store.as_ref(), &query)
+    let page = crate::services::run_service::list_runs(st.run.store().as_ref(), &query)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 
@@ -882,7 +734,7 @@ struct PushRunInputsPayload {
 
 #[tracing::instrument(skip(st, payload), fields(run_id = %id))]
 async fn push_run_inputs(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Json(payload): Json<PushRunInputsPayload>,
 ) -> Result<Response, ApiError> {
@@ -893,7 +745,7 @@ async fn push_run_inputs(
         ));
     }
 
-    let service = RunControlService::new(st);
+    let service = RunControlService::new(st.run.clone());
     let result = match payload.mode.input_mode() {
         Some(mode) => service.inject_run_input(&id, messages, mode).await,
         None => {
@@ -916,10 +768,10 @@ async fn push_run_inputs(
 
 #[tracing::instrument(skip(st), fields(run_id = %id))]
 async fn cancel_run(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
 ) -> Result<Response, ApiError> {
-    RunControlService::new(st)
+    RunControlService::new(st.run.clone())
         .cancel_run(&id)
         .await
         .map_err(map_run_control_error)?;
@@ -936,10 +788,10 @@ async fn cancel_run(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn cancel_thread(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
 ) -> Result<Response, ApiError> {
-    RunControlService::new(st)
+    RunControlService::new(st.run.clone())
         .cancel_run(&id)
         .await
         .map_err(|error| match error {
@@ -968,7 +820,7 @@ struct DecisionPayload {
 
 #[tracing::instrument(skip(st, payload), fields(run_id = %id))]
 async fn submit_decision(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Json(payload): Json<DecisionPayload>,
 ) -> Result<Response, ApiError> {
@@ -992,7 +844,7 @@ async fn submit_decision(
         updated_at: crate::time::now_millis(),
     };
 
-    RunControlService::new(st)
+    RunControlService::new(st.run.clone())
         .decide(&id, payload.tool_call_id.clone(), resume)
         .await
         .map_err(map_run_control_error)?;
@@ -1010,7 +862,7 @@ async fn submit_decision(
 
 #[tracing::instrument(skip(st, payload), fields(thread_id = %id))]
 async fn submit_thread_decision(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Json(payload): Json<DecisionPayload>,
 ) -> Result<Response, ApiError> {
@@ -1034,7 +886,7 @@ async fn submit_thread_decision(
         updated_at: crate::time::now_millis(),
     };
 
-    RunControlService::new(st)
+    RunControlService::new(st.run.clone())
         .decide(&id, payload.tool_call_id.clone(), resume)
         .await
         .map_err(|error| match error {
@@ -1067,7 +919,7 @@ struct ListRunsParams {
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn list_thread_runs(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
     Query(params): Query<ListRunsParams>,
 ) -> Result<Json<Value>, ApiError> {
@@ -1094,7 +946,7 @@ async fn list_thread_runs(
         thread_id: Some(id),
         status,
     };
-    let page = crate::services::run_service::list_runs(st.store.as_ref(), &query)
+    let page = crate::services::run_service::list_runs(st.run.store().as_ref(), &query)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 
@@ -1108,10 +960,10 @@ async fn list_thread_runs(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn latest_thread_run(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
-    let record = crate::services::run_service::latest_run(st.store.as_ref(), &id)
+    let record = crate::services::run_service::latest_run(st.run.store().as_ref(), &id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or(ApiError::RunNotFound(format!("no runs for thread {id}")))?;
@@ -1121,10 +973,10 @@ async fn latest_thread_run(
 
 #[tracing::instrument(skip(st), fields(thread_id = %id))]
 async fn active_thread_run(
-    State(st): State<AppState>,
+    State(st): State<RunRoutesState>,
     Path(id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
-    let active = RunControlService::new(st)
+    let active = RunControlService::new(st.run.clone())
         .get_active_run(&id)
         .await
         .map_err(map_run_control_error)?;

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -1,5 +1,4 @@
 //! Axum router setup — unified route registration.
-use crate::eval_router::eval_routes;
 use crate::services::trace_service::{get_trace, list_traces, pin_trace};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
@@ -14,15 +13,10 @@ use crate::app::{RunRoutesState, ServerState, TraceRoutesState};
 use crate::http_run::wire_sse_relay;
 use crate::http_sse::{sse_body_stream, sse_response};
 use crate::mailbox::{ACTIVE_RUN_CONFLICT_MESSAGE, MailboxDispatchStatus, MailboxError};
-use crate::protocols::a2a::a2a_routes;
-use crate::protocols::ag_ui::http::ag_ui_routes;
-use crate::protocols::ai_sdk_v6::http::ai_sdk_routes;
-use crate::protocols::mcp::http::mcp_routes;
 use crate::query::{self, MessageQueryParams, ThreadQueryParams};
 use crate::services::run_control_service::{
     InputMode, InterruptMode, RunControlError, RunControlService,
 };
-use crate::{config_routes::config_routes, event_routes::event_routes};
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::storage::{ChildThreadDeleteStrategy, StorageError};
 use awaken_runtime::RunActivation;

--- a/crates/awaken-server/src/routes_test.rs
+++ b/crates/awaken-server/src/routes_test.rs
@@ -428,7 +428,7 @@ fn list_params_explicit_values() {
 
 mod health_integration {
     use super::*;
-    use crate::app::{AppState, ServerConfig};
+    use crate::app::{ServerConfig, ServerState};
     use crate::mailbox::{Mailbox, MailboxConfig};
     use awaken_runtime::AgentRuntime;
     use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
@@ -448,7 +448,7 @@ mod health_integration {
         }
     }
 
-    fn make_app_state() -> AppState {
+    fn make_app_state() -> ServerState {
         let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
         let store = Arc::new(InMemoryStore::new());
         let mailbox_store = Arc::new(InMemoryMailboxStore::new());
@@ -459,7 +459,7 @@ mod health_integration {
             "test".to_string(),
             MailboxConfig::default(),
         ));
-        AppState::new(
+        ServerState::new(
             runtime,
             mailbox,
             store.clone(),
@@ -477,7 +477,7 @@ mod health_integration {
             expose_config_routes: false,
             ..AdminApiConfig::default()
         });
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/v1/agents")
@@ -500,10 +500,9 @@ mod health_integration {
             expose_config_routes: false,
             ..AdminApiConfig::default()
         });
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         for uri in [
-            "/v1/system/info",
             "/v1/agents/runtime-stats",
             "/v1/agents/default/runtime-stats",
         ] {
@@ -515,9 +514,16 @@ mod health_integration {
             assert_eq!(
                 resp.status(),
                 StatusCode::NOT_FOUND,
-                "{uri} must not be mounted when the admin surface is disabled"
+                "{uri} must not be mounted when the config-admin surface is disabled"
             );
         }
+
+        let req = axum::http::Request::builder()
+            .uri("/v1/system/info")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]
@@ -531,7 +537,7 @@ mod health_integration {
             bearer_token: Some(token),
             ..AdminApiConfig::default()
         });
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/v1/system/info")
@@ -550,29 +556,28 @@ mod health_integration {
     }
 
     #[tokio::test]
-    async fn config_routes_mounted_by_default() {
+    async fn config_routes_are_absent_without_config_module() {
         use axum::http::StatusCode;
 
         let state = make_app_state();
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/v1/agents")
             .body(axum::body::Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
-        assert_ne!(
+        assert_eq!(
             resp.status(),
             StatusCode::NOT_FOUND,
-            "default config routes must remain mounted; got {}",
-            resp.status()
+            "config routes require a ConfigModuleState"
         );
     }
 
     #[tokio::test]
     async fn health_live_returns_200() {
         let state = make_app_state();
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/health/live")
@@ -585,7 +590,7 @@ mod health_integration {
     #[tokio::test]
     async fn system_info_returns_real_fields() {
         let state = make_app_state();
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/v1/system/info")
@@ -607,7 +612,7 @@ mod health_integration {
     #[tokio::test]
     async fn health_ready_returns_healthy_with_working_store() {
         let state = make_app_state();
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/health")
@@ -626,7 +631,7 @@ mod health_integration {
     #[tokio::test]
     async fn metrics_endpoint_is_installed_and_records_http_requests() {
         let state = make_app_state();
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/health/live")
@@ -743,14 +748,14 @@ mod health_integration {
             "test".to_string(),
             MailboxConfig::default(),
         ));
-        let state = AppState::new(
+        let state = ServerState::new(
             runtime,
             mailbox,
             store,
             Arc::new(StubResolver),
             ServerConfig::default(),
         );
-        let app = build_router(&state).with_state(state);
+        let app = build_router(&state);
 
         let req = axum::http::Request::builder()
             .uri("/health")

--- a/crates/awaken-server/src/routes_test.rs
+++ b/crates/awaken-server/src/routes_test.rs
@@ -466,6 +466,7 @@ mod health_integration {
             Arc::new(StubResolver),
             ServerConfig::default(),
         )
+        .with_admin_api_bearer_token("test-admin-token")
     }
 
     #[tokio::test]
@@ -496,10 +497,12 @@ mod health_integration {
         use crate::app::AdminApiConfig;
         use axum::http::StatusCode;
 
-        let state = make_app_state().with_admin_api_config(AdminApiConfig {
-            expose_config_routes: false,
-            ..AdminApiConfig::default()
-        });
+        let state = make_app_state()
+            .with_admin_api_config(AdminApiConfig {
+                expose_config_routes: false,
+                ..AdminApiConfig::default()
+            })
+            .with_admin_api_bearer_token("test-admin-token");
         let app = build_router(&state);
 
         for uri in [
@@ -520,6 +523,7 @@ mod health_integration {
 
         let req = axum::http::Request::builder()
             .uri("/v1/system/info")
+            .header(axum::http::header::AUTHORIZATION, "Bearer test-admin-token")
             .body(axum::body::Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -594,6 +598,7 @@ mod health_integration {
 
         let req = axum::http::Request::builder()
             .uri("/v1/system/info")
+            .header(axum::http::header::AUTHORIZATION, "Bearer test-admin-token")
             .body(axum::body::Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -39,6 +39,7 @@ mod managed_config;
 mod skill_publish;
 #[cfg(test)]
 mod skill_tests;
+mod versioned_publish;
 
 use managed_config::ManagedConfigSnapshot;
 
@@ -73,6 +74,8 @@ pub enum ConfigRuntimeError {
     PeriodicRefresh(String),
     #[error("config change listener error: {0}")]
     ChangeListener(String),
+    #[error("versioned registry error: {0}")]
+    VersionedRegistry(String),
     #[error("storage error: {0}")]
     Storage(#[from] StorageError),
 }
@@ -194,7 +197,7 @@ pub trait ProviderExecutorFactory: Send + Sync {
 /// so token caches, single-flight refreshes, and metrics are unified
 /// across all providers in this process. The default constructor creates
 /// a fresh broker, suitable for tests; production wiring should pass the
-/// `AppState`-scoped broker via [`with_broker`](Self::with_broker).
+/// `ServerState`-scoped broker via [`with_broker`](Self::with_broker).
 pub struct GenaiProviderExecutorFactory;
 
 /// Provider executor factory backed by genai and a caller-supplied credential broker.
@@ -547,6 +550,7 @@ pub struct ConfigRuntimeManager {
     /// Optional audit logger — if set, `apply_seed` emits a `SeedApply` event
     /// per non-empty bucket of the resulting [`SeedReport`].
     audit_log: Option<Arc<crate::services::audit_log::AuditLogger>>,
+    versioned_registry: Option<versioned_publish::VersionedRegistryPublicationTarget>,
 }
 
 impl ConfigRuntimeManager {
@@ -590,6 +594,7 @@ impl ConfigRuntimeManager {
             mcp_refresh_interval: RwLock::new(None),
             min_apply_interval: Duration::ZERO,
             audit_log: None,
+            versioned_registry: None,
         })
     }
 
@@ -887,7 +892,6 @@ impl ConfigRuntimeManager {
 
     async fn publish(&self, managed: ManagedConfigSnapshot) -> Result<u64, ConfigRuntimeError> {
         let prepared_skills = self.prepare_skill_specs(&managed.skills)?;
-
         let prepared_mcp = self.prepare_mcp_registry(&managed.mcp_servers).await?;
         let (candidate, next_provider_cache) = match self.compile_registry_set(
             &managed.providers,
@@ -908,7 +912,13 @@ impl ConfigRuntimeManager {
             return Err(error);
         }
 
-        let version = match self.runtime.replace_registry_set(candidate) {
+        if let Err(error) = self.publish_versioned_registry(&managed).await {
+            prepared_mcp.cleanup().await;
+            return Err(error);
+        }
+
+        let runtime_set = self.published_or_candidate_registry_set(candidate).await;
+        let version = match self.runtime.replace_registry_set(runtime_set) {
             Some(version) => version,
             None => {
                 prepared_mcp.cleanup().await;
@@ -1313,7 +1323,7 @@ impl ConfigRuntimeManager {
 /// Misconfigured material is rejected here (eager validation) rather
 /// than at first inference. The provided broker is shared with all
 /// dynamic providers built by the same caller; passing the
-/// `AppState::credential_broker` is the production wiring.
+/// `ServerState::credential_broker` is the production wiring.
 pub fn build_genai_provider_executor_with_broker(
     spec: &ProviderSpec,
     broker: Arc<dyn awaken_runtime::credentials::CredentialBroker>,
@@ -2431,138 +2441,6 @@ mod tests {
         );
     }
 
-    fn minimal_agent_spec(id: &str) -> AgentSpec {
-        AgentSpec {
-            id: id.into(),
-            model_id: "test-model".into(),
-            system_prompt: "test prompt".into(),
-            max_rounds: 1,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn deserialize_namespace_decodes_legacy_bare_spec() {
-        let spec = minimal_agent_spec("agent-a");
-        let value = serde_json::to_value(&spec).expect("serialization must succeed");
-        let entries = vec![("agent-a".to_string(), value)];
-        let result: Vec<AgentSpec> =
-            deserialize_namespace(&entries).expect("legacy bare spec must decode");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "agent-a");
-    }
-
-    #[test]
-    fn deserialize_namespace_decodes_envelope() {
-        use awaken_contract::ConfigRecord;
-        let spec = minimal_agent_spec("agent-b");
-        let record = ConfigRecord {
-            spec,
-            meta: awaken_contract::RecordMeta::new_user(),
-        };
-        let value = record
-            .to_value()
-            .expect("envelope serialization must succeed");
-        let entries = vec![("agent-b".to_string(), value)];
-        let result: Vec<AgentSpec> = deserialize_namespace(&entries).expect("envelope must decode");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "agent-b");
-    }
-
-    #[test]
-    fn deserialize_namespace_skips_hidden_envelope() {
-        use awaken_contract::{ConfigRecord, RecordMeta};
-        let visible = minimal_agent_spec("visible");
-        let hidden = minimal_agent_spec("hidden");
-
-        let mut hidden_meta = RecordMeta::new_user();
-        hidden_meta.hidden = true;
-
-        let visible_record = ConfigRecord {
-            spec: visible,
-            meta: RecordMeta::new_user(),
-        };
-        let hidden_record = ConfigRecord {
-            spec: hidden,
-            meta: hidden_meta,
-        };
-
-        let entries = vec![
-            (
-                "visible".to_string(),
-                visible_record.to_value().expect("serialize visible"),
-            ),
-            (
-                "hidden".to_string(),
-                hidden_record.to_value().expect("serialize hidden"),
-            ),
-        ];
-        let result: Vec<AgentSpec> = deserialize_namespace(&entries).expect("decode must succeed");
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].id, "visible");
-    }
-
-    #[test]
-    fn deserialize_namespace_skips_hidden_before_effective_validation() {
-        use awaken_contract::{ConfigRecord, RecordMeta};
-
-        let mut hidden_meta = RecordMeta::new_user();
-        hidden_meta.hidden = true;
-        hidden_meta.user_overrides = Some(json!({ "unknown_patch_field": true }));
-
-        let hidden_record = ConfigRecord {
-            spec: json!({ "not": "an agent spec" }),
-            meta: hidden_meta,
-        };
-        let entries = vec![(
-            "hidden".to_string(),
-            hidden_record.to_value().expect("serialize hidden"),
-        )];
-
-        let result: Vec<AgentSpec> =
-            deserialize_namespace(&entries).expect("hidden invalid record must be skipped");
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn deserialize_namespace_mixes_legacy_and_envelope() {
-        use awaken_contract::ConfigRecord;
-        let bare_spec = minimal_agent_spec("bare");
-        let envelope_spec = minimal_agent_spec("envelope");
-
-        let bare_value = serde_json::to_value(&bare_spec).expect("serialize bare");
-        let envelope_record = ConfigRecord {
-            spec: envelope_spec,
-            meta: awaken_contract::RecordMeta::new_user(),
-        };
-        let envelope_value = envelope_record.to_value().expect("serialize envelope");
-
-        let entries = vec![
-            ("bare".to_string(), bare_value),
-            ("envelope".to_string(), envelope_value),
-        ];
-        let result: Vec<AgentSpec> =
-            deserialize_namespace(&entries).expect("mixed decode must succeed");
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].id, "bare");
-        assert_eq!(result[1].id, "envelope");
-    }
-
-    #[test]
-    fn deserialize_namespace_propagates_decode_error() {
-        let bad_value = json!({"completely": "wrong"});
-        let entries = vec![("bad".to_string(), bad_value)];
-        let err = deserialize_namespace::<AgentSpec>(&entries)
-            .expect_err("invalid spec must produce an error");
-        assert!(
-            matches!(
-                err,
-                ConfigRuntimeError::Storage(StorageError::Serialization(_))
-            ),
-            "expected Storage(Serialization(_)), got: {err:?}"
-        );
-    }
-
     /// Replaces the former `bootstrap_if_empty` test.  Asserts that
     /// `apply_seed` stores each spec as a ConfigRecord envelope whose
     /// `meta.source` is `RecordSource::Builtin { binary_version }`.
@@ -2796,6 +2674,7 @@ mod tests {
                 }],
                 tools: Vec::new(),
                 skills: Vec::new(),
+                source_config_revisions: Vec::new(),
                 fingerprint: 1,
             })
             .await

--- a/crates/awaken-server/src/services/config_runtime/managed_config.rs
+++ b/crates/awaken-server/src/services/config_runtime/managed_config.rs
@@ -1,6 +1,8 @@
 use awaken_contract::{
-    AgentSpec, McpServerSpec, ModelBindingSpec, ProviderSpec, SkillSpec, ToolSpec,
+    AgentSpec, ConfigRecord, ConfigRevisionRef, McpServerSpec, ModelBindingSpec, ProviderSpec,
+    SkillSpec, ToolSpec,
 };
+use serde_json::Value;
 
 use super::{
     ConfigRuntimeError, ConfigRuntimeManager, NS_AGENTS, NS_MCP_SERVERS, NS_MODELS, NS_PROVIDERS,
@@ -14,6 +16,7 @@ pub(crate) struct ManagedConfigSnapshot {
     pub(crate) mcp_servers: Vec<McpServerSpec>,
     pub(crate) tools: Vec<ToolSpec>,
     pub(crate) skills: Vec<SkillSpec>,
+    pub(crate) source_config_revisions: Vec<ConfigRevisionRef>,
     pub(crate) fingerprint: u64,
 }
 
@@ -36,6 +39,12 @@ impl ConfigRuntimeManager {
             (NS_TOOLS, &tool_values),
             (NS_SKILLS, &skill_values),
         ])?;
+        let mut source_config_revisions = Vec::new();
+        source_config_revisions.extend(config_revision_refs(NS_PROVIDERS, &provider_values)?);
+        source_config_revisions.extend(config_revision_refs(NS_MODELS, &model_values)?);
+        source_config_revisions.extend(config_revision_refs(NS_AGENTS, &agent_values)?);
+        source_config_revisions.extend(config_revision_refs(NS_TOOLS, &tool_values)?);
+        source_config_revisions.extend(config_revision_refs(NS_SKILLS, &skill_values)?);
 
         Ok(ManagedConfigSnapshot {
             providers: deserialize_namespace(&provider_values)?,
@@ -44,7 +53,167 @@ impl ConfigRuntimeManager {
             mcp_servers: deserialize_namespace(&mcp_values)?,
             tools: deserialize_namespace(&tool_values)?,
             skills: deserialize_namespace(&skill_values)?,
+            source_config_revisions,
             fingerprint,
         })
+    }
+}
+
+fn config_revision_refs(
+    namespace: &str,
+    entries: &[(String, Value)],
+) -> Result<Vec<ConfigRevisionRef>, ConfigRuntimeError> {
+    let mut refs = Vec::new();
+    for (id, value) in entries {
+        let record: ConfigRecord<Value> = ConfigRecord::from_value(value.clone())
+            .map_err(|error| {
+                awaken_contract::contract::storage::StorageError::Serialization(error.to_string())
+            })
+            .map_err(ConfigRuntimeError::Storage)?;
+        if record.meta.hidden {
+            continue;
+        }
+        refs.push(ConfigRevisionRef {
+            namespace: namespace.to_string(),
+            id: id.clone(),
+            revision: record.meta.revision,
+        });
+    }
+    Ok(refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use awaken_contract::contract::storage::StorageError;
+    use awaken_contract::{AgentSpec, ConfigRecord, RecordMeta};
+    use serde_json::json;
+
+    use super::super::{ConfigRuntimeError, deserialize_namespace};
+
+    fn minimal_agent_spec(id: &str) -> AgentSpec {
+        AgentSpec {
+            id: id.into(),
+            model_id: "test-model".into(),
+            system_prompt: "test prompt".into(),
+            max_rounds: 1,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn deserialize_namespace_decodes_legacy_bare_spec() {
+        let spec = minimal_agent_spec("agent-a");
+        let value = serde_json::to_value(&spec).expect("serialization must succeed");
+        let entries = vec![("agent-a".to_string(), value)];
+        let result: Vec<AgentSpec> =
+            deserialize_namespace(&entries).expect("legacy bare spec must decode");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "agent-a");
+    }
+
+    #[test]
+    fn deserialize_namespace_decodes_envelope() {
+        let spec = minimal_agent_spec("agent-b");
+        let record = ConfigRecord {
+            spec,
+            meta: RecordMeta::new_user(),
+        };
+        let value = record
+            .to_value()
+            .expect("envelope serialization must succeed");
+        let entries = vec![("agent-b".to_string(), value)];
+        let result: Vec<AgentSpec> = deserialize_namespace(&entries).expect("envelope must decode");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "agent-b");
+    }
+
+    #[test]
+    fn deserialize_namespace_skips_hidden_envelope() {
+        let visible = minimal_agent_spec("visible");
+        let hidden = minimal_agent_spec("hidden");
+
+        let mut hidden_meta = RecordMeta::new_user();
+        hidden_meta.hidden = true;
+
+        let visible_record = ConfigRecord {
+            spec: visible,
+            meta: RecordMeta::new_user(),
+        };
+        let hidden_record = ConfigRecord {
+            spec: hidden,
+            meta: hidden_meta,
+        };
+
+        let entries = vec![
+            (
+                "visible".to_string(),
+                visible_record.to_value().expect("serialize visible"),
+            ),
+            (
+                "hidden".to_string(),
+                hidden_record.to_value().expect("serialize hidden"),
+            ),
+        ];
+        let result: Vec<AgentSpec> = deserialize_namespace(&entries).expect("decode must succeed");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "visible");
+    }
+
+    #[test]
+    fn deserialize_namespace_skips_hidden_before_effective_validation() {
+        let mut hidden_meta = RecordMeta::new_user();
+        hidden_meta.hidden = true;
+        hidden_meta.user_overrides = Some(json!({ "unknown_patch_field": true }));
+
+        let hidden_record = ConfigRecord {
+            spec: json!({ "not": "an agent spec" }),
+            meta: hidden_meta,
+        };
+        let entries = vec![(
+            "hidden".to_string(),
+            hidden_record.to_value().expect("serialize hidden"),
+        )];
+
+        let result: Vec<AgentSpec> =
+            deserialize_namespace(&entries).expect("hidden invalid record must be skipped");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn deserialize_namespace_mixes_legacy_and_envelope() {
+        let bare_spec = minimal_agent_spec("bare");
+        let envelope_spec = minimal_agent_spec("envelope");
+
+        let bare_value = serde_json::to_value(&bare_spec).expect("serialize bare");
+        let envelope_record = ConfigRecord {
+            spec: envelope_spec,
+            meta: RecordMeta::new_user(),
+        };
+        let envelope_value = envelope_record.to_value().expect("serialize envelope");
+
+        let entries = vec![
+            ("bare".to_string(), bare_value),
+            ("envelope".to_string(), envelope_value),
+        ];
+        let result: Vec<AgentSpec> =
+            deserialize_namespace(&entries).expect("mixed decode must succeed");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].id, "bare");
+        assert_eq!(result[1].id, "envelope");
+    }
+
+    #[test]
+    fn deserialize_namespace_propagates_decode_error() {
+        let bad_value = json!({"completely": "wrong"});
+        let entries = vec![("bad".to_string(), bad_value)];
+        let err = deserialize_namespace::<AgentSpec>(&entries)
+            .expect_err("invalid spec must produce an error");
+        assert!(
+            matches!(
+                err,
+                ConfigRuntimeError::Storage(StorageError::Serialization(_))
+            ),
+            "expected Storage(Serialization(_)), got: {err:?}"
+        );
     }
 }

--- a/crates/awaken-server/src/services/config_runtime/versioned_publish.rs
+++ b/crates/awaken-server/src/services/config_runtime/versioned_publish.rs
@@ -1,0 +1,465 @@
+use std::sync::Arc;
+
+use awaken_contract::{
+    ProviderSpec, RegistryResourcePublish, VersionSelector, VersionedRegistryStore,
+};
+use awaken_runtime::registry::RegistrySet;
+use serde::Serialize;
+use serde_json::json;
+
+use super::{ConfigRuntimeError, ConfigRuntimeManager};
+use crate::services::config_runtime::managed_config::ManagedConfigSnapshot;
+use crate::services::frozen_registry::{
+    FrozenAgentRegistryMaterializer, LatestPublicationResolver,
+};
+
+pub(super) struct VersionedRegistryPublicationTarget {
+    pub(super) scope_id: String,
+    pub(super) store: Arc<dyn VersionedRegistryStore>,
+}
+
+impl ConfigRuntimeManager {
+    #[must_use]
+    pub fn with_versioned_registry_store(
+        mut self,
+        scope_id: impl Into<String>,
+        store: Arc<dyn VersionedRegistryStore>,
+    ) -> Self {
+        let scope_id = scope_id.into();
+        if let Some(handle) = self.runtime.registry_handle() {
+            self.runtime
+                .set_run_resolver(Arc::new(LatestPublicationResolver::new(
+                    scope_id.clone(),
+                    store.clone(),
+                    handle,
+                )));
+        }
+        self.versioned_registry = Some(VersionedRegistryPublicationTarget { scope_id, store });
+        self
+    }
+
+    /// Pick the `RegistrySet` to install via runtime hot-swap: prefer
+    /// the materialized `RegistryPublication`, fall back to the editing
+    /// candidate when no versioned store is wired or materialization
+    /// fails (ADR-0035 D8/D11). Takes ownership of `candidate` so the
+    /// caller never accidentally hot-swaps with stale editing data after
+    /// a successful publication.
+    pub(super) async fn published_or_candidate_registry_set(
+        &self,
+        candidate: RegistrySet,
+    ) -> RegistrySet {
+        let Some(target) = self.versioned_registry.as_ref() else {
+            return candidate;
+        };
+        let materializer = FrozenAgentRegistryMaterializer::new(target.store.clone());
+        match materializer
+            .materialize(VersionSelector::LatestPublication {
+                scope_id: target.scope_id.clone(),
+            })
+            .await
+        {
+            Ok(frozen) => frozen.to_registry_set(&candidate),
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "failed to materialize published registry set; falling back to candidate"
+                );
+                candidate
+            }
+        }
+    }
+
+    pub(super) async fn publish_versioned_registry(
+        &self,
+        managed: &ManagedConfigSnapshot,
+    ) -> Result<(), ConfigRuntimeError> {
+        let Some(target) = &self.versioned_registry else {
+            return Ok(());
+        };
+
+        let mut resources = Vec::new();
+        append_provider_specs(&managed.providers, &mut resources)?;
+        append_specs(
+            awaken_contract::REGISTRY_KIND_MODEL,
+            &managed.models,
+            |spec| spec.id.as_str(),
+            &mut resources,
+        )?;
+        append_specs(
+            awaken_contract::REGISTRY_KIND_AGENT,
+            &managed.agents,
+            |spec| spec.id.as_str(),
+            &mut resources,
+        )?;
+        append_specs(
+            awaken_contract::REGISTRY_KIND_TOOL,
+            &managed.tools,
+            |spec| spec.id.as_str(),
+            &mut resources,
+        )?;
+        append_specs(
+            awaken_contract::REGISTRY_KIND_SKILL,
+            &managed.skills,
+            |spec| spec.id.as_str(),
+            &mut resources,
+        )?;
+
+        if resources.is_empty() {
+            return Ok(());
+        }
+
+        target
+            .store
+            .publish_resources_and_create_publication(
+                &target.scope_id,
+                &uuid::Uuid::now_v7().to_string(),
+                resources,
+                managed.source_config_revisions.clone(),
+                None,
+                json!({ "config_fingerprint": managed.fingerprint }),
+            )
+            .await
+            .map_err(to_config_error)?;
+        Ok(())
+    }
+}
+
+fn append_provider_specs(
+    specs: &[ProviderSpec],
+    resources: &mut Vec<RegistryResourcePublish>,
+) -> Result<(), ConfigRuntimeError> {
+    for spec in specs {
+        if spec.api_key.as_ref().is_some_and(|value| !value.is_empty()) {
+            return Err(ConfigRuntimeError::VersionedRegistry(format!(
+                "provider '{}' cannot be published with plaintext api_key; use a runtime credential reference",
+                spec.id
+            )));
+        }
+    }
+    append_specs(
+        awaken_contract::REGISTRY_KIND_PROVIDER,
+        specs,
+        |spec| spec.id.as_str(),
+        resources,
+    )
+}
+
+fn append_specs<T>(
+    kind: &str,
+    specs: &[T],
+    id: fn(&T) -> &str,
+    resources: &mut Vec<RegistryResourcePublish>,
+) -> Result<(), ConfigRuntimeError>
+where
+    T: Serialize,
+{
+    for spec in specs {
+        let id = id(spec);
+        let value = serde_json::to_value(spec).map_err(|error| {
+            ConfigRuntimeError::VersionedRegistry(format!(
+                "failed to serialize {kind}/{id}: {error}"
+            ))
+        })?;
+        resources.push(RegistryResourcePublish {
+            kind: kind.to_string(),
+            id: id.to_string(),
+            value,
+            value_schema_version: 1,
+            metadata: json!({}),
+        });
+    }
+    Ok(())
+}
+
+fn to_config_error(error: awaken_contract::VersionedRegistryError) -> ConfigRuntimeError {
+    ConfigRuntimeError::VersionedRegistry(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use awaken_contract::contract::config_store::ConfigStore;
+    use awaken_contract::contract::executor::{
+        InferenceExecutionError, InferenceRequest, LlmExecutor,
+    };
+    use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
+    use awaken_contract::{
+        AgentSpec, BuiltinSeedSet, BuiltinSpec, ConfigRecord, ModelBindingSpec, ProviderSpec,
+        RecordMeta, RegistryPublication,
+    };
+    use awaken_stores::{InMemoryStore, InMemoryVersionedRegistryStore};
+
+    use super::*;
+    use crate::services::config_runtime::ProviderExecutorFactory;
+
+    struct StubExecutor;
+
+    #[async_trait::async_trait]
+    impl LlmExecutor for StubExecutor {
+        async fn execute(
+            &self,
+            _: InferenceRequest,
+        ) -> Result<StreamResult, InferenceExecutionError> {
+            Ok(StreamResult {
+                content: vec![],
+                tool_calls: vec![],
+                usage: Some(TokenUsage::default()),
+                stop_reason: Some(StopReason::EndTurn),
+                has_incomplete_tool_calls: false,
+            })
+        }
+
+        fn name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    struct StubFactory;
+
+    impl ProviderExecutorFactory for StubFactory {
+        fn build(&self, _spec: &ProviderSpec) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
+            Ok(Arc::new(StubExecutor))
+        }
+    }
+
+    async fn make_manager_with_versioned_store() -> (
+        ConfigRuntimeManager,
+        Arc<dyn ConfigStore>,
+        Arc<InMemoryVersionedRegistryStore>,
+    ) {
+        let config_store = Arc::new(InMemoryStore::new()) as Arc<dyn ConfigStore>;
+        let thread_store = Arc::new(InMemoryStore::new());
+        let runtime = Arc::new(
+            awaken_runtime::builder::AgentRuntimeBuilder::new()
+                .with_provider("boot", Arc::new(StubExecutor))
+                .with_model_binding(
+                    "boot",
+                    awaken_runtime::registry::traits::ModelBinding {
+                        provider_id: "boot".into(),
+                        upstream_model: "boot-model".into(),
+                    },
+                )
+                .with_agent_spec(AgentSpec {
+                    id: "boot".into(),
+                    model_id: "boot".into(),
+                    system_prompt: "boot".into(),
+                    max_rounds: 1,
+                    ..Default::default()
+                })
+                .with_in_memory_thread_run_store(thread_store)
+                .build()
+                .expect("build runtime"),
+        );
+        let versioned = Arc::new(InMemoryVersionedRegistryStore::new());
+        let manager = ConfigRuntimeManager::new(runtime, Arc::clone(&config_store))
+            .expect("manager")
+            .with_provider_factory(Arc::new(StubFactory))
+            .with_versioned_registry_store("default", versioned.clone());
+
+        (manager, config_store, versioned)
+    }
+
+    fn base_seed(system_prompt: &str) -> BuiltinSeedSet {
+        base_seed_with_provider_api_key(system_prompt, None)
+    }
+
+    fn base_seed_with_provider_api_key(
+        system_prompt: &str,
+        api_key: Option<&str>,
+    ) -> BuiltinSeedSet {
+        BuiltinSeedSet {
+            binary_version: "test".to_string(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "provider-1".to_string(),
+                    adapter: "openai".to_string(),
+                    api_key: api_key.map(Into::into),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelBindingSpec::new("model-1", "provider-1", "upstream")),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "agent-1".to_string(),
+                    model_id: "model-1".to_string(),
+                    system_prompt: system_prompt.to_string(),
+                    ..Default::default()
+                })),
+            ],
+        }
+    }
+
+    fn entry_version(publication: &RegistryPublication, kind: &str, id: &str) -> u64 {
+        publication
+            .entries
+            .iter()
+            .find(|entry| entry.kind == kind && entry.id == id)
+            .unwrap_or_else(|| panic!("publication must include {kind}/{id}"))
+            .version
+    }
+
+    #[tokio::test]
+    async fn apply_publishes_managed_config_to_versioned_registry() {
+        let (manager, _, versioned) = make_manager_with_versioned_store().await;
+
+        manager
+            .apply_seed(&base_seed("system"))
+            .await
+            .expect("seed config");
+
+        manager.apply().await.expect("apply config");
+
+        let publication = versioned
+            .latest_publication("default")
+            .await
+            .expect("read latest publication")
+            .expect("publication");
+        assert!(publication.entries.iter().any(|entry| {
+            entry.kind == awaken_contract::REGISTRY_KIND_AGENT && entry.id == "agent-1"
+        }));
+        assert!(publication.entries.iter().any(|entry| {
+            entry.kind == awaken_contract::REGISTRY_KIND_MODEL && entry.id == "model-1"
+        }));
+        assert!(publication.entries.iter().any(|entry| {
+            entry.kind == awaken_contract::REGISTRY_KIND_PROVIDER && entry.id == "provider-1"
+        }));
+        assert!(publication.source_config_revisions.iter().any(|revision| {
+            revision.namespace == "agents" && revision.id == "agent-1" && revision.revision > 0
+        }));
+    }
+
+    #[tokio::test]
+    async fn apply_rejects_provider_api_key_before_versioned_publish() {
+        let (manager, _, versioned) = make_manager_with_versioned_store().await;
+
+        manager
+            .apply_seed(&base_seed_with_provider_api_key(
+                "system",
+                Some("sk-test-secret"),
+            ))
+            .await
+            .expect("seed config");
+
+        let error = manager
+            .apply()
+            .await
+            .expect_err("provider api_key must not be published as plaintext");
+        assert!(
+            matches!(
+                error,
+                ConfigRuntimeError::VersionedRegistry(ref message)
+                    if message.contains("provider-1") && message.contains("api_key")
+            ),
+            "expected versioned registry secret error, got: {error:?}"
+        );
+        assert!(
+            versioned
+                .latest_publication("default")
+                .await
+                .expect("read latest publication")
+                .is_none(),
+            "failed publish must not create a publication"
+        );
+        assert!(
+            versioned
+                .current(
+                    "default",
+                    awaken_contract::REGISTRY_KIND_PROVIDER,
+                    "provider-1"
+                )
+                .await
+                .expect("read provider current")
+                .is_none(),
+            "failed publish must not create a provider resource version"
+        );
+    }
+
+    #[tokio::test]
+    async fn reapply_keeps_versions_and_changed_config_bumps_changed_resource() {
+        let (manager, config_store, versioned) = make_manager_with_versioned_store().await;
+
+        manager
+            .apply_seed(&base_seed("system"))
+            .await
+            .expect("seed config");
+        manager.apply().await.expect("first apply");
+        let first = versioned
+            .latest_publication("default")
+            .await
+            .expect("read first publication")
+            .expect("first publication");
+        let first_agent_version =
+            entry_version(&first, awaken_contract::REGISTRY_KIND_AGENT, "agent-1");
+        let first_model_version =
+            entry_version(&first, awaken_contract::REGISTRY_KIND_MODEL, "model-1");
+
+        manager.apply().await.expect("unchanged apply");
+        let unchanged = versioned
+            .latest_publication("default")
+            .await
+            .expect("read unchanged publication")
+            .expect("unchanged publication");
+        assert_eq!(
+            entry_version(&unchanged, awaken_contract::REGISTRY_KIND_AGENT, "agent-1"),
+            first_agent_version,
+            "unchanged effective config must reuse the existing agent resource version"
+        );
+        assert_eq!(
+            entry_version(&unchanged, awaken_contract::REGISTRY_KIND_MODEL, "model-1"),
+            first_model_version,
+            "unchanged effective config must reuse the existing model resource version"
+        );
+
+        let mut meta = RecordMeta::new_user();
+        meta.revision = 7;
+        let changed = ConfigRecord {
+            spec: AgentSpec {
+                id: "agent-1".to_string(),
+                model_id: "model-1".to_string(),
+                system_prompt: "changed".to_string(),
+                ..Default::default()
+            },
+            meta,
+        };
+        config_store
+            .put(
+                "agents",
+                "agent-1",
+                &changed.to_value().expect("serialize changed agent"),
+            )
+            .await
+            .expect("write changed config");
+
+        manager.apply().await.expect("changed apply");
+        let changed_publication = versioned
+            .latest_publication("default")
+            .await
+            .expect("read changed publication")
+            .expect("changed publication");
+        assert!(
+            entry_version(
+                &changed_publication,
+                awaken_contract::REGISTRY_KIND_AGENT,
+                "agent-1"
+            ) > first_agent_version,
+            "changed effective agent config must publish a new agent resource version"
+        );
+        assert_eq!(
+            entry_version(
+                &changed_publication,
+                awaken_contract::REGISTRY_KIND_MODEL,
+                "model-1"
+            ),
+            first_model_version,
+            "unchanged model config must keep its existing resource version"
+        );
+        assert!(
+            changed_publication
+                .source_config_revisions
+                .iter()
+                .any(|revision| revision.namespace == "agents"
+                    && revision.id == "agent-1"
+                    && revision.revision == 7),
+            "publication must retain the source config revision that produced the registry version"
+        );
+    }
+}

--- a/crates/awaken-server/src/services/config_service.rs
+++ b/crates/awaken-server/src/services/config_service.rs
@@ -9,7 +9,7 @@ use awaken_contract::{
 use axum::http::HeaderMap;
 use serde_json::{Value, json};
 
-use crate::app::AppState;
+use crate::app::{ConfigRoutesState, ServerState};
 use crate::services::audit_log::AuditLogger;
 use crate::services::config_envelope::unwrap_spec;
 
@@ -179,28 +179,47 @@ pub struct ProviderTestResult {
     pub error: Option<String>,
 }
 
-pub struct ConfigService<'a> {
-    state: &'a AppState,
+pub trait ConfigServiceStateProvider {
+    fn config_service_state(&self) -> Result<ConfigRoutesState, ConfigServiceError>;
+}
+
+impl ConfigServiceStateProvider for ConfigRoutesState {
+    fn config_service_state(&self) -> Result<ConfigRoutesState, ConfigServiceError> {
+        Ok(self.clone())
+    }
+}
+
+impl ConfigServiceStateProvider for ServerState {
+    fn config_service_state(&self) -> Result<ConfigRoutesState, ConfigServiceError> {
+        self.config_routes_state()
+            .ok_or(ConfigServiceError::NotEnabled)
+    }
+}
+
+pub struct ConfigService {
+    state: ConfigRoutesState,
     store: Arc<dyn ConfigStore>,
     audit: Option<Arc<AuditLogger>>,
 }
 
-impl<'a> ConfigService<'a> {
-    pub fn new(state: &'a AppState) -> Result<Self, ConfigServiceError> {
-        let store = state
-            .config_store
-            .clone()
-            .ok_or(ConfigServiceError::NotEnabled)?;
+impl ConfigService {
+    pub fn new<S: ConfigServiceStateProvider + ?Sized>(
+        state: &S,
+    ) -> Result<Self, ConfigServiceError> {
+        let state = state.config_service_state()?;
+        let store = state.config.config_store.clone();
+        let audit = state.config.audit_log.clone();
         Ok(Self {
             state,
             store,
-            audit: state.audit_log(),
+            audit,
         })
     }
 
     pub async fn capabilities(&self) -> Result<Value, ConfigServiceError> {
         let registries = self
             .state
+            .run
             .runtime
             .registry_set()
             .ok_or(ConfigServiceError::Apply(
@@ -272,13 +291,14 @@ impl<'a> ConfigService<'a> {
 
         let skills = self
             .state
+            .config
             .skill_catalog_provider
             .as_ref()
             .map(|provider| provider.list_skills())
             .unwrap_or_default();
 
         Ok(json!({
-            "agents": self.state.resolver.agent_ids(),
+            "agents": self.state.run.resolver.agent_ids(),
             "tools": tools,
             "plugins": plugins,
             "skills": skills,
@@ -675,7 +695,8 @@ pub(super) fn map_runtime_error(error: ConfigRuntimeError) -> ConfigServiceError
         ConfigRuntimeError::RuntimeNotConfigurable
         | ConfigRuntimeError::PartialBootstrap
         | ConfigRuntimeError::PeriodicRefresh(_)
-        | ConfigRuntimeError::ChangeListener(_) => ConfigServiceError::Apply(error.to_string()),
+        | ConfigRuntimeError::ChangeListener(_)
+        | ConfigRuntimeError::VersionedRegistry(_) => ConfigServiceError::Apply(error.to_string()),
         ConfigRuntimeError::Storage(error) => ConfigServiceError::Storage(error),
     }
 }

--- a/crates/awaken-server/src/services/config_service/agent_overrides.rs
+++ b/crates/awaken-server/src/services/config_service/agent_overrides.rs
@@ -11,7 +11,7 @@ use super::{
     overrides_not_supported_for_user_record,
 };
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     /// POST /v1/config/agents/:id/overrides
     ///
     /// Dry-run validation for the override patch payload. It validates the

--- a/crates/awaken-server/src/services/config_service/audit.rs
+++ b/crates/awaken-server/src/services/config_service/audit.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use super::{ConfigNamespace, ConfigService};
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     /// Emit an audit event if an audit logger is configured.
     ///
     /// Best-effort: the call is fire-and-forget (matching the `AuditLogger::emit` contract).

--- a/crates/awaken-server/src/services/config_service/dependencies.rs
+++ b/crates/awaken-server/src/services/config_service/dependencies.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use super::normalization::effective_visible_record;
 use super::{ConfigNamespace, ConfigService, ConfigServiceError, DependentRef};
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     /// Return all records in other namespaces that reference `id` in `namespace`.
     ///
     /// - Providers: scans models for `provider_id == id`
@@ -77,6 +77,7 @@ impl<'a> ConfigService<'a> {
 
     fn current_tool_ids_with_prefix(&self, prefix: &str) -> Vec<String> {
         self.state
+            .run
             .runtime
             .registry_set()
             .map(|registries| {

--- a/crates/awaken-server/src/services/config_service/mcp.rs
+++ b/crates/awaken-server/src/services/config_service/mcp.rs
@@ -4,7 +4,7 @@ use crate::services::config_envelope::unwrap_spec;
 
 use super::{ConfigNamespace, ConfigService, ConfigServiceError};
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     pub(super) async fn normalize_mcp_server_payload(
         &self,
         path_id: Option<&str>,

--- a/crates/awaken-server/src/services/config_service/normalization.rs
+++ b/crates/awaken-server/src/services/config_service/normalization.rs
@@ -5,7 +5,7 @@ use crate::services::config_envelope::{apply_overrides, unwrap_spec};
 
 use super::{ConfigNamespace, ConfigService, ConfigServiceError};
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     pub(super) async fn prepare_body(
         &self,
         namespace: ConfigNamespace,

--- a/crates/awaken-server/src/services/config_service/provider.rs
+++ b/crates/awaken-server/src/services/config_service/provider.rs
@@ -13,7 +13,7 @@ use super::{
     effective_visible_record,
 };
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     pub async fn preview_remove_provider(
         &self,
         id: &str,
@@ -67,6 +67,7 @@ impl<'a> ConfigService<'a> {
     ) -> Result<Vec<SerializableRegistryDiagnostic>, ConfigServiceError> {
         let registries = self
             .state
+            .run
             .runtime
             .registry_set()
             .ok_or(ConfigServiceError::Apply(

--- a/crates/awaken-server/src/services/config_service/restore.rs
+++ b/crates/awaken-server/src/services/config_service/restore.rs
@@ -5,7 +5,7 @@ use crate::services::config_envelope::unwrap_spec;
 
 use super::{ConfigNamespace, ConfigService, ConfigServiceError, RestoreError};
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     /// Restore a resource to a previous version identified by the audit event ULID `version`.
     ///
     /// Per ADR-0028 D2-D4:
@@ -13,8 +13,9 @@ impl<'a> ConfigService<'a> {
     /// - Validates that the event resource matches `<namespace>/<id>` (cross-resource rejected).
     /// - Selects the spec payload: `after` for Create/Update/Publish/Restore; `before` for Delete.
     /// - Returns `RestoreError::NotRestorable` for Restart events (no spec payload).
-    /// - Calls `persist_and_apply_locked` directly (both create and update paths) to avoid
-    ///   emitting a spurious Update audit event; only a single Restore event is written.
+    /// - Calls `persist_only_locked` (both create and update paths). Per ADR-0035 D11
+    ///   restore is an editing-store operation: it does NOT trigger the runtime
+    ///   hot-swap. Operators must run `publish` to promote the restored payload.
     /// - Emits a Restore audit event with `restored_from` set to the source ULID.
     pub async fn restore(
         &self,
@@ -83,16 +84,11 @@ impl<'a> ConfigService<'a> {
                     format!("restored payload id '{body_id}' does not match URL id '{id}'"),
                 )));
             }
-            self.persist_and_apply_locked(
-                manager.as_ref(),
-                namespace,
-                id,
-                before.clone(),
-                prepared,
-                headers,
-            )
-            .await
-            .map_err(RestoreError::Service)?
+            // ADR-0035 D11: restore writes ConfigStore only; runtime
+            // hot-swap is reserved for an explicit publish step.
+            self.persist_only_locked(namespace, id, before.clone(), prepared)
+                .await
+                .map_err(RestoreError::Service)?
         } else {
             // Resource does not exist — restore from a deleted state.
             let (body_id, prepared) = self
@@ -116,16 +112,10 @@ impl<'a> ConfigService<'a> {
                 )));
             }
 
-            self.persist_and_apply_locked(
-                manager.as_ref(),
-                namespace,
-                &body_id,
-                None,
-                prepared.clone(),
-                headers,
-            )
-            .await
-            .map_err(RestoreError::Service)?
+            // ADR-0035 D11: restore-from-deleted is editing-store only.
+            self.persist_only_locked(namespace, &body_id, None, prepared.clone())
+                .await
+                .map_err(RestoreError::Service)?
         };
 
         // Emit restore audit event.

--- a/crates/awaken-server/src/services/config_service/storage.rs
+++ b/crates/awaken-server/src/services/config_service/storage.rs
@@ -9,15 +9,12 @@ use crate::services::config_envelope::unwrap_spec;
 
 use super::{ConfigNamespace, ConfigService, ConfigServiceError, map_runtime_error};
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     pub(super) fn runtime_manager(
         &self,
     ) -> Result<&Arc<crate::services::config_runtime::ConfigRuntimeManager>, ConfigServiceError>
     {
-        self.state
-            .config_runtime_manager
-            .as_ref()
-            .ok_or(ConfigServiceError::NotEnabled)
+        Ok(&self.state.config.runtime_manager)
     }
 
     fn user_record_from_body(body: &Value, previous: Option<&Value>) -> ConfigRecord<Value> {
@@ -168,6 +165,38 @@ impl<'a> ConfigService<'a> {
             .await?;
         }
         Ok(())
+    }
+
+    /// Write the payload to ConfigStore without invoking the runtime
+    /// hot-swap. ADR-0035 D11: "Restore from audit log remains valid as
+    /// an editing-store operation. Registry rollback is separate." Use
+    /// this from restore-style flows so the runtime continues observing
+    /// the previously-published `RegistryPublication` until an operator
+    /// explicitly publishes the restored payload.
+    pub(super) async fn persist_only_locked(
+        &self,
+        namespace: ConfigNamespace,
+        id: &str,
+        previous: Option<Value>,
+        body: Value,
+    ) -> Result<Value, ConfigServiceError> {
+        self.validate_payload(namespace, &body)?;
+        let mut record = Self::user_record_from_body(&body, previous.as_ref());
+        match previous.as_ref() {
+            Some(previous) => {
+                let expected_revision = ConfigRecord::<Value>::from_value(previous.clone())
+                    .map_err(|e| ConfigServiceError::Serialization(e.to_string()))?
+                    .meta
+                    .revision;
+                self.cas_put_record(namespace, id, &mut record, expected_revision)
+                    .await?
+            }
+            None => {
+                self.insert_record_absent(namespace, id, &mut record, 1)
+                    .await?
+            }
+        };
+        self.redact_response(namespace, body)
     }
 
     pub(super) async fn persist_and_apply_locked(

--- a/crates/awaken-server/src/services/config_service/tests.rs
+++ b/crates/awaken-server/src/services/config_service/tests.rs
@@ -15,7 +15,7 @@ use awaken_runtime::registry::traits::ModelBinding;
 use serde_json::{Value, json};
 use tokio::sync::Notify;
 
-use crate::app::{AppState, ServerConfig};
+use crate::app::{ServerConfig, ServerState};
 use crate::mailbox::{Mailbox, MailboxConfig};
 use crate::services::config_runtime::{ConfigRuntimeManager, ProviderExecutorFactory};
 
@@ -238,7 +238,9 @@ fn bootstrap_agent() -> AgentSpec {
     }
 }
 
-async fn build_state(config_store: Arc<dyn ConfigStore>) -> (AppState, Arc<ConfigRuntimeManager>) {
+async fn build_state(
+    config_store: Arc<dyn ConfigStore>,
+) -> (ServerState, Arc<ConfigRuntimeManager>) {
     let thread_store = Arc::new(awaken_stores::InMemoryStore::new());
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
@@ -282,7 +284,7 @@ async fn build_state(config_store: Arc<dyn ConfigStore>) -> (AppState, Arc<Confi
         "config-service-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -420,7 +422,7 @@ async fn service_requires_runtime_manager_for_mutations() {
         "config-service-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         thread_store,
@@ -429,18 +431,20 @@ async fn service_requires_runtime_manager_for_mutations() {
     )
     .with_config_store(Arc::new(awaken_stores::InMemoryStore::new()));
 
-    let service = ConfigService::new(&state).expect("config service");
-    let error = service
-        .create_with_headers(
-            ConfigNamespace::Providers,
-            json!({
-                "id": "missing-manager",
-                "adapter": "stub"
-            }),
-            &axum::http::HeaderMap::new(),
-        )
-        .await
-        .expect_err("missing manager should reject writes");
+    let error = match ConfigService::new(&state) {
+        Ok(service) => service
+            .create_with_headers(
+                ConfigNamespace::Providers,
+                json!({
+                    "id": "missing-manager",
+                    "adapter": "stub"
+                }),
+                &axum::http::HeaderMap::new(),
+            )
+            .await
+            .expect_err("missing manager should reject writes"),
+        Err(error) => error,
+    };
     assert!(matches!(error, ConfigServiceError::NotEnabled));
 }
 
@@ -1083,7 +1087,7 @@ async fn delete_rollback_re_emits_envelope() {
         "rollback-test".into(),
         crate::mailbox::MailboxConfig::default(),
     ));
-    let state_failing = crate::app::AppState::new(
+    let state_failing = crate::app::ServerState::new(
         runtime_failing.clone(),
         mailbox_failing,
         thread_store,
@@ -1687,7 +1691,7 @@ impl Tool for StubTool {
 async fn build_test_service_with_tool(
     id: &str,
     description: &str,
-) -> (ConfigService<'static>, Arc<AuditLogger>) {
+) -> (ConfigService, Arc<AuditLogger>) {
     use awaken_contract::{BuiltinSeedSet, BuiltinSpec, RecordMeta};
 
     let config_store: Arc<dyn awaken_contract::contract::config_store::ConfigStore> =
@@ -1773,7 +1777,7 @@ async fn build_test_service_with_tool(
         "tool-override-test".into(),
         crate::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -1786,7 +1790,7 @@ async fn build_test_service_with_tool(
 
     // SAFETY: state is owned for the duration of the test; the 'static bound is
     // satisfied by leaking the Box – acceptable in tests only.
-    let state: &'static AppState = Box::leak(Box::new(state));
+    let state: &'static ServerState = Box::leak(Box::new(state));
     let service = ConfigService::new(state).expect("config service");
     (service, audit_logger)
 }
@@ -2155,7 +2159,7 @@ async fn patch_tool_overrides_apply_failure_emits_apply_failed_audit_event() {
         "apply-failed-test".into(),
         crate::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime_failing.clone(),
         mailbox,
         thread_store,
@@ -2166,7 +2170,7 @@ async fn patch_tool_overrides_apply_failure_emits_apply_failed_audit_event() {
     .with_config_runtime_manager(manager_failing)
     .with_audit_log(audit_logger.clone());
 
-    let state: &'static AppState = Box::leak(Box::new(state));
+    let state: &'static ServerState = Box::leak(Box::new(state));
     let service = ConfigService::new(state).expect("failing config service");
 
     // Step 3: attempt patch_tool_overrides — apply_locked fails.

--- a/crates/awaken-server/src/services/config_service/tool_overrides.rs
+++ b/crates/awaken-server/src/services/config_service/tool_overrides.rs
@@ -10,7 +10,7 @@ use super::{
     overrides_not_supported_for_user_record,
 };
 
-impl<'a> ConfigService<'a> {
+impl ConfigService {
     /// PATCH /v1/config/tools/:id/overrides — see ADR-0029.
     pub async fn patch_tool_overrides(
         &self,

--- a/crates/awaken-server/src/services/dataset_service.rs
+++ b/crates/awaken-server/src/services/dataset_service.rs
@@ -24,7 +24,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
-use crate::app::AppState;
+use crate::app::EvalRoutesState;
 use crate::error::ApiError;
 use crate::services::dataset_wire::{
     AppendFixtureRequest, CreateDatasetRequest, CurateItemsRequest, DatasetSummaryWire,
@@ -32,9 +32,7 @@ use crate::services::dataset_wire::{
     ImportTracesRequest, ImportTracesResponse, ListDatasetsResponse, ListParams,
     ProviderScriptMode, PutDatasetRequest,
 };
-use crate::services::eval_common::{
-    config_store_or_unavailable, map_storage_error, map_trace_store_error,
-};
+use crate::services::eval_common::{eval_config_store, map_storage_error, map_trace_store_error};
 
 // `DATASETS_NAMESPACE` re-exported from `awaken_eval::dataset` is the
 // single source of truth — see the const's docstring there.
@@ -111,12 +109,12 @@ fn curate_trace_payload(
 /// `GET /v1/eval/datasets` — list dataset summaries.
 #[tracing::instrument(skip_all)]
 pub async fn list_datasets(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Query(params): Query<ListParams>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = config_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_config_store(&state);
     let raw = store
         .list(DATASETS_NAMESPACE, params.offset, params.limit)
         .await
@@ -144,13 +142,13 @@ pub async fn list_datasets(
 /// with the rest of the config CRUD surface.
 #[tracing::instrument(skip_all, fields(id = ?id_param.id))]
 pub async fn create_dataset(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Query(id_param): Query<IdParam>,
     Json(body): Json<CreateDatasetRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = config_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_config_store(&state);
     let id = id_param
         .id
         .or(body.id.clone())
@@ -177,12 +175,12 @@ pub async fn create_dataset(
 /// `GET /v1/eval/datasets/:id` — fetch one dataset record.
 #[tracing::instrument(skip_all, fields(id = %id))]
 pub async fn get_dataset(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = config_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_config_store(&state);
     let value = store
         .get(DATASETS_NAMESPACE, &id)
         .await
@@ -198,16 +196,16 @@ pub async fn get_dataset(
 /// as `409 Conflict` instead of last-write-wins.
 #[tracing::instrument(skip_all, fields(id = %id))]
 pub async fn put_dataset(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<PutDatasetRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
     body.spec
         .validate_for_write()
         .map_err(ApiError::BadRequest)?;
-    let store = config_store_or_unavailable(&state)?;
+    let store = eval_config_store(&state);
     let mut meta = match store
         .get(DATASETS_NAMESPACE, &id)
         .await
@@ -258,18 +256,18 @@ pub async fn put_dataset(
 /// fixture id already exists in the dataset (use PUT to mutate).
 #[tracing::instrument(skip_all, fields(id = %id, fixture_id = %body.fixture.id))]
 pub async fn append_fixture(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<AppendFixtureRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
     validate_min_judge_score(
         &body.fixture.expect,
         &format!("fixture {}", body.fixture.id),
     )
     .map_err(ApiError::BadRequest)?;
-    let store = config_store_or_unavailable(&state)?;
+    let store = eval_config_store(&state);
     let existing_value = store
         .get(DATASETS_NAMESPACE, &id)
         .await
@@ -319,13 +317,13 @@ pub async fn append_fixture(
 /// instead of destroying their work.
 #[tracing::instrument(skip_all, fields(id = %id))]
 pub async fn delete_dataset(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Query(params): Query<DeleteDatasetParams>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = config_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_config_store(&state);
     match params.expected_revision {
         Some(expected) => store
             .delete_if_revision(DATASETS_NAMESPACE, &id, expected)
@@ -346,15 +344,17 @@ pub async fn delete_dataset(
 /// edit between `get` and `put_if_revision` surfaces as `409 Conflict`.
 #[tracing::instrument(skip_all, fields(id = %id, run_id = %body.from_run_id))]
 pub async fn curate_items(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<CurateItemsRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = config_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_config_store(&state);
     let trace_store = state
-        .trace_store()
+        .trace
+        .as_ref()
+        .map(|trace| trace.trace_store.clone())
         .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
     require_non_empty_expected(&body.expect)?;
 
@@ -442,15 +442,17 @@ pub async fn curate_items(
 /// appended under CAS; existing fixture ids are skipped (no clobber).
 #[tracing::instrument(skip_all, fields(id = %id, agent_id = ?body.agent_id))]
 pub async fn import_traces(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<ImportTracesRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = config_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_config_store(&state);
     let trace_store = state
-        .trace_store()
+        .trace
+        .as_ref()
+        .map(|trace| trace.trace_store.clone())
         .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
     require_non_empty_expected(&body.expect)?;
 
@@ -477,7 +479,7 @@ pub async fn import_traces(
         .map(|s| std::time::UNIX_EPOCH + std::time::Duration::from_secs(s));
     let max_count = body
         .max_count
-        .unwrap_or(state.config.eval_limits.default_import_traces_max);
+        .unwrap_or(state.limits.default_import_traces_max);
     let filter = awaken_ext_observability::trace_store::TraceFilter {
         agent_id: body.agent_id.clone(),
         since,
@@ -596,19 +598,21 @@ pub async fn import_traces(
 /// captured on its first inference) — partial traces 400 out.
 #[tracing::instrument(skip_all, fields(id = %id, run_count = body.run_ids.len()))]
 pub async fn import_dialogue(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Json(body): Json<ImportDialogueRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
     if body.run_ids.is_empty() {
         return Err(ApiError::BadRequest("run_ids must be non-empty".into()));
     }
     require_non_empty_expected(&body.expect)?;
-    let store = config_store_or_unavailable(&state)?;
+    let store = eval_config_store(&state);
     let trace_store = state
-        .trace_store()
+        .trace
+        .as_ref()
+        .map(|trace| trace.trace_store.clone())
         .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
 
     let existing_value = store

--- a/crates/awaken-server/src/services/eval_common.rs
+++ b/crates/awaken-server/src/services/eval_common.rs
@@ -13,20 +13,15 @@ use awaken_contract::contract::storage::StorageError;
 use awaken_contract::registry_spec::{AgentSpec, ModelBindingSpec, ProviderSpec};
 use awaken_ext_observability::trace_store::TraceStoreError;
 
-use crate::app::AppState;
+use crate::app::EvalRoutesState;
 use crate::error::ApiError;
 use crate::services::config_runtime::build_genai_provider_executor_with_broker;
 
-/// Fetch the attached `ConfigStore` or surface a 503 — both eval
-/// services depend on it being wired and otherwise return identical
-/// "config store not configured" messages.
-pub(crate) fn config_store_or_unavailable(
-    state: &AppState,
-) -> Result<Arc<dyn ConfigStore>, ApiError> {
-    state
-        .config_store
-        .clone()
-        .ok_or_else(|| ApiError::ServiceUnavailable("config store not configured".into()))
+/// Fetch the config store required by `EvalRoutesState`. Route composition only
+/// mounts eval handlers once this module state exists, so handlers do not carry
+/// a second "config store not configured" branch.
+pub(crate) fn eval_config_store(state: &EvalRoutesState) -> Arc<dyn ConfigStore> {
+    state.config.config_store.clone()
 }
 
 /// Resolve a `model_id` against the registry to a live executor + its
@@ -41,10 +36,10 @@ pub(crate) fn config_store_or_unavailable(
 /// `NotFound` on either lookup becomes `404` with a message identifying
 /// which side missed.
 pub(crate) async fn resolve_live_executor(
-    state: &AppState,
+    state: &EvalRoutesState,
     model_id: &str,
 ) -> Result<ResolvedLiveExecutor, ApiError> {
-    let store = config_store_or_unavailable(state)?;
+    let store = eval_config_store(state);
 
     let binding_value = store
         .get("models", model_id)
@@ -78,8 +73,9 @@ pub(crate) async fn resolve_live_executor(
             .map_err(|err| ApiError::Internal(format!("decoding provider: {err}")))?;
     let provider = provider_record.spec;
 
-    let executor = build_genai_provider_executor_with_broker(&provider, state.credential_broker())
-        .map_err(|err| ApiError::Internal(format!("building provider executor: {err}")))?;
+    let executor =
+        build_genai_provider_executor_with_broker(&provider, state.run.credential_broker.clone())
+            .map_err(|err| ApiError::Internal(format!("building provider executor: {err}")))?;
     Ok(ResolvedLiveExecutor {
         upstream_model: binding.upstream_model.clone(),
         binding,
@@ -105,10 +101,10 @@ pub(crate) struct ResolvedLiveExecutor {
 /// `NotFound` becomes a 404 identifying the missing record so the
 /// caller can correct the id rather than seeing an opaque 500.
 pub(crate) async fn resolve_agent_spec(
-    state: &AppState,
+    state: &EvalRoutesState,
     agent_id: &str,
 ) -> Result<AgentSpec, ApiError> {
-    let store = config_store_or_unavailable(state)?;
+    let store = eval_config_store(state);
     let raw = store
         .get("agents", agent_id)
         .await

--- a/crates/awaken-server/src/services/eval_events.rs
+++ b/crates/awaken-server/src/services/eval_events.rs
@@ -123,7 +123,7 @@ fn completed_payload(run: &EvalRun, mode: &'static str, persisted: bool) -> Valu
 mod tests {
     use super::*;
     use awaken_contract::contract::event_store::{EventReader, EventScope};
-    use awaken_eval::{EvalRunItem, MatrixCell, ReplayReport};
+    use awaken_eval::{EvalRunExecutionMode, EvalRunItem, MatrixCell, ReplayReport};
     use awaken_stores::InMemoryEventStore;
 
     fn report(passed: bool, cost_usd: Option<f64>) -> ReplayReport {
@@ -156,6 +156,7 @@ mod tests {
             id: "eval_1".to_string(),
             dataset_id: "dataset-a".to_string(),
             dataset_revision: 7,
+            execution_mode: EvalRunExecutionMode::Live,
             items: vec![
                 EvalRunItem {
                     fixture_id: "fixture-1".to_string(),
@@ -168,7 +169,9 @@ mod tests {
                 },
                 EvalRunItem {
                     fixture_id: "fixture-2".to_string(),
-                    cell: None,
+                    cell: Some(MatrixCell {
+                        model_id: Some("model-b".to_string()),
+                    }),
                     report: report(false, Some(0.5)),
                     trace_run_id: None,
                     sample_index: None,

--- a/crates/awaken-server/src/services/eval_events.rs
+++ b/crates/awaken-server/src/services/eval_events.rs
@@ -1,0 +1,214 @@
+use awaken_contract::contract::event_store::{
+    AppendOptions, CanonicalEventDraft, CanonicalEventKind, EventScope, EventStoreError,
+    EventVisibility, EventWriter,
+};
+use awaken_eval::EvalRun;
+use serde_json::{Value, json};
+
+use crate::app::EvalRoutesState;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvalRunStartedEvent {
+    pub eval_run_id: String,
+    pub dataset_id: String,
+    pub dataset_revision: u64,
+    pub mode: &'static str,
+    pub planned_item_count: usize,
+    pub started_at_secs: u64,
+}
+
+pub(crate) async fn record_eval_run_started(state: &EvalRoutesState, event: EvalRunStartedEvent) {
+    let Some(writer) = state
+        .events
+        .as_ref()
+        .map(|events| events.event_store.clone())
+    else {
+        return;
+    };
+    if let Err(error) = append_eval_event(
+        writer.as_ref(),
+        "EvalRunStarted",
+        &event.eval_run_id,
+        json!({
+            "eval_run_id": event.eval_run_id.as_str(),
+            "dataset_id": event.dataset_id.as_str(),
+            "dataset_revision": event.dataset_revision,
+            "mode": event.mode,
+            "planned_item_count": event.planned_item_count,
+            "started_at_secs": event.started_at_secs,
+        }),
+    )
+    .await
+    {
+        tracing::error!(error = %error, eval_run_id = %event.eval_run_id, "failed to record eval run started event");
+    }
+}
+
+pub(crate) async fn record_eval_run_completed(
+    state: &EvalRoutesState,
+    run: &EvalRun,
+    mode: &'static str,
+    persisted: bool,
+) {
+    let Some(writer) = state
+        .events
+        .as_ref()
+        .map(|events| events.event_store.clone())
+    else {
+        return;
+    };
+    if let Err(error) = append_eval_event(
+        writer.as_ref(),
+        "EvalRunCompleted",
+        &run.id,
+        completed_payload(run, mode, persisted),
+    )
+    .await
+    {
+        tracing::error!(error = %error, eval_run_id = %run.id, "failed to record eval run completed event");
+    }
+}
+
+async fn append_eval_event(
+    writer: &dyn EventWriter,
+    event_kind: &'static str,
+    eval_run_id: &str,
+    payload: Value,
+) -> Result<(), EventStoreError> {
+    let mut draft = CanonicalEventDraft::new(
+        vec![EventScope::run(eval_run_id.to_string())],
+        CanonicalEventKind::new(event_kind)?,
+        payload,
+        "eval",
+    )?;
+    draft.visibility = EventVisibility::Internal;
+    draft.correlation_id = Some(eval_run_id.to_string());
+    writer
+        .append(
+            draft,
+            AppendOptions {
+                writer_id: Some("eval".to_string()),
+                idempotency_key: Some(format!("{event_kind}/{eval_run_id}")),
+                expected_prior_cursors: Default::default(),
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+fn completed_payload(run: &EvalRun, mode: &'static str, persisted: bool) -> Value {
+    let passed_count = run.items.iter().filter(|item| item.report.passed).count();
+    let failed_count = run.items.len().saturating_sub(passed_count);
+    let total_cost_usd = run
+        .items
+        .iter()
+        .filter_map(|item| item.report.cost_usd)
+        .sum::<f64>();
+    json!({
+        "eval_run_id": run.id,
+        "dataset_id": run.dataset_id,
+        "dataset_revision": run.dataset_revision,
+        "mode": mode,
+        "item_count": run.items.len(),
+        "passed_count": passed_count,
+        "failed_count": failed_count,
+        "total_cost_usd": total_cost_usd,
+        "started_at_secs": run.started_at_secs,
+        "ended_at_secs": run.ended_at_secs,
+        "persisted": persisted,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::event_store::{EventReader, EventScope};
+    use awaken_eval::{EvalRunItem, MatrixCell, ReplayReport};
+    use awaken_stores::InMemoryEventStore;
+
+    fn report(passed: bool, cost_usd: Option<f64>) -> ReplayReport {
+        ReplayReport {
+            fixture_id: "fixture-1".to_string(),
+            passed,
+            failures: Vec::new(),
+            final_text: "ok".to_string(),
+            inference_count: 1,
+            tool_count: 0,
+            tool_failures: 0,
+            total_input_tokens: 10,
+            total_output_tokens: 5,
+            total_tokens: 15,
+            session_duration_ms: 20,
+            elapsed_ms: 20,
+            tool_calls_by_agent: Vec::new(),
+            error_type: None,
+            inference_error_count: 0,
+            runtime_failure: None,
+            cost_usd,
+            revision_count: 0,
+            judge_score: None,
+            judge_reasoning: None,
+        }
+    }
+
+    fn eval_run() -> EvalRun {
+        EvalRun {
+            id: "eval_1".to_string(),
+            dataset_id: "dataset-a".to_string(),
+            dataset_revision: 7,
+            items: vec![
+                EvalRunItem {
+                    fixture_id: "fixture-1".to_string(),
+                    cell: Some(MatrixCell {
+                        model_id: Some("model-a".to_string()),
+                    }),
+                    report: report(true, Some(0.25)),
+                    trace_run_id: None,
+                    sample_index: None,
+                },
+                EvalRunItem {
+                    fixture_id: "fixture-2".to_string(),
+                    cell: None,
+                    report: report(false, Some(0.5)),
+                    trace_run_id: None,
+                    sample_index: None,
+                },
+            ],
+            started_at_secs: 10,
+            ended_at_secs: 12,
+        }
+    }
+
+    #[tokio::test]
+    async fn append_eval_events_are_scoped_to_eval_run() {
+        let store = InMemoryEventStore::new();
+        append_eval_event(
+            &store,
+            "EvalRunStarted",
+            "eval_1",
+            json!({"eval_run_id":"eval_1","planned_item_count":2}),
+        )
+        .await
+        .unwrap();
+        append_eval_event(
+            &store,
+            "EvalRunCompleted",
+            "eval_1",
+            completed_payload(&eval_run(), "dataset_live_matrix", true),
+        )
+        .await
+        .unwrap();
+
+        let page = store
+            .list(EventScope::run("eval_1"), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(page.events.len(), 2);
+        assert_eq!(page.events[0].event_kind.as_str(), "EvalRunStarted");
+        assert_eq!(page.events[1].event_kind.as_str(), "EvalRunCompleted");
+        assert_eq!(page.events[1].payload["passed_count"], 1);
+        assert_eq!(page.events[1].payload["failed_count"], 1);
+        assert_eq!(page.events[1].payload["total_cost_usd"], 0.75);
+        assert_eq!(page.events[1].visibility, EventVisibility::Internal);
+    }
+}

--- a/crates/awaken-server/src/services/eval_run_service.rs
+++ b/crates/awaken-server/src/services/eval_run_service.rs
@@ -20,11 +20,9 @@ use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
-use crate::app::AppState;
+use crate::app::EvalRoutesState;
 use crate::error::ApiError;
-use crate::services::eval_common::{
-    config_store_or_unavailable, map_storage_error, resolve_live_executor,
-};
+use crate::services::eval_common::{eval_config_store, map_storage_error, resolve_live_executor};
 
 // ── Wire types ────────────────────────────────────────────────────────────
 
@@ -237,10 +235,8 @@ pub(crate) fn map_eval_run_store_error(err: EvalRunStoreError) -> ApiError {
     }
 }
 
-fn eval_run_store_or_unavailable(state: &AppState) -> Result<Arc<dyn EvalRunStore>, ApiError> {
-    state
-        .eval_run_store()
-        .ok_or_else(|| ApiError::ServiceUnavailable("eval run store not configured".into()))
+fn eval_run_store(state: &EvalRoutesState) -> Arc<dyn EvalRunStore> {
+    state.eval.eval_run_store.clone()
 }
 
 fn epoch_secs_now() -> u64 {
@@ -260,15 +256,15 @@ fn epoch_secs_now() -> u64 {
 /// background execution with `GET /v1/eval/runs/:id` polling.
 #[tracing::instrument(skip_all, fields(dataset_id = %body.dataset_id))]
 pub async fn start_eval_run(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Json(body): Json<StartRunRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let config_store = config_store_or_unavailable(&state)?;
-    let run_store = eval_run_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let config_store = eval_config_store(&state);
+    let run_store = eval_run_store(&state);
     let execution_mode = execution_mode_from_request(&body);
-    let limits = state.config.eval_limits.clone();
+    let limits = state.limits.clone();
 
     // ── Request-shape validation (no I/O) ─────────────────────────────
     //
@@ -465,7 +461,7 @@ pub async fn start_eval_run(
         None
     };
 
-    let trace_store = state.trace_store();
+    let trace_store = state.trace.as_ref().map(|trace| trace.trace_store.clone());
     let trace_sink: Option<Arc<dyn MetricsSink>> = trace_store
         .as_ref()
         .map(|store| Arc::new(TraceStoreSink::new(store.clone())) as Arc<dyn MetricsSink>);
@@ -477,7 +473,25 @@ pub async fn start_eval_run(
     // recorded time matches when the work actually began. Setting it
     // after-the-fact (the earlier shape) collapsed started ≈ ended for
     // every run and broke duration / list filtering / time-series.
+    let eval_run_id = mint_run_id();
     let started_at_secs = epoch_secs_now();
+    let eval_mode = if is_live_mode(execution_mode) {
+        "dataset_live_matrix"
+    } else {
+        "dataset_scripted"
+    };
+    crate::services::eval_events::record_eval_run_started(
+        &state,
+        crate::services::eval_events::EvalRunStartedEvent {
+            eval_run_id: eval_run_id.clone(),
+            dataset_id: body.dataset_id.clone(),
+            dataset_revision,
+            mode: eval_mode,
+            planned_item_count: total_units,
+            started_at_secs,
+        },
+    )
+    .await;
     let items: Vec<EvalRunItem> = if is_live_mode(execution_mode) {
         let walltime = body.max_walltime_secs.unwrap_or(60);
         let max_total_tokens = body.max_total_tokens.unwrap_or(DEFAULT_MAX_TOTAL_TOKENS);
@@ -503,7 +517,7 @@ pub async fn start_eval_run(
     };
 
     let run = EvalRun {
-        id: mint_run_id(),
+        id: eval_run_id,
         dataset_id: body.dataset_id.clone(),
         dataset_revision,
         execution_mode,
@@ -512,6 +526,7 @@ pub async fn start_eval_run(
         ended_at_secs: epoch_secs_now(),
     };
     run_store.write(&run).map_err(map_eval_run_store_error)?;
+    crate::services::eval_events::record_eval_run_completed(&state, &run, eval_mode, true).await;
 
     // Baseline was preflight-validated above; just use the already-loaded
     // copy. `baseline_run_id` is transient — not persisted onto the
@@ -532,12 +547,12 @@ pub async fn start_eval_run(
 /// `GET /v1/eval/runs` — list run summaries.
 #[tracing::instrument(skip_all)]
 pub async fn list_eval_runs(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Query(params): Query<ListRunsQuery>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = eval_run_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_run_store(&state);
     let filter = EvalRunFilter {
         dataset_id: params.dataset_id,
         since_secs: params.since_secs,
@@ -551,13 +566,13 @@ pub async fn list_eval_runs(
 /// `GET /v1/eval/runs/:id` (with optional `?baseline=` for D7).
 #[tracing::instrument(skip_all, fields(id = %id))]
 pub async fn get_eval_run(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Path(id): Path<String>,
     Query(params): Query<GetRunQuery>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = eval_run_store_or_unavailable(&state)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = eval_run_store(&state);
     let wants_diff = params.baseline.is_some();
     let run = store.read(&id).map_err(|err| match err {
         EvalRunStoreError::DuplicateItemKeys(_, msg) if wants_diff => {
@@ -721,7 +736,7 @@ pub(crate) struct MatrixOptions {
 /// pre-resolved before any provider call so a missing model fails fast
 /// (404) instead of burning tokens on the cells that did resolve.
 async fn run_matrix_cells(
-    state: &AppState,
+    state: &EvalRoutesState,
     fixtures: &[Fixture],
     cells: &[MatrixCell],
     options: MatrixOptions,

--- a/crates/awaken-server/src/services/frozen_registry.rs
+++ b/crates/awaken-server/src/services/frozen_registry.rs
@@ -1,0 +1,585 @@
+use std::sync::Arc;
+
+use awaken_contract::contract::run::RunResolutionScope;
+use awaken_contract::contract::versioned_registry::VersionedRecord;
+use awaken_contract::skill_spec::SkillSpec;
+use awaken_contract::tool_spec::ToolSpec;
+use awaken_contract::{
+    AgentSpec, ModelBindingSpec, PinnedRegistryEntry, PinnedRegistryManifest, ProviderSpec,
+    REGISTRY_KIND_AGENT, REGISTRY_KIND_MODEL, REGISTRY_KIND_PLUGIN_CONFIG, REGISTRY_KIND_PROVIDER,
+    REGISTRY_KIND_SKILL, REGISTRY_KIND_TOOL, RegistryGraphValidationError,
+    RegistryGraphValidationRequest, RegistryGraphValidator, StandardRegistryGraphValidator,
+    VersionSelector, VersionedRegistryError, VersionedRegistryStore,
+};
+use awaken_runtime::registry::{
+    PinnedAgentSpecRegistry, PinnedRegistryError, PinnedSpecMap, RegistryHandle,
+};
+use awaken_runtime::resolution::{
+    PersistenceRequirement, ResolutionRequest, ResolveError, ResolvedRunPlan, Resolver,
+};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FrozenRegistryMaterializationError {
+    #[error("registry graph validation failed: {0}")]
+    Graph(#[from] RegistryGraphValidationError),
+    #[error("versioned registry error: {0}")]
+    Registry(#[from] VersionedRegistryError),
+    #[error("pinned registry error: {0}")]
+    Pinned(#[from] PinnedRegistryError),
+    #[error("invalid frozen registry graph: {0}")]
+    InvalidGraph(String),
+}
+
+#[non_exhaustive]
+pub struct FrozenAgentRegistry {
+    pub manifest: PinnedRegistryManifest,
+    pub agents: Arc<PinnedAgentSpecRegistry>,
+    /// Pinned model bindings reachable from the manifest (ADR-0035 D8).
+    pub models: Arc<PinnedSpecMap<ModelBindingSpec>>,
+    /// Pinned provider specs reachable from the manifest.
+    pub providers: Arc<PinnedSpecMap<ProviderSpec>>,
+    /// Pinned skill specs reachable from the manifest.
+    pub skills: Arc<PinnedSpecMap<SkillSpec>>,
+    /// Pinned tool specs reachable from the manifest.
+    pub tools: Arc<PinnedSpecMap<ToolSpec>>,
+    /// Pinned plugin-config payloads. Stored as raw `serde_json::Value`
+    /// because plugin_config payload shapes are extension-specific.
+    pub plugin_configs: Arc<PinnedSpecMap<Value>>,
+}
+
+impl FrozenAgentRegistry {
+    /// Build a `RegistrySet` suitable for `RunActivation.pinned_registry_set`
+    /// (ADR-0035 D9). `live` supplies the runtime objects we cannot
+    /// rebuild from specs alone (tool/provider/plugin executors / backend
+    /// factories); agents and models are sourced from the frozen pins so
+    /// resolution honors the pinned graph.
+    #[must_use]
+    pub fn to_registry_set(
+        &self,
+        live: &awaken_runtime::registry::RegistrySet,
+    ) -> awaken_runtime::registry::RegistrySet {
+        awaken_runtime::registry::RegistrySet {
+            agents: self.agents.clone() as Arc<dyn awaken_runtime::registry::AgentSpecRegistry>,
+            models: self.models.clone() as Arc<dyn awaken_runtime::registry::ModelRegistry>,
+            tools: live.tools.clone(),
+            providers: live.providers.clone(),
+            plugins: live.plugins.clone(),
+            backends: live.backends.clone(),
+        }
+    }
+}
+
+pub struct FrozenAgentRegistryMaterializer {
+    store: Arc<dyn VersionedRegistryStore>,
+    validator: StandardRegistryGraphValidator,
+}
+
+pub struct LatestPublicationResolver {
+    scope_id: String,
+    materializer: FrozenAgentRegistryMaterializer,
+    registry_handle: RegistryHandle,
+}
+
+impl LatestPublicationResolver {
+    #[must_use]
+    pub fn new(
+        scope_id: impl Into<String>,
+        store: Arc<dyn VersionedRegistryStore>,
+        registry_handle: RegistryHandle,
+    ) -> Self {
+        Self {
+            scope_id: scope_id.into(),
+            materializer: FrozenAgentRegistryMaterializer::new(store),
+            registry_handle,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Resolver for LatestPublicationResolver {
+    async fn resolve(
+        &self,
+        mut request: ResolutionRequest,
+    ) -> Result<ResolvedRunPlan, ResolveError> {
+        let live = self.registry_handle.snapshot().into_registries();
+        if matches!(request.resolution_scope, RunResolutionScope::Live)
+            && request.features.requested_persistence == PersistenceRequirement::NotRequired
+        {
+            return awaken_runtime::registry::resolve::RegistrySetResolver::new(live)
+                .resolve(request)
+                .await;
+        }
+        let selector = match request.resolution_scope.clone() {
+            RunResolutionScope::Live => VersionSelector::LatestPublication {
+                scope_id: self.scope_id.clone(),
+            },
+            RunResolutionScope::Pinned(manifest) => VersionSelector::Manifest {
+                scope_id: self.scope_id.clone(),
+                manifest,
+            },
+        };
+        let frozen = self
+            .materializer
+            .materialize(selector)
+            .await
+            .map_err(|error| ResolveError::Runtime(error.to_string()))?;
+        request.resolution_scope = RunResolutionScope::Pinned(frozen.manifest.clone());
+        awaken_runtime::registry::resolve::RegistrySetResolver::new(frozen.to_registry_set(&live))
+            .resolve(request)
+            .await
+    }
+}
+
+impl FrozenAgentRegistryMaterializer {
+    #[must_use]
+    pub fn new(store: Arc<dyn VersionedRegistryStore>) -> Self {
+        Self {
+            validator: StandardRegistryGraphValidator::new(Arc::clone(&store)),
+            store,
+        }
+    }
+
+    pub async fn materialize(
+        &self,
+        selector: VersionSelector,
+    ) -> Result<FrozenAgentRegistry, FrozenRegistryMaterializationError> {
+        let base_manifest = self.base_manifest(&selector).await?;
+        let scope_id = selector_scope_id(&selector);
+        let report = self
+            .validator
+            .validate(RegistryGraphValidationRequest {
+                root: selector,
+                reference_policy: Default::default(),
+            })
+            .await?;
+        let manifest = PinnedRegistryManifest {
+            publication_id: base_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.publication_id.clone()),
+            registry_snapshot_version: base_manifest
+                .as_ref()
+                .and_then(|manifest| manifest.registry_snapshot_version),
+            entries: report.entries.clone(),
+        };
+        let agents = self.load_pinned_agents(&scope_id, &report.entries).await?;
+        let models = self
+            .load_pinned_kind::<ModelBindingSpec>(
+                &scope_id,
+                &report.entries,
+                REGISTRY_KIND_MODEL,
+                |spec| spec.id.clone(),
+            )
+            .await?;
+        let providers = self
+            .load_pinned_kind::<ProviderSpec>(
+                &scope_id,
+                &report.entries,
+                REGISTRY_KIND_PROVIDER,
+                |spec| spec.id.clone(),
+            )
+            .await?;
+        let skills = self
+            .load_pinned_kind::<SkillSpec>(
+                &scope_id,
+                &report.entries,
+                REGISTRY_KIND_SKILL,
+                |spec| spec.id.clone(),
+            )
+            .await?;
+        let tools = self
+            .load_pinned_kind::<ToolSpec>(&scope_id, &report.entries, REGISTRY_KIND_TOOL, |spec| {
+                spec.id.clone()
+            })
+            .await?;
+        // plugin_config payloads have no canonical Rust type, so they are
+        // keyed by the pinned entry id rather than an inner field.
+        let plugin_configs = self
+            .load_pinned_kind::<Value>(
+                &scope_id,
+                &report.entries,
+                REGISTRY_KIND_PLUGIN_CONFIG,
+                |_| String::new(),
+            )
+            .await?;
+        Ok(FrozenAgentRegistry {
+            manifest,
+            agents: Arc::new(agents),
+            models: Arc::new(models),
+            providers: Arc::new(providers),
+            skills: Arc::new(skills),
+            tools: Arc::new(tools),
+            plugin_configs: Arc::new(plugin_configs),
+        })
+    }
+
+    async fn load_pinned_kind<T: DeserializeOwned>(
+        &self,
+        scope_id: &str,
+        entries: &[PinnedRegistryEntry],
+        kind: &'static str,
+        spec_id: impl Fn(&T) -> String,
+    ) -> Result<PinnedSpecMap<T>, FrozenRegistryMaterializationError> {
+        let mut map: PinnedSpecMap<T> = PinnedSpecMap::new(kind);
+        for entry in entries.iter().filter(|entry| entry.kind == kind) {
+            let record = self
+                .store
+                .get(scope_id, &entry.kind, &entry.id, entry.version)
+                .await?
+                .ok_or_else(|| RegistryGraphValidationError::MissingVersion {
+                    kind: entry.kind.clone(),
+                    id: entry.id.clone(),
+                    version: entry.version,
+                })?;
+            self.verify_record_against_entry(&record, entry)?;
+            let spec: T = serde_json::from_value(record.value).map_err(|error| {
+                RegistryGraphValidationError::InvalidReference {
+                    kind: entry.kind.clone(),
+                    id: entry.id.clone(),
+                    reason: format!("invalid {kind} spec: {error}"),
+                }
+            })?;
+            let derived_id = spec_id(&spec);
+            let key = if derived_id.is_empty() {
+                entry.id.clone()
+            } else {
+                derived_id
+            };
+            map.insert(key, spec, entry.clone())?;
+        }
+        Ok(map)
+    }
+
+    fn verify_record_against_entry(
+        &self,
+        record: &VersionedRecord<Value>,
+        entry: &PinnedRegistryEntry,
+    ) -> Result<(), FrozenRegistryMaterializationError> {
+        record
+            .verify_content_hash()
+            .map_err(|error| RegistryGraphValidationError::Backend(error.to_string()))?;
+        if record.content_hash != entry.content_hash {
+            return Err(RegistryGraphValidationError::ContentHashMismatch {
+                kind: entry.kind.clone(),
+                id: entry.id.clone(),
+                version: entry.version,
+                expected: entry.content_hash.clone(),
+                actual: record.content_hash.clone(),
+            }
+            .into());
+        }
+        Ok(())
+    }
+
+    async fn base_manifest(
+        &self,
+        selector: &VersionSelector,
+    ) -> Result<Option<PinnedRegistryManifest>, FrozenRegistryMaterializationError> {
+        match selector {
+            VersionSelector::LatestPublication { scope_id } => Ok(self
+                .store
+                .latest_pinned_manifest(scope_id)
+                .await?
+                .ok_or_else(|| RegistryGraphValidationError::MissingResource {
+                    kind: "publication".to_string(),
+                    id: "latest".to_string(),
+                })?
+                .into()),
+            VersionSelector::Publication {
+                scope_id,
+                snapshot_version,
+            } => Ok(self
+                .store
+                .pinned_manifest_for_publication(scope_id, *snapshot_version)
+                .await?
+                .ok_or_else(|| RegistryGraphValidationError::MissingVersion {
+                    kind: "publication".to_string(),
+                    id: scope_id.clone(),
+                    version: *snapshot_version,
+                })?
+                .into()),
+            VersionSelector::Manifest { manifest, .. } => Ok(Some(manifest.clone())),
+            VersionSelector::Exact { .. } => Ok(None),
+        }
+    }
+
+    async fn load_pinned_agents(
+        &self,
+        scope_id: &str,
+        entries: &[PinnedRegistryEntry],
+    ) -> Result<PinnedAgentSpecRegistry, FrozenRegistryMaterializationError> {
+        let mut pinned_agents = Vec::new();
+        for entry in entries
+            .iter()
+            .filter(|entry| entry.kind == REGISTRY_KIND_AGENT)
+        {
+            let record = self
+                .store
+                .get(scope_id, &entry.kind, &entry.id, entry.version)
+                .await?
+                .ok_or_else(|| RegistryGraphValidationError::MissingVersion {
+                    kind: entry.kind.clone(),
+                    id: entry.id.clone(),
+                    version: entry.version,
+                })?;
+            // ADR-0035 D9: resume must recompute the hash and reject any
+            // record whose stored bytes no longer match its content_hash,
+            // and also reject any drift between the pinned entry hash and
+            // the stored hash. The graph validator already runs this check,
+            // but loading happens separately and a concurrent column rewrite
+            // would otherwise be loaded without notice.
+            self.verify_record_against_entry(&record, entry)?;
+            let spec = serde_json::from_value::<AgentSpec>(record.value).map_err(|error| {
+                RegistryGraphValidationError::InvalidReference {
+                    kind: entry.kind.clone(),
+                    id: entry.id.clone(),
+                    reason: format!("invalid AgentSpec: {error}"),
+                }
+            })?;
+            pinned_agents.push((spec, entry.clone()));
+        }
+        if pinned_agents.is_empty() {
+            return Err(FrozenRegistryMaterializationError::InvalidGraph(
+                "frozen agent registry requires at least one agent".to_string(),
+            ));
+        }
+        Ok(PinnedAgentSpecRegistry::from_pinned_agents(pinned_agents)?)
+    }
+}
+
+fn selector_scope_id(selector: &VersionSelector) -> String {
+    match selector {
+        VersionSelector::LatestPublication { scope_id }
+        | VersionSelector::Publication { scope_id, .. }
+        | VersionSelector::Exact { scope_id, .. }
+        | VersionSelector::Manifest { scope_id, .. } => scope_id.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::versioned_registry::PublishOutcome;
+    use awaken_contract::{ModelBindingSpec, ProviderSpec, VersionRef};
+    use awaken_runtime::registry::AgentSpecRegistry;
+    use awaken_stores::InMemoryVersionedRegistryStore;
+    use serde_json::{Value, json};
+
+    #[tokio::test]
+    async fn materializes_latest_publication_into_pinned_agent_registry() {
+        let store = InMemoryVersionedRegistryStore::new();
+        let provider = publish_provider(&store, "provider-1").await;
+        let model = publish_model(&store, "model-1", "provider-1").await;
+        let delegate = publish_agent(&store, agent("delegate", "model-1", [])).await;
+        let root = publish_agent(&store, agent("root", "model-1", ["delegate"])).await;
+        store
+            .create_publication(
+                "default",
+                "pub-1",
+                refs([&provider, &model, &delegate, &root]),
+                Vec::new(),
+                None,
+                json!({}),
+            )
+            .await
+            .unwrap();
+
+        let materializer = FrozenAgentRegistryMaterializer::new(Arc::new(store));
+        let frozen = materializer
+            .materialize(VersionSelector::LatestPublication {
+                scope_id: "default".to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(frozen.manifest.publication_id.as_deref(), Some("pub-1"));
+        assert_eq!(frozen.manifest.registry_snapshot_version, Some(1));
+        assert_eq!(frozen.agents.get_agent("root").unwrap().id, "root");
+        assert_eq!(
+            frozen.agents.pin_for_agent("delegate").unwrap().version,
+            delegate.version
+        );
+    }
+
+    #[tokio::test]
+    async fn materializes_exact_agent_with_current_references() {
+        let store = InMemoryVersionedRegistryStore::new();
+        publish_provider(&store, "provider-1").await;
+        publish_model(&store, "model-1", "provider-1").await;
+        let root = publish_agent(&store, agent("root", "model-1", [])).await;
+
+        let materializer = FrozenAgentRegistryMaterializer::new(Arc::new(store));
+        let frozen = materializer
+            .materialize(VersionSelector::Exact {
+                scope_id: "default".to_string(),
+                kind: "agent".to_string(),
+                id: "root".to_string(),
+                version: root.version,
+            })
+            .await
+            .unwrap();
+
+        assert!(frozen.manifest.publication_id.is_none());
+        assert_eq!(frozen.agents.pin_for_agent("root").unwrap().version, 1);
+        assert!(frozen.manifest.entries.iter().any(|entry| {
+            entry.kind == awaken_contract::REGISTRY_KIND_MODEL && entry.id == "model-1"
+        }));
+    }
+
+    #[tokio::test]
+    async fn rejects_graphs_without_agents() {
+        let store = InMemoryVersionedRegistryStore::new();
+        let provider = publish_provider(&store, "provider-1").await;
+        let manifest = PinnedRegistryManifest {
+            publication_id: None,
+            registry_snapshot_version: None,
+            entries: vec![provider],
+        };
+        let materializer = FrozenAgentRegistryMaterializer::new(Arc::new(store));
+        let error = materialization_error(
+            materializer
+                .materialize(VersionSelector::Manifest {
+                    scope_id: "default".to_string(),
+                    manifest,
+                })
+                .await,
+        );
+
+        assert!(matches!(
+            error,
+            FrozenRegistryMaterializationError::InvalidGraph(message)
+                if message.contains("at least one agent")
+        ));
+    }
+
+    /// ADR-0035 D9: the resume path must reject a manifest whose stored
+    /// `content_hash` diverges from the published canonical bytes. The
+    /// validator alone is unit-tested in `registry_graph_validator.rs`,
+    /// but only the materializer guarantees that the resume entry point
+    /// actually runs the check before handing a frozen registry to the
+    /// runtime.
+    #[tokio::test]
+    async fn materialize_rejects_manifest_drift() {
+        let store = InMemoryVersionedRegistryStore::new();
+        let provider = publish_provider(&store, "provider-1").await;
+        let model = publish_model(&store, "model-1", "provider-1").await;
+        let root = publish_agent(&store, agent("root", "model-1", [])).await;
+
+        let mut tampered_root = root.clone();
+        tampered_root.content_hash = "sha256:deadbeef".to_string();
+        let manifest = PinnedRegistryManifest {
+            publication_id: None,
+            registry_snapshot_version: None,
+            entries: vec![tampered_root, model, provider],
+        };
+
+        let materializer = FrozenAgentRegistryMaterializer::new(Arc::new(store));
+        let error = materialization_error(
+            materializer
+                .materialize(VersionSelector::Manifest {
+                    scope_id: "default".to_string(),
+                    manifest,
+                })
+                .await,
+        );
+
+        match error {
+            FrozenRegistryMaterializationError::Graph(
+                RegistryGraphValidationError::ContentHashMismatch {
+                    kind, id, expected, ..
+                },
+            ) => {
+                assert_eq!(kind, "agent");
+                assert_eq!(id, "root");
+                assert_eq!(expected, "sha256:deadbeef");
+            }
+            other => panic!("expected Graph(ContentHashMismatch), got {other:?}"),
+        }
+    }
+
+    async fn publish_agent(
+        store: &InMemoryVersionedRegistryStore,
+        spec: AgentSpec,
+    ) -> PinnedRegistryEntry {
+        let id = spec.id.clone();
+        publish(store, "agent", &id, serde_json::to_value(spec).unwrap()).await
+    }
+
+    async fn publish_model(
+        store: &InMemoryVersionedRegistryStore,
+        id: &str,
+        provider_id: &str,
+    ) -> PinnedRegistryEntry {
+        let spec = ModelBindingSpec::new(id, provider_id, "upstream");
+        publish(store, "model", id, serde_json::to_value(spec).unwrap()).await
+    }
+
+    async fn publish_provider(
+        store: &InMemoryVersionedRegistryStore,
+        id: &str,
+    ) -> PinnedRegistryEntry {
+        let spec = ProviderSpec {
+            id: id.to_string(),
+            adapter: "openai".to_string(),
+            ..Default::default()
+        };
+        publish(store, "provider", id, serde_json::to_value(spec).unwrap()).await
+    }
+
+    async fn publish(
+        store: &InMemoryVersionedRegistryStore,
+        kind: &str,
+        id: &str,
+        value: Value,
+    ) -> PinnedRegistryEntry {
+        let outcome = store
+            .publish_resource("default", kind, id, value, 1, json!({}))
+            .await
+            .unwrap();
+        let record = match outcome {
+            PublishOutcome::Created(record) | PublishOutcome::Noop(record) => record,
+        };
+        PinnedRegistryEntry {
+            kind: kind.to_string(),
+            id: id.to_string(),
+            version: record.version,
+            content_hash: record.content_hash,
+        }
+    }
+
+    fn agent<'a>(
+        id: &str,
+        model_id: &str,
+        delegates: impl IntoIterator<Item = &'a str>,
+    ) -> AgentSpec {
+        AgentSpec {
+            id: id.to_string(),
+            model_id: model_id.to_string(),
+            system_prompt: "system".to_string(),
+            delegates: delegates.into_iter().map(str::to_string).collect(),
+            ..Default::default()
+        }
+    }
+
+    fn refs<'a>(entries: impl IntoIterator<Item = &'a PinnedRegistryEntry>) -> Vec<VersionRef> {
+        entries
+            .into_iter()
+            .map(|entry| VersionRef {
+                kind: entry.kind.clone(),
+                id: entry.id.clone(),
+                version: entry.version,
+            })
+            .collect()
+    }
+
+    fn materialization_error(
+        result: Result<FrozenAgentRegistry, FrozenRegistryMaterializationError>,
+    ) -> FrozenRegistryMaterializationError {
+        match result {
+            Ok(_) => panic!("expected frozen registry materialization error"),
+            Err(error) => error,
+        }
+    }
+}

--- a/crates/awaken-server/src/services/mod.rs
+++ b/crates/awaken-server/src/services/mod.rs
@@ -8,12 +8,15 @@ pub mod dataset_service;
 pub mod dataset_wire;
 pub mod eval_cell;
 pub mod eval_common;
+pub mod eval_events;
 pub mod eval_run_service;
+pub mod frozen_registry;
 pub mod online_eval_service;
 #[cfg(feature = "permission")]
 pub mod permission_preview;
 pub mod run_control_service;
 pub mod run_service;
+pub mod thread_events;
 pub mod thread_service;
 pub mod tool_overrides;
 pub mod trace_retention;

--- a/crates/awaken-server/src/services/online_eval_service.rs
+++ b/crates/awaken-server/src/services/online_eval_service.rs
@@ -30,7 +30,7 @@ use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 
-use crate::app::AppState;
+use crate::app::EvalRoutesState;
 use crate::error::ApiError;
 use crate::services::eval_cell::{
     DEFAULT_MAX_TOTAL_TOKENS, LiveCellOptions, ResolvedCell, run_live_eval_cells,
@@ -145,21 +145,13 @@ pub struct OnlineEvalResponse {
 /// `EvalRun` whose items are one per cell.
 #[tracing::instrument(skip_all, fields(models = ?body.models))]
 pub async fn start_online_eval(
-    State(state): State<AppState>,
+    State(state): State<EvalRoutesState>,
     headers: HeaderMap,
     Json(body): Json<OnlineEvalRequest>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
 
-    // Fail fast on persist+no-store BEFORE any model resolution or
-    // provider call. Otherwise we'd burn tokens on a request that the
-    // persistence layer is already known to reject — bad UX, real $.
-    if body.persist && state.eval_run_store().is_none() {
-        return Err(ApiError::ServiceUnavailable(
-            "EvalRunStore is required when persist=true".into(),
-        ));
-    }
-    let limits = state.config.eval_limits.clone();
+    let limits = state.limits.clone();
     if body.models.is_empty() {
         return Err(ApiError::BadRequest(
             "models must contain at least one model id".into(),
@@ -275,9 +267,22 @@ pub async fn start_online_eval(
 
     // Capture started_at_secs BEFORE the per-cell execution loop so the
     // recorded time matches when work actually began.
+    let eval_run_id = mint_run_id();
     let started_at_secs = epoch_secs_now();
+    crate::services::eval_events::record_eval_run_started(
+        &state,
+        crate::services::eval_events::EvalRunStartedEvent {
+            eval_run_id: eval_run_id.clone(),
+            dataset_id: ADHOC_DATASET_ID.to_string(),
+            dataset_revision: 0,
+            mode: "online_live_matrix",
+            planned_item_count: total_units,
+            started_at_secs,
+        },
+    )
+    .await;
     // Run cells × samples in parallel with bounded concurrency.
-    let trace_store = state.trace_store();
+    let trace_store = state.trace.as_ref().map(|trace| trace.trace_store.clone());
     let trace_sink = trace_store.as_ref().map(|store| {
         Arc::new(TraceStoreSink::new(store.clone()))
             as Arc<dyn awaken_ext_observability::MetricsSink>
@@ -301,7 +306,7 @@ pub async fn start_online_eval(
     .await?;
 
     let run = EvalRun {
-        id: mint_run_id(),
+        id: eval_run_id,
         dataset_id: ADHOC_DATASET_ID.into(),
         dataset_revision: 0,
         execution_mode: EvalRunExecutionMode::Live,
@@ -311,21 +316,21 @@ pub async fn start_online_eval(
     };
 
     let persisted = if body.persist {
-        if let Some(store) = state.eval_run_store() {
-            store
-                .write(&run)
-                .map_err(super::eval_run_service::map_eval_run_store_error)?;
-            true
-        } else {
-            // EvalRunStore not configured — surface explicitly rather
-            // than silently lying about persistence.
-            return Err(ApiError::ServiceUnavailable(
-                "persist=true requested but EvalRunStore is not configured".into(),
-            ));
-        }
+        let store = state.eval.eval_run_store.clone();
+        store
+            .write(&run)
+            .map_err(super::eval_run_service::map_eval_run_store_error)?;
+        true
     } else {
         false
     };
+    crate::services::eval_events::record_eval_run_completed(
+        &state,
+        &run,
+        "online_live_matrix",
+        persisted,
+    )
+    .await;
 
     Ok(Json(OnlineEvalResponse { run, persisted }).into_response())
 }

--- a/crates/awaken-server/src/services/permission_preview.rs
+++ b/crates/awaken-server/src/services/permission_preview.rs
@@ -23,7 +23,7 @@ use awaken_ext_permission::{
 };
 use serde::Serialize;
 
-use crate::app::AppState;
+use crate::app::ConfigRoutesState;
 use crate::services::config_service::{ConfigNamespace, ConfigService, ConfigServiceError};
 
 #[derive(Debug, Clone, Serialize)]
@@ -85,7 +85,7 @@ pub enum PermissionPreviewError {
 
 /// Run the preview for the given agent id and return the analysis.
 pub async fn preview_agent_permissions(
-    state: &AppState,
+    state: &ConfigRoutesState,
     agent_id: &str,
 ) -> Result<PermissionPreviewResponse, PermissionPreviewError> {
     let service = ConfigService::new(state).map_err(PermissionPreviewError::Config)?;
@@ -99,6 +99,7 @@ pub async fn preview_agent_permissions(
         .map_err(|err| PermissionPreviewError::InvalidSpec(err.to_string()))?;
 
     let registries = state
+        .run
         .runtime
         .registry_set()
         .ok_or(PermissionPreviewError::RegistryUnavailable)?;

--- a/crates/awaken-server/src/services/run_control_service.rs
+++ b/crates/awaken-server/src/services/run_control_service.rs
@@ -12,9 +12,9 @@ use awaken_contract::contract::mailbox::MailboxInterrupt;
 use awaken_contract::contract::message::Message;
 use awaken_contract::contract::storage::{RunQuery, RunRecord, RunWaitingState, StorageError};
 use awaken_contract::contract::suspension::ToolCallResume;
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 
-use crate::app::AppState;
+use crate::app::RunModuleState;
 use crate::mailbox::{MailboxError, MailboxSubmitResult};
 
 /// How injected user input should interact with any active work.
@@ -89,11 +89,11 @@ pub enum RunControlError {
 /// Unified control plane for active runs.
 #[derive(Clone)]
 pub struct RunControlService {
-    state: AppState,
+    state: RunModuleState,
 }
 
 impl RunControlService {
-    pub fn new(state: AppState) -> Self {
+    pub fn new(state: RunModuleState) -> Self {
         Self { state }
     }
 
@@ -102,7 +102,7 @@ impl RunControlService {
         &self,
         thread_id: &str,
     ) -> Result<Option<ActiveRun>, RunControlError> {
-        if let Some(thread) = self.state.store.load_thread(thread_id).await? {
+        if let Some(thread) = self.state.store().load_thread(thread_id).await? {
             if let Some(active) = self
                 .load_projected_run(
                     thread_id,
@@ -138,7 +138,7 @@ impl RunControlService {
         let Some(run_id) = run_id else {
             return Ok(None);
         };
-        let Some(run) = self.state.store.load_run(run_id).await? else {
+        let Some(run) = self.state.store().load_run(run_id).await? else {
             return Ok(None);
         };
         if run.thread_id == thread_id && allowed_statuses.contains(&run.status) {
@@ -153,7 +153,7 @@ impl RunControlService {
         for status in [RunStatus::Running, RunStatus::Waiting] {
             let page = self
                 .state
-                .store
+                .store()
                 .list_runs(&RunQuery {
                     offset: 0,
                     limit: 200,
@@ -200,11 +200,11 @@ impl RunControlService {
         tool_call_id: String,
         resume: ToolCallResume,
     ) -> Result<(), RunControlError> {
-        let run = if let Some(run) = self.state.store.load_run(id).await? {
+        let run = if let Some(run) = self.state.store().load_run(id).await? {
             run
         } else if let Some(active) = self.get_active_run(id).await? {
             self.state
-                .store
+                .store()
                 .load_run(&active.run_id)
                 .await?
                 .ok_or_else(|| RunControlError::RunNotFound(active.run_id.clone()))?
@@ -219,11 +219,20 @@ impl RunControlService {
             return Err(RunControlError::DecisionTargetNotFound(id.to_string()));
         }
 
-        let request = RunRequest::new(run.thread_id.clone(), Vec::new())
+        let request = RunActivation::new(run.thread_id.clone(), Vec::new())
             .with_agent_id(run.agent_id.clone())
             .with_continue_run_id(run.run_id.clone())
-            .with_decisions(vec![(tool_call_id, resume)]);
+            .with_decisions(vec![(tool_call_id.clone(), resume.clone())]);
         self.state.mailbox.submit_background(request).await?;
+        self.state
+            .mailbox
+            .record_mailbox_decision_received_for_run(
+                &run,
+                &tool_call_id,
+                &resume,
+                "durable_dispatch",
+            )
+            .await;
         Ok(())
     }
 
@@ -260,7 +269,7 @@ impl RunControlService {
     ) -> Result<MailboxSubmitResult, RunControlError> {
         let thread = self
             .state
-            .store
+            .store()
             .load_thread(thread_id)
             .await?
             .ok_or_else(|| RunControlError::ThreadNotFound(thread_id.to_string()))?;
@@ -274,7 +283,7 @@ impl RunControlService {
                 .map_err(RunControlError::Mailbox)?;
         }
 
-        let mut request = RunRequest::new(thread_id.to_string(), messages);
+        let mut request = RunActivation::new(thread_id.to_string(), messages);
         if mode == InputMode::ResumeOpenRun {
             let run = self
                 .load_open_waiting_run(thread_id, thread.open_run_id.as_deref())
@@ -302,12 +311,12 @@ impl RunControlService {
     ) -> Result<MailboxSubmitResult, RunControlError> {
         let _thread = self
             .state
-            .store
+            .store()
             .load_thread(thread_id)
             .await?
             .ok_or_else(|| RunControlError::ThreadNotFound(thread_id.to_string()))?;
 
-        let mut request = RunRequest::new(thread_id.to_string(), messages);
+        let mut request = RunActivation::new(thread_id.to_string(), messages);
         if let Some(agent_id) = agent_id {
             request = request.with_agent_id(agent_id);
         }
@@ -328,7 +337,7 @@ impl RunControlService {
     ) -> Result<MailboxSubmitResult, RunControlError> {
         let run = self
             .state
-            .store
+            .store()
             .load_run(run_id)
             .await?
             .ok_or_else(|| RunControlError::RunNotFound(run_id.to_string()))?;
@@ -340,7 +349,7 @@ impl RunControlService {
         }
 
         if run.status == RunStatus::Waiting && run.is_resumable_waiting() {
-            let request = RunRequest::new(run.thread_id.clone(), messages)
+            let request = RunActivation::new(run.thread_id.clone(), messages)
                 .with_agent_id(run.agent_id)
                 .with_continue_run_id(run.run_id);
             return self
@@ -363,13 +372,13 @@ impl RunControlService {
     ) -> Result<MailboxSubmitResult, RunControlError> {
         let run = self
             .state
-            .store
+            .store()
             .load_run(run_id)
             .await?
             .ok_or_else(|| RunControlError::RunNotFound(run_id.to_string()))?;
 
         let request =
-            RunRequest::new(run.thread_id.clone(), messages).with_agent_id(run.agent_id.clone());
+            RunActivation::new(run.thread_id.clone(), messages).with_agent_id(run.agent_id.clone());
         self.state
             .mailbox
             .submit_live_then_queue(request, Some(&run.run_id))
@@ -389,7 +398,7 @@ impl RunControlService {
         };
         let run = self
             .state
-            .store
+            .store()
             .load_run(open_run_id)
             .await?
             .ok_or_else(|| RunControlError::RunNotFound(open_run_id.to_string()))?;

--- a/crates/awaken-server/src/services/thread_events.rs
+++ b/crates/awaken-server/src/services/thread_events.rs
@@ -1,0 +1,269 @@
+use awaken_contract::contract::event_store::{
+    AppendOptions, CanonicalEventDraft, CanonicalEventKind, EventScope, EventStoreError,
+    EventWriter,
+};
+use awaken_contract::contract::storage::{ChildThreadDeleteStrategy, StorageError};
+use awaken_contract::thread::Thread;
+use serde_json::{Value, json};
+
+use crate::app::RunRoutesState;
+use crate::services::thread_service::{
+    CreateThreadOptions, DeleteThreadOptions, UpdateThreadOptions,
+};
+
+pub(crate) async fn create_thread(
+    state: &RunRoutesState,
+    options: CreateThreadOptions,
+) -> Result<Thread, StorageError> {
+    let thread = crate::services::thread_service::create_thread_with_options(
+        state.run.store().as_ref(),
+        options,
+    )
+    .await?;
+    record_thread_created(state, &thread).await;
+    Ok(thread)
+}
+
+pub(crate) async fn update_thread(
+    state: &RunRoutesState,
+    thread_id: &str,
+    options: UpdateThreadOptions,
+) -> Result<Thread, StorageError> {
+    let before = state
+        .run
+        .store()
+        .load_thread(thread_id)
+        .await?
+        .ok_or_else(|| StorageError::NotFound(thread_id.to_string()))?;
+    let thread = crate::services::thread_service::update_thread(
+        state.run.store().as_ref(),
+        thread_id,
+        options,
+    )
+    .await?;
+    record_thread_updated(state, &before, &thread).await;
+    Ok(thread)
+}
+
+pub(crate) async fn delete_thread(
+    state: &RunRoutesState,
+    thread_id: &str,
+    options: DeleteThreadOptions,
+) -> Result<(), StorageError> {
+    let thread = state
+        .run
+        .store()
+        .load_thread(thread_id)
+        .await?
+        .ok_or_else(|| StorageError::NotFound(thread_id.to_string()))?;
+    crate::services::thread_service::delete_thread(state.run.store().as_ref(), thread_id, options)
+        .await?;
+    record_thread_deleted(state, &thread, options.child_strategy).await;
+    Ok(())
+}
+
+pub(crate) async fn record_thread_created(state: &RunRoutesState, thread: &Thread) {
+    record_thread_event(
+        state,
+        "ThreadCreated",
+        thread,
+        thread_payload(thread, None, None),
+        Some(format!("ThreadCreated/{}", thread.id)),
+    )
+    .await;
+}
+
+pub(crate) async fn record_thread_updated(state: &RunRoutesState, before: &Thread, after: &Thread) {
+    record_thread_event(
+        state,
+        "ThreadUpdated",
+        after,
+        thread_payload(after, Some(before), None),
+        None,
+    )
+    .await;
+}
+
+pub(crate) async fn record_thread_deleted(
+    state: &RunRoutesState,
+    thread: &Thread,
+    child_strategy: ChildThreadDeleteStrategy,
+) {
+    record_thread_event(
+        state,
+        "ThreadDeleted",
+        thread,
+        thread_payload(thread, None, Some(child_strategy)),
+        Some(format!("ThreadDeleted/{}", thread.id)),
+    )
+    .await;
+}
+
+async fn record_thread_event(
+    state: &RunRoutesState,
+    event_kind: &'static str,
+    thread: &Thread,
+    payload: Value,
+    idempotency_key: Option<String>,
+) {
+    let Some(writer) = state
+        .events
+        .as_ref()
+        .map(|events| events.event_store.clone())
+    else {
+        return;
+    };
+    if let Err(error) = append_thread_event(
+        writer.as_ref(),
+        event_kind,
+        thread,
+        payload,
+        idempotency_key,
+    )
+    .await
+    {
+        tracing::error!(error = %error, thread_id = %thread.id, event_kind, "failed to record thread event");
+    }
+}
+
+async fn append_thread_event(
+    writer: &dyn EventWriter,
+    event_kind: &'static str,
+    thread: &Thread,
+    payload: Value,
+    idempotency_key: Option<String>,
+) -> Result<(), EventStoreError> {
+    let mut draft = CanonicalEventDraft::new(
+        scopes_for_thread(thread),
+        CanonicalEventKind::new(event_kind)?,
+        payload,
+        "server",
+    )?;
+    draft.correlation_id = Some(thread.id.clone());
+    writer
+        .append(
+            draft,
+            AppendOptions {
+                writer_id: Some("thread-service".to_string()),
+                idempotency_key,
+                expected_prior_cursors: Default::default(),
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+fn scopes_for_thread(thread: &Thread) -> Vec<EventScope> {
+    vec![EventScope::thread(thread.id.clone())]
+}
+
+fn thread_payload(
+    thread: &Thread,
+    before: Option<&Thread>,
+    child_strategy: Option<ChildThreadDeleteStrategy>,
+) -> Value {
+    let mut payload = json!({
+        "thread_id": thread.id,
+        "resource_id": thread.resource_id,
+        "parent_thread_id": thread.parent_thread_id,
+        "title": thread.metadata.title,
+        "created_at": thread.metadata.created_at,
+        "updated_at": thread.metadata.updated_at,
+    });
+    if let Some(before) = before
+        && let Some(map) = payload.as_object_mut()
+    {
+        map.insert(
+            "previous".to_string(),
+            json!({
+                "resource_id": before.resource_id,
+                "parent_thread_id": before.parent_thread_id,
+                "title": before.metadata.title,
+                "updated_at": before.metadata.updated_at,
+            }),
+        );
+    }
+    if let Some(child_strategy) = child_strategy
+        && let Some(map) = payload.as_object_mut()
+    {
+        map.insert("child_strategy".to_string(), json!(child_strategy));
+    }
+    payload
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use awaken_contract::contract::event_store::{EventReader, EventVisibility};
+    use awaken_stores::InMemoryEventStore;
+
+    fn child_thread() -> Thread {
+        let mut thread = Thread::with_id("thread-1")
+            .with_title("Child")
+            .with_resource_id("resource-a")
+            .with_parent_thread_id("parent-1");
+        thread.metadata.created_at = Some(10);
+        thread.metadata.updated_at = Some(20);
+        thread
+    }
+
+    #[tokio::test]
+    async fn append_thread_event_indexes_thread_scope() {
+        let store = InMemoryEventStore::new();
+        append_thread_event(
+            &store,
+            "ThreadCreated",
+            &child_thread(),
+            thread_payload(&child_thread(), None, None),
+            Some("ThreadCreated/thread-1".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let by_thread = store
+            .list(EventScope::thread("thread-1"), None, 10)
+            .await
+            .unwrap();
+
+        assert_eq!(by_thread.events.len(), 1);
+        assert_eq!(by_thread.events[0].event_kind.as_str(), "ThreadCreated");
+        assert_eq!(by_thread.events[0].payload["resource_id"], "resource-a");
+        assert_eq!(by_thread.events[0].payload["parent_thread_id"], "parent-1");
+        assert_eq!(by_thread.events[0].visibility, EventVisibility::Public);
+    }
+
+    #[tokio::test]
+    async fn thread_update_payload_carries_previous_lineage() {
+        let store = InMemoryEventStore::new();
+        let before = child_thread();
+        let mut after = child_thread();
+        after.resource_id = Some("resource-b".to_string());
+        after.parent_thread_id = Some("parent-2".to_string());
+        after.metadata.updated_at = Some(30);
+
+        append_thread_event(
+            &store,
+            "ThreadUpdated",
+            &after,
+            thread_payload(&after, Some(&before), None),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let page = store
+            .list(EventScope::thread("thread-1"), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(page.events[0].payload["resource_id"], "resource-b");
+        assert_eq!(page.events[0].payload["parent_thread_id"], "parent-2");
+        assert_eq!(
+            page.events[0].payload["previous"]["resource_id"],
+            "resource-a"
+        );
+        assert_eq!(
+            page.events[0].payload["previous"]["parent_thread_id"],
+            "parent-1"
+        );
+    }
+}

--- a/crates/awaken-server/src/services/trace_retention.rs
+++ b/crates/awaken-server/src/services/trace_retention.rs
@@ -73,7 +73,7 @@ impl RetentionHandle {
 ///
 /// ## Embedding
 ///
-/// Call this function after constructing your [`AppState`] and hold the
+/// Call this function after constructing your [`ServerState`] and hold the
 /// returned [`RetentionHandle`] for the lifetime of the server so the
 /// spawned task is not orphaned:
 ///

--- a/crates/awaken-server/src/services/trace_service.rs
+++ b/crates/awaken-server/src/services/trace_service.rs
@@ -13,7 +13,7 @@ use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::app::AppState;
+use crate::app::TraceRoutesState;
 use crate::error::ApiError;
 
 // ── Wire type ──────────────────────────────────────────────────────────────
@@ -102,14 +102,12 @@ fn map_trace_store_error(err: TraceStoreError) -> ApiError {
 // into every tracing event under this span.
 #[tracing::instrument(skip_all, fields(agent_id = ?params.agent_id))]
 pub async fn list_traces(
-    State(state): State<AppState>,
+    State(state): State<TraceRoutesState>,
     headers: axum::http::HeaderMap,
     Query(params): Query<ListTracesQuery>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = state
-        .trace_store()
-        .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = state.trace.trace_store.clone();
 
     // The `since` parse error preserves the original {error, detail}
     // wire shape; clients depend on the two-field split.
@@ -179,15 +177,13 @@ pub struct GetTraceQuery {
 // tracked as a follow-up (`TraceStore::read_page`).
 #[tracing::instrument(skip_all, fields(run_id = %run_id))]
 pub async fn get_trace(
-    State(state): State<AppState>,
+    State(state): State<TraceRoutesState>,
     headers: axum::http::HeaderMap,
     Path(run_id): Path<String>,
     Query(params): Query<GetTraceQuery>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = state
-        .trace_store()
-        .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = state.trace.trace_store.clone();
 
     let offset = params.offset.unwrap_or(0);
     // F17: clamp `limit` to a positive value. `limit=0` would freeze a
@@ -244,14 +240,12 @@ pub async fn get_trace(
 // `skip_all` keeps the bearer header out of trace logs.
 #[tracing::instrument(skip_all, fields(run_id = %run_id))]
 pub async fn pin_trace(
-    State(state): State<AppState>,
+    State(state): State<TraceRoutesState>,
     headers: axum::http::HeaderMap,
     Path(run_id): Path<String>,
 ) -> Result<Response, ApiError> {
-    crate::config_routes::ensure_admin_auth(&state, &headers)?;
-    let store = state
-        .trace_store()
-        .ok_or_else(|| ApiError::ServiceUnavailable("trace store not configured".into()))?;
+    crate::config_routes::ensure_admin_auth(&state.admin, &headers)?;
+    let store = state.trace.trace_store.clone();
 
     store
         .mark_referenced(&run_id, ReferenceKind::OperatorPin)

--- a/crates/awaken-server/src/system_routes.rs
+++ b/crates/awaken-server/src/system_routes.rs
@@ -1,0 +1,37 @@
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde_json::json;
+
+use crate::app::SystemRoutesState;
+
+pub(crate) fn system_routes() -> Router<SystemRoutesState> {
+    Router::new()
+        .route("/v1/system/info", get(system_info))
+        .route("/v1/system/modules", get(system_modules))
+}
+
+#[tracing::instrument(skip(state))]
+async fn system_info(State(state): State<SystemRoutesState>, headers: HeaderMap) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state.admin, &headers) {
+        return err.into_response();
+    }
+    Json(json!({
+        "version": env!("CARGO_PKG_VERSION"),
+        "uptime_seconds": state.admin.started_at.elapsed().as_secs(),
+        "config_store_enabled": state.config_store_enabled,
+        "audit_log_enabled": state.audit_log_enabled,
+        "runtime_stats_enabled": state.runtime_stats_enabled,
+    }))
+    .into_response()
+}
+
+#[tracing::instrument(skip(state))]
+async fn system_modules(State(state): State<SystemRoutesState>, headers: HeaderMap) -> Response {
+    if let Err(err) = crate::config_routes::ensure_admin_auth(&state.admin, &headers) {
+        return err.into_response();
+    }
+    Json(json!({ "modules": state.mounted_modules })).into_response()
+}

--- a/crates/awaken-server/src/transport/replay_buffer.rs
+++ b/crates/awaken-server/src/transport/replay_buffer.rs
@@ -28,12 +28,18 @@ impl EventReplayBuffer {
         }
     }
 
-    /// Allocate a sequence ID, format the JSON as a complete SSE frame
-    /// (`id: {seq}\ndata: {json}\n\n`), store it, notify subscribers,
-    /// and return `(seq, frame)`.
+    /// Allocate a sequence ID, format the JSON as an SSE frame
+    /// (`data: {json}\n\n`), store it, notify subscribers, and return
+    /// `(seq, frame)`.
+    ///
+    /// ADR-0034 D3: frames intentionally omit the SSE `id:` field so the
+    /// in-process buffer sequence is never leaked as a `Last-Event-ID`
+    /// the client could resend. Durable reconnect uses
+    /// `ProtocolReplayCursor` from `ProtocolReplayLog`; the buffer is a
+    /// live-only cache and reattaches replay the full retained window.
     pub fn push_json(&self, json: &str) -> (u64, Bytes) {
         let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
-        let frame = Bytes::from(format!("id: {seq}\ndata: {json}\n\n"));
+        let frame = Bytes::from(format!("data: {json}\n\n"));
         {
             let mut frames = self.frames.lock();
             frames.push_back((seq, frame.clone()));
@@ -124,8 +130,8 @@ mod tests {
 
         let replayed = buf.replay_after(1);
         assert_eq!(replayed.len(), 2);
-        assert!(String::from_utf8_lossy(&replayed[0]).contains("id: 2\n"));
-        assert!(String::from_utf8_lossy(&replayed[1]).contains("id: 3\n"));
+        assert!(String::from_utf8_lossy(&replayed[0]).contains(r#""a":2"#));
+        assert!(String::from_utf8_lossy(&replayed[1]).contains(r#""a":3"#));
     }
 
     #[test]
@@ -166,8 +172,8 @@ mod tests {
         // Oldest frames (seq 1, 2) should be evicted; remaining are seq 3, 4, 5.
         let replayed = buf.replay_after(0);
         assert_eq!(replayed.len(), 3);
-        assert!(String::from_utf8_lossy(&replayed[0]).contains("id: 3\n"));
-        assert!(String::from_utf8_lossy(&replayed[2]).contains("id: 5\n"));
+        assert!(String::from_utf8_lossy(&replayed[0]).contains(r#""n":3"#));
+        assert!(String::from_utf8_lossy(&replayed[2]).contains(r#""n":5"#));
     }
 
     #[test]
@@ -193,7 +199,6 @@ mod tests {
 
         let frame = rx.try_recv().unwrap();
         let s = String::from_utf8_lossy(&frame);
-        assert!(s.contains("id: 1\n"));
         assert!(s.contains(r#"{"event":"hello"}"#));
     }
 
@@ -207,7 +212,7 @@ mod tests {
         buf.push_json(r#"{"n":3}"#);
 
         let frame = rx.try_recv().unwrap();
-        assert!(String::from_utf8_lossy(&frame).contains("id: 3\n"));
+        assert!(String::from_utf8_lossy(&frame).contains(r#""n":3"#));
         assert!(rx.try_recv().is_err());
     }
 
@@ -254,13 +259,13 @@ mod tests {
         // Subscribe after seq 1 — should get frames 2, 3 replayed
         let (replayed, mut live_rx) = buf.subscribe_after(1);
         assert_eq!(replayed.len(), 2);
-        assert!(String::from_utf8_lossy(&replayed[0]).contains("id: 2\n"));
-        assert!(String::from_utf8_lossy(&replayed[1]).contains("id: 3\n"));
+        assert!(String::from_utf8_lossy(&replayed[0]).contains(r#""n":2"#));
+        assert!(String::from_utf8_lossy(&replayed[1]).contains(r#""n":3"#));
 
         // Push a new frame — live_rx should receive it
         buf.push_json(r#"{"n":4}"#);
         let frame = live_rx.try_recv().unwrap();
-        assert!(String::from_utf8_lossy(&frame).contains("id: 4\n"));
+        assert!(String::from_utf8_lossy(&frame).contains(r#""n":4"#));
 
         // No extra frames (no duplicates)
         assert!(live_rx.try_recv().is_err());

--- a/crates/awaken-server/tests/a2a_gateway.rs
+++ b/crates/awaken-server/tests/a2a_gateway.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // ADR-0038 D7: integration tests exercise the legacy checkpoint API directly
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -23,8 +24,8 @@ use awaken_protocol_a2a::{
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::extensions::a2a::A2aBackendFactory;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_runtime::{AgentRuntime, BackendAbortRequest, ExecutionBackendFactory, RunRequest};
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_runtime::{AgentRuntime, BackendAbortRequest, ExecutionBackendFactory, RunActivation};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -401,7 +402,7 @@ fn make_gateway_app_with_options(
         "gateway-test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -410,7 +411,7 @@ fn make_gateway_app_with_options(
     );
 
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         store,
         runtime,
     }
@@ -468,7 +469,7 @@ fn make_delegate_gateway_app(mock_base_url: &str) -> TestApp {
         "gateway-test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -477,7 +478,7 @@ fn make_delegate_gateway_app(mock_base_url: &str) -> TestApp {
     );
 
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         store,
         runtime,
     }
@@ -1095,7 +1096,7 @@ async fn gateway_continuation_uses_requested_run_remote_state_not_latest_run() {
 
     test.runtime
         .run(
-            RunRequest::new(
+            RunActivation::new(
                 "gateway-explicit-continue",
                 vec![Message::user("resume the older waiting run")],
             )

--- a/crates/awaken-server/tests/a2a_http.rs
+++ b/crates/awaken-server/tests/a2a_http.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // ADR-0038 D7: integration tests exercise the legacy checkpoint API directly
 //! A2A HTTP integration tests for the current A2A v1.0 surface.
 
 use async_trait::async_trait;
@@ -20,7 +21,7 @@ use awaken_runtime::extensions::background::{
     TaskResult as BackgroundTaskResult, TaskStatus,
 };
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -203,14 +204,14 @@ where
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
         runtime.resolver_arc(),
         config,
     );
-    (build_router(&state).with_state(state), store)
+    (build_router(&state), store)
 }
 
 fn build_test_app<E>(agent_ids: &[&str], executor: Arc<E>, config: ServerConfig) -> axum::Router
@@ -283,14 +284,14 @@ fn build_background_cancel_fixture()
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    (build_router(&state).with_state(state), store, manager)
+    (build_router(&state), store, manager)
 }
 
 async fn request_json(

--- a/crates/awaken-server/tests/a2a_loopback.rs
+++ b/crates/awaken-server/tests/a2a_loopback.rs
@@ -34,7 +34,7 @@ use awaken_runtime::extensions::background::{
     TaskResult as BackgroundTaskResult, TaskStatus,
 };
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::InMemoryMailboxStore;
@@ -342,7 +342,7 @@ async fn a2a_loopback_remote_self_cancel_cascades_background_children() {
         "loopback-test".to_string(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -350,7 +350,7 @@ async fn a2a_loopback_remote_self_cancel_cascades_background_children() {
         ServerConfig::default(),
     );
 
-    let router = build_router(&state).with_state(state);
+    let router = build_router(&state);
     let server_handle = tokio::spawn(async move {
         axum::serve(listener, router).await.ok();
     });
@@ -518,14 +518,14 @@ async fn a2a_dual_server_remote_self_cancel_cascades_background_children() {
         "dual-loopback-worker".to_string(),
         MailboxConfig::default(),
     ));
-    let worker_state = AppState::new(
+    let worker_state = ServerState::new(
         worker_runtime.clone(),
         worker_mailbox,
         worker_store.clone(),
         worker_runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    let worker_router = build_router(&worker_state).with_state(worker_state);
+    let worker_router = build_router(&worker_state);
     let worker_handle = tokio::spawn(async move {
         axum::serve(worker_listener, worker_router).await.ok();
     });
@@ -601,14 +601,14 @@ async fn a2a_dual_server_remote_self_cancel_cascades_background_children() {
         "dual-loopback-orchestrator".to_string(),
         MailboxConfig::default(),
     ));
-    let orchestrator_state = AppState::new(
+    let orchestrator_state = ServerState::new(
         orchestrator_runtime.clone(),
         orchestrator_mailbox,
         orchestrator_store.clone(),
         orchestrator_runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    let orchestrator_router = build_router(&orchestrator_state).with_state(orchestrator_state);
+    let orchestrator_router = build_router(&orchestrator_state);
     let orchestrator_handle = tokio::spawn(async move {
         axum::serve(orchestrator_listener, orchestrator_router)
             .await
@@ -842,7 +842,7 @@ async fn a2a_loopback_orchestrator_delegates_to_worker() {
         MailboxConfig::default(),
     ));
 
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -852,7 +852,7 @@ async fn a2a_loopback_orchestrator_delegates_to_worker() {
 
     // -- Start server ---------------------------------------------------------
 
-    let router = build_router(&state).with_state(state);
+    let router = build_router(&state);
     let server_handle = tokio::spawn(async move {
         axum::serve(listener, router).await.ok();
     });

--- a/crates/awaken-server/tests/admin_security.rs
+++ b/crates/awaken-server/tests/admin_security.rs
@@ -9,7 +9,7 @@ use awaken_contract::registry_spec::{AgentSpec, ModelBindingSpec, ProviderSpec};
 use awaken_contract::{BuiltinSeedSet, BuiltinSpec};
 use awaken_ext_observability::RuntimeStatsRegistry;
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_server::app::{AdminApiConfig, AppState, ServerConfig};
+use awaken_server::app::{AdminApiConfig, ServerConfig, ServerState};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
 use awaken_server::services::audit_log::AuditLogger;
@@ -116,7 +116,7 @@ async fn build_secure_admin_router() -> axum::Router {
         "admin-security-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -132,7 +132,7 @@ async fn build_secure_admin_router() -> axum::Router {
         ..Default::default()
     });
 
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 async fn request(

--- a/crates/awaken-server/tests/agent_dashboard_e2e.rs
+++ b/crates/awaken-server/tests/agent_dashboard_e2e.rs
@@ -35,13 +35,15 @@ use awaken_ext_observability::{
 };
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{ServerConfig, ServerState};
+use awaken_server::app::{AdminApiConfig, ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
 use axum::http::{Request, StatusCode};
 use serde_json::{Value, json};
 use tower::ServiceExt;
+
+const ADMIN_TOKEN: &str = "test-admin-token";
 
 // ---------------------------------------------------------------------------
 // Scripted executor
@@ -161,6 +163,10 @@ fn build_app(response: &str) -> (axum::Router, Arc<RuntimeStatsRegistry>) {
         runtime.resolver_arc(),
         ServerConfig::default(),
     )
+    .with_admin_api_config(AdminApiConfig {
+        bearer_token: Some(ADMIN_TOKEN.into()),
+        ..Default::default()
+    })
     .with_runtime_stats(Arc::clone(&registry));
 
     let app = build_router(&state);
@@ -205,6 +211,7 @@ async fn fetch_json(app: axum::Router, uri: &str) -> (StatusCode, Value) {
             Request::builder()
                 .method("GET")
                 .uri(uri)
+                .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
                 .body(axum::body::Body::empty())
                 .unwrap(),
         )

--- a/crates/awaken-server/tests/agent_dashboard_e2e.rs
+++ b/crates/awaken-server/tests/agent_dashboard_e2e.rs
@@ -3,7 +3,7 @@
 //! Wires a real `AgentRuntime` with a scripted `LlmExecutor` and an
 //! `ObservabilityPlugin` whose sink list contains a shared
 //! `RuntimeStatsRegistry`. The same registry is also installed on
-//! `AppState`. After driving real chat requests through the AI SDK route,
+//! `ServerState`. After driving real chat requests through the AI SDK route,
 //! the test queries `/v1/agents/:id/runtime-stats` and asserts the
 //! endpoint reflects what the runtime actually did.
 //!
@@ -35,7 +35,7 @@ use awaken_ext_observability::{
 };
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -82,7 +82,7 @@ impl LlmExecutor for ScriptedExecutor {
 }
 
 /// Adapter that lets the plugin own a `MetricsSink` value while sharing
-/// the underlying registry state with `AppState` via the same backing
+/// the underlying registry state with `ServerState` via the same backing
 /// `Arc<Mutex<...>>`.
 #[derive(Clone)]
 struct SharedRegistrySink(RuntimeStatsRegistry);
@@ -109,7 +109,7 @@ impl MetricsSink for SharedRegistrySink {
 fn build_app(response: &str) -> (axum::Router, Arc<RuntimeStatsRegistry>) {
     let registry = Arc::new(RuntimeStatsRegistry::new());
 
-    // The plugin sink and the AppState share the same registry instance —
+    // The plugin sink and the ServerState share the same registry instance —
     // RuntimeStatsRegistry's Clone keeps the inner Arc<Mutex<...>>, so
     // both views see the same buckets.
     let plugin_sink = SharedRegistrySink((*registry).clone());
@@ -154,7 +154,7 @@ fn build_app(response: &str) -> (axum::Router, Arc<RuntimeStatsRegistry>) {
         awaken_server::mailbox::MailboxConfig::default(),
     ));
 
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -163,7 +163,7 @@ fn build_app(response: &str) -> (axum::Router, Arc<RuntimeStatsRegistry>) {
     )
     .with_runtime_stats(Arc::clone(&registry));
 
-    let app = build_router(&state).with_state(state);
+    let app = build_router(&state);
     (app, registry)
 }
 

--- a/crates/awaken-server/tests/agent_runtime_stats.rs
+++ b/crates/awaken-server/tests/agent_runtime_stats.rs
@@ -13,13 +13,15 @@ use awaken_ext_observability::{
 };
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{ServerConfig, ServerState};
+use awaken_server::app::{AdminApiConfig, ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
 use axum::http::{Request, StatusCode};
 use serde_json::Value;
 use tower::ServiceExt;
+
+const ADMIN_TOKEN: &str = "test-admin-token";
 
 /// Stub executor — never invoked in these tests because no run is driven;
 /// it only exists so `AgentRuntimeBuilder::build()` succeeds.
@@ -83,7 +85,11 @@ fn build_app(runtime_stats: Option<Arc<RuntimeStatsRegistry>>) -> axum::Router {
         store.clone(),
         runtime.resolver_arc(),
         ServerConfig::default(),
-    );
+    )
+    .with_admin_api_config(AdminApiConfig {
+        bearer_token: Some(ADMIN_TOKEN.into()),
+        ..Default::default()
+    });
     if let Some(reg) = runtime_stats {
         state = state.with_runtime_stats(reg);
     }
@@ -160,6 +166,7 @@ async fn fetch(app: axum::Router, uri: &str) -> (StatusCode, Value) {
             Request::builder()
                 .method("GET")
                 .uri(uri)
+                .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
                 .body(axum::body::Body::empty())
                 .unwrap(),
         )

--- a/crates/awaken-server/tests/agent_runtime_stats.rs
+++ b/crates/awaken-server/tests/agent_runtime_stats.rs
@@ -13,7 +13,7 @@ use awaken_ext_observability::{
 };
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -77,7 +77,7 @@ fn build_app(runtime_stats: Option<Arc<RuntimeStatsRegistry>>) -> axum::Router {
         "test".into(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let mut state = AppState::new(
+    let mut state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -87,7 +87,7 @@ fn build_app(runtime_stats: Option<Arc<RuntimeStatsRegistry>>) -> axum::Router {
     if let Some(reg) = runtime_stats {
         state = state.with_runtime_stats(reg);
     }
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 fn ctx(agent: &str) -> SpanContext {

--- a/crates/awaken-server/tests/ai_sdk_multi_turn.rs
+++ b/crates/awaken-server/tests/ai_sdk_multi_turn.rs
@@ -11,7 +11,7 @@ use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage}
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -78,14 +78,14 @@ fn make_app() -> axum::Router {
         "test".into(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 /// Turn 3 of a multi-turn conversation where turns 1-2 included tool calls.

--- a/crates/awaken-server/tests/audit_log_routes.rs
+++ b/crates/awaken-server/tests/audit_log_routes.rs
@@ -21,6 +21,8 @@ use http_body_util::BodyExt;
 use serde_json::{Value, json};
 use tower::ServiceExt;
 
+const ADMIN_TOKEN: &str = "audit-admin-token";
+
 struct ImmediateExecutor;
 
 #[async_trait]
@@ -123,9 +125,7 @@ async fn build_test_app_with_audit(token: Option<&str>) -> axum::Router {
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);
 
-    if let Some(tok) = token {
-        state = state.with_admin_api_bearer_token(tok);
-    }
+    state = state.with_admin_api_bearer_token(token.unwrap_or(ADMIN_TOKEN));
 
     build_router(&state)
 }
@@ -182,13 +182,14 @@ async fn build_test_app_without_audit() -> axum::Router {
         ServerConfig::default(),
     )
     .with_config_store(config_store)
-    .with_config_runtime_manager(manager);
+    .with_config_runtime_manager(manager)
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
     // No audit_log attached.
     build_router(&state)
 }
 
 async fn get_audit_log(app: &axum::Router, qs: &str) -> (StatusCode, Value) {
-    get_audit_log_with_token(app, qs, None).await
+    get_audit_log_with_token(app, qs, Some(ADMIN_TOKEN)).await
 }
 
 async fn get_audit_log_with_token(
@@ -218,6 +219,7 @@ async fn create_config(app: &axum::Router, namespace: &str, body: &Value) -> Sta
         .method("POST")
         .uri(format!("/v1/config/{namespace}"))
         .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
         .body(Body::from(serde_json::to_vec(body).unwrap()))
         .unwrap();
     app.clone().oneshot(req).await.unwrap().status()
@@ -349,7 +351,7 @@ async fn cursor_pagination_across_many_entries() {
 #[tokio::test]
 async fn unauthorized_without_token_returns_401() {
     let app = build_test_app_with_audit(Some("secret-token")).await;
-    let (status, _body) = get_audit_log(&app, "").await;
+    let (status, _body) = get_audit_log_with_token(&app, "", None).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
 }
 
@@ -444,7 +446,8 @@ async fn seed_apply_event_visible_via_http_query() {
     )
     .with_config_store(config_store)
     .with_config_runtime_manager(manager)
-    .with_audit_log(audit_logger);
+    .with_audit_log(audit_logger)
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
 
     let app = build_router(&state);
 

--- a/crates/awaken-server/tests/audit_log_routes.rs
+++ b/crates/awaken-server/tests/audit_log_routes.rs
@@ -7,7 +7,7 @@ use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequ
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::{AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec};
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
 use awaken_server::services::audit_log::AuditLogger;
@@ -112,7 +112,7 @@ async fn build_test_app_with_audit(token: Option<&str>) -> axum::Router {
         "audit-test".into(),
         MailboxConfig::default(),
     ));
-    let mut state = AppState::new(
+    let mut state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -127,7 +127,7 @@ async fn build_test_app_with_audit(token: Option<&str>) -> axum::Router {
         state = state.with_admin_api_bearer_token(tok);
     }
 
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 async fn build_test_app_without_audit() -> axum::Router {
@@ -174,7 +174,7 @@ async fn build_test_app_without_audit() -> axum::Router {
         "audit-test-no-log".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -184,7 +184,7 @@ async fn build_test_app_without_audit() -> axum::Router {
     .with_config_store(config_store)
     .with_config_runtime_manager(manager);
     // No audit_log attached.
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 async fn get_audit_log(app: &axum::Router, qs: &str) -> (StatusCode, Value) {
@@ -435,7 +435,7 @@ async fn seed_apply_event_visible_via_http_query() {
         "seed-audit-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -446,7 +446,7 @@ async fn seed_apply_event_visible_via_http_query() {
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);
 
-    let app = build_router(&state).with_state(state);
+    let app = build_router(&state);
 
     let (status, body) = get_audit_log(&app, "action=seed_apply").await;
     assert_eq!(status, StatusCode::OK, "body: {body}");

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -30,7 +30,7 @@ use awaken_runtime::engine::RetryConfigKey;
 use awaken_runtime::registry::ToolRegistry;
 use awaken_runtime::registry::memory::MapToolRegistry;
 use awaken_server::app::{
-    AdminApiConfig, AppState, ServerConfig, SkillCatalogArgument, SkillCatalogContext,
+    AdminApiConfig, ServerConfig, ServerState, SkillCatalogArgument, SkillCatalogContext,
     SkillCatalogEntry, SkillCatalogProvider,
 };
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
@@ -667,7 +667,7 @@ async fn make_app_without_skill_sink() -> TestApp {
         "config-api-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -678,7 +678,7 @@ async fn make_app_without_skill_sink() -> TestApp {
     .with_config_runtime_manager(manager.clone());
 
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         runtime,
         store,
         manager,
@@ -728,7 +728,7 @@ async fn make_app_with_skill_catalog_config_and_admin(
         "config-api-test".into(),
         MailboxConfig::default(),
     ));
-    let mut state = AppState::new(
+    let mut state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -745,7 +745,7 @@ async fn make_app_with_skill_catalog_config_and_admin(
     }
 
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         runtime,
         store,
         manager,
@@ -1537,7 +1537,7 @@ async fn documented_config_driven_agent_tuning_publishes_sections_and_retry() {
         "config-doc-scenario-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store,
@@ -1546,7 +1546,7 @@ async fn documented_config_driven_agent_tuning_publishes_sections_and_retry() {
     )
     .with_config_store(config_store)
     .with_config_runtime_manager(manager);
-    let router = build_router(&state).with_state(state);
+    let router = build_router(&state);
 
     let (status, _) = request_json(
         &router,
@@ -2532,9 +2532,9 @@ async fn apply_if_changed_returns_some_after_store_mutation() {
 // ── MCP server status and restart endpoint smoke tests ──────────────────────
 
 #[tokio::test]
-async fn mcp_status_returns_503_when_no_runtime_configured() {
-    // Build a state without a config_runtime_manager so the MCP status endpoint
-    // returns 503 Service Unavailable.
+async fn mcp_status_routes_absent_without_config_module() {
+    // Build a state without a config module so config-backed MCP admin
+    // endpoints are absent instead of carrying handler-local fallbacks.
     let store = Arc::new(InMemoryStore::new());
     let thread_store = store.clone();
     use awaken_contract::AgentSpec;
@@ -2593,15 +2593,15 @@ async fn mcp_status_returns_503_when_no_runtime_configured() {
         "mcp-status-test".into(),
         MailboxConfig::default(),
     ));
-    // No config_runtime_manager attached → MCP endpoints return 503.
-    let state = awaken_server::app::AppState::new(
+    // No config module attached → config-backed MCP admin endpoints are absent.
+    let state = awaken_server::app::ServerState::new(
         runtime.clone(),
         mailbox,
         thread_store as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    let router = build_router(&state).with_state(state);
+    let router = build_router(&state);
 
     let (status, _body) = request_json(
         &router,
@@ -2610,7 +2610,7 @@ async fn mcp_status_returns_503_when_no_runtime_configured() {
         None,
     )
     .await;
-    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(status, StatusCode::NOT_FOUND);
 
     let (status, _body) = request_json(
         &router,
@@ -2619,7 +2619,7 @@ async fn mcp_status_returns_503_when_no_runtime_configured() {
         None,
     )
     .await;
-    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -2725,7 +2725,7 @@ async fn mcp_status_route_surfaces_session_reconnect_init_fields() {
         "mcp-status-fields-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -2734,7 +2734,7 @@ async fn mcp_status_route_surfaces_session_reconnect_init_fields() {
     )
     .with_config_store(config_store)
     .with_config_runtime_manager(manager.clone());
-    let router = build_router(&state).with_state(state);
+    let router = build_router(&state);
 
     // Register an MCP server so the factory's `connect` is called and
     // the stub registry becomes active.
@@ -3472,7 +3472,7 @@ async fn audit_event_emitted_for_patch_and_delete() {
         "override-audit-test".into(),
         MailboxConfig::default(),
     ));
-    let state = awaken_server::app::AppState::new(
+    let state = awaken_server::app::ServerState::new(
         runtime.clone(),
         mailbox,
         thread_store,
@@ -3721,7 +3721,7 @@ async fn make_permission_preview_app() -> axum::Router {
         "permission-preview-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store,
@@ -3730,7 +3730,7 @@ async fn make_permission_preview_app() -> axum::Router {
     )
     .with_config_store(config_store)
     .with_config_runtime_manager(manager);
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 /// Standalone runtime+manager+store for permission preview tests, with a

--- a/crates/awaken-server/tests/config_api.rs
+++ b/crates/awaken-server/tests/config_api.rs
@@ -46,6 +46,9 @@ use serde_json::{Value, json};
 use tokio::sync::broadcast;
 use tower::ServiceExt;
 
+const ADMIN_TOKEN: &str = "admin-token";
+const ADMIN_AUTH_HEADER: &str = "Bearer admin-token";
+
 struct ImmediateExecutor;
 
 #[async_trait]
@@ -675,7 +678,8 @@ async fn make_app_without_skill_sink() -> TestApp {
         ServerConfig::default(),
     )
     .with_config_store(config_store)
-    .with_config_runtime_manager(manager.clone());
+    .with_config_runtime_manager(manager.clone())
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
 
     TestApp {
         router: build_router(&state),
@@ -737,9 +741,11 @@ async fn make_app_with_skill_catalog_config_and_admin(
     )
     .with_config_store(config_store)
     .with_config_runtime_manager(manager.clone());
-    if let Some(admin_config) = admin_config {
-        state = state.with_admin_api_config(admin_config);
-    }
+    state = if let Some(admin_config) = admin_config {
+        state.with_admin_api_config(admin_config)
+    } else {
+        state.with_admin_api_bearer_token(ADMIN_TOKEN)
+    };
     if let Some(provider) = skill_catalog_provider {
         state = state.with_skill_catalog_provider(provider);
     }
@@ -759,7 +765,14 @@ async fn request_json(
     uri: &str,
     body: Option<Value>,
 ) -> (StatusCode, Value) {
-    request_json_with_headers(router, method, uri, body, &[]).await
+    request_json_with_headers(
+        router,
+        method,
+        uri,
+        body,
+        &[("authorization", ADMIN_AUTH_HEADER)],
+    )
+    .await
 }
 
 async fn request_json_with_headers(
@@ -824,7 +837,8 @@ async fn wait_until(
 async fn admin_config_routes_require_bearer_token_when_configured() {
     let app = make_app_with_admin_token("admin-token").await;
 
-    let (status, body) = request_json(&app.router, Method::GET, "/v1/capabilities", None).await;
+    let (status, body) =
+        request_json_with_headers(&app.router, Method::GET, "/v1/capabilities", None, &[]).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert!(body["error"].as_str().unwrap().contains("authentication"));
 
@@ -853,7 +867,8 @@ async fn admin_config_routes_require_bearer_token_when_configured() {
         "/v1/config/diagnostics",
         "/v1/config/providers/bootstrap/removal-preview",
     ] {
-        let (status, body) = request_json(&app.router, Method::GET, uri, None).await;
+        let (status, body) =
+            request_json_with_headers(&app.router, Method::GET, uri, None, &[]).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED, "uri: {uri}, body: {body}");
 
         let (status, body) = request_json_with_headers(
@@ -1545,7 +1560,8 @@ async fn documented_config_driven_agent_tuning_publishes_sections_and_retry() {
         ServerConfig::default(),
     )
     .with_config_store(config_store)
-    .with_config_runtime_manager(manager);
+    .with_config_runtime_manager(manager)
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
     let router = build_router(&state);
 
     let (status, _) = request_json(
@@ -2600,7 +2616,8 @@ async fn mcp_status_routes_absent_without_config_module() {
         thread_store as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
         runtime.resolver_arc(),
         ServerConfig::default(),
-    );
+    )
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
     let router = build_router(&state);
 
     let (status, _body) = request_json(
@@ -2733,7 +2750,8 @@ async fn mcp_status_route_surfaces_session_reconnect_init_fields() {
         ServerConfig::default(),
     )
     .with_config_store(config_store)
-    .with_config_runtime_manager(manager.clone());
+    .with_config_runtime_manager(manager.clone())
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
     let router = build_router(&state);
 
     // Register an MCP server so the factory's `connect` is called and
@@ -3481,7 +3499,8 @@ async fn audit_event_emitted_for_patch_and_delete() {
     )
     .with_config_store(config_store.clone() as Arc<dyn ConfigStore>)
     .with_config_runtime_manager(manager)
-    .with_audit_log(audit_logger.clone());
+    .with_audit_log(audit_logger.clone())
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
 
     let headers = axum::http::HeaderMap::new();
 
@@ -3729,7 +3748,8 @@ async fn make_permission_preview_app() -> axum::Router {
         ServerConfig::default(),
     )
     .with_config_store(config_store)
-    .with_config_runtime_manager(manager);
+    .with_config_runtime_manager(manager)
+    .with_admin_api_bearer_token(ADMIN_TOKEN);
     build_router(&state)
 }
 

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -16,7 +16,7 @@ use awaken_contract::{AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, 
 use awaken_runtime::AgentRuntime;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
 use awaken_server::services::config_runtime::{
@@ -109,6 +109,10 @@ where
     S: ConfigStore + ThreadRunStore + Send + Sync + 'static,
     F: FnOnce(Arc<S>) -> Arc<dyn CommitCoordinator>,
 {
+    // ADR-0038 D7: the runtime's CommitCoordinator must wrap the same
+    // ThreadRunStore handle as the mailbox uses. The backend-specific
+    // coordinator factory is supplied by the caller so FileStore tests can
+    // pair with FileCommitCoordinator, etc.
     let coordinator = make_coordinator(Arc::clone(&store));
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
@@ -143,7 +147,7 @@ where
         server_name.to_string(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone() as Arc<dyn ThreadRunStore>,
@@ -154,7 +158,7 @@ where
     .with_config_runtime_manager(manager);
 
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         runtime,
         store,
     }
@@ -171,10 +175,16 @@ fn postgres_coordinator(store: Arc<PostgresStore>) -> Arc<dyn CommitCoordinator>
     ) as Arc<dyn CommitCoordinator>
 }
 
-async fn make_thread_app<S>(store: Arc<S>, server_name: &str) -> axum::Router
+async fn make_thread_app<S, F>(
+    store: Arc<S>,
+    server_name: &str,
+    make_coordinator: F,
+) -> axum::Router
 where
     S: ThreadRunStore + Send + Sync + 'static,
+    F: FnOnce(Arc<S>) -> Arc<dyn CommitCoordinator>,
 {
+    let coordinator = make_coordinator(Arc::clone(&store));
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("mock", Arc::new(ImmediateExecutor))
@@ -192,6 +202,8 @@ where
                 max_rounds: 0,
                 ..Default::default()
             })
+            .with_thread_run_store(store.clone() as Arc<dyn ThreadRunStore>)
+            .with_commit_coordinator(coordinator)
             .build()
             .expect("build runtime"),
     );
@@ -203,14 +215,14 @@ where
         server_name.to_string(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store as Arc<dyn ThreadRunStore>,
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 #[cfg(feature = "nats")]
@@ -582,7 +594,7 @@ async fn file_store_thread_lineage_filters_round_trip_via_http() {
 async fn file_store_thread_hierarchy_management_round_trip_via_http() {
     let dir = tempfile::tempdir().expect("tempdir");
     let store = Arc::new(FileStore::new(dir.path()));
-    let router = make_thread_app(store.clone(), "file-hierarchy-test").await;
+    let router = make_thread_app(store.clone(), "file-hierarchy-test", file_coordinator).await;
 
     assert_thread_hierarchy_management_round_trip(&router, &store, "file-parent").await;
     assert_thread_hierarchy_rejects_missing_parent(&router).await;
@@ -731,7 +743,12 @@ async fn postgres_store_thread_lineage_filters_round_trip_via_http() {
 #[ignore = "requires PostgreSQL via DATABASE_URL"]
 async fn postgres_store_thread_hierarchy_management_round_trip_via_http() {
     let (store, _pool, _prefix) = make_postgres_store("cfg_hierarchy").await;
-    let router = make_thread_app(store.clone(), "postgres-hierarchy-test").await;
+    let router = make_thread_app(
+        store.clone(),
+        "postgres-hierarchy-test",
+        postgres_coordinator,
+    )
+    .await;
 
     assert_thread_hierarchy_management_round_trip(&router, &store, "pg-parent").await;
     assert_thread_hierarchy_rejects_missing_parent(&router).await;
@@ -747,7 +764,14 @@ async fn nats_buffered_store_thread_routes_round_trip_via_http() {
             .await
             .expect("connect buffered nats store"),
     );
-    let router = make_thread_app(store.clone(), "nats-lineage-test").await;
+    let router = make_thread_app(store.clone(), "nats-lineage-test", |_| {
+        // NATS-buffered thread store fronts an InMemoryStore inner; tests
+        // rely on the runtime/mailbox coordinator path matching that buffer,
+        // not the inner store directly.
+        awaken_stores::MemoryCommitCoordinator::wrap(Arc::new(awaken_stores::InMemoryStore::new()))
+            as Arc<dyn awaken_contract::contract::commit_coordinator::CommitCoordinator>
+    })
+    .await;
 
     store
         .save_thread(

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -29,6 +29,8 @@ use serde_json::{Value, json};
 use sqlx::PgPool;
 use tower::ServiceExt;
 
+const ADMIN_TOKEN: &str = "config-backends-admin-token";
+
 #[cfg(feature = "nats")]
 use awaken_stores::{InMemoryStore, NatsBufferedThreadConfig, NatsBufferedThreadStore};
 #[cfg(feature = "nats")]
@@ -154,6 +156,7 @@ where
         runtime.resolver_arc(),
         ServerConfig::default(),
     )
+    .with_admin_api_bearer_token(ADMIN_TOKEN)
     .with_config_store(config_store)
     .with_config_runtime_manager(manager);
 
@@ -295,7 +298,10 @@ async fn send_request(
     uri: &str,
     body: Option<Value>,
 ) -> (StatusCode, String) {
-    let mut builder = Request::builder().method(method).uri(uri);
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {ADMIN_TOKEN}"));
     let request = if let Some(body) = body {
         builder = builder.header("content-type", "application/json");
         builder

--- a/crates/awaken-server/tests/e2e_tensorzero.rs
+++ b/crates/awaken-server/tests/e2e_tensorzero.rs
@@ -33,7 +33,7 @@ use awaken_contract::registry_spec::{AgentSpec, ProviderSpec};
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::credentials::{AwakenCredentialBroker, CredentialBroker};
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_server::services::config_runtime::build_genai_provider_executor_with_broker;
 use std::sync::Arc as StdArc;
@@ -514,7 +514,7 @@ async fn tz_router_provider_compiles_smoke() {
         awaken_server::mailbox::MailboxConfig::default(),
     ));
 
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -524,7 +524,7 @@ async fn tz_router_provider_compiles_smoke() {
 
     // Building the router should not fail. We do not drive a request: that
     // path requires an upstream key and is covered by REST-level tests above.
-    let _router: axum::Router = build_router(&state).with_state(state);
+    let _router: axum::Router = build_router(&state);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/awaken-server/tests/eval_api.rs
+++ b/crates/awaken-server/tests/eval_api.rs
@@ -6,7 +6,7 @@
 //!   /v1/eval/runs              — list / start
 //!   /v1/eval/runs/:id          — fetch (+ optional ?baseline= diff)
 //!
-//! Each test stands up a minimal `AppState` with in-memory
+//! Each test stands up a minimal `ServerState` with in-memory
 //! ConfigStore + file-backed TraceStore + file-backed EvalRunStore, then
 //! drives the router via `tower::ServiceExt::oneshot`. The harness is
 //! deliberately leaner than `config_api.rs`: eval CRUD doesn't touch the
@@ -18,6 +18,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use awaken_contract::config_record::{ConfigRecord, RecordMeta};
 use awaken_contract::contract::config_store::ConfigStore;
+use awaken_contract::contract::event_store::{EventReader, EventScope, EventVisibility};
 use awaken_contract::contract::storage::StorageError;
 use awaken_eval::test_support::UnusedExecutor;
 use awaken_eval::{
@@ -27,10 +28,11 @@ use awaken_eval::{
 use awaken_ext_observability::trace_store::{TraceStore, file::FileTraceStore};
 use awaken_ext_observability::{DelegationSpan, GenAISpan, MetricsEvent, SpanContext};
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_server::app::{AdminApiConfig, AppState, ServerConfig};
+use awaken_server::app::{AdminApiConfig, ServerConfig, ServerState};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
-use awaken_stores::InMemoryStore;
+use awaken_server::services::config_runtime::ConfigRuntimeManager;
+use awaken_stores::{InMemoryEventStore, InMemoryStore};
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
@@ -61,6 +63,7 @@ struct TestApp {
     /// store's `write()` would normally reject) write the JSON file
     /// straight to `{root}/eval_runs/{yyyy-mm}/{run_id}.json`.
     eval_run_root: std::path::PathBuf,
+    event_store: Arc<InMemoryEventStore>,
 }
 
 async fn build_test_app_without_run_store() -> axum::Router {
@@ -68,7 +71,8 @@ async fn build_test_app_without_run_store() -> axum::Router {
     // EvalRunStore attached so the online handler must refuse
     // persist=true BEFORE any provider call burns tokens.
     let thread_store = Arc::new(InMemoryStore::new());
-    let config_store = Arc::new(InMemoryStore::new());
+    let config_store: Arc<dyn awaken_contract::contract::config_store::ConfigStore> =
+        Arc::new(InMemoryStore::new());
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
             .with_provider("bootstrap", Arc::new(UnusedExecutor))
@@ -84,7 +88,12 @@ async fn build_test_app_without_run_store() -> axum::Router {
         "eval-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let config_runtime_manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager"),
+    );
+
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -94,15 +103,14 @@ async fn build_test_app_without_run_store() -> axum::Router {
             ..ServerConfig::default()
         },
     )
-    .with_config_store(
-        config_store as Arc<dyn awaken_contract::contract::config_store::ConfigStore>,
-    )
+    .with_config_store(config_store)
+    .with_config_runtime_manager(config_runtime_manager)
     .with_admin_api_config(AdminApiConfig {
         expose_config_routes: true,
         ..AdminApiConfig::default()
     })
     .with_admin_api_bearer_token(BEARER);
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 async fn build_test_app() -> TestApp {
@@ -114,6 +122,7 @@ async fn build_test_app_with_config_store(config_store: Arc<dyn ConfigStore>) ->
     let trace_store = Arc::new(FileTraceStore::new(temp_dir("eval-trace")).unwrap());
     let eval_run_root = temp_dir("eval-runs");
     let eval_run_store = Arc::new(FileEvalRunStore::new(eval_run_root.clone()).unwrap());
+    let event_store = Arc::new(InMemoryEventStore::new());
 
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
@@ -131,7 +140,12 @@ async fn build_test_app_with_config_store(config_store: Arc<dyn ConfigStore>) ->
         MailboxConfig::default(),
     ));
 
-    let state = AppState::new(
+    let config_runtime_manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager"),
+    );
+
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -142,8 +156,10 @@ async fn build_test_app_with_config_store(config_store: Arc<dyn ConfigStore>) ->
         },
     )
     .with_config_store(config_store.clone())
+    .with_config_runtime_manager(config_runtime_manager)
     .with_trace_store(trace_store.clone() as Arc<dyn TraceStore>)
     .with_eval_run_store(eval_run_store.clone() as Arc<dyn EvalRunStore>)
+    .with_event_store(event_store.clone())
     .with_admin_api_config(AdminApiConfig {
         expose_config_routes: true,
         expose_trace_routes: true,
@@ -152,11 +168,12 @@ async fn build_test_app_with_config_store(config_store: Arc<dyn ConfigStore>) ->
     .with_admin_api_bearer_token(BEARER);
 
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         config_store,
         trace_store,
         eval_run_store,
         eval_run_root,
+        event_store,
     }
 }
 
@@ -1134,6 +1151,22 @@ async fn start_eval_run_drives_dataset_and_persists() {
     }
     // No baseline requested → no diff.
     assert!(body["diff"].is_null());
+
+    let run_id = run["id"].as_str().unwrap();
+    let page = app
+        .event_store
+        .list(EventScope::run(run_id), None, 10)
+        .await
+        .unwrap();
+    assert_eq!(page.events.len(), 2);
+    assert_eq!(page.events[0].event_kind.as_str(), "EvalRunStarted");
+    assert_eq!(page.events[0].payload["dataset_id"], "DS-RUN");
+    assert_eq!(page.events[0].payload["planned_item_count"], 2);
+    assert_eq!(page.events[1].event_kind.as_str(), "EvalRunCompleted");
+    assert_eq!(page.events[1].payload["item_count"], 2);
+    assert_eq!(page.events[1].payload["passed_count"], 2);
+    assert_eq!(page.events[1].payload["persisted"], true);
+    assert_eq!(page.events[1].visibility, EventVisibility::Internal);
 }
 
 #[tokio::test]
@@ -2327,10 +2360,10 @@ async fn online_eval_404s_on_unknown_model() {
 }
 
 #[tokio::test]
-async fn online_eval_503s_on_persist_without_run_store() {
-    // Persist=true with no EvalRunStore wired must fail BEFORE any
-    // model resolution / provider call — otherwise we burn tokens on a
-    // request the persistence layer is known to reject.
+async fn online_eval_route_absent_without_eval_run_store() {
+    // Eval routes are mounted only when the eval module is wired. This keeps
+    // absent optional modules as 404 route absence instead of handler-local
+    // service-unavailable fallbacks.
     let app = build_test_app_without_run_store().await;
     let (status, body) = request(
         &app,
@@ -2343,14 +2376,7 @@ async fn online_eval_503s_on_persist_without_run_store() {
         })),
     )
     .await;
-    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-    assert!(
-        body["error"]
-            .as_str()
-            .unwrap_or("")
-            .contains("EvalRunStore is required"),
-        "body: {body}"
-    );
+    assert_eq!(status, StatusCode::NOT_FOUND, "body: {body}");
 }
 
 #[tokio::test]

--- a/crates/awaken-server/tests/http_api.rs
+++ b/crates/awaken-server/tests/http_api.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)] // ADR-0038 D7: integration tests exercise the legacy checkpoint API directly
 //! HTTP API contract tests — migrated from tirea-agentos-server/tests/http_api.rs.
 //!
 //! Validates route construction, request/response serialization,
@@ -264,6 +265,7 @@ fn run_status_transitions() {
 
 mod integration {
     use async_trait::async_trait;
+    use awaken_contract::contract::event_store::{EventReader, EventScope};
     use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequest};
     use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
     use awaken_contract::contract::lifecycle::RunStatus;
@@ -274,18 +276,82 @@ mod integration {
         WaitingReason,
     };
     use awaken_contract::contract::suspension::ToolCallResumeMode;
+    use awaken_contract::contract::versioned_registry::PinnedRegistryManifest;
     use awaken_contract::registry_spec::AgentSpec;
     use awaken_contract::thread::Thread;
     use awaken_runtime::builder::AgentRuntimeBuilder;
     use awaken_runtime::registry::traits::ModelBinding;
-    use awaken_server::app::{AppState, ServerConfig};
+    use awaken_server::app::{ServerConfig, ServerState};
     use awaken_server::routes::build_router;
-    use awaken_stores::memory::InMemoryStore;
+    use awaken_stores::{InMemoryEventStore, memory::InMemoryStore};
     use axum::body::to_bytes;
     use axum::http::{Request, StatusCode};
     use serde_json::{Value, json};
     use std::sync::Arc;
     use tower::ServiceExt;
+
+    struct TestRunResolver {
+        inner: Arc<dyn awaken_runtime::AgentResolver>,
+    }
+
+    #[async_trait]
+    impl awaken_runtime::Resolver for TestRunResolver {
+        async fn resolve(
+            &self,
+            req: awaken_runtime::ResolutionRequest,
+        ) -> Result<awaken_runtime::ResolvedRunPlan, awaken_runtime::ResolveError> {
+            let agent_id = match &req.target {
+                awaken_runtime::ResolutionTarget::Root { agent_id, .. } => agent_id.as_str(),
+                awaken_runtime::ResolutionTarget::Delegate { agent_id, .. } => agent_id.as_str(),
+                awaken_runtime::ResolutionTarget::Handoff { agent_id, .. } => agent_id.as_str(),
+            };
+            let execution = self.inner.resolve_execution(agent_id).unwrap_or_else(|_| {
+                let agent = awaken_runtime::ResolvedAgent::new(
+                    agent_id,
+                    "test-model",
+                    "test",
+                    Arc::new(ImmediateExecutor),
+                );
+                awaken_runtime::ExecutionPlan::from_resolved_agent(&agent)
+            });
+            let tools = match &execution {
+                awaken_runtime::ExecutionPlan::Local(agent) => agent
+                    .tool_descriptors()
+                    .into_iter()
+                    .map(|descriptor| awaken_runtime::ResolvedTool { descriptor })
+                    .collect(),
+                awaken_runtime::ExecutionPlan::Remote(_) => Vec::new(),
+            };
+            Ok(awaken_runtime::ResolvedRunPlan::Replayable(
+                awaken_runtime::ResolvedRun {
+                    agent_spec: execution.spec().clone(),
+                    role: awaken_runtime::ExecutionRole::Root,
+                    model: awaken_runtime::ResolvedModelBinding {
+                        upstream_model: match &execution {
+                            awaken_runtime::ExecutionPlan::Local(agent) => {
+                                agent.upstream_model.clone()
+                            }
+                            awaken_runtime::ExecutionPlan::Remote(agent) => {
+                                agent.spec.model_id.clone()
+                            }
+                        },
+                    },
+                    execution,
+                    tools,
+                    overrides: req.overrides,
+                    backend_profile: awaken_runtime::BackendProfile::full_local(),
+                    requirements: awaken_runtime::BackendRequirements::from_features(&req.features),
+                    scope: awaken_runtime::ReplayableScope {
+                        manifest: PinnedRegistryManifest {
+                            publication_id: Some("test-publication".into()),
+                            registry_snapshot_version: Some(1),
+                            entries: Vec::new(),
+                        },
+                    },
+                },
+            ))
+        }
+    }
 
     struct ImmediateExecutor;
 
@@ -312,10 +378,12 @@ mod integration {
         router: axum::Router,
         store: Arc<InMemoryStore>,
         mailbox_store: Arc<awaken_stores::InMemoryMailboxStore>,
+        event_store: Arc<InMemoryEventStore>,
     }
 
     fn make_test_app() -> TestApp {
         let store = Arc::new(InMemoryStore::new());
+        let event_store = Arc::new(InMemoryEventStore::new());
         let runtime = Arc::new(
             AgentRuntimeBuilder::new()
                 .with_model_binding(
@@ -337,6 +405,9 @@ mod integration {
                 .build()
                 .expect("build runtime"),
         );
+        runtime.set_run_resolver(Arc::new(TestRunResolver {
+            inner: runtime.resolver_arc(),
+        }));
         let mailbox_store = Arc::new(awaken_stores::InMemoryMailboxStore::new());
         let mailbox = std::sync::Arc::new(awaken_server::mailbox::Mailbox::new(
             runtime.clone(),
@@ -345,17 +416,19 @@ mod integration {
             "test".to_string(),
             awaken_server::mailbox::MailboxConfig::default(),
         ));
-        let state = AppState::new(
+        let state = ServerState::new(
             runtime.clone(),
             mailbox,
             store.clone(),
             runtime.resolver_arc(),
             ServerConfig::default(),
-        );
+        )
+        .with_event_store(event_store.clone());
         TestApp {
-            router: build_router(&state).with_state(state),
+            router: build_router(&state),
             store,
             mailbox_store,
+            event_store,
         }
     }
 
@@ -730,6 +803,23 @@ mod integration {
         let thread = test.store.load_thread(thread_id).await.unwrap().unwrap();
         assert_eq!(thread.resource_id.as_deref(), Some("resource-a"));
         assert_eq!(thread.parent_thread_id.as_deref(), Some(parent_id.as_str()));
+
+        let by_thread = test
+            .event_store
+            .list(EventScope::thread(thread_id), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(by_thread.events.len(), 1);
+        assert_eq!(by_thread.events[0].event_kind.as_str(), "ThreadCreated");
+        assert_eq!(by_thread.events[0].payload["resource_id"], "resource-a");
+        assert_eq!(
+            by_thread.events[0].payload["parent_thread_id"],
+            parent_id.as_str()
+        );
+        assert_eq!(
+            by_thread.events[0].scopes,
+            vec![EventScope::thread(thread_id)]
+        );
     }
 
     #[tokio::test]
@@ -904,6 +994,17 @@ mod integration {
         let thread = test.store.load_thread(&id).await.unwrap().unwrap();
         assert_eq!(thread.resource_id.as_deref(), Some("resource-b"));
         assert_eq!(thread.parent_thread_id.as_deref(), Some(parent_id.as_str()));
+
+        let page = test
+            .event_store
+            .list(EventScope::thread(id.as_str()), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(page.events.len(), 1);
+        assert_eq!(page.events[0].event_kind.as_str(), "ThreadUpdated");
+        assert_eq!(page.events[0].payload["resource_id"], "resource-b");
+        assert_eq!(page.events[0].payload["parent_thread_id"], parent_id);
+        assert!(page.events[0].payload["previous"]["resource_id"].is_null());
     }
 
     #[tokio::test]
@@ -973,6 +1074,15 @@ mod integration {
         // Verify it's gone
         let (status2, _) = get_json(test.router, &format!("/v1/threads/{id}")).await;
         assert_eq!(status2, StatusCode::NOT_FOUND);
+
+        let page = test
+            .event_store
+            .list(EventScope::thread(id.as_str()), None, 10)
+            .await
+            .unwrap();
+        assert_eq!(page.events.len(), 1);
+        assert_eq!(page.events[0].event_kind.as_str(), "ThreadDeleted");
+        assert_eq!(page.events[0].payload["child_strategy"], "detach");
     }
 
     #[tokio::test]

--- a/crates/awaken-server/tests/protocol_ag_ui_e2e.rs
+++ b/crates/awaken-server/tests/protocol_ag_ui_e2e.rs
@@ -14,7 +14,7 @@ use awaken_contract::contract::tool::{
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -208,7 +208,7 @@ fn make_ag_ui_app(llm: Arc<dyn LlmExecutor>, tools: Vec<(String, Arc<dyn Tool>)>
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -216,7 +216,7 @@ fn make_ag_ui_app(llm: Arc<dyn LlmExecutor>, tools: Vec<(String, Arc<dyn Tool>)>
         ServerConfig::default(),
     );
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         store,
     }
 }
@@ -1008,14 +1008,14 @@ async fn multiple_sequential_runs_on_same_thread() {
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    let router = build_router(&state).with_state(state);
+    let router = build_router(&state);
 
     // First run
     let (status1, body1) = post_ag_ui_run(

--- a/crates/awaken-server/tests/protocol_mcp.rs
+++ b/crates/awaken-server/tests/protocol_mcp.rs
@@ -10,7 +10,7 @@ use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage}
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -88,14 +88,14 @@ fn make_mcp_app() -> axum::Router {
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store,
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 async fn mcp_post(

--- a/crates/awaken-server/tests/protocol_parity.rs
+++ b/crates/awaken-server/tests/protocol_parity.rs
@@ -12,11 +12,12 @@ use awaken_contract::contract::transport::Transcoder;
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::protocols::{
     acp::encoder::AcpEncoder, ag_ui::encoder::AgUiEncoder, ai_sdk_v6::encoder::AiSdkEncoder,
 };
 use awaken_server::routes::build_router;
+use awaken_stores::MemoryCommitCoordinator;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
 use axum::http::{Request, StatusCode};
@@ -51,6 +52,12 @@ impl awaken_contract::contract::executor::LlmExecutor for ImmediateExecutor {
 // ── Helpers ──
 
 fn make_app() -> axum::Router {
+    // ADR-0038 D7: the mailbox checkpoint requires a CommitCoordinator
+    // whose `thread_run_store()` Arc-points at the same store as the
+    // mailbox's `run_store`. Build the coordinator first and share its
+    // wrapped store everywhere downstream.
+    let store = Arc::new(InMemoryStore::new());
+    let coordinator = MemoryCommitCoordinator::wrap(Arc::clone(&store));
     let runtime = {
         let builder = AgentRuntimeBuilder::new()
             .with_model_binding(
@@ -61,6 +68,13 @@ fn make_app() -> axum::Router {
                 },
             )
             .with_provider("mock", Arc::new(ImmediateExecutor))
+            .with_thread_run_store(
+                Arc::clone(&store) as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>
+            )
+            .with_commit_coordinator(
+                coordinator
+                    as Arc<dyn awaken_contract::contract::commit_coordinator::CommitCoordinator>,
+            )
             .with_agent_spec(AgentSpec {
                 id: "test".into(),
                 model_id: "test-model".into(),
@@ -70,23 +84,22 @@ fn make_app() -> axum::Router {
             });
         Arc::new(builder.build().expect("build runtime"))
     };
-    let store = Arc::new(InMemoryStore::new());
     let mailbox_store = std::sync::Arc::new(awaken_stores::InMemoryMailboxStore::new());
     let mailbox = std::sync::Arc::new(awaken_server::mailbox::Mailbox::new(
         runtime.clone(),
         mailbox_store,
-        store.clone(),
+        Arc::clone(&store) as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
-        store.clone(),
+        Arc::clone(&store) as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
         runtime.resolver_arc(),
         ServerConfig::default(),
     );
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 async fn post_sse(app: axum::Router, uri: &str, payload: Value) -> (StatusCode, String) {

--- a/crates/awaken-server/tests/public_api_compat.rs
+++ b/crates/awaken-server/tests/public_api_compat.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use awaken_contract::contract::event_sink::EventSink;
 use awaken_contract::contract::suspension::ToolCallResume;
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 
 use awaken_server::mailbox::{MailboxDispatchStatus, RunDispatchExecutor};
 use awaken_server::services::run_control_service::InputMode;
@@ -14,7 +14,7 @@ struct OldExecutorShape;
 impl RunDispatchExecutor for OldExecutorShape {
     async fn run(
         &self,
-        _request: RunRequest,
+        _request: RunActivation,
         _sink: Arc<dyn EventSink>,
     ) -> Result<
         awaken_runtime::loop_runner::AgentRunResult,

--- a/crates/awaken-server/tests/public_api_compat_extended.rs
+++ b/crates/awaken-server/tests/public_api_compat_extended.rs
@@ -21,7 +21,7 @@ use awaken_contract::contract::lifecycle::{RunStatus, TerminationReason};
 use awaken_contract::contract::mailbox::{MailboxInterrupt, MailboxStore};
 use awaken_contract::contract::storage::{RunWaitingState, ThreadRunStore};
 use awaken_contract::contract::suspension::ToolCallResume;
-use awaken_runtime::RunRequest;
+use awaken_runtime::RunActivation;
 use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
 use awaken_server::app::{MailboxLifecycleMode, ServerConfig, ShutdownConfig};
 use awaken_server::mailbox::{
@@ -42,7 +42,7 @@ struct OldExec;
 impl RunDispatchExecutor for OldExec {
     async fn run(
         &self,
-        _: RunRequest,
+        _: RunActivation,
         _: Arc<dyn EventSink>,
     ) -> Result<AgentRunResult, AgentLoopError> {
         unreachable!()
@@ -62,7 +62,7 @@ impl RunDispatchExecutor for OldExec {
 fn mailbox_submit_signature_intact() {
     let _submit: for<'a> fn(
         &'a Arc<Mailbox>,
-        RunRequest,
+        RunActivation,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<
@@ -77,7 +77,7 @@ fn mailbox_submit_signature_intact() {
 
     let _submit_bg: for<'a> fn(
         &'a Arc<Mailbox>,
-        RunRequest,
+        RunActivation,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<MailboxSubmitResult, MailboxError>> + Send + 'a,
@@ -116,21 +116,30 @@ fn mailbox_interrupt_struct_literal_keeps_0_2_fields() {
 
 #[test]
 fn mailbox_new_signature_intact() {
-    let _new: fn(
-        Arc<OldExec>,
-        Arc<dyn MailboxStore>,
-        Arc<dyn ThreadRunStore>,
-        String,
-        MailboxConfig,
-    ) -> Mailbox = Mailbox::new::<OldExec>;
+    // 0.6.0 collapses the previous `Mailbox::new` / `Mailbox::new_with_executor`
+    // pair into a single constructor that accepts any `IntoDispatchExecutor`
+    // (both `Arc<Concrete>` and `Arc<dyn RunDispatchExecutor>`). The two
+    // smoke calls below cover the two prior input shapes through the new
+    // unified signature.
+    let mailbox_store: Arc<dyn MailboxStore> = Arc::new(awaken_stores::InMemoryMailboxStore::new());
+    let run_store: Arc<dyn ThreadRunStore> = Arc::new(awaken_stores::InMemoryStore::new());
+    let concrete: Arc<OldExec> = Arc::new(OldExec);
+    let erased: Arc<dyn RunDispatchExecutor> = concrete.clone();
 
-    let _new_with: fn(
-        Arc<dyn RunDispatchExecutor>,
-        Arc<dyn MailboxStore>,
-        Arc<dyn ThreadRunStore>,
-        String,
-        MailboxConfig,
-    ) -> Mailbox = Mailbox::new_with_executor;
+    let _ = Mailbox::new(
+        concrete,
+        Arc::clone(&mailbox_store),
+        Arc::clone(&run_store),
+        "compat".to_string(),
+        MailboxConfig::default(),
+    );
+    let _ = Mailbox::new(
+        erased,
+        mailbox_store,
+        run_store,
+        "compat".to_string(),
+        MailboxConfig::default(),
+    );
 }
 
 #[test]

--- a/crates/awaken-server/tests/restore_routes.rs
+++ b/crates/awaken-server/tests/restore_routes.rs
@@ -7,7 +7,7 @@ use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequ
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::{AgentSpec, BuiltinSeedSet, BuiltinSpec, ModelBindingSpec, ProviderSpec};
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
 use awaken_server::services::audit_log::AuditLogger;
@@ -112,7 +112,7 @@ async fn build_test_app() -> axum::Router {
         "restore-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -123,7 +123,7 @@ async fn build_test_app() -> axum::Router {
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);
 
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────
@@ -405,7 +405,7 @@ async fn restore_restart_event_returns_422() {
         "restart-restore-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -415,7 +415,7 @@ async fn restore_restart_event_returns_422() {
     .with_config_store(config_store)
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);
-    let app = build_router(&state).with_state(state);
+    let app = build_router(&state);
 
     let (status, body) = post_json(
         &app,
@@ -488,9 +488,14 @@ async fn unknown_version_returns_404_unknown() {
     assert_eq!(body["reason"], "unknown");
 }
 
-/// Restore failure when the referenced model no longer exists returns 422.
+/// ADR-0035 D11: restore is an editing-store operation and does NOT
+/// trigger the runtime hot-swap. It succeeds even when the restored
+/// payload references resources that were deleted from the published
+/// graph; cross-resource validation happens at the next explicit
+/// publish, not at restore time. A separate test should assert the
+/// publish-time failure.
 #[tokio::test]
-async fn restore_fails_when_referenced_model_is_gone() {
+async fn restore_does_not_validate_references_at_edit_time() {
     let app = build_test_app().await;
 
     // Create provider + model + agent referencing the model.
@@ -558,18 +563,19 @@ async fn restore_fails_when_referenced_model_is_gone() {
         .expect("create event")
         .to_string();
 
-    // Restore to original version — should fail because model is gone.
+    // Restore to original version — succeeds at the editing layer per
+    // ADR-0035 D11; the runtime continues to observe the previously
+    // published config until an explicit publish promotes the restored
+    // record (and that publish is where missing-reference validation
+    // would surface).
     let (status, body) = post_json(
         &app,
         "/v1/config/agents/agent-orphan/restore",
         &json!({ "version": create_event_id }),
     )
     .await;
-    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "body: {body}");
-    assert!(
-        body["error"].is_string(),
-        "body must contain error message: {body}"
-    );
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["model_id"], "model-restore-test");
 }
 
 /// The restore audit event has `restored_from` populated.
@@ -714,7 +720,7 @@ async fn restore_rejects_seed_apply_event() {
         "seed-restore-test".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -724,7 +730,7 @@ async fn restore_rejects_seed_apply_event() {
     .with_config_store(config_store)
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);
-    let app = build_router(&state).with_state(state);
+    let app = build_router(&state);
 
     // POST restore with the SeedApply event ULID.
     // The agent id in the URL doesn't matter — the event type check fires first.

--- a/crates/awaken-server/tests/restore_routes.rs
+++ b/crates/awaken-server/tests/restore_routes.rs
@@ -45,6 +45,8 @@ impl LlmExecutor for ImmediateExecutor {
 
 struct TestProviderFactory;
 
+const ADMIN_TOKEN: &str = "restore-test-token";
+
 impl ProviderExecutorFactory for TestProviderFactory {
     fn build(&self, spec: &ProviderSpec) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
         if spec.adapter.eq_ignore_ascii_case("stub") {
@@ -119,6 +121,7 @@ async fn build_test_app() -> axum::Router {
         resolver,
         ServerConfig::default(),
     )
+    .with_admin_api_bearer_token(ADMIN_TOKEN)
     .with_config_store(config_store)
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);
@@ -133,6 +136,7 @@ async fn post_json(app: &axum::Router, uri: &str, body: &Value) -> (StatusCode, 
         .method("POST")
         .uri(uri)
         .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
         .body(Body::from(serde_json::to_vec(body).unwrap()))
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();
@@ -147,6 +151,7 @@ async fn put_json(app: &axum::Router, uri: &str, body: &Value) -> (StatusCode, V
         .method("PUT")
         .uri(uri)
         .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
         .body(Body::from(serde_json::to_vec(body).unwrap()))
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();
@@ -161,6 +166,7 @@ async fn patch_json(app: &axum::Router, uri: &str, body: &Value) -> (StatusCode,
         .method("PATCH")
         .uri(uri)
         .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
         .body(Body::from(serde_json::to_vec(body).unwrap()))
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();
@@ -174,6 +180,7 @@ async fn delete_resource(app: &axum::Router, uri: &str) -> StatusCode {
     let req = Request::builder()
         .method("DELETE")
         .uri(uri)
+        .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
         .body(Body::empty())
         .unwrap();
     app.clone().oneshot(req).await.unwrap().status()
@@ -188,6 +195,7 @@ async fn get_audit_log(app: &axum::Router, qs: &str) -> Value {
     let req = Request::builder()
         .method("GET")
         .uri(&uri)
+        .header("authorization", format!("Bearer {ADMIN_TOKEN}"))
         .body(Body::empty())
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();
@@ -412,6 +420,7 @@ async fn restore_restart_event_returns_422() {
         resolver,
         ServerConfig::default(),
     )
+    .with_admin_api_bearer_token(ADMIN_TOKEN)
     .with_config_store(config_store)
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);
@@ -727,6 +736,7 @@ async fn restore_rejects_seed_apply_event() {
         resolver,
         ServerConfig::default(),
     )
+    .with_admin_api_bearer_token(ADMIN_TOKEN)
     .with_config_store(config_store)
     .with_config_runtime_manager(manager)
     .with_audit_log(audit_logger);

--- a/crates/awaken-server/tests/run_api.rs
+++ b/crates/awaken-server/tests/run_api.rs
@@ -248,6 +248,8 @@ struct TestApp {
     store: Arc<InMemoryStore>,
 }
 
+const TEST_ADMIN_TOKEN: &str = "run-api-test-token";
+
 fn make_test_app_with_runtime(
     runtime: Arc<awaken_runtime::AgentRuntime>,
     store: Arc<InMemoryStore>,
@@ -269,7 +271,8 @@ fn make_test_app_with_runtime(
         store.clone(),
         runtime.resolver_arc(),
         ServerConfig::default(),
-    );
+    )
+    .with_admin_api_bearer_token(TEST_ADMIN_TOKEN);
     TestApp {
         router: build_router(&state),
         store,
@@ -364,6 +367,7 @@ async fn post_json(app: axum::Router, uri: &str, payload: Value) -> (StatusCode,
                 .method("POST")
                 .uri(uri)
                 .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {TEST_ADMIN_TOKEN}"))
                 .body(axum::body::Body::from(payload.to_string()))
                 .expect("request build"),
         )

--- a/crates/awaken-server/tests/run_api.rs
+++ b/crates/awaken-server/tests/run_api.rs
@@ -1,7 +1,7 @@
 //! Run API lifecycle tests — validates start, list, and contract behavior.
 //!
 //! Mirrors high-value run API tests from uncarve's tirea-agentos-server/tests/run_api.rs,
-//! adapted to awaken's AppState + Mailbox architecture.
+//! adapted to awaken's ServerState + Mailbox architecture.
 //!
 //! NOTE: Control operations (cancel, decision) are now unified under
 //! `/v1/threads/:id/{cancel,decision}`. The `/v1/runs` namespace is
@@ -13,6 +13,7 @@ use awaken_contract::contract::executor::{InferenceExecutionError, InferenceRequ
 use awaken_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
 use awaken_contract::contract::lifecycle::{RunStatus, TerminationReason};
 use awaken_contract::contract::storage::{RunRecord, RunStore, ThreadStore};
+use awaken_contract::contract::versioned_registry::PinnedRegistryManifest;
 use awaken_contract::registry_spec::AgentSpec;
 use awaken_contract::registry_spec::RemoteEndpoint;
 use awaken_runtime::builder::AgentRuntimeBuilder;
@@ -21,7 +22,7 @@ use awaken_runtime::extensions::a2a::{
     DelegateRunResult, DelegateRunStatus,
 };
 use awaken_runtime::registry::traits::ModelBinding;
-use awaken_server::app::{AppState, ServerConfig};
+use awaken_server::app::{ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
@@ -29,6 +30,57 @@ use axum::http::{Request, StatusCode};
 use serde_json::{Value, json};
 use std::sync::Arc;
 use tower::ServiceExt;
+
+struct TestRunResolver {
+    inner: Arc<dyn awaken_runtime::AgentResolver>,
+}
+
+#[async_trait]
+impl awaken_runtime::Resolver for TestRunResolver {
+    async fn resolve(
+        &self,
+        req: awaken_runtime::ResolutionRequest,
+    ) -> Result<awaken_runtime::ResolvedRunPlan, awaken_runtime::ResolveError> {
+        let agent_id = match &req.target {
+            awaken_runtime::ResolutionTarget::Root { agent_id, .. } => agent_id.as_str(),
+            awaken_runtime::ResolutionTarget::Delegate { agent_id, .. } => agent_id.as_str(),
+            awaken_runtime::ResolutionTarget::Handoff { agent_id, .. } => agent_id.as_str(),
+        };
+        let execution = self.inner.resolve_execution(agent_id)?;
+        let tools = match &execution {
+            awaken_runtime::ExecutionPlan::Local(agent) => agent
+                .tool_descriptors()
+                .into_iter()
+                .map(|descriptor| awaken_runtime::ResolvedTool { descriptor })
+                .collect(),
+            awaken_runtime::ExecutionPlan::Remote(_) => Vec::new(),
+        };
+        Ok(awaken_runtime::ResolvedRunPlan::Replayable(
+            awaken_runtime::ResolvedRun {
+                agent_spec: execution.spec().clone(),
+                role: awaken_runtime::ExecutionRole::Root,
+                model: awaken_runtime::ResolvedModelBinding {
+                    upstream_model: match &execution {
+                        awaken_runtime::ExecutionPlan::Local(agent) => agent.upstream_model.clone(),
+                        awaken_runtime::ExecutionPlan::Remote(agent) => agent.spec.model_id.clone(),
+                    },
+                },
+                execution,
+                tools,
+                overrides: req.overrides,
+                backend_profile: awaken_runtime::BackendProfile::full_local(),
+                requirements: awaken_runtime::BackendRequirements::from_features(&req.features),
+                scope: awaken_runtime::ReplayableScope {
+                    manifest: PinnedRegistryManifest {
+                        publication_id: Some("test-publication".into()),
+                        registry_snapshot_version: Some(1),
+                        entries: Vec::new(),
+                    },
+                },
+            },
+        ))
+    }
+}
 
 // ── Mock executor ──
 
@@ -200,6 +252,9 @@ fn make_test_app_with_runtime(
     runtime: Arc<awaken_runtime::AgentRuntime>,
     store: Arc<InMemoryStore>,
 ) -> TestApp {
+    runtime.set_run_resolver(Arc::new(TestRunResolver {
+        inner: runtime.resolver_arc(),
+    }));
     let mailbox_store = std::sync::Arc::new(awaken_stores::InMemoryMailboxStore::new());
     let mailbox = std::sync::Arc::new(awaken_server::mailbox::Mailbox::new(
         runtime.clone(),
@@ -208,7 +263,7 @@ fn make_test_app_with_runtime(
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -216,7 +271,7 @@ fn make_test_app_with_runtime(
         ServerConfig::default(),
     );
     TestApp {
-        router: build_router(&state).with_state(state),
+        router: build_router(&state),
         store,
     }
 }
@@ -838,6 +893,9 @@ async fn ai_sdk_agent_preview_requires_admin_token_when_configured() {
             .expect("build runtime"),
     );
     let mailbox_store = Arc::new(awaken_stores::InMemoryMailboxStore::new());
+    runtime.set_run_resolver(Arc::new(TestRunResolver {
+        inner: runtime.resolver_arc(),
+    }));
     let mailbox = Arc::new(awaken_server::mailbox::Mailbox::new(
         runtime.clone(),
         mailbox_store,
@@ -845,7 +903,7 @@ async fn ai_sdk_agent_preview_requires_admin_token_when_configured() {
         "test".to_string(),
         awaken_server::mailbox::MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime.clone(),
         mailbox,
         store.clone(),
@@ -853,7 +911,7 @@ async fn ai_sdk_agent_preview_requires_admin_token_when_configured() {
         ServerConfig::default(),
     )
     .with_admin_api_bearer_token("expected-token");
-    let router = build_router(&state).with_state(state);
+    let router = build_router(&state);
 
     // No Authorization header → 401.
     let (status, _) = post_json(

--- a/crates/awaken-server/tests/trace_routes.rs
+++ b/crates/awaken-server/tests/trace_routes.rs
@@ -10,7 +10,7 @@ use awaken_ext_observability::trace_store::file::FileTraceStore;
 use awaken_ext_observability::trace_store::{RunSummary, TraceStore};
 use awaken_ext_observability::{GenAISpan, MetricsEvent, SpanContext};
 use awaken_runtime::builder::AgentRuntimeBuilder;
-use awaken_server::app::{AdminApiConfig, AppState, ServerConfig};
+use awaken_server::app::{AdminApiConfig, ServerConfig, ServerState};
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
 use awaken_server::routes::build_router;
 use awaken_stores::InMemoryStore;
@@ -117,7 +117,7 @@ async fn build_test_app(token: Option<&str>, store: Arc<dyn TraceStore>) -> axum
         MailboxConfig::default(),
     ));
 
-    let mut state = AppState::new(
+    let mut state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -139,7 +139,7 @@ async fn build_test_app(token: Option<&str>, store: Arc<dyn TraceStore>) -> axum
         state = state.with_admin_api_bearer_token(tok);
     }
 
-    build_router(&state).with_state(state)
+    build_router(&state)
 }
 
 fn temp_trace_dir() -> std::path::PathBuf {
@@ -411,7 +411,7 @@ async fn trace_routes_require_admin_auth() {
 }
 
 #[tokio::test]
-async fn list_traces_no_store_returns_503() {
+async fn trace_routes_absent_without_trace_store() {
     // Build a server without a trace store attached.
     let thread_store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(
@@ -429,24 +429,25 @@ async fn list_traces_no_store_returns_503() {
         "trace-no-store".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
         resolver,
         ServerConfig::default(),
     )
-    // F20: routes are opt-in. The test asserts the in-routes behaviour
-    // when a trace store is missing, so it must still mount the routes.
+    // ADR-0041 mounts optional module routes only when their concrete module
+    // state exists; enabling the surface without a TraceStore still leaves the
+    // trace router absent.
     .with_admin_api_config(AdminApiConfig {
         expose_trace_routes: true,
         ..AdminApiConfig::default()
     });
     // No trace store, no bearer token needed for this surface.
-    let app = build_router(&state).with_state(state);
+    let app = build_router(&state);
 
     let (status, _) = get(&app, "/v1/traces", None).await;
-    assert_eq!(status, 503);
+    assert_eq!(status, 404);
 }
 
 #[tokio::test]
@@ -473,7 +474,7 @@ async fn default_admin_api_config_omits_trace_routes() {
         "trace-default-off".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -481,7 +482,7 @@ async fn default_admin_api_config_omits_trace_routes() {
         ServerConfig::default(),
     )
     .with_trace_store(store as Arc<dyn TraceStore>);
-    let app = build_router(&state).with_state(state);
+    let app = build_router(&state);
     let (status, _) = get(&app, "/v1/traces", None).await;
     assert_eq!(
         status, 404,
@@ -510,7 +511,7 @@ async fn expose_trace_routes_false_returns_404() {
         "trace-disabled".into(),
         MailboxConfig::default(),
     ));
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         thread_store,
@@ -523,7 +524,7 @@ async fn expose_trace_routes_false_returns_404() {
         ..AdminApiConfig::default()
     });
 
-    let app = build_router(&state).with_state(state);
+    let app = build_router(&state);
     let (status, _) = get(&app, "/v1/traces", None).await;
     assert_eq!(
         status, 404,

--- a/crates/awaken-server/tests/transport_tests.rs
+++ b/crates/awaken-server/tests/transport_tests.rs
@@ -543,22 +543,19 @@ async fn resumable_relay_frames_have_sequential_ids() {
         chunks.push(String::from_utf8(chunk.to_vec()).unwrap());
     }
 
+    // ADR-0034 D3: transient buffer frames omit SSE `id:` so the
+    // in-process sequence is never leaked as a durable Last-Event-ID.
     assert_eq!(chunks.len(), 3);
-    assert!(
-        chunks[0].starts_with("id: 1\n"),
-        "first frame should have id 1: {}",
-        chunks[0]
-    );
-    assert!(
-        chunks[1].starts_with("id: 2\n"),
-        "second frame should have id 2: {}",
-        chunks[1]
-    );
-    assert!(
-        chunks[2].starts_with("id: 3\n"),
-        "third frame should have id 3: {}",
-        chunks[2]
-    );
+    for chunk in &chunks {
+        assert!(
+            !chunk.contains("id:"),
+            "frame must not advertise id: {chunk}"
+        );
+        assert!(
+            chunk.starts_with("data:"),
+            "frame must start with data: {chunk}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -605,12 +602,13 @@ async fn resumable_relay_replay_after_partial_consumption() {
     // Drain all
     while sse_rx.recv().await.is_some() {}
 
-    // Simulate client reconnect: "I last saw event 2"
+    // Simulate client reconnect: "I last saw event 2". ADR-0034 D3: replay
+    // frames carry only `data:` content; server-side seq is internal.
     let replayed = buffer_clone.replay_after(2);
     assert_eq!(replayed.len(), 3, "should replay events 3, 4, 5");
-    assert!(String::from_utf8_lossy(&replayed[0]).starts_with("id: 3\n"));
-    assert!(String::from_utf8_lossy(&replayed[1]).starts_with("id: 4\n"));
-    assert!(String::from_utf8_lossy(&replayed[2]).starts_with("id: 5\n"));
+    assert!(String::from_utf8_lossy(&replayed[0]).contains(r#"msg2"#));
+    assert!(String::from_utf8_lossy(&replayed[1]).contains(r#"msg3"#));
+    assert!(String::from_utf8_lossy(&replayed[2]).contains(r#"msg4"#));
 }
 
 #[tokio::test]
@@ -633,7 +631,7 @@ async fn resumable_relay_subscribe_after_catches_live_events() {
     buffer.push_json(r#"{"n":4}"#);
 
     let live_frame = live_rx.recv().await.unwrap();
-    assert!(String::from_utf8_lossy(&live_frame).contains("id: 4\n"));
+    assert!(String::from_utf8_lossy(&live_frame).contains(r#""n":4"#));
 
     // No duplicate of events 2 or 3 in live stream
     assert!(live_rx.try_recv().is_err());
@@ -692,13 +690,15 @@ async fn resumable_relay_with_ai_sdk_encoder() {
         chunks.push(String::from_utf8(chunk.to_vec()).unwrap());
     }
 
-    // All frames should have id: N prefix
+    // ADR-0034 D3: frames carry only `data:` — server-side seq is internal.
     for (i, chunk) in chunks.iter().enumerate() {
         assert!(
-            chunk.starts_with(&format!("id: {}\n", i + 1)),
-            "chunk {} should have sequential id: {}",
-            i,
-            chunk,
+            !chunk.contains("id:"),
+            "chunk {i} must not advertise SSE id: {chunk}",
+        );
+        assert!(
+            chunk.starts_with("data:"),
+            "chunk {i} must start with data: {chunk}",
         );
     }
 


### PR DESCRIPTION
Stack entry 5/8.\n\nScope:\n- Server state modules, durable mailbox/outbox wiring, config runtime, audit/events.\n- Fixes admin/eval/config fail-closed behavior: mounted admin surfaces require bearer token; no token is 401/startup denial.\n\nValidation:\n- cargo check --workspace\n- cargo test -p awaken-server --lib admin_auth\n- cargo test -p awaken-server --lib validate_admin_surface\n- cargo test -p awaken-server --lib build_service_router\n- pre-push validate passed.