### PR TITLE
⚡ perf(scope): push scope prefix into backend list_runs/list_threads queries

### DIFF
--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -49,7 +49,10 @@ const REMOTE_ENDPOINT: RemoteEndpoint = {
 
 function rustAgentSpecPatchFields(): string[] {
   const source = readFileSync(
-    new URL("../../../../crates/awaken-contract/src/agent_spec_patch.rs", import.meta.url),
+    new URL(
+      "../../../../crates/awaken-runtime-contract/src/agent_spec_patch.rs",
+      import.meta.url,
+    ),
     "utf8",
   );
   const structMatch = source.match(/pub struct AgentSpecPatch \{([\s\S]*?)\n\}/);

--- a/crates/awaken-server-contract/src/contract/storage.rs
+++ b/crates/awaken-server-contract/src/contract/storage.rs
@@ -242,6 +242,7 @@ struct ThreadCursorToken {
     offset: usize,
     resource_id: Option<String>,
     parent_filter: ThreadParentFilter,
+    id_prefix: Option<String>,
 }
 
 /// Pagination/filter query for listing threads.
@@ -307,20 +308,26 @@ impl ThreadQuery {
                 offset,
                 resource_id: normalized.resource_id,
                 parent_filter: normalized.parent_filter,
+                id_prefix: normalized.id_prefix,
             },
         )
     }
 
     /// Decode a cursor and verify it belongs to this exact query shape.
     pub fn decode_cursor(&self, cursor: &str) -> Result<usize, String> {
+        let normalized = self.normalized();
         if let Ok(offset) = cursor.parse::<usize>() {
-            return Ok(offset);
+            return if normalized.has_filters() {
+                Err("cursor does not match thread query filters".to_string())
+            } else {
+                Ok(offset)
+            };
         }
 
-        let normalized = self.normalized();
         let token: ThreadCursorToken = decode_cursor_token(THREAD_CURSOR_PREFIX, cursor)?;
         if token.resource_id != normalized.resource_id
             || token.parent_filter != normalized.parent_filter
+            || token.id_prefix != normalized.id_prefix
         {
             return Err("cursor does not match thread query filters".to_string());
         }
@@ -694,23 +701,41 @@ impl ThreadStore for ScopedThreadRunStore {
     }
 
     async fn list_threads(&self, offset: usize, limit: usize) -> Result<Vec<String>, StorageError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
         // Push the scope prefix to the backend so it filters and paginates at
         // the source instead of streaming every scope's threads into memory.
-        let page = self
-            .inner
-            .list_threads_query(&ThreadQuery {
-                offset,
-                limit,
-                resource_id: None,
-                parent_filter: ThreadParentFilter::Any,
-                id_prefix: Some(self.scope_prefix()),
-            })
-            .await?;
-        Ok(page
-            .items
-            .into_iter()
-            .filter_map(|id| self.unscoped(&id).map(str::to_string))
-            .collect())
+        // ThreadQuery caps one page at 200; loop internally so this legacy
+        // vector API preserves the caller-requested `limit`.
+        let scope_prefix = self.scope_prefix();
+        let mut next_offset = offset;
+        let mut items = Vec::with_capacity(limit.min(200));
+        while items.len() < limit {
+            let page_limit = (limit - items.len()).min(200);
+            let page = self
+                .inner
+                .list_threads_query(&ThreadQuery {
+                    offset: next_offset,
+                    limit: page_limit,
+                    resource_id: None,
+                    parent_filter: ThreadParentFilter::Any,
+                    id_prefix: Some(scope_prefix.clone()),
+                })
+                .await?;
+            let page_len = page.items.len();
+            items.extend(
+                page.items
+                    .into_iter()
+                    .filter_map(|id| self.unscoped(&id).map(str::to_string)),
+            );
+            if !page.has_more || page_len == 0 {
+                break;
+            }
+            next_offset = next_offset.saturating_add(page_len);
+        }
+        Ok(items)
     }
 
     async fn load_messages(&self, thread_id: &str) -> Result<Option<Vec<Message>>, StorageError> {

--- a/crates/awaken-server-contract/src/contract/storage.rs
+++ b/crates/awaken-server-contract/src/contract/storage.rs
@@ -257,6 +257,11 @@ pub struct ThreadQuery {
     /// Filter by parent/root lineage.
     #[serde(default, skip_serializing_if = "ThreadParentFilter::is_any")]
     pub parent_filter: ThreadParentFilter,
+    /// Backend-level scope filter: keep only thread IDs that start with this
+    /// prefix. Pushed down so a scoped listing never scans the full thread set
+    /// of a shared backend (ADR-0042 scope boundary). `None` means no filter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id_prefix: Option<String>,
 }
 
 impl Default for ThreadQuery {
@@ -266,6 +271,7 @@ impl Default for ThreadQuery {
             limit: 50,
             resource_id: None,
             parent_filter: ThreadParentFilter::Any,
+            id_prefix: None,
         }
     }
 }
@@ -274,7 +280,9 @@ impl ThreadQuery {
     /// Return true when the query carries any non-pagination filter.
     #[must_use]
     pub fn has_filters(&self) -> bool {
-        normalize_lineage_id(self.resource_id.as_deref()).is_some() || !self.parent_filter.is_any()
+        normalize_lineage_id(self.resource_id.as_deref()).is_some()
+            || !self.parent_filter.is_any()
+            || self.id_prefix.is_some()
     }
 
     /// Return a copy with normalized lineage filters.
@@ -285,6 +293,7 @@ impl ThreadQuery {
             limit: self.limit.min(200),
             resource_id: normalize_lineage_id(self.resource_id.as_deref()),
             parent_filter: self.parent_filter.normalized(),
+            id_prefix: self.id_prefix.clone(),
         }
     }
 
