### PR TITLE
🧹 refactor(contract): narrow thread commit surface

### DIFF
--- a/apps/admin-console/src/lib/agent-editor-helpers.test.ts
+++ b/apps/admin-console/src/lib/agent-editor-helpers.test.ts
@@ -49,7 +49,10 @@ const REMOTE_ENDPOINT: RemoteEndpoint = {
 
 function rustAgentSpecPatchFields(): string[] {
   const source = readFileSync(
-    new URL("../../../../crates/awaken-contract/src/agent_spec_patch.rs", import.meta.url),
+    new URL(
+      "../../../../crates/awaken-runtime-contract/src/agent_spec_patch.rs",
+      import.meta.url,
+    ),
     "utf8",
   );
   const structMatch = source.match(/pub struct AgentSpecPatch \{([\s\S]*?)\n\}/);

--- a/crates/awaken-ext-mcp/tests/e2e_server_everything.rs
+++ b/crates/awaken-ext-mcp/tests/e2e_server_everything.rs
@@ -14,9 +14,10 @@
 //!   1. `MCP_E2E_SERVER_BIN` env var (path to a pre-installed
 //!      `mcp-server-everything` executable). Preferred in CI so each
 //!      test doesn't pay the `npx` startup cost.
-//!   2. Fallback to the pinned `npx -y
-//!      @modelcontextprotocol/server-everything@2026.1.26 stdio`.
-//!      First run downloads (~5s); subsequent runs hit the npm cache.
+//!   2. Fallback to the pinned `npx -y --package
+//!      @modelcontextprotocol/server-everything@2026.1.26
+//!      mcp-server-everything stdio`. First run downloads (~5s);
+//!      subsequent runs hit the npm cache.
 //!
 //! ## Scope
 //!
@@ -36,6 +37,7 @@ use tokio::process::{Child, Command};
 
 static E2E_SERVER_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
 const SERVER_EVERYTHING_PACKAGE: &str = "@modelcontextprotocol/server-everything@2026.1.26";
+const SERVER_EVERYTHING_BIN: &str = "mcp-server-everything";
 
 async fn e2e_server_lock() -> tokio::sync::MutexGuard<'static, ()> {
     E2E_SERVER_LOCK
@@ -54,7 +56,9 @@ fn server_command() -> (String, Vec<String>) {
         "npx".to_string(),
         vec![
             "-y".to_string(),
+            "--package".to_string(),
             SERVER_EVERYTHING_PACKAGE.to_string(),
+            SERVER_EVERYTHING_BIN.to_string(),
             "stdio".to_string(),
         ],
     )
@@ -68,7 +72,9 @@ fn streamable_http_server_command() -> (String, Vec<String>) {
         "npx".to_string(),
         vec![
             "-y".to_string(),
+            "--package".to_string(),
             SERVER_EVERYTHING_PACKAGE.to_string(),
+            SERVER_EVERYTHING_BIN.to_string(),
             "streamableHttp".to_string(),
         ],
     )

--- a/crates/awaken-runtime-contract/src/contract/commit_coordinator.rs
+++ b/crates/awaken-runtime-contract/src/contract/commit_coordinator.rs
@@ -1,28 +1,16 @@
-//! Cross-store commit coordination for runtime checkpoints (ADR-0036).
+//! Cross-store checkpoint commit boundary for runtime durability (ADR-0036).
 //!
-//! `CommitCoordinator` is the contract-layer abstraction that owns the
-//! transaction spanning `ThreadRunStore` writes and `EventStore` appends.
-//! It is the only place that observes both stores at once; the stores
-//! themselves remain backend-agnostic.
+//! `CommitCoordinator` is the runtime-facing write boundary for one atomic
+//! logical mutation: append-only message delta + latest run projection + optional
+//! thread-scoped state. It is the only place that observes both the message and
+//! event persistence stores at once; concrete backends remain backend-agnostic.
 //!
-//! Runtime tee for durable `AgentEvent` variants is folded into this
-//! commit boundary through a staging step: a `CanonicalEventStager`
-//! receives drafts from the reshaped `DurableEventSink`, and the
-//! `LoopRunner` drains the staged drafts into a `Checkpoint`
-//! at checkpoint cadence.
-//!
-//! This boundary is deliberately limited to runtime checkpoints:
-//! thread messages, run records, canonical event appends, and outbox rows
-//! carried by the checkpoint plan. `ConfigStore` writes are outside this
-//! coordinator and therefore are not atomic with checkpoints or audit
-//! events. Mailbox dispatch result updates are also a separate, idempotent
-//! state machine; callers should treat dispatch completion and final
-//! `ThreadRunStore` run projection as eventually reconciled rather than a
-//! single coordinator transaction.
+//! Server-side staging of canonical drafts and outbox rows is composed through
+//! `awaken-server-contract`, so this contract stays focused on the runtime
+//! commit-plan invariants.
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use thiserror::Error;
 
 use std::sync::Arc;
@@ -104,78 +92,12 @@ impl StagedCanonicalEvent {
     }
 }
 
-/// Server-authored canonical event attached to the same checkpoint plan as
-/// the state transition that made the fact true.
-#[derive(Debug, Clone, PartialEq)]
-pub struct ServerCanonicalEvent {
-    pub draft: CanonicalEventDraft,
-    pub options: AppendOptions,
-}
+// ── thread commit plan ───────────────────────────────────────────────
 
-impl ServerCanonicalEvent {
-    /// Construct a server-authored canonical event with default append options.
-    #[must_use]
-    pub fn new(draft: CanonicalEventDraft) -> Self {
-        Self {
-            draft,
-            options: AppendOptions::default(),
-        }
-    }
-
-    /// Attach append options (idempotency, expected cursors).
-    #[must_use]
-    pub fn with_options(mut self, options: AppendOptions) -> Self {
-        self.options = options;
-        self
-    }
-}
-
-/// Outcome for advisory server canonical publication through an outbox.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ServerEventPublishOutcome {
-    Enqueued { dedupe_key: String },
-}
-
-/// Failure surface for advisory server canonical publication.
-#[derive(Debug, Error, Clone, PartialEq, Eq)]
-pub enum EventPublishError {
-    #[error("validation error: {0}")]
-    Validation(String),
-    #[error("outbox enqueue failed: {0}")]
-    Enqueue(#[from] OutboxError),
-    #[error("serialization error: {0}")]
-    Serialization(String),
-}
-
-/// Long-lived publisher for advisory server-authored canonical events.
-#[async_trait]
-pub trait OutboxServerEventPublisher: Send + Sync {
-    async fn publish(
-        &self,
-        draft: CanonicalEventDraft,
-        options: AppendOptions,
-    ) -> Result<ServerEventPublishOutcome, EventPublishError>;
-}
-
-/// Non-replay diagnostic event.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct DiagnosticEvent {
-    pub kind: String,
-    #[serde(default)]
-    pub payload: Value,
-}
-
-/// Fire-and-forget diagnostic event publisher.
-pub trait DiagnosticEventPublisher: Send + Sync {
-    fn record(&self, event: DiagnosticEvent);
-}
-
-// ── checkpoint commit plan ───────────────────────────────────────────
-
-/// One atomic checkpoint commit.
+/// One atomic thread commit.
 ///
-/// The committed message log is **append-only**: `messages` is always a delta
-/// appended to the thread's committed log, guarded by `expected_message_version`
+/// The committed message log is **append-only**: `message_delta` is always a delta
+/// appended to the thread's committed log, guarded by `expected_message_count`
 /// (the committed message count the caller observed, ADR-0042 D5). There is no
 /// whole-list overwrite on the commit path — compaction is itself an append of a
 /// summary message (see `MessageRecord::compaction`), never a rewrite.
