### PR TITLE
Fix admin route gating and stop condition wiring

### DIFF
--- a/apps/admin-console/src/components/auth-provider.test.tsx
+++ b/apps/admin-console/src/components/auth-provider.test.tsx
@@ -26,7 +26,7 @@ function emptyCapabilities(): Awaited<ReturnType<typeof configApi.capabilities>>
       providers: [],
       namespaces: [],
     },
-  } as Awaited<ReturnType<typeof configApi.capabilities>>;
+  };
 }
 
 function Consumer() {

--- a/apps/admin-console/src/components/auth-provider.tsx
+++ b/apps/admin-console/src/components/auth-provider.tsx
@@ -41,16 +41,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const seq = ++refreshSeqRef.current;
     setStatus("checking");
     try {
-      const capabilities = await configApi.capabilities();
-      if (capabilities.kind !== "ok") {
-        throw new ConfigApiError(
-          capabilities.kind === "route_absent" ? 404 : 503,
-          capabilities.kind === "route_absent"
-            ? "capabilities route is not exposed"
-            : (capabilities.message ?? "capabilities store is unavailable"),
-        );
-      }
-      if (refreshSeqRef.current === seq) setStatus("ok");
+      const result = await configApi.capabilities();
+      if (refreshSeqRef.current !== seq) return;
+      setStatus(result.kind === "registry_unavailable" ? "disconnected" : "ok");
     } catch (probeError) {
       if (refreshSeqRef.current !== seq) return;
       if (probeError instanceof ConfigApiError) {

--- a/apps/admin-console/src/components/dashboard/runtime-activity-card.tsx
+++ b/apps/admin-console/src/components/dashboard/runtime-activity-card.tsx
@@ -13,8 +13,8 @@ import type { AgentRuntimeSnapshot } from "@/lib/config-api";
 const ERROR_RATE_WARN = 0.05;
 
 /** State shape mirrors `WorkloadState` so both top cards distinguish
- *  loading / disabled / error / ready the same way. The dashboard
- *  derives this from the runtime-stats slot. */
+ *  loading / route_absent / registry_unavailable / error / ready the
+ *  same way. The dashboard derives this from the runtime-stats slot. */
 export type RuntimeActivityState =
   | { kind: "loading" }
   | { kind: "route_absent" }

--- a/apps/admin-console/src/lib/api/capabilities.test.ts
+++ b/apps/admin-console/src/lib/api/capabilities.test.ts
@@ -63,14 +63,14 @@ describe("capabilitiesApi", () => {
     await expect(capabilitiesApi.capabilities()).resolves.toEqual({ kind: "route_absent" });
   });
 
-  it("reports store_unavailable on 503 instead of returning empty capabilities", async () => {
+  it("reports registry_unavailable on 503 instead of returning empty capabilities", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(jsonResponse({ error: "registry unavailable" }, 503)),
     );
 
     await expect(capabilitiesApi.capabilities()).resolves.toEqual({
-      kind: "store_unavailable",
+      kind: "registry_unavailable",
       message: "registry unavailable",
     });
   });

--- a/apps/admin-console/src/lib/api/capabilities.ts
+++ b/apps/admin-console/src/lib/api/capabilities.ts
@@ -11,10 +11,6 @@ export const EMPTY_CAPABILITIES: Capabilities = {
   namespaces: [],
 };
 
-export function capabilitiesFromResult(result?: CapabilitiesResult | null): Capabilities | null {
-  return result?.kind === "ok" ? result.capabilities : null;
-}
-
 function normalizeCapabilities(capabilities: Capabilities): Capabilities {
   return {
     ...capabilities,
@@ -32,6 +28,16 @@ function normalizeCapabilities(capabilities: Capabilities): Capabilities {
   };
 }
 
+export function capabilitiesFromResult(
+  result?: CapabilitiesResult | Capabilities | null,
+): Capabilities | null {
+  if (!result) return null;
+  if ("kind" in result) {
+    return result.kind === "ok" ? result.capabilities : null;
+  }
+  return result;
+}
+
 export const capabilitiesApi = {
   capabilities: async (): Promise<CapabilitiesResult> => {
     try {
@@ -46,7 +52,7 @@ export const capabilitiesApi = {
         return { kind: "route_absent" };
       }
       if (err instanceof ConfigApiError && err.status === 503) {
-        return { kind: "store_unavailable", message: err.message };
+        return { kind: "registry_unavailable", message: err.message };
       }
       throw err;
     }

--- a/apps/admin-console/src/lib/api/types.ts
+++ b/apps/admin-console/src/lib/api/types.ts
@@ -308,7 +308,7 @@ export interface Capabilities {
 export type CapabilitiesResult =
   | { kind: "ok"; capabilities: Capabilities }
   | { kind: "route_absent" }
-  | { kind: "store_unavailable"; message?: string };
+  | { kind: "registry_unavailable"; message?: string };
 
 /** Wire-format mirror of `GET /v1/mcp-servers/:id/status` response. */
 export interface McpServerStatusResponse {

--- a/apps/admin-console/src/lib/config-api.test.ts
+++ b/apps/admin-console/src/lib/config-api.test.ts
@@ -367,7 +367,7 @@ describe("configApi", () => {
     );
 
     await expect(configApi.capabilities()).resolves.toMatchObject({
-      kind: "store_unavailable",
+      kind: "registry_unavailable",
       message: "unavailable",
     });
   });

--- a/apps/admin-console/src/lib/config-api.test.ts
+++ b/apps/admin-console/src/lib/config-api.test.ts
@@ -371,6 +371,7 @@ describe("configApi", () => {
       message: "unavailable",
     });
   });
+
 });
 
 // ── deriveSourceState ─────────────────────────────────────────────────────────

--- a/apps/admin-console/src/lib/query/hooks/dashboard.ts
+++ b/apps/admin-console/src/lib/query/hooks/dashboard.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   capabilitiesApi,
   capabilitiesFromResult,
+  EMPTY_CAPABILITIES,
   configResourceApi,
   ConfigApiError,
   type AgentSpec,
@@ -74,22 +75,14 @@ export function useDashboardQuery(range: TimeRange) {
           loadOptionalSystemInfo(),
         ]);
       const degraded: DegradedSlots = {};
+      if (capabilitiesResult.kind === "registry_unavailable") {
+        throw new Error(capabilitiesResult.message ?? "Capabilities registry unavailable");
+      }
       if (mcp.degraded) degraded.mcpServers = true;
       if (providers.degraded) degraded.providers = true;
       if (models.degraded) degraded.models = true;
       if (agents.degraded) degraded.agents = true;
-      if (capabilitiesResult.kind !== "ok") {
-        throw new ConfigApiError(
-          capabilitiesResult.kind === "route_absent" ? 404 : 503,
-          capabilitiesResult.kind === "route_absent"
-            ? "capabilities route is not exposed"
-            : (capabilitiesResult.message ?? "capabilities store is unavailable"),
-        );
-      }
-      const capabilities = capabilitiesFromResult(capabilitiesResult);
-      if (!capabilities) {
-        throw new ConfigApiError(500, "capabilities response was empty");
-      }
+      const capabilities = capabilitiesFromResult(capabilitiesResult) ?? EMPTY_CAPABILITIES;
       return {
         capabilities,
         mcpServers: mcp.items,

--- a/apps/admin-console/src/pages/agent-editor-page.tsx
+++ b/apps/admin-console/src/pages/agent-editor-page.tsx
@@ -10,6 +10,7 @@ import {
   type PermissionPreviewResponse,
   type RecordMeta,
   ConfigApiError,
+  capabilitiesFromResult,
   configApi,
   deriveSourceState,
 } from "@/lib/config-api";
@@ -162,8 +163,7 @@ export function AgentEditorPage() {
     enabled: !isNew && Boolean(id),
     optional: true,
   });
-  const capabilities =
-    capabilitiesQuery.data?.kind === "ok" ? capabilitiesQuery.data.capabilities : null;
+  const capabilities = capabilitiesFromResult(capabilitiesQuery.data);
   const loading = capabilitiesQuery.isPending || (!isNew && agentQuery.isPending);
   const agentError = !isNew && agentQuery.error ? safeErrorMessage(agentQuery.error) : null;
   const mcpServersError = mcpServersQuery.error ? safeErrorMessage(mcpServersQuery.error) : null;

--- a/apps/admin-console/src/pages/assistant-page.tsx
+++ b/apps/admin-console/src/pages/assistant-page.tsx
@@ -5,11 +5,11 @@ import { useTranslation } from "react-i18next";
 import {
   adminAssistantApi,
   adminAssistantRunUrl,
+  capabilitiesFromResult,
   type AdminAssistantConfig,
 } from "@/lib/config-api";
 import { adminAuthHeaders } from "@/lib/api/http";
 import { useCapabilitiesQuery } from "@/lib/query/hooks/capabilities";
-import { capabilitiesFromResult } from "@/lib/api";
 import {
   describeToolCallState,
   previewPayload,

--- a/apps/admin-console/src/pages/providers-page.tsx
+++ b/apps/admin-console/src/pages/providers-page.tsx
@@ -181,11 +181,15 @@ export function ProvidersPage() {
     prepareSave,
     auxiliaryQueryKey: PROVIDER_AUXILIARY_QUERY_KEY,
     auxiliaryLoaders: () =>
-      capabilitiesApi.capabilities().then((result) => {
-        const caps = capabilitiesFromResult(result);
-        if (!caps) return [FALLBACK_ADAPTERS, []];
-        return [caps.supported_adapters ?? FALLBACK_ADAPTERS, caps.models ?? []];
-      }),
+      capabilitiesApi
+        .capabilities()
+        .then((result) => {
+          if (result.kind === "registry_unavailable") {
+            throw new Error(result.message ?? "Capabilities registry unavailable");
+          }
+          const caps = capabilitiesFromResult(result);
+          return [caps?.supported_adapters ?? FALLBACK_ADAPTERS, caps?.models ?? []];
+        }),
   });
 
   const serverAdapters = crud.auxiliaryData[0] as string[] | undefined;

--- a/apps/admin-console/src/pages/skill-detail-page.tsx
+++ b/apps/admin-console/src/pages/skill-detail-page.tsx
@@ -21,12 +21,14 @@ export function SkillDetailPage() {
     ? capabilitiesQuery.error instanceof Error
       ? capabilitiesQuery.error.message
       : String(capabilitiesQuery.error)
+    : capabilitiesQuery.data?.kind === "registry_unavailable"
+      ? capabilitiesQuery.data.message ?? "Capabilities registry unavailable"
     : null;
   const capabilities = capabilitiesFromResult(capabilitiesQuery.data);
   const skill = useMemo(() => {
-    if (!id || !capabilities) return undefined;
-    return capabilities.skills.find((s) => s.id === id) ?? null;
-  }, [capabilities, id]);
+    if (!id || capabilitiesQuery.data === undefined) return undefined;
+    return capabilities?.skills.find((s) => s.id === id) ?? null;
+  }, [capabilities, capabilitiesQuery.data, id]);
   const agents = agentsQuery.data?.items ?? EMPTY_AGENTS;
 
   const usedByAgents = useMemo(() => {

--- a/apps/admin-console/src/pages/skills-page.tsx
+++ b/apps/admin-console/src/pages/skills-page.tsx
@@ -45,8 +45,10 @@ export function SkillsPage() {
           ? capabilitiesQuery.error.message
           : String(capabilitiesQuery.error),
       );
+    } else if (capabilitiesQuery.data?.kind === "registry_unavailable") {
+      toast.error(capabilitiesQuery.data.message ?? "Capabilities registry unavailable");
     }
-  }, [capabilitiesQuery.error, toast]);
+  }, [capabilitiesQuery.data, capabilitiesQuery.error, toast]);
 
   const visibleSkills = useMemo(() => filterSkills(skills, filter), [skills, filter]);
 