@@ -322,6 +331,13 @@ impl ThreadQuery {
     #[must_use]
     pub fn matches_thread(&self, thread: &Thread) -> bool {
         let normalized = self.normalized();
+        if normalized
+            .id_prefix
+            .as_deref()
+            .is_some_and(|prefix| !thread.id.starts_with(prefix))
+        {
+            return false;
+        }
         if normalized
             .resource_id
             .as_deref()
@@ -497,6 +513,21 @@ pub struct RunQuery {
     pub thread_id: Option<String>,
     /// Filter by run status.
     pub status: Option<RunStatus>,
+    /// Backend-level scope filter: keep only runs whose `thread_id` starts with
+    /// this prefix. Pushed down so a scoped listing never scans the full run
+    /// table of a shared backend (ADR-0042 scope boundary). `None` means no
+    /// prefix filter.
+    pub id_prefix: Option<String>,
+}
+
+impl RunQuery {
+    /// True when `thread_id` passes the optional `id_prefix` filter.
+    #[must_use]
+    pub fn matches_id_prefix(&self, thread_id: &str) -> bool {
+        self.id_prefix
+            .as_deref()
+            .is_none_or(|prefix| thread_id.starts_with(prefix))
+    }
 }
 
 impl Default for RunQuery {
@@ -506,6 +537,7 @@ impl Default for RunQuery {
             limit: 50,
             thread_id: None,
             status: None,
+            id_prefix: None,
         }
     }
 }
@@ -539,6 +571,12 @@ impl ScopedThreadRunStore {
 
     fn scoped(&self, id: &str) -> String {
         scoped_key(&self.scope_id, id)
+    }
+
+    /// Prefix shared by every key in this scope (`scope:<len>:<scope>:`). Pushed
+    /// to the backend as a filter so scoped listings never scan other scopes.
+    fn scope_prefix(&self) -> String {
+        scoped_key(&self.scope_id, "")
     }
 
     fn unscoped<'a>(&self, id: &'a str) -> Option<&'a str> {
@@ -656,27 +694,23 @@ impl ThreadStore for ScopedThreadRunStore {
     }
 
     async fn list_threads(&self, offset: usize, limit: usize) -> Result<Vec<String>, StorageError> {
-        const SCAN_LIMIT: usize = 200;
-
-        let mut inner_offset = 0;
-        let mut scoped_ids = Vec::new();
-        loop {
-            let ids = self.inner.list_threads(inner_offset, SCAN_LIMIT).await?;
-            if ids.is_empty() {
-                break;
-            }
-            let count = ids.len();
-            scoped_ids.extend(
-                ids.into_iter()
-                    .filter_map(|id| self.unscoped(&id).map(str::to_string)),
-            );
-            if count < SCAN_LIMIT {
-                break;
-            }
-            inner_offset += count;
-        }
-
-        Ok(scoped_ids.into_iter().skip(offset).take(limit).collect())
+        // Push the scope prefix to the backend so it filters and paginates at
+        // the source instead of streaming every scope's threads into memory.
+        let page = self
+            .inner
+            .list_threads_query(&ThreadQuery {
+                offset,
+                limit,
+                resource_id: None,
+                parent_filter: ThreadParentFilter::Any,
+                id_prefix: Some(self.scope_prefix()),
+            })
+            .await?;
+        Ok(page
+            .items
+            .into_iter()
+            .filter_map(|id| self.unscoped(&id).map(str::to_string))
+            .collect())
     }
 
     async fn load_messages(&self, thread_id: &str) -> Result<Option<Vec<Message>>, StorageError> {
@@ -800,6 +834,7 @@ impl RunStore for ScopedThreadRunStore {
                     limit: query.limit,
                     thread_id: Some(self.scoped(thread_id)),
                     status: query.status,
+                    id_prefix: None,
                 })
                 .await?;
             let items = inner_page
@@ -814,47 +849,29 @@ impl RunStore for ScopedThreadRunStore {
             });
         }
 
-        // Cross-scope listing: the backend exposes no scope filter, so scan in
-        // bounded batches and keep only the requested window in memory. This
-        // avoids loading the entire shared run table at once (which coupled
-        // one scope's query latency/memory to every other scope's data volume).
-        const SCAN_LIMIT: usize = 200;
-        let window_end = query.offset.saturating_add(query.limit);
-        let mut inner_offset = 0;
-        let mut in_scope_seen = 0usize;
-        let mut items: Vec<RunRecord> = Vec::new();
-        loop {
-            let page = self
-                .inner
-                .list_runs(&RunQuery {
-                    offset: inner_offset,
-                    limit: SCAN_LIMIT,
-                    thread_id: None,
-                    status: query.status,
-                })
-                .await?;
-            let count = page.items.len();
-            if count == 0 {
-                break;
-            }
-            for record in page.items {
-                if let Some(decoded) = self.decode_run(record) {
-                    if in_scope_seen >= query.offset && in_scope_seen < window_end {
-                        items.push(decoded);
-                    }
-                    in_scope_seen += 1;
-                }
-            }
-            if count < SCAN_LIMIT {
-                break;
-            }
-            inner_offset += count;
-        }
-        let has_more = query.limit > 0 && query.offset.saturating_add(items.len()) < in_scope_seen;
+        // Cross-scope listing: push the scope prefix to the backend so it
+        // filters and paginates at the source. Every returned row is in scope,
+        // so `decode_run` never drops one and the page totals are exact — no
+        // full-table scan, no in-memory windowing.
+        let inner_page = self
+            .inner
+            .list_runs(&RunQuery {
+                offset: query.offset,
+                limit: query.limit,
+                thread_id: None,
+                status: query.status,
+                id_prefix: Some(self.scope_prefix()),
+            })
+            .await?;
+        let items = inner_page
+            .items
+            .into_iter()
+            .filter_map(|record| self.decode_run(record))
+            .collect();
         Ok(RunPage {
             items,
-            total: in_scope_seen,
-            has_more,
+            total: inner_page.total,
+            has_more: inner_page.has_more,
         })
     }
 }

