### PR TITLE
Make mailbox and A2A push outbox pluggable

### DIFF
--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use awaken_contract::RedactedString;
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::event_store::EventStore;
+use awaken_contract::contract::outbox::OutboxStore;
 use awaken_contract::contract::storage::ThreadRunStore;
 use awaken_ext_observability::RuntimeStatsRegistry;
 use awaken_runtime::credentials::CredentialBroker;
@@ -332,6 +333,41 @@ impl ServerState {
         )
     }
 
+    /// Build server state with a process-local mailbox implementation.
+    ///
+    /// This keeps every run-control and protocol route available when an
+    /// external mailbox backend is not wired. The local mailbox is in-memory and
+    /// best-effort; use [`ServerState::new`] with an externally backed
+    /// [`Mailbox`] for durable or multi-replica deployments.
+    pub fn new_with_local_mailbox(
+        runtime: Arc<AgentRuntime>,
+        store: Arc<dyn ThreadRunStore>,
+        resolver: Arc<dyn AgentResolver>,
+        config: ServerConfig,
+    ) -> Self {
+        let mailbox = Arc::new(Mailbox::new(
+            runtime.clone(),
+            Arc::new(awaken_stores::InMemoryMailboxStore::new()),
+            store.clone(),
+            "local".to_string(),
+            crate::mailbox::MailboxConfig::default(),
+        ));
+        Self::new(runtime, mailbox, store, resolver, config)
+    }
+
+    /// Build server state without an externally supplied mailbox backend.
+    ///
+    /// The server still installs a process-local mailbox so API behavior stays
+    /// consistent; only durability and cross-process delivery semantics differ.
+    pub fn new_without_external_mailbox(
+        runtime: Arc<AgentRuntime>,
+        store: Arc<dyn ThreadRunStore>,
+        resolver: Arc<dyn AgentResolver>,
+        config: ServerConfig,
+    ) -> Self {
+        Self::new_with_local_mailbox(runtime, store, resolver, config)
+    }
+
     #[must_use]
     pub fn with_credential_broker(mut self, broker: Arc<dyn CredentialBroker>) -> Self {
         self.run = self.run.with_credential_broker(broker);
@@ -350,6 +386,24 @@ impl ServerState {
 
     pub fn runtime_stats(&self) -> Option<Arc<RuntimeStatsRegistry>> {
         self.run.runtime_stats.clone()
+    }
+
+    pub fn with_a2a_push_webhook_outbox(
+        self,
+        outbox: Arc<dyn OutboxStore>,
+    ) -> Result<Self, crate::outbox_relay::OutboxRelayError> {
+        self.with_a2a_push_webhook_relay(
+            outbox,
+            crate::protocol_replay_state::A2aPushWebhookRelayConfig::default(),
+        )
+    }
+
+    pub fn with_a2a_push_webhook_relay(
+        self,
+        outbox: Arc<dyn OutboxStore>,
+        config: crate::protocol_replay_state::A2aPushWebhookRelayConfig,
+    ) -> Result<Self, crate::outbox_relay::OutboxRelayError> {
+        crate::protocol_replay_state::with_a2a_push_webhook_relay(self, outbox, config)
     }
 
     #[must_use]
@@ -658,6 +712,7 @@ pub async fn serve(state: ServerState) -> std::io::Result<()> {
                 state
                     .run
                     .mailbox
+                    .clone()
                     .start_lifecycle_ready(MailboxLifecycleConfig {
                         maintenance_callback: Some(Arc::new(move || {
                             cleanup_state

--- a/crates/awaken-server/src/app/modules.rs
+++ b/crates/awaken-server/src/app/modules.rs
@@ -1,8 +1,10 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 
 use awaken_contract::contract::config_store::ConfigStore;
 use awaken_contract::contract::event_store::EventStore;
+use awaken_contract::contract::outbox::OutboxStore;
 use awaken_contract::contract::storage::ThreadRunStore;
 use awaken_ext_observability::RuntimeStatsRegistry;
 use awaken_ext_observability::trace_store::TraceStore;
@@ -14,6 +16,8 @@ use awaken_contract::RedactedString;
 use super::{AdminApiConfig, AuditLogConfig, ReplayBufferMap, ServerState, SkillCatalogProvider};
 use crate::eval_limits::EvalLimits;
 use crate::mailbox::Mailbox;
+use crate::outbox_relay::OutboxRelayError;
+use crate::protocol_replay_state::A2aPushWebhookRelayConfig;
 use crate::services::audit_log::AuditLogger;
 
 #[derive(Clone)]
@@ -41,6 +45,10 @@ impl RunModuleState {
             credential_broker: Arc::new(awaken_runtime::credentials::AwakenCredentialBroker::new()),
             runtime_stats: None,
         }
+    }
+
+    pub fn mailbox(&self) -> Arc<Mailbox> {
+        self.mailbox.clone()
     }
 
     #[must_use]
@@ -115,6 +123,83 @@ pub struct TraceModuleState {
 pub struct ProtocolModuleState {
     pub replay_buffers: ReplayBufferMap,
     pub mcp_http: Arc<crate::protocols::mcp::http::McpHttpState>,
+    pub a2a_push_outbox: Arc<dyn OutboxStore>,
+    pub a2a_push_relay_config: A2aPushWebhookRelayConfig,
+    pub a2a_push_driver_keys: Arc<parking_lot::Mutex<HashSet<(Option<String>, String, String)>>>,
+}
+
+impl ProtocolModuleState {
+    /// Build protocol state with a process-local, in-memory A2A push outbox.
+    ///
+    /// The default outbox is best-effort and non-durable: queued webhook
+    /// deliveries are lost on restart and are not shared across replicas. Because
+    /// an outbox relay is registered, the A2A agent card advertises
+    /// `pushNotifications: true` for the default state. For durable or
+    /// multi-replica webhook delivery, inject an external outbox via
+    /// [`ServerState::with_a2a_push_webhook_outbox`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_a2a_push_outbox(
+            Arc::new(awaken_stores::InMemoryOutboxStore::new()),
+            A2aPushWebhookRelayConfig::default(),
+        )
+    }
+
+    #[must_use]
+    pub fn with_a2a_push_outbox(
+        outbox: Arc<dyn OutboxStore>,
+        relay_config: A2aPushWebhookRelayConfig,
+    ) -> Self {
+        Self {
+            replay_buffers: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+            mcp_http: Arc::new(crate::protocols::mcp::http::McpHttpState::new()),
+            a2a_push_outbox: outbox,
+            a2a_push_relay_config: relay_config,
+            a2a_push_driver_keys: Arc::new(parking_lot::Mutex::new(HashSet::new())),
+        }
+    }
+
+    pub(crate) fn register_a2a_push_webhook_relay(&self) -> Result<(), OutboxRelayError> {
+        crate::protocol_replay_state::register_a2a_push_webhook_relay_for_buffers(
+            &self.replay_buffers,
+            self.a2a_push_outbox.clone(),
+            self.a2a_push_relay_config.clone(),
+        )
+    }
+
+    pub(crate) fn register_a2a_push_driver(
+        &self,
+        task_id: &str,
+        tenant: Option<&str>,
+        config_id: &str,
+    ) -> bool {
+        let key = (
+            tenant.map(ToOwned::to_owned),
+            task_id.to_string(),
+            config_id.to_string(),
+        );
+        self.a2a_push_driver_keys.lock().insert(key) // true if newly inserted
+    }
+
+    pub(crate) fn unregister_a2a_push_driver(
+        &self,
+        task_id: &str,
+        tenant: Option<&str>,
+        config_id: &str,
+    ) {
+        let key = (
+            tenant.map(ToOwned::to_owned),
+            task_id.to_string(),
+            config_id.to_string(),
+        );
+        self.a2a_push_driver_keys.lock().remove(&key);
+    }
+}
+
+impl Default for ProtocolModuleState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Clone)]
@@ -217,10 +302,7 @@ impl ServerState {
             events: None,
             eval: None,
             trace: None,
-            protocol: ProtocolModuleState {
-                replay_buffers: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
-                mcp_http: Arc::new(crate::protocols::mcp::http::McpHttpState::new()),
-            },
+            protocol: ProtocolModuleState::new(),
             admin: AdminModuleState {
                 admin_api_config: super::AdminApiConfig::default(),
                 audit_log_config: super::AuditLogConfig::default(),
@@ -228,12 +310,10 @@ impl ServerState {
             },
             server_config,
         };
-        crate::protocol_replay_state::register_a2a_push_webhook_relay_for_buffers(
-            &state.protocol.replay_buffers,
-            Arc::new(awaken_stores::InMemoryOutboxStore::new()),
-            crate::protocol_replay_state::A2aPushWebhookRelayConfig::default(),
-        )
-        .expect("default A2A push webhook relay config is valid");
+        state
+            .protocol
+            .register_a2a_push_webhook_relay()
+            .expect("default A2A push webhook relay config is valid");
         state
     }
 
@@ -263,7 +343,20 @@ impl ServerState {
 
     #[must_use]
     pub fn with_protocol(mut self, protocol: ProtocolModuleState) -> Self {
+        let previous_buffers = self.protocol.replay_buffers.clone();
         self.protocol = protocol;
+        // Replacing the protocol module swaps the replay-buffer identity used by
+        // the relay registry. Migrate attachments registered against the previous
+        // buffers (log/projector/fanout) so a relay configured before this call is
+        // not silently orphaned, then (re)register the replacement module's A2A
+        // push outbox instead of falling back to a hidden in-memory store.
+        crate::protocol_replay_state::migrate_protocol_attachments(
+            &previous_buffers,
+            &self.protocol.replay_buffers,
+        );
+        self.protocol
+            .register_a2a_push_webhook_relay()
+            .expect("default A2A push webhook relay config is valid");
         self
     }
 
@@ -386,5 +479,24 @@ impl ServerState {
             admin: self.admin_module(),
             trace: self.trace_module()?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_push_driver_registry_is_single_flight_per_task_tenant_config() {
+        let protocol = ProtocolModuleState::new();
+
+        assert!(protocol.register_a2a_push_driver("task-1", Some("tenant-1"), "cfg-1"));
+        assert!(!protocol.register_a2a_push_driver("task-1", Some("tenant-1"), "cfg-1"));
+
+        assert!(protocol.register_a2a_push_driver("task-1", Some("tenant-1"), "cfg-2"));
+        assert!(protocol.register_a2a_push_driver("task-2", Some("tenant-1"), "cfg-1"));
+
+        protocol.unregister_a2a_push_driver("task-1", Some("tenant-1"), "cfg-1");
+        assert!(protocol.register_a2a_push_driver("task-1", Some("tenant-1"), "cfg-1"));
     }
 }

--- a/crates/awaken-server/src/app_test.rs
+++ b/crates/awaken-server/src/app_test.rs
@@ -601,3 +601,145 @@ async fn config_module_state_reuses_preset_logger() {
         "ConfigModuleState must expose the pre-set AuditLogger instance"
     );
 }
+
+fn local_component_state() -> ServerState {
+    use awaken_stores::InMemoryStore;
+
+    struct StubResolver;
+    impl awaken_runtime::AgentResolver for StubResolver {
+        fn resolve(
+            &self,
+            agent_id: &str,
+        ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
+            Err(awaken_runtime::RuntimeError::AgentNotFound {
+                agent_id: agent_id.to_string(),
+            })
+        }
+    }
+
+    let runtime = Arc::new(
+        awaken_runtime::builder::AgentRuntimeBuilder::new()
+            .build_unchecked()
+            .expect("build runtime"),
+    );
+    let store = Arc::new(InMemoryStore::new());
+    ServerState::new_with_local_mailbox(
+        runtime,
+        store as Arc<dyn ThreadRunStore>,
+        Arc::new(StubResolver),
+        ServerConfig::default(),
+    )
+}
+
+#[test]
+fn server_state_with_local_mailbox_uses_local_components() {
+    let state = local_component_state();
+
+    assert!(
+        crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(
+            &state.protocol.replay_buffers
+        )
+        .is_some(),
+        "A2A push outbox should default to a local in-memory implementation"
+    );
+}
+
+#[test]
+fn with_protocol_preserves_default_a2a_push_outbox_for_new_replay_buffers() {
+    let state = local_component_state();
+    let protocol = ProtocolModuleState::new();
+
+    assert!(
+        crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(&protocol.replay_buffers)
+            .is_none(),
+        "fresh protocol module should carry an outbox but not register its buffers until mounted"
+    );
+
+    let state = state.with_protocol(protocol);
+
+    assert!(
+        crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(
+            &state.protocol.replay_buffers
+        )
+        .is_some(),
+        "with_protocol should attach the local A2A push outbox to the replacement buffers"
+    );
+}
+
+#[test]
+fn a2a_push_outbox_can_replace_default_local_outbox() {
+    use awaken_contract::contract::outbox::OutboxStore;
+    use awaken_stores::InMemoryOutboxStore;
+
+    let state = local_component_state();
+    let default_outbox = crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(
+        &state.protocol.replay_buffers,
+    )
+    .expect("default A2A push outbox should be attached");
+
+    let replacement: Arc<dyn OutboxStore> = Arc::new(InMemoryOutboxStore::new());
+    assert!(
+        !Arc::ptr_eq(&default_outbox, &replacement),
+        "replacement should be a distinct outbox instance"
+    );
+
+    let state = crate::protocol_replay_state::with_a2a_push_webhook_relay(
+        state,
+        replacement.clone(),
+        crate::protocol_replay_state::A2aPushWebhookRelayConfig::default(),
+    )
+    .expect("replace A2A push outbox");
+
+    let attached = crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(
+        &state.protocol.replay_buffers,
+    )
+    .expect("replacement A2A push outbox should be attached");
+    assert!(
+        Arc::ptr_eq(&attached, &replacement),
+        "explicit A2A push outbox should replace the local default"
+    );
+    assert!(
+        Arc::ptr_eq(&state.protocol.a2a_push_outbox, &replacement),
+        "server state should carry the explicit A2A push outbox as a module dependency"
+    );
+}
+
+#[test]
+fn server_state_method_injects_a2a_push_outbox_dependency() {
+    use awaken_contract::contract::outbox::OutboxStore;
+    use awaken_stores::InMemoryOutboxStore;
+
+    let replacement: Arc<dyn OutboxStore> = Arc::new(InMemoryOutboxStore::new());
+    let state = local_component_state()
+        .with_a2a_push_webhook_outbox(replacement.clone())
+        .expect("inject A2A push outbox");
+
+    let attached = crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(
+        &state.protocol.replay_buffers,
+    )
+    .expect("injected A2A push outbox should be registered");
+    assert!(Arc::ptr_eq(&attached, &replacement));
+    assert!(Arc::ptr_eq(&state.protocol.a2a_push_outbox, &replacement));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn mailbox_routes_remain_available_with_local_mailbox() {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    let state = local_component_state();
+    let app = crate::routes::build_router(&state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/threads/local-thread/mailbox")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/crates/awaken-server/src/protocol_replay_state.rs
+++ b/crates/awaken-server/src/protocol_replay_state.rs
@@ -303,10 +303,12 @@ pub fn with_protocol_fanout_relay(
 }
 
 pub fn with_a2a_push_webhook_relay(
-    state: ServerState,
+    mut state: ServerState,
     outbox: Arc<dyn OutboxStore>,
     config: A2aPushWebhookRelayConfig,
 ) -> Result<ServerState, OutboxRelayError> {
+    state.protocol.a2a_push_outbox = outbox.clone();
+    state.protocol.a2a_push_relay_config = config.clone();
     register_a2a_push_webhook_relay_for_buffers(&state.protocol.replay_buffers, outbox, config)?;
     Ok(state)
 }
@@ -336,6 +338,27 @@ pub(crate) fn register_a2a_push_webhook_relay_for_buffers(
             a2a_push_relay: Some(A2aPushWebhookRelayAttachment { outbox, config }),
         });
     Ok(())
+}
+
+/// Move every relay attachment (log, projector, fanout, A2A push) from `old`
+/// replay buffers to `new`.
+///
+/// The registry is keyed by replay-buffer identity, so replacing a state's
+/// protocol module — which swaps in fresh `replay_buffers` — would otherwise
+/// orphan any attachment registered before the swap. `start_protocol_relays`
+/// looks attachments up by the current buffers, so an orphaned projector/fanout/
+/// log relay would silently never start.
+pub(crate) fn migrate_protocol_attachments(old: &ReplayBufferMap, new: &ReplayBufferMap) {
+    if Arc::ptr_eq(old, new) {
+        return;
+    }
+    let mut registry = registry().lock();
+    prune(&mut registry);
+    let Some(mut attachment) = registry.remove(&key(old)) else {
+        return;
+    };
+    attachment.replay_buffers = Arc::downgrade(new);
+    registry.insert(key(new), attachment);
 }
 
 pub fn a2a_push_webhook_outbox_for_buffers(

--- a/crates/awaken-server/src/protocol_replay_state/tests.rs
+++ b/crates/awaken-server/src/protocol_replay_state/tests.rs
@@ -178,6 +178,40 @@ async fn protocol_projector_relay_projects_attached_outbox_in_background() {
 }
 
 #[tokio::test]
+async fn with_protocol_migrates_relay_attachments_to_new_buffers() {
+    use crate::app::ProtocolModuleState;
+
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
+    let outbox = Arc::new(InMemoryOutboxStore::new());
+
+    // Configure a projector relay *before* replacing the protocol module.
+    let state = with_protocol_replay_log(make_state(), replay_log.clone());
+    let state = with_protocol_projector_relay(
+        state,
+        outbox,
+        event_store as Arc<dyn EventLookup>,
+        replay_log as Arc<dyn ProtocolReplayWriter>,
+        fast_config(),
+    )
+    .unwrap();
+
+    // Replacing the protocol module swaps replay-buffer identity. The projector
+    // attachment and replay log must migrate so the relay still starts instead
+    // of being silently orphaned under the previous buffers.
+    let state = state.with_protocol(ProtocolModuleState::new());
+
+    assert!(
+        protocol_replay_log(&state).is_some(),
+        "replay log configured before with_protocol must survive the swap"
+    );
+    let handle = start_protocol_projector_relay(&state)
+        .unwrap()
+        .expect("projector relay configured before with_protocol must survive the swap");
+    handle.shutdown().await;
+}
+
+#[tokio::test]
 async fn protocol_fanout_relay_publishes_attached_outbox_in_background() {
     let replay_log = Arc::new(InMemoryProtocolReplayLog::new());
     let outbox = Arc::new(InMemoryOutboxStore::new());

--- a/crates/awaken-server/src/protocols/a2a/agent_card.rs
+++ b/crates/awaken-server/src/protocols/a2a/agent_card.rs
@@ -114,7 +114,14 @@ fn build_agent_card(
         documentation_url: None,
         capabilities: AgentCapabilities {
             streaming: true,
-            push_notifications: true,
+            // Advertised whenever an A2A push outbox relay is registered. The
+            // default state registers a process-local, best-effort in-memory
+            // outbox, so this is `true` by default; durability/multi-replica
+            // semantics depend on the injected outbox (see `ProtocolModuleState`).
+            push_notifications: crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(
+                &st.protocol.replay_buffers,
+            )
+            .is_some(),
             state_transition_history: false,
             extended_agent_card: supports_extended_card,
         },

--- a/crates/awaken-server/src/protocols/a2a/message.rs
+++ b/crates/awaken-server/src/protocols/a2a/message.rs
@@ -127,7 +127,7 @@ async fn send_message(
     }
 
     st.run
-        .mailbox
+        .mailbox()
         .submit_background(request)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -195,7 +195,7 @@ async fn stream_message(
     }
 
     st.run
-        .mailbox
+        .mailbox()
         .submit_background(request)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -515,7 +515,7 @@ async fn thread_has_prior_context(
 
     let pending = st
         .run
-        .mailbox
+        .mailbox()
         .list_dispatches(
             thread_id,
             Some(&[RunDispatchStatus::Queued, RunDispatchStatus::Claimed]),

--- a/crates/awaken-server/src/protocols/a2a/push_config.rs
+++ b/crates/awaken-server/src/protocols/a2a/push_config.rs
@@ -6,7 +6,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use uuid::Uuid;
 
-use crate::app::ProtocolRoutesState;
+use crate::app::{ProtocolModuleState, ProtocolRoutesState};
 
 use super::common::{
     ensure_supported_version, load_thread_metadata_projection, parse_page_token,
@@ -173,9 +173,15 @@ async fn delete_push_config(
     ensure_supported_version(&headers)?;
     ensure_task_visible(&st, &task_id, tenant.as_deref()).await?;
 
-    let mut configs = load_push_notification_configs(&st, &task_id, tenant.as_deref()).await?;
+    // Load the full config set (all tenants) and remove only the matching
+    // (tenant, config id) entry. A tenant-scoped delete must not drop configs
+    // owned by other tenants when the whole task list is persisted back.
+    let mut configs = load_push_notification_configs(&st, &task_id, None).await?;
     let before = configs.len();
-    configs.retain(|config| config.id.as_deref() != Some(config_id.as_str()));
+    configs.retain(|config| {
+        !(config.id.as_deref() == Some(config_id.as_str())
+            && config.agent_id.as_deref() == tenant.as_deref())
+    });
     if configs.len() == before {
         return Err(A2aError::push_config_not_found(task_id, config_id));
     }
@@ -279,18 +285,34 @@ async fn save_push_notification_configs(
     save_thread_push_notification_configs(st, &thread_id, exists, thread, task_id, configs).await
 }
 
+/// Insert or replace `config` within the task's full config list, scoped to its
+/// owning tenant. Matching is keyed on `(tenant, config id)` so a write for one
+/// tenant never overwrites another tenant's config that shares a config id.
+fn upsert_into(
+    configs: &mut Vec<PushNotificationConfig>,
+    tenant: Option<&str>,
+    config: PushNotificationConfig,
+) {
+    if let Some(position) = configs
+        .iter()
+        .position(|existing| existing.id == config.id && existing.agent_id.as_deref() == tenant)
+    {
+        configs[position] = config;
+    } else {
+        configs.push(config);
+    }
+}
+
 async fn upsert_push_notification_config(
     st: &ProtocolRoutesState,
     task_id: &str,
     tenant: Option<&str>,
     config: PushNotificationConfig,
 ) -> Result<(), A2aError> {
-    let mut configs = load_push_notification_configs(st, task_id, tenant).await?;
-    if let Some(position) = configs.iter().position(|existing| existing.id == config.id) {
-        configs[position] = config;
-    } else {
-        configs.push(config);
-    }
+    // Load the full config set (all tenants) so a tenant-scoped write preserves
+    // configs owned by other tenants when the whole task list is persisted back.
+    let mut configs = load_push_notification_configs(st, task_id, None).await?;
+    upsert_into(&mut configs, tenant, config);
     save_push_notification_configs(st, task_id, configs).await
 }
 
@@ -302,15 +324,10 @@ pub(super) async fn upsert_push_notification_config_for_thread(
     config: PushNotificationConfig,
 ) -> Result<(), A2aError> {
     let (exists, thread) = load_thread_metadata_projection(st, thread_id).await?;
+    // Operate on the full config set; `upsert_into` scopes the replace to the
+    // owning tenant so other tenants' configs survive the whole-task write.
     let mut configs = load_thread_push_notification_configs(&thread, task_id)?;
-    if let Some(tenant) = tenant {
-        configs.retain(|existing| existing.agent_id.as_deref() == Some(tenant));
-    }
-    if let Some(position) = configs.iter().position(|existing| existing.id == config.id) {
-        configs[position] = config;
-    } else {
-        configs.push(config);
-    }
+    upsert_into(&mut configs, tenant, config);
     save_thread_push_notification_configs(st, thread_id, exists, thread, task_id, configs).await
 }
 
@@ -361,14 +378,49 @@ async fn save_thread_push_notification_configs(
     Ok(())
 }
 
+/// Releases the single-flight dedupe key for an A2A push driver when the driver
+/// task ends. Using `Drop` covers normal completion, early error returns, task
+/// panics, and task aborts — an explicit unregister at the end of the task body
+/// would be skipped on panic/abort and leak the key, blocking re-registration.
+struct PushDriverGuard {
+    protocol: ProtocolModuleState,
+    task_id: String,
+    tenant: Option<String>,
+    config_id: String,
+}
+
+impl Drop for PushDriverGuard {
+    fn drop(&mut self) {
+        self.protocol.unregister_a2a_push_driver(
+            &self.task_id,
+            self.tenant.as_deref(),
+            &self.config_id,
+        );
+    }
+}
+
 pub(super) fn spawn_push_notification_driver(
     st: ProtocolRoutesState,
     task_id: String,
     tenant: Option<String>,
     config: PushNotificationConfig,
 ) {
+    let config_id = config.id.clone().unwrap_or_default();
+    if !st
+        .protocol
+        .register_a2a_push_driver(&task_id, tenant.as_deref(), &config_id)
+    {
+        return;
+    }
+
     tokio::spawn(async move {
-        if let Err(err) = drive_push_notification(st, task_id, tenant, config).await {
+        let _guard = PushDriverGuard {
+            protocol: st.protocol.clone(),
+            task_id: task_id.clone(),
+            tenant: tenant.clone(),
+            config_id: config_id.clone(),
+        };
+        if let Err(err) = drive_push_notification(st, task_id, tenant, config_id).await {
             tracing::warn!(error = ?err, "A2A push notification driver stopped with error");
         }
     });
@@ -378,7 +430,7 @@ async fn drive_push_notification(
     st: ProtocolRoutesState,
     task_id: String,
     tenant: Option<String>,
-    config: PushNotificationConfig,
+    config_id: String,
 ) -> Result<(), A2aError> {
     let outbox = crate::protocol_replay_state::a2a_push_webhook_outbox_for_buffers(
         &st.protocol.replay_buffers,
@@ -386,16 +438,14 @@ async fn drive_push_notification(
     .ok_or_else(|| {
         A2aError::Internal("A2A push notification outbox relay is not configured".to_string())
     })?;
-    let config_id = config.id.clone().unwrap_or_default();
     let mut projector = TaskStreamProjector::new(InitialStreamEvent::StatusUpdate);
 
     loop {
-        if find_push_notification_config(&st, &task_id, tenant.as_deref(), &config_id)
-            .await?
-            .is_none()
-        {
+        let Some(config) =
+            find_push_notification_config(&st, &task_id, tenant.as_deref(), &config_id).await?
+        else {
             break;
-        }
+        };
 
         let snapshot = load_task_snapshot(&st, &task_id, tenant.as_deref(), usize::MAX, true)
             .await?
@@ -436,4 +486,76 @@ async fn drive_push_notification(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(id: &str, tenant: Option<&str>, url: &str) -> PushNotificationConfig {
+        PushNotificationConfig {
+            agent_id: tenant.map(ToOwned::to_owned),
+            id: Some(id.to_string()),
+            task_id: Some("task-1".to_string()),
+            url: url.to_string(),
+            token: None,
+            authentication: None,
+        }
+    }
+
+    #[test]
+    fn upsert_into_is_scoped_per_tenant() {
+        let mut configs = Vec::new();
+        // The same config id under two different tenants must coexist; a write
+        // for one tenant must not overwrite another tenant's entry.
+        upsert_into(
+            &mut configs,
+            Some("a"),
+            config("shared", Some("a"), "http://a/1"),
+        );
+        upsert_into(
+            &mut configs,
+            Some("b"),
+            config("shared", Some("b"), "http://b/1"),
+        );
+        assert_eq!(configs.len(), 2);
+
+        // Updating tenant "a" replaces only its entry and leaves "b" untouched.
+        upsert_into(
+            &mut configs,
+            Some("a"),
+            config("shared", Some("a"), "http://a/2"),
+        );
+        assert_eq!(configs.len(), 2);
+        let a = configs
+            .iter()
+            .find(|c| c.agent_id.as_deref() == Some("a"))
+            .unwrap();
+        assert_eq!(a.url, "http://a/2");
+        let b = configs
+            .iter()
+            .find(|c| c.agent_id.as_deref() == Some("b"))
+            .unwrap();
+        assert_eq!(b.url, "http://b/1");
+    }
+
+    #[test]
+    fn push_driver_guard_releases_key_on_drop() {
+        let protocol = ProtocolModuleState::new();
+        assert!(protocol.register_a2a_push_driver("task-1", Some("a"), "cfg-1"));
+        // A second registration is rejected while the driver is live.
+        assert!(!protocol.register_a2a_push_driver("task-1", Some("a"), "cfg-1"));
+
+        let guard = PushDriverGuard {
+            protocol: protocol.clone(),
+            task_id: "task-1".to_string(),
+            tenant: Some("a".to_string()),
+            config_id: "cfg-1".to_string(),
+        };
+        drop(guard);
+
+        // Once the guard drops (e.g. driver task panicked or was aborted) the key
+        // is released and re-registration succeeds.
+        assert!(protocol.register_a2a_push_driver("task-1", Some("a"), "cfg-1"));
+    }
 }

--- a/crates/awaken-server/src/protocols/a2a/task.rs
+++ b/crates/awaken-server/src/protocols/a2a/task.rs
@@ -17,6 +17,7 @@ use super::common::{
 };
 use super::conversion::{awaken_message_to_a2a_message, message_to_artifacts};
 use super::error::A2aError;
+
 use super::types::{
     BLOCKING_POLL_INTERVAL, BLOCKING_WAIT_TIMEOUT, DEFAULT_PAGE_SIZE, GetTaskQuery, ListTasksQuery,
     MAX_PAGE_SIZE, ResolvedTask, StoredTaskBinding, StoredTaskBindings, TASK_BINDINGS_METADATA_KEY,
@@ -80,9 +81,8 @@ pub(super) async fn cancel_task(
         ));
     }
 
-    let queued_dispatches = st
-        .run
-        .mailbox
+    let mailbox = st.run.mailbox();
+    let queued_dispatches = mailbox
         .list_dispatches(
             &existing.task.id,
             Some(&[RunDispatchStatus::Queued]),
@@ -94,16 +94,12 @@ pub(super) async fn cancel_task(
 
     let mut cancelled = false;
     for dispatch in queued_dispatches {
-        cancelled |= st
-            .run
-            .mailbox
+        cancelled |= mailbox
             .cancel(&dispatch.dispatch_id)
             .await
             .map_err(|e| A2aError::Internal(e.to_string()))?;
     }
-    cancelled |= st
-        .run
-        .mailbox
+    cancelled |= mailbox
         .cancel(&existing.task.id)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -233,7 +229,7 @@ pub(super) async fn resolve_task(
     {
         let dispatch = st
             .run
-            .mailbox
+            .mailbox()
             .load_dispatch(task_id)
             .await
             .map_err(|e| A2aError::Internal(e.to_string()))?;
@@ -246,7 +242,7 @@ pub(super) async fn resolve_task(
 
     let Some(dispatch) = st
         .run
-        .mailbox
+        .mailbox()
         .load_dispatch(task_id)
         .await
         .map_err(|e| A2aError::Internal(e.to_string()))?
@@ -376,7 +372,7 @@ pub(super) async fn load_task_snapshot(
         Some(dispatch)
     } else {
         st.run
-            .mailbox
+            .mailbox()
             .list_dispatches(&thread_id, None, 100, 0)
             .await
             .map_err(|e| A2aError::Internal(e.to_string()))?
@@ -632,7 +628,7 @@ pub(super) async fn collect_task_ids(st: &ProtocolRoutesState) -> Result<Vec<Str
         for thread_id in batch {
             let dispatches = st
                 .run
-                .mailbox
+                .mailbox()
                 .list_dispatches(
                     &thread_id,
                     Some(&[RunDispatchStatus::Queued, RunDispatchStatus::Claimed]),

--- a/crates/awaken-server/src/protocols/ag_ui/http.rs
+++ b/crates/awaken-server/src/protocols/ag_ui/http.rs
@@ -216,7 +216,7 @@ async fn interrupt_thread(
 ) -> Result<Response, ApiError> {
     let interrupted = st
         .run
-        .mailbox
+        .mailbox()
         .interrupt(&thread_id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -304,7 +304,7 @@ async fn ag_ui_run_inner(
     }
     let (_result, event_rx) = st
         .run
-        .mailbox
+        .mailbox()
         .submit(request)
         .await
         .map_err(map_mailbox_error)?;

--- a/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
+++ b/crates/awaken-server/src/protocols/ai_sdk_v6/http.rs
@@ -278,20 +278,13 @@ async fn ai_sdk_chat_inner(st: S, payload: AiSdkChatRequest) -> Result<Response,
     // decisions to resume the run on a fresh SSE stream.
     if !decisions.is_empty() {
         let (new_event_tx, new_event_rx) = tokio::sync::mpsc::channel(256);
-        let reconnected = st
-            .run
-            .mailbox
-            .reconnect_sink(&thread_id, new_event_tx)
-            .await;
+        let mailbox = st.run.mailbox();
+        let reconnected = mailbox.reconnect_sink(&thread_id, new_event_tx).await;
 
         if reconnected {
             let mut any_delivered = false;
             for (tool_call_id, resume) in &decisions {
-                if st
-                    .run
-                    .mailbox
-                    .send_decision(&thread_id, tool_call_id.clone(), resume.clone())
-                {
+                if mailbox.send_decision(&thread_id, tool_call_id.clone(), resume.clone()) {
                     any_delivered = true;
                 }
             }
@@ -350,7 +343,7 @@ async fn ai_sdk_chat_inner(st: S, payload: AiSdkChatRequest) -> Result<Response,
     }
     let (_result, event_rx) = st
         .run
-        .mailbox
+        .mailbox()
         .submit(request)
         .await
         .map_err(map_mailbox_error)?;
@@ -631,7 +624,7 @@ async fn cancel_thread(
 ) -> Result<Response, ApiError> {
     let cancelled = st
         .run
-        .mailbox
+        .mailbox()
         .cancel(&thread_id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -656,7 +649,7 @@ async fn interrupt_thread(
 ) -> Result<Response, ApiError> {
     let interrupted = st
         .run
-        .mailbox
+        .mailbox()
         .interrupt(&thread_id)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;

--- a/crates/awaken-server/src/protocols/mcp/http.rs
+++ b/crates/awaken-server/src/protocols/mcp/http.rs
@@ -73,9 +73,12 @@ struct McpHttpSession {
 impl McpHttpSession {
     fn new(
         runtime: &Arc<awaken_runtime::AgentRuntime>,
-        mailbox: Arc<crate::mailbox::Mailbox>,
+        mailbox: Option<Arc<crate::mailbox::Mailbox>>,
     ) -> Arc<Self> {
-        let (server, mut channels) = super::create_mcp_server_with_mailbox(runtime, mailbox);
+        let (server, mut channels) = match mailbox {
+            Some(mailbox) => super::create_mcp_server_with_mailbox(runtime, mailbox),
+            None => super::create_mcp_server(runtime),
+        };
         let session = Arc::new(Self {
             id: Uuid::new_v4().to_string(),
             server,
@@ -319,7 +322,7 @@ async fn handle_request_post(
             ));
         }
 
-        let session = McpHttpSession::new(&st.run.runtime, Arc::clone(&st.run.mailbox));
+        let session = McpHttpSession::new(&st.run.runtime, Some(st.run.mailbox()));
         let response = session.dispatch_json_request(request).await?;
         if response.is_success() {
             if let Some(version) = response_protocol_version(&response) {
@@ -824,7 +827,7 @@ mod tests {
     #[tokio::test]
     async fn sse_prime_frame_contains_empty_data_event() {
         let state = make_app_state();
-        let session = McpHttpSession::new(&state.run.runtime, Arc::clone(&state.run.mailbox));
+        let session = McpHttpSession::new(&state.run.runtime, Some(state.run.mailbox()));
         let frame = session.prime_sse_frame();
         let text = std::str::from_utf8(&frame).unwrap();
         assert!(text.contains("data:\n\n"));

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -589,7 +589,7 @@ async fn push_mailbox(
 
     let result = st
         .run
-        .mailbox
+        .mailbox()
         .submit_background(RunActivation::new(id, messages))
         .await
         .map_err(map_mailbox_error)?;
@@ -614,7 +614,7 @@ async fn peek_mailbox(
     let limit = params.limit.clamp(1, 200);
     let dispatches = st
         .run
-        .mailbox
+        .mailbox()
         .list_dispatches(&id, None, limit, offset)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
@@ -663,7 +663,7 @@ async fn start_run(
     let request = RunActivation::new(thread_id, messages).with_agent_id(agent_id);
     let (_result, event_rx) = st
         .run
-        .mailbox
+        .mailbox()
         .submit(request)
         .await
         .map_err(map_mailbox_error)?;

--- a/crates/awaken-server/src/services/run_control_service.rs
+++ b/crates/awaken-server/src/services/run_control_service.rs
@@ -15,7 +15,8 @@ use awaken_contract::contract::suspension::ToolCallResume;
 use awaken_runtime::RunActivation;
 
 use crate::app::RunModuleState;
-use crate::mailbox::{MailboxError, MailboxSubmitResult};
+use crate::mailbox::{Mailbox, MailboxError, MailboxSubmitResult};
+use std::sync::Arc;
 
 /// How injected user input should interact with any active work.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -95,6 +96,10 @@ pub struct RunControlService {
 impl RunControlService {
     pub fn new(state: RunModuleState) -> Self {
         Self { state }
+    }
+
+    fn mailbox(&self) -> Arc<Mailbox> {
+        self.state.mailbox()
     }
 
     /// Return the most recent running or waiting run for a thread.
@@ -181,9 +186,8 @@ impl RunControlService {
         tool_call_id: String,
         resume: ToolCallResume,
     ) -> Result<(), RunControlError> {
-        if self
-            .state
-            .mailbox
+        let mailbox = self.mailbox();
+        if mailbox
             .send_decision_live(id, tool_call_id.clone(), resume.clone())
             .await?
         {
@@ -223,9 +227,9 @@ impl RunControlService {
             .with_agent_id(run.agent_id.clone())
             .with_continue_run_id(run.run_id.clone())
             .with_decisions(vec![(tool_call_id.clone(), resume.clone())]);
-        self.state.mailbox.submit_background(request).await?;
-        self.state
-            .mailbox
+        let mailbox = self.mailbox();
+        mailbox.submit_background(request).await?;
+        mailbox
             .record_mailbox_decision_received_for_run(
                 &run,
                 &tool_call_id,
@@ -238,7 +242,7 @@ impl RunControlService {
 
     /// Cancel an active run or queued mailbox dispatch by run ID, dispatch ID, or thread ID.
     pub async fn cancel_run(&self, id: &str) -> Result<(), RunControlError> {
-        if self.state.mailbox.cancel(id).await? {
+        if self.mailbox().cancel(id).await? {
             Ok(())
         } else {
             Err(RunControlError::RunNotFound(id.to_string()))
@@ -251,7 +255,7 @@ impl RunControlService {
         thread_id: &str,
         _mode: InterruptMode,
     ) -> Result<MailboxInterrupt, RunControlError> {
-        let interrupted = self.state.mailbox.interrupt(thread_id).await?;
+        let interrupted = self.mailbox().interrupt(thread_id).await?;
         if interrupted.active_dispatch.is_some() || interrupted.superseded_count > 0 {
             Ok(interrupted)
         } else {
@@ -276,8 +280,7 @@ impl RunControlService {
 
         if mode == InputMode::InterruptThenQueue {
             let _ = self
-                .state
-                .mailbox
+                .mailbox()
                 .interrupt(thread_id)
                 .await
                 .map_err(RunControlError::Mailbox)?;
@@ -295,8 +298,7 @@ impl RunControlService {
             request = request.with_agent_id(agent_id);
         }
 
-        self.state
-            .mailbox
+        self.mailbox()
             .submit_background(request)
             .await
             .map_err(RunControlError::Mailbox)
@@ -321,8 +323,7 @@ impl RunControlService {
             request = request.with_agent_id(agent_id);
         }
 
-        self.state
-            .mailbox
+        self.mailbox()
             .submit_live_then_queue(request, None)
             .await
             .map_err(RunControlError::Mailbox)
@@ -353,8 +354,7 @@ impl RunControlService {
                 .with_agent_id(run.agent_id)
                 .with_continue_run_id(run.run_id);
             return self
-                .state
-                .mailbox
+                .mailbox()
                 .submit_background(request)
                 .await
                 .map_err(RunControlError::Mailbox);
@@ -379,8 +379,7 @@ impl RunControlService {
 
         let request =
             RunActivation::new(run.thread_id.clone(), messages).with_agent_id(run.agent_id.clone());
-        self.state
-            .mailbox
+        self.mailbox()
             .submit_live_then_queue(request, Some(&run.run_id))
             .await
             .map_err(RunControlError::Mailbox)

--- a/crates/awaken-server/tests/a2a_http.rs
+++ b/crates/awaken-server/tests/a2a_http.rs
@@ -205,6 +205,12 @@ where
         runtime.resolver_arc(),
         config,
     );
+    let state = awaken_server::protocol_replay_state::with_a2a_push_webhook_relay(
+        state,
+        Arc::new(awaken_stores::InMemoryOutboxStore::new()),
+        awaken_server::protocol_replay_state::A2aPushWebhookRelayConfig::default(),
+    )
+    .expect("test A2A push outbox relay config");
     (build_router(&state), store)
 }
 
@@ -494,6 +500,110 @@ async fn a2a_http_dispatch_matrix_handles_default_and_tenant_routes() {
     assert!(
         body.contains("\"task\""),
         "missing stream task body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn tenant_scoped_push_config_write_preserves_other_tenants() {
+    // A task bound to agent "alpha" is reachable via both the default route
+    // (no tenant) and the "alpha" tenant route, so a single task can hold push
+    // configs under different tenants. A tenant-scoped create/delete must not
+    // clobber configs owned by another tenant when persisting the whole task.
+    let app = make_test_app(&["alpha"]);
+
+    let (status, body) = request_json(
+        &app,
+        "POST",
+        "/v1/a2a/alpha/message:send",
+        &[("content-type", "application/json")],
+        Some(send_message_payload(
+            "task-multitenant",
+            "thread-multitenant",
+            "msg-multitenant",
+            "hello",
+        )),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "send failed: {body}");
+
+    let default_uri = "/v1/a2a/tasks/task-multitenant/pushNotificationConfigs";
+    let tenant_uri = "/v1/a2a/alpha/tasks/task-multitenant/pushNotificationConfigs";
+
+    // Create a config on the default (no-tenant) surface.
+    let (status, cfg) = request_json(
+        &app,
+        "POST",
+        default_uri,
+        &[("content-type", "application/json")],
+        Some(json!({ "id": "cfg-default", "url": "http://127.0.0.1:9/default" })),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "create default config failed: {cfg}"
+    );
+
+    // Create a config on the alpha tenant surface for the same task.
+    let (status, cfg) = request_json(
+        &app,
+        "POST",
+        tenant_uri,
+        &[("content-type", "application/json")],
+        Some(json!({ "id": "cfg-alpha", "url": "http://127.0.0.1:9/alpha" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "create alpha config failed: {cfg}");
+
+    // The default route is unscoped, so it lists every config on the task.
+    let config_ids = |list: &Value| -> Vec<String> {
+        list["configs"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|cfg| cfg["id"].as_str().map(str::to_string))
+            .collect()
+    };
+
+    // The tenant-scoped write must not have dropped the default config.
+    let (status, list) = request_json(&app, "GET", default_uri, &[], None).await;
+    assert_eq!(status, StatusCode::OK, "list default failed: {list}");
+    let ids = config_ids(&list);
+    assert!(
+        ids.iter().any(|id| id == "cfg-default"),
+        "default tenant config dropped by alpha write: {list}"
+    );
+    assert!(
+        ids.iter().any(|id| id == "cfg-alpha"),
+        "alpha config missing after alpha write: {list}"
+    );
+
+    // Deleting the alpha config must likewise leave the default config intact.
+    let (status, _ct, _body) = request_text(
+        &app,
+        "DELETE",
+        &format!("{tenant_uri}/cfg-alpha"),
+        &[],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let (status, list) = request_json(&app, "GET", default_uri, &[], None).await;
+    assert_eq!(status, StatusCode::OK, "list default after delete: {list}");
+    let ids = config_ids(&list);
+    assert_eq!(
+        ids,
+        vec!["cfg-default".to_string()],
+        "alpha delete must remove only the alpha config: {list}"
+    );
+
+    // And the alpha surface should now report no configs.
+    let (status, list) = request_json(&app, "GET", tenant_uri, &[], None).await;
+    assert_eq!(status, StatusCode::OK, "list alpha after delete: {list}");
+    assert!(
+        list["configs"].as_array().is_none_or(Vec::is_empty),
+        "alpha config should be deleted: {list}"
     );
 }
 

--- a/crates/awaken-server/tests/run_api.rs
+++ b/crates/awaken-server/tests/run_api.rs
@@ -305,6 +305,40 @@ fn make_test_app_with_executor(
     make_test_app_with_runtime(runtime, store)
 }
 
+fn make_test_app_with_local_components() -> TestApp {
+    let store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_model(ModelSpec::new("test-model", "mock", "mock-model"))
+            .with_provider("mock", Arc::new(ImmediateExecutor))
+            .with_agent_spec(AgentSpec {
+                id: "test-agent".into(),
+                model_id: "test-model".into(),
+                system_prompt: "test".into(),
+                max_rounds: 0,
+                ..Default::default()
+            })
+            .with_in_memory_thread_run_store(store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    runtime.set_run_resolver(Arc::new(TestRunResolver {
+        inner: runtime.resolver_arc(),
+    }));
+
+    let mut state = ServerState::new_with_local_mailbox(
+        runtime.clone(),
+        store.clone() as Arc<dyn awaken_contract::contract::storage::ThreadRunStore>,
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+    state.admin.admin_api_config.bearer_token = Some(TEST_ADMIN_TOKEN.into());
+    TestApp {
+        router: build_router(&state),
+        store,
+    }
+}
+
 fn make_test_app_with_remote_root_agent() -> TestApp {
     let store = Arc::new(InMemoryStore::new());
     let runtime = Arc::new(
@@ -463,6 +497,54 @@ async fn start_run_streams_sse_with_run_lifecycle() {
 
     let run_finish = find_event(&events, "run_finish");
     assert!(run_finish.is_some(), "no run_finish event in SSE: {body}");
+}
+
+#[tokio::test]
+async fn start_run_streams_sse_with_local_mailbox_default() {
+    let test = make_test_app_with_local_components();
+    let (status, body) = post_json(
+        test.router.clone(),
+        "/v1/runs",
+        json!({
+            "agentId": "test-agent",
+            "threadId": "thread-local-components",
+            "messages": [{"role": "user", "content": "hello"}]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "unexpected: {body}");
+
+    let events = extract_sse_events(&body);
+    assert!(
+        find_event(&events, "run_start").is_some(),
+        "no run_start event in SSE: {body}"
+    );
+    assert!(
+        find_event(&events, "run_finish").is_some(),
+        "no run_finish event in SSE: {body}"
+    );
+
+    let run = test
+        .store
+        .latest_run("thread-local-components")
+        .await
+        .expect("latest run lookup")
+        .expect("run should be persisted");
+    assert_eq!(run.status, RunStatus::Done);
+}
+
+#[tokio::test]
+async fn a2a_agent_card_advertises_push_notifications_with_local_outbox_default() {
+    let test = make_test_app_with_local_components();
+    let (status, body) = get_json(test.router, "/.well-known/agent-card.json").await;
+    assert_eq!(status, StatusCode::OK, "unexpected: {body}");
+
+    let body = serde_json::from_str::<Value>(&body).expect("agent card json");
+    assert_eq!(body["name"].as_str(), Some("test-agent"));
+    assert_eq!(
+        body["capabilities"]["pushNotifications"].as_bool(),
+        Some(true)
+    );
 }
 
 #[tokio::test]

--- a/crates/awaken-stores/src/file.rs
+++ b/crates/awaken-stores/src/file.rs
@@ -329,10 +329,41 @@ impl FileStore {
         messages: &[Message],
         ops: &mut Vec<StagedFileOp>,
     ) -> Result<(), StorageError> {
-        self.stage_delete_message_records(thread_id, ops).await?;
+        // Write the replacement records first, then remove stale records only when the new
+        // message set is shorter than the existing set. This avoids staging duplicate
+        // delete+write operations on the same target path in one transaction.
         for (index, message) in messages.iter().enumerate() {
             self.stage_write_message_record(thread_id, index as u64 + 1, message, ops)
                 .await?;
+        }
+
+        let records_dir = self.thread_message_records_dir(thread_id);
+        let new_len = messages.len() as u64;
+        if new_len == 0 {
+            return self.stage_delete_message_records(thread_id, ops).await;
+        }
+
+        if !records_dir.exists() {
+            return Ok(());
+        }
+        let mut entries = tokio::fs::read_dir(&records_dir)
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|error| StorageError::Io(error.to_string()))?
+        {
+            let path = entry.path();
+            let Some(stem) = path.file_stem().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let Ok(seq) = stem.parse::<u64>() else {
+                continue;
+            };
+            if seq > new_len && path.extension().is_some_and(|ext| ext == "json") {
+                ops.push(StagedFileOp::Delete(stage_delete(path)?));
+            }
         }
         Ok(())
     }

--- a/crates/awaken-stores/tests/file_store.rs
+++ b/crates/awaken-stores/tests/file_store.rs
@@ -539,6 +539,104 @@ async fn checkpoint_overwrites_messages() {
 }
 
 #[tokio::test]
+async fn checkpoint_replace_shorter_removes_stale_records() {
+    let tmp = TempDir::new().unwrap();
+    let store = FileStore::new(tmp.path());
+    store
+        .checkpoint(
+            "t-1",
+            &[
+                Message::user("m1"),
+                Message::user("m2"),
+                Message::user("m3"),
+            ],
+            &make_run("run-1", "t-1", 100),
+        )
+        .await
+        .unwrap();
+
+    // Replacing with a shorter set must delete the now-stale high-seq records
+    // (seq > new_len), not leave them dangling.
+    store
+        .checkpoint(
+            "t-1",
+            &[Message::user("only")],
+            &make_run("run-2", "t-1", 200),
+        )
+        .await
+        .unwrap();
+
+    let msgs = ThreadStore::load_messages(&store, "t-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msgs.len(), 1, "stale records leaked: {msgs:?}");
+    assert_eq!(msgs[0].text(), "only");
+}
+
+#[tokio::test]
+async fn checkpoint_replace_longer_writes_all_records() {
+    let tmp = TempDir::new().unwrap();
+    let store = FileStore::new(tmp.path());
+    store
+        .checkpoint(
+            "t-1",
+            &[Message::user("a1")],
+            &make_run("run-1", "t-1", 100),
+        )
+        .await
+        .unwrap();
+
+    store
+        .checkpoint(
+            "t-1",
+            &[
+                Message::user("b1"),
+                Message::user("b2"),
+                Message::user("b3"),
+            ],
+            &make_run("run-2", "t-1", 200),
+        )
+        .await
+        .unwrap();
+
+    let msgs = ThreadStore::load_messages(&store, "t-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msgs.len(), 3);
+    assert_eq!(
+        msgs.iter().map(Message::text).collect::<Vec<_>>(),
+        ["b1", "b2", "b3"]
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_replace_empty_clears_records() {
+    let tmp = TempDir::new().unwrap();
+    let store = FileStore::new(tmp.path());
+    store
+        .checkpoint(
+            "t-1",
+            &[Message::user("m1"), Message::user("m2")],
+            &make_run("run-1", "t-1", 100),
+        )
+        .await
+        .unwrap();
+
+    store
+        .checkpoint("t-1", &[], &make_run("run-2", "t-1", 200))
+        .await
+        .unwrap();
+
+    let msgs = ThreadStore::load_messages(&store, "t-1").await.unwrap();
+    assert!(
+        msgs.as_ref().is_none_or(Vec::is_empty),
+        "records not cleared: {msgs:?}"
+    );
+}
+
+#[tokio::test]
 async fn load_messages_nonexistent() {
     let tmp = TempDir::new().unwrap();
     let store = FileStore::new(tmp.path());

--- a/docs/adr/0041-server-state-modules.md
+++ b/docs/adr/0041-server-state-modules.md
@@ -98,6 +98,18 @@ pub struct AdminModuleState {
 }
 ```
 
+`ServerState::new` requires a mailbox. Callers that do not provide an
+external mailbox backend use `ServerState::new_with_local_mailbox`, which
+installs an in-memory mailbox so run-control and protocol routes keep the same
+HTTP surface. This local mailbox is process-local and best-effort; durable and
+multi-replica deployments provide an externally backed `Mailbox`.
+
+Default protocol wiring also attaches an in-memory A2A push webhook outbox to
+the active `ProtocolModuleState` replay buffers. This preserves the public A2A
+capability surface for single-process servers. Deployments that require retry
+durability across restart or replicas replace it with a durable `OutboxStore`
+via `with_a2a_push_webhook_relay`.
+
 `APP_STATE_EXTRAS` is deleted. Its fields move as follows:
 
 | Existing source | New owner |


### PR DESCRIPTION
## Summary
- Refresh README/API activation docs included on branch
- Make server mailbox and A2A push outbox pluggable with local defaults preserving API behavior
- Rename local-mailbox construction semantics and remove fake optional/no-mailbox surfaces
- Preserve default A2A push outbox when replacing protocol state and document local best-effort semantics
- Add tests covering local mailbox/outbox defaults, A2A outbox replacement, and protocol replacement regression

## Validation
- cargo fmt --check
- cargo check -p awaken-server --all-features --tests
- cargo clippy -p awaken-server --all-features --tests
- cargo test -p awaken-server --all-features
- pre-push: cargo clippy --workspace --lib --bins --examples --locked -- -D clippy::correctness
- pre-push: admin-console npm run ci