--- a/crates/awaken-runtime-contract/src/config_validation/tests.rs
+++ b/crates/awaken-runtime-contract/src/config_validation/tests.rs
@@ -97,6 +97,12 @@ fn validate_agent_spec_patch_enforces_stop_condition_bounds() {
     }))
     .expect_err("patch stop conditions must enforce pattern length");
     assert!(err.to_string().contains("content_match.pattern"));
+
+    let err = validate_agent_spec_patch(json!({
+        "stop_conditions": [{"type": "content_match", "pattern": "["}]
+    }))
+    .expect_err("patch content_match pattern must be valid regex");
+    assert!(err.to_string().contains("valid regex"));
 }
 
 #[test]

--- a/crates/awaken-runtime-contract/src/config_validation/tests.rs
+++ b/crates/awaken-runtime-contract/src/config_validation/tests.rs
@@ -93,6 +93,12 @@ fn validate_agent_spec_rejects_unknown_stop_condition_fields() {
 #[test]
 fn validate_agent_spec_patch_enforces_stop_condition_bounds() {
     let err = validate_agent_spec_patch(json!({
+        "stop_conditions": [{"type": "content_match", "pattern": "["}]
+    }))
+    .expect_err("patch content_match pattern must be valid regex");
+    assert!(err.to_string().contains("valid regex"));
+
+    let err = validate_agent_spec_patch(json!({
         "stop_conditions": [{"type": "content_match", "pattern": "x".repeat(1025)}]
     }))
     .expect_err("patch stop conditions must enforce pattern length");

--- a/crates/awaken-runtime/src/policies/policy.rs
+++ b/crates/awaken-runtime/src/policies/policy.rs
@@ -206,13 +206,13 @@ impl StopPolicy for StopOnToolPolicy {
 
 pub struct ContentMatchPolicy {
     pattern: String,
-    regex: Option<Regex>,
+    regex: Result<Regex, String>,
 }
 
 impl ContentMatchPolicy {
     pub fn new(pattern: impl Into<String>) -> Self {
         let pattern = pattern.into();
-        let regex = Regex::new(&pattern).ok();
+        let regex = Regex::new(&pattern).map_err(|error| error.to_string());
         Self { pattern, regex }
     }
 }
@@ -226,8 +226,17 @@ impl StopPolicy for ContentMatchPolicy {
         if self.pattern.is_empty() {
             return StopDecision::Continue;
         }
-        let Some(regex) = &self.regex else {
-            return StopDecision::Continue;
+        let regex = match &self.regex {
+            Ok(regex) => regex,
+            Err(error) => {
+                return StopDecision::Stop {
+                    code: "content_match_invalid_regex".into(),
+                    detail: format!(
+                        "content_match stop condition has invalid regex {}: {error}",
+                        self.pattern
+                    ),
+                };
+            }
         };
         if regex.is_match(&stats.last_response_text) {
             StopDecision::Stop {
@@ -256,6 +265,9 @@ impl StopPolicy for LoopDetectionPolicy {
     }
 
     fn evaluate(&self, stats: &StopPolicyStats) -> StopDecision {
+        // This policy intentionally detects exact repeated response text only.
+        // Whitespace, timestamp, or formatting differences are treated as
+        // distinct responses.
         if self.window < 2 || stats.recent_response_texts.len() < self.window {
             return StopDecision::Continue;
         }

--- a/crates/awaken-runtime/src/policies/tests.rs
+++ b/crates/awaken-runtime/src/policies/tests.rs
@@ -328,6 +328,24 @@ fn declarative_content_match_policy_supports_regex_patterns() {
 }
 
 #[test]
+fn declarative_content_match_policy_stops_on_invalid_regex() {
+    let policies = policies_from_specs(&[StopConditionSpec::ContentMatch {
+        pattern: "[".into(),
+    }]);
+    let stats = StopPolicyStats {
+        last_response_text: "any response".into(),
+        ..base_stats()
+    };
+    assert!(
+        matches!(
+            policies[0].evaluate(&stats),
+            StopDecision::Stop { code, .. } if code == "content_match_invalid_regex"
+        ),
+        "invalid regex must fail closed instead of silently continuing"
+    );
+}
+
+#[test]
 fn declarative_loop_detection_policy_fires_for_repeated_window() {
     let policies = policies_from_specs(&[StopConditionSpec::LoopDetection { window: 3 }]);
     let stats = StopPolicyStats {
@@ -337,6 +355,19 @@ fn declarative_loop_detection_policy_fires_for_repeated_window() {
     assert!(
         matches!(policies[0].evaluate(&stats), StopDecision::Stop { code, .. } if code == "loop_detection")
     );
+}
+
+#[test]
+fn declarative_loop_detection_requires_exact_repeated_response_text() {
+    let policies = policies_from_specs(&[StopConditionSpec::LoopDetection { window: 3 }]);
+    let stats = StopPolicyStats {
+        recent_response_texts: vec!["same".into(), "same ".into(), "same".into()],
+        ..base_stats()
+    };
+    assert!(matches!(
+        policies[0].evaluate(&stats),
+        StopDecision::Continue
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- decouple admin run stats, run summary, and capabilities routes from config CRUD exposure
- make system module reporting reflect actual route gates and validate eval route prerequisites
- add frontend degradation for capabilities, run summary, and runtime stats with distinct 404/503 states
- wire declarative stop_conditions through AgentSpec, resolution, and loop runner; implement stop_on_tool, content_match, and loop_detection policies

## Tests
- cargo test -p awaken-runtime-contract -p awaken-runtime -p awaken-server
- cargo clippy -p awaken-runtime-contract -p awaken-runtime -p awaken-server --all-targets -- -D warnings
- pnpm --dir apps/admin-console test
- pnpm --dir apps/admin-console typecheck
- pre-push: admin-console-ci, validate