--- a/crates/awaken-server-contract/src/contract/store_traits.rs
+++ b/crates/awaken-server-contract/src/contract/store_traits.rs
@@ -182,6 +182,7 @@ pub trait ThreadStore: Send + Sync {
                 limit: PAGE_LIMIT,
                 resource_id: None,
                 parent_filter: ThreadParentFilter::Parent(parent_thread_id.to_owned()),
+                id_prefix: None,
             };
             let page = self.list_threads_query(&query).await?;
             let count = page.items.len();

--- a/crates/awaken-server-contract/src/contract/store_traits_tests.rs
+++ b/crates/awaken-server-contract/src/contract/store_traits_tests.rs
@@ -227,6 +227,38 @@ async fn thread_store_query_zero_limit_returns_empty_terminated_page() {
     assert!(page.next_cursor.is_none());
 }
 
+#[test]
+fn thread_query_cursor_binds_id_prefix_filter() {
+    let query = ThreadQuery {
+        offset: 0,
+        limit: 1,
+        resource_id: None,
+        parent_filter: ThreadParentFilter::Any,
+        id_prefix: Some("scope:5:a%_\\:".to_string()),
+    };
+    let cursor = query.encode_cursor(1);
+
+    assert_eq!(query.decode_cursor(&cursor).unwrap(), 1);
+    assert!(
+        ThreadQuery {
+            id_prefix: Some("scope:6:a%_\\:".to_string()),
+            ..query.clone()
+        }
+        .decode_cursor(&cursor)
+        .is_err()
+    );
+    assert!(
+        ThreadQuery {
+            id_prefix: None,
+            ..query.clone()
+        }
+        .decode_cursor(&cursor)
+        .is_err()
+    );
+    assert!(query.decode_cursor("1").is_err());
+    assert_eq!(ThreadQuery::default().decode_cursor("1").unwrap(), 1);
+}
+
 #[tokio::test]
 async fn thread_store_query_filters_root_threads() {
     let store = MockThreadStore::default();

--- a/crates/awaken-server-contract/src/contract/store_traits_tests.rs
+++ b/crates/awaken-server-contract/src/contract/store_traits_tests.rs
@@ -176,6 +176,7 @@ async fn thread_store_default_query_filters_lineage() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         })
         .await
         .unwrap();
@@ -199,6 +200,7 @@ async fn thread_store_query_normalizes_lineage_filters() {
             limit: 10,
             resource_id: Some(" resource-a ".to_string()),
             parent_filter: ThreadParentFilter::Parent(" parent-1 ".to_string()),
+            id_prefix: None,
         })
         .await
         .unwrap();
@@ -251,6 +253,7 @@ async fn thread_store_query_filters_root_threads() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Root,
+            id_prefix: None,
         })
         .await
         .unwrap();

--- a/crates/awaken-server-contract/src/tests/storage.rs
+++ b/crates/awaken-server-contract/src/tests/storage.rs
@@ -135,6 +135,7 @@ impl RunStore for MockThreadRunStore {
                     .is_none_or(|id| record.thread_id == id)
             })
             .filter(|record| query.status.is_none_or(|status| record.status == status))
+            .filter(|record| query.matches_id_prefix(&record.thread_id))
             .cloned()
             .collect();
         items.sort_by_key(|record| record.created_at);
@@ -250,6 +251,7 @@ async fn scoped_list_runs_isolates_and_paginates_across_scopes() {
         limit,
         thread_id: thread_id.map(str::to_owned),
         status: None,
+        id_prefix: None,
     };
 
     // Cross-scope list (no thread_id): scope-a sees only its own 5 runs.

--- a/crates/awaken-server/src/mailbox/server_event_capture.rs
+++ b/crates/awaken-server/src/mailbox/server_event_capture.rs
@@ -339,6 +339,7 @@ impl Mailbox {
                     limit,
                     thread_id: None,
                     status: None,
+                    id_prefix: None,
                 })
                 .await?;
             for run in &page.items {

--- a/crates/awaken-server/src/query.rs
+++ b/crates/awaken-server/src/query.rs
@@ -242,6 +242,7 @@ impl ThreadQueryParams {
                     .map(ThreadParentFilter::Parent)
                     .unwrap_or(ThreadParentFilter::Any)
             },
+            id_prefix: None,
         })
     }
 }