@@ -185,54 +107,87 @@ pub trait DiagnosticEventPublisher: Send + Sync {
 /// `EventStore` write) and any additional inline-writer outbox rows the caller
 /// wants atomic with the checkpoint.
 #[derive(Debug, Clone)]
-pub struct Checkpoint {
+pub struct ThreadCommit {
     pub thread_id: String,
     /// The delta appended to the committed log.
-    pub messages: Vec<Message>,
+    pub message_delta: Vec<Message>,
     /// Append version guard: the committed message count the caller observed.
-    pub expected_message_version: Option<u64>,
-    pub run: RunRecord,
+    pub expected_message_count: Option<u64>,
+    pub run_projection: RunRecord,
     /// Thread-scoped persisted state to write in the same transaction, if it
     /// changed this checkpoint. `None` leaves the stored thread state untouched.
     /// Run-scoped state stays on `run` ([`RunRecord::state`]); thread-scoped
     /// state persists across runs (split by `KeyScope`).
-    pub thread_state: Option<PersistedState>,
+    pub thread_state_snapshot: Option<PersistedState>,
 }
 
-impl Checkpoint {
-    /// Build an append-delta checkpoint plan: `messages` are appended to the
-    /// thread's committed log, guarded by `expected_message_version` (the
+/// Compatibility name retained for existing call sites.
+#[deprecated(since = "0.6.0", note = "Use `ThreadCommit`.")]
+pub type Checkpoint = ThreadCommit;
+
+impl ThreadCommit {
+    /// Build an append-delta commit: `message_delta` is appended to the
+    /// thread's committed log, guarded by `expected_message_count` (the
     /// committed message count the caller observed). No staged events.
-    pub fn append(
+    pub fn append_messages(
         thread_id: impl Into<String>,
-        messages: Vec<Message>,
-        expected_message_version: Option<u64>,
-        run: RunRecord,
+        message_delta: Vec<Message>,
+        expected_message_count: Option<u64>,
+        run_projection: RunRecord,
     ) -> Self {
         Self {
             thread_id: thread_id.into(),
-            messages,
-            expected_message_version,
-            run,
-            thread_state: None,
+            message_delta,
+            expected_message_count,
+            run_projection,
+            thread_state_snapshot: None,
         }
+    }
+
+    /// Compatibility constructor retained for legacy naming.
+    #[deprecated(since = "0.6.0", note = "Use `append_messages`.")]
+    pub fn append(
+        thread_id: impl Into<String>,
+        message_delta: Vec<Message>,
+        expected_message_count: Option<u64>,
+        run_projection: RunRecord,
+    ) -> Self {
+        Self::append_messages(
+            thread_id,
+            message_delta,
+            expected_message_count,
+            run_projection,
+        )
     }
 
     /// Attach thread-scoped state to persist atomically with this checkpoint.
     #[must_use]
-    pub fn with_thread_state(mut self, thread_state: PersistedState) -> Self {
-        self.thread_state = Some(thread_state);
+    pub fn with_thread_state_snapshot(mut self, thread_state: PersistedState) -> Self {
+        self.thread_state_snapshot = Some(thread_state);
         self
     }
 
-    /// Build an unguarded checkpoint for **state/status-only** writes that add no
-    /// contended message delta. By construction this carries no `messages`: an
+    /// Compatibility setter retained for legacy naming.
+    #[deprecated(since = "0.6.0", note = "Use `with_thread_state_snapshot`.")]
+    #[must_use]
+    pub fn with_thread_state(self, thread_state: PersistedState) -> Self {
+        self.with_thread_state_snapshot(thread_state)
+    }
+
+    /// Build an unguarded commit for **run/state-only** writes that add no
+    /// contended message delta. By construction this carries no `message_delta`: an
     /// unguarded append of real message content could duplicate or reorder
     /// committed messages under retry/concurrency, so the message delta is not
-    /// expressible here. To append a message delta, use [`Self::append`] with an
-    /// explicit `expected_message_version` guard.
-    pub fn checkpoint_only(thread_id: impl Into<String>, run: RunRecord) -> Self {
-        Self::append(thread_id, Vec::new(), None, run)
+    /// expressible here. To append a message delta, use [`Self::append_messages`] with an
+    /// explicit `expected_message_count` guard.
+    pub fn run_projection_only(thread_id: impl Into<String>, run_projection: RunRecord) -> Self {
+        Self::append_messages(thread_id, Vec::new(), None, run_projection)
+    }
+
+    /// Compatibility constructor retained for legacy naming.
+    #[deprecated(since = "0.6.0", note = "Use `run_projection_only`.")]
+    pub fn checkpoint_only(thread_id: impl Into<String>, run_projection: RunRecord) -> Self {
+        Self::run_projection_only(thread_id, run_projection)
     }
 
     /// Pre-commit validation that mirrors the runtime invariants.
@@ -242,31 +197,31 @@ impl Checkpoint {
                 "thread_id must be non-empty".to_string(),
             ));
         }
-        if self.run.thread_id != self.thread_id {
+        if self.run_projection.thread_id != self.thread_id {
             return Err(CommitError::Validation(format!(
                 "run.thread_id '{}' must match checkpoint thread_id '{}'",
-                self.run.thread_id, self.thread_id
+                self.run_projection.thread_id, self.thread_id
             )));
         }
-        if self.run.run_id.trim().is_empty() {
+        if self.run_projection.run_id.trim().is_empty() {
             return Err(CommitError::Validation(
                 "run.run_id must be non-empty".to_string(),
             ));
         }
-        if self.run.agent_id.trim().is_empty() {
+        if self.run_projection.agent_id.trim().is_empty() {
             return Err(CommitError::Validation(
                 "run.agent_id must be non-empty".to_string(),
             ));
         }
-        // `expected_message_version` is the append version guard. `None` is only
+        // `expected_message_count` is the append version guard. `None` is only
         // permitted when there is no message delta (seed/status/state writes):
         // appending real message content without a version guard would let a
         // retry or concurrent writer duplicate or reorder committed messages
         // that `MessageVersionConflict` is meant to catch. A non-empty delta
         // therefore requires `Some(version)`.
-        if !self.messages.is_empty() && self.expected_message_version.is_none() {
+        if !self.message_delta.is_empty() && self.expected_message_count.is_none() {
             return Err(CommitError::Validation(
-                "append with a non-empty message delta requires an expected_message_version guard"
+                "append with a non-empty message delta requires an expected_message_count guard"
                     .to_string(),
             ));
         }
@@ -276,19 +231,16 @@ impl Checkpoint {
 
 // ── commit outcome ───────────────────────────────────────────────────
 
-/// Identifiers assigned by stores during a successful commit.
+/// Runtime-facing outcome for a successful thread commit.
+///
+/// Server-side staged commits may expose event/outbox ids through
+/// `awaken-server-contract`; the runtime contract only needs success/failure.
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct CheckpointCommitOutcome {
-    /// Canonical event ids in the same order as the input
-    /// `canonical_drafts`. Empty when the plan staged no events.
-    pub canonical_event_ids: Vec<String>,
-    /// Server-authored canonical event ids in the same order as the input
-    /// `server_events`. Empty when the plan attached no server events.
-    pub server_event_ids: Vec<String>,
-    /// Outbox ids in the same order as `additional_outbox`. Empty when
-    /// the plan attached no inline-writer outbox rows.
-    pub additional_outbox_ids: Vec<String>,
-}
+pub struct ThreadCommitOutcome;
+
+/// Compatibility name retained for existing call sites.
+#[deprecated(since = "0.6.0", note = "Use `ThreadCommitOutcome`.")]
+pub type CheckpointCommitOutcome = ThreadCommitOutcome;
 
 // ── error ───────────────────────────────────────────────────────────
 
@@ -371,7 +323,7 @@ impl CommitError {
 /// Out of scope: configuration writes and mailbox dispatch lifecycle
 /// mutations. Those stores have their own concurrency contracts. When a
 /// workflow needs checkpoint durability, it must express the write through a
-/// [`Checkpoint`]; otherwise it is intentionally outside this
+/// [`ThreadCommit`]; otherwise it is intentionally outside this
 /// transaction boundary.
 #[async_trait]
 pub trait CommitCoordinator: Send + Sync {
@@ -391,8 +343,8 @@ pub trait CommitCoordinator: Send + Sync {
     /// ordering and failure semantics.
     async fn commit_checkpoint(
         &self,
-        plan: Checkpoint,
-    ) -> Result<CheckpointCommitOutcome, CommitError>;
+        plan: ThreadCommit,
+    ) -> Result<ThreadCommitOutcome, CommitError>;
 }
 
 #[cfg(test)]
@@ -448,7 +400,7 @@ mod tests {
 
     #[test]
     fn plan_checkpoint_only_validates() {
-        let plan = Checkpoint::checkpoint_only("t-1", sample_run_record());
+        let plan = ThreadCommit::run_projection_only("t-1", sample_run_record());
         plan.validate().unwrap();
     }
 
@@ -456,7 +408,7 @@ mod tests {
     fn plan_rejects_blank_thread_id() {
         let mut run = sample_run_record();
         run.thread_id = String::new();
-        let plan = Checkpoint::checkpoint_only("", run);
+        let plan = ThreadCommit::run_projection_only("", run);
         let err = plan.validate().unwrap_err();
         assert!(matches!(err, CommitError::Validation(_)));
     }
@@ -465,7 +417,7 @@ mod tests {
     fn plan_rejects_thread_run_mismatch() {
         let mut run = sample_run_record();
         run.thread_id = "other-thread".to_string();
-        let plan = Checkpoint::checkpoint_only("t-1", run);
+        let plan = ThreadCommit::run_projection_only("t-1", run);
         let err = plan.validate().unwrap_err();
         assert!(
             matches!(err, CommitError::Validation(message) if message.contains("run.thread_id"))
@@ -476,7 +428,7 @@ mod tests {
     fn plan_rejects_blank_run_id() {
         let mut run = sample_run_record();
         run.run_id = "   ".to_string();
-        let plan = Checkpoint::checkpoint_only("t-1", run);
+        let plan = ThreadCommit::run_projection_only("t-1", run);
         let err = plan.validate().unwrap_err();
         assert!(matches!(err, CommitError::Validation(message) if message.contains("run.run_id")));
     }
@@ -485,7 +437,7 @@ mod tests {
     fn plan_rejects_blank_agent_id() {
         let mut run = sample_run_record();
         run.agent_id.clear();
-        let plan = Checkpoint::checkpoint_only("t-1", run);
+        let plan = ThreadCommit::run_projection_only("t-1", run);
         let err = plan.validate().unwrap_err();
         assert!(
             matches!(err, CommitError::Validation(message) if message.contains("run.agent_id"))
@@ -497,9 +449,9 @@ mod tests {
     #[test]
     fn checkpoint_only_allows_empty_message_state_write() {
         // No message delta + no version guard is the legitimate state/status write.
-        let plan = Checkpoint::checkpoint_only("t-1", sample_run_record());
-        assert_eq!(plan.expected_message_version, None);
-        assert!(plan.messages.is_empty());
+        let plan = ThreadCommit::run_projection_only("t-1", sample_run_record());
+        assert_eq!(plan.expected_message_count, None);
+        assert!(plan.message_delta.is_empty());
         plan.validate().unwrap();
     }
 
@@ -508,24 +460,29 @@ mod tests {
         // A non-empty delta without a version guard must fail validation — it
         // could duplicate/reorder committed messages under retry/concurrency.
         // `checkpoint_only` cannot express this, so go through `append` directly.
-        let plan = Checkpoint::append("t-1", vec![Message::user("a")], None, sample_run_record());
+        let plan = ThreadCommit::append_messages(
+            "t-1",
+            vec![Message::user("a")],
+            None,
+            sample_run_record(),
+        );
         let err = plan.validate().unwrap_err();
         assert!(
-            matches!(&err, CommitError::Validation(message) if message.contains("version guard")),
-            "expected version-guard validation error, got {err:?}"
+            matches!(&err, CommitError::Validation(message) if message.contains("expected_message_count")),
+            "expected message-count guard validation error, got {err:?}"
         );
     }
 
     #[test]
     fn append_plan_carries_delta_and_expected_version() {
-        let plan = Checkpoint::append(
+        let plan = ThreadCommit::append_messages(
             "t-1",
             vec![Message::user("hi")],
             Some(3),
             sample_run_record(),
         );
-        assert_eq!(plan.expected_message_version, Some(3));
-        assert_eq!(plan.messages.len(), 1);
+        assert_eq!(plan.expected_message_count, Some(3));
+        assert_eq!(plan.message_delta.len(), 1);
         plan.validate().unwrap();
     }
 
@@ -533,8 +490,8 @@ mod tests {
     fn state_only_checkpoint_accepts_none_version() {
         // `None` is valid only for an EMPTY delta (seed/status/state-only write);
         // a non-empty delta requires `Some(version)` (see the rejection test below).
-        let plan = Checkpoint::append("t-1", Vec::new(), None, sample_run_record());
-        assert_eq!(plan.expected_message_version, None);
+        let plan = ThreadCommit::append_messages("t-1", Vec::new(), None, sample_run_record());
+        assert_eq!(plan.expected_message_count, None);
         plan.validate().unwrap();
     }
 
@@ -542,7 +499,7 @@ mod tests {
     fn append_plan_still_validates_run_thread_match() {
         let mut run = sample_run_record();
         run.thread_id = "other-thread".to_string();
-        let plan = Checkpoint::append("t-1", Vec::new(), Some(0), run);
+        let plan = ThreadCommit::append_messages("t-1", Vec::new(), Some(0), run);
         let err = plan.validate().unwrap_err();
         assert!(
             matches!(err, CommitError::Validation(message) if message.contains("run.thread_id"))

--- a/crates/awaken-runtime-contract/src/contract/commit_coordinator.rs
+++ b/crates/awaken-runtime-contract/src/contract/commit_coordinator.rs
@@ -2,8 +2,7 @@
 //!
 //! `CommitCoordinator` is the runtime-facing write boundary for one atomic
 //! logical mutation: append-only message delta + latest run projection + optional
-//! thread-scoped state. It is the only place that observes both the message and
-//! event persistence stores at once; concrete backends remain backend-agnostic.
+//! thread-scoped state. Concrete backends remain backend-agnostic.
 //!
 //! Server-side staging of canonical drafts and outbox rows is composed through
 //! `awaken-server-contract`, so this contract stays focused on the runtime
@@ -102,10 +101,10 @@ impl StagedCanonicalEvent {
 /// whole-list overwrite on the commit path — compaction is itself an append of a
 /// summary message (see `MessageRecord::compaction`), never a rewrite.
 ///
-/// `ThreadRunStore` checkpoint inputs (thread id, message delta, run record) are
-/// committed together with `canonical_drafts` (each appended via the shared
-/// `EventStore` write) and any additional inline-writer outbox rows the caller
-/// wants atomic with the checkpoint.
+/// Runtime-facing commits carry only thread durability data: thread id, message
+/// delta, latest run projection, and an optional thread-state snapshot.
+/// Server-side staged event/outbox writes are supplied through
+/// `awaken-server-contract`.
 #[derive(Debug, Clone)]
 pub struct ThreadCommit {
     pub thread_id: String,
@@ -199,18 +198,18 @@ impl ThreadCommit {
         }
         if self.run_projection.thread_id != self.thread_id {
             return Err(CommitError::Validation(format!(
-                "run.thread_id '{}' must match checkpoint thread_id '{}'",
+                "run_projection.thread_id '{}' must match thread commit thread_id '{}'",
                 self.run_projection.thread_id, self.thread_id
             )));
         }
         if self.run_projection.run_id.trim().is_empty() {
             return Err(CommitError::Validation(
-                "run.run_id must be non-empty".to_string(),
+                "run_projection.run_id must be non-empty".to_string(),
             ));
         }
         if self.run_projection.agent_id.trim().is_empty() {
             return Err(CommitError::Validation(
-                "run.agent_id must be non-empty".to_string(),
+                "run_projection.agent_id must be non-empty".to_string(),
             ));
         }
         // `expected_message_count` is the append version guard. `None` is only
@@ -307,12 +306,10 @@ impl CommitError {
 
 /// Cross-store atomic commit boundary (ADR-0036 D2).
 ///
-/// Implementations open a backend transaction, drive the
-/// `ThreadRunStore` checkpoint write, append each staged canonical
-/// draft (which transitively inserts the canonical outbox row in the
-/// same transaction per ADR-0034 D9), insert any inline-writer outbox
-/// rows from `additional_outbox`, and commit. Any failure rolls the
-/// transaction back and surfaces `CommitError`.
+/// Implementations open a backend transaction, drive the runtime thread commit
+/// write, and commit. Server coordinators that also need staged event/outbox
+/// writes expose that wider surface through `awaken-server-contract`. Any
+/// failure rolls the transaction back and surfaces `CommitError`.
 ///
 /// Coordinator construction is the place where scope compatibility is
 /// validated: a coordinator that pairs stores from mismatched backends
@@ -419,9 +416,10 @@ mod tests {
         run.thread_id = "other-thread".to_string();
         let plan = ThreadCommit::run_projection_only("t-1", run);
         let err = plan.validate().unwrap_err();
-        assert!(
-            matches!(err, CommitError::Validation(message) if message.contains("run.thread_id"))
-        );
+        assert!(matches!(
+            err,
+            CommitError::Validation(message) if message.contains("run_projection.thread_id")
+        ));
     }
 
     #[test]
@@ -430,7 +428,10 @@ mod tests {
         run.run_id = "   ".to_string();
         let plan = ThreadCommit::run_projection_only("t-1", run);
         let err = plan.validate().unwrap_err();
-        assert!(matches!(err, CommitError::Validation(message) if message.contains("run.run_id")));
+        assert!(matches!(
+            err,
+            CommitError::Validation(message) if message.contains("run_projection.run_id")
+        ));
     }
 
     #[test]
@@ -439,9 +440,10 @@ mod tests {
         run.agent_id.clear();
         let plan = ThreadCommit::run_projection_only("t-1", run);
         let err = plan.validate().unwrap_err();
-        assert!(
-            matches!(err, CommitError::Validation(message) if message.contains("run.agent_id"))
-        );
+        assert!(matches!(
+            err,
+            CommitError::Validation(message) if message.contains("run_projection.agent_id")
+        ));
     }
 
     // ── ADR-0042 A: append-only checkpoint plan ──────────────────
@@ -501,9 +503,10 @@ mod tests {
         run.thread_id = "other-thread".to_string();
         let plan = ThreadCommit::append_messages("t-1", Vec::new(), Some(0), run);
         let err = plan.validate().unwrap_err();
-        assert!(
-            matches!(err, CommitError::Validation(message) if message.contains("run.thread_id"))
-        );
+        assert!(matches!(
+            err,
+            CommitError::Validation(message) if message.contains("run_projection.thread_id")
+        ));
     }
 
     #[test]

--- a/crates/awaken-runtime-contract/src/contract/storage.rs
+++ b/crates/awaken-runtime-contract/src/contract/storage.rs
@@ -313,7 +313,7 @@ impl RunRecord {
 /// otherwise risk by stitching separate `load_messages`/`latest_run`/
 /// `load_thread_state` calls while a concurrent commit advances the thread.
 ///
-/// This is the read-side counterpart to [`Checkpoint`](crate::contract::commit_coordinator::Checkpoint):
+/// This is the read-side counterpart to [`ThreadCommit`](crate::contract::commit_coordinator::ThreadCommit):
 /// `commit_checkpoint(checkpoint)` writes, `load_checkpoint(thread)` reads back.
 #[derive(Debug, Clone, Default)]
 pub struct CheckpointSnapshot {

--- a/crates/awaken-runtime-contract/src/lib.rs
+++ b/crates/awaken-runtime-contract/src/lib.rs
@@ -86,10 +86,11 @@ pub use contract::progress::{
 
 // ── commit coordinator ──
 pub use contract::commit_coordinator::{
-    CanonicalEventStager, Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError,
-    DiagnosticEvent, DiagnosticEventPublisher, EventPublishError, OutboxServerEventPublisher,
-    ServerCanonicalEvent, ServerEventPublishOutcome, StagedCanonicalEvent, TransactionScopeId,
+    CanonicalEventStager, CommitCoordinator, CommitError, StagedCanonicalEvent, ThreadCommit,
+    ThreadCommitOutcome, TransactionScopeId,
 };
+#[allow(deprecated)]
+pub use contract::commit_coordinator::{Checkpoint, CheckpointCommitOutcome};
 
 // ── canonical event store (data vocabulary; store traits live in
 // awaken-server-contract) ──

--- a/crates/awaken-runtime/src/backend/checkpoint.rs
+++ b/crates/awaken-runtime/src/backend/checkpoint.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use awaken_runtime_contract::contract::commit_coordinator::Checkpoint;
+use awaken_runtime_contract::contract::commit_coordinator::ThreadCommit;
 use awaken_runtime_contract::contract::identity::RunIdentity;
 use awaken_runtime_contract::contract::lifecycle::{RunStatus, TerminationReason};
 use awaken_runtime_contract::contract::message::{Message, Role};
@@ -142,12 +142,12 @@ pub(super) async fn persist_remote_root_checkpoint(
             let mut record = base_record.clone();
             record.output = output;
             let mut plan =
-                Checkpoint::append(thread_id.to_string(), delta, Some(expected_version), record);
+                ThreadCommit::append_messages(thread_id.to_string(), delta, Some(expected_version), record);
             if let Some(thread_state) = thread_state
                 .as_ref()
                 .filter(|state| !state.extensions.is_empty())
             {
-                plan = plan.with_thread_state(thread_state.clone());
+                plan = plan.with_thread_state_snapshot(thread_state.clone());
             }
             plan
         },

--- a/crates/awaken-runtime/src/extensions/a2a/a2a_backend/checkpoint.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/a2a_backend/checkpoint.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use awaken_runtime_contract::contract::commit_coordinator::Checkpoint;
+use awaken_runtime_contract::contract::commit_coordinator::ThreadCommit;
 use awaken_runtime_contract::contract::lifecycle::RunStatus;
 use awaken_runtime_contract::contract::storage::RunRecord;
 use awaken_runtime_contract::now_ms;
@@ -100,7 +100,7 @@ pub(super) async fn persist_accepted_checkpoint(
                 })
                 .cloned()
                 .collect();
-            Checkpoint::append(
+            ThreadCommit::append_messages(
                 root.run_identity.thread_id.clone(),
                 delta,
                 Some(expected_version),

--- a/crates/awaken-runtime/src/loop_runner/checkpoint.rs
+++ b/crates/awaken-runtime/src/loop_runner/checkpoint.rs
@@ -7,7 +7,7 @@ use crate::checkpoint_store::RuntimeCheckpointStore;
 use crate::hooks::PhaseContext;
 use crate::phase::{ExecutionEnv, PhaseRuntime};
 use awaken_runtime_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError,
+    CommitCoordinator, CommitError, ThreadCommit, ThreadCommitOutcome,
 };
 use awaken_runtime_contract::contract::event::AgentEvent;
 use awaken_runtime_contract::contract::event_sink::EventSink;
@@ -69,7 +69,7 @@ pub enum CommitAppendError {
 /// The single version-guarded append-commit entry point shared by every
 /// runtime checkpoint path (ADR-0038 C6a: loop-runner, remote-root backend,
 /// A2A). It reads the committed log, hands the caller the committed messages
-/// plus the expected version so the caller can build its delta + `Checkpoint`,
+/// plus the expected version so the caller can build its delta + `ThreadCommit`,
 /// commits, and retries on `MessageVersionConflict`. Callers supply only the
 /// delta/plan builder; the read + version-guard + retry policy lives here.
 pub(crate) async fn commit_checkpoint_appending<F>(
@@ -77,9 +77,9 @@ pub(crate) async fn commit_checkpoint_appending<F>(
     storage: &dyn RuntimeCheckpointStore,
     thread_id: &str,
     mut build: F,
-) -> Result<CheckpointCommitOutcome, CommitAppendError>
+) -> Result<ThreadCommitOutcome, CommitAppendError>
 where
-    F: FnMut(&[Message], u64) -> Checkpoint,
+    F: FnMut(&[Message], u64) -> ThreadCommit,
 {
     for _ in 0..MAX_APPEND_ATTEMPTS {
         let committed = storage
@@ -213,7 +213,7 @@ pub(super) async fn persist_checkpoint(
 
     let lifecycle = store.read::<RunLifecycle>().unwrap_or_default();
     // Split persisted state by scope (ADR-0038 C4): run-scoped keys ride on
-    // the run record, thread-scoped keys land in `Checkpoint.thread_state`
+    // the run record, thread-scoped keys land in `ThreadCommit.thread_state_snapshot`
     // and are written in the same commit transaction.
     let state = store
         .export_run_scoped()
@@ -339,7 +339,7 @@ pub(super) async fn persist_checkpoint(
             stamp_compaction_marks(&mut delta, committed_messages, store);
             let mut record = base_record.clone();
             record.output = output;
-            let mut plan = Checkpoint::append(
+            let mut plan = ThreadCommit::append_messages(
                 run_identity.thread_id.clone(),
                 delta,
                 Some(expected_version),
@@ -348,7 +348,7 @@ pub(super) async fn persist_checkpoint(
             // Only attach thread_state when thread-scoped keys exist, so threads
             // without thread-scoped state don't write empty rows on every commit.
             if !thread_state.extensions.is_empty() {
-                plan = plan.with_thread_state(thread_state.clone());
+                plan = plan.with_thread_state_snapshot(thread_state.clone());
             }
             plan
         },

--- a/crates/awaken-runtime/src/loop_runner/checkpoint_tests.rs
+++ b/crates/awaken-runtime/src/loop_runner/checkpoint_tests.rs
@@ -772,7 +772,7 @@ fn stamp_compaction_marks_skips_when_boundary_absent_from_committed() {
 mod commit_append_retry {
     use super::*;
     use awaken_runtime_contract::contract::commit_coordinator::{
-        CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+        CommitCoordinator, CommitError, ThreadCommitOutcome, TransactionScopeId,
     };
     use awaken_runtime_contract::contract::storage::StorageError;
     use awaken_runtime_contract::thread::Thread;
@@ -830,22 +830,22 @@ mod commit_append_retry {
         }
         async fn commit_checkpoint(
             &self,
-            plan: Checkpoint,
-        ) -> Result<CheckpointCommitOutcome, CommitError> {
+            plan: ThreadCommit,
+        ) -> Result<ThreadCommitOutcome, CommitError> {
             self.seen_versions
                 .lock()
-                .push(plan.expected_message_version.unwrap_or_default());
+                .push(plan.expected_message_count.unwrap_or_default());
             let call = self.calls.fetch_add(1, Ordering::SeqCst);
             if call == 0 {
                 // The racing writer landed one extra committed message.
                 let actual = self.committed.fetch_add(1, Ordering::SeqCst) + 1;
                 return Err(CommitError::MessageVersionConflict {
                     thread_id: plan.thread_id.clone(),
-                    expected: plan.expected_message_version.unwrap_or_default(),
+                    expected: plan.expected_message_count.unwrap_or_default(),
                     actual,
                 });
             }
-            Ok(CheckpointCommitOutcome::default())
+            Ok(ThreadCommitOutcome)
         }
     }
 
@@ -864,7 +864,7 @@ mod commit_append_retry {
         let outcome =
             commit_checkpoint_appending(&coordinator, &storage, "t-1", |committed, ver| {
                 // Build a trivial append whose guard is the freshly-read version.
-                Checkpoint::append(
+                ThreadCommit::append_messages(
                     "t-1".to_string(),
                     vec![Message::user(format!("delta-after-{}", committed.len()))],
                     Some(ver),
@@ -900,8 +900,8 @@ mod commit_append_retry {
             }
             async fn commit_checkpoint(
                 &self,
-                plan: Checkpoint,
-            ) -> Result<CheckpointCommitOutcome, CommitError> {
+                plan: ThreadCommit,
+            ) -> Result<ThreadCommitOutcome, CommitError> {
                 Err(CommitError::MessageVersionConflict {
                     thread_id: plan.thread_id.clone(),
                     expected: 0,
@@ -913,7 +913,7 @@ mod commit_append_retry {
             committed: Arc::new(AtomicU64::new(0)),
         };
         let result = commit_checkpoint_appending(&AlwaysConflict, &storage, "t-x", |_c, ver| {
-            Checkpoint::append(
+            ThreadCommit::append_messages(
                 "t-x".to_string(),
                 Vec::new(),
                 Some(ver),

--- a/crates/awaken-runtime/src/run.rs
+++ b/crates/awaken-runtime/src/run.rs
@@ -400,9 +400,9 @@ mod tests {
         }
         async fn commit_checkpoint(
             &self,
-            _plan: awaken_runtime_contract::contract::commit_coordinator::Checkpoint,
+            _plan: awaken_runtime_contract::contract::commit_coordinator::ThreadCommit,
         ) -> Result<
-            awaken_runtime_contract::contract::commit_coordinator::CheckpointCommitOutcome,
+            awaken_runtime_contract::contract::commit_coordinator::ThreadCommitOutcome,
             awaken_runtime_contract::contract::commit_coordinator::CommitError,
         > {
             unreachable!("routing test does not commit")

--- a/crates/awaken-runtime/src/state/persistence.rs
+++ b/crates/awaken-runtime/src/state/persistence.rs
@@ -11,7 +11,7 @@ impl StateStore {
         self.export_filtered(|_| true)
     }
 
-    /// Export only thread-scoped persistent keys (for `Checkpoint.thread_state`).
+    /// Export only thread-scoped persistent keys (for `ThreadCommit.thread_state`).
     pub fn export_thread_scoped(&self) -> Result<PersistedState, StateError> {
         self.export_filtered(|scope| scope == KeyScope::Thread)
     }

--- a/crates/awaken-runtime/tests/builder_commit_coordinator.rs
+++ b/crates/awaken-runtime/tests/builder_commit_coordinator.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use awaken_runtime::builder::AgentRuntimeBuilder;
 use awaken_runtime_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+    CommitCoordinator, CommitError, ThreadCommit, ThreadCommitOutcome, TransactionScopeId,
 };
 use awaken_runtime_contract::contract::storage::RuntimeCheckpointStore;
 use awaken_server_contract::contract::storage::{ThreadRunCheckpointStore, ThreadRunStore};
@@ -37,9 +37,9 @@ impl CommitCoordinator for NoopCoord {
 
     async fn commit_checkpoint(
         &self,
-        _plan: Checkpoint,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
-        Ok(CheckpointCommitOutcome::default())
+        _plan: ThreadCommit,
+    ) -> Result<ThreadCommitOutcome, CommitError> {
+        Ok(ThreadCommitOutcome)
     }
 }
 

--- a/crates/awaken-server-contract/src/contract/staged_commit.rs
+++ b/crates/awaken-server-contract/src/contract/staged_commit.rs
@@ -179,12 +179,12 @@ fn validate_event_scope_membership(
                 thread_id: scope_thread,
             } if scope_thread != thread_id => {
                 return Err(CommitError::Validation(format!(
-                    "event thread scope '{scope_thread}' must match checkpoint thread_id '{thread_id}'"
+                    "event thread scope '{scope_thread}' must match thread commit thread_id '{thread_id}'"
                 )));
             }
             EventScope::Run { run_id: scope_run } if scope_run != run_id => {
                 return Err(CommitError::Validation(format!(
-                    "event run scope '{scope_run}' must match checkpoint run_id '{run_id}'"
+                    "event run scope '{scope_run}' must match thread commit run_projection.run_id '{run_id}'"
                 )));
             }
             _ => {}
@@ -194,12 +194,12 @@ fn validate_event_scope_membership(
 }
 
 /// A [`CommitCoordinator`] that can additionally commit staged event/outbox
-/// writes atomically with the checkpoint. Store coordinators implement this;
+/// writes atomically with the thread commit. Store coordinators implement this;
 /// the runtime-facing [`CommitCoordinator::commit_checkpoint`] is equivalent to
 /// a staged commit with [`ThreadCommitStagedWrites::default`].
 #[async_trait]
 pub trait StagedCommitCoordinator: CommitCoordinator {
-    /// Commit a checkpoint together with staged event/outbox writes in one
+    /// Commit a thread commit together with staged event/outbox writes in one
     /// transaction. See [`CommitCoordinator::commit_checkpoint`] for ordering
     /// and failure semantics.
     async fn commit_checkpoint_staged(

--- a/crates/awaken-server-contract/src/contract/staged_commit.rs
+++ b/crates/awaken-server-contract/src/contract/staged_commit.rs
@@ -1,8 +1,8 @@
 //! Server-side staged checkpoint commit (ADR-0036 / ADR-0038).
 //!
 //! Canonical events and outbox rows committed atomically with a checkpoint are
-//! kept off the runtime-facing [`Checkpoint`] so the runtime never
-//! names event/outbox vocabulary. They flow through [`CheckpointStagedWrites`]
+//! kept off the runtime-facing [`ThreadCommit`] so the runtime never
+//! names event/outbox vocabulary. They flow through [`ThreadCommitStagedWrites`]
 //! and [`StagedCommitCoordinator::commit_checkpoint_staged`], which store
 //! coordinators implement; the runtime-facing
 //! [`CommitCoordinator::commit_checkpoint`] is equivalent to a staged commit
@@ -11,23 +11,97 @@
 use crate::contract::outbox::OutboxMessageDraft;
 use async_trait::async_trait;
 use awaken_runtime_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError, ServerCanonicalEvent,
-    StagedCanonicalEvent,
+    CommitCoordinator, CommitError, StagedCanonicalEvent, ThreadCommit,
 };
-use awaken_runtime_contract::contract::event_store::{CanonicalEventDraft, EventScope};
+use awaken_runtime_contract::contract::event_store::{
+    AppendOptions, CanonicalEventDraft, EventScope,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+/// Server-authored canonical event attached to the same thread commit as
+/// the state transition that made the fact true.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ServerCanonicalEvent {
+    pub draft: CanonicalEventDraft,
+    pub options: AppendOptions,
+}
+
+impl ServerCanonicalEvent {
+    /// Construct a server-authored canonical event with default append options.
+    #[must_use]
+    pub fn new(draft: CanonicalEventDraft) -> Self {
+        Self {
+            draft,
+            options: AppendOptions::default(),
+        }
+    }
+
+    /// Attach append options (idempotency, expected cursors).
+    #[must_use]
+    pub fn with_options(mut self, options: AppendOptions) -> Self {
+        self.options = options;
+        self
+    }
+}
+
+/// Outcome for advisory server canonical publication through an outbox.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServerEventPublishOutcome {
+    Enqueued { dedupe_key: String },
+}
+
+/// Failure surface for advisory server canonical publication.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum EventPublishError {
+    #[error("validation error: {0}")]
+    Validation(String),
+    #[error("outbox enqueue failed: {0}")]
+    Enqueue(#[from] crate::contract::outbox::OutboxError),
+    #[error("serialization error: {0}")]
+    Serialization(String),
+}
+
+/// Long-lived publisher for advisory server-authored canonical events.
+#[async_trait]
+pub trait OutboxServerEventPublisher: Send + Sync {
+    async fn publish(
+        &self,
+        draft: CanonicalEventDraft,
+        options: AppendOptions,
+    ) -> Result<ServerEventPublishOutcome, EventPublishError>;
+}
+
+/// Non-replay diagnostic event.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DiagnosticEvent {
+    pub kind: String,
+    #[serde(default)]
+    pub payload: Value,
+}
+
+/// Fire-and-forget diagnostic event publisher.
+pub trait DiagnosticEventPublisher: Send + Sync {
+    fn record(&self, event: DiagnosticEvent);
+}
 
 /// Event/outbox writes committed atomically with a checkpoint, supplied by
 /// server-side writers: the runtime tee's canonical drafts (drained from the
 /// dispatch [`EventBuffer`](awaken_runtime_contract::contract::commit_coordinator::CanonicalEventStager)),
 /// server-authored canonical events, and inline outbox rows.
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct CheckpointStagedWrites {
+pub struct ThreadCommitStagedWrites {
     pub canonical_drafts: Vec<StagedCanonicalEvent>,
     pub server_events: Vec<ServerCanonicalEvent>,
     pub additional_outbox: Vec<OutboxMessageDraft>,
 }
 
-impl CheckpointStagedWrites {
+/// Compatibility name retained for existing server/store call sites.
+#[deprecated(since = "0.6.0", note = "Use `ThreadCommitStagedWrites`.")]
+pub type CheckpointStagedWrites = ThreadCommitStagedWrites;
+
+impl ThreadCommitStagedWrites {
     /// Whether there are no staged writes — a plain checkpoint.
     #[must_use]
     pub fn is_empty(&self) -> bool {
@@ -80,6 +154,20 @@ impl CheckpointStagedWrites {
     }
 }
 
+/// Identifiers assigned by stores during a successful staged commit.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ThreadCommitStagedOutcome {
+    /// Canonical event ids in the same order as the input
+    /// `canonical_drafts`. Empty when the staged commit carried no events.
+    pub canonical_event_ids: Vec<String>,
+    /// Server-authored canonical event ids in the same order as the input
+    /// `server_events`. Empty when the staged commit attached no server events.
+    pub server_event_ids: Vec<String>,
+    /// Outbox ids in the same order as `additional_outbox`. Empty when
+    /// the staged commit attached no inline-writer outbox rows.
+    pub additional_outbox_ids: Vec<String>,
+}
+
 fn validate_event_scope_membership(
     draft: &CanonicalEventDraft,
     thread_id: &str,
@@ -108,7 +196,7 @@ fn validate_event_scope_membership(
 /// A [`CommitCoordinator`] that can additionally commit staged event/outbox
 /// writes atomically with the checkpoint. Store coordinators implement this;
 /// the runtime-facing [`CommitCoordinator::commit_checkpoint`] is equivalent to
-/// a staged commit with [`CheckpointStagedWrites::default`].
+/// a staged commit with [`ThreadCommitStagedWrites::default`].
 #[async_trait]
 pub trait StagedCommitCoordinator: CommitCoordinator {
     /// Commit a checkpoint together with staged event/outbox writes in one
@@ -116,9 +204,9 @@ pub trait StagedCommitCoordinator: CommitCoordinator {
     /// and failure semantics.
     async fn commit_checkpoint_staged(
         &self,
-        plan: Checkpoint,
-        staged: CheckpointStagedWrites,
-    ) -> Result<CheckpointCommitOutcome, CommitError>;
+        plan: ThreadCommit,
+        staged: ThreadCommitStagedWrites,
+    ) -> Result<ThreadCommitStagedOutcome, CommitError>;
 }
 
 #[cfg(test)]
@@ -141,12 +229,12 @@ mod tests {
 
     #[test]
     fn empty_is_empty() {
-        assert!(CheckpointStagedWrites::default().is_empty());
+        assert!(ThreadCommitStagedWrites::default().is_empty());
     }
 
     #[test]
     fn validate_accepts_matching_scope() {
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             StagedCanonicalEvent::new(draft("RunStarted", "t", "r")),
         ]);
         staged.validate("t", "r").unwrap();
@@ -154,7 +242,7 @@ mod tests {
 
     #[test]
     fn validate_rejects_wrong_thread_scope() {
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             StagedCanonicalEvent::new(draft("RunStarted", "other", "r")),
         ]);
         let err = staged.validate("t", "r").unwrap_err();
@@ -163,10 +251,9 @@ mod tests {
 
     #[test]
     fn validate_rejects_wrong_run_scope() {
-        let staged =
-            CheckpointStagedWrites::default().with_server_events(vec![ServerCanonicalEvent::new(
-                draft("RunSubmitted", "t", "other"),
-            )]);
+        let staged = ThreadCommitStagedWrites::default().with_server_events(vec![
+            ServerCanonicalEvent::new(draft("RunSubmitted", "t", "other")),
+        ]);
         let err = staged.validate("t", "r").unwrap_err();
         assert!(matches!(err, CommitError::Validation(m) if m.contains("run scope")));
     }

--- a/crates/awaken-server-contract/src/lib.rs
+++ b/crates/awaken-server-contract/src/lib.rs
@@ -29,7 +29,13 @@ pub use contract::registry_graph::*;
 pub use contract::scope::{
     DEFAULT_SCOPE_ID, RequestSurface, ScopeContext, ScopeError, ScopeId, scoped_key, unscoped_key,
 };
-pub use contract::staged_commit::{CheckpointStagedWrites, StagedCommitCoordinator};
+#[allow(deprecated)]
+pub use contract::staged_commit::CheckpointStagedWrites;
+pub use contract::staged_commit::{
+    DiagnosticEvent, DiagnosticEventPublisher, EventPublishError, OutboxServerEventPublisher,
+    ServerCanonicalEvent, ServerEventPublishOutcome, StagedCommitCoordinator,
+    ThreadCommitStagedOutcome, ThreadCommitStagedWrites,
+};
 pub use contract::storage::ScopedThreadRunStore;
 pub use contract::versioned_registry::*;
 

--- a/crates/awaken-server/src/mailbox.rs
+++ b/crates/awaken-server/src/mailbox.rs
@@ -13,9 +13,7 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 
 use awaken_runtime::RunActivation;
-use awaken_server_contract::contract::commit_coordinator::{
-    CommitCoordinator, OutboxServerEventPublisher,
-};
+use awaken_server_contract::contract::commit_coordinator::CommitCoordinator;
 use awaken_server_contract::contract::event::AgentEvent;
 use awaken_server_contract::contract::event_sink::EventSink;
 use awaken_server_contract::contract::mailbox::{MailboxStore, RunDispatchStatus};
@@ -23,7 +21,9 @@ use awaken_server_contract::contract::message::Message;
 use awaken_server_contract::contract::run::{
     RunActivationSnapshot, RunInputSnapshot, RunIntent, RunKind, RunOptions, RunTraceContext,
 };
-use awaken_server_contract::contract::staged_commit::StagedCommitCoordinator;
+use awaken_server_contract::contract::staged_commit::{
+    OutboxServerEventPublisher, StagedCommitCoordinator,
+};
 use awaken_server_contract::contract::storage::{RunRecord, StorageError, ThreadRunStore};
 use awaken_server_contract::contract::suspension::{ToolCallOutcome, ToolCallResume};
 use awaken_server_contract::contract::tool_intercept::{AdapterKind, RunMode};

--- a/crates/awaken-server/src/mailbox/checkpoint.rs
+++ b/crates/awaken-server/src/mailbox/checkpoint.rs
@@ -1,4 +1,4 @@
-use awaken_server_contract::contract::commit_coordinator::{Checkpoint, CommitError};
+use awaken_server_contract::contract::commit_coordinator::{CommitError, ThreadCommit};
 use awaken_server_contract::contract::message::Message;
 use awaken_server_contract::contract::storage::RunRecord;
 
@@ -18,7 +18,7 @@ impl Mailbox {
         // for tests. This helper seeds a fresh thread, so the message delta is
         // a guarded append against version 0 (a non-empty delta must carry a
         // version guard; ADR-0042 A).
-        let plan = Checkpoint::append(
+        let plan = ThreadCommit::append_messages(
             thread_id.to_string(),
             messages.to_vec(),
             Some(0),
@@ -44,7 +44,7 @@ impl Mailbox {
         expected_version: Option<u64>,
         run: &RunRecord,
     ) -> Result<bool, MailboxError> {
-        let plan = Checkpoint::append(
+        let plan = ThreadCommit::append_messages(
             thread_id.to_string(),
             delta.to_vec(),
             expected_version,
@@ -84,7 +84,7 @@ mod tests {
     use awaken_runtime::RunActivation;
     use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult};
     use awaken_server_contract::contract::commit_coordinator::{
-        CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+        CommitCoordinator, CommitError, ThreadCommitOutcome, TransactionScopeId,
     };
     use awaken_server_contract::contract::event_sink::EventSink;
     use awaken_server_contract::contract::lifecycle::RunStatus;
@@ -117,14 +117,14 @@ mod tests {
 
         async fn commit_checkpoint(
             &self,
-            plan: Checkpoint,
-        ) -> Result<CheckpointCommitOutcome, CommitError> {
+            plan: ThreadCommit,
+        ) -> Result<ThreadCommitOutcome, CommitError> {
             self.commits.fetch_add(1, Ordering::SeqCst);
             #[allow(deprecated)]
             self.store
-                .checkpoint(&plan.thread_id, &plan.messages, &plan.run)
+                .checkpoint(&plan.thread_id, &plan.message_delta, &plan.run_projection)
                 .await?;
-            Ok(CheckpointCommitOutcome::default())
+            Ok(ThreadCommitOutcome)
         }
     }
 

--- a/crates/awaken-server/src/mailbox/coordinator_facade.rs
+++ b/crates/awaken-server/src/mailbox/coordinator_facade.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use awaken_server_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+    CommitCoordinator, CommitError, ThreadCommit, ThreadCommitOutcome, TransactionScopeId,
 };
 use awaken_server_contract::contract::storage::{
     RuntimeCheckpointStore, ThreadRunCheckpointStore, ThreadRunStore,
@@ -75,20 +75,20 @@ impl CommitCoordinator for MailboxRunStoreCoordinator {
 
     async fn commit_checkpoint(
         &self,
-        plan: Checkpoint,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
+        plan: ThreadCommit,
+    ) -> Result<ThreadCommitOutcome, CommitError> {
         plan.validate()?;
         self.store
             .checkpoint_append(
                 &plan.thread_id,
-                &plan.messages,
-                plan.expected_message_version,
-                &plan.run,
+                &plan.message_delta,
+                plan.expected_message_count,
+                &plan.run_projection,
             )
             .await
             .map_err(|error| {
                 CommitError::StoreWrite(error).reclassify_append_conflict(&plan.thread_id)
             })?;
-        Ok(CheckpointCommitOutcome::default())
+        Ok(ThreadCommitOutcome)
     }
 }

--- a/crates/awaken-server/src/mailbox/pending_delivery_tests.rs
+++ b/crates/awaken-server/src/mailbox/pending_delivery_tests.rs
@@ -768,24 +768,20 @@ async fn freeze_retry_after_conflict_does_not_leave_phantom_trigger_ids() {
 struct FailingEventPublisher;
 
 #[async_trait]
-impl awaken_server_contract::contract::commit_coordinator::OutboxServerEventPublisher
-    for FailingEventPublisher
-{
+impl awaken_server_contract::OutboxServerEventPublisher for FailingEventPublisher {
     async fn publish(
         &self,
         _draft: awaken_server_contract::contract::event_store::CanonicalEventDraft,
         _options: awaken_server_contract::contract::event_store::AppendOptions,
     ) -> Result<
-        awaken_server_contract::contract::commit_coordinator::ServerEventPublishOutcome,
-        awaken_server_contract::contract::commit_coordinator::EventPublishError,
+        awaken_server_contract::ServerEventPublishOutcome,
+        awaken_server_contract::EventPublishError,
     > {
-        Err(
-            awaken_server_contract::contract::commit_coordinator::EventPublishError::Enqueue(
-                awaken_server_contract::contract::outbox::OutboxError::Io(
-                    "event publisher unavailable".to_string(),
-                ),
+        Err(awaken_server_contract::EventPublishError::Enqueue(
+            awaken_server_contract::contract::outbox::OutboxError::Io(
+                "event publisher unavailable".to_string(),
             ),
-        )
+        ))
     }
 }
 

--- a/crates/awaken-server/src/mailbox/runtime_event_capture.rs
+++ b/crates/awaken-server/src/mailbox/runtime_event_capture.rs
@@ -1,14 +1,12 @@
 use std::sync::Arc;
 
 use awaken_runtime::EventBuffer;
-use awaken_server_contract::contract::commit_coordinator::{
-    CanonicalEventStager, OutboxServerEventPublisher,
-};
+use awaken_server_contract::contract::commit_coordinator::CanonicalEventStager;
 use awaken_server_contract::contract::event_sink::EventSink;
 use awaken_server_contract::contract::mailbox::RunDispatch;
 use awaken_server_contract::{
-    AgentEventNormalizationContext, DurableEventSink, RuntimeEventDurability,
-    ScopedAgentEventNormalizer,
+    AgentEventNormalizationContext, DurableEventSink, OutboxServerEventPublisher,
+    RuntimeEventDurability, ScopedAgentEventNormalizer,
 };
 
 use crate::transport::channel_sink::ReconnectableEventSink;

--- a/crates/awaken-server/src/mailbox/staging_coordinator.rs
+++ b/crates/awaken-server/src/mailbox/staging_coordinator.rs
@@ -5,7 +5,7 @@
 //! `DurableEventSink` (which stages canonical drafts as runtime events flow)
 //! and with this coordinator (which drains them at commit time). Wrapping the
 //! mailbox's base [`CommitCoordinator`] this way keeps the staging buffer off
-//! the runtime entirely: the runtime builds a plain `Checkpoint`
+//! the runtime entirely: the runtime builds a plain `ThreadCommit`
 //! and never observes the canonical drafts, while atomicity (drafts + run
 //! record commit together) is preserved here.
 
@@ -14,11 +14,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use awaken_runtime::EventBuffer;
 use awaken_server_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError, StagedCanonicalEvent,
+    CommitCoordinator, CommitError, StagedCanonicalEvent, ThreadCommit, ThreadCommitOutcome,
     TransactionScopeId,
 };
 use awaken_server_contract::contract::staged_commit::{
-    CheckpointStagedWrites, StagedCommitCoordinator,
+    StagedCommitCoordinator, ThreadCommitStagedWrites,
 };
 use awaken_server_contract::contract::storage::RuntimeCheckpointStore;
 use parking_lot::Mutex;
@@ -60,8 +60,8 @@ impl CommitCoordinator for StagingCommitCoordinator {
 
     async fn commit_checkpoint(
         &self,
-        plan: Checkpoint,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
+        plan: ThreadCommit,
+    ) -> Result<ThreadCommitOutcome, CommitError> {
         // Accumulate newly staged drafts onto any that an earlier (conflicted)
         // attempt staged, so a version-conflict retry never drops events.
         let drafts = {
@@ -69,18 +69,19 @@ impl CommitCoordinator for StagingCommitCoordinator {
             pending.extend(self.buffer.drain());
             pending.clone()
         };
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(drafts);
-        let outcome = self.inner.commit_checkpoint_staged(plan, staged).await?;
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(drafts);
+        self.inner.commit_checkpoint_staged(plan, staged).await?;
         // Success: the drafts are durable, so the pending buffer is cleared.
         // On error we leave `pending` intact for the runtime's retry.
         self.pending.lock().clear();
-        Ok(outcome)
+        Ok(ThreadCommitOutcome)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use awaken_server_contract::ThreadCommitStagedOutcome;
     use awaken_server_contract::contract::commit_coordinator::CanonicalEventStager;
     use awaken_server_contract::contract::event_store::{
         CanonicalEventDraft, CanonicalEventKind, EventScope, EventVisibility,
@@ -137,10 +138,11 @@ mod tests {
         }
         async fn commit_checkpoint(
             &self,
-            plan: Checkpoint,
-        ) -> Result<CheckpointCommitOutcome, CommitError> {
-            self.commit_checkpoint_staged(plan, CheckpointStagedWrites::default())
-                .await
+            plan: ThreadCommit,
+        ) -> Result<ThreadCommitOutcome, CommitError> {
+            self.commit_checkpoint_staged(plan, ThreadCommitStagedWrites::default())
+                .await?;
+            Ok(ThreadCommitOutcome)
         }
     }
 
@@ -148,9 +150,9 @@ mod tests {
     impl StagedCommitCoordinator for RecordingCoordinator {
         async fn commit_checkpoint_staged(
             &self,
-            plan: Checkpoint,
-            staged: CheckpointStagedWrites,
-        ) -> Result<CheckpointCommitOutcome, CommitError> {
+            plan: ThreadCommit,
+            staged: ThreadCommitStagedWrites,
+        ) -> Result<ThreadCommitStagedOutcome, CommitError> {
             let kinds: Vec<String> = staged
                 .canonical_drafts
                 .iter()
@@ -165,7 +167,7 @@ mod tests {
                     actual: 1,
                 });
             }
-            Ok(CheckpointCommitOutcome::default())
+            Ok(ThreadCommitStagedOutcome::default())
         }
     }
 
@@ -177,7 +179,7 @@ mod tests {
         let inner = RecordingCoordinator::new(0);
         let staging = StagingCommitCoordinator::new(inner.clone(), buffer.clone());
 
-        let plan = Checkpoint::checkpoint_only("t-1", run_record());
+        let plan = ThreadCommit::run_projection_only("t-1", run_record());
         staging.commit_checkpoint(plan).await.unwrap();
 
         let observed = inner.observed.lock();
@@ -196,7 +198,7 @@ mod tests {
         let staging = StagingCommitCoordinator::new(inner.clone(), buffer.clone());
 
         let conflict = staging
-            .commit_checkpoint(Checkpoint::checkpoint_only("t-1", run_record()))
+            .commit_checkpoint(ThreadCommit::run_projection_only("t-1", run_record()))
             .await;
         assert!(matches!(
             conflict,
@@ -204,7 +206,7 @@ mod tests {
         ));
         // Retry: buffer is already empty, but the draft was retained.
         staging
-            .commit_checkpoint(Checkpoint::checkpoint_only("t-1", run_record()))
+            .commit_checkpoint(ThreadCommit::run_projection_only("t-1", run_record()))
             .await
             .unwrap();
 
@@ -226,13 +228,13 @@ mod tests {
         let staging = StagingCommitCoordinator::new(inner.clone(), buffer.clone());
 
         staging
-            .commit_checkpoint(Checkpoint::checkpoint_only("t-1", run_record()))
+            .commit_checkpoint(ThreadCommit::run_projection_only("t-1", run_record()))
             .await
             .unwrap();
         // Second checkpoint with a fresh draft must not re-include the first.
         buffer.stage(sample_draft("StepEnd"));
         staging
-            .commit_checkpoint(Checkpoint::checkpoint_only("t-1", run_record()))
+            .commit_checkpoint(ThreadCommit::run_projection_only("t-1", run_record()))
             .await
             .unwrap();
 

--- a/crates/awaken-server/src/mailbox/tests.rs
+++ b/crates/awaken-server/src/mailbox/tests.rs
@@ -9,10 +9,7 @@ use awaken_runtime::extensions::background::{
 use awaken_runtime::loop_runner::{AgentLoopError, AgentRunResult, build_agent_env};
 use awaken_runtime::{AgentRuntime, Plugin, ResolvedAgent};
 use awaken_server_contract::RuntimeEventDurability;
-use awaken_server_contract::contract::commit_coordinator::{
-    Checkpoint, CommitCoordinator, EventPublishError, OutboxServerEventPublisher,
-    ServerEventPublishOutcome,
-};
+use awaken_server_contract::contract::commit_coordinator::{CommitCoordinator, ThreadCommit};
 use awaken_server_contract::contract::content::ContentBlock;
 use awaken_server_contract::contract::event_store::{
     AppendOptions, CanonicalEventDraft, EventReader, EventScope, EventWriter,
@@ -37,6 +34,9 @@ use awaken_server_contract::contract::tool::{
 };
 use awaken_server_contract::now_ms;
 use awaken_server_contract::thread::Thread;
+use awaken_server_contract::{
+    EventPublishError, OutboxServerEventPublisher, ServerEventPublishOutcome,
+};
 use awaken_stores::{
     InMemoryEventStore, InMemoryMailboxStore, InMemoryOutboxStore, InMemoryStore,
     MemoryCommitCoordinator, PendingMessageStore,
@@ -1162,7 +1162,7 @@ impl CommittingEmittingMailboxRuntime {
                 .unwrap_or_else(|| "agent-1".to_string()),
             ..Default::default()
         };
-        let plan = Checkpoint::checkpoint_only(request.thread_id(), run);
+        let plan = ThreadCommit::run_projection_only(request.thread_id(), run);
         coordinator
             .commit_checkpoint(plan)
             .await

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -634,7 +634,7 @@ async fn file_store_thread_hierarchy_management_round_trip_via_http() {
 
 fn unique_postgres_prefix(seed: &str) -> String {
     let uuid_short = uuid::Uuid::now_v7().simple().to_string();
-    format!("pgs_{}_{}", &uuid_short[..12], &seed[..seed.len().min(8)])
+    format!("pgs_{}_{}", &uuid_short[12..28], &seed[..seed.len().min(8)])
 }
 
 async fn make_postgres_store(seed: &str) -> (Arc<PostgresStore>, PgPool, String) {

--- a/crates/awaken-stores/src/commit_batch.rs
+++ b/crates/awaken-stores/src/commit_batch.rs
@@ -9,10 +9,12 @@
 
 use std::future::Future;
 
-use awaken_server_contract::contract::commit_coordinator::{CheckpointCommitOutcome, CommitError};
+use awaken_server_contract::contract::commit_coordinator::CommitError;
 use awaken_server_contract::contract::event_store::EventWriter;
 use awaken_server_contract::contract::outbox::OutboxStore;
-use awaken_server_contract::contract::staged_commit::CheckpointStagedWrites;
+use awaken_server_contract::contract::staged_commit::{
+    ThreadCommitStagedOutcome, ThreadCommitStagedWrites,
+};
 use awaken_server_contract::contract::storage::StorageError;
 
 use crate::memory_event_store::InMemoryEventStore;
@@ -30,11 +32,11 @@ use crate::memory_outbox::InMemoryOutboxStore;
 /// `write_thread_run` may also perform backend-specific snapshot/restore for
 /// the thread-run store; this helper does not touch that state.
 pub(crate) async fn run_commit_batch<W, Fut>(
-    staged: &CheckpointStagedWrites,
+    staged: &ThreadCommitStagedWrites,
     events: &InMemoryEventStore,
     outbox: &InMemoryOutboxStore,
     write_thread_run: W,
-) -> Result<CheckpointCommitOutcome, CommitError>
+) -> Result<ThreadCommitStagedOutcome, CommitError>
 where
     W: FnOnce() -> Fut,
     Fut: Future<Output = Result<(), StorageError>>,
@@ -94,7 +96,7 @@ where
         return Err(CommitError::StoreWrite(error));
     }
 
-    Ok(CheckpointCommitOutcome {
+    Ok(ThreadCommitStagedOutcome {
         canonical_event_ids,
         server_event_ids,
         additional_outbox_ids,
@@ -122,7 +124,7 @@ mod tests {
         EventVisibility, EventWriter,
     };
     use awaken_server_contract::contract::outbox::{OutboxMessageDraft, OutboxStatus, OutboxStore};
-    use awaken_server_contract::contract::staged_commit::CheckpointStagedWrites;
+    use awaken_server_contract::contract::staged_commit::ThreadCommitStagedWrites;
     use awaken_server_contract::contract::storage::StorageError;
 
     use super::run_commit_batch;
@@ -170,7 +172,7 @@ mod tests {
         // Build a plan whose canonical_drafts collide with the seeded draft.
         let mut colliding = sample_draft("RunStarted", "t-1", "r-1");
         colliding.payload = serde_json::json!({"kind": "RunStarted", "diff": true});
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             StagedCanonicalEvent::new(colliding).with_options(opts),
         ]);
 
@@ -211,7 +213,7 @@ mod tests {
         let mut bad = OutboxMessageDraft::new("lane", "target", serde_json::json!({})).unwrap();
         bad.lane.clear();
 
-        let staged = CheckpointStagedWrites::default()
+        let staged = ThreadCommitStagedWrites::default()
             .with_canonical_drafts(vec![StagedCanonicalEvent::new(sample_draft(
                 "RunStarted",
                 "t-2",
@@ -252,7 +254,7 @@ mod tests {
     async fn write_thread_run_failure_rolls_back_events_and_outbox() {
         let (events, outbox) = fresh().await;
 
-        let staged = CheckpointStagedWrites::default()
+        let staged = ThreadCommitStagedWrites::default()
             .with_canonical_drafts(vec![StagedCanonicalEvent::new(sample_draft(
                 "RunStarted",
                 "t-3",
@@ -292,7 +294,7 @@ mod tests {
     #[tokio::test]
     async fn happy_path_returns_ids_and_runs_write() {
         let (events, outbox) = fresh().await;
-        let staged = CheckpointStagedWrites::default()
+        let staged = ThreadCommitStagedWrites::default()
             .with_canonical_drafts(vec![StagedCanonicalEvent::new(sample_draft(
                 "RunStarted",
                 "t-ok",

--- a/crates/awaken-stores/src/file_commit_coordinator.rs
+++ b/crates/awaken-stores/src/file_commit_coordinator.rs
@@ -17,10 +17,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use awaken_server_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+    CommitCoordinator, CommitError, ThreadCommit, ThreadCommitOutcome, TransactionScopeId,
 };
 use awaken_server_contract::contract::staged_commit::{
-    CheckpointStagedWrites, StagedCommitCoordinator,
+    StagedCommitCoordinator, ThreadCommitStagedOutcome, ThreadCommitStagedWrites,
 };
 use awaken_server_contract::contract::storage::{ThreadRunStore, ThreadStore};
 use tokio::sync::Mutex;
@@ -110,10 +110,11 @@ impl CommitCoordinator for FileCommitCoordinator {
 
     async fn commit_checkpoint(
         &self,
-        plan: Checkpoint,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
-        self.commit_checkpoint_staged(plan, CheckpointStagedWrites::default())
-            .await
+        plan: ThreadCommit,
+    ) -> Result<ThreadCommitOutcome, CommitError> {
+        self.commit_checkpoint_staged(plan, ThreadCommitStagedWrites::default())
+            .await?;
+        Ok(ThreadCommitOutcome)
     }
 }
 
@@ -121,11 +122,11 @@ impl CommitCoordinator for FileCommitCoordinator {
 impl StagedCommitCoordinator for FileCommitCoordinator {
     async fn commit_checkpoint_staged(
         &self,
-        plan: Checkpoint,
-        staged: CheckpointStagedWrites,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
+        plan: ThreadCommit,
+        staged: ThreadCommitStagedWrites,
+    ) -> Result<ThreadCommitStagedOutcome, CommitError> {
         plan.validate()?;
-        staged.validate(&plan.thread_id, &plan.run.run_id)?;
+        staged.validate(&plan.thread_id, &plan.run_projection.run_id)?;
 
         let _guard = self.commit_lock.lock().await;
 
@@ -137,13 +138,13 @@ impl StagedCommitCoordinator for FileCommitCoordinator {
             thread_run
                 .checkpoint_append(
                     &plan_ref.thread_id,
-                    &plan_ref.messages,
-                    plan_ref.expected_message_version,
-                    &plan_ref.run,
+                    &plan_ref.message_delta,
+                    plan_ref.expected_message_count,
+                    &plan_ref.run_projection,
                 )
                 .await
                 .map(|_| ())?;
-            if let Some(thread_state) = &plan_ref.thread_state {
+            if let Some(thread_state) = &plan_ref.thread_state_snapshot {
                 thread_run
                     .save_thread_state(&plan_ref.thread_id, thread_state)
                     .await?;
@@ -185,7 +186,7 @@ mod tests {
     }
 
     use awaken_server_contract::contract::commit_coordinator::{
-        Checkpoint, CommitError, StagedCanonicalEvent,
+        CommitError, StagedCanonicalEvent, ThreadCommit,
     };
     use awaken_server_contract::contract::event_store::{
         AppendOptions, CanonicalEventDraft, CanonicalEventKind, EventReader, EventScope,
@@ -194,7 +195,7 @@ mod tests {
     use awaken_server_contract::contract::lifecycle::RunStatus;
     use awaken_server_contract::contract::outbox::OutboxMessageDraft;
     use awaken_server_contract::contract::staged_commit::{
-        CheckpointStagedWrites, StagedCommitCoordinator,
+        StagedCommitCoordinator, ThreadCommitStagedWrites,
     };
     use awaken_server_contract::contract::storage::{RunRecord, RunStore, ThreadStore};
 
@@ -265,8 +266,9 @@ mod tests {
         let thread_id = unique("thread");
         let run_id = unique("run");
 
-        let plan = Checkpoint::checkpoint_only(thread_id.clone(), run_record(&thread_id, &run_id));
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let plan =
+            ThreadCommit::run_projection_only(thread_id.clone(), run_record(&thread_id, &run_id));
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             StagedCanonicalEvent::new(sample_draft("RunStarted", &thread_id, &run_id)),
         ]);
 
@@ -312,8 +314,9 @@ mod tests {
 
         let mut collide = sample_draft("RunStarted", &thread_id, &run_id);
         collide.payload = serde_json::json!({"kind": "RunStarted", "diff": true});
-        let plan = Checkpoint::checkpoint_only(thread_id.clone(), run_record(&thread_id, &run_id));
-        let staged = CheckpointStagedWrites::default()
+        let plan =
+            ThreadCommit::run_projection_only(thread_id.clone(), run_record(&thread_id, &run_id));
+        let staged = ThreadCommitStagedWrites::default()
             .with_canonical_drafts(vec![StagedCanonicalEvent::new(collide).with_options(opts)]);
 
         let result = coord.commit_checkpoint_staged(plan, staged).await;
@@ -356,9 +359,11 @@ mod tests {
             idempotency_key: Some("k-shared".into()),
             ..Default::default()
         };
-        let first_plan =
-            Checkpoint::checkpoint_only(thread_id.clone(), run_record(&thread_id, &first_run));
-        let first_staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let first_plan = ThreadCommit::run_projection_only(
+            thread_id.clone(),
+            run_record(&thread_id, &first_run),
+        );
+        let first_staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             StagedCanonicalEvent::new(sample_draft("RunStarted", &thread_id, &first_run))
                 .with_options(opts.clone()),
         ]);
@@ -381,9 +386,11 @@ mod tests {
         // different payload — fails at the event-append step.
         let mut collide = sample_draft("RunStarted", &thread_id, &second_run);
         collide.payload = serde_json::json!({"kind": "RunStarted", "diff": true});
-        let second_plan =
-            Checkpoint::checkpoint_only(thread_id.clone(), run_record(&thread_id, &second_run));
-        let second_staged = CheckpointStagedWrites::default()
+        let second_plan = ThreadCommit::run_projection_only(
+            thread_id.clone(),
+            run_record(&thread_id, &second_run),
+        );
+        let second_staged = ThreadCommitStagedWrites::default()
             .with_canonical_drafts(vec![StagedCanonicalEvent::new(collide).with_options(opts)]);
         let result = coord
             .commit_checkpoint_staged(second_plan, second_staged)
@@ -413,8 +420,9 @@ mod tests {
         let mut bad = OutboxMessageDraft::new("lane", "target", serde_json::json!({})).unwrap();
         bad.lane.clear();
 
-        let plan = Checkpoint::checkpoint_only(thread_id.clone(), run_record(&thread_id, &run_id));
-        let staged = CheckpointStagedWrites::default()
+        let plan =
+            ThreadCommit::run_projection_only(thread_id.clone(), run_record(&thread_id, &run_id));
+        let staged = ThreadCommitStagedWrites::default()
             .with_canonical_drafts(vec![StagedCanonicalEvent::new(sample_draft(
                 "RunStarted",
                 &thread_id,
@@ -459,10 +467,11 @@ mod tests {
             extensions: Default::default(),
         };
 
-        let plan = Checkpoint::checkpoint_only(thread_id.clone(), run_record(&thread_id, &run_id))
-            .with_thread_state(state.clone());
+        let plan =
+            ThreadCommit::run_projection_only(thread_id.clone(), run_record(&thread_id, &run_id))
+                .with_thread_state_snapshot(state.clone());
         coord
-            .commit_checkpoint_staged(plan, CheckpointStagedWrites::default())
+            .commit_checkpoint_staged(plan, ThreadCommitStagedWrites::default())
             .await
             .expect("commit with thread_state succeeds");
         assert_eq!(
@@ -476,8 +485,11 @@ mod tests {
         let run_id2 = unique("run");
         coord
             .commit_checkpoint_staged(
-                Checkpoint::checkpoint_only(thread_id.clone(), run_record(&thread_id, &run_id2)),
-                CheckpointStagedWrites::default(),
+                ThreadCommit::run_projection_only(
+                    thread_id.clone(),
+                    run_record(&thread_id, &run_id2),
+                ),
+                ThreadCommitStagedWrites::default(),
             )
             .await
             .expect("commit without thread_state succeeds");

--- a/crates/awaken-stores/src/memory_commit_coordinator.rs
+++ b/crates/awaken-stores/src/memory_commit_coordinator.rs
@@ -22,12 +22,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use awaken_server_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+    CommitCoordinator, CommitError, ThreadCommit, ThreadCommitOutcome, TransactionScopeId,
 };
 use awaken_server_contract::contract::message::Message;
 use awaken_server_contract::contract::message::PendingMessageRecord;
 use awaken_server_contract::contract::staged_commit::{
-    CheckpointStagedWrites, StagedCommitCoordinator,
+    StagedCommitCoordinator, ThreadCommitStagedOutcome, ThreadCommitStagedWrites,
 };
 use awaken_server_contract::contract::storage::{RunRecord, ThreadRunStore, ThreadStore};
 use awaken_server_contract::thread::Thread;
@@ -142,10 +142,11 @@ impl CommitCoordinator for MemoryCommitCoordinator {
 
     async fn commit_checkpoint(
         &self,
-        plan: Checkpoint,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
-        self.commit_checkpoint_staged(plan, CheckpointStagedWrites::default())
-            .await
+        plan: ThreadCommit,
+    ) -> Result<ThreadCommitOutcome, CommitError> {
+        self.commit_checkpoint_staged(plan, ThreadCommitStagedWrites::default())
+            .await?;
+        Ok(ThreadCommitOutcome)
     }
 }
 
@@ -153,11 +154,11 @@ impl CommitCoordinator for MemoryCommitCoordinator {
 impl StagedCommitCoordinator for MemoryCommitCoordinator {
     async fn commit_checkpoint_staged(
         &self,
-        plan: Checkpoint,
-        staged: CheckpointStagedWrites,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
+        plan: ThreadCommit,
+        staged: ThreadCommitStagedWrites,
+    ) -> Result<ThreadCommitStagedOutcome, CommitError> {
         plan.validate()?;
-        staged.validate(&plan.thread_id, &plan.run.run_id)?;
+        staged.validate(&plan.thread_id, &plan.run_projection.run_id)?;
 
         // Serialise commits so concurrent attempts do not interleave
         // partial state.
@@ -175,13 +176,13 @@ impl StagedCommitCoordinator for MemoryCommitCoordinator {
                 thread_run
                     .checkpoint_append(
                         &plan_ref.thread_id,
-                        &plan_ref.messages,
-                        plan_ref.expected_message_version,
-                        &plan_ref.run,
+                        &plan_ref.message_delta,
+                        plan_ref.expected_message_count,
+                        &plan_ref.run_projection,
                     )
                     .await
                     .map(|_| ())?;
-                if let Some(thread_state) = &plan_ref.thread_state {
+                if let Some(thread_state) = &plan_ref.thread_state_snapshot {
                     thread_run
                         .save_thread_state(&plan_ref.thread_id, thread_state)
                         .await?;
@@ -213,7 +214,7 @@ mod tests {
     };
     use awaken_server_contract::contract::lifecycle::RunStatus;
     use awaken_server_contract::contract::staged_commit::{
-        CheckpointStagedWrites, StagedCommitCoordinator,
+        StagedCommitCoordinator, ThreadCommitStagedWrites,
     };
     use awaken_server_contract::contract::storage::{RunRecord, ThreadStore};
     use serde_json::json;
@@ -258,11 +259,9 @@ mod tests {
     #[tokio::test]
     async fn commit_empty_plan_persists_checkpoint() {
         let (coord, thread_run, events, _outbox) = build_coordinator();
-        let plan = Checkpoint::checkpoint_only("t-1", run_record("t-1", "r-1"));
+        let plan = ThreadCommit::run_projection_only("t-1", run_record("t-1", "r-1"));
 
-        let outcome = coord.commit_checkpoint(plan).await.unwrap();
-        assert!(outcome.canonical_event_ids.is_empty());
-        assert!(outcome.additional_outbox_ids.is_empty());
+        coord.commit_checkpoint(plan).await.unwrap();
 
         // Thread persisted.
         let loaded = thread_run.load_thread("t-1").await.unwrap();
@@ -275,8 +274,8 @@ mod tests {
     #[tokio::test]
     async fn commit_with_drafts_appends_and_persists() {
         let (coord, thread_run, events, _outbox) = build_coordinator();
-        let plan = Checkpoint::checkpoint_only("t-2", run_record("t-2", "r-2"));
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let plan = ThreadCommit::run_projection_only("t-2", run_record("t-2", "r-2"));
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             StagedCanonicalEvent::new(sample_draft("RunStarted", "t-2", "r-2")),
             StagedCanonicalEvent::new(sample_draft("RunCompleted", "t-2", "r-2")),
         ]);
@@ -295,7 +294,7 @@ mod tests {
         use awaken_server_contract::contract::message::Message;
         let (coord, thread_run, _events, _outbox) = build_coordinator();
 
-        let plan = Checkpoint::append(
+        let plan = ThreadCommit::append_messages(
             "t-ap",
             vec![Message::user("a")],
             Some(0),
@@ -303,7 +302,7 @@ mod tests {
         );
         coord.commit_checkpoint(plan).await.unwrap();
 
-        let plan = Checkpoint::append(
+        let plan = ThreadCommit::append_messages(
             "t-ap",
             vec![Message::user("b"), Message::user("c")],
             Some(1),
@@ -320,7 +319,7 @@ mod tests {
         use awaken_server_contract::contract::message::Message;
         let (coord, thread_run, _events, _outbox) = build_coordinator();
 
-        let plan = Checkpoint::append(
+        let plan = ThreadCommit::append_messages(
             "t-c",
             vec![Message::user("a"), Message::user("b")],
             Some(0),
@@ -330,7 +329,7 @@ mod tests {
 
         // Committed length is 2, so expecting 0 must reclassify to a
         // message-level conflict carrying the thread id.
-        let plan = Checkpoint::append(
+        let plan = ThreadCommit::append_messages(
             "t-c",
             vec![Message::user("c")],
             Some(0),
@@ -375,8 +374,8 @@ mod tests {
         let mut conflicting_draft = sample_draft("RunStarted", "t-3", "r-3");
         conflicting_draft.payload = json!({"kind": "RunStarted", "different": true});
 
-        let plan = Checkpoint::checkpoint_only("t-3", run_record("t-3", "r-3"));
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let plan = ThreadCommit::run_projection_only("t-3", run_record("t-3", "r-3"));
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             StagedCanonicalEvent::new(conflicting_draft).with_options(seed_options),
         ]);
 
@@ -412,8 +411,8 @@ mod tests {
         let mut conflicting_second = sample_draft("ToolCallReady", "t-4", "r-4");
         conflicting_second.payload = json!({"kind": "ToolCallReady", "diff": true});
 
-        let plan = Checkpoint::checkpoint_only("t-4", run_record("t-4", "r-4"));
-        let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+        let plan = ThreadCommit::run_projection_only("t-4", run_record("t-4", "r-4"));
+        let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
             // First draft would succeed in isolation.
             StagedCanonicalEvent::new(sample_draft("RunStarted", "t-4", "r-4")),
             // Second draft conflicts via idempotency.
@@ -431,7 +430,7 @@ mod tests {
             post_count, pre_count,
             "first append should be rolled back when second fails"
         );
-        // Checkpoint never advanced.
+        // ThreadCommit never advanced.
         assert!(thread_run.load_thread("t-4").await.unwrap().is_none());
     }
 
@@ -443,8 +442,8 @@ mod tests {
             StagedCanonicalEvent::new(sample_draft("RunCompleted", "t-5", "r-5")),
         ];
 
-        let plan = Checkpoint::checkpoint_only("t-5", run_record("t-5", "r-5"));
-        let staged_writes = CheckpointStagedWrites::default().with_canonical_drafts(staged);
+        let plan = ThreadCommit::run_projection_only("t-5", run_record("t-5", "r-5"));
+        let staged_writes = ThreadCommitStagedWrites::default().with_canonical_drafts(staged);
 
         coord
             .commit_checkpoint_staged(plan, staged_writes)
@@ -474,8 +473,9 @@ mod tests {
             revision: 7,
             extensions: Default::default(),
         };
-        let plan = Checkpoint::append("t-ts", Vec::new(), Some(0), run_record("t-ts", "r-ts"))
-            .with_thread_state(state.clone());
+        let plan =
+            ThreadCommit::append_messages("t-ts", Vec::new(), Some(0), run_record("t-ts", "r-ts"))
+                .with_thread_state_snapshot(state.clone());
         coord.commit_checkpoint(plan).await.unwrap();
 
         assert_eq!(
@@ -501,14 +501,19 @@ mod tests {
         };
         coord
             .commit_checkpoint(
-                Checkpoint::append("t-ts2", Vec::new(), Some(0), run_record("t-ts2", "r-1"))
-                    .with_thread_state(state.clone()),
+                ThreadCommit::append_messages(
+                    "t-ts2",
+                    Vec::new(),
+                    Some(0),
+                    run_record("t-ts2", "r-1"),
+                )
+                .with_thread_state_snapshot(state.clone()),
             )
             .await
             .unwrap();
         // A later checkpoint that carries no thread_state must not clear it.
         coord
-            .commit_checkpoint(Checkpoint::append(
+            .commit_checkpoint(ThreadCommit::append_messages(
                 "t-ts2",
                 Vec::new(),
                 Some(0),

--- a/crates/awaken-stores/src/postgres_commit_coordinator.rs
+++ b/crates/awaken-stores/src/postgres_commit_coordinator.rs
@@ -11,10 +11,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use awaken_server_contract::contract::commit_coordinator::{
-    Checkpoint, CheckpointCommitOutcome, CommitCoordinator, CommitError, TransactionScopeId,
+    CommitCoordinator, CommitError, ThreadCommit, ThreadCommitOutcome, TransactionScopeId,
 };
 use awaken_server_contract::contract::staged_commit::{
-    CheckpointStagedWrites, StagedCommitCoordinator,
+    StagedCommitCoordinator, ThreadCommitStagedOutcome, ThreadCommitStagedWrites,
 };
 use awaken_server_contract::contract::storage::StorageError;
 
@@ -71,10 +71,11 @@ impl CommitCoordinator for PgCommitCoordinator {
 
     async fn commit_checkpoint(
         &self,
-        plan: Checkpoint,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
-        self.commit_checkpoint_staged(plan, CheckpointStagedWrites::default())
-            .await
+        plan: ThreadCommit,
+    ) -> Result<ThreadCommitOutcome, CommitError> {
+        self.commit_checkpoint_staged(plan, ThreadCommitStagedWrites::default())
+            .await?;
+        Ok(ThreadCommitOutcome)
     }
 }
 
@@ -82,11 +83,11 @@ impl CommitCoordinator for PgCommitCoordinator {
 impl StagedCommitCoordinator for PgCommitCoordinator {
     async fn commit_checkpoint_staged(
         &self,
-        plan: Checkpoint,
-        staged: CheckpointStagedWrites,
-    ) -> Result<CheckpointCommitOutcome, CommitError> {
+        plan: ThreadCommit,
+        staged: ThreadCommitStagedWrites,
+    ) -> Result<ThreadCommitStagedOutcome, CommitError> {
         plan.validate()?;
-        staged.validate(&plan.thread_id, &plan.run.run_id)?;
+        staged.validate(&plan.thread_id, &plan.run_projection.run_id)?;
         self.store
             .ensure_schema()
             .await
@@ -131,9 +132,9 @@ impl StagedCommitCoordinator for PgCommitCoordinator {
             .checkpoint_append_in_tx(
                 &mut tx,
                 &plan.thread_id,
-                &plan.messages,
-                plan.expected_message_version,
-                &plan.run,
+                &plan.message_delta,
+                plan.expected_message_count,
+                &plan.run_projection,
             )
             .await
             .map_err(|error| match error {
@@ -147,7 +148,7 @@ impl StagedCommitCoordinator for PgCommitCoordinator {
                 other => CommitError::StoreWrite(other),
             })?;
 
-        if let Some(thread_state) = &plan.thread_state {
+        if let Some(thread_state) = &plan.thread_state_snapshot {
             self.store
                 .save_thread_state_tx(&mut tx, &plan.thread_id, thread_state)
                 .await
@@ -158,7 +159,7 @@ impl StagedCommitCoordinator for PgCommitCoordinator {
             .await
             .map_err(|error| CommitError::Commit(error.to_string()))?;
 
-        Ok(CheckpointCommitOutcome {
+        Ok(ThreadCommitStagedOutcome {
             canonical_event_ids,
             server_event_ids,
             additional_outbox_ids,

--- a/crates/awaken-stores/tests/adr0036_mandatory.rs
+++ b/crates/awaken-stores/tests/adr0036_mandatory.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use awaken_server_contract::contract::commit_coordinator::{
-    CanonicalEventStager, Checkpoint, CommitCoordinator, CommitError, StagedCanonicalEvent,
+    CanonicalEventStager, CommitCoordinator, CommitError, StagedCanonicalEvent, ThreadCommit,
 };
 use awaken_server_contract::contract::durable_event_sink::{
     AgentEventNormalizationContext, DurableEventSink, RuntimeEventDurability,
@@ -23,7 +23,7 @@ use awaken_server_contract::contract::event_store::{
 };
 use awaken_server_contract::contract::lifecycle::RunStatus;
 use awaken_server_contract::contract::staged_commit::{
-    CheckpointStagedWrites, StagedCommitCoordinator,
+    StagedCommitCoordinator, ThreadCommitStagedWrites,
 };
 use awaken_server_contract::contract::storage::{RunRecord, ThreadStore};
 use awaken_stores::{
@@ -217,7 +217,7 @@ async fn phase_crash_replay() {
     );
 
     // Sanity: a subsequent successful commit (post-replay) writes cleanly.
-    let plan = Checkpoint::checkpoint_only("t-crash", run_record("t-crash", "r-crash"));
+    let plan = ThreadCommit::run_projection_only("t-crash", run_record("t-crash", "r-crash"));
     coord.commit_checkpoint(plan).await.unwrap();
     assert!(thread_run.load_thread("t-crash").await.unwrap().is_some());
 }
@@ -280,8 +280,8 @@ async fn memory_commit_atomicity() {
     let mut conflicting = sample_draft("RunStarted", "t-ma", "r-ma", "k-collide");
     conflicting.draft.payload = json!({"kind": "RunStarted", "diverged": true});
 
-    let plan = Checkpoint::checkpoint_only("t-ma", run_record("t-ma", "r-ma"));
-    let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![conflicting]);
+    let plan = ThreadCommit::run_projection_only("t-ma", run_record("t-ma", "r-ma"));
+    let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![conflicting]);
 
     let result = coord.commit_checkpoint_staged(plan, staged).await;
     assert!(

--- a/crates/awaken-stores/tests/postgres_commit_coordinator.rs
+++ b/crates/awaken-stores/tests/postgres_commit_coordinator.rs
@@ -5,7 +5,7 @@ mod postgres_fixture;
 use std::sync::Arc;
 
 use awaken_server_contract::contract::commit_coordinator::{
-    Checkpoint, CommitCoordinator, CommitError, StagedCanonicalEvent,
+    CommitCoordinator, CommitError, StagedCanonicalEvent, ThreadCommit,
 };
 use awaken_server_contract::contract::event_store::{
     AppendOptions, CanonicalEventDraft, CanonicalEventKind, EventReader, EventScope,
@@ -13,7 +13,7 @@ use awaken_server_contract::contract::event_store::{
 };
 use awaken_server_contract::contract::lifecycle::RunStatus;
 use awaken_server_contract::contract::staged_commit::{
-    CheckpointStagedWrites, StagedCommitCoordinator,
+    StagedCommitCoordinator, ThreadCommitStagedWrites,
 };
 use awaken_server_contract::contract::storage::{RunRecord, ThreadRunStore, ThreadStore};
 use awaken_stores::{PgCommitCoordinator, PostgresStore};
@@ -22,11 +22,11 @@ use serde_json::json;
 use postgres_fixture::PostgresFixture;
 
 fn unique_prefix(name: &str) -> String {
-    // Postgres caps identifier length at 63 chars; the longest suffix added
-    // to a base prefix is `_event_scope_index` (18 chars), so the prefix
-    // budget is ~45. Use the first 8 chars of a v7 uuid for uniqueness.
+    // Postgres caps identifier length at 63 chars; keep the prefix compact
+    // and use UUID v7's random segment so concurrent tests in the same
+    // millisecond do not collide on timestamp-only prefixes.
     let uuid_short = uuid::Uuid::now_v7().simple().to_string();
-    format!("pgc_{}_{}", name, &uuid_short[..8])
+    format!("pgc_{}_{}", name, &uuid_short[12..28])
 }
 
 fn run_record(thread_id: &str, run_id: &str) -> RunRecord {
@@ -66,8 +66,8 @@ async fn pg_commit_atomicity_persists_checkpoint_and_events() {
     let fixture = PostgresFixture::start().await;
     let (coord, store) = build_coord(&fixture, &unique_prefix("happy")).await;
 
-    let plan = Checkpoint::checkpoint_only("t-1", run_record("t-1", "r-1"));
-    let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+    let plan = ThreadCommit::run_projection_only("t-1", run_record("t-1", "r-1"));
+    let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
         StagedCanonicalEvent::new(sample_draft("RunStarted", "t-1", "r-1")),
         StagedCanonicalEvent::new(sample_draft("RunCompleted", "t-1", "r-1")),
     ]);
@@ -105,8 +105,8 @@ async fn pg_commit_rolls_back_on_idempotency_conflict() {
     let mut conflicting_draft = sample_draft("RunStarted", "t-2", "r-2");
     conflicting_draft.payload = json!({"kind": "RunStarted", "different": true});
 
-    let plan = Checkpoint::checkpoint_only("t-2", run_record("t-2", "r-2"));
-    let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+    let plan = ThreadCommit::run_projection_only("t-2", run_record("t-2", "r-2"));
+    let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
         StagedCanonicalEvent::new(conflicting_draft).with_options(seed_opts),
     ]);
 
@@ -143,8 +143,8 @@ async fn pg_commit_rolls_back_partial_appends_when_later_draft_fails() {
     let mut conflicting_second = sample_draft("ToolCallReady", "t-3", "r-3");
     conflicting_second.payload = json!({"kind": "ToolCallReady", "diff": true});
 
-    let plan = Checkpoint::checkpoint_only("t-3", run_record("t-3", "r-3"));
-    let staged = CheckpointStagedWrites::default().with_canonical_drafts(vec![
+    let plan = ThreadCommit::run_projection_only("t-3", run_record("t-3", "r-3"));
+    let staged = ThreadCommitStagedWrites::default().with_canonical_drafts(vec![
         // First draft would succeed in isolation.
         StagedCanonicalEvent::new(sample_draft("RunStarted", "t-3", "r-3")),
         // Second draft conflicts via idempotency.
@@ -184,10 +184,10 @@ async fn pg_commit_persists_thread_state_in_same_transaction() {
         revision: 11,
         extensions: Default::default(),
     };
-    let plan = Checkpoint::checkpoint_only("t-ts", run_record("t-ts", "r-ts"))
-        .with_thread_state(state.clone());
+    let plan = ThreadCommit::run_projection_only("t-ts", run_record("t-ts", "r-ts"))
+        .with_thread_state_snapshot(state.clone());
     coord
-        .commit_checkpoint_staged(plan, CheckpointStagedWrites::default())
+        .commit_checkpoint_staged(plan, ThreadCommitStagedWrites::default())
         .await
         .unwrap();
     assert_eq!(
@@ -199,8 +199,8 @@ async fn pg_commit_persists_thread_state_in_same_transaction() {
     // A later commit without thread_state must not clear the stored value.
     coord
         .commit_checkpoint_staged(
-            Checkpoint::checkpoint_only("t-ts", run_record("t-ts", "r-ts2")),
-            CheckpointStagedWrites::default(),
+            ThreadCommit::run_projection_only("t-ts", run_record("t-ts", "r-ts2")),
+            ThreadCommitStagedWrites::default(),
         )
         .await
         .unwrap();
@@ -219,7 +219,7 @@ async fn pg_load_checkpoint_reads_messages_run_and_thread_state_together() {
         revision: 3,
         extensions: Default::default(),
     };
-    let plan = Checkpoint::append(
+    let plan = ThreadCommit::append_messages(
         "t-ck",
         vec![
             Message::user("hi").with_id("m-1".to_string()),
@@ -228,9 +228,9 @@ async fn pg_load_checkpoint_reads_messages_run_and_thread_state_together() {
         Some(0),
         run_record("t-ck", "r-ck"),
     )
-    .with_thread_state(state.clone());
+    .with_thread_state_snapshot(state.clone());
     coord
-        .commit_checkpoint_staged(plan, CheckpointStagedWrites::default())
+        .commit_checkpoint_staged(plan, ThreadCommitStagedWrites::default())
         .await
         .unwrap();
 

--- a/crates/awaken-stores/tests/postgres_event_store.rs
+++ b/crates/awaken-stores/tests/postgres_event_store.rs
@@ -26,7 +26,7 @@ async fn test_store(prefix: &str) -> PostgresStore {
 
 fn unique_prefix(name: &str) -> String {
     let uuid_short = uuid::Uuid::now_v7().simple().to_string();
-    format!("pge_{}_{}", &uuid_short[..12], &name[..name.len().min(8)])
+    format!("pge_{}_{}", &uuid_short[12..28], &name[..name.len().min(8)])
 }
 
 fn kind(name: &str) -> CanonicalEventKind {

--- a/crates/awaken-stores/tests/postgres_outbox_store.rs
+++ b/crates/awaken-stores/tests/postgres_outbox_store.rs
@@ -19,7 +19,7 @@ async fn test_store(prefix: &str) -> PostgresStore {
 
 fn unique_prefix(name: &str) -> String {
     let uuid_short = uuid::Uuid::now_v7().simple().to_string();
-    format!("pgo_{}_{}", &uuid_short[..12], &name[..name.len().min(8)])
+    format!("pgo_{}_{}", &uuid_short[12..28], &name[..name.len().min(8)])
 }
 
 fn draft(payload: i64) -> OutboxMessageDraft {

--- a/crates/awaken-stores/tests/postgres_protocol_replay_log.rs
+++ b/crates/awaken-stores/tests/postgres_protocol_replay_log.rs
@@ -24,7 +24,7 @@ async fn test_store(prefix: &str) -> PostgresStore {
 
 fn unique_prefix(name: &str) -> String {
     let uuid_short = uuid::Uuid::now_v7().simple().to_string();
-    format!("pgr_{}_{}", &uuid_short[..12], &name[..name.len().min(8)])
+    format!("pgr_{}_{}", &uuid_short[12..28], &name[..name.len().min(8)])
 }
 
 fn stream(protocol_version: &str) -> ProtocolStreamKey {

--- a/crates/awaken-stores/tests/postgres_store.rs
+++ b/crates/awaken-stores/tests/postgres_store.rs
@@ -61,7 +61,7 @@ fn unique_prefix(prefix: &str) -> Option<String> {
     let uuid_short = uuid::Uuid::now_v7().simple().to_string();
     Some(format!(
         "pgs_{}_{}",
-        &uuid_short[..12],
+        &uuid_short[12..28],
         &prefix[..prefix.len().min(8)]
     ))
 }

--- a/crates/awaken-stores/tests/postgres_stream_checkpoint.rs
+++ b/crates/awaken-stores/tests/postgres_stream_checkpoint.rs
@@ -26,7 +26,7 @@ async fn postgres_stream_checkpoint_put_get_delete_roundtrip() {
         .unwrap_or_else(|_| "postgres://localhost/awaken_test".to_string());
     let pool = PgPool::connect(&url).await.unwrap();
     let uuid_short = uuid::Uuid::now_v7().simple().to_string();
-    let prefix = format!("pgsc_{}", &uuid_short[..12]);
+    let prefix = format!("pgsc_{}", &uuid_short[12..28]);
     let store = PostgresStore::with_prefix(pool, prefix);
     store.ensure_schema().await.unwrap();
 


### PR DESCRIPTION
## Summary

Narrow the runtime-facing commit contract from checkpoint/event-outbox terminology toward `ThreadCommit` / `message_delta` / `run_projection`, and move server-only event/outbox publish types to the server contract.

## API changes

- `ThreadCommit` is the primary runtime commit request type.
- `Checkpoint` remains as a deprecated type-name alias only. It does not preserve old struct field names such as `messages`, `expected_message_version`, `run`, or `thread_state`.
- Deprecated aliases and legacy constructors are retained, but struct field names changed. Call sites using struct literals or field access must migrate to `ThreadCommit` fields.
- `ThreadCommitOutcome` is intentionally unit-like for the runtime-facing commit path.
- `CheckpointCommitOutcome` remains as a deprecated type-name alias only. It does not preserve old `canonical_event_ids`, `server_event_ids`, or `additional_outbox_ids` fields.
- `CommitCoordinator::commit_checkpoint` no longer returns server/canonical/outbox IDs. Server-side callers that need those IDs should use the staged server contract API (`awaken_server_contract::contract::staged_commit::{ThreadCommitStagedOutcome, StagedCommitCoordinator}`).
- Server-only publish/diagnostic types moved to `awaken_server_contract::contract::staged_commit`.

## Migration notes

Deprecated aliases preserve type-name compatibility only. Struct field names and outcome fields changed; callers constructing or destructuring the old structs must migrate to the new field names and server staged outcome type.

Import migration for server-only types:

```rust
use awaken_server_contract::contract::staged_commit::{
    DiagnosticEvent, DiagnosticEventPublisher, EventPublishError, OutboxServerEventPublisher,
    ServerCanonicalEvent, ServerEventPublishOutcome,
};
```

## Commit structure

- `refactor(contract)`: runtime/server commit surface changes.
- `test(ci)`: MCP reference e2e startup, admin contract-path test, and concurrent Postgres test-prefix stabilization.
- `refactor(contract)`: public docs/error wording now consistently describes thread commits and `run_projection` instead of legacy checkpoint/run field names.

## Validation

Passed locally:

```text
cargo fmt --all -- --check
cargo check --workspace --locked
cargo clippy --workspace --lib --bins --examples --locked -- -D clippy::correctness
cargo test --workspace --locked
cargo test --locked -p awaken-doctest
cargo test --locked -p awaken-doctest --examples
cargo test --locked -p awaken-ext-mcp --test e2e_server_everything -- --ignored --test-threads=1
Postgres ignored store/event/outbox/replay/commit/stream checkpoint tests
NATS store tests and Postgres/NATS server integration
pnpm install --frozen-lockfile
pnpm frontend build/ci jobs for ai-sdk, copilotkit, admin-console, design-tokens, and www
cargo audit with CI ignores
pnpm audit --audit-level high --prod for admin-console and www
admin browser e2e
cargo test -p awaken-runtime-contract --lib commit_coordinator
cargo test -p awaken-server-contract --lib staged_commit
```

Failed locally / expected environment gap:

```text
pnpm --filter awaken-e2e exec playwright install --with-deps chromium
```

Local machine lacks passwordless sudo; GitHub runner has it. Running visual e2e without the system deps produced only Mermaid baseline height differences.

Not run locally:

```text
schedule/workflow_dispatch-only NATS stress job
```

Known warning: existing `clippy::type_complexity` warning in `crates/awaken-server/src/app/modules.rs`; CI denies only `clippy::correctness`.