### PR TITLE
fix(skills): seed run-start visibility; demote non-pluggable policy surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,11 @@ Development work lands here before the next versioned release.
   extension field**, not an agentskills core field. `disable-model-invocation` is
   a hard gate: it hides the skill AND blocks every model-facing tool (`skill`,
   `load_skill_resource`, `skill_script`); an explicit runtime `Show` cannot
-  override it. `paths` is a non-standard field, parsed but inert (no effect on
-  visibility). `EmbeddedSkill` now maps the same frontmatter as `FsSkill`.
+  override it. This is not an access-control boundary: explicit user invocation
+  via `/skill-name` remains governed by `user-invocable`, not
+  `disable-model-invocation`. `paths` is a non-standard field, parsed but inert
+  (no effect on visibility, activation, or resource/script scope). `EmbeddedSkill`
+  now maps the same frontmatter as `FsSkill`.
 
   | Removed (was public) | Replacement |
   |---|---|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,23 +60,29 @@ Development work lands here before the next versioned release.
 
 - **BREAKING — skill/tool visibility policy surfaces demoted to declarative.**
   Visibility/deferral are now metadata- and config-driven, not pluggable code
-  traits, so the trait surfaces are removed from the public API. Skill catalog
-  visibility follows the [agentskills spec](https://agentskills.io/specification):
-  skills are surfaced by `name` + `description` and gated only by
-  `disable-model-invocation`. `paths` is a non-standard field that is parsed but
-  does **not** affect visibility.
+  traits, so the trait surfaces are removed from the public API. Skill discovery
+  aligns with the [agentskills spec](https://agentskills.io/specification)
+  progressive-disclosure model (skills surfaced by `name` + `description`).
+  Catalog visibility is gated by `disable-model-invocation` — an **Awaken
+  extension field**, not an agentskills core field. `disable-model-invocation` is
+  a hard gate: it hides the skill AND blocks every model-facing tool (`skill`,
+  `load_skill_resource`, `skill_script`); an explicit runtime `Show` cannot
+  override it. `paths` is a non-standard field, parsed but inert (no effect on
+  visibility). `EmbeddedSkill` now maps the same frontmatter as `FsSkill`.
 
   | Removed (was public) | Replacement |
   |---|---|
   | `awaken_ext_skills::SkillVisibilityPolicy` (trait) | declarative metadata; no trait |
   | `awaken_ext_skills::DefaultSkillVisibilityPolicy` | `awaken_ext_skills::effective_visibility(meta, state)` |
+  | `SkillVisibilityStateValue.modes` (was `pub`) | now `pub(crate)`; use `explicit()` / `effective_visibility` |
   | `awaken_ext_deferred_tools::policy` (module, now private) | `DeferredToolsConfig` / `config.resolve_mode` |
   | `DeferralPolicy` / `ConfigOnlyPolicy` / `DeferralDecision` | classification via config `resolve_mode` |
 
-  `SkillVisibilityAction` gains `SeedBatch` (insert-if-absent) for run-start
-  seeding; `SetBatch` is retained for explicit overwrite. No deprecated shims —
-  these surfaces had no in-tree consumers and the crates are pre-1.0
-  (`0.5.1-dev`); downstream code resolves visibility via `effective_visibility`.
+  Resolve catalog visibility only through `effective_visibility(meta, state)`;
+  never read the state map directly (absent ≠ Visible). No run-start visibility
+  seed: visibility resolves from live metadata + explicit runtime overrides. No
+  deprecated shims — these surfaces had no in-tree consumers and the crates are
+  pre-1.0 (`0.5.1-dev`).
 
 - **AgentSpec catalog fields** — `allowed_tools` / `excluded_tools` are now
   strict literal-id lists, and two new fields `allowed_tool_patterns` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,26 @@ Development work lands here before the next versioned release.
   client-side. A lefthook `check-legacy-model-binding` hook prevents
   reintroduction of any deprecated symbol.
 
+- **BREAKING — skill/tool visibility policy surfaces demoted to declarative.**
+  Visibility/deferral are now metadata- and config-driven, not pluggable code
+  traits, so the trait surfaces are removed from the public API. Skill catalog
+  visibility follows the [agentskills spec](https://agentskills.io/specification):
+  skills are surfaced by `name` + `description` and gated only by
+  `disable-model-invocation`. `paths` is a non-standard field that is parsed but
+  does **not** affect visibility.
+
+  | Removed (was public) | Replacement |
+  |---|---|
+  | `awaken_ext_skills::SkillVisibilityPolicy` (trait) | declarative metadata; no trait |
+  | `awaken_ext_skills::DefaultSkillVisibilityPolicy` | `awaken_ext_skills::effective_visibility(meta, state)` |
+  | `awaken_ext_deferred_tools::policy` (module, now private) | `DeferredToolsConfig` / `config.resolve_mode` |
+  | `DeferralPolicy` / `ConfigOnlyPolicy` / `DeferralDecision` | classification via config `resolve_mode` |
+
+  `SkillVisibilityAction` gains `SeedBatch` (insert-if-absent) for run-start
+  seeding; `SetBatch` is retained for explicit overwrite. No deprecated shims —
+  these surfaces had no in-tree consumers and the crates are pre-1.0
+  (`0.5.1-dev`); downstream code resolves visibility via `effective_visibility`.
+
 - **AgentSpec catalog fields** — `allowed_tools` / `excluded_tools` are now
   strict literal-id lists, and two new fields `allowed_tool_patterns` /
   `excluded_tool_patterns` carry glob patterns (`*` is the only wildcard;

--- a/crates/awaken-ext-deferred-tools/src/lib.rs
+++ b/crates/awaken-ext-deferred-tools/src/lib.rs
@@ -1,6 +1,9 @@
 pub mod config;
 pub mod plugin;
-pub mod policy;
+// Internal: initial tool classification is declarative (`config.resolve_mode`);
+// this module holds the live re-deferral mechanism (`DiscBetaEvaluator`) and is
+// not a user-pluggable policy surface.
+mod policy;
 pub mod state;
 pub mod tool_search;
 

--- a/crates/awaken-ext-deferred-tools/src/policy.rs
+++ b/crates/awaken-ext-deferred-tools/src/policy.rs
@@ -1,46 +1,13 @@
 //! Deferral policy — separated from mechanism.
+//!
+//! Initial tool classification is declarative and resolved directly from config
+//! (`DeferredToolsConfig::resolve_mode`), consistent with the config-driven
+//! policy model used elsewhere (e.g. `awaken-ext-permission`) — there is no
+//! pluggable policy trait. The only live runtime policy is `DiscBetaEvaluator`,
+//! which may re-defer idle tools mid-session.
 
 use crate::config::{DeferredToolsConfig, ToolLoadMode};
-use crate::state::{DeferralStateValue, DiscBetaStateValue, ToolUsageStatsValue};
-
-/// A decision about what mode a tool should be in.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DeferralDecision {
-    pub tool_id: String,
-    pub target_mode: ToolLoadMode,
-}
-
-/// Policy for initial tool classification (session start).
-pub trait DeferralPolicy: Send + Sync {
-    fn evaluate(
-        &self,
-        stats: &ToolUsageStatsValue,
-        current_state: &DeferralStateValue,
-        config: &DeferredToolsConfig,
-        tool_ids: &[String],
-    ) -> Vec<DeferralDecision>;
-}
-
-/// Applies config rules only, with no dynamic adjustment based on usage.
-pub struct ConfigOnlyPolicy;
-
-impl DeferralPolicy for ConfigOnlyPolicy {
-    fn evaluate(
-        &self,
-        _stats: &ToolUsageStatsValue,
-        _current_state: &DeferralStateValue,
-        config: &DeferredToolsConfig,
-        tool_ids: &[String],
-    ) -> Vec<DeferralDecision> {
-        tool_ids
-            .iter()
-            .map(|id| DeferralDecision {
-                tool_id: id.clone(),
-                target_mode: config.resolve_mode(id),
-            })
-            .collect()
-    }
-}
+use crate::state::{DeferralStateValue, DiscBetaStateValue};
 
 /// DiscBeta-based evaluator for mid-session dynamic re-defer.
 ///

--- a/crates/awaken-ext-deferred-tools/src/tests/plugin_tests.rs
+++ b/crates/awaken-ext-deferred-tools/src/tests/plugin_tests.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use crate::config::{DeferralRule, DeferredToolsConfig, DeferredToolsConfigKey, ToolLoadMode};
 use crate::plugin::DeferredToolsPlugin;
 use crate::plugin::hooks::DeferredToolsBeforeInferenceHook;
-use crate::state::{DeferralRegistry, DeferralState};
+use crate::state::{DeferralRegistry, DeferralState, DeferralStateAction};
 
 fn tool(id: &str) -> ToolDescriptor {
     ToolDescriptor::new(id, id, format!("{id} tool")).with_parameters(json!({
@@ -81,6 +81,67 @@ fn plugin_on_activate_rejects_invalid_agent_config() {
     let err = plugin.on_activate(&spec, &mut patch).unwrap_err();
 
     assert!(err.to_string().contains(DeferredToolsConfigKey::KEY));
+}
+
+/// A runtime-promoted tool must survive the REAL BeforeInference hook even when
+/// config says it should be Deferred: config-only classification must not re-defer
+/// or exclude it. Drives `DeferredToolsBeforeInferenceHook::run` end to end (the
+/// sibling policy_tests version only simulates the hook logic).
+#[tokio::test]
+async fn promoted_tool_survives_real_before_inference_hook() {
+    let store = StateStore::new();
+    store
+        .install_plugin(DeferredToolsPlugin::new(vec![
+            tool("mcp__query"),
+            tool("mcp__other"),
+        ]))
+        .unwrap();
+
+    // Config defers everything by default; mcp__query is promoted at runtime.
+    let spec = AgentSpec::new("deferred-agent")
+        .with_config::<DeferredToolsConfigKey>(DeferredToolsConfig {
+            enabled: Some(true),
+            default_mode: ToolLoadMode::Deferred,
+            rules: vec![],
+            ..Default::default()
+        })
+        .unwrap();
+
+    let plugin = DeferredToolsPlugin::new(vec![tool("mcp__query"), tool("mcp__other")]);
+    let mut patch = MutationBatch::new();
+    plugin.on_activate(&spec, &mut patch).unwrap();
+    store.commit(patch).unwrap();
+
+    // ToolSearch / skill activation promotes mcp__query to eager.
+    let mut promote = MutationBatch::new();
+    promote.update::<DeferralState>(DeferralStateAction::Promote("mcp__query".into()));
+    store.commit(promote).unwrap();
+    assert_eq!(
+        store.read::<DeferralState>().unwrap().modes["mcp__query"],
+        ToolLoadMode::Eager
+    );
+
+    // Run the real hook with the config attached.
+    let ctx =
+        PhaseContext::new(Phase::BeforeInference, store.snapshot()).with_agent_spec(spec.into());
+    let cmd = DeferredToolsBeforeInferenceHook.run(&ctx).await.unwrap();
+
+    // Collect the tools the hook excludes from this inference step.
+    let excluded: Vec<&str> = cmd
+        .scheduled_actions()
+        .iter()
+        .filter(|a| a.key == "runtime.exclude_tool")
+        .filter_map(|a| a.payload.as_str())
+        .collect();
+
+    assert!(
+        excluded.contains(&"mcp__other"),
+        "a genuinely deferred tool must be excluded (proves the hook ran)"
+    );
+    assert!(
+        !excluded.contains(&"mcp__query"),
+        "a runtime-promoted tool must NOT be re-deferred/excluded by config-only logic"
+    );
 }
 
 #[tokio::test]

--- a/crates/awaken-ext-deferred-tools/src/tests/policy_tests.rs
+++ b/crates/awaken-ext-deferred-tools/src/tests/policy_tests.rs
@@ -4,55 +4,6 @@ use crate::config::*;
 use crate::policy::*;
 use crate::state::*;
 
-fn make_config() -> DeferredToolsConfig {
-    DeferredToolsConfig {
-        enabled: Some(true),
-        rules: vec![DeferralRule {
-            tool: "Bash".into(),
-            mode: ToolLoadMode::Eager,
-        }],
-        ..Default::default()
-    }
-}
-
-#[test]
-fn config_only_initial_classification() {
-    let policy = ConfigOnlyPolicy;
-    let stats = ToolUsageStatsValue::default();
-    let state = DeferralStateValue::default();
-    let tool_ids = vec![
-        "Bash".to_string(),
-        "mcp__query".to_string(),
-        "Read".to_string(),
-    ];
-    let decisions = policy.evaluate(&stats, &state, &make_config(), &tool_ids);
-    assert_eq!(decisions.len(), 3);
-    assert_eq!(
-        decisions
-            .iter()
-            .find(|d| d.tool_id == "Bash")
-            .unwrap()
-            .target_mode,
-        ToolLoadMode::Eager
-    );
-    assert_eq!(
-        decisions
-            .iter()
-            .find(|d| d.tool_id == "mcp__query")
-            .unwrap()
-            .target_mode,
-        ToolLoadMode::Deferred
-    );
-    assert_eq!(
-        decisions
-            .iter()
-            .find(|d| d.tool_id == "Read")
-            .unwrap()
-            .target_mode,
-        ToolLoadMode::Deferred
-    );
-}
-
 // --- DiscBetaEvaluator tests ---
 
 fn make_disc_beta_config() -> DeferredToolsConfig {
@@ -235,53 +186,17 @@ fn disc_beta_respects_defer_after_threshold() {
 }
 
 // ---------------------------------------------------------------------------
-// Bug reproduction: ConfigOnlyPolicy re-defers runtime-promoted tools
+// Runtime promote survival
 // ---------------------------------------------------------------------------
 //
 // When ToolSearch (or skill activation) promotes a deferred tool at runtime,
-// the next BeforeInference hook runs ConfigOnlyPolicy which re-evaluates
-// all tools against static config rules. Since config still says the tool
-// should be Deferred, ConfigOnlyPolicy emits a Defer decision that
-// immediately reverses the promote — the tool is only visible for 1 turn.
+// BeforeInference must NOT re-classify tools from static config (which would
+// immediately reverse the promote). Only DiscBeta may re-defer, and only for
+// genuinely idle tools.
 
-/// Simulates the OLD (buggy) BeforeInference hook that re-ran ConfigOnlyPolicy
-/// every turn, overriding runtime promotes.
-fn simulate_before_inference_old(
-    state: &DeferralStateValue,
-    config: &DeferredToolsConfig,
-    policy: &dyn DeferralPolicy,
-    disc_beta: &DiscBetaStateValue,
-    usage_stats: &ToolUsageStatsValue,
-) -> DeferralStateValue {
-    let tool_ids: Vec<String> = state.modes.keys().cloned().collect();
-    let decisions = policy.evaluate(usage_stats, state, config, &tool_ids);
-
-    let mut effective = state.clone();
-    for decision in &decisions {
-        let current = state
-            .modes
-            .get(&decision.tool_id)
-            .copied()
-            .unwrap_or(ToolLoadMode::Eager);
-        if current != decision.target_mode {
-            effective
-                .modes
-                .insert(decision.tool_id.clone(), decision.target_mode);
-        }
-    }
-
-    let re_defer_ids =
-        DiscBetaEvaluator::tools_to_defer(disc_beta, &effective, config, usage_stats.total_turns);
-    for id in re_defer_ids {
-        effective.modes.insert(id, ToolLoadMode::Deferred);
-    }
-
-    effective
-}
-
-/// Simulates the FIXED BeforeInference hook: no ConfigOnlyPolicy re-evaluation,
-/// only DiscBeta re-defer for idle tools.
-fn simulate_before_inference_fixed(
+/// Simulates the BeforeInference hook: no config re-classification, only
+/// DiscBeta re-defer for idle tools.
+fn simulate_before_inference(
     state: &DeferralStateValue,
     config: &DeferredToolsConfig,
     disc_beta: &DiscBetaStateValue,
@@ -298,43 +213,9 @@ fn simulate_before_inference_fixed(
     effective
 }
 
-/// Demonstrates the bug: ConfigOnlyPolicy re-defers a runtime-promoted tool
-/// after just 1 turn.
+/// A runtime-promoted tool survives BeforeInference (not re-deferred from config).
 #[test]
-fn config_only_policy_re_defers_promoted_tool_old_behavior() {
-    let config = DeferredToolsConfig {
-        enabled: Some(true),
-        rules: vec![],
-        ..Default::default()
-    };
-    let policy = ConfigOnlyPolicy;
-    let disc_beta = DiscBetaStateValue::default();
-    let stats = ToolUsageStatsValue::default();
-
-    let mut state = DeferralStateValue::default();
-    state
-        .modes
-        .insert("mcp__query".into(), ToolLoadMode::Deferred);
-
-    // ToolSearch promotes mcp__query.
-    DeferralState::apply(
-        &mut state,
-        DeferralStateAction::Promote("mcp__query".into()),
-    );
-    assert_eq!(state.modes["mcp__query"], ToolLoadMode::Eager);
-
-    // OLD hook: ConfigOnlyPolicy overrides the promote.
-    let effective = simulate_before_inference_old(&state, &config, &policy, &disc_beta, &stats);
-    assert_eq!(
-        effective.modes["mcp__query"],
-        ToolLoadMode::Deferred,
-        "OLD behavior: ConfigOnlyPolicy re-deferred a runtime-promoted tool"
-    );
-}
-
-/// Verifies the fix: runtime-promoted tool survives BeforeInference.
-#[test]
-fn promoted_tool_survives_before_inference_after_fix() {
+fn promoted_tool_survives_before_inference() {
     let config = DeferredToolsConfig {
         enabled: Some(true),
         rules: vec![],
@@ -354,16 +235,15 @@ fn promoted_tool_survives_before_inference_after_fix() {
         DeferralStateAction::Promote("mcp__query".into()),
     );
 
-    // FIXED hook: no ConfigOnlyPolicy, only DiscBeta.
-    let effective = simulate_before_inference_fixed(&state, &config, &disc_beta, &stats);
+    let effective = simulate_before_inference(&state, &config, &disc_beta, &stats);
     assert_eq!(
         effective.modes["mcp__query"],
         ToolLoadMode::Eager,
-        "FIXED: promoted tool should survive BeforeInference"
+        "promoted tool should survive BeforeInference"
     );
 }
 
-/// Verifies DiscBeta can still re-defer an idle promoted tool after the fix.
+/// DiscBeta can still re-defer an idle promoted tool.
 #[test]
 fn disc_beta_still_re_defers_idle_promoted_tool() {
     let config = DeferredToolsConfig {
@@ -399,7 +279,7 @@ fn disc_beta_still_re_defers_idle_promoted_tool() {
         ..Default::default()
     };
 
-    let effective = simulate_before_inference_fixed(&state, &config, &disc_beta, &stats);
+    let effective = simulate_before_inference(&state, &config, &disc_beta, &stats);
     assert_eq!(
         effective.modes["mcp__query"],
         ToolLoadMode::Deferred,

--- a/crates/awaken-ext-skills/src/embedded.rs
+++ b/crates/awaken-ext-skills/src/embedded.rs
@@ -2,7 +2,7 @@ use crate::error::SkillError;
 use crate::skill::{
     LoadedAsset, LoadedReference, ScriptResult, Skill, SkillMeta, SkillResource, SkillResourceKind,
 };
-use crate::skill_md::{parse_allowed_tools, parse_skill_md};
+use crate::skill_md::parse_skill_md;
 use async_trait::async_trait;
 use base64::Engine as _;
 use sha2::{Digest, Sha256};
@@ -37,26 +37,9 @@ impl EmbeddedSkill {
         let doc =
             parse_skill_md(data.skill_md).map_err(|e| SkillError::InvalidSkillMd(e.to_string()))?;
 
-        let fm = &doc.frontmatter;
-        let id = fm.name.clone();
-
-        let allowed_tools = fm
-            .allowed_tools
-            .as_deref()
-            .map(parse_allowed_tools)
-            .transpose()
-            .map_err(|e| SkillError::InvalidSkillMd(e.to_string()))?
-            .unwrap_or_default()
-            .into_iter()
-            .map(|t| t.raw)
-            .collect::<Vec<_>>();
-
-        let meta = SkillMeta::new(
-            id.clone(),
-            id.clone(),
-            fm.description.clone(),
-            allowed_tools,
-        );
+        let meta = crate::skill_md::meta_from_frontmatter(doc.frontmatter)
+            .map_err(SkillError::InvalidSkillMd)?;
+        let id = meta.id.clone();
 
         let mut references = HashMap::new();
         for &(path, content) in data.references {
@@ -222,6 +205,37 @@ More instructions.
             skill.meta.allowed_tools,
             vec!["read_file".to_string(), "write_file".to_string()]
         );
+    }
+
+    #[test]
+    fn meta_respects_disable_model_invocation_frontmatter() {
+        // EmbeddedSkill must map the visibility/invocation frontmatter (not just
+        // allowed-tools), consistent with FsSkill — visibility seeding, catalog
+        // render, and the activation guard all depend on SkillMeta.
+        let md = "\
+---
+name: blocked
+description: hidden from the model
+disable-model-invocation: true
+user-invocable: false
+when-to-use: only on request
+paths: \"*.rs\"
+---
+Body
+";
+        let data = EmbeddedSkillData {
+            skill_md: md,
+            references: &[],
+            assets: &[],
+        };
+        let skill = EmbeddedSkill::new(&data).unwrap();
+        assert!(
+            !skill.meta.model_invocable,
+            "disable-model-invocation must map"
+        );
+        assert!(!skill.meta.user_invocable, "user-invocable must map");
+        assert_eq!(skill.meta.when_to_use.as_deref(), Some("only on request"));
+        assert_eq!(skill.meta.paths, vec!["*.rs".to_string()]);
     }
 
     #[test]

--- a/crates/awaken-ext-skills/src/lib.rs
+++ b/crates/awaken-ext-skills/src/lib.rs
@@ -54,6 +54,7 @@ pub use state::{SkillRenderedActivation, SkillState, SkillStateUpdate, SkillStat
 pub use tools::{LoadSkillResourceTool, SkillActivateTool, SkillScriptTool};
 pub use visibility::{
     SkillVisibility, SkillVisibilityAction, SkillVisibilityStateKey, SkillVisibilityStateValue,
+    effective_visibility,
 };
 
 #[cfg(feature = "mcp")]

--- a/crates/awaken-ext-skills/src/lib.rs
+++ b/crates/awaken-ext-skills/src/lib.rs
@@ -53,8 +53,7 @@ pub use skill_md::SkillArgumentDef;
 pub use state::{SkillRenderedActivation, SkillState, SkillStateUpdate, SkillStateValue};
 pub use tools::{LoadSkillResourceTool, SkillActivateTool, SkillScriptTool};
 pub use visibility::{
-    DefaultSkillVisibilityPolicy, SkillVisibility, SkillVisibilityAction, SkillVisibilityPolicy,
-    SkillVisibilityStateKey, SkillVisibilityStateValue,
+    SkillVisibility, SkillVisibilityAction, SkillVisibilityStateKey, SkillVisibilityStateValue,
 };
 
 #[cfg(feature = "mcp")]

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -17,8 +17,8 @@ use crate::registry::SkillRegistry;
 use crate::skill::SkillMeta;
 use crate::state::SkillState;
 use crate::visibility::{
-    DefaultSkillVisibilityPolicy, SkillVisibility, SkillVisibilityAction, SkillVisibilityPolicy,
-    SkillVisibilityStateKey, SkillVisibilityStateValue,
+    DefaultSkillVisibilityPolicy, SkillVisibility, SkillVisibilityAction, SkillVisibilityStateKey,
+    SkillVisibilityStateValue,
 };
 
 /// Injects a skills catalog into the LLM context so the model can discover and activate skills.

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -18,7 +18,7 @@ use crate::skill::SkillMeta;
 use crate::state::SkillState;
 use crate::visibility::{
     DefaultSkillVisibilityPolicy, SkillVisibility, SkillVisibilityAction, SkillVisibilityStateKey,
-    SkillVisibilityStateValue,
+    SkillVisibilityStateValue, effective_visibility,
 };
 
 /// Injects a skills catalog into the LLM context so the model can discover and activate skills.
@@ -61,7 +61,8 @@ impl SkillDiscoveryPlugin {
 
     /// Compute initial per-skill visibility from the registry using the default
     /// policy (ADR-0020 D3): a skill starts `Hidden` if `disable-model-invocation`
-    /// is set or it is path-conditional, otherwise `Visible`.
+    /// is set, otherwise `Visible`. Path-conditional hiding is deferred until the
+    /// file-match promote hook exists (ADR-0020 D5, future).
     pub(crate) fn seed_visibility_entries(&self) -> Vec<(String, SkillVisibility)> {
         let metas: Vec<SkillMeta> = self
             .registry
@@ -83,16 +84,12 @@ impl SkillDiscoveryPlugin {
             .snapshot()
             .values()
             .filter(|s| {
-                // Filter by visibility policy state (ADR-0020). Explicit Show/Hide
-                // in the run-scoped state wins; otherwise fall back to the
-                // declarative metadata policy rather than failing open. This keeps
-                // `model_invocable=false` / path-conditional skills out of the
-                // catalog even when the seed missed them or the state is absent.
-                let meta = s.meta();
-                let vis = visibility
-                    .and_then(|v| v.explicit(&meta.id))
-                    .unwrap_or_else(|| DefaultSkillVisibilityPolicy.evaluate(meta));
-                vis != SkillVisibility::Hidden
+                // Filter by visibility (ADR-0020) through the single source of
+                // truth: explicit Show/Hide in the run-scoped state wins, else the
+                // declarative metadata policy — never failing open. This keeps
+                // `model_invocable=false` skills out of the catalog even when the
+                // seed missed them or the state is absent.
+                effective_visibility(s.meta(), visibility) != SkillVisibility::Hidden
             })
             .map(|s| s.meta().clone())
             .collect();
@@ -160,7 +157,13 @@ impl SkillDiscoveryPlugin {
         out.push_str("</skills_usage>");
 
         if out.len() > self.max_chars {
-            out.truncate(self.max_chars);
+            // Walk back to the nearest char boundary: `String::truncate` panics
+            // when the index lands inside a multibyte UTF-8 sequence (CJK, emoji).
+            let mut cut = self.max_chars;
+            while cut > 0 && !out.is_char_boundary(cut) {
+                cut -= 1;
+            }
+            out.truncate(cut);
         }
 
         out.trim_end().to_string()
@@ -359,6 +362,26 @@ mod tests {
     }
 
     #[test]
+    fn render_catalog_truncation_handles_multibyte_without_panic() {
+        // `max_chars` may fall inside a multibyte UTF-8 sequence (CJK, emoji).
+        // `String::truncate` panics on a non-char-boundary index, so rendering
+        // must walk back to the nearest boundary instead.
+        let skill: Arc<dyn Skill> =
+            Arc::new(MockSkill(SkillMeta::new("s", "s", "中".repeat(80), vec![])));
+        let mut plugin = SkillDiscoveryPlugin::new(make_registry(vec![skill]));
+        // Sweep cut points across several byte offsets; with 3-byte chars at
+        // least some of these land mid-character.
+        for max in 56..=64 {
+            plugin.max_chars = max;
+            let out = plugin.render_catalog(&HashSet::new(), None);
+            assert!(
+                out.len() <= max,
+                "output must respect max_chars (max={max})"
+            );
+        }
+    }
+
+    #[test]
     fn render_catalog_char_limit_truncates_output() {
         let mut skills: Vec<Arc<dyn Skill>> = Vec::new();
         for i in 0..10 {
@@ -418,8 +441,8 @@ mod tests {
         );
         assert_eq!(
             entries.get("conditional"),
-            Some(&SkillVisibility::Hidden),
-            "path-conditional skills must seed Hidden until promoted"
+            Some(&SkillVisibility::Visible),
+            "path-conditional hiding is deferred until the file-match promote hook (ADR-0020 D5, future)"
         );
     }
 
@@ -488,24 +511,30 @@ mod tests {
     }
 
     #[test]
-    fn render_catalog_omitted_path_conditional_skill_is_hidden() {
-        // A state map that omits a path-conditional skill must not fail open: the
-        // absent skill falls back to the metadata policy (Hidden).
+    fn render_catalog_omitted_skill_falls_back_to_metadata_policy() {
+        // A skill absent from the state map must not fail open blindly: it falls
+        // back to the metadata policy. A `disable-model-invocation` skill stays
+        // Hidden; a path-conditional skill stays Visible (hiding deferred).
         let skills: Vec<Arc<dyn Skill>> = vec![
             Arc::new(MockSkill(mock_meta("shown"))),
             Arc::new(MockSkill(path_conditional_meta("cond"))),
+            Arc::new(MockSkill(hidden_meta("blocked"))),
         ];
         let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
 
-        // State knows about `shown` only; `cond` is absent from the map.
+        // State knows about `shown` only; `cond` and `blocked` are absent.
         let mut state = SkillVisibilityStateValue::default();
         state.modes.insert("shown".into(), SkillVisibility::Visible);
 
         let catalog = plugin.render_catalog(&HashSet::new(), Some(&state));
         assert!(catalog.contains("<name>shown</name>"));
         assert!(
-            !catalog.contains("<name>cond</name>"),
-            "path-conditional skill absent from state must fall back to Hidden"
+            catalog.contains("<name>cond</name>"),
+            "path-conditional skill stays visible until the promote hook exists"
+        );
+        assert!(
+            !catalog.contains("<name>blocked</name>"),
+            "disable-model-invocation skill absent from state must fall back to Hidden"
         );
     }
 
@@ -600,6 +629,59 @@ mod tests {
         assert!(batch.is_empty(), "empty registry has nothing to seed");
     }
 
+    #[tokio::test]
+    async fn activation_seed_committed_and_first_inference_excludes_blocked_skill() {
+        // End-to-end: install → run-start on_activate seed → commit through the
+        // real StateStore → first BeforeInference hook reads the committed state
+        // → catalog excludes the disable-model-invocation skill.
+        use awaken_contract::registry_spec::AgentSpec;
+        use awaken_contract::state::MutationBatch;
+        use awaken_runtime::state::StateStore;
+
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("shown"))),
+            Arc::new(MockSkill(hidden_meta("blocked"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+
+        // Install so the run-scoped visibility key is registered for commit.
+        let store = StateStore::new();
+        store.install_plugin(plugin.clone()).unwrap();
+
+        // Run-start activation produces the seed; commit it for real.
+        let mut batch = MutationBatch::new();
+        Plugin::on_activate(&plugin, &AgentSpec::new("agent"), &mut batch).unwrap();
+        store.commit(batch).unwrap();
+
+        // The committed seed records the blocked skill Hidden, the other Visible.
+        let seeded = store
+            .read::<SkillVisibilityStateKey>()
+            .expect("on_activate must commit a visibility seed");
+        assert_eq!(seeded.explicit("shown"), Some(SkillVisibility::Visible));
+        assert_eq!(seeded.explicit("blocked"), Some(SkillVisibility::Hidden));
+
+        // First BeforeInference: the hook reads the committed snapshot state.
+        let ctx = PhaseContext::new(Phase::BeforeInference, store.snapshot());
+        let hook = SkillDiscoveryHook { plugin };
+        let cmd = PhaseHook::run(&hook, &ctx).await.unwrap();
+
+        let actions = cmd.scheduled_actions();
+        assert_eq!(
+            actions.len(),
+            1,
+            "a single catalog message must be scheduled"
+        );
+        let rendered = serde_json::to_string(&actions[0].payload).unwrap();
+        assert!(
+            rendered.contains("shown"),
+            "the visible skill must appear in the first-inference catalog"
+        );
+        assert!(
+            !rendered.contains("blocked"),
+            "a seeded-Hidden skill must never reach the first-inference catalog"
+        );
+    }
+
     #[test]
     fn seed_visibility_entries_covers_every_skill() {
         let skills: Vec<Arc<dyn Skill>> = vec![
@@ -616,9 +698,11 @@ mod tests {
     }
 
     #[test]
-    fn path_conditional_skill_appears_after_promote() {
-        // ADR-0020: a path-conditional skill starts Hidden, then a file-match
-        // hook / ToolSearch promotes it via SkillVisibilityAction.
+    fn path_conditional_skill_visible_by_default_and_action_controllable() {
+        // ADR-0020 D5 (future): a file-match hook will Hide path-conditional
+        // skills until a matching file is touched. That hook does not exist yet,
+        // so a `paths` skill seeds Visible. The Hide/Show action plumbing it will
+        // rely on is exercised here so it is ready when the matcher lands.
         let plugin = SkillDiscoveryPlugin::new(make_registry(vec![Arc::new(MockSkill(
             path_conditional_meta("cond"),
         ))]));
@@ -628,10 +712,23 @@ mod tests {
             state.modes.insert(id, vis);
         }
         assert!(
+            plugin
+                .render_catalog(&HashSet::new(), Some(&state))
+                .contains("<name>cond</name>"),
+            "path-conditional skill stays visible until the promote hook exists"
+        );
+
+        SkillVisibilityStateKey::apply(
+            &mut state,
+            SkillVisibilityAction::Hide {
+                skill_id: "cond".into(),
+            },
+        );
+        assert!(
             !plugin
                 .render_catalog(&HashSet::new(), Some(&state))
                 .contains("<name>cond</name>"),
-            "path-conditional skill must start hidden"
+            "an explicit Hide must remove the skill from the catalog"
         );
 
         SkillVisibilityStateKey::apply(
@@ -644,7 +741,7 @@ mod tests {
             plugin
                 .render_catalog(&HashSet::new(), Some(&state))
                 .contains("<name>cond</name>"),
-            "promoted skill must appear in the catalog"
+            "a subsequent ShowBatch must re-promote the skill"
         );
     }
 }

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -83,10 +83,16 @@ impl SkillDiscoveryPlugin {
             .snapshot()
             .values()
             .filter(|s| {
-                // Filter by visibility policy state (ADR-0020).
-                visibility
-                    .map(|v| v.visibility_of(&s.meta().id) != SkillVisibility::Hidden)
-                    .unwrap_or(true)
+                // Filter by visibility policy state (ADR-0020). Explicit Show/Hide
+                // in the run-scoped state wins; otherwise fall back to the
+                // declarative metadata policy rather than failing open. This keeps
+                // `model_invocable=false` / path-conditional skills out of the
+                // catalog even when the seed missed them or the state is absent.
+                let meta = s.meta();
+                let vis = visibility
+                    .and_then(|v| v.explicit(&meta.id))
+                    .unwrap_or_else(|| DefaultSkillVisibilityPolicy.evaluate(meta));
+                vis != SkillVisibility::Hidden
             })
             .map(|s| s.meta().clone())
             .collect();
@@ -454,6 +460,81 @@ mod tests {
         assert!(
             !catalog.contains("<name>nope</name>"),
             "disable-model-invocation skill must not appear in the catalog"
+        );
+    }
+
+    // --- Fail-open visibility default (FIX #12) ------------------------------
+
+    #[test]
+    fn render_catalog_none_visibility_hides_non_model_invocable() {
+        // With no visibility state at all, a `model_invocable=false` skill must
+        // fall back to the declarative metadata policy (Hidden), while a normal
+        // skill remains visible.
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("normal"))),
+            Arc::new(MockSkill(hidden_meta("no_invoke"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+
+        let catalog = plugin.render_catalog(&HashSet::new(), None);
+        assert!(
+            catalog.contains("<name>normal</name>"),
+            "a normal skill must render when visibility state is missing"
+        );
+        assert!(
+            !catalog.contains("<name>no_invoke</name>"),
+            "disable-model-invocation skill must not fail open when state is None"
+        );
+    }
+
+    #[test]
+    fn render_catalog_omitted_path_conditional_skill_is_hidden() {
+        // A state map that omits a path-conditional skill must not fail open: the
+        // absent skill falls back to the metadata policy (Hidden).
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("shown"))),
+            Arc::new(MockSkill(path_conditional_meta("cond"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+
+        // State knows about `shown` only; `cond` is absent from the map.
+        let mut state = SkillVisibilityStateValue::default();
+        state.modes.insert("shown".into(), SkillVisibility::Visible);
+
+        let catalog = plugin.render_catalog(&HashSet::new(), Some(&state));
+        assert!(catalog.contains("<name>shown</name>"));
+        assert!(
+            !catalog.contains("<name>cond</name>"),
+            "path-conditional skill absent from state must fall back to Hidden"
+        );
+    }
+
+    #[test]
+    fn render_catalog_explicit_state_overrides_metadata_policy() {
+        // Explicit Show on an otherwise-hidden skill wins; explicit Hide on an
+        // otherwise-visible skill wins.
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(hidden_meta("promoted"))),
+            Arc::new(MockSkill(mock_meta("suppressed"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+
+        let mut state = SkillVisibilityStateValue::default();
+        state
+            .modes
+            .insert("promoted".into(), SkillVisibility::Visible);
+        state
+            .modes
+            .insert("suppressed".into(), SkillVisibility::Hidden);
+
+        let catalog = plugin.render_catalog(&HashSet::new(), Some(&state));
+        assert!(
+            catalog.contains("<name>promoted</name>"),
+            "explicit Show must override the Hidden metadata default"
+        );
+        assert!(
+            !catalog.contains("<name>suppressed</name>"),
+            "explicit Hide must override the Visible metadata default"
         );
     }
 

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -6,8 +6,6 @@ use async_trait::async_trait;
 use awaken_contract::StateError;
 use awaken_contract::contract::context_message::ContextMessage;
 use awaken_contract::model::Phase;
-use awaken_contract::registry_spec::AgentSpec;
-use awaken_contract::state::MutationBatch;
 use awaken_runtime::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
 use awaken_runtime::state::StateKeyOptions;
 use awaken_runtime::{PhaseContext, PhaseHook, StateCommand};
@@ -17,8 +15,7 @@ use crate::registry::SkillRegistry;
 use crate::skill::SkillMeta;
 use crate::state::SkillState;
 use crate::visibility::{
-    DefaultSkillVisibilityPolicy, SkillVisibility, SkillVisibilityAction, SkillVisibilityStateKey,
-    SkillVisibilityStateValue, effective_visibility,
+    SkillVisibility, SkillVisibilityStateKey, SkillVisibilityStateValue, effective_visibility,
 };
 
 /// Injects a skills catalog into the LLM context so the model can discover and activate skills.
@@ -59,29 +56,6 @@ impl SkillDiscoveryPlugin {
             .replace('>', "&gt;")
     }
 
-    /// Compute the run-start visibility seed (ADR-0020 D3).
-    ///
-    /// Only **Hidden** entries are emitted — i.e. skills with
-    /// `disable-model-invocation` (`model_invocable == false`). Visible skills are
-    /// deliberately left unseeded so they resolve through
-    /// [`effective_visibility`] against live metadata; seeding them as explicit
-    /// `Visible` would mask a later metadata change (e.g. registry hot-reload
-    /// flipping a skill to non-invocable). The seed is applied insert-if-absent
-    /// (`SeedBatch`) so it never clobbers a runtime `Show`/`Hide`.
-    ///
-    /// `paths` is **not** a visibility input: the agentskills spec has no
-    /// path/glob conditional activation, so `paths`-bearing skills are surfaced
-    /// by description like any other (model-invoked).
-    pub(crate) fn seed_visibility_entries(&self) -> Vec<(String, SkillVisibility)> {
-        self.registry
-            .snapshot()
-            .values()
-            .map(|s| s.meta().clone())
-            .filter(|m| DefaultSkillVisibilityPolicy.evaluate(m) == SkillVisibility::Hidden)
-            .map(|m| (m.id, SkillVisibility::Hidden))
-            .collect()
-    }
-
     pub(crate) fn render_catalog(
         &self,
         _active: &HashSet<String>,
@@ -109,6 +83,19 @@ impl SkillDiscoveryPlugin {
         metas.sort_by(|a, b| a.id.cmp(&b.id));
 
         let total = metas.len();
+        const USAGE: &str = concat!(
+            "<skills_usage>\n",
+            "If a listed skill is relevant, call tool \"skill\" with {\"skill\": \"<id or name>\"} before answering.\n",
+            "Skill resources are not auto-loaded: use \"load_skill_resource\" with {\"skill\": \"<id>\", \"path\": \"references/<file>|assets/<file>\"}.\n",
+            "To run skill scripts: use \"skill_script\" with {\"skill\": \"<id>\", \"script\": \"scripts/<file>\", \"args\": [..]}.\n",
+            "</skills_usage>",
+        );
+        const CLOSE: &str = "</available_skills>\n";
+        // Budget reserved so the closing tag, an optional truncation note, and the
+        // usage block always fit — this keeps the emitted structure well-formed
+        // rather than hard-cutting through a tag mid-render.
+        let reserve = CLOSE.len() + USAGE.len() + 96;
+
         let mut out = String::new();
         out.push_str("<available_skills>\n");
 
@@ -136,20 +123,23 @@ impl SkillDiscoveryPlugin {
             }
             let desc = Self::escape_text(&desc);
 
-            out.push_str("<skill>\n");
-            out.push_str(&format!("<name>{}</name>\n", id));
+            let mut block = String::from("<skill>\n");
+            block.push_str(&format!("<name>{}</name>\n", id));
             if !desc.trim().is_empty() {
-                out.push_str(&format!("<description>{}</description>\n", desc));
+                block.push_str(&format!("<description>{}</description>\n", desc));
             }
-            out.push_str("</skill>\n");
-            shown += 1;
+            block.push_str("</skill>\n");
 
-            if out.len() >= self.max_chars {
+            // Stop before this skill would push us past the budget, leaving room
+            // for the closing structure. The first skill is always emitted.
+            if shown > 0 && out.len() + block.len() + reserve > self.max_chars {
                 break;
             }
+            out.push_str(&block);
+            shown += 1;
         }
 
-        out.push_str("</available_skills>\n");
+        out.push_str(CLOSE);
 
         if shown < total {
             out.push_str(&format!(
@@ -158,15 +148,12 @@ impl SkillDiscoveryPlugin {
             ));
         }
 
-        out.push_str("<skills_usage>\n");
-        out.push_str("If a listed skill is relevant, call tool \"skill\" with {\"skill\": \"<id or name>\"} before answering.\n");
-        out.push_str("Skill resources are not auto-loaded: use \"load_skill_resource\" with {\"skill\": \"<id>\", \"path\": \"references/<file>|assets/<file>\"}.\n");
-        out.push_str("To run skill scripts: use \"skill_script\" with {\"skill\": \"<id>\", \"script\": \"scripts/<file>\", \"args\": [..]}.\n");
-        out.push_str("</skills_usage>");
+        out.push_str(USAGE);
 
+        // Last-resort cap for a pathologically small budget (smaller than the
+        // structural overhead): walk back to a char boundary so `truncate` never
+        // panics on a multibyte (CJK/emoji) sequence.
         if out.len() > self.max_chars {
-            // Walk back to the nearest char boundary: `String::truncate` panics
-            // when the index lands inside a multibyte UTF-8 sequence (CJK, emoji).
             let mut cut = self.max_chars;
             while cut > 0 && !out.is_char_boundary(cut) {
                 cut -= 1;
@@ -251,23 +238,12 @@ impl Plugin for SkillDiscoveryPlugin {
         Ok(())
     }
 
-    /// Seed run-scoped skill visibility at run start (ADR-0020 D3): skills with
-    /// `disable-model-invocation` start `Hidden`. Applied insert-if-absent
-    /// (`SeedBatch`) so an already-present runtime `Show`/`Hide` is preserved
-    /// across re-activation / handoff / resume. Initial visibility derives only
-    /// from skill metadata; `_agent_spec` is not consulted (config-driven initial
-    /// visibility is future scope, ADR-0020 D5).
-    fn on_activate(
-        &self,
-        _agent_spec: &AgentSpec,
-        patch: &mut MutationBatch,
-    ) -> Result<(), StateError> {
-        let entries = self.seed_visibility_entries();
-        if !entries.is_empty() {
-            patch.update::<SkillVisibilityStateKey>(SkillVisibilityAction::SeedBatch { entries });
-        }
-        Ok(())
-    }
+    // No `on_activate` seed: visibility is resolved at render time by
+    // `effective_visibility` (hard gate on `disable-model-invocation`, else
+    // explicit runtime override, else Visible). Seeding metadata-derived defaults
+    // into the run-scoped override map is unnecessary (no fail-open) and harmful
+    // (a stale seed would mask later metadata changes), so the run-scoped state
+    // holds only genuine runtime `Show`/`Hide` overrides.
 }
 
 #[cfg(test)]
@@ -432,46 +408,6 @@ mod tests {
         m
     }
 
-    #[test]
-    fn on_activate_seeds_visibility_state_key() {
-        use awaken_contract::registry_spec::AgentSpec;
-        use awaken_contract::state::MutationBatch;
-
-        let skills: Vec<Arc<dyn Skill>> = vec![Arc::new(MockSkill(hidden_meta("no_model_invoke")))];
-        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
-
-        let spec = AgentSpec::new("agent");
-        let mut batch = MutationBatch::new();
-        Plugin::on_activate(&plugin, &spec, &mut batch).unwrap();
-
-        assert!(
-            !batch.is_empty(),
-            "on_activate must seed the visibility state when skills exist"
-        );
-    }
-
-    #[test]
-    fn seeded_visibility_excludes_hidden_skill_from_catalog() {
-        let skills: Vec<Arc<dyn Skill>> = vec![
-            Arc::new(MockSkill(mock_meta("shown"))),
-            Arc::new(MockSkill(hidden_meta("nope"))),
-        ];
-        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
-
-        // Apply the seed exactly as SkillVisibilityStateKey::apply(SeedBatch) would.
-        let mut state = SkillVisibilityStateValue::default();
-        for (id, vis) in plugin.seed_visibility_entries() {
-            state.modes.insert(id, vis);
-        }
-
-        let catalog = plugin.render_catalog(&HashSet::new(), Some(&state));
-        assert!(catalog.contains("<name>shown</name>"));
-        assert!(
-            !catalog.contains("<name>nope</name>"),
-            "disable-model-invocation skill must not appear in the catalog"
-        );
-    }
-
     // --- Fail-open visibility default (FIX #12) ------------------------------
 
     #[test]
@@ -525,11 +461,12 @@ mod tests {
     }
 
     #[test]
-    fn render_catalog_explicit_state_overrides_metadata_policy() {
-        // Explicit Show on an otherwise-hidden skill wins; explicit Hide on an
-        // otherwise-visible skill wins.
+    fn render_catalog_explicit_hide_wins_but_hard_gate_holds() {
+        // For a model-invocable skill, an explicit Hide overrides the Visible
+        // default. For a disable-model-invocation skill, the hard gate holds even
+        // against an explicit Show — it can never be revealed to the model.
         let skills: Vec<Arc<dyn Skill>> = vec![
-            Arc::new(MockSkill(hidden_meta("promoted"))),
+            Arc::new(MockSkill(hidden_meta("blocked"))),
             Arc::new(MockSkill(mock_meta("suppressed"))),
         ];
         let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
@@ -537,15 +474,15 @@ mod tests {
         let mut state = SkillVisibilityStateValue::default();
         state
             .modes
-            .insert("promoted".into(), SkillVisibility::Visible);
+            .insert("blocked".into(), SkillVisibility::Visible); // attempted Show
         state
             .modes
             .insert("suppressed".into(), SkillVisibility::Hidden);
 
         let catalog = plugin.render_catalog(&HashSet::new(), Some(&state));
         assert!(
-            catalog.contains("<name>promoted</name>"),
-            "explicit Show must override the Hidden metadata default"
+            !catalog.contains("<name>blocked</name>"),
+            "the hard gate must keep a disable-model-invocation skill out, even with Show"
         );
         assert!(
             !catalog.contains("<name>suppressed</name>"),
@@ -602,26 +539,12 @@ mod tests {
         );
     }
 
-    #[test]
-    fn on_activate_empty_registry_produces_no_seed() {
-        use awaken_contract::registry_spec::AgentSpec;
-        use awaken_contract::state::MutationBatch;
-
-        let plugin = SkillDiscoveryPlugin::new(make_registry(vec![]));
-        let spec = AgentSpec::new("agent");
-        let mut batch = MutationBatch::new();
-        Plugin::on_activate(&plugin, &spec, &mut batch).unwrap();
-
-        assert!(batch.is_empty(), "empty registry has nothing to seed");
-    }
-
     #[tokio::test]
-    async fn activation_seed_committed_and_first_inference_excludes_blocked_skill() {
-        // End-to-end: install → run-start on_activate seed → commit through the
-        // real StateStore → first BeforeInference hook reads the committed state
-        // → catalog excludes the disable-model-invocation skill.
-        use awaken_contract::registry_spec::AgentSpec;
-        use awaken_contract::state::MutationBatch;
+    async fn first_inference_excludes_disabled_skill_without_seed() {
+        // End-to-end with NO seed: install → first BeforeInference hook resolves
+        // visibility via effective_visibility (hard gate) against an empty state →
+        // the disable-model-invocation skill never reaches the catalog, the normal
+        // one does. Proves the fail-open fix without any run-start seeding.
         use awaken_runtime::state::StateStore;
 
         let skills: Vec<Arc<dyn Skill>> = vec![
@@ -629,109 +552,32 @@ mod tests {
             Arc::new(MockSkill(hidden_meta("blocked"))),
         ];
         let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
-
-        // Install so the run-scoped visibility key is registered for commit.
         let store = StateStore::new();
         store.install_plugin(plugin.clone()).unwrap();
 
-        // Run-start activation produces the seed; commit it for real.
-        let mut batch = MutationBatch::new();
-        Plugin::on_activate(&plugin, &AgentSpec::new("agent"), &mut batch).unwrap();
-        store.commit(batch).unwrap();
+        // No seed is committed; the visibility state is absent.
+        assert!(store.read::<SkillVisibilityStateKey>().is_none());
 
-        // The committed seed records only the blocked skill (Hidden). The visible
-        // skill is left unseeded — it resolves Visible via the metadata fallback.
-        let seeded = store
-            .read::<SkillVisibilityStateKey>()
-            .expect("on_activate must commit a visibility seed");
-        assert_eq!(seeded.explicit("blocked"), Some(SkillVisibility::Hidden));
-        assert_eq!(
-            seeded.explicit("shown"),
-            None,
-            "a model-invocable skill must not be seeded with an explicit entry"
-        );
-
-        // First BeforeInference: the hook reads the committed snapshot state.
         let ctx = PhaseContext::new(Phase::BeforeInference, store.snapshot());
         let hook = SkillDiscoveryHook { plugin };
         let cmd = PhaseHook::run(&hook, &ctx).await.unwrap();
 
         let actions = cmd.scheduled_actions();
-        assert_eq!(
-            actions.len(),
-            1,
-            "a single catalog message must be scheduled"
-        );
+        assert_eq!(actions.len(), 1, "a catalog message must be scheduled");
         let rendered = serde_json::to_string(&actions[0].payload).unwrap();
         assert!(
             rendered.contains("shown"),
-            "the visible skill must appear in the first-inference catalog"
+            "the model-invocable skill must appear in the first-inference catalog"
         );
         assert!(
             !rendered.contains("blocked"),
-            "a seeded-Hidden skill must never reach the first-inference catalog"
-        );
-    }
-
-    #[tokio::test]
-    async fn runtime_override_survives_reactivation_seed() {
-        // A runtime Hide on a normally-visible skill must NOT be reset when the
-        // plugin re-activates (handoff / resume / sub-agent) and re-seeds. The
-        // insert-if-absent SeedBatch guarantees the explicit override wins.
-        use awaken_contract::registry_spec::AgentSpec;
-        use awaken_contract::state::MutationBatch;
-        use awaken_runtime::state::StateStore;
-
-        let skills: Vec<Arc<dyn Skill>> = vec![
-            Arc::new(MockSkill(mock_meta("a"))),
-            Arc::new(MockSkill(hidden_meta("blocked"))),
-        ];
-        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
-        let store = StateStore::new();
-        store.install_plugin(plugin.clone()).unwrap();
-
-        // First activation seeds blocked=Hidden.
-        let mut batch = MutationBatch::new();
-        Plugin::on_activate(&plugin, &AgentSpec::new("agent"), &mut batch).unwrap();
-        store.commit(batch).unwrap();
-
-        // A tool/user hides the otherwise-visible skill "a" at runtime.
-        let mut override_batch = MutationBatch::new();
-        crate::visibility::hide_skill(&mut override_batch, "a");
-        store.commit(override_batch).unwrap();
-
-        // Re-activation re-runs the seed (insert-if-absent).
-        let mut reseed = MutationBatch::new();
-        Plugin::on_activate(&plugin, &AgentSpec::new("agent"), &mut reseed).unwrap();
-        store.commit(reseed).unwrap();
-
-        let state = store.read::<SkillVisibilityStateKey>().unwrap();
-        assert_eq!(
-            state.explicit("a"),
-            Some(SkillVisibility::Hidden),
-            "runtime Hide must survive re-activation"
-        );
-        assert_eq!(state.explicit("blocked"), Some(SkillVisibility::Hidden));
-    }
-
-    #[test]
-    fn seed_visibility_entries_only_covers_hidden_skills() {
-        let skills: Vec<Arc<dyn Skill>> = vec![
-            Arc::new(MockSkill(mock_meta("a"))),             // visible
-            Arc::new(MockSkill(hidden_meta("b"))),           // model_invocable=false
-            Arc::new(MockSkill(path_conditional_meta("c"))), // paths, still visible
-        ];
-        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
-        let entries = plugin.seed_visibility_entries();
-        assert_eq!(
-            entries,
-            vec![("b".to_string(), SkillVisibility::Hidden)],
-            "only the disable-model-invocation skill is seeded"
+            "disable-model-invocation must hard-gate the skill out, with no seed"
         );
     }
 
     #[test]
     fn paths_skill_is_visible_and_action_controllable() {
+        use crate::visibility::SkillVisibilityAction;
         // The agentskills spec has no path/glob conditional activation, so a
         // `paths`-bearing skill is surfaced like any other (Visible, model-invoked
         // by description). It is still controllable through the generic
@@ -740,10 +586,8 @@ mod tests {
             path_conditional_meta("cond"),
         ))]));
 
+        // No seed; start from empty state. The paths skill resolves Visible.
         let mut state = SkillVisibilityStateValue::default();
-        for (id, vis) in plugin.seed_visibility_entries() {
-            state.modes.insert(id, vis);
-        }
         assert!(
             plugin
                 .render_catalog(&HashSet::new(), Some(&state))

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -458,7 +458,7 @@ mod tests {
         ];
         let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
 
-        // Apply the seed exactly as SkillVisibilityStateKey::apply(SetBatch) would.
+        // Apply the seed exactly as SkillVisibilityStateKey::apply(SeedBatch) would.
         let mut state = SkillVisibilityStateValue::default();
         for (id, vis) in plugin.seed_visibility_entries() {
             state.modes.insert(id, vis);
@@ -500,7 +500,7 @@ mod tests {
     fn render_catalog_omitted_skill_falls_back_to_metadata_policy() {
         // A skill absent from the state map must not fail open blindly: it falls
         // back to the metadata policy. A `disable-model-invocation` skill stays
-        // Hidden; a path-conditional skill stays Visible (hiding deferred).
+        // Hidden; a `paths`-bearing skill stays Visible (paths does not gate it).
         let skills: Vec<Arc<dyn Skill>> = vec![
             Arc::new(MockSkill(mock_meta("shown"))),
             Arc::new(MockSkill(path_conditional_meta("cond"))),
@@ -516,7 +516,7 @@ mod tests {
         assert!(catalog.contains("<name>shown</name>"));
         assert!(
             catalog.contains("<name>cond</name>"),
-            "path-conditional skill stays visible until the promote hook exists"
+            "a paths-bearing skill stays visible (paths does not gate visibility)"
         );
         assert!(
             !catalog.contains("<name>blocked</name>"),

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -6,6 +6,8 @@ use async_trait::async_trait;
 use awaken_contract::StateError;
 use awaken_contract::contract::context_message::ContextMessage;
 use awaken_contract::model::Phase;
+use awaken_contract::registry_spec::AgentSpec;
+use awaken_contract::state::MutationBatch;
 use awaken_runtime::plugins::{Plugin, PluginDescriptor, PluginRegistrar};
 use awaken_runtime::state::StateKeyOptions;
 use awaken_runtime::{PhaseContext, PhaseHook, StateCommand};
@@ -14,7 +16,10 @@ use crate::SKILLS_DISCOVERY_PLUGIN_ID;
 use crate::registry::SkillRegistry;
 use crate::skill::SkillMeta;
 use crate::state::SkillState;
-use crate::visibility::{SkillVisibility, SkillVisibilityStateKey, SkillVisibilityStateValue};
+use crate::visibility::{
+    DefaultSkillVisibilityPolicy, SkillVisibility, SkillVisibilityAction, SkillVisibilityPolicy,
+    SkillVisibilityStateKey, SkillVisibilityStateValue,
+};
 
 /// Injects a skills catalog into the LLM context so the model can discover and activate skills.
 #[derive(Clone)]
@@ -52,6 +57,20 @@ impl SkillDiscoveryPlugin {
         s.replace('&', "&amp;")
             .replace('<', "&lt;")
             .replace('>', "&gt;")
+    }
+
+    /// Compute initial per-skill visibility from the registry using the default
+    /// policy (ADR-0020 D3): a skill starts `Hidden` if `disable-model-invocation`
+    /// is set or it is path-conditional, otherwise `Visible`.
+    pub(crate) fn seed_visibility_entries(&self) -> Vec<(String, SkillVisibility)> {
+        let metas: Vec<SkillMeta> = self
+            .registry
+            .snapshot()
+            .values()
+            .map(|s| s.meta().clone())
+            .collect();
+        let refs: Vec<&SkillMeta> = metas.iter().collect();
+        DefaultSkillVisibilityPolicy.seed(&refs)
     }
 
     pub(crate) fn render_catalog(
@@ -214,6 +233,20 @@ impl Plugin for SkillDiscoveryPlugin {
 
         Ok(())
     }
+
+    /// Seed run-scoped skill visibility at run start (ADR-0020 D3) so that
+    /// `disable-model-invocation` and path-conditional skills start `Hidden`.
+    fn on_activate(
+        &self,
+        _agent_spec: &AgentSpec,
+        patch: &mut MutationBatch,
+    ) -> Result<(), StateError> {
+        let entries = self.seed_visibility_entries();
+        if !entries.is_empty() {
+            patch.update::<SkillVisibilityStateKey>(SkillVisibilityAction::SetBatch { entries });
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -342,5 +375,85 @@ mod tests {
         let s = plugin.render_catalog(&active, None);
         assert!(s.contains("truncated"));
         assert_eq!(s.matches("<skill>").count(), 2);
+    }
+
+    // --- Visibility seeding (ADR-0020 D3) -----------------------------------
+
+    fn hidden_meta(id: &str) -> SkillMeta {
+        let mut m = mock_meta(id);
+        m.model_invocable = false; // frontmatter `disable-model-invocation: true`
+        m
+    }
+
+    fn path_conditional_meta(id: &str) -> SkillMeta {
+        let mut m = mock_meta(id);
+        m.paths = vec!["src/**/*.rs".to_string()];
+        m
+    }
+
+    #[test]
+    fn seed_visibility_entries_classifies_by_metadata() {
+        use std::collections::HashMap;
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("visible"))),
+            Arc::new(MockSkill(hidden_meta("no_model_invoke"))),
+            Arc::new(MockSkill(path_conditional_meta("conditional"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+
+        let entries: HashMap<String, SkillVisibility> =
+            plugin.seed_visibility_entries().into_iter().collect();
+
+        assert_eq!(entries.get("visible"), Some(&SkillVisibility::Visible));
+        assert_eq!(
+            entries.get("no_model_invoke"),
+            Some(&SkillVisibility::Hidden),
+            "disable-model-invocation skills must seed Hidden"
+        );
+        assert_eq!(
+            entries.get("conditional"),
+            Some(&SkillVisibility::Hidden),
+            "path-conditional skills must seed Hidden until promoted"
+        );
+    }
+
+    #[test]
+    fn on_activate_seeds_visibility_state_key() {
+        use awaken_contract::registry_spec::AgentSpec;
+        use awaken_contract::state::MutationBatch;
+
+        let skills: Vec<Arc<dyn Skill>> = vec![Arc::new(MockSkill(hidden_meta("no_model_invoke")))];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+
+        let spec = AgentSpec::new("agent");
+        let mut batch = MutationBatch::new();
+        Plugin::on_activate(&plugin, &spec, &mut batch).unwrap();
+
+        assert!(
+            !batch.is_empty(),
+            "on_activate must seed the visibility state when skills exist"
+        );
+    }
+
+    #[test]
+    fn seeded_visibility_excludes_hidden_skill_from_catalog() {
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("shown"))),
+            Arc::new(MockSkill(hidden_meta("nope"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+
+        // Apply the seed exactly as SkillVisibilityStateKey::apply(SetBatch) would.
+        let mut state = SkillVisibilityStateValue::default();
+        for (id, vis) in plugin.seed_visibility_entries() {
+            state.modes.insert(id, vis);
+        }
+
+        let catalog = plugin.render_catalog(&HashSet::new(), Some(&state));
+        assert!(catalog.contains("<name>shown</name>"));
+        assert!(
+            !catalog.contains("<name>nope</name>"),
+            "disable-model-invocation skill must not appear in the catalog"
+        );
     }
 }

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -456,4 +456,114 @@ mod tests {
             "disable-model-invocation skill must not appear in the catalog"
         );
     }
+
+    fn make_ctx_with_visibility(entries: Vec<(String, SkillVisibility)>) -> PhaseContext {
+        let mut state_map = StateMap::default();
+        let mut val = SkillVisibilityStateValue::default();
+        for (id, vis) in entries {
+            val.modes.insert(id, vis);
+        }
+        state_map.insert::<SkillVisibilityStateKey>(val);
+        let snapshot = Snapshot::new(0, Arc::new(state_map));
+        PhaseContext::new(Phase::BeforeInference, snapshot)
+    }
+
+    #[tokio::test]
+    async fn hook_skips_catalog_when_all_skills_hidden() {
+        // The runtime read path: the hook reads SkillVisibilityStateKey from the
+        // phase context and must honor it. All skills hidden => no catalog message.
+        let skills: Vec<Arc<dyn Skill>> = vec![Arc::new(MockSkill(mock_meta("only")))];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+        let hook = SkillDiscoveryHook { plugin };
+
+        let ctx = make_ctx_with_visibility(vec![("only".into(), SkillVisibility::Hidden)]);
+        let cmd = PhaseHook::run(&hook, &ctx).await.unwrap();
+        assert!(
+            cmd.is_empty(),
+            "hook must emit no catalog when every skill is hidden"
+        );
+    }
+
+    #[tokio::test]
+    async fn hook_renders_only_visible_skills_from_seeded_state() {
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("shown"))),
+            Arc::new(MockSkill(mock_meta("gone"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+        let hook = SkillDiscoveryHook {
+            plugin: plugin.clone(),
+        };
+
+        let ctx = make_ctx_with_visibility(vec![
+            ("shown".into(), SkillVisibility::Visible),
+            ("gone".into(), SkillVisibility::Hidden),
+        ]);
+        let cmd = PhaseHook::run(&hook, &ctx).await.unwrap();
+        assert!(
+            !cmd.scheduled_actions().is_empty(),
+            "a visible skill must still produce a catalog"
+        );
+    }
+
+    #[test]
+    fn on_activate_empty_registry_produces_no_seed() {
+        use awaken_contract::registry_spec::AgentSpec;
+        use awaken_contract::state::MutationBatch;
+
+        let plugin = SkillDiscoveryPlugin::new(make_registry(vec![]));
+        let spec = AgentSpec::new("agent");
+        let mut batch = MutationBatch::new();
+        Plugin::on_activate(&plugin, &spec, &mut batch).unwrap();
+
+        assert!(batch.is_empty(), "empty registry has nothing to seed");
+    }
+
+    #[test]
+    fn seed_visibility_entries_covers_every_skill() {
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("a"))),
+            Arc::new(MockSkill(hidden_meta("b"))),
+            Arc::new(MockSkill(path_conditional_meta("c"))),
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+        assert_eq!(
+            plugin.seed_visibility_entries().len(),
+            3,
+            "every registered skill must get a seeded visibility entry"
+        );
+    }
+
+    #[test]
+    fn path_conditional_skill_appears_after_promote() {
+        // ADR-0020: a path-conditional skill starts Hidden, then a file-match
+        // hook / ToolSearch promotes it via SkillVisibilityAction.
+        let plugin = SkillDiscoveryPlugin::new(make_registry(vec![Arc::new(MockSkill(
+            path_conditional_meta("cond"),
+        ))]));
+
+        let mut state = SkillVisibilityStateValue::default();
+        for (id, vis) in plugin.seed_visibility_entries() {
+            state.modes.insert(id, vis);
+        }
+        assert!(
+            !plugin
+                .render_catalog(&HashSet::new(), Some(&state))
+                .contains("<name>cond</name>"),
+            "path-conditional skill must start hidden"
+        );
+
+        SkillVisibilityStateKey::apply(
+            &mut state,
+            SkillVisibilityAction::ShowBatch {
+                skill_ids: vec!["cond".into()],
+            },
+        );
+        assert!(
+            plugin
+                .render_catalog(&HashSet::new(), Some(&state))
+                .contains("<name>cond</name>"),
+            "promoted skill must appear in the catalog"
+        );
+    }
 }

--- a/crates/awaken-ext-skills/src/plugin/discovery.rs
+++ b/crates/awaken-ext-skills/src/plugin/discovery.rs
@@ -59,19 +59,27 @@ impl SkillDiscoveryPlugin {
             .replace('>', "&gt;")
     }
 
-    /// Compute initial per-skill visibility from the registry using the default
-    /// policy (ADR-0020 D3): a skill starts `Hidden` if `disable-model-invocation`
-    /// is set, otherwise `Visible`. Path-conditional hiding is deferred until the
-    /// file-match promote hook exists (ADR-0020 D5, future).
+    /// Compute the run-start visibility seed (ADR-0020 D3).
+    ///
+    /// Only **Hidden** entries are emitted — i.e. skills with
+    /// `disable-model-invocation` (`model_invocable == false`). Visible skills are
+    /// deliberately left unseeded so they resolve through
+    /// [`effective_visibility`] against live metadata; seeding them as explicit
+    /// `Visible` would mask a later metadata change (e.g. registry hot-reload
+    /// flipping a skill to non-invocable). The seed is applied insert-if-absent
+    /// (`SeedBatch`) so it never clobbers a runtime `Show`/`Hide`.
+    ///
+    /// `paths` is **not** a visibility input: the agentskills spec has no
+    /// path/glob conditional activation, so `paths`-bearing skills are surfaced
+    /// by description like any other (model-invoked).
     pub(crate) fn seed_visibility_entries(&self) -> Vec<(String, SkillVisibility)> {
-        let metas: Vec<SkillMeta> = self
-            .registry
+        self.registry
             .snapshot()
             .values()
             .map(|s| s.meta().clone())
-            .collect();
-        let refs: Vec<&SkillMeta> = metas.iter().collect();
-        DefaultSkillVisibilityPolicy.seed(&refs)
+            .filter(|m| DefaultSkillVisibilityPolicy.evaluate(m) == SkillVisibility::Hidden)
+            .map(|m| (m.id, SkillVisibility::Hidden))
+            .collect()
     }
 
     pub(crate) fn render_catalog(
@@ -243,8 +251,12 @@ impl Plugin for SkillDiscoveryPlugin {
         Ok(())
     }
 
-    /// Seed run-scoped skill visibility at run start (ADR-0020 D3) so that
-    /// `disable-model-invocation` and path-conditional skills start `Hidden`.
+    /// Seed run-scoped skill visibility at run start (ADR-0020 D3): skills with
+    /// `disable-model-invocation` start `Hidden`. Applied insert-if-absent
+    /// (`SeedBatch`) so an already-present runtime `Show`/`Hide` is preserved
+    /// across re-activation / handoff / resume. Initial visibility derives only
+    /// from skill metadata; `_agent_spec` is not consulted (config-driven initial
+    /// visibility is future scope, ADR-0020 D5).
     fn on_activate(
         &self,
         _agent_spec: &AgentSpec,
@@ -252,7 +264,7 @@ impl Plugin for SkillDiscoveryPlugin {
     ) -> Result<(), StateError> {
         let entries = self.seed_visibility_entries();
         if !entries.is_empty() {
-            patch.update::<SkillVisibilityStateKey>(SkillVisibilityAction::SetBatch { entries });
+            patch.update::<SkillVisibilityStateKey>(SkillVisibilityAction::SeedBatch { entries });
         }
         Ok(())
     }
@@ -418,32 +430,6 @@ mod tests {
         let mut m = mock_meta(id);
         m.paths = vec!["src/**/*.rs".to_string()];
         m
-    }
-
-    #[test]
-    fn seed_visibility_entries_classifies_by_metadata() {
-        use std::collections::HashMap;
-        let skills: Vec<Arc<dyn Skill>> = vec![
-            Arc::new(MockSkill(mock_meta("visible"))),
-            Arc::new(MockSkill(hidden_meta("no_model_invoke"))),
-            Arc::new(MockSkill(path_conditional_meta("conditional"))),
-        ];
-        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
-
-        let entries: HashMap<String, SkillVisibility> =
-            plugin.seed_visibility_entries().into_iter().collect();
-
-        assert_eq!(entries.get("visible"), Some(&SkillVisibility::Visible));
-        assert_eq!(
-            entries.get("no_model_invoke"),
-            Some(&SkillVisibility::Hidden),
-            "disable-model-invocation skills must seed Hidden"
-        );
-        assert_eq!(
-            entries.get("conditional"),
-            Some(&SkillVisibility::Visible),
-            "path-conditional hiding is deferred until the file-match promote hook (ADR-0020 D5, future)"
-        );
     }
 
     #[test]
@@ -653,12 +639,17 @@ mod tests {
         Plugin::on_activate(&plugin, &AgentSpec::new("agent"), &mut batch).unwrap();
         store.commit(batch).unwrap();
 
-        // The committed seed records the blocked skill Hidden, the other Visible.
+        // The committed seed records only the blocked skill (Hidden). The visible
+        // skill is left unseeded — it resolves Visible via the metadata fallback.
         let seeded = store
             .read::<SkillVisibilityStateKey>()
             .expect("on_activate must commit a visibility seed");
-        assert_eq!(seeded.explicit("shown"), Some(SkillVisibility::Visible));
         assert_eq!(seeded.explicit("blocked"), Some(SkillVisibility::Hidden));
+        assert_eq!(
+            seeded.explicit("shown"),
+            None,
+            "a model-invocable skill must not be seeded with an explicit entry"
+        );
 
         // First BeforeInference: the hook reads the committed snapshot state.
         let ctx = PhaseContext::new(Phase::BeforeInference, store.snapshot());
@@ -682,27 +673,69 @@ mod tests {
         );
     }
 
-    #[test]
-    fn seed_visibility_entries_covers_every_skill() {
+    #[tokio::test]
+    async fn runtime_override_survives_reactivation_seed() {
+        // A runtime Hide on a normally-visible skill must NOT be reset when the
+        // plugin re-activates (handoff / resume / sub-agent) and re-seeds. The
+        // insert-if-absent SeedBatch guarantees the explicit override wins.
+        use awaken_contract::registry_spec::AgentSpec;
+        use awaken_contract::state::MutationBatch;
+        use awaken_runtime::state::StateStore;
+
         let skills: Vec<Arc<dyn Skill>> = vec![
             Arc::new(MockSkill(mock_meta("a"))),
-            Arc::new(MockSkill(hidden_meta("b"))),
-            Arc::new(MockSkill(path_conditional_meta("c"))),
+            Arc::new(MockSkill(hidden_meta("blocked"))),
         ];
         let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+        let store = StateStore::new();
+        store.install_plugin(plugin.clone()).unwrap();
+
+        // First activation seeds blocked=Hidden.
+        let mut batch = MutationBatch::new();
+        Plugin::on_activate(&plugin, &AgentSpec::new("agent"), &mut batch).unwrap();
+        store.commit(batch).unwrap();
+
+        // A tool/user hides the otherwise-visible skill "a" at runtime.
+        let mut override_batch = MutationBatch::new();
+        crate::visibility::hide_skill(&mut override_batch, "a");
+        store.commit(override_batch).unwrap();
+
+        // Re-activation re-runs the seed (insert-if-absent).
+        let mut reseed = MutationBatch::new();
+        Plugin::on_activate(&plugin, &AgentSpec::new("agent"), &mut reseed).unwrap();
+        store.commit(reseed).unwrap();
+
+        let state = store.read::<SkillVisibilityStateKey>().unwrap();
         assert_eq!(
-            plugin.seed_visibility_entries().len(),
-            3,
-            "every registered skill must get a seeded visibility entry"
+            state.explicit("a"),
+            Some(SkillVisibility::Hidden),
+            "runtime Hide must survive re-activation"
+        );
+        assert_eq!(state.explicit("blocked"), Some(SkillVisibility::Hidden));
+    }
+
+    #[test]
+    fn seed_visibility_entries_only_covers_hidden_skills() {
+        let skills: Vec<Arc<dyn Skill>> = vec![
+            Arc::new(MockSkill(mock_meta("a"))),             // visible
+            Arc::new(MockSkill(hidden_meta("b"))),           // model_invocable=false
+            Arc::new(MockSkill(path_conditional_meta("c"))), // paths, still visible
+        ];
+        let plugin = SkillDiscoveryPlugin::new(make_registry(skills));
+        let entries = plugin.seed_visibility_entries();
+        assert_eq!(
+            entries,
+            vec![("b".to_string(), SkillVisibility::Hidden)],
+            "only the disable-model-invocation skill is seeded"
         );
     }
 
     #[test]
-    fn path_conditional_skill_visible_by_default_and_action_controllable() {
-        // ADR-0020 D5 (future): a file-match hook will Hide path-conditional
-        // skills until a matching file is touched. That hook does not exist yet,
-        // so a `paths` skill seeds Visible. The Hide/Show action plumbing it will
-        // rely on is exercised here so it is ready when the matcher lands.
+    fn paths_skill_is_visible_and_action_controllable() {
+        // The agentskills spec has no path/glob conditional activation, so a
+        // `paths`-bearing skill is surfaced like any other (Visible, model-invoked
+        // by description). It is still controllable through the generic
+        // Show/Hide action mechanism.
         let plugin = SkillDiscoveryPlugin::new(make_registry(vec![Arc::new(MockSkill(
             path_conditional_meta("cond"),
         ))]));
@@ -715,7 +748,7 @@ mod tests {
             plugin
                 .render_catalog(&HashSet::new(), Some(&state))
                 .contains("<name>cond</name>"),
-            "path-conditional skill stays visible until the promote hook exists"
+            "a paths-bearing skill is visible by default (paths does not gate visibility)"
         );
 
         SkillVisibilityStateKey::apply(

--- a/crates/awaken-ext-skills/src/registry.rs
+++ b/crates/awaken-ext-skills/src/registry.rs
@@ -1,6 +1,6 @@
 use crate::error::{SkillError, SkillRegistryError, SkillRegistryManagerError, SkillWarning};
-use crate::skill::{Skill, SkillContext, SkillMeta};
-use crate::skill_md::{SkillFrontmatter, parse_allowed_tools, parse_skill_md};
+use crate::skill::{Skill, SkillMeta};
+use crate::skill_md::{SkillFrontmatter, parse_skill_md};
 use awaken_contract::PeriodicRefresher;
 use std::collections::HashMap;
 use std::fs;
@@ -545,44 +545,7 @@ fn build_fs_skill(dir_name: &str, skill_md: &Path) -> Result<FsSkill, String> {
         ));
     }
 
-    let allowed_tools = fm
-        .allowed_tools
-        .as_deref()
-        .map(parse_allowed_tools)
-        .transpose()
-        .map_err(|e| e.to_string())?
-        .unwrap_or_default()
-        .into_iter()
-        .map(|t| t.raw)
-        .collect::<Vec<_>>();
-
-    // Parse paths: comma or newline separated, trimmed, deduplicated.
-    let paths: Vec<String> = fm
-        .paths
-        .as_deref()
-        .map(|s| {
-            s.split([',', '\n'])
-                .map(str::trim)
-                .filter(|p| !p.is_empty() && *p != "**")
-                .map(String::from)
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let context = match fm.context.as_deref() {
-        Some("fork") => SkillContext::Fork,
-        _ => SkillContext::Inline,
-    };
-
-    let mut meta = SkillMeta::new(fm.name.clone(), fm.name, fm.description, allowed_tools);
-    meta.when_to_use = fm.when_to_use;
-    meta.arguments = fm.arguments.unwrap_or_default();
-    meta.argument_hint = fm.argument_hint;
-    meta.user_invocable = fm.user_invocable.unwrap_or(true);
-    meta.model_invocable = !fm.disable_model_invocation.unwrap_or(false);
-    meta.model_override = fm.model;
-    meta.context = context;
-    meta.paths = paths;
+    let meta = crate::skill_md::meta_from_frontmatter(fm)?;
 
     Ok(FsSkill {
         meta,

--- a/crates/awaken-ext-skills/src/skill_md.rs
+++ b/crates/awaken-ext-skills/src/skill_md.rs
@@ -43,7 +43,9 @@ pub struct SkillFrontmatter {
     /// Whether the user can invoke this skill via `/skill-name` (default: true).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_invocable: Option<bool>,
-    /// If true, this skill is hidden from the LLM catalog (default: false).
+    /// If true, this skill is hidden from the LLM catalog and blocked from
+    /// model-facing skill tools (default: false). This is not access control:
+    /// explicit `/skill-name` user invocation is governed by `user-invocable`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disable_model_invocation: Option<bool>,
     /// Override the model used when this skill is activated.
@@ -52,7 +54,8 @@ pub struct SkillFrontmatter {
     /// Execution mode: "inline" (default) or "fork".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<String>,
-    /// Comma/newline-separated glob patterns for conditional activation.
+    /// Comma/newline-separated glob patterns. Parsed for forward-compatible
+    /// metadata round-tripping only; currently inert.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub paths: Option<String>,
 }

--- a/crates/awaken-ext-skills/src/skill_md.rs
+++ b/crates/awaken-ext-skills/src/skill_md.rs
@@ -1,7 +1,9 @@
 use awaken_contract::{AllowedTool, parse_skill_allowed_tool_token, parse_skill_allowed_tools};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use unicode_normalization::UnicodeNormalization;
+
+use crate::skill::{SkillContext, SkillMeta};
 
 /// YAML frontmatter for a skill.
 ///
@@ -70,6 +72,55 @@ pub struct SkillArgumentDef {
 pub struct SkillDoc {
     pub frontmatter: SkillFrontmatter,
     pub body: String,
+}
+
+/// Build a [`SkillMeta`] from parsed frontmatter, mapping every
+/// visibility/invocation field. This is the single mapping both `FsSkill` and
+/// `EmbeddedSkill` use, so embedded and filesystem skills honor
+/// `disable-model-invocation`, `user-invocable`, `when-to-use`, `paths`, etc.
+/// identically. `id` and `name` both come from `name`.
+pub fn meta_from_frontmatter(fm: SkillFrontmatter) -> Result<SkillMeta, String> {
+    let allowed_tools = fm
+        .allowed_tools
+        .as_deref()
+        .map(parse_allowed_tools)
+        .transpose()
+        .map_err(|e| e.to_string())?
+        .unwrap_or_default()
+        .into_iter()
+        .map(|t| t.raw)
+        .collect::<Vec<_>>();
+
+    // Parse paths: comma or newline separated, trimmed, deduplicated (order kept).
+    let paths: Vec<String> = fm
+        .paths
+        .as_deref()
+        .map(|s| {
+            let mut seen = HashSet::new();
+            s.split([',', '\n'])
+                .map(str::trim)
+                .filter(|p| !p.is_empty() && *p != "**")
+                .filter(|p| seen.insert(p.to_string()))
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let context = match fm.context.as_deref() {
+        Some("fork") => SkillContext::Fork,
+        _ => SkillContext::Inline,
+    };
+
+    let mut meta = SkillMeta::new(fm.name.clone(), fm.name, fm.description, allowed_tools);
+    meta.when_to_use = fm.when_to_use;
+    meta.arguments = fm.arguments.unwrap_or_default();
+    meta.argument_hint = fm.argument_hint;
+    meta.user_invocable = fm.user_invocable.unwrap_or(true);
+    meta.model_invocable = !fm.disable_model_invocation.unwrap_or(false);
+    meta.model_override = fm.model;
+    meta.context = context;
+    meta.paths = paths;
+    Ok(meta)
 }
 
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]

--- a/crates/awaken-ext-skills/src/tools.rs
+++ b/crates/awaken-ext-skills/src/tools.rs
@@ -107,8 +107,8 @@ impl Tool for SkillActivateTool {
         };
         let meta = skill.meta();
 
-        // `disable-model-invocation` is the hard invocation guard, not just a
-        // catalog hint (catalog hiding only controls discovery noise).
+        // Hard guard for the MODEL path (this tool); `user-invocable` (/skill-name)
+        // is a separate path, unaffected. Catalog hiding only controls noise.
         if !meta.model_invocable {
             return Ok(tool_error(
                 SKILL_ACTIVATE_TOOL_ID,

--- a/crates/awaken-ext-skills/src/tools.rs
+++ b/crates/awaken-ext-skills/src/tools.rs
@@ -54,10 +54,36 @@ impl SkillActivateTool {
     pub fn new(registry: Arc<dyn SkillRegistry>) -> Self {
         Self { registry }
     }
+}
 
-    fn resolve(&self, key: &str) -> Option<Arc<dyn Skill>> {
-        self.registry.get(key.trim())
+/// Resolve a skill for a MODEL-facing tool call: look it up, error if unknown,
+/// and enforce the `disable-model-invocation` hard guard. `disable-model-invocation`
+/// must block every model entry point — activation, resource loading, and script
+/// execution — not just the catalog. Returns the skill, or the `ToolResult` to
+/// return early. (`/skill-name` user invocation is a separate path.)
+fn resolve_for_model(
+    registry: &Arc<dyn SkillRegistry>,
+    key: &str,
+    tool_id: &str,
+) -> Result<Arc<dyn Skill>, Box<ToolResult>> {
+    let skill = registry.get(key.trim()).ok_or_else(|| {
+        Box::new(tool_error(
+            tool_id,
+            "unknown_skill",
+            format!("Unknown skill: {key}"),
+        ))
+    })?;
+    if !skill.meta().model_invocable {
+        return Err(Box::new(tool_error(
+            tool_id,
+            "model_invocation_disabled",
+            format!(
+                "Skill '{}' has disable-model-invocation set",
+                skill.meta().id
+            ),
+        )));
     }
+    Ok(skill)
 }
 
 #[async_trait::async_trait]
@@ -94,29 +120,11 @@ impl Tool for SkillActivateTool {
             }
         };
 
-        let skill = self.resolve(&key).ok_or_else(|| {
-            tool_error(
-                SKILL_ACTIVATE_TOOL_ID,
-                "unknown_skill",
-                format!("Unknown skill: {key}"),
-            )
-        });
-        let skill = match skill {
+        let skill = match resolve_for_model(&self.registry, &key, SKILL_ACTIVATE_TOOL_ID) {
             Ok(s) => s,
-            Err(r) => return Ok(r.into()),
+            Err(r) => return Ok((*r).into()),
         };
         let meta = skill.meta();
-
-        // Hard guard for the MODEL path (this tool); `user-invocable` (/skill-name)
-        // is a separate path, unaffected. Catalog hiding only controls noise.
-        if !meta.model_invocable {
-            return Ok(tool_error(
-                SKILL_ACTIVATE_TOOL_ID,
-                "model_invocation_disabled",
-                format!("Skill '{}' has disable-model-invocation set", meta.id),
-            )
-            .into());
-        }
 
         let activation_args = activation_args(&args);
         let activation = skill
@@ -241,10 +249,6 @@ impl LoadSkillResourceTool {
     pub fn new(registry: Arc<dyn SkillRegistry>) -> Self {
         Self { registry }
     }
-
-    fn resolve(&self, key: &str) -> Option<Arc<dyn Skill>> {
-        self.registry.get(key.trim())
-    }
 }
 
 #[async_trait::async_trait]
@@ -281,12 +285,9 @@ impl Tool for LoadSkillResourceTool {
             Err(err) => return Ok(err.into_tool_result(tool_name).into()),
         };
 
-        let skill = self
-            .resolve(&key)
-            .ok_or_else(|| tool_error(tool_name, "unknown_skill", format!("Unknown skill: {key}")));
-        let skill = match skill {
+        let skill = match resolve_for_model(&self.registry, &key, tool_name) {
             Ok(v) => v,
-            Err(r) => return Ok(r.into()),
+            Err(r) => return Ok((*r).into()),
         };
         let meta = skill.meta();
 
@@ -372,10 +373,6 @@ impl SkillScriptTool {
     pub fn new(registry: Arc<dyn SkillRegistry>) -> Self {
         Self { registry }
     }
-
-    fn resolve(&self, key: &str) -> Option<Arc<dyn Skill>> {
-        self.registry.get(key.trim())
-    }
 }
 
 #[async_trait::async_trait]
@@ -416,16 +413,9 @@ impl Tool for SkillScriptTool {
             })
             .unwrap_or_default();
 
-        let skill = self.resolve(&key).ok_or_else(|| {
-            tool_error(
-                SKILL_SCRIPT_TOOL_ID,
-                "unknown_skill",
-                format!("Unknown skill: {key}"),
-            )
-        });
-        let skill = match skill {
+        let skill = match resolve_for_model(&self.registry, &key, SKILL_SCRIPT_TOOL_ID) {
             Ok(v) => v,
-            Err(r) => return Ok(r.into()),
+            Err(r) => return Ok((*r).into()),
         };
         let meta = skill.meta();
 

--- a/crates/awaken-ext-skills/src/tools.rs
+++ b/crates/awaken-ext-skills/src/tools.rs
@@ -107,6 +107,17 @@ impl Tool for SkillActivateTool {
         };
         let meta = skill.meta();
 
+        // `disable-model-invocation` is the hard invocation guard, not just a
+        // catalog hint (catalog hiding only controls discovery noise).
+        if !meta.model_invocable {
+            return Ok(tool_error(
+                SKILL_ACTIVATE_TOOL_ID,
+                "model_invocation_disabled",
+                format!("Skill '{}' has disable-model-invocation set", meta.id),
+            )
+            .into());
+        }
+
         let activation_args = activation_args(&args);
         let activation = skill
             .activate(activation_args)
@@ -754,25 +765,9 @@ mod tests {
         assert!(required.iter().any(|v: &Value| v.as_str() == Some("skill")));
     }
 
-    #[tokio::test]
-    async fn skill_activate_empty_skill_id_returns_error() {
-        let registry = Arc::new(InMemorySkillRegistry::new());
-        let tool = SkillActivateTool::new(registry);
-        let ctx = ToolCallContext::test_default();
-
-        let result = tool.execute(json!({"skill": ""}), &ctx).await.unwrap();
-        assert!(result.result.is_error());
-    }
-
-    #[tokio::test]
-    async fn skill_activate_whitespace_only_skill_id_returns_error() {
-        let registry = Arc::new(InMemorySkillRegistry::new());
-        let tool = SkillActivateTool::new(registry);
-        let ctx = ToolCallContext::test_default();
-
-        let result = tool.execute(json!({"skill": "   "}), &ctx).await.unwrap();
-        assert!(result.result.is_error());
-    }
+    // empty / whitespace-only skill-id and model-invocation-disabled execute()
+    // error paths live in tests/skills_integration.rs (this module is over the
+    // modular size limit).
 
     // ── LoadSkillResourceTool descriptor ──
 

--- a/crates/awaken-ext-skills/src/visibility.rs
+++ b/crates/awaken-ext-skills/src/visibility.rs
@@ -44,6 +44,17 @@ impl SkillVisibilityStateValue {
             .unwrap_or(SkillVisibility::Visible)
     }
 
+    /// Returns the EXPLICIT visibility entry for a skill, or `None` when the
+    /// skill carries no recorded Show/Hide state.
+    ///
+    /// Unlike [`visibility_of`](Self::visibility_of), this does not fail open to
+    /// `Visible`. Callers use the `None` case to fall back to the declarative
+    /// metadata policy ([`DefaultSkillVisibilityPolicy`]) rather than blindly
+    /// showing skills that were never seeded.
+    pub fn explicit(&self, skill_id: &str) -> Option<SkillVisibility> {
+        self.modes.get(skill_id).copied()
+    }
+
     /// Returns an iterator over all hidden skill IDs.
     pub fn hidden_ids(&self) -> impl Iterator<Item = &str> {
         self.modes
@@ -184,6 +195,14 @@ mod tests {
     fn state_value_default_visibility_of_unknown_skill() {
         let state = SkillVisibilityStateValue::default();
         assert_eq!(state.visibility_of("unknown"), SkillVisibility::Visible);
+    }
+
+    #[test]
+    fn explicit_returns_none_for_unknown_skill() {
+        let mut state = SkillVisibilityStateValue::default();
+        state.modes.insert("known".into(), SkillVisibility::Hidden);
+        assert_eq!(state.explicit("unknown"), None);
+        assert_eq!(state.explicit("known"), Some(SkillVisibility::Hidden));
     }
 
     #[test]

--- a/crates/awaken-ext-skills/src/visibility.rs
+++ b/crates/awaken-ext-skills/src/visibility.rs
@@ -402,9 +402,8 @@ mod tests {
 
     #[test]
     fn default_policy_visible_when_only_paths_present() {
-        // Path-conditional hiding is deferred until a file-match promote hook
-        // exists (ADR-0020 D5, future). Until then a `paths`-only skill stays
-        // Visible rather than vanishing from the catalog with no way back.
+        // `paths` is not in the agentskills spec and does not gate visibility, so
+        // a `paths`-only skill is Visible (surfaced by description, model-invoked).
         let policy = DefaultSkillVisibilityPolicy;
         let mut meta = SkillMeta::new("s1", "s1", "desc", vec![]);
         meta.paths = vec!["*.tsx".into()];

--- a/crates/awaken-ext-skills/src/visibility.rs
+++ b/crates/awaken-ext-skills/src/visibility.rs
@@ -114,47 +114,38 @@ impl StateKey for SkillVisibilityStateKey {
 }
 
 // ---------------------------------------------------------------------------
-// Policy trait
+// Default visibility policy
 // ---------------------------------------------------------------------------
 
-/// Policy that decides the initial visibility for each skill at run start.
+/// Default per-skill visibility decision (ADR-0020).
 ///
-/// Implementations can incorporate config rules, feature flags, or dynamic
-/// criteria.  The default implementation uses `SkillMeta` fields only.
-pub trait SkillVisibilityPolicy: Send + Sync {
-    /// Evaluate visibility for a single skill.
-    fn evaluate(&self, meta: &SkillMeta) -> SkillVisibility;
-
-    /// Batch-evaluate all skills and return actions to seed the visibility state.
-    fn seed(&self, metas: &[&SkillMeta]) -> Vec<(String, SkillVisibility)> {
-        metas
-            .iter()
-            .map(|m| (m.id.clone(), self.evaluate(m)))
-            .collect()
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Default policy
-// ---------------------------------------------------------------------------
-
-/// Default policy based on `SkillMeta` fields.
-///
-/// A skill is `Hidden` if:
+/// Visibility is **declarative** — derived from skill metadata, not a
+/// user-pluggable strategy (mirroring `awaken-ext-permission`, where policy is
+/// declarative rule data). A skill starts `Hidden` if:
 /// - `model_invocable` is `false` (frontmatter `disable-model-invocation: true`), OR
-/// - `paths` is non-empty (conditional skill — starts hidden until file match).
+/// - `paths` is non-empty (conditional skill — hidden until a file match promotes it).
 ///
-/// Otherwise it is `Visible`.
+/// Otherwise it is `Visible`. Seeded once at run start; later changes flow
+/// through `SkillVisibilityAction` (tool-, plugin-, or config-driven).
 #[derive(Debug, Clone, Default)]
-pub struct DefaultSkillVisibilityPolicy;
+pub(crate) struct DefaultSkillVisibilityPolicy;
 
-impl SkillVisibilityPolicy for DefaultSkillVisibilityPolicy {
-    fn evaluate(&self, meta: &SkillMeta) -> SkillVisibility {
+impl DefaultSkillVisibilityPolicy {
+    /// Evaluate visibility for a single skill from its metadata.
+    pub(crate) fn evaluate(&self, meta: &SkillMeta) -> SkillVisibility {
         if !meta.model_invocable || !meta.paths.is_empty() {
             SkillVisibility::Hidden
         } else {
             SkillVisibility::Visible
         }
+    }
+
+    /// Batch-evaluate all skills to seed the visibility state at run start.
+    pub(crate) fn seed(&self, metas: &[&SkillMeta]) -> Vec<(String, SkillVisibility)> {
+        metas
+            .iter()
+            .map(|m| (m.id.clone(), self.evaluate(m)))
+            .collect()
     }
 }
 

--- a/crates/awaken-ext-skills/src/visibility.rs
+++ b/crates/awaken-ext-skills/src/visibility.rs
@@ -1,8 +1,11 @@
 //! Skill visibility state, actions, and policy (ADR-0020).
 //!
 //! Follows the mechanism-policy separation pattern established by
-//! `awaken-ext-permission` (PermissionPolicy + PermissionOverrides)
-//! and `awaken-ext-deferred-tools` (DeferralState + DeferralPolicy).
+//! `awaken-ext-permission` (PermissionPolicy + PermissionOverrides) and
+//! `awaken-ext-deferred-tools` (`DeferralState` plus declarative config
+//! classification via `resolve_mode`, not a pluggable policy trait). Here the
+//! mechanism is `SkillVisibilityStateKey` + `SkillVisibilityAction`; the policy
+//! is the declarative, metadata-derived `DefaultSkillVisibilityPolicy`.
 
 use std::collections::HashMap;
 
@@ -36,21 +39,13 @@ pub struct SkillVisibilityStateValue {
 }
 
 impl SkillVisibilityStateValue {
-    /// Returns the effective visibility for the given skill.
-    pub fn visibility_of(&self, skill_id: &str) -> SkillVisibility {
-        self.modes
-            .get(skill_id)
-            .copied()
-            .unwrap_or(SkillVisibility::Visible)
-    }
-
     /// Returns the EXPLICIT visibility entry for a skill, or `None` when the
     /// skill carries no recorded Show/Hide state.
     ///
-    /// Unlike [`visibility_of`](Self::visibility_of), this does not fail open to
-    /// `Visible`. Callers use the `None` case to fall back to the declarative
-    /// metadata policy ([`DefaultSkillVisibilityPolicy`]) rather than blindly
-    /// showing skills that were never seeded.
+    /// This deliberately does not fail open to `Visible`: this value records
+    /// only explicit overrides. Resolving the visibility a skill should actually
+    /// have — explicit override, else metadata policy — is the job of
+    /// [`effective_visibility`], the single source of truth for the catalog.
     pub fn explicit(&self, skill_id: &str) -> Option<SkillVisibility> {
         self.modes.get(skill_id).copied()
     }
@@ -96,6 +91,15 @@ pub struct SkillVisibilityStateKey;
 
 impl StateKey for SkillVisibilityStateKey {
     const KEY: &'static str = "skills.visibility";
+    /// `Commutative` here means "parallel batches touching this key may merge
+    /// without conflict" — each op is a per-skill-ID map insert, resolved
+    /// last-write-wins, exactly like the `PermissionOverridesKey` reducer
+    /// (`AllowTool`/`DenyTool` on the same tool). It is not strict mathematical
+    /// commutativity: two parallel ops on the *same* ID resolve by concatenation
+    /// order. `Exclusive` would be wrong — it would make two hooks that both
+    /// adjust visibility hard-conflict, defeating additive promotion. The seed
+    /// (run-start `on_activate`) never races runtime overrides: it is committed
+    /// before any tool runs.
     const MERGE: MergeStrategy = MergeStrategy::Commutative;
     const SCOPE: KeyScope = KeyScope::Run;
 
@@ -132,19 +136,23 @@ impl StateKey for SkillVisibilityStateKey {
 ///
 /// Visibility is **declarative** — derived from skill metadata, not a
 /// user-pluggable strategy (mirroring `awaken-ext-permission`, where policy is
-/// declarative rule data). A skill starts `Hidden` if:
-/// - `model_invocable` is `false` (frontmatter `disable-model-invocation: true`), OR
-/// - `paths` is non-empty (conditional skill — hidden until a file match promotes it).
+/// declarative rule data). A skill starts `Hidden` when `model_invocable` is
+/// `false` (frontmatter `disable-model-invocation: true`); otherwise `Visible`.
 ///
-/// Otherwise it is `Visible`. Seeded once at run start; later changes flow
-/// through `SkillVisibilityAction` (tool-, plugin-, or config-driven).
+/// Path-conditional hiding (a non-empty `paths` set, shown only when a matching
+/// file is touched) is **deferred**: until the file-match promote hook lands
+/// (ADR-0020 D5, future), `paths`-only skills stay `Visible` rather than being
+/// hidden with no built-in way to bring them back.
+///
+/// Seeded once at run start; later changes flow through `SkillVisibilityAction`
+/// (tool-, plugin-, or config-driven).
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DefaultSkillVisibilityPolicy;
 
 impl DefaultSkillVisibilityPolicy {
     /// Evaluate visibility for a single skill from its metadata.
     pub(crate) fn evaluate(&self, meta: &SkillMeta) -> SkillVisibility {
-        if !meta.model_invocable || !meta.paths.is_empty() {
+        if !meta.model_invocable {
             SkillVisibility::Hidden
         } else {
             SkillVisibility::Visible
@@ -158,6 +166,26 @@ impl DefaultSkillVisibilityPolicy {
             .map(|m| (m.id.clone(), self.evaluate(m)))
             .collect()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Effective visibility (single source of truth)
+// ---------------------------------------------------------------------------
+
+/// Resolve the visibility a skill should have in the catalog.
+///
+/// This is the one rule every read path must use: an explicit Show/Hide in the
+/// run-scoped state ([`SkillVisibilityStateValue::explicit`]) wins; otherwise it
+/// falls back to the declarative metadata policy ([`DefaultSkillVisibilityPolicy`])
+/// rather than failing open. Because the policy type is crate-private, this
+/// function is the public entry point for reproducing the catalog's decision.
+pub fn effective_visibility(
+    meta: &SkillMeta,
+    state: Option<&SkillVisibilityStateValue>,
+) -> SkillVisibility {
+    state
+        .and_then(|s| s.explicit(&meta.id))
+        .unwrap_or_else(|| DefaultSkillVisibilityPolicy.evaluate(meta))
 }
 
 // ---------------------------------------------------------------------------
@@ -192,12 +220,6 @@ mod tests {
     }
 
     #[test]
-    fn state_value_default_visibility_of_unknown_skill() {
-        let state = SkillVisibilityStateValue::default();
-        assert_eq!(state.visibility_of("unknown"), SkillVisibility::Visible);
-    }
-
-    #[test]
     fn explicit_returns_none_for_unknown_skill() {
         let mut state = SkillVisibilityStateValue::default();
         state.modes.insert("known".into(), SkillVisibility::Hidden);
@@ -214,7 +236,7 @@ mod tests {
                 skill_id: "s1".into(),
             },
         );
-        assert_eq!(state.visibility_of("s1"), SkillVisibility::Hidden);
+        assert_eq!(state.explicit("s1"), Some(SkillVisibility::Hidden));
 
         SkillVisibilityStateKey::apply(
             &mut state,
@@ -222,7 +244,7 @@ mod tests {
                 skill_id: "s1".into(),
             },
         );
-        assert_eq!(state.visibility_of("s1"), SkillVisibility::Visible);
+        assert_eq!(state.explicit("s1"), Some(SkillVisibility::Visible));
     }
 
     #[test]
@@ -234,7 +256,7 @@ mod tests {
                 skill_id: "s1".into(),
             },
         );
-        assert_eq!(state.visibility_of("s1"), SkillVisibility::Hidden);
+        assert_eq!(state.explicit("s1"), Some(SkillVisibility::Hidden));
     }
 
     #[test]
@@ -258,8 +280,8 @@ mod tests {
                 skill_ids: vec!["s1".into(), "s2".into()],
             },
         );
-        assert_eq!(state.visibility_of("s1"), SkillVisibility::Visible);
-        assert_eq!(state.visibility_of("s2"), SkillVisibility::Visible);
+        assert_eq!(state.explicit("s1"), Some(SkillVisibility::Visible));
+        assert_eq!(state.explicit("s2"), Some(SkillVisibility::Visible));
     }
 
     #[test]
@@ -275,9 +297,9 @@ mod tests {
                 ],
             },
         );
-        assert_eq!(state.visibility_of("s1"), SkillVisibility::Hidden);
-        assert_eq!(state.visibility_of("s2"), SkillVisibility::Visible);
-        assert_eq!(state.visibility_of("s3"), SkillVisibility::Hidden);
+        assert_eq!(state.explicit("s1"), Some(SkillVisibility::Hidden));
+        assert_eq!(state.explicit("s2"), Some(SkillVisibility::Visible));
+        assert_eq!(state.explicit("s3"), Some(SkillVisibility::Hidden));
     }
 
     #[test]
@@ -312,8 +334,8 @@ mod tests {
         state.modes.insert("s2".into(), SkillVisibility::Visible);
         let json = serde_json::to_value(&state).unwrap();
         let parsed: SkillVisibilityStateValue = serde_json::from_value(json).unwrap();
-        assert_eq!(parsed.visibility_of("s1"), SkillVisibility::Hidden);
-        assert_eq!(parsed.visibility_of("s2"), SkillVisibility::Visible);
+        assert_eq!(parsed.explicit("s1"), Some(SkillVisibility::Hidden));
+        assert_eq!(parsed.explicit("s2"), Some(SkillVisibility::Visible));
     }
 
     // --- Default policy tests ---
@@ -334,11 +356,63 @@ mod tests {
     }
 
     #[test]
-    fn default_policy_hidden_when_paths_present() {
+    fn default_policy_visible_when_only_paths_present() {
+        // Path-conditional hiding is deferred until a file-match promote hook
+        // exists (ADR-0020 D5, future). Until then a `paths`-only skill stays
+        // Visible rather than vanishing from the catalog with no way back.
         let policy = DefaultSkillVisibilityPolicy;
         let mut meta = SkillMeta::new("s1", "s1", "desc", vec![]);
         meta.paths = vec!["*.tsx".into()];
-        assert_eq!(policy.evaluate(&meta), SkillVisibility::Hidden);
+        assert_eq!(policy.evaluate(&meta), SkillVisibility::Visible);
+    }
+
+    // --- Effective visibility (single source of truth) ---
+
+    #[test]
+    fn effective_visibility_explicit_state_wins_over_metadata() {
+        // Explicit Show promotes a metadata-Hidden skill; explicit Hide suppresses
+        // a metadata-Visible one.
+        let mut blocked = SkillMeta::new("blocked", "blocked", "d", vec![]);
+        blocked.model_invocable = false;
+        let normal = SkillMeta::new("normal", "normal", "d", vec![]);
+
+        let mut state = SkillVisibilityStateValue::default();
+        state
+            .modes
+            .insert("blocked".into(), SkillVisibility::Visible);
+        state.modes.insert("normal".into(), SkillVisibility::Hidden);
+
+        assert_eq!(
+            effective_visibility(&blocked, Some(&state)),
+            SkillVisibility::Visible
+        );
+        assert_eq!(
+            effective_visibility(&normal, Some(&state)),
+            SkillVisibility::Hidden
+        );
+    }
+
+    #[test]
+    fn effective_visibility_falls_back_to_metadata_policy_when_absent() {
+        let mut blocked = SkillMeta::new("blocked", "blocked", "d", vec![]);
+        blocked.model_invocable = false;
+        let normal = SkillMeta::new("normal", "normal", "d", vec![]);
+
+        // No state at all, and a state that omits the skill: both fall back.
+        assert_eq!(
+            effective_visibility(&normal, None),
+            SkillVisibility::Visible
+        );
+        assert_eq!(
+            effective_visibility(&blocked, None),
+            SkillVisibility::Hidden
+        );
+
+        let empty = SkillVisibilityStateValue::default();
+        assert_eq!(
+            effective_visibility(&blocked, Some(&empty)),
+            SkillVisibility::Hidden
+        );
     }
 
     #[test]

--- a/crates/awaken-ext-skills/src/visibility.rs
+++ b/crates/awaken-ext-skills/src/visibility.rs
@@ -5,7 +5,8 @@
 //! `awaken-ext-deferred-tools` (`DeferralState` plus declarative config
 //! classification via `resolve_mode`, not a pluggable policy trait). Here the
 //! mechanism is `SkillVisibilityStateKey` + `SkillVisibilityAction`; the policy
-//! is the declarative, metadata-derived `DefaultSkillVisibilityPolicy`.
+//! is declarative and metadata-derived, resolved by [`effective_visibility`]
+//! (hard gate on `disable-model-invocation`, else explicit override, else Visible).
 
 use std::collections::HashMap;
 
@@ -36,11 +37,12 @@ pub enum SkillVisibility {
 pub struct SkillVisibilityStateValue {
     /// Skill ID → **explicit** visibility override.
     ///
-    /// Absence does NOT mean `Visible`: it means "no explicit runtime override".
-    /// Callers must resolve actual visibility through [`effective_visibility`],
-    /// which falls back to the declarative metadata policy. Reading this map
-    /// directly and treating absent as `Visible` re-introduces the fail-open bug.
-    pub modes: HashMap<String, SkillVisibility>,
+    /// Crate-private so external code cannot bypass [`effective_visibility`] by
+    /// reading the raw map (treating absent as `Visible` would re-introduce the
+    /// fail-open bug, and reading it directly ignores the `disable-model-invocation`
+    /// hard gate). Absence means "no explicit runtime override"; resolve actual
+    /// visibility through [`effective_visibility`] / [`SkillVisibilityStateValue::explicit`].
+    pub(crate) modes: HashMap<String, SkillVisibility>,
 }
 
 impl SkillVisibilityStateValue {
@@ -79,15 +81,8 @@ pub enum SkillVisibilityAction {
     /// Make multiple skills visible at once.
     ShowBatch { skill_ids: Vec<String> },
     /// Batch-set visibility, overwriting any existing entry (last-write-wins).
-    /// For explicit runtime control; not for run-start seeding (use `SeedBatch`).
+    /// For explicit runtime control (tools, plugins, future user/config paths).
     SetBatch {
-        entries: Vec<(String, SkillVisibility)>,
-    },
-    /// Seed initial visibility at run start, **insert-if-absent**: an entry is
-    /// written only when the skill has no existing state. This guarantees the
-    /// seed never clobbers a runtime `Show`/`Hide` that already happened (e.g. on
-    /// re-activation, handoff, resume, or sub-agent activation).
-    SeedBatch {
         entries: Vec<(String, SkillVisibility)>,
     },
 }
@@ -132,11 +127,6 @@ impl StateKey for SkillVisibilityStateKey {
                     value.modes.insert(id, SkillVisibility::Visible);
                 }
             }
-            SkillVisibilityAction::SeedBatch { entries } => {
-                for (id, vis) in entries {
-                    value.modes.entry(id).or_insert(vis);
-                }
-            }
             SkillVisibilityAction::SetBatch { entries } => {
                 for (id, vis) in entries {
                     value.modes.insert(id, vis);
@@ -147,56 +137,34 @@ impl StateKey for SkillVisibilityStateKey {
 }
 
 // ---------------------------------------------------------------------------
-// Default visibility policy
-// ---------------------------------------------------------------------------
-
-/// Default per-skill visibility decision (ADR-0020).
-///
-/// Visibility is **declarative** — derived from skill metadata, not a
-/// user-pluggable strategy (mirroring `awaken-ext-permission`, where policy is
-/// declarative rule data). A skill is `Hidden` when `model_invocable` is `false`
-/// (frontmatter `disable-model-invocation: true`); otherwise `Visible`.
-///
-/// `paths` is **not** an input. The agentskills specification has no
-/// path/glob-based conditional activation — skills are surfaced by their
-/// `description` (progressive disclosure) and model-invoked. `paths` is a
-/// non-standard awaken field, retained as parsed metadata but with no effect on
-/// catalog visibility.
-///
-/// Used by [`effective_visibility`] as the fallback when a skill has no explicit
-/// runtime `Show`/`Hide` override.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct DefaultSkillVisibilityPolicy;
-
-impl DefaultSkillVisibilityPolicy {
-    /// Evaluate visibility for a single skill from its metadata.
-    pub(crate) fn evaluate(&self, meta: &SkillMeta) -> SkillVisibility {
-        if !meta.model_invocable {
-            SkillVisibility::Hidden
-        } else {
-            SkillVisibility::Visible
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Effective visibility (single source of truth)
 // ---------------------------------------------------------------------------
 
-/// Resolve the visibility a skill should have in the catalog.
+/// Resolve the visibility a skill should have in the catalog. This is the one
+/// rule every read path must use; never fail open by reading the raw state map.
 ///
-/// This is the one rule every read path must use: an explicit Show/Hide in the
-/// run-scoped state ([`SkillVisibilityStateValue::explicit`]) wins; otherwise it
-/// falls back to the declarative metadata policy ([`DefaultSkillVisibilityPolicy`])
-/// rather than failing open. Because the policy type is crate-private, this
-/// function is the public entry point for reproducing the catalog's decision.
+/// Two layers:
+/// 1. **Hard gate** — `disable-model-invocation` (`model_invocable == false`) is
+///    always `Hidden`, evaluated against *live* metadata. A runtime `Show` cannot
+///    override it (it is the same boundary `SkillActivateTool` enforces), and the
+///    decision tracks metadata changes (e.g. registry hot-reload) rather than a
+///    stale seed.
+/// 2. **Soft runtime visibility** — for model-invocable skills, an explicit
+///    `Show`/`Hide` override wins; otherwise the skill is `Visible` (surfaced by
+///    description, per the agentskills progressive-disclosure model).
+///
+/// `paths` is not consulted: the agentskills spec has no path/glob conditional
+/// activation, so `paths` is parsed but inert.
 pub fn effective_visibility(
     meta: &SkillMeta,
     state: Option<&SkillVisibilityStateValue>,
 ) -> SkillVisibility {
+    if !meta.model_invocable {
+        return SkillVisibility::Hidden;
+    }
     state
         .and_then(|s| s.explicit(&meta.id))
-        .unwrap_or_else(|| DefaultSkillVisibilityPolicy.evaluate(meta))
+        .unwrap_or(SkillVisibility::Visible)
 }
 
 // ---------------------------------------------------------------------------
@@ -314,40 +282,6 @@ mod tests {
     }
 
     #[test]
-    fn seed_batch_inserts_only_when_absent() {
-        // SeedBatch must never clobber an existing explicit runtime override:
-        // a prior Show/Hide wins; only skills with no entry get the seeded value.
-        let mut state = SkillVisibilityStateValue::default();
-        // Runtime override happened first (e.g. a tool promoted s1).
-        SkillVisibilityStateKey::apply(
-            &mut state,
-            SkillVisibilityAction::Show {
-                skill_id: "s1".into(),
-            },
-        );
-        // Re-activation seeds s1=Hidden and s2=Hidden.
-        SkillVisibilityStateKey::apply(
-            &mut state,
-            SkillVisibilityAction::SeedBatch {
-                entries: vec![
-                    ("s1".into(), SkillVisibility::Hidden),
-                    ("s2".into(), SkillVisibility::Hidden),
-                ],
-            },
-        );
-        assert_eq!(
-            state.explicit("s1"),
-            Some(SkillVisibility::Visible),
-            "seed must not overwrite an existing runtime override"
-        );
-        assert_eq!(
-            state.explicit("s2"),
-            Some(SkillVisibility::Hidden),
-            "seed fills entries that are absent"
-        );
-    }
-
-    #[test]
     fn hidden_ids_iterator() {
         let mut state = SkillVisibilityStateValue::default();
         SkillVisibilityStateKey::apply(
@@ -383,44 +317,27 @@ mod tests {
         assert_eq!(parsed.explicit("s2"), Some(SkillVisibility::Visible));
     }
 
-    // --- Default policy tests ---
-
-    #[test]
-    fn default_policy_visible_for_normal_skill() {
-        let policy = DefaultSkillVisibilityPolicy;
-        let meta = SkillMeta::new("s1", "s1", "desc", vec![]);
-        assert_eq!(policy.evaluate(&meta), SkillVisibility::Visible);
-    }
-
-    #[test]
-    fn default_policy_hidden_when_model_invocable_false() {
-        let policy = DefaultSkillVisibilityPolicy;
-        let mut meta = SkillMeta::new("s1", "s1", "desc", vec![]);
-        meta.model_invocable = false;
-        assert_eq!(policy.evaluate(&meta), SkillVisibility::Hidden);
-    }
-
-    #[test]
-    fn default_policy_visible_when_only_paths_present() {
-        // `paths` is not in the agentskills spec and does not gate visibility, so
-        // a `paths`-only skill is Visible (surfaced by description, model-invoked).
-        let policy = DefaultSkillVisibilityPolicy;
-        let mut meta = SkillMeta::new("s1", "s1", "desc", vec![]);
-        meta.paths = vec!["*.tsx".into()];
-        assert_eq!(policy.evaluate(&meta), SkillVisibility::Visible);
-    }
-
     // --- Effective visibility (single source of truth) ---
 
     #[test]
-    fn effective_visibility_explicit_state_wins_over_metadata() {
-        // Explicit Show promotes a metadata-Hidden skill; explicit Hide suppresses
-        // a metadata-Visible one.
+    fn effective_visibility_ignores_paths() {
+        // `paths` is not in the agentskills spec and does not gate visibility.
+        let mut meta = SkillMeta::new("s1", "s1", "desc", vec![]);
+        meta.paths = vec!["*.tsx".into(), "src/**/*.rs".into()];
+        assert_eq!(effective_visibility(&meta, None), SkillVisibility::Visible);
+    }
+
+    #[test]
+    fn effective_visibility_hard_gates_disable_model_invocation() {
+        // `disable-model-invocation` is a HARD gate: even an explicit Show must
+        // NOT reveal it to the model. For a normal (model-invocable) skill,
+        // explicit Show/Hide overrides do apply.
         let mut blocked = SkillMeta::new("blocked", "blocked", "d", vec![]);
         blocked.model_invocable = false;
         let normal = SkillMeta::new("normal", "normal", "d", vec![]);
 
         let mut state = SkillVisibilityStateValue::default();
+        // An explicit Show on the blocked skill must be ignored by the hard gate.
         state
             .modes
             .insert("blocked".into(), SkillVisibility::Visible);
@@ -428,11 +345,13 @@ mod tests {
 
         assert_eq!(
             effective_visibility(&blocked, Some(&state)),
-            SkillVisibility::Visible
+            SkillVisibility::Hidden,
+            "an explicit Show must not override disable-model-invocation"
         );
         assert_eq!(
             effective_visibility(&normal, Some(&state)),
-            SkillVisibility::Hidden
+            SkillVisibility::Hidden,
+            "explicit Hide applies to a model-invocable skill"
         );
     }
 
@@ -457,14 +376,5 @@ mod tests {
             effective_visibility(&blocked, Some(&empty)),
             SkillVisibility::Hidden
         );
-    }
-
-    #[test]
-    fn default_policy_ignores_paths() {
-        // `paths` is not in the agentskills spec and must not affect visibility.
-        let policy = DefaultSkillVisibilityPolicy;
-        let mut meta = SkillMeta::new("s1", "s1", "desc", vec![]);
-        meta.paths = vec!["src/**/*.rs".into(), "*.tsx".into()];
-        assert_eq!(policy.evaluate(&meta), SkillVisibility::Visible);
     }
 }

--- a/crates/awaken-ext-skills/src/visibility.rs
+++ b/crates/awaken-ext-skills/src/visibility.rs
@@ -34,7 +34,12 @@ pub enum SkillVisibility {
 /// Per-skill visibility state (run-scoped).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SkillVisibilityStateValue {
-    /// Skill ID → visibility.  Skills absent from the map are treated as `Visible`.
+    /// Skill ID → **explicit** visibility override.
+    ///
+    /// Absence does NOT mean `Visible`: it means "no explicit runtime override".
+    /// Callers must resolve actual visibility through [`effective_visibility`],
+    /// which falls back to the declarative metadata policy. Reading this map
+    /// directly and treating absent as `Visible` re-introduces the fail-open bug.
     pub modes: HashMap<String, SkillVisibility>,
 }
 
@@ -73,8 +78,16 @@ pub enum SkillVisibilityAction {
     Hide { skill_id: String },
     /// Make multiple skills visible at once.
     ShowBatch { skill_ids: Vec<String> },
-    /// Batch-set initial visibility (typically used at run start).
+    /// Batch-set visibility, overwriting any existing entry (last-write-wins).
+    /// For explicit runtime control; not for run-start seeding (use `SeedBatch`).
     SetBatch {
+        entries: Vec<(String, SkillVisibility)>,
+    },
+    /// Seed initial visibility at run start, **insert-if-absent**: an entry is
+    /// written only when the skill has no existing state. This guarantees the
+    /// seed never clobbers a runtime `Show`/`Hide` that already happened (e.g. on
+    /// re-activation, handoff, resume, or sub-agent activation).
+    SeedBatch {
         entries: Vec<(String, SkillVisibility)>,
     },
 }
@@ -119,6 +132,11 @@ impl StateKey for SkillVisibilityStateKey {
                     value.modes.insert(id, SkillVisibility::Visible);
                 }
             }
+            SkillVisibilityAction::SeedBatch { entries } => {
+                for (id, vis) in entries {
+                    value.modes.entry(id).or_insert(vis);
+                }
+            }
             SkillVisibilityAction::SetBatch { entries } => {
                 for (id, vis) in entries {
                     value.modes.insert(id, vis);
@@ -136,16 +154,17 @@ impl StateKey for SkillVisibilityStateKey {
 ///
 /// Visibility is **declarative** — derived from skill metadata, not a
 /// user-pluggable strategy (mirroring `awaken-ext-permission`, where policy is
-/// declarative rule data). A skill starts `Hidden` when `model_invocable` is
-/// `false` (frontmatter `disable-model-invocation: true`); otherwise `Visible`.
+/// declarative rule data). A skill is `Hidden` when `model_invocable` is `false`
+/// (frontmatter `disable-model-invocation: true`); otherwise `Visible`.
 ///
-/// Path-conditional hiding (a non-empty `paths` set, shown only when a matching
-/// file is touched) is **deferred**: until the file-match promote hook lands
-/// (ADR-0020 D5, future), `paths`-only skills stay `Visible` rather than being
-/// hidden with no built-in way to bring them back.
+/// `paths` is **not** an input. The agentskills specification has no
+/// path/glob-based conditional activation — skills are surfaced by their
+/// `description` (progressive disclosure) and model-invoked. `paths` is a
+/// non-standard awaken field, retained as parsed metadata but with no effect on
+/// catalog visibility.
 ///
-/// Seeded once at run start; later changes flow through `SkillVisibilityAction`
-/// (tool-, plugin-, or config-driven).
+/// Used by [`effective_visibility`] as the fallback when a skill has no explicit
+/// runtime `Show`/`Hide` override.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DefaultSkillVisibilityPolicy;
 
@@ -157,14 +176,6 @@ impl DefaultSkillVisibilityPolicy {
         } else {
             SkillVisibility::Visible
         }
-    }
-
-    /// Batch-evaluate all skills to seed the visibility state at run start.
-    pub(crate) fn seed(&self, metas: &[&SkillMeta]) -> Vec<(String, SkillVisibility)> {
-        metas
-            .iter()
-            .map(|m| (m.id.clone(), self.evaluate(m)))
-            .collect()
     }
 }
 
@@ -303,6 +314,40 @@ mod tests {
     }
 
     #[test]
+    fn seed_batch_inserts_only_when_absent() {
+        // SeedBatch must never clobber an existing explicit runtime override:
+        // a prior Show/Hide wins; only skills with no entry get the seeded value.
+        let mut state = SkillVisibilityStateValue::default();
+        // Runtime override happened first (e.g. a tool promoted s1).
+        SkillVisibilityStateKey::apply(
+            &mut state,
+            SkillVisibilityAction::Show {
+                skill_id: "s1".into(),
+            },
+        );
+        // Re-activation seeds s1=Hidden and s2=Hidden.
+        SkillVisibilityStateKey::apply(
+            &mut state,
+            SkillVisibilityAction::SeedBatch {
+                entries: vec![
+                    ("s1".into(), SkillVisibility::Hidden),
+                    ("s2".into(), SkillVisibility::Hidden),
+                ],
+            },
+        );
+        assert_eq!(
+            state.explicit("s1"),
+            Some(SkillVisibility::Visible),
+            "seed must not overwrite an existing runtime override"
+        );
+        assert_eq!(
+            state.explicit("s2"),
+            Some(SkillVisibility::Hidden),
+            "seed fills entries that are absent"
+        );
+    }
+
+    #[test]
     fn hidden_ids_iterator() {
         let mut state = SkillVisibilityStateValue::default();
         SkillVisibilityStateKey::apply(
@@ -416,15 +461,11 @@ mod tests {
     }
 
     #[test]
-    fn default_policy_seed_batch() {
+    fn default_policy_ignores_paths() {
+        // `paths` is not in the agentskills spec and must not affect visibility.
         let policy = DefaultSkillVisibilityPolicy;
-        let m1 = SkillMeta::new("visible", "visible", "ok", vec![]);
-        let mut m2 = SkillMeta::new("hidden", "hidden", "ok", vec![]);
-        m2.model_invocable = false;
-        let metas: Vec<&SkillMeta> = vec![&m1, &m2];
-        let result = policy.seed(&metas);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], ("visible".into(), SkillVisibility::Visible));
-        assert_eq!(result[1], ("hidden".into(), SkillVisibility::Hidden));
+        let mut meta = SkillMeta::new("s1", "s1", "desc", vec![]);
+        meta.paths = vec!["src/**/*.rs".into(), "*.tsx".into()];
+        assert_eq!(policy.evaluate(&meta), SkillVisibility::Visible);
     }
 }

--- a/crates/awaken-ext-skills/tests/skills_integration.rs
+++ b/crates/awaken-ext-skills/tests/skills_integration.rs
@@ -13,7 +13,8 @@ use awaken_ext_skills::registry::{InMemorySkillRegistry, SkillRegistry};
 use awaken_ext_skills::skill::{Skill, SkillResourceKind};
 use awaken_ext_skills::state::{SkillState, SkillStateUpdate, SkillStateValue};
 use awaken_ext_skills::{
-    EmbeddedSkill, EmbeddedSkillData, FsSkill, SkillActivateTool, SkillSubsystem,
+    EmbeddedSkill, EmbeddedSkillData, FsSkill, LoadSkillResourceTool, SkillActivateTool,
+    SkillScriptTool, SkillSubsystem,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -552,6 +553,75 @@ async fn activate_tool_rejects_model_invocation_disabled_skill() {
             .unwrap_or("")
             .contains("model_invocation_disabled"),
         "error must identify the model-invocation guard"
+    );
+}
+
+fn blocked_skill_registry() -> (TempDir, std::sync::Arc<dyn SkillRegistry>) {
+    let td = TempDir::new().unwrap();
+    let root = td.path().join("skills");
+    fs::create_dir_all(root.join("blocked-skill")).unwrap();
+    fs::write(
+        root.join("blocked-skill").join("SKILL.md"),
+        SKILL_NO_MODEL_INVOKE_MD,
+    )
+    .unwrap();
+    let skills = FsSkill::into_arc_skills(FsSkill::discover(root).unwrap().skills);
+    let registry: std::sync::Arc<dyn SkillRegistry> =
+        Arc::new(InMemorySkillRegistry::from_skills(skills));
+    (td, registry)
+}
+
+#[tokio::test]
+async fn load_skill_resource_rejects_model_invocation_disabled_skill() {
+    // The guard must cover ALL model-facing tools, not just activation: the model
+    // must not be able to read a disable-model-invocation skill's resources.
+    let (_td, registry) = blocked_skill_registry();
+    let tool = LoadSkillResourceTool::new(registry);
+    let ctx = ToolCallContext::test_default();
+
+    let result = tool
+        .execute(
+            json!({"skill": "blocked-skill", "path": "references/x.md"}),
+            &ctx,
+        )
+        .await
+        .unwrap();
+    assert!(result.result.is_error());
+    assert!(
+        result
+            .result
+            .message
+            .as_deref()
+            .unwrap_or("")
+            .contains("model_invocation_disabled"),
+        "load_skill_resource must enforce the model-invocation guard"
+    );
+}
+
+#[tokio::test]
+async fn skill_script_rejects_model_invocation_disabled_skill() {
+    // Same guard for script execution: the model must not run a
+    // disable-model-invocation skill's scripts.
+    let (_td, registry) = blocked_skill_registry();
+    let tool = SkillScriptTool::new(registry);
+    let ctx = ToolCallContext::test_default();
+
+    let result = tool
+        .execute(
+            json!({"skill": "blocked-skill", "script": "scripts/run.sh"}),
+            &ctx,
+        )
+        .await
+        .unwrap();
+    assert!(result.result.is_error());
+    assert!(
+        result
+            .result
+            .message
+            .as_deref()
+            .unwrap_or("")
+            .contains("model_invocation_disabled"),
+        "skill_script must enforce the model-invocation guard"
     );
 }
 

--- a/crates/awaken-ext-skills/tests/skills_integration.rs
+++ b/crates/awaken-ext-skills/tests/skills_integration.rs
@@ -7,11 +7,15 @@
 use std::fs;
 use std::sync::Arc;
 
+use awaken_contract::contract::tool::{Tool, ToolCallContext};
 use awaken_contract::state::StateKey;
 use awaken_ext_skills::registry::{InMemorySkillRegistry, SkillRegistry};
 use awaken_ext_skills::skill::{Skill, SkillResourceKind};
 use awaken_ext_skills::state::{SkillState, SkillStateUpdate, SkillStateValue};
-use awaken_ext_skills::{EmbeddedSkill, EmbeddedSkillData, FsSkill, SkillSubsystem};
+use awaken_ext_skills::{
+    EmbeddedSkill, EmbeddedSkillData, FsSkill, SkillActivateTool, SkillSubsystem,
+};
+use serde_json::json;
 use tempfile::TempDir;
 
 const SKILL_A_MD: &str = "\
@@ -496,4 +500,73 @@ async fn full_skill_lifecycle_register_activate_load() {
     } else {
         panic!("expected reference");
     }
+}
+
+// ── SkillActivateTool::execute error paths ─────────────────────────
+
+const SKILL_NO_MODEL_INVOKE_MD: &str = "\
+---
+name: blocked-skill
+description: A skill the model must not be able to activate
+disable-model-invocation: true
+---
+# Blocked Skill
+
+This skill is user-invocable only.
+";
+
+#[tokio::test]
+async fn activate_tool_rejects_model_invocation_disabled_skill() {
+    // `disable-model-invocation` is the hard invocation guard: the model entry
+    // point (SkillActivateTool) must refuse to activate such a skill even though
+    // it parses and registers normally. Driven through FsSkill so the frontmatter
+    // → meta mapping is exercised end to end.
+    let td = TempDir::new().unwrap();
+    let root = td.path().join("skills");
+    fs::create_dir_all(root.join("blocked-skill")).unwrap();
+    fs::write(
+        root.join("blocked-skill").join("SKILL.md"),
+        SKILL_NO_MODEL_INVOKE_MD,
+    )
+    .unwrap();
+    let skills = FsSkill::into_arc_skills(FsSkill::discover(root).unwrap().skills);
+    assert!(
+        !skills[0].meta().model_invocable,
+        "frontmatter disable-model-invocation must clear model_invocable"
+    );
+
+    let registry = Arc::new(InMemorySkillRegistry::from_skills(skills));
+    let tool = SkillActivateTool::new(registry);
+    let ctx = ToolCallContext::test_default();
+
+    let result = tool
+        .execute(json!({"skill": "blocked-skill"}), &ctx)
+        .await
+        .unwrap();
+    assert!(result.result.is_error());
+    assert!(
+        result
+            .result
+            .message
+            .as_deref()
+            .unwrap_or("")
+            .contains("model_invocation_disabled"),
+        "error must identify the model-invocation guard"
+    );
+}
+
+#[tokio::test]
+async fn activate_tool_rejects_empty_skill_id() {
+    let tool = SkillActivateTool::new(Arc::new(InMemorySkillRegistry::new()));
+    let ctx = ToolCallContext::test_default();
+    let result = tool.execute(json!({"skill": ""}), &ctx).await.unwrap();
+    assert!(result.result.is_error());
+}
+
+#[tokio::test]
+async fn activate_tool_rejects_whitespace_only_skill_id() {
+    let tool = SkillActivateTool::new(Arc::new(InMemorySkillRegistry::new()));
+    let ctx = ToolCallContext::test_default();
+    let result = tool.execute(json!({"skill": "   "}), &ctx).await.unwrap();
+    assert!(result.result.is_error());
 }

--- a/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
+++ b/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
@@ -11,8 +11,18 @@ embedded sources and unconditionally injects **all** of them into the LLM catalo
 before every inference turn. There is no mechanism to:
 
 1. **Hide** a skill that should not appear in the catalog (e.g. `disable-model-invocation`).
-2. **Conditionally show** a skill only when the user touches matching files (`paths` patterns).
-3. **Dynamically promote/demote** skills from plugins, tools, or configuration at runtime.
+2. **Dynamically promote/demote** skills from plugins, tools, or configuration at runtime.
+
+### Alignment with the agentskills specification
+
+The [agentskills spec](https://agentskills.io/specification) defines skill discovery
+as **progressive disclosure**: a skill's `name` + `description` are surfaced to the
+agent for all skills, and the agent (model) decides when to use one. The spec defines
+no path/glob-based conditional activation. The only access controls are
+`disable-model-invocation` (hide from the model) and `user-invocable` (the `/skill-name`
+slash path). This ADR therefore gates catalog visibility **only** on
+`disable-model-invocation`; `paths` is a non-standard awaken field that does **not**
+affect visibility (see D1/D3).
 
 The permission system (`awaken-ext-permission`) already demonstrates a clean
 mechanism-policy separation: `PermissionPolicy` (thread-scoped) + `PermissionOverrides`
@@ -38,7 +48,11 @@ New optional frontmatter fields (all backward-compatible):
 | `disable-model-invocation` | `Option<bool>` | false | Hide from LLM catalog |
 | `model` | `Option<String>` | None | Model override on activation |
 | `context` | `Option<"inline"\|"fork">` | "inline" | Execution mode |
-| `paths` | `Option<String>` | None | Comma/newline-separated glob patterns |
+| `paths` | `Option<String>` | None | Glob patterns; **non-standard, parsed but inert** (does not gate visibility) |
+
+`paths` is retained as parsed metadata for forward compatibility and possible
+non-standard tooling, but it is **not** part of the agentskills spec and has no
+effect on catalog visibility or activation.
 
 Remove `deny_unknown_fields` from `SkillFrontmatter` serde attribute to allow
 forward-compatible extension without breaking existing SKILL.md files.
@@ -49,32 +63,42 @@ forward-compatible extension without breaking existing SKILL.md files.
 SkillVisibility = Visible | Hidden
 
 SkillVisibilityAction:
-  Show(id)              — make a skill visible
-  Hide(id)              — hide a skill
-  ShowBatch(Vec<id>)    — promote multiple skills
-  SetBatch(Vec<(id, vis)>) — set initial visibility for all skills
+  Show(id)               — explicit runtime override → visible
+  Hide(id)               — explicit runtime override → hidden
+  ShowBatch(Vec<id>)     — promote multiple skills (override → visible)
+  SetBatch(Vec<(id,vis)>)  — overwrite entries (last-write-wins); explicit control
+  SeedBatch(Vec<(id,vis)>) — run-start seed, INSERT-IF-ABSENT (never clobbers an
+                             existing override)
 ```
 
-Run-scoped (`KeyScope::Run`) with commutative merge (set-last-write-wins per skill ID).
-This mirrors `PermissionOverrides` scoping — visibility does not leak across runs.
+The map records **explicit runtime overrides only**; absence means "no override",
+resolved against metadata by `effective_visibility` (see D3/D4).
+
+Run-scoped (`KeyScope::Run`), so visibility does not leak across runs (mirrors
+`PermissionOverrides`). Merge is `Commutative` in the same sense as
+`PermissionOverridesKey`: parallel batches may merge without conflict, per-skill
+last-write-wins. `SeedBatch` is insert-if-absent so the run-start seed cannot
+overwrite a runtime `Show`/`Hide` on re-activation, handoff, resume, or sub-agent
+activation.
 
 ### D3: Declarative initial visibility, seeded at run start
 
 Initial visibility is a declarative decision derived from skill metadata — not a
-user-pluggable policy trait. A skill starts `Hidden` when `model_invocable ==
-false` (frontmatter `disable-model-invocation: true`); otherwise `Visible`.
+user-pluggable policy trait. A skill is `Hidden` when `model_invocable == false`
+(frontmatter `disable-model-invocation: true`); otherwise `Visible`. `paths` is
+**not** an input — there is no path-conditional hiding (the agentskills spec has no
+such mechanism; see Context).
 
-Path-conditional hiding (a non-empty `paths` set, shown only when a matching file
-is touched) is **deferred**. The file-match promote hook that would bring such a
-skill back is future scope (see D5), so until it lands, `paths`-only skills seed
-`Visible` rather than disappearing from the catalog with no built-in recovery.
+`SkillDiscoveryPlugin::on_activate` seeds **only the Hidden skills** at run start, via
+`SkillVisibilityAction::SeedBatch` (insert-if-absent). Visible skills are deliberately
+left unseeded: seeding them as explicit `Visible` would mask a later metadata change
+(e.g. a registry hot-reload flipping a skill to non-invocable). With no seeded entry,
+such skills always resolve through live metadata via `effective_visibility` (D4).
 
 Initial visibility is derived **only from skill metadata**; `on_activate` does not
-read `AgentSpec`. `SkillDiscoveryPlugin::on_activate` evaluates the metadata policy
-against the registry snapshot and seeds `SkillVisibilityState` via
-`SkillVisibilityAction::SetBatch` at run start. Subsequent changes come through
-actions (tools, plugins). This mirrors `awaken-ext-permission`, where policy is
-declarative rule data rather than a code trait.
+read `AgentSpec` (config-driven initial visibility is future scope, see D5). This
+mirrors `awaken-ext-permission`, where policy is declarative rule data rather than a
+code trait.
 
 ### D4: Catalog rendering filters by visibility state
 
@@ -86,7 +110,13 @@ failing open). Also renders `when_to_use` into skill descriptions.
 Catalog hiding is **discovery/noise control, not an invocation boundary**. The hard
 guard is `model_invocable`: `SkillActivateTool` (the model's entry point) refuses to
 activate a skill whose `disable-model-invocation` is set, regardless of whether it
-was rendered. A path-conditional skill that is merely `Hidden` stays invocable.
+was rendered.
+
+This guard applies to the **model** path only. `user-invocable` (`/skill-name`) is a
+separate invocation path that does not route through `SkillActivateTool`, so the
+`model_invocable` guard cannot block a legitimate user invocation. The two controls
+are orthogonal: `disable-model-invocation` governs the model; `user-invocable` governs
+the slash path.
 
 ### D5: Dynamic control through existing action infrastructure
 
@@ -96,9 +126,11 @@ Any plugin, tool, or phase hook can schedule `SkillVisibilityAction`:
 - **Tool-driven**: ToolSearch or custom tools can promote hidden skills.
 - **Config-driven** (future, not yet implemented): Agent spec YAML rules set initial
   visibility. `on_activate` currently ignores `AgentSpec` and seeds from metadata only.
-- **Conditional activation** (future, not in this ADR scope): An `AfterToolExecute`
-  hook matches file paths against skill `paths` patterns and promotes matching skills.
-  Until this exists, path-conditional hiding is not applied (see D3).
+
+Note: path/glob conditional activation (hide a `paths` skill until a matching file is
+touched) is **not** part of this design — it is absent from the agentskills spec. If a
+non-standard extension ever wants it, it would build an `AfterToolExecute` hook on top
+of this same action mechanism, but `paths` does not gate visibility today.
 
 ### D6: Parameter substitution in `activate()`
 
@@ -109,8 +141,8 @@ directory (FsSkill only).
 ## Consequences
 
 - **Catalog noise reduction**: Skills with `disable-model-invocation` no longer
-  consume context budget. (Noise reduction for unfulfilled `paths` patterns lands
-  with the conditional-activation hook in D5.)
+  consume context budget. Other skills (including `paths`-bearing ones) are surfaced
+  by description per the agentskills progressive-disclosure model.
 - **Extensibility**: The mechanism (state key + `SkillVisibilityAction`) is the
   extension surface — tools, plugins, and config drive visibility changes at
   runtime without changing the catalog rendering mechanism.

--- a/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
+++ b/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
@@ -17,8 +17,8 @@ before every inference turn. There is no mechanism to:
 The permission system (`awaken-ext-permission`) already demonstrates a clean
 mechanism-policy separation: `PermissionPolicy` (thread-scoped) + `PermissionOverrides`
 (run-scoped) → `evaluate_tool_permission()` → Allow/Deny/Ask. The deferred-tools
-extension follows the same pattern: `DeferralState` + `DeferralPolicy` trait →
-Eager/Deferred.
+extension follows the same pattern with a `DeferralState` mechanism and declarative
+config classification (`resolve_mode`) → Eager/Deferred.
 
 Skill visibility should follow this established pattern rather than introducing
 ad-hoc filtering logic.
@@ -58,19 +58,18 @@ SkillVisibilityAction:
 Run-scoped (`KeyScope::Run`) with commutative merge (set-last-write-wins per skill ID).
 This mirrors `PermissionOverrides` scoping — visibility does not leak across runs.
 
-### D3: `SkillVisibilityPolicy` trait for initial visibility decisions
+### D3: Declarative initial visibility, seeded at run start
 
-```rust
-pub trait SkillVisibilityPolicy: Send + Sync {
-    fn evaluate(&self, meta: &SkillMeta) -> SkillVisibility;
-}
-```
+Initial visibility is a declarative decision derived from skill metadata — not a
+user-pluggable policy trait. A skill starts `Hidden` when `model_invocable ==
+false` or `paths` is non-empty (conditional skills start hidden, promoted on file
+match); otherwise `Visible`.
 
-Default implementation: `Visible` unless `model_invocable == false` or `paths` is
-non-empty (conditional skills start hidden, promoted on file match).
-
-Policy is evaluated once at run start to seed `SkillVisibilityState`. Subsequent
-changes come through actions (tools, plugins, hooks).
+`SkillDiscoveryPlugin::on_activate` evaluates this against the registry snapshot
+and seeds `SkillVisibilityState` via `SkillVisibilityAction::SetBatch` at run
+start. Subsequent changes come through actions (tools, plugins, config). This
+mirrors `awaken-ext-permission`, where policy is declarative rule data rather than
+a code trait.
 
 ### D4: Catalog rendering filters by visibility state
 
@@ -98,8 +97,9 @@ directory (FsSkill only).
 
 - **Catalog noise reduction**: Skills with `disable-model-invocation` or unfulfilled
   `paths` patterns no longer consume context budget.
-- **Extensibility**: New visibility policies (e.g. Bayesian skill recommendation) can
-  be plugged in without changing the catalog rendering mechanism.
+- **Extensibility**: The mechanism (state key + `SkillVisibilityAction`) is the
+  extension surface — tools, plugins, and config drive visibility changes at
+  runtime without changing the catalog rendering mechanism.
 - **Consistency**: Follows the same mechanism-policy pattern as permission and
   deferred-tools, reducing cognitive load for contributors.
 - **Backward compatibility**: All new frontmatter fields are optional; removing

--- a/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
+++ b/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
@@ -15,14 +15,21 @@ before every inference turn. There is no mechanism to:
 
 ### Alignment with the agentskills specification
 
-The [agentskills spec](https://agentskills.io/specification) defines skill discovery
-as **progressive disclosure**: a skill's `name` + `description` are surfaced to the
-agent for all skills, and the agent (model) decides when to use one. The spec defines
-no path/glob-based conditional activation. The only access controls are
-`disable-model-invocation` (hide from the model) and `user-invocable` (the `/skill-name`
-slash path). This ADR therefore gates catalog visibility **only** on
-`disable-model-invocation`; `paths` is a non-standard awaken field that does **not**
-affect visibility (see D1/D3).
+Awaken aligns with the [agentskills spec](https://agentskills.io/specification)
+**progressive-disclosure** model: a skill's `name` + `description` are surfaced to the
+agent at startup for all skills, the full `SKILL.md` loads on activation, and resources
+load on demand; the agent (model) decides when to use a skill. The spec's frontmatter is
+`name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`.
+
+The visibility/invocation fields this ADR relies on are **Awaken extensions**, not part
+of the agentskills core spec:
+
+- `disable-model-invocation` — hide from the model catalog and block model invocation.
+- `user-invocable` — controls the `/skill-name` user slash path.
+- `paths` — parsed but **inert**; there is no path/glob conditional activation in the spec.
+
+This ADR therefore gates catalog visibility **only** on `disable-model-invocation`
+(see D1/D3).
 
 The permission system (`awaken-ext-permission`) already demonstrates a clean
 mechanism-policy separation: `PermissionPolicy` (thread-scoped) + `PermissionOverrides`

--- a/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
+++ b/docs/adr/0020-skill-visibility-mechanism-policy-separation.md
@@ -62,30 +62,43 @@ This mirrors `PermissionOverrides` scoping — visibility does not leak across r
 
 Initial visibility is a declarative decision derived from skill metadata — not a
 user-pluggable policy trait. A skill starts `Hidden` when `model_invocable ==
-false` or `paths` is non-empty (conditional skills start hidden, promoted on file
-match); otherwise `Visible`.
+false` (frontmatter `disable-model-invocation: true`); otherwise `Visible`.
 
-`SkillDiscoveryPlugin::on_activate` evaluates this against the registry snapshot
-and seeds `SkillVisibilityState` via `SkillVisibilityAction::SetBatch` at run
-start. Subsequent changes come through actions (tools, plugins, config). This
-mirrors `awaken-ext-permission`, where policy is declarative rule data rather than
-a code trait.
+Path-conditional hiding (a non-empty `paths` set, shown only when a matching file
+is touched) is **deferred**. The file-match promote hook that would bring such a
+skill back is future scope (see D5), so until it lands, `paths`-only skills seed
+`Visible` rather than disappearing from the catalog with no built-in recovery.
+
+Initial visibility is derived **only from skill metadata**; `on_activate` does not
+read `AgentSpec`. `SkillDiscoveryPlugin::on_activate` evaluates the metadata policy
+against the registry snapshot and seeds `SkillVisibilityState` via
+`SkillVisibilityAction::SetBatch` at run start. Subsequent changes come through
+actions (tools, plugins). This mirrors `awaken-ext-permission`, where policy is
+declarative rule data rather than a code trait.
 
 ### D4: Catalog rendering filters by visibility state
 
 `SkillDiscoveryPlugin::render_catalog()` reads `SkillVisibilityState` from the phase
-context and excludes `Hidden` skills. Also renders `when_to_use` into skill
-descriptions.
+context and excludes `Hidden` skills, resolving each skill through
+`effective_visibility` (explicit Show/Hide wins, else the metadata policy — never
+failing open). Also renders `when_to_use` into skill descriptions.
+
+Catalog hiding is **discovery/noise control, not an invocation boundary**. The hard
+guard is `model_invocable`: `SkillActivateTool` (the model's entry point) refuses to
+activate a skill whose `disable-model-invocation` is set, regardless of whether it
+was rendered. A path-conditional skill that is merely `Hidden` stays invocable.
 
 ### D5: Dynamic control through existing action infrastructure
 
 Any plugin, tool, or phase hook can schedule `SkillVisibilityAction`:
 
-- **Config-driven**: Agent spec YAML rules set initial visibility.
 - **Plugin-driven**: Phase hooks mutate visibility state.
 - **Tool-driven**: ToolSearch or custom tools can promote hidden skills.
-- **Conditional activation**: An `AfterToolExecute` hook can match file paths against
-  skill `paths` patterns and promote matching skills (future, not in this ADR scope).
+- **Config-driven** (future, not yet implemented): Agent spec YAML rules set initial
+  visibility. `on_activate` currently ignores `AgentSpec` and seeds from metadata only.
+- **Conditional activation** (future, not in this ADR scope): An `AfterToolExecute`
+  hook matches file paths against skill `paths` patterns and promotes matching skills.
+  Until this exists, path-conditional hiding is not applied (see D3).
 
 ### D6: Parameter substitution in `activate()`
 
@@ -95,8 +108,9 @@ directory (FsSkill only).
 
 ## Consequences
 
-- **Catalog noise reduction**: Skills with `disable-model-invocation` or unfulfilled
-  `paths` patterns no longer consume context budget.
+- **Catalog noise reduction**: Skills with `disable-model-invocation` no longer
+  consume context budget. (Noise reduction for unfulfilled `paths` patterns lands
+  with the conditional-activation hook in D5.)
 - **Extensibility**: The mechanism (state key + `SkillVisibilityAction`) is the
   extension surface — tools, plugins, and config drive visibility changes at
   runtime without changing the catalog rendering mechanism.


### PR DESCRIPTION
## Summary

Fixes skill-catalog **fail-open** (previously `disable-model-invocation` and other non-visible skills could still appear) and hardens `disable-model-invocation` into a real invocation guard, while demoting non-pluggable policy surfaces to a declarative model consistent with `awaken-ext-permission` and the agentskills progressive-disclosure spec.

> This summary reflects the current head. Earlier descriptions of a run-start `SetBatch`/`SeedBatch` seed and `paths`-based hiding are superseded — see below.

### Visibility model
`effective_visibility(meta, state)` is the single resolver, in two layers:
1. **Hard gate** — `disable-model-invocation` (`model_invocable == false`) is always Hidden, evaluated against *live* metadata. An explicit runtime `Show` cannot override it.
2. **Soft runtime** — for model-invocable skills an explicit `Show`/`Hide` wins, else Visible (surfaced by description).

There is **no run-start seed**: the run-scoped `SkillVisibilityState` holds only genuine runtime overrides; defaults come from live metadata at resolve time. This removes the fail-open without a seed (a seed would mask later metadata changes). `render_catalog` resolves every skill through `effective_visibility` and renders within a budget so the catalog stays well-formed under truncation (and is multibyte/UTF-8 safe).

### Invocation guard
`disable-model-invocation` blocks **all** model-facing tools — `skill`, `load_skill_resource`, `skill_script` — via a shared `resolve_for_model` guard, not just the catalog. `/skill-name` user invocation is a separate path, unaffected.

### Spec alignment
Aligns with the [agentskills](https://agentskills.io/specification) progressive-disclosure model (name + description). `disable-model-invocation`, `user-invocable`, and `paths` are **Awaken extensions**, not agentskills core fields. `paths` is parsed but **inert** (no path/glob conditional activation). `EmbeddedSkill` now maps the same frontmatter as `FsSkill` via a shared `meta_from_frontmatter`, so embedded skills honor `disable-model-invocation` etc.

### Breaking changes
Pre-1.0 (`0.5.1-dev`), no in-tree consumers; documented in `CHANGELOG.md` with a migration table. Removed `SkillVisibilityPolicy` / `DefaultSkillVisibilityPolicy`; `awaken-ext-deferred-tools::policy` is now private (with `DeferralPolicy` / `ConfigOnlyPolicy` / `DeferralDecision` gone). `SkillVisibilityStateValue.modes` is now `pub(crate)` — resolve via `effective_visibility`. Added `effective_visibility`. No deprecated shims.

### Tests
- `effective_visibility` hard-gate + override matrix; `render_catalog` matrix (no-state / explicit override) with multibyte-safe, structure-safe truncation.
- Guard regression for all three model-facing tools (`activate` / `load_skill_resource` / `skill_script`).
- End-to-end: first `BeforeInference` hook excludes a `disable-model-invocation` skill with no seed.
- `EmbeddedSkill` frontmatter mapping; deferred-tools real-hook promotion regression.

### Verification
`cargo test -p awaken-ext-skills -p awaken-ext-deferred-tools` green; `cargo clippy --all-targets` clean; `cargo build --workspace` clean.