@@ -532,6 +533,7 @@ mod tests {
             limit: 20,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         }
         .encode_cursor(4);
         let params: ThreadQueryParams = serde_json::from_value(serde_json::json!({
@@ -551,6 +553,7 @@ mod tests {
                 limit: 20,
                 resource_id: Some("resource-a".to_string()),
                 parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+                id_prefix: None,
             }
         );
     }
@@ -574,6 +577,7 @@ mod tests {
             limit: 20,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Root,
+            id_prefix: None,
         }
         .encode_cursor(4);
         let params: ThreadQueryParams = serde_json::from_value(serde_json::json!({
@@ -610,6 +614,7 @@ mod tests {
             limit: 20,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         }
         .encode_cursor(4);
         let params: ThreadQueryParams = serde_json::from_value(serde_json::json!({

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -749,6 +749,7 @@ async fn list_runs(
         limit: params.limit.clamp(1, 200),
         thread_id: None,
         status,
+        id_prefix: None,
     };
     let page = crate::services::run_service::list_runs(st.run.store().as_ref(), &query)
         .await
@@ -995,6 +996,7 @@ async fn list_thread_runs(
         limit: params.limit.clamp(1, 200),
         thread_id: Some(id),
         status,
+        id_prefix: None,
     };
     let page = crate::services::run_service::list_runs(st.run.store().as_ref(), &query)
         .await

--- a/crates/awaken-server/src/services/run_control_service.rs
+++ b/crates/awaken-server/src/services/run_control_service.rs
@@ -166,6 +166,7 @@ impl RunControlService {
                     limit: 200,
                     thread_id: Some(thread_id.to_string()),
                     status: Some(status),
+                    id_prefix: None,
                 })
                 .await?;
             candidates.extend(page.items);

--- a/crates/awaken-server/src/services/run_service.rs
+++ b/crates/awaken-server/src/services/run_service.rs
@@ -27,6 +27,7 @@ pub async fn runs_summary(store: &dyn RunStore) -> Result<RunsSummary, StorageEr
             limit: 1,
             thread_id: None,
             status: Some(status),
+            id_prefix: None,
         };
         store.list_runs(&q).await.map(|page| page.total as u64)
     }

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -900,6 +900,7 @@ async fn postgres_nats_two_server_instances_share_runtime_mailbox_without_duplic
             limit: 20,
             thread_id: Some("pg-nats-background-thread".to_string()),
             status: Some(RunStatus::Done),
+            id_prefix: None,
         },
     )
     .await

--- a/crates/awaken-stores/src/file.rs
+++ b/crates/awaken-stores/src/file.rs
@@ -1365,6 +1365,7 @@ impl RunStore for FileStore {
             .into_iter()
             .filter(|r| query.thread_id.as_deref().is_none_or(|t| r.thread_id == t))
             .filter(|r| query.status.is_none_or(|s| r.status == s))
+            .filter(|r| query.matches_id_prefix(&r.thread_id))
             .collect();
         filtered.sort_by_key(|r| r.created_at);
         let total = filtered.len();

--- a/crates/awaken-stores/src/memory/mod.rs
+++ b/crates/awaken-stores/src/memory/mod.rs
@@ -427,6 +427,7 @@ impl RunStore for InMemoryStore {
             .values()
             .filter(|r| query.thread_id.as_deref().is_none_or(|t| r.thread_id == t))
             .filter(|r| query.status.is_none_or(|s| r.status == s))
+            .filter(|r| query.matches_id_prefix(&r.thread_id))
             .cloned()
             .collect();
         filtered.sort_by_key(|r| r.created_at);

--- a/crates/awaken-stores/src/memory/tests.rs
+++ b/crates/awaken-stores/src/memory/tests.rs
@@ -795,6 +795,7 @@ async fn run_list_filters_by_thread_and_status() {
         status: Some(RunStatus::Running),
         offset: 0,
         limit: 100,
+        id_prefix: None,
     };
     let page = store.list_runs(&query).await.unwrap();
     assert_eq!(page.items.len(), 1);
@@ -842,6 +843,7 @@ async fn concurrent_run_mutations_are_safe() {
             status: None,
             offset: 0,
             limit: 200,
+            id_prefix: None,
         })
         .await
         .unwrap();

--- a/crates/awaken-stores/src/nats_buffered_thread/reader.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/reader.rs
@@ -263,6 +263,9 @@ pub async fn list_runs<T: ThreadRunStore + Send + Sync + 'static>(
         if query.status.is_some_and(|status| run.status != status) {
             continue;
         }
+        if !query.matches_id_prefix(&run.thread_id) {
+            continue;
+        }
         by_id.insert(run.run_id.clone(), run);
     }
 

--- a/crates/awaken-stores/src/postgres/run.rs
+++ b/crates/awaken-stores/src/postgres/run.rs
@@ -139,8 +139,8 @@ impl RunStore for PostgresStore {
         self.ensure_schema().await?;
 
         // Build WHERE conditions with positional binds in a stable order:
-        // thread_id, status, id_prefix. The scope prefix is pushed down as an
-        // indexed `LIKE 'prefix%'` so a scoped listing never scans other scopes.
+        // thread_id, status, id_prefix. The scope prefix is pushed down as a
+        // `LIKE 'prefix%'` filter so a scoped listing never returns other scopes.
         let mut conditions = Vec::new();
         let mut idx = 1;
         if query.thread_id.is_some() {

--- a/crates/awaken-stores/src/postgres/run.rs
+++ b/crates/awaken-stores/src/postgres/run.rs
@@ -138,15 +138,24 @@ impl RunStore for PostgresStore {
     async fn list_runs(&self, query: &RunQuery) -> Result<RunPage, StorageError> {
         self.ensure_schema().await?;
 
-        // Build count query
+        // Build WHERE conditions with positional binds in a stable order:
+        // thread_id, status, id_prefix. The scope prefix is pushed down as an
+        // indexed `LIKE 'prefix%'` so a scoped listing never scans other scopes.
         let mut conditions = Vec::new();
+        let mut idx = 1;
         if query.thread_id.is_some() {
-            conditions.push("thread_id = $1".to_string());
+            conditions.push(format!("thread_id = ${idx}"));
+            idx += 1;
         }
         if query.status.is_some() {
-            let idx = if query.thread_id.is_some() { 2 } else { 1 };
             conditions.push(format!("status = ${idx}"));
+            idx += 1;
         }
+        if query.id_prefix.is_some() {
+            conditions.push(format!("thread_id LIKE ${idx} ESCAPE '\\'"));
+            idx += 1;
+        }
+        let _ = idx;
 
         let where_clause = if conditions.is_empty() {
             String::new()
@@ -163,6 +172,8 @@ impl RunStore for PostgresStore {
             query.offset
         );
 
+        let like_pattern = query.id_prefix.as_deref().map(like_prefix_pattern);
+
         // This is simplified — in production you'd use a proper query builder.
         // For the feature-gated postgres backend, we use raw string queries.
         let (total,): (i64,) = {
@@ -172,6 +183,9 @@ impl RunStore for PostgresStore {
             }
             if let Some(status) = query.status {
                 q = q.bind(format!("{status:?}").to_lowercase());
+            }
+            if let Some(ref pattern) = like_pattern {
+                q = q.bind(pattern);
             }
             q.fetch_one(&self.pool)
                 .await
@@ -185,6 +199,9 @@ impl RunStore for PostgresStore {
             }
             if let Some(status) = query.status {
                 q = q.bind(format!("{status:?}").to_lowercase());
+            }
+            if let Some(ref pattern) = like_pattern {
+                q = q.bind(pattern);
             }
             q.fetch_all(&self.pool)
                 .await
@@ -517,6 +534,21 @@ impl ThreadRunStore for PostgresStore {
             thread_state,
         }))
     }
+}
+
+/// Build a SQL `LIKE` pattern matching ids that start with `prefix`. The LIKE
+/// wildcards `%`, `_` and the escape char `\` are escaped so a scope id with
+/// those characters cannot widen the match (used with `ESCAPE '\'`).
+pub(super) fn like_prefix_pattern(prefix: &str) -> String {
+    let mut pattern = String::with_capacity(prefix.len() + 1);
+    for ch in prefix.chars() {
+        if matches!(ch, '%' | '_' | '\\') {
+            pattern.push('\\');
+        }
+        pattern.push(ch);
+    }
+    pattern.push('%');
+    pattern
 }
 
 fn run_record_from_pg_row(row: PgRow) -> RunRecord {

--- a/crates/awaken-stores/src/postgres/thread.rs
+++ b/crates/awaken-stores/src/postgres/thread.rs
@@ -536,17 +536,25 @@ impl ThreadStore for PostgresStore {
         };
         let limit = query.limit.min(i64::MAX as usize) as i64;
         let offset = query.offset.min(i64::MAX as usize) as i64;
+        // Scope prefix pushed down as an indexed `LIKE 'prefix%'` so a scoped
+        // listing filters at the source instead of scanning every scope.
+        let like_pattern = query
+            .id_prefix
+            .as_deref()
+            .map(super::run::like_prefix_pattern);
         let count_sql = format!(
             "SELECT COUNT(*)::BIGINT FROM {}
              WHERE ($1::text IS NULL OR resource_id = $1)
                AND (($3::bool AND parent_thread_id IS NULL)
-                    OR (NOT $3::bool AND ($2::text IS NULL OR parent_thread_id = $2)))",
+                    OR (NOT $3::bool AND ($2::text IS NULL OR parent_thread_id = $2)))
+               AND ($4::text IS NULL OR id LIKE $4 ESCAPE '\\')",
             self.threads_table
         );
         let total: (i64,) = sqlx::query_as(&count_sql)
             .bind(query.resource_id.as_deref())
             .bind(parent_thread_id)
             .bind(root_only)
+            .bind(like_pattern.as_deref())
             .fetch_one(&self.pool)
             .await
             .map_err(|e| StorageError::Io(e.to_string()))?;
@@ -556,6 +564,7 @@ impl ThreadStore for PostgresStore {
              WHERE ($1::text IS NULL OR resource_id = $1)
                AND (($3::bool AND parent_thread_id IS NULL)
                     OR (NOT $3::bool AND ($2::text IS NULL OR parent_thread_id = $2)))
+               AND ($6::text IS NULL OR id LIKE $6 ESCAPE '\\')
              ORDER BY updated_at DESC, id ASC
              LIMIT $4 OFFSET $5",
             self.threads_table
@@ -566,6 +575,7 @@ impl ThreadStore for PostgresStore {
             .bind(root_only)
             .bind(limit)
             .bind(offset)
+            .bind(like_pattern.as_deref())
             .fetch_all(&self.pool)
             .await
             .map_err(|e| StorageError::Io(e.to_string()))?;

--- a/crates/awaken-stores/src/postgres/thread.rs
+++ b/crates/awaken-stores/src/postgres/thread.rs
@@ -536,8 +536,8 @@ impl ThreadStore for PostgresStore {
         };
         let limit = query.limit.min(i64::MAX as usize) as i64;
         let offset = query.offset.min(i64::MAX as usize) as i64;
-        // Scope prefix pushed down as an indexed `LIKE 'prefix%'` so a scoped
-        // listing filters at the source instead of scanning every scope.
+        // Scope prefix pushed down as a `LIKE 'prefix%'` filter so a scoped
+        // listing filters at the source instead of returning every scope.
         let like_pattern = query
             .id_prefix
             .as_deref()
@@ -586,9 +586,9 @@ impl ThreadStore for PostgresStore {
             items,
             total,
             has_more: next_offset < total,
-            next_cursor: (next_offset < total).then(|| next_offset.to_string()),
+            next_cursor: (next_offset < total).then(|| query.encode_cursor(next_offset)),
             prev_cursor: (query.offset > 0)
-                .then(|| query.offset.saturating_sub(query.limit).to_string()),
+                .then(|| query.encode_cursor(query.offset.saturating_sub(query.limit))),
         })
     }
 

--- a/crates/awaken-stores/tests/file_store.rs
+++ b/crates/awaken-stores/tests/file_store.rs
@@ -106,6 +106,7 @@ async fn list_threads_query_filters_lineage() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         })
         .await
         .unwrap();
@@ -141,6 +142,7 @@ async fn list_threads_query_filters_root_threads() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Root,
+            id_prefix: None,
         })
         .await
         .unwrap();

