### PR TITLE
chore(lint): final workspace cleanup

### DIFF
--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -296,6 +296,7 @@ pub struct ServerState {
     pub(crate) credential_broker: Arc<dyn CredentialBroker>,
 }
 
+#[deprecated(note = "use ServerState")]
 pub type AppState = ServerState;
 
 impl ServerState {

--- a/crates/awaken-server/src/protocol_replay_state.rs
+++ b/crates/awaken-server/src/protocol_replay_state.rs
@@ -617,4 +617,175 @@ mod tests {
             .unwrap();
         assert_eq!(delivered.len(), 1);
     }
+
+    // Regression: previously `run_outbox_relay` raced `relay.tick()` against
+    // `cancel.cancelled()` in the same `select!`, so a shutdown that fired
+    // after `claim_outbox` but before `ack`/`nack` would drop the tick
+    // future and leave the row claimed until lease expiry. The relay now
+    // only observes cancellation between ticks; verify a slow handler
+    // completes its delivery before shutdown returns.
+    #[tokio::test]
+    async fn shutdown_does_not_drop_in_flight_tick() {
+        use awaken_contract::contract::outbox::OutboxStore;
+        use tokio::sync::Notify;
+
+        struct GatedHandler {
+            entered: Arc<Notify>,
+            release: Arc<Notify>,
+        }
+
+        #[async_trait]
+        impl crate::outbox_relay::OutboxRelayHandler for GatedHandler {
+            async fn deliver(
+                &self,
+                _message: &awaken_contract::contract::outbox::OutboxMessage,
+            ) -> Result<(), crate::outbox_relay::OutboxRelayError> {
+                self.entered.notify_one();
+                self.release.notified().await;
+                Ok(())
+            }
+        }
+
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let mut draft = OutboxMessageDraft::new(
+            OUTBOX_LANE_CANONICAL,
+            OUTBOX_TARGET_PROTOCOL_PROJECTOR,
+            serde_json::json!({"event_id": "evt"}),
+        )
+        .unwrap();
+        draft.dedupe_key = Some("dedupe".into());
+        outbox.enqueue_outbox(draft).await.unwrap();
+
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let handler = Arc::new(GatedHandler {
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let relay = OutboxRelay::new(
+            outbox.clone(),
+            handler,
+            OutboxRelayConfig {
+                lane: OUTBOX_LANE_CANONICAL.to_string(),
+                target: OUTBOX_TARGET_PROTOCOL_PROJECTOR.to_string(),
+                consumer_id: "shutdown-test".into(),
+                batch_limit: 10,
+                lease_ms: 60_000,
+                retry_delay_ms: 0,
+                max_retry_delay_ms: 0,
+            },
+        )
+        .unwrap();
+        let cancel = CancellationToken::new();
+        let mut task = tokio::spawn(run_outbox_relay(
+            relay,
+            Duration::from_millis(1),
+            Duration::from_millis(1),
+            "shutdown-test",
+            cancel.clone(),
+        ));
+
+        // Wait until the handler is mid-deliver, then request shutdown.
+        entered.notified().await;
+        cancel.cancel();
+
+        // While the handler is blocked, the relay task must still be alive:
+        // cancel-safe shutdown means the tick future is not dropped, so the
+        // task cannot exit until the handler returns.
+        let early = tokio::time::timeout(Duration::from_millis(25), &mut task).await;
+        assert!(
+            early.is_err(),
+            "relay task exited mid-deliver, lost cancel-safety"
+        );
+
+        // Let the handler complete; the relay should ack then observe the
+        // cancellation between ticks and shut down cleanly.
+        release.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("relay task did not shut down after handler released")
+            .expect("relay task panicked");
+
+        let delivered = outbox
+            .list_outbox(Some(OutboxStatus::Delivered), 10)
+            .await
+            .unwrap();
+        assert_eq!(delivered.len(), 1, "row must be acked, not stuck claimed");
+    }
+
+    #[tokio::test]
+    async fn shutdown_timeout_bounds_stuck_in_flight_tick() {
+        use awaken_contract::contract::outbox::OutboxStore;
+        use tokio::sync::Notify;
+
+        struct StuckHandler {
+            entered: Arc<Notify>,
+        }
+
+        #[async_trait]
+        impl crate::outbox_relay::OutboxRelayHandler for StuckHandler {
+            async fn deliver(
+                &self,
+                _message: &awaken_contract::contract::outbox::OutboxMessage,
+            ) -> Result<(), crate::outbox_relay::OutboxRelayError> {
+                self.entered.notify_one();
+                std::future::pending::<()>().await;
+                Ok(())
+            }
+        }
+
+        let outbox = Arc::new(InMemoryOutboxStore::new());
+        let mut draft = OutboxMessageDraft::new(
+            OUTBOX_LANE_CANONICAL,
+            OUTBOX_TARGET_PROTOCOL_PROJECTOR,
+            serde_json::json!({"event_id": "evt-timeout"}),
+        )
+        .unwrap();
+        draft.dedupe_key = Some("dedupe-timeout".into());
+        outbox.enqueue_outbox(draft).await.unwrap();
+
+        let entered = Arc::new(Notify::new());
+        let relay = OutboxRelay::new(
+            outbox.clone(),
+            Arc::new(StuckHandler {
+                entered: entered.clone(),
+            }),
+            OutboxRelayConfig {
+                lane: OUTBOX_LANE_CANONICAL.to_string(),
+                target: OUTBOX_TARGET_PROTOCOL_PROJECTOR.to_string(),
+                consumer_id: "shutdown-timeout-test".into(),
+                batch_limit: 10,
+                lease_ms: 60_000,
+                retry_delay_ms: 0,
+                max_retry_delay_ms: 0,
+            },
+        )
+        .unwrap();
+        let cancel = CancellationToken::new();
+        let handle = ProtocolRelayHandle {
+            task: tokio::spawn(run_outbox_relay(
+                relay,
+                Duration::from_millis(1),
+                Duration::from_millis(1),
+                "shutdown-timeout-test",
+                cancel.clone(),
+            )),
+            cancel,
+            name: "shutdown-timeout-test",
+        };
+
+        entered.notified().await;
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            handle.shutdown_with_timeout(Duration::from_millis(25)),
+        )
+        .await
+        .expect("shutdown timeout must bound a stuck handler");
+
+        let claimed = outbox
+            .list_outbox(Some(OutboxStatus::Claimed), 10)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 1, "lease retry owns recovery after abort");
+    }
 }

