### PR TITLE
feat(protocols): durable replay-backed adapters

### DIFF
--- a/crates/awaken-protocol-a2a/src/lib.rs
+++ b/crates/awaken-protocol-a2a/src/lib.rs
@@ -58,9 +58,14 @@ pub struct AgentInterface {
     pub protocol_binding: String,
     /// Supported protocol version for this interface.
     pub protocol_version: String,
-    /// Optional tenant path parameter value.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tenant: Option<String>,
+    /// Optional agent path parameter value (was `tenant` pre-0.6).
+    #[serde(
+        default,
+        alias = "agent_id",
+        alias = "tenant",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_id: Option<String>,
 }
 
 /// Provider metadata.
@@ -302,8 +307,17 @@ pub struct Artifact {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SendMessageRequest {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tenant: Option<String>,
+    /// Optional agent selector — equivalent to the path agent in
+    /// `/v1/a2a/{agent}/message:send`. Renamed from `tenant` in 0.6 to
+    /// reflect that the value is an agent identifier, not a tenancy
+    /// scope.
+    #[serde(
+        default,
+        alias = "agent_id",
+        alias = "tenant",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_id: Option<String>,
     pub message: Message,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub configuration: Option<SendMessageConfiguration>,
@@ -376,8 +390,14 @@ pub struct AuthenticationInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PushNotificationConfig {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tenant: Option<String>,
+    /// Optional agent selector mirroring `SendMessageRequest.agent_id`.
+    #[serde(
+        default,
+        alias = "agent_id",
+        alias = "tenant",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -449,7 +469,7 @@ mod tests {
                 url: "https://example.com/v1/a2a".into(),
                 protocol_binding: "HTTP+JSON".into(),
                 protocol_version: "1.0".into(),
-                tenant: None,
+                agent_id: None,
             }],
             provider: None,
             version: "1.0.0".into(),
@@ -524,9 +544,53 @@ mod tests {
     }
 
     #[test]
+    fn a2a_agent_selector_accepts_legacy_tenant_alias() {
+        let request: SendMessageRequest = serde_json::from_value(json!({
+            "tenant": "agent-legacy",
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}]
+            }
+        }))
+        .unwrap();
+        assert_eq!(request.agent_id.as_deref(), Some("agent-legacy"));
+
+        let interface: AgentInterface = serde_json::from_value(json!({
+            "url": "https://example.com/v1/a2a/agent-legacy",
+            "protocolBinding": "HTTP+JSON",
+            "protocolVersion": "1.0",
+            "tenant": "agent-legacy"
+        }))
+        .unwrap();
+        assert_eq!(interface.agent_id.as_deref(), Some("agent-legacy"));
+
+        let config: PushNotificationConfig = serde_json::from_value(json!({
+            "tenant": "agent-legacy",
+            "url": "https://example.com/webhook"
+        }))
+        .unwrap();
+        assert_eq!(config.agent_id.as_deref(), Some("agent-legacy"));
+    }
+
+    #[test]
+    fn a2a_agent_selector_accepts_snake_case_alias() {
+        let request: SendMessageRequest = serde_json::from_value(json!({
+            "agent_id": "agent-snake",
+            "message": {
+                "messageId": "msg-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}]
+            }
+        }))
+        .unwrap();
+        assert_eq!(request.agent_id.as_deref(), Some("agent-snake"));
+    }
+
+    #[test]
     fn push_notification_config_roundtrip() {
         let config = PushNotificationConfig {
-            tenant: Some("tenant-a".into()),
+            agent_id: Some("agent-a".into()),
             id: Some("cfg-1".into()),
             task_id: Some("task-1".into()),
             url: "https://example.com/webhook".into(),

--- a/crates/awaken-runtime/src/extensions/a2a/a2a_backend.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/a2a_backend.rs
@@ -450,7 +450,7 @@ impl A2aBackend {
         let url = format!("{}/message:send", self.interface_base_url());
 
         let request = SendMessageRequest {
-            tenant: None,
+            agent_id: None,
             message,
             configuration: Some(SendMessageConfiguration {
                 accepted_output_modes: vec![

--- a/crates/awaken-runtime/src/registry/composite.rs
+++ b/crates/awaken-runtime/src/registry/composite.rs
@@ -229,7 +229,7 @@ fn agent_card_to_spec(
 
     Ok(AgentSpec {
         id: interface
-            .tenant
+            .agent_id
             .clone()
             .unwrap_or_else(|| slugify_agent_name(&card.name)),
         // Remote agents don't need a local model — they run on the remote server.
@@ -239,7 +239,7 @@ fn agent_card_to_spec(
             backend: "a2a".into(),
             base_url: interface.url.clone(),
             auth: source.bearer_token.clone().map(RemoteAuth::bearer),
-            target: interface.tenant.clone(),
+            target: interface.agent_id.clone(),
             ..Default::default()
         }),
         registry: Some(source.name.clone()),
@@ -427,7 +427,7 @@ mod tests {
                 url: "https://test.example.com/v1/a2a".into(),
                 protocol_binding: "HTTP+JSON".into(),
                 protocol_version: "1.0".into(),
-                tenant: Some("test-agent".into()),
+                agent_id: Some("test-agent".into()),
             }],
             provider: None,
             version: "1.0.0".into(),

--- a/crates/awaken-server/src/protocol_replay_state.rs
+++ b/crates/awaken-server/src/protocol_replay_state.rs
@@ -12,6 +12,7 @@ use awaken_contract::contract::outbox::{
 use awaken_contract::contract::protocol_replay_log::{ProtocolReplayLog, ProtocolReplayLookup};
 use parking_lot::Mutex;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::app::{ReplayBufferEntry, ReplayBufferMap, ServerState};
 use crate::outbox_relay::{OutboxRelay, OutboxRelayConfig, OutboxRelayError};
@@ -96,6 +97,7 @@ impl Default for ProtocolFanoutRelayConfig {
 
 pub struct ProtocolRelayHandle {
     task: JoinHandle<()>,
+    cancel: CancellationToken,
     name: &'static str,
 }
 
@@ -104,11 +106,31 @@ pub type ProtocolFanoutRelayHandle = ProtocolRelayHandle;
 
 impl ProtocolRelayHandle {
     pub async fn shutdown(self) {
-        self.task.abort();
-        if let Err(error) = self.task.await
-            && !error.is_cancelled()
-        {
-            tracing::warn!(error = %error, relay = self.name, "outbox relay failed during shutdown");
+        self.shutdown_with_timeout(Duration::from_secs(30)).await;
+    }
+
+    pub async fn shutdown_with_timeout(self, timeout: Duration) {
+        self.cancel.cancel();
+        let mut task = self.task;
+        match tokio::time::timeout(timeout, &mut task).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) if error.is_cancelled() => {}
+            Ok(Err(error)) => {
+                tracing::warn!(error = %error, relay = self.name, "outbox relay failed during shutdown");
+            }
+            Err(_) => {
+                tracing::warn!(
+                    relay = self.name,
+                    timeout_ms = timeout.as_millis(),
+                    "outbox relay shutdown timed out; aborting task and relying on lease retry"
+                );
+                task.abort();
+                if let Err(error) = task.await
+                    && !error.is_cancelled()
+                {
+                    tracing::warn!(error = %error, relay = self.name, "outbox relay failed after abort");
+                }
+            }
         }
     }
 }
@@ -280,13 +302,16 @@ pub(crate) fn start_protocol_projector_relay(
     ));
     let relay = OutboxRelay::new(attachment.outbox, handler, attachment.config.relay.clone())?;
     let config = attachment.config;
+    let cancel = CancellationToken::new();
     Ok(Some(ProtocolRelayHandle {
         task: tokio::spawn(run_outbox_relay(
             relay,
             config.idle_sleep,
             config.error_sleep,
             "protocol projector relay",
+            cancel.clone(),
         )),
+        cancel,
         name: "protocol projector relay",
     }))
 }
@@ -310,13 +335,16 @@ pub(crate) fn start_protocol_fanout_relay(
     ));
     let relay = OutboxRelay::new(attachment.outbox, handler, attachment.config.relay.clone())?;
     let config = attachment.config;
+    let cancel = CancellationToken::new();
     Ok(Some(ProtocolRelayHandle {
         task: tokio::spawn(run_outbox_relay(
             relay,
             config.idle_sleep,
             config.error_sleep,
             "protocol fanout relay",
+            cancel.clone(),
         )),
+        cancel,
         name: "protocol fanout relay",
     }))
 }
@@ -326,8 +354,12 @@ async fn run_outbox_relay(
     idle_sleep: Duration,
     error_sleep: Duration,
     name: &'static str,
+    cancel: CancellationToken,
 ) {
     loop {
+        if cancel.is_cancelled() {
+            break;
+        }
         match relay.tick().await {
             Ok(stats) if stats.claimed == 0 => wait(idle_sleep).await,
             Ok(_) => {}
@@ -335,6 +367,9 @@ async fn run_outbox_relay(
                 tracing::warn!(error = %error, relay = name, "outbox relay tick failed");
                 wait(error_sleep).await;
             }
+        }
+        if cancel.is_cancelled() {
+            break;
         }
     }
 }

--- a/crates/awaken-server/src/protocols/a2a/agent_card.rs
+++ b/crates/awaken-server/src/protocols/a2a/agent_card.rs
@@ -104,7 +104,7 @@ fn build_agent_card(
             url: interface_url(headers, tenant),
             protocol_binding: "HTTP+JSON".to_string(),
             protocol_version: A2A_VERSION.to_string(),
-            tenant: tenant.map(ToOwned::to_owned),
+            agent_id: tenant.map(ToOwned::to_owned),
         }],
         provider: Some(AgentProvider {
             organization: "Awaken".to_string(),

--- a/crates/awaken-server/src/protocols/a2a/message.rs
+++ b/crates/awaken-server/src/protocols/a2a/message.rs
@@ -354,7 +354,7 @@ async fn prepare_send_request(
     payload: SendMessageRequest,
 ) -> Result<PreparedRequest, A2aError> {
     let mut violations = Vec::new();
-    let request_tenant = trim_to_option(payload.tenant.as_deref());
+    let request_tenant = trim_to_option(payload.agent_id.as_deref());
     let effective_tenant = match (path_tenant, request_tenant) {
         (Some(path), Some(body)) if path != body => {
             violations.push(FieldViolation {

--- a/crates/awaken-server/src/protocols/a2a/push_config.rs
+++ b/crates/awaken-server/src/protocols/a2a/push_config.rs
@@ -206,7 +206,7 @@ pub(super) fn normalize_push_config(
             "push notification taskId must match the enclosing task",
         ));
     }
-    if let Some(existing_tenant) = trim_to_option(config.tenant.as_deref())
+    if let Some(existing_tenant) = trim_to_option(config.agent_id.as_deref())
         && tenant != Some(existing_tenant.as_str())
     {
         return Err(A2aError::invalid(
@@ -225,7 +225,7 @@ pub(super) fn normalize_push_config(
 
     config.id.get_or_insert_with(|| Uuid::now_v7().to_string());
     config.task_id = Some(task_id.to_string());
-    config.tenant = tenant.map(ToOwned::to_owned);
+    config.agent_id = tenant.map(ToOwned::to_owned);
     Ok(config)
 }
 
@@ -249,7 +249,7 @@ pub(super) async fn load_push_notification_configs(
 
     let mut configs = load_thread_push_notification_configs(&thread, task_id)?;
     if let Some(tenant) = tenant {
-        configs.retain(|config| config.tenant.as_deref() == Some(tenant));
+        configs.retain(|config| config.agent_id.as_deref() == Some(tenant));
     }
     configs.sort_by(|left, right| left.id.cmp(&right.id));
     Ok(configs)
@@ -305,7 +305,7 @@ pub(super) async fn upsert_push_notification_config_for_thread(
     let (exists, thread) = load_thread_metadata_projection(st, thread_id).await?;
     let mut configs = load_thread_push_notification_configs(&thread, task_id)?;
     if let Some(tenant) = tenant {
-        configs.retain(|existing| existing.tenant.as_deref() == Some(tenant));
+        configs.retain(|existing| existing.agent_id.as_deref() == Some(tenant));
     }
     if let Some(position) = configs.iter().position(|existing| existing.id == config.id) {
         configs[position] = config;

--- a/crates/awaken-server/src/protocols/mcp/adapter.rs
+++ b/crates/awaken-server/src/protocols/mcp/adapter.rs
@@ -15,6 +15,8 @@ use tokio::sync::mpsc;
 
 use awaken_contract::contract::event::AgentEvent;
 use awaken_contract::contract::message::Message;
+use awaken_contract::contract::storage::RunRequestOrigin;
+use awaken_contract::contract::tool_intercept::AdapterKind;
 use awaken_runtime::{AgentRuntime, RunActivation};
 
 use super::JSON_RPC_VERSION;
@@ -98,8 +100,10 @@ impl McpTool for AgentMcpTool {
 
             let thread_id = format!("mcp-{}", uuid::Uuid::now_v7());
             let messages = vec![Message::user(&text)];
-            let request =
-                RunActivation::new(thread_id, messages).with_agent_id(self.agent_id.clone());
+            let request = RunActivation::new(thread_id, messages)
+                .with_agent_id(self.agent_id.clone())
+                .with_origin(RunRequestOrigin::Mcp)
+                .with_adapter(AdapterKind::Mcp);
 
             let (event_tx, mut event_rx) = mpsc::unbounded_channel();
             let sink = Arc::new(ChannelEventSink::new(event_tx));

--- a/crates/awaken-server/tests/protocol_a2a.rs
+++ b/crates/awaken-server/tests/protocol_a2a.rs
@@ -16,7 +16,7 @@ fn agent_card_roundtrip_uses_supported_interfaces() {
             url: "http://localhost:3000/v1/a2a".into(),
             protocol_binding: "HTTP+JSON".into(),
             protocol_version: "1.0".into(),
-            tenant: Some("alpha".into()),
+            agent_id: Some("alpha".into()),
         }],
         provider: None,
         version: "1.0.0".into(),
@@ -58,7 +58,7 @@ fn agent_card_roundtrip_uses_supported_interfaces() {
     let parsed: AgentCard = serde_json::from_value(value).unwrap();
     assert_eq!(parsed.supported_interfaces[0].protocol_version, "1.0");
     assert_eq!(
-        parsed.supported_interfaces[0].tenant.as_deref(),
+        parsed.supported_interfaces[0].agent_id.as_deref(),
         Some("alpha")
     );
 }
@@ -84,7 +84,7 @@ fn part_serializes_without_legacy_type_discriminator() {
 #[test]
 fn send_message_request_uses_role_and_wrapper_parts() {
     let request = SendMessageRequest {
-        tenant: Some("alpha".into()),
+        agent_id: Some("alpha".into()),
         message: A2aMessage {
             task_id: Some("task-1".into()),
             context_id: Some("task-1".into()),
@@ -96,7 +96,7 @@ fn send_message_request_uses_role_and_wrapper_parts() {
         configuration: Some(SendMessageConfiguration {
             accepted_output_modes: vec!["text/plain".into()],
             task_push_notification_config: Some(PushNotificationConfig {
-                tenant: Some("alpha".into()),
+                agent_id: Some("alpha".into()),
                 id: None,
                 task_id: Some("task-1".into()),
                 url: "https://example.com".into(),


### PR DESCRIPTION
Stack entry 6/8.\n\nScope:\n- Protocol adapter and replay/projector changes for AI SDK, MCP, A2A, and related server paths.\n\nValidation:\n- cargo check --workspace\n- pre-push validate passed.