--- a/crates/awaken-stores/tests/file_thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/file_thread_store_conformance.rs
@@ -28,3 +28,4 @@ conformance_test!(checkpoint_append_rejects_stale_version);
 conformance_test!(checkpoint_append_rejects_existing_message_id);
 conformance_test!(list_runs_filters_by_id_prefix);
 conformance_test!(list_threads_query_filters_by_id_prefix);
+conformance_test!(list_threads_query_id_prefix_paginates_and_binds_cursor);

--- a/crates/awaken-stores/tests/file_thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/file_thread_store_conformance.rs
@@ -26,3 +26,5 @@ conformance_test!(checkpoint_append_assigns_version);
 conformance_test!(checkpoint_append_unconditional_appends);
 conformance_test!(checkpoint_append_rejects_stale_version);
 conformance_test!(checkpoint_append_rejects_existing_message_id);
+conformance_test!(list_runs_filters_by_id_prefix);
+conformance_test!(list_threads_query_filters_by_id_prefix);

--- a/crates/awaken-stores/tests/memory_store.rs
+++ b/crates/awaken-stores/tests/memory_store.rs
@@ -108,6 +108,7 @@ async fn list_threads_query_filters_lineage() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         })
         .await
         .unwrap();

--- a/crates/awaken-stores/tests/memory_thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/memory_thread_store_conformance.rs
@@ -25,6 +25,8 @@ conformance_test!(checkpoint_append_rejects_stale_version);
 conformance_test!(checkpoint_append_rejects_existing_message_id);
 conformance_test!(list_threads_query_filters_lineage);
 conformance_test!(list_threads_query_filters_root_threads);