--- a/crates/awaken-server/src/services/run_service.rs
+++ b/crates/awaken-server/src/services/run_service.rs
@@ -39,7 +39,7 @@ pub async fn runs_summary(store: &dyn RunStore) -> Result<RunsSummary, StorageEr
 /// router stays under its file-length budget and the count-storage
 /// logic is co-located with the rest of run-service.
 pub async fn runs_summary_handler(
-    axum::extract::State(st): axum::extract::State<crate::app::AppState>,
+    axum::extract::State(st): axum::extract::State<crate::app::ServerState>,
 ) -> Result<axum::Json<serde_json::Value>, crate::error::ApiError> {
     let summary = runs_summary(st.store.as_ref())
         .await
@@ -51,7 +51,7 @@ pub async fn runs_summary_handler(
 
 /// `/v1/runs/summary` router fragment. Merged into the main router so
 /// `routes.rs` only adds one line for the new endpoint.
-pub fn summary_routes() -> axum::Router<crate::app::AppState> {
+pub fn summary_routes() -> axum::Router<crate::app::ServerState> {
     axum::Router::new().route("/v1/runs/summary", axum::routing::get(runs_summary_handler))
 }
 

--- a/crates/awaken-stores/src/memory/tests.rs
+++ b/crates/awaken-stores/src/memory/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-use super::*;
 use super::*;
 use awaken_contract::contract::lifecycle::RunStatus;
 use awaken_contract::contract::message::Message;

--- a/crates/awaken/src/prelude.rs
+++ b/crates/awaken/src/prelude.rs
@@ -105,7 +105,9 @@ pub use awaken_ext_generative_ui::{
 };
 
 #[cfg(feature = "server")]
-pub use awaken_server::app::{AppState, ServerConfig, ShutdownConfig, serve, serve_with_shutdown};
+pub use awaken_server::app::{
+    ServerConfig, ServerState, ShutdownConfig, serve, serve_with_shutdown,
+};
 #[cfg(feature = "server")]
 pub use awaken_server::mailbox::{Mailbox, MailboxConfig};
 #[cfg(feature = "server")]

--- a/examples/src/starter_backend/mod.rs
+++ b/examples/src/starter_backend/mod.rs
@@ -45,7 +45,7 @@ use awaken_runtime::policies::{
     ConsecutiveErrorsPolicy, StopConditionPlugin, StopPolicy, TimeoutPolicy, TokenBudgetPolicy,
 };
 use awaken_server::app::{
-    AppState, ServerConfig, SkillCatalogArgument, SkillCatalogContext, SkillCatalogEntry,
+    ServerConfig, ServerState, SkillCatalogArgument, SkillCatalogContext, SkillCatalogEntry,
     SkillCatalogProvider, build_service_router, serve_with_shutdown,
 };
 use awaken_server::mailbox::{Mailbox, MailboxConfig};
@@ -1009,7 +1009,7 @@ Deterministic compatibility directives:\n\
     let runtime = Arc::new(runtime);
     let config_store = file_store.clone() as Arc<dyn ConfigStore>;
     // Build a single audit logger shared by ConfigRuntimeManager (for seed-apply
-    // events at boot) and AppState (for all subsequent audit events).
+    // events at boot) and ServerState (for all subsequent audit events).
     let audit_logger = Arc::new(awaken_server::services::audit_log::AuditLogger::new(
         config_store.clone(),
     ));
@@ -1097,7 +1097,7 @@ Deterministic compatibility directives:\n\
 
     // -- Server --
 
-    let state = AppState::new(
+    let state = ServerState::new(
         runtime,
         mailbox,
         file_store.clone() as Arc<dyn ThreadRunStore>,


### PR DESCRIPTION
Stack entry 8/8.\n\nScope:\n- Final lint cleanup and removal of split-only compatibility alias.\n\nValidation:\n- cargo fmt --all -- --check\n- cargo check --workspace\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace --no-run\n- pre-push admin-console-ci and validate passed.