+conformance_test!(list_runs_filters_by_id_prefix);
+conformance_test!(list_threads_query_filters_by_id_prefix);
 conformance_test!(checkpoint_rejects_missing_parent_thread);
 conformance_test!(checkpoint_rejects_cycle_parent_assignment);
 conformance_test!(delete_thread_with_detach_preserves_children);

--- a/crates/awaken-stores/tests/memory_thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/memory_thread_store_conformance.rs
@@ -27,6 +27,7 @@ conformance_test!(list_threads_query_filters_lineage);
 conformance_test!(list_threads_query_filters_root_threads);
 conformance_test!(list_runs_filters_by_id_prefix);
 conformance_test!(list_threads_query_filters_by_id_prefix);
+conformance_test!(list_threads_query_id_prefix_paginates_and_binds_cursor);
 conformance_test!(checkpoint_rejects_missing_parent_thread);
 conformance_test!(checkpoint_rejects_cycle_parent_assignment);
 conformance_test!(delete_thread_with_detach_preserves_children);

--- a/crates/awaken-stores/tests/nats_buffered_thread_conformance.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_conformance.rs
@@ -142,3 +142,11 @@ async fn nats_list_threads_query_filters_by_id_prefix() {
     thread_store_conformance::list_threads_query_filters_by_id_prefix(&store).await;
     store.shutdown().await.unwrap();
 }
+
+#[tokio::test]
+async fn nats_list_threads_query_id_prefix_paginates_and_binds_cursor() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::list_threads_query_id_prefix_paginates_and_binds_cursor(&store).await;
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/nats_buffered_thread_conformance.rs
+++ b/crates/awaken-stores/tests/nats_buffered_thread_conformance.rs
@@ -126,3 +126,19 @@ async fn nats_load_run_returns_none_for_unknown() {
     thread_store_conformance::load_run_returns_none_for_unknown(&store).await;
     store.shutdown().await.unwrap();
 }
+
+#[tokio::test]
+async fn nats_list_runs_filters_by_id_prefix() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::list_runs_filters_by_id_prefix(&store).await;
+    store.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn nats_list_threads_query_filters_by_id_prefix() {
+    let fixture = NatsFixture::start().await;
+    let store = make_store(&fixture).await;
+    thread_store_conformance::list_threads_query_filters_by_id_prefix(&store).await;
+    store.shutdown().await.unwrap();
+}

--- a/crates/awaken-stores/tests/postgres_store.rs
+++ b/crates/awaken-stores/tests/postgres_store.rs
@@ -908,3 +908,73 @@ async fn list_threads_query_filters_by_id_prefix() {
     assert_eq!(page.total, 2);
     assert!(page.items.iter().all(|id| id.starts_with("sa-")));
 }
+
+#[tokio::test]
+#[ignore]
+async fn list_threads_query_id_prefix_paginates_and_binds_cursor() {
+    let Some(store) = make_prefixed_store("pg_threads_prefix_escape").await else {
+        return;
+    };
+    let prefix = "scope:5:a%_\\:";
+    store
+        .save_thread(&Thread::with_id(format!("{prefix}thread-1")))
+        .await
+        .unwrap();
+    store
+        .save_thread(&Thread::with_id(format!("{prefix}thread-2")))
+        .await
+        .unwrap();
+    store
+        .save_thread(&Thread::with_id("scope:6:a%_\\:thread-3"))
+        .await
+        .unwrap();
+    store
+        .save_thread(&Thread::with_id("scope:5:aXY\\:thread-4"))
+        .await
+        .unwrap();
+
+    let query = ThreadQuery {
+        offset: 0,
+        limit: 1,
+        resource_id: None,
+        parent_filter: ThreadParentFilter::Any,
+        id_prefix: Some(prefix.to_string()),
+    };
+    let page = store.list_threads_query(&query).await.unwrap();
+
+    assert_eq!(page.total, 2);
+    assert_eq!(page.items.len(), 1);
+    assert!(page.items.iter().all(|id| id.starts_with(prefix)));
+    assert!(page.has_more);
+    let cursor = page.next_cursor.expect("prefix page should expose cursor");
+    let next_offset = query.decode_cursor(&cursor).unwrap();
+    assert_eq!(next_offset, 1);
+    assert!(
+        ThreadQuery {
+            id_prefix: Some("scope:6:a%_\\:".to_string()),
+            ..query.clone()
+        }
+        .decode_cursor(&cursor)
+        .is_err()
+    );
+    assert!(
+        ThreadQuery {
+            id_prefix: None,
+            ..query.clone()
+        }
+        .decode_cursor(&cursor)
+        .is_err()
+    );
+
+    let page = store
+        .list_threads_query(&ThreadQuery {
+            offset: next_offset,
+            ..query
+        })
+        .await
+        .unwrap();
+    assert_eq!(page.total, 2);
+    assert_eq!(page.items.len(), 1);
+    assert!(page.items.iter().all(|id| id.starts_with(prefix)));
+    assert!(!page.has_more);
+}

--- a/crates/awaken-stores/tests/postgres_store.rs
+++ b/crates/awaken-stores/tests/postgres_store.rs
@@ -155,6 +155,7 @@ async fn list_threads_query_filters_lineage() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         })
         .await
         .unwrap();
@@ -192,6 +193,7 @@ async fn list_threads_query_filters_root_threads() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Root,
+            id_prefix: None,
         })
         .await
         .unwrap();
@@ -500,6 +502,7 @@ async fn ensure_schema_normalizes_legacy_thread_lineage_columns_from_json() {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         })
         .await
         .unwrap();
@@ -845,4 +848,63 @@ async fn deleting_missing_config_does_not_emit_notify_event() {
         result.is_err(),
         "deleting a missing config entry should not emit a notify event"
     );
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_runs_filters_by_id_prefix() {
+    let Some(store) = make_prefixed_store("pg_runs_prefix").await else {
+        return;
+    };
+    store
+        .checkpoint("sa-t1", &[], &make_run("sa-r1", "sa-t1", 1))
+        .await
+        .unwrap();
+    store
+        .checkpoint("sa-t2", &[], &make_run("sa-r2", "sa-t2", 2))
+        .await
+        .unwrap();
+    store
+        .checkpoint("sb-t1", &[], &make_run("sb-r1", "sb-t1", 3))
+        .await
+        .unwrap();
+
+    let page = store
+        .list_runs(&RunQuery {
+            offset: 0,
+            limit: 50,
+            thread_id: None,
+            status: None,
+            id_prefix: Some("sa-".to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(page.total, 2);
+    assert!(page.items.iter().all(|r| r.thread_id.starts_with("sa-")));
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_threads_query_filters_by_id_prefix() {
+    let Some(store) = make_prefixed_store("pg_threads_prefix").await else {
+        return;
+    };
+    store.save_thread(&Thread::with_id("sa-t1")).await.unwrap();
+    store.save_thread(&Thread::with_id("sa-t2")).await.unwrap();
+    store.save_thread(&Thread::with_id("sb-t1")).await.unwrap();
+
+    let page = store
+        .list_threads_query(&ThreadQuery {
+            offset: 0,
+            limit: 50,
+            resource_id: None,
+            parent_filter: ThreadParentFilter::Any,
+            id_prefix: Some("sa-".to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(page.total, 2);
+    assert!(page.items.iter().all(|id| id.starts_with("sa-")));
 }

--- a/crates/awaken-stores/tests/thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/thread_store_conformance.rs
@@ -4,8 +4,8 @@
 use awaken_server_contract::contract::lifecycle::RunStatus;
 use awaken_server_contract::contract::message::{Message, MessageMetadata};
 use awaken_server_contract::contract::storage::{
-    ChildThreadDeleteStrategy, MessageOrder, MessageQuery, MessageVisibilityFilter, RunRecord,
-    RunRequestSnapshot, StorageError, ThreadParentFilter, ThreadQuery, ThreadRunStore,
+    ChildThreadDeleteStrategy, MessageOrder, MessageQuery, MessageVisibilityFilter, RunQuery,
+    RunRecord, RunRequestSnapshot, StorageError, ThreadParentFilter, ThreadQuery, ThreadRunStore,
 };
 use awaken_server_contract::thread::Thread;
 
@@ -243,12 +243,72 @@ pub async fn list_threads_query_filters_lineage<S: ThreadRunStore>(store: &S) {
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Parent("parent-1".to_string()),
+            id_prefix: None,
         })
         .await
         .unwrap();
 
     assert_eq!(page.items, vec!["t-filter-match"]);
     assert_eq!(page.total, 1);
+    assert!(!page.has_more);
+}
+
+/// ADR-0042 scope boundary: `RunQuery::id_prefix` must filter at the backend so
+/// a scoped listing returns only its own runs (and exact totals), never the full
+/// shared run table.
+pub async fn list_runs_filters_by_id_prefix<S: ThreadRunStore>(store: &S) {
+    store
+        .checkpoint("sa-t1", &[], &make_run("sa-r1", "sa-t1", RunStatus::Done))
+        .await
+        .unwrap();
+    store
+        .checkpoint("sa-t2", &[], &make_run("sa-r2", "sa-t2", RunStatus::Done))
+        .await
+        .unwrap();
+    store
+        .checkpoint("sb-t1", &[], &make_run("sb-r1", "sb-t1", RunStatus::Done))
+        .await
+        .unwrap();
+
+    let page = store
+        .list_runs(&RunQuery {
+            offset: 0,
+            limit: 50,
+            thread_id: None,
+            status: None,
+            id_prefix: Some("sa-".to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(page.total, 2, "only the two sa- runs are in scope");
+    assert!(page.items.iter().all(|r| r.thread_id.starts_with("sa-")));
+    assert!(page.items.iter().any(|r| r.run_id == "sa-r1"));
+    assert!(page.items.iter().any(|r| r.run_id == "sa-r2"));
+    assert!(!page.has_more);
+}
+
+/// ADR-0042 scope boundary: `ThreadQuery::id_prefix` must filter at the backend.
+pub async fn list_threads_query_filters_by_id_prefix<S: ThreadRunStore>(store: &S) {
+    store.save_thread(&Thread::with_id("sa-t1")).await.unwrap();
+    store.save_thread(&Thread::with_id("sa-t2")).await.unwrap();
+    store.save_thread(&Thread::with_id("sb-t1")).await.unwrap();
+
+    let page = store
+        .list_threads_query(&ThreadQuery {
+            offset: 0,
+            limit: 50,
+            resource_id: None,
+            parent_filter: ThreadParentFilter::Any,
+            id_prefix: Some("sa-".to_string()),
+        })
+        .await
+        .unwrap();
+
+    let mut items = page.items.clone();
+    items.sort();
+    assert_eq!(items, vec!["sa-t1".to_string(), "sa-t2".to_string()]);
+    assert_eq!(page.total, 2);
     assert!(!page.has_more);
 }
 
@@ -272,6 +332,7 @@ pub async fn list_threads_query_filters_root_threads<S: ThreadRunStore>(store: &
             limit: 10,
             resource_id: Some("resource-a".to_string()),
             parent_filter: ThreadParentFilter::Root,
+            id_prefix: None,
         })
         .await
         .unwrap();

--- a/crates/awaken-stores/tests/thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/thread_store_conformance.rs
@@ -312,6 +312,74 @@ pub async fn list_threads_query_filters_by_id_prefix<S: ThreadRunStore>(store: &
     assert!(!page.has_more);
 }
 
+/// ADR-0042 scope boundary: prefix filters must be applied before pagination,
+/// must escape LIKE metacharacters consistently, and cursors must stay bound to
+/// the exact prefix that produced them.
+pub async fn list_threads_query_id_prefix_paginates_and_binds_cursor<S: ThreadRunStore>(store: &S) {
+    let prefix = "scope:4:a%_:";
+    store
+        .save_thread(&Thread::with_id(format!("{prefix}thread-1")))
+        .await
+        .unwrap();
+    store
+        .save_thread(&Thread::with_id(format!("{prefix}thread-2")))
+        .await
+        .unwrap();
+    store
+        .save_thread(&Thread::with_id("scope:5:a%_:thread-3"))
+        .await
+        .unwrap();
+    store
+        .save_thread(&Thread::with_id("scope:4:aXY:thread-4"))
+        .await
+        .unwrap();
+
+    let query = ThreadQuery {
+        offset: 0,
+        limit: 1,
+        resource_id: None,
+        parent_filter: ThreadParentFilter::Any,
+        id_prefix: Some(prefix.to_string()),
+    };
+    let page = store.list_threads_query(&query).await.unwrap();
+
+    assert_eq!(page.total, 2);
+    assert_eq!(page.items.len(), 1);
+    assert!(page.items.iter().all(|id| id.starts_with(prefix)));
+    assert!(page.has_more);
+    let cursor = page.next_cursor.expect("prefix page should expose cursor");
+    let next_offset = query.decode_cursor(&cursor).unwrap();
+    assert_eq!(next_offset, 1);
+    assert!(
+        ThreadQuery {
+            id_prefix: Some("scope:5:a%_:".to_string()),
+            ..query.clone()
+        }
+        .decode_cursor(&cursor)
+        .is_err()
+    );
+    assert!(
+        ThreadQuery {
+            id_prefix: None,
+            ..query.clone()
+        }
+        .decode_cursor(&cursor)
+        .is_err()
+    );
+
+    let page = store
+        .list_threads_query(&ThreadQuery {
+            offset: next_offset,
+            ..query
+        })
+        .await
+        .unwrap();
+    assert_eq!(page.total, 2);
+    assert_eq!(page.items.len(), 1);
+    assert!(page.items.iter().all(|id| id.starts_with(prefix)));
+    assert!(!page.has_more);
+}
+
 pub async fn list_threads_query_filters_root_threads<S: ThreadRunStore>(store: &S) {
     let mut matching_root = Thread::with_id("t-root-match").with_resource_id("resource-a");
     matching_root.metadata.updated_at = Some(300);


### PR DESCRIPTION
## Summary

Make scoped listings filter at the backend instead of scanning the full shared table and filtering in `ScopedThreadRunStore`. Scope keys share the prefix `scope:<len>:<scope>:`, so scoped `list_runs` / `list_threads` now pass that prefix into backend queries and paginate after filtering.

## Changes

- Contract: add `id_prefix: Option<String>` to `RunQuery` and `ThreadQuery`; include `id_prefix` in thread cursor tokens so cursors are bound to the exact filter set.
- Scoped wrapper: `list_runs` pushes `scope_prefix()` directly; legacy `list_threads(offset, limit)` also pushes the prefix but loops across 200-row `ThreadQuery` pages so caller-requested limits above 200 keep their old vector API behavior.
- Backends: memory/file use the shared filtered pagination path; Postgres uses `LIKE 'prefix%' ESCAPE '\'` with escaping for `%`, `_`, and `\`; NATS filters its read-your-writes pending merge by prefix.
- Postgres thread pagination now returns `ThreadQuery::encode_cursor(...)` instead of a bare offset, so prefix/resource/parent filters are validated on cursor reuse.
- Admin test path is updated to read `AgentSpecPatch` from `awaken-runtime-contract`; this duplicates #258's CI fix so this PR can pass independently against `main`.

## Review fixes

- Cursor tokens reject `None -> Some(prefix)` and `prefix A -> prefix B`; matching prefix cursors continue to work.
- Prefix filtering is tested with metacharacters and common-prefix scopes. Postgres keeps the backslash-specific `LIKE` escaping coverage.
- `total` / `has_more` are asserted after prefix filtering, including paginated prefix queries.
- Removed the unsupported "indexed LIKE" wording from code and PR text; this PR claims prefix pushdown, not a proven index plan.

## Validation

Passed locally:

```text
cargo fmt --all -- --check
cargo test -p awaken-server-contract --lib thread_query_cursor_binds_id_prefix_filter
cargo test -p awaken-stores --test memory_thread_store_conformance list_threads_query_id_prefix_paginates_and_binds_cursor
cargo test -p awaken-stores --features file --test file_thread_store_conformance list_threads_query_id_prefix_paginates_and_binds_cursor
cargo test --locked -p awaken-stores --features postgres --test postgres_store list_threads_query_id_prefix_paginates_and_binds_cursor -- --ignored
cargo test --locked -p awaken-stores --features nats --test nats_buffered_thread_conformance nats_list_threads_query_id_prefix_paginates_and_binds_cursor -- --test-threads=1
pnpm install --frozen-lockfile
pre-push hook: admin-console-ci + validate
```

Known warning: existing `clippy::type_complexity` warning in `crates/awaken-server/src/app/modules.rs`; CI denies only `clippy::correctness`.