### PR TITLE
Harden runtime and mailbox invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,40 @@
 - Commits: `<emoji> <type>(<scope>): <subject>` (<=100 chars, <=4 lines), no PM terms
 - When hooks fail: follow `<system-reminder>` and "-> Next:" guidance
 
+## Documentation Truth Sources
+
+`AGENTS.md` is the guardrail index, not the complete architecture source. Do not
+duplicate schemas, state machines, or decision rationale outside the canonical
+source. Non-canonical docs use a one-sentence summary plus a link.
+
+- Registry publication, pinning, and replayability: `docs/adr/0035-published-versioned-registry-and-runtime-pinning.md`
+- Runtime event atomicity and staging: `docs/adr/0036-runtime-commit-atomicity-and-event-buffer.md`
+- Durable runtime write boundary: `docs/adr/0038-runtime-commit-boundary.md`
+- Run activation identity and layering: `docs/adr/0039-run-activation-layering.md`
+- Resolution and resolved run plans: `docs/adr/0040-resolver-resolved-run.md`
+- Mailbox architecture: `docs/adr/0019-mailbox-architecture.md`
+- Dispatch data model: `docs/adr/0022-run-dispatch-data-model.md`
+- Protocol/object mapping: `docs/adr/protocol-object-model-mapping.md`
+
+Accepted ADRs are append-mostly. Major meaning changes require a new
+superseding ADR or a short amendment note that links the superseding ADR.
+
+## Architecture Guardrails
+
+These are hard rules derived from accepted ADRs. If a change appears to need an
+exception, update the owning ADR first; do not bypass the rule in code.
+
+- **A-G1: Durable runtime writes go through `CommitCoordinator`.** Source: [ADR-0038](docs/adr/0038-runtime-commit-boundary.md). Enforcer: `ThreadCommit::validate`, runtime builder coordinator checks, and store write-entry validation. Validation: `crates/awaken-runtime/tests/builder_commit_coordinator.rs` and coordinator conformance tests in `crates/awaken-stores/tests/`.
+- **A-G2: `RunRecord` persistence rejects illegal status-field combinations.** Source: [ADR-0022](docs/adr/0022-run-dispatch-data-model.md) and [ADR-0038](docs/adr/0038-runtime-commit-boundary.md). Enforcer: `RunRecord::validate_for_persist` at every store write/decode boundary. Validation: run-store tests in `crates/awaken-stores/tests/`.
+- **A-G3: Thread message logs are thread-owned, append-only, id-addressed, and role-valid.** Source: [ADR-0038](docs/adr/0038-runtime-commit-boundary.md). Enforcer: message append validation before commit. Validation: contract and store tests under `crates/awaken-runtime-contract/` and `crates/awaken-stores/tests/`.
+- **A-G4: Thread run projection cannot be overwritten by stale run updates.** Source: [ADR-0022](docs/adr/0022-run-dispatch-data-model.md). Enforcer: projection update timestamp/order validation. Validation: runtime-contract projection tests.
+- **A-G5: Pinned registry resolution fails closed.** Source: [ADR-0035](docs/adr/0035-published-versioned-registry-and-runtime-pinning.md) and [ADR-0040](docs/adr/0040-resolver-resolved-run.md). Enforcer: pinned materialization errors surface as resolve/dispatch failures; live registry fallback is forbidden for pinned scope. Validation: registry graph and mailbox pinned-resolution tests.
+- **A-G6: `ResolvedRunPlan::Replayable` requires snapshot provenance.** Source: [ADR-0040](docs/adr/0040-resolver-resolved-run.md). Enforcer: replayable plan construction is restricted to materialized pinned snapshots. Validation: resolution characterization tests in `crates/awaken-runtime/src/registry/resolve/pipeline/tests.rs`.
+- **A-G7: Runtime event capture requires a staged commit coordinator.** Source: [ADR-0036](docs/adr/0036-runtime-commit-atomicity-and-event-buffer.md). Enforcer: mailbox construction rejects capture wiring without a staged coordinator. Validation: mailbox wiring tests in `crates/awaken-server/src/mailbox/tests.rs`.
+- **A-G8: Mailbox run reads and runtime commits must be same-source.** Source: [ADR-0019](docs/adr/0019-mailbox-architecture.md) and [ADR-0038](docs/adr/0038-runtime-commit-boundary.md). Enforcer: mailbox construction validates run-store/coordinator identity. Validation: mailbox construction tests in `crates/awaken-server/src/mailbox/tests.rs`.
+- **A-G9: Dispatch lifecycle transitions reject impossible lease/claim combinations.** Source: [ADR-0022](docs/adr/0022-run-dispatch-data-model.md). Enforcer: `RunDispatch::validate_for_persist` at queue/store boundaries. Validation: mailbox and mailbox-store tests.
+- **A-G10: Public facade exports stay narrow.** Source: [ADR-0037](docs/adr/0037-0.6.0-design-overhaul-overview.md), [ADR-0039](docs/adr/0039-run-activation-layering.md), and [ADR-0040](docs/adr/0040-resolver-resolved-run.md). Enforcer: public API compatibility tests and dependency-direction hooks. Validation: public API tests under `crates/awaken-runtime/tests/` and example compilation checks.
+
 ## Key Patterns
 
 - Error handling: Rust `thiserror` with project error enum; use `.context()` for error chaining

--- a/crates/awaken-contract/tests/agent_spec_patch.rs
+++ b/crates/awaken-contract/tests/agent_spec_patch.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use awaken_contract::contract::inference::{ContextWindowPolicy, ReasoningEffort};
+use awaken_contract::contract::lifecycle::StopConditionSpec;
 use awaken_contract::registry_spec::RemoteEndpoint;
 use awaken_contract::{AgentSpec, AgentSpecPatch, merge_agent_spec};
 use serde_json::{Value, json};
@@ -90,6 +91,7 @@ fn serde_round_trip_full_patch() {
         system_prompt: Some("You are helpful.".into()),
         max_rounds: Some(10),
         max_continuation_retries: Some(3),
+        stop_conditions: Some(vec![StopConditionSpec::Timeout { seconds: 30 }]),
         context_policy: Some(Some(ContextWindowPolicy::default())),
         plugin_ids: Some(vec!["plugin-a".into(), "plugin-b".into()]),
         active_hook_filter: Some(["plugin-a".to_string()].into_iter().collect()),

--- a/crates/awaken-doctest/examples/http_app_builder.rs
+++ b/crates/awaken-doctest/examples/http_app_builder.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use awaken::prelude::*;
-use awaken::server::app::ServerState;
+use awaken::server::prelude::*;
 use awaken::stores::{InMemoryMailboxStore, InMemoryStore};
 
 fn main() {

--- a/crates/awaken-ext-skills/src/mcp_bridge.rs
+++ b/crates/awaken-ext-skills/src/mcp_bridge.rs
@@ -759,7 +759,8 @@ impl SkillRegistry for McpPromptSkillRegistryManager {
 mod tests {
     use super::*;
     use awaken_ext_mcp::{
-        McpProgressUpdate, McpPromptDefinition, McpResourceDefinition, McpToolTransport,
+        McpCallContext, McpProgressUpdate, McpPromptDefinition, McpResourceDefinition,
+        McpToolTransport,
     };
     use mcp::transport::{McpServerConnectionConfig, ServerCapabilities, TransportTypeId};
     use serde_json::json;
@@ -891,7 +892,8 @@ mod tests {
             &self,
             _name: &str,
             _args: Value,
-            _progress_tx: Option<mpsc::UnboundedSender<McpProgressUpdate>>,
+            _progress_tx: Option<mpsc::Sender<McpProgressUpdate>>,
+            _context: McpCallContext,
         ) -> Result<mcp::CallToolResult, mcp::transport::McpTransportError> {
             Ok(mcp::CallToolResult {
                 content: Vec::new(),

--- a/crates/awaken-runtime-contract/src/contract/commit_coordinator.rs
+++ b/crates/awaken-runtime-contract/src/contract/commit_coordinator.rs
@@ -329,6 +329,13 @@ pub trait CommitCoordinator: Send + Sync {
     /// scope compatibility per ADR-0036 D3.
     fn scope(&self) -> TransactionScopeId;
 
+    /// Return an identity for the thread/run store backing this coordinator,
+    /// when the implementation can prove it. Server facades use this to reject
+    /// mismatched read stores before runtime dispatch starts.
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        None
+    }
+
     /// Return the runtime read port backed by the same store the coordinator
     /// commits to. The runtime uses this for resume reads (e.g. `load_run`);
     /// writes flow through [`Self::commit_checkpoint`]. The full store CRUD +

--- a/crates/awaken-runtime-contract/src/contract/message.rs
+++ b/crates/awaken-runtime-contract/src/contract/message.rs
@@ -108,7 +108,11 @@ pub struct CompactionMark {
 
 impl MessageRecord {
     /// Build a record from a thread-owned message payload.
-    pub fn from_message(thread_id: impl Into<String>, seq: u64, message: Message) -> Self {
+    pub fn from_message(thread_id: impl Into<String>, seq: u64, mut message: Message) -> Self {
+        let message_id = message.id.clone().unwrap_or_else(gen_message_id);
+        if message.id.is_none() {
+            message.id = Some(message_id.clone());
+        }
         let produced_by_run_id = message
             .metadata
             .as_ref()
@@ -123,7 +127,7 @@ impl MessageRecord {
             .as_ref()
             .and_then(|metadata| metadata.compaction);
         Self {
-            message_id: message.id.clone().unwrap_or_else(gen_message_id),
+            message_id,
             thread_id: thread_id.into(),
             seq,
             message,

--- a/crates/awaken-runtime-contract/src/contract/message/tests.rs
+++ b/crates/awaken-runtime-contract/src/contract/message/tests.rs
@@ -344,6 +344,22 @@ fn message_record_projects_thread_sequence_and_producer() {
 }
 
 #[test]
+fn message_record_from_message_backfills_payload_id() {
+    let msg: Message =
+        serde_json::from_str(r#"{"role":"user","content":[{"type":"text","text":"legacy"}]}"#)
+            .unwrap();
+    assert!(msg.id.is_none());
+
+    let record = MessageRecord::from_message("thread-1", 1, msg);
+
+    assert!(!record.message_id.trim().is_empty());
+    assert_eq!(
+        record.message.id.as_deref(),
+        Some(record.message_id.as_str())
+    );
+}
+
+#[test]
 fn strip_unpaired_tool_calls_from_view_keeps_answered_calls_only() {
     let mut assistant = Message::assistant("tools");
     assistant.tool_calls = Some(vec![

--- a/crates/awaken-runtime-contract/src/contract/run.rs
+++ b/crates/awaken-runtime-contract/src/contract/run.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::identity::RunOrigin;
 use super::inference::InferenceOverride;
 use super::message::Message;
-use super::storage::{MessageSeqRange, RunRequestOrigin};
+use super::storage::{MessageSeqRange, RunRequestOrigin, StorageError};
 use super::suspension::ToolCallResume;
 use super::tool::ToolDescriptor;
 use super::tool_intercept::{AdapterKind, RunMode};
@@ -30,6 +30,48 @@ impl RunIntent {
     }
 }
 
+fn require_non_empty(field: &str, value: &str) -> Result<(), StorageError> {
+    if value.trim().is_empty() {
+        return Err(StorageError::Validation(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+fn require_optional_non_empty(field: &str, value: Option<&str>) -> Result<(), StorageError> {
+    if let Some(value) = value {
+        require_non_empty(field, value)?;
+    }
+    Ok(())
+}
+
+fn validate_message_id_list(field: &str, ids: &[String]) -> Result<(), StorageError> {
+    for (idx, id) in ids.iter().enumerate() {
+        require_non_empty(&format!("{field}[{idx}]"), id)?;
+    }
+    Ok(())
+}
+
+fn validate_seq_range(field: &str, range: MessageSeqRange) -> Result<(), StorageError> {
+    if range.from_seq == 0 || range.from_seq > range.to_seq {
+        return Err(StorageError::Validation(format!(
+            "{field} range must be non-empty and 1-based"
+        )));
+    }
+    Ok(())
+}
+
+impl RunIntent {
+    /// Validate model-level invariants that cannot be represented by the
+    /// public compatibility fields alone.
+    pub fn validate(&self) -> Result<(), StorageError> {
+        require_non_empty("run intent thread_id", &self.thread_id)?;
+        require_optional_non_empty("run intent agent_id", self.agent_id.as_deref())?;
+        self.kind.validate()
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum RunKind {
@@ -41,6 +83,18 @@ pub enum RunKind {
     ContinuationFromRun {
         run_id: String,
     },
+}
+
+impl RunKind {
+    pub fn validate(&self) -> Result<(), StorageError> {
+        match self {
+            Self::NewIntent => Ok(()),
+            Self::HitlResume { run_id } => require_non_empty("hitl resume run_id", run_id),
+            Self::ContinuationFromRun { run_id } => {
+                require_non_empty("continuation run_id", run_id)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,6 +123,32 @@ pub struct RunInputSnapshot {
     pub context_policy: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compacted_snapshot_id: Option<String>,
+}
+
+impl RunInputSnapshot {
+    pub fn validate(&self) -> Result<(), StorageError> {
+        require_non_empty("run input snapshot thread_id", &self.thread_id)?;
+        if let Some(range) = self.range {
+            validate_seq_range("run input snapshot", range)?;
+        }
+        validate_message_id_list(
+            "run input snapshot trigger_message_ids",
+            &self.trigger_message_ids,
+        )?;
+        validate_message_id_list(
+            "run input snapshot selected_message_ids",
+            &self.selected_message_ids,
+        )?;
+        require_optional_non_empty(
+            "run input snapshot context_policy",
+            self.context_policy.as_deref(),
+        )?;
+        require_optional_non_empty(
+            "run input snapshot compacted_snapshot_id",
+            self.compacted_snapshot_id.as_deref(),
+        )?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -109,6 +189,24 @@ impl RunTraceContext {
     }
 }
 
+impl RunTraceContext {
+    pub fn validate(&self) -> Result<(), StorageError> {
+        require_optional_non_empty("run trace parent_run_id", self.parent_run_id.as_deref())?;
+        require_optional_non_empty(
+            "run trace parent_thread_id",
+            self.parent_thread_id.as_deref(),
+        )?;
+        require_optional_non_empty("run trace dispatch_id", self.dispatch_id.as_deref())?;
+        require_optional_non_empty("run trace session_id", self.session_id.as_deref())?;
+        require_optional_non_empty(
+            "run trace transport_request_id",
+            self.transport_request_id.as_deref(),
+        )?;
+        require_optional_non_empty("run trace correlation_id", self.correlation_id.as_deref())?;
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunActivationSnapshot {
     pub intent: RunIntent,
@@ -121,6 +219,31 @@ pub struct RunActivationSnapshot {
     /// server owns the referenced content; the runtime treats it as opaque.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolution_id: Option<String>,
+}
+
+impl RunActivationSnapshot {
+    pub fn validate(&self) -> Result<(), StorageError> {
+        self.intent.validate()?;
+        self.input.validate()?;
+        self.trace.validate()?;
+        if self.intent.thread_id != self.input.thread_id {
+            return Err(StorageError::Validation(format!(
+                "run activation intent.thread_id '{}' must match input.thread_id '{}'",
+                self.intent.thread_id, self.input.thread_id
+            )));
+        }
+        for (idx, (call_id, _)) in self.seeded_decisions.iter().enumerate() {
+            require_non_empty(
+                &format!("run activation seeded_decisions[{idx}].call_id"),
+                call_id,
+            )?;
+        }
+        require_optional_non_empty(
+            "run activation resolution_id",
+            self.resolution_id.as_deref(),
+        )?;
+        Ok(())
+    }
 }
 
 impl From<RunRequestOrigin> for RunOrigin {
@@ -170,6 +293,74 @@ mod tests {
         let value = serde_json::to_value(&snapshot).expect("serialize snapshot");
         assert_eq!(value["resolution_id"], "resolution-1");
         assert_eq!(value["intent"]["thread_id"], "thread");
+    }
+
+    #[test]
+    fn activation_snapshot_validate_rejects_thread_mismatch() {
+        let snapshot = RunActivationSnapshot {
+            intent: RunIntent::new("thread-a"),
+            input: RunInputSnapshot {
+                thread_id: "thread-b".into(),
+                ..Default::default()
+            },
+            options: RunOptions::default(),
+            trace: RunTraceContext::default(),
+            seeded_decisions: Vec::new(),
+            resolution_id: None,
+        };
+
+        let err = snapshot.validate().unwrap_err();
+
+        assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("intent.thread_id") && message.contains("input.thread_id")));
+    }
+
+    #[test]
+    fn activation_snapshot_validate_rejects_empty_resume_run_id() {
+        let snapshot = RunActivationSnapshot {
+            intent: RunIntent {
+                agent_id: Some("agent-a".into()),
+                thread_id: "thread".into(),
+                kind: RunKind::HitlResume { run_id: " ".into() },
+            },
+            input: RunInputSnapshot {
+                thread_id: "thread".into(),
+                ..Default::default()
+            },
+            options: RunOptions::default(),
+            trace: RunTraceContext::default(),
+            seeded_decisions: Vec::new(),
+            resolution_id: None,
+        };
+
+        let err = snapshot.validate().unwrap_err();
+
+        assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("hitl resume run_id")));
+    }
+
+    #[test]
+    fn activation_snapshot_validate_rejects_invalid_input_range() {
+        let snapshot = RunActivationSnapshot {
+            intent: RunIntent::new("thread"),
+            input: RunInputSnapshot {
+                thread_id: "thread".into(),
+                range: Some(MessageSeqRange {
+                    from_seq: 0,
+                    to_seq: 1,
+                }),
+                ..Default::default()
+            },
+            options: RunOptions::default(),
+            trace: RunTraceContext::default(),
+            seeded_decisions: Vec::new(),
+            resolution_id: None,
+        };
+
+        let err = snapshot.validate().unwrap_err();
+
+        assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("range")));
     }
 
     #[test]

--- a/crates/awaken-runtime-contract/src/contract/storage.rs
+++ b/crates/awaken-runtime-contract/src/contract/storage.rs
@@ -276,6 +276,121 @@ pub struct RunRecord {
 }
 
 impl RunRecord {
+    /// Validate storage-level invariants before a run is persisted.
+    pub fn validate_for_persist(&self) -> Result<(), StorageError> {
+        require_non_empty("run_id", &self.run_id)?;
+        require_non_empty("thread_id", &self.thread_id)?;
+        require_non_empty("agent_id", &self.agent_id)?;
+
+        if let Some(activation) = &self.activation {
+            activation.validate()?;
+            if activation.intent.thread_id != self.thread_id {
+                return Err(StorageError::Validation(format!(
+                    "run activation thread_id '{}' must match run thread_id '{}'",
+                    activation.intent.thread_id, self.thread_id
+                )));
+            }
+        }
+
+        if let Some(input) = &self.input {
+            validate_run_message_input(&self.thread_id, input)?;
+        }
+        if let Some(output) = &self.output {
+            validate_run_message_output(&self.thread_id, output)?;
+        }
+
+        match self.status {
+            RunStatus::Created | RunStatus::Running => {
+                if self.waiting.is_some() {
+                    return Err(StorageError::Validation(format!(
+                        "{:?} run '{}' must not carry waiting state",
+                        self.status, self.run_id
+                    )));
+                }
+                if self.outcome.is_some() {
+                    return Err(StorageError::Validation(format!(
+                        "{:?} run '{}' must not carry terminal outcome",
+                        self.status, self.run_id
+                    )));
+                }
+                if self.finished_at.is_some() {
+                    return Err(StorageError::Validation(format!(
+                        "{:?} run '{}' must not carry finished_at",
+                        self.status, self.run_id
+                    )));
+                }
+            }
+            RunStatus::Waiting => {
+                if self.waiting.is_none() {
+                    return Err(StorageError::Validation(format!(
+                        "waiting run '{}' must carry waiting state",
+                        self.run_id
+                    )));
+                }
+                if self.outcome.is_some() {
+                    return Err(StorageError::Validation(format!(
+                        "waiting run '{}' must not carry terminal outcome",
+                        self.run_id
+                    )));
+                }
+                if self.finished_at.is_some() {
+                    return Err(StorageError::Validation(format!(
+                        "waiting run '{}' must not carry finished_at",
+                        self.run_id
+                    )));
+                }
+            }
+            RunStatus::Done => {
+                if self.waiting.is_some() {
+                    return Err(StorageError::Validation(format!(
+                        "done run '{}' must not carry waiting state",
+                        self.run_id
+                    )));
+                }
+                if self.finished_at.is_none() {
+                    return Err(StorageError::Validation(format!(
+                        "done run '{}' must carry finished_at",
+                        self.run_id
+                    )));
+                }
+                if let Some(outcome) = &self.outcome {
+                    if self
+                        .termination_reason
+                        .as_ref()
+                        .is_some_and(|reason| reason != &outcome.termination_reason)
+                    {
+                        return Err(StorageError::Validation(format!(
+                            "done run '{}' termination_reason must match outcome.termination_reason",
+                            self.run_id
+                        )));
+                    }
+                    if self
+                        .final_output
+                        .as_ref()
+                        .is_some_and(|output| Some(output) != outcome.final_output.as_ref())
+                    {
+                        return Err(StorageError::Validation(format!(
+                            "done run '{}' final_output must match outcome.final_output",
+                            self.run_id
+                        )));
+                    }
+                    if self
+                        .error_payload
+                        .as_ref()
+                        .is_some_and(|payload| Some(payload) != outcome.error_payload.as_ref())
+                    {
+                        return Err(StorageError::Validation(format!(
+                            "done run '{}' error_payload must match outcome.error_payload",
+                            self.run_id
+                        )));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Return the structured waiting reason for a non-terminal run.
     ///
     /// Waiting state is durable and structured. Runtime status reason strings
@@ -300,6 +415,63 @@ impl RunRecord {
     pub fn is_background_task_waiting(&self) -> bool {
         self.waiting_reason() == Some(WaitingReason::BackgroundTasks)
     }
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), StorageError> {
+    if value.trim().is_empty() {
+        return Err(StorageError::Validation(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_seq_range(field: &str, range: MessageSeqRange) -> Result<(), StorageError> {
+    if range.from_seq == 0 || range.from_seq > range.to_seq {
+        return Err(StorageError::Validation(format!(
+            "{field} range must be non-empty and 1-based"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_run_message_input(
+    run_thread_id: &str,
+    input: &RunMessageInput,
+) -> Result<(), StorageError> {
+    if input.thread_id != run_thread_id {
+        return Err(StorageError::Validation(format!(
+            "run input thread_id '{}' must match run thread_id '{}'",
+            input.thread_id, run_thread_id
+        )));
+    }
+    if let Some(range) = input.range {
+        validate_seq_range("run input", range)?;
+    }
+    Ok(())
+}
+
+fn validate_run_message_output(
+    run_thread_id: &str,
+    output: &RunMessageOutput,
+) -> Result<(), StorageError> {
+    if output.thread_id != run_thread_id {
+        return Err(StorageError::Validation(format!(
+            "run output thread_id '{}' must match run thread_id '{}'",
+            output.thread_id, run_thread_id
+        )));
+    }
+    if let Some(range) = output.range {
+        validate_seq_range("run output", range)?;
+        if range.len() as usize != output.message_ids.len() {
+            return Err(StorageError::Validation(format!(
+                "run output message_ids length {} must match range length {}",
+                output.message_ids.len(),
+                range.len()
+            )));
+        }
+    }
+    Ok(())
 }
 
 // ── consistent checkpoint snapshot ───────────────────────────────────

--- a/crates/awaken-runtime-contract/src/contract/storage/message_append.rs
+++ b/crates/awaken-runtime-contract/src/contract/storage/message_append.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
-use super::{Message, StorageError};
+use super::StorageError;
+use crate::contract::message::{CompactionMark, Message, Role};
 
 /// Validate that a checkpoint append delta contains only new message ids.
 ///
@@ -16,10 +17,13 @@ pub fn validate_append_only_delta(
         .filter_map(|message| message.id.as_deref())
         .collect();
     let mut delta_ids = HashSet::new();
-    for message in delta {
-        let Some(message_id) = message.id.as_deref() else {
-            continue;
-        };
+    for (index, message) in delta.iter().enumerate() {
+        let summary_seq = existing.len() as u64 + index as u64 + 1;
+        validate_message_for_append(message, summary_seq)?;
+        let message_id = message
+            .id
+            .as_deref()
+            .expect("validate_message_for_append requires message id");
         if existing_ids.contains(message_id) {
             return Err(StorageError::Validation(format!(
                 "append delta contains already committed message id '{message_id}'"
@@ -30,6 +34,109 @@ pub fn validate_append_only_delta(
                 "append delta contains duplicate message id '{message_id}'"
             )));
         }
+    }
+    Ok(())
+}
+
+fn validate_message_for_append(message: &Message, summary_seq: u64) -> Result<(), StorageError> {
+    validate_message_shape(message, "append delta")?;
+    let message_id = message
+        .id
+        .as_deref()
+        .expect("validate_message_shape requires message id");
+
+    if let Some(mark) = message
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.compaction)
+    {
+        validate_compaction_mark(message_id, mark, summary_seq)?;
+    }
+
+    Ok(())
+}
+
+pub fn validate_message_shape(message: &Message, context: &str) -> Result<(), StorageError> {
+    let Some(message_id) = message.id.as_deref() else {
+        return Err(StorageError::Validation(format!(
+            "{context} message id must not be missing"
+        )));
+    };
+    if message_id.trim().is_empty() {
+        return Err(StorageError::Validation(format!(
+            "{context} message id must not be empty"
+        )));
+    }
+
+    match message.role {
+        Role::Tool => {
+            let Some(tool_call_id) = message.tool_call_id.as_deref() else {
+                return Err(StorageError::Validation(format!(
+                    "tool message '{message_id}' must carry tool_call_id"
+                )));
+            };
+            if tool_call_id.trim().is_empty() {
+                return Err(StorageError::Validation(format!(
+                    "tool message '{message_id}' tool_call_id must not be empty"
+                )));
+            }
+        }
+        _ => {
+            if message.tool_call_id.is_some() {
+                return Err(StorageError::Validation(format!(
+                    "non-tool message '{message_id}' must not carry tool_call_id"
+                )));
+            }
+        }
+    }
+
+    if message.role != Role::Assistant && message.tool_calls.is_some() {
+        return Err(StorageError::Validation(format!(
+            "non-assistant message '{message_id}' must not carry tool_calls"
+        )));
+    }
+
+    let Some(tool_calls) = message.tool_calls.as_ref() else {
+        return Ok(());
+    };
+
+    let mut ids = HashSet::new();
+    for call in tool_calls {
+        if call.id.trim().is_empty() {
+            return Err(StorageError::Validation(format!(
+                "assistant message '{message_id}' tool call id must not be empty"
+            )));
+        }
+        if call.name.trim().is_empty() {
+            return Err(StorageError::Validation(format!(
+                "assistant message '{message_id}' tool call name must not be empty"
+            )));
+        }
+        if !ids.insert(call.id.as_str()) {
+            return Err(StorageError::Validation(format!(
+                "assistant message '{message_id}' contains duplicate tool call id '{}'",
+                call.id
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_compaction_mark(
+    message_id: &str,
+    mark: CompactionMark,
+    summary_seq: u64,
+) -> Result<(), StorageError> {
+    if mark.from_seq == 0 || mark.from_seq > mark.to_seq {
+        return Err(StorageError::Validation(format!(
+            "compaction mark on message '{message_id}' must be 1-based and non-empty"
+        )));
+    }
+    if mark.to_seq >= summary_seq {
+        return Err(StorageError::Validation(format!(
+            "compaction mark on summary message '{message_id}' must not cover the summary seq {summary_seq}"
+        )));
     }
     Ok(())
 }

--- a/crates/awaken-runtime-contract/src/contract/storage/tests.rs
+++ b/crates/awaken-runtime-contract/src/contract/storage/tests.rs
@@ -1,5 +1,104 @@
 use super::*;
 
+fn valid_run_record(status: RunStatus) -> RunRecord {
+    let mut run = RunRecord {
+        run_id: "run-1".to_string(),
+        thread_id: "thread-1".to_string(),
+        agent_id: "agent-1".to_string(),
+        status,
+        created_at: 1,
+        updated_at: 1,
+        ..Default::default()
+    };
+    if status == RunStatus::Waiting {
+        run.waiting = Some(RunWaitingState {
+            reason: WaitingReason::UserInput,
+            ticket_ids: Vec::new(),
+            tickets: Vec::new(),
+            since_dispatch_id: None,
+            message: None,
+        });
+    }
+    if status == RunStatus::Done {
+        run.finished_at = Some(1);
+    }
+    run
+}
+
+#[test]
+fn run_record_validate_rejects_waiting_without_waiting_state() {
+    let mut run = valid_run_record(RunStatus::Waiting);
+    run.waiting = None;
+
+    let err = run.validate_for_persist().unwrap_err();
+
+    assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("waiting") && message.contains("waiting state")));
+}
+
+#[test]
+fn run_record_validate_rejects_done_without_finished_at() {
+    let mut run = valid_run_record(RunStatus::Done);
+    run.finished_at = None;
+
+    let err = run.validate_for_persist().unwrap_err();
+
+    assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("done") && message.contains("finished_at")));
+}
+
+#[test]
+fn run_record_validate_rejects_mismatched_activation_thread() {
+    let mut run = valid_run_record(RunStatus::Running);
+    run.activation = Some(crate::contract::run::RunActivationSnapshot {
+        intent: crate::contract::run::RunIntent::new("other-thread"),
+        input: crate::contract::run::RunInputSnapshot {
+            thread_id: "other-thread".into(),
+            ..Default::default()
+        },
+        options: crate::contract::run::RunOptions::default(),
+        trace: crate::contract::run::RunTraceContext::default(),
+        seeded_decisions: Vec::new(),
+        resolution_id: None,
+    });
+
+    let err = run.validate_for_persist().unwrap_err();
+
+    assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("activation thread_id") && message.contains("run thread_id")));
+}
+
+#[test]
+fn run_record_validate_rejects_mismatched_output_thread() {
+    let mut run = valid_run_record(RunStatus::Running);
+    run.output = Some(RunMessageOutput {
+        thread_id: "other-thread".to_string(),
+        range: MessageSeqRange::new(1, 1),
+        message_ids: vec!["m-1".to_string()],
+    });
+
+    let err = run.validate_for_persist().unwrap_err();
+
+    assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("run output thread_id")));
+}
+
+#[test]
+fn run_record_validate_rejects_mismatched_terminal_outcome() {
+    let mut run = valid_run_record(RunStatus::Done);
+    run.termination_reason = Some(TerminationReason::NaturalEnd);
+    run.outcome = Some(RunOutcome {
+        termination_reason: TerminationReason::Cancelled,
+        final_output: None,
+        error_payload: None,
+    });
+
+    let err = run.validate_for_persist().unwrap_err();
+
+    assert!(matches!(err, StorageError::Validation(message)
+            if message.contains("termination_reason")));
+}
+
 #[test]
 fn merge_checkpoint_append_messages_rejects_existing_id() {
     let mut existing = vec![
@@ -32,6 +131,122 @@ fn merge_checkpoint_append_messages_rejects_duplicate_delta_id() {
     assert!(matches!(err, StorageError::Validation(message) if message.contains("duplicate")));
     assert_eq!(existing.len(), 1, "committed log must remain untouched");
     assert_eq!(existing[0].text(), "first");
+}
+
+#[test]
+fn merge_checkpoint_append_messages_rejects_missing_delta_id() {
+    let mut existing = vec![Message::user("first").with_id("msg-1".to_string())];
+    let mut missing_id = Message::assistant("missing id");
+    missing_id.id = None;
+
+    let err = message_append::merge_checkpoint_append_messages(&mut existing, &[missing_id])
+        .expect_err("append delta must reject messages without ids");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("id")));
+    assert_eq!(existing.len(), 1, "committed log must remain untouched");
+}
+
+#[test]
+fn merge_checkpoint_append_messages_rejects_tool_without_call_id() {
+    let mut existing = Vec::new();
+    let mut tool = Message::tool("call-1", "result").with_id("msg-1".to_string());
+    tool.tool_call_id = None;
+
+    let err = message_append::merge_checkpoint_append_messages(&mut existing, &[tool])
+        .expect_err("tool messages must carry a tool_call_id");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("tool_call_id")));
+    assert!(existing.is_empty(), "committed log must remain untouched");
+}
+
+#[test]
+fn merge_checkpoint_append_messages_rejects_non_tool_call_id() {
+    let mut existing = Vec::new();
+    let mut user = Message::user("bad").with_id("msg-1".to_string());
+    user.tool_call_id = Some("call-1".to_string());
+
+    let err = message_append::merge_checkpoint_append_messages(&mut existing, &[user])
+        .expect_err("non-tool messages must not carry tool_call_id");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("tool_call_id")));
+    assert!(existing.is_empty(), "committed log must remain untouched");
+}
+
+#[test]
+fn merge_checkpoint_append_messages_rejects_invalid_assistant_tool_calls() {
+    let mut existing = Vec::new();
+    let duplicate_calls = Message::assistant_with_tool_calls(
+        "calls",
+        vec![
+            crate::contract::message::ToolCall::new("call-1", "search", serde_json::json!({})),
+            crate::contract::message::ToolCall::new("call-1", "fetch", serde_json::json!({})),
+        ],
+    )
+    .with_id("msg-1".to_string());
+
+    let err = message_append::merge_checkpoint_append_messages(&mut existing, &[duplicate_calls])
+        .expect_err("assistant tool call ids must be unique");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("duplicate")));
+    assert!(existing.is_empty(), "committed log must remain untouched");
+}
+
+#[test]
+fn merge_checkpoint_append_messages_rejects_empty_tool_call_name() {
+    let mut existing = Vec::new();
+    let assistant = Message::assistant_with_tool_calls(
+        "calls",
+        vec![crate::contract::message::ToolCall::new(
+            "call-1",
+            " ",
+            serde_json::json!({}),
+        )],
+    )
+    .with_id("msg-1".to_string());
+
+    let err = message_append::merge_checkpoint_append_messages(&mut existing, &[assistant])
+        .expect_err("assistant tool call names must be non-empty");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("name")));
+    assert!(existing.is_empty(), "committed log must remain untouched");
+}
+
+#[test]
+fn merge_checkpoint_append_messages_rejects_invalid_compaction_range() {
+    let mut existing = Vec::new();
+    let mut summary = Message::system("summary").with_id("summary-1".to_string());
+    summary.metadata = Some(crate::contract::message::MessageMetadata {
+        compaction: Some(crate::contract::message::CompactionMark {
+            from_seq: 0,
+            to_seq: 1,
+        }),
+        ..Default::default()
+    });
+
+    let err = message_append::merge_checkpoint_append_messages(&mut existing, &[summary])
+        .expect_err("compaction range must be 1-based and non-empty");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("compaction")));
+    assert!(existing.is_empty(), "committed log must remain untouched");
+}
+
+#[test]
+fn merge_checkpoint_append_messages_rejects_compaction_covering_summary() {
+    let mut existing = vec![Message::user("first").with_id("msg-1".to_string())];
+    let mut summary = Message::system("summary").with_id("summary-1".to_string());
+    summary.metadata = Some(crate::contract::message::MessageMetadata {
+        compaction: Some(crate::contract::message::CompactionMark {
+            from_seq: 1,
+            to_seq: 2,
+        }),
+        ..Default::default()
+    });
+
+    let err = message_append::merge_checkpoint_append_messages(&mut existing, &[summary])
+        .expect_err("compaction range must not include the summary message itself");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("summary")));
+    assert_eq!(existing.len(), 1, "committed log must remain untouched");
 }
 
 #[test]

--- a/crates/awaken-runtime-contract/src/thread.rs
+++ b/crates/awaken-runtime-contract/src/thread.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use crate::contract::lifecycle::RunStatus;
-use crate::contract::storage::RunRecord;
+use crate::contract::storage::{RunRecord, StorageError};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -65,6 +65,9 @@ pub struct Thread {
     /// Most recently known run for this thread.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub latest_run_id: Option<String>,
+    /// `updated_at` watermark for the projected latest run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_run_updated_at: Option<u64>,
 }
 
 impl Thread {
@@ -78,6 +81,7 @@ impl Thread {
             active_run_id: None,
             open_run_id: None,
             latest_run_id: None,
+            latest_run_updated_at: None,
         }
     }
 
@@ -91,6 +95,7 @@ impl Thread {
             active_run_id: None,
             open_run_id: None,
             latest_run_id: None,
+            latest_run_updated_at: None,
         }
     }
 
@@ -121,6 +126,26 @@ impl Thread {
         self.parent_thread_id = normalize_lineage_id_owned(self.parent_thread_id.take());
     }
 
+    /// Validate model-level invariants before persisting a thread projection.
+    pub fn validate_for_persist(&self) -> Result<(), StorageError> {
+        require_non_empty("thread id", &self.id)?;
+        require_optional_non_empty("thread resource_id", self.resource_id.as_deref())?;
+        require_optional_non_empty("thread parent_thread_id", self.parent_thread_id.as_deref())?;
+        require_optional_non_empty("thread active_run_id", self.active_run_id.as_deref())?;
+        require_optional_non_empty("thread open_run_id", self.open_run_id.as_deref())?;
+        require_optional_non_empty("thread latest_run_id", self.latest_run_id.as_deref())?;
+
+        if normalize_lineage_id(self.parent_thread_id.as_deref()).as_deref() == Some(self.id.trim())
+        {
+            return Err(StorageError::Validation(format!(
+                "thread '{}' cannot parent itself",
+                self.id
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Ensure timestamps are initialized and mark the thread as updated.
     pub fn touch(&mut self, now: u64) {
         self.metadata.created_at.get_or_insert(now);
@@ -129,7 +154,18 @@ impl Thread {
 
     /// Update the thread's run pointers from a durable run record.
     pub fn apply_run_projection(&mut self, run: &RunRecord) {
+        let is_current_projection = self
+            .latest_run_updated_at
+            .is_none_or(|latest_updated_at| run.updated_at >= latest_updated_at);
+        if !is_current_projection {
+            if run.status == RunStatus::Done {
+                self.clear_run_projection_if_matches(&run.run_id);
+            }
+            return;
+        }
+
         self.latest_run_id = Some(run.run_id.clone());
+        self.latest_run_updated_at = Some(run.updated_at);
         if self.parent_thread_id.is_none() {
             self.parent_thread_id = normalize_lineage_id(
                 run.request
@@ -151,15 +187,35 @@ impl Thread {
                 self.open_run_id = Some(run.run_id.clone());
             }
             RunStatus::Done => {
-                if self.active_run_id.as_deref() == Some(run.run_id.as_str()) {
-                    self.active_run_id = None;
-                }
-                if self.open_run_id.as_deref() == Some(run.run_id.as_str()) {
-                    self.open_run_id = None;
-                }
+                self.clear_run_projection_if_matches(&run.run_id);
             }
         }
     }
+
+    fn clear_run_projection_if_matches(&mut self, run_id: &str) {
+        if self.active_run_id.as_deref() == Some(run_id) {
+            self.active_run_id = None;
+        }
+        if self.open_run_id.as_deref() == Some(run_id) {
+            self.open_run_id = None;
+        }
+    }
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), StorageError> {
+    if value.trim().is_empty() {
+        return Err(StorageError::Validation(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+fn require_optional_non_empty(field: &str, value: Option<&str>) -> Result<(), StorageError> {
+    if let Some(value) = value {
+        require_non_empty(field, value)?;
+    }
+    Ok(())
 }
 
 impl Default for Thread {
@@ -304,6 +360,26 @@ mod tests {
     }
 
     #[test]
+    fn thread_validate_rejects_empty_id() {
+        let thread = Thread::with_id(" ");
+
+        let err = thread.validate_for_persist().unwrap_err();
+
+        assert!(matches!(err, StorageError::Validation(message) if message.contains("thread id")));
+    }
+
+    #[test]
+    fn thread_validate_rejects_self_parent() {
+        let thread = Thread::with_id("thread-1").with_parent_thread_id(" thread-1 ");
+
+        let err = thread.validate_for_persist().unwrap_err();
+
+        assert!(
+            matches!(err, StorageError::Validation(message) if message.contains("parent itself"))
+        );
+    }
+
+    #[test]
     fn touch_initializes_created_and_updated_at() {
         let mut thread = Thread::with_id("t-1");
 
@@ -394,6 +470,22 @@ mod tests {
         assert!(thread.open_run_id.is_none());
         assert!(thread.active_run_id.is_none());
         assert_eq!(thread.latest_run_id.as_deref(), Some("run-1"));
+    }
+
+    #[test]
+    fn apply_run_projection_ignores_older_run_projection() {
+        let mut thread = Thread::with_id("thread-1");
+        let mut newer = run_record("run-new", RunStatus::Running);
+        newer.updated_at = 20;
+        let mut older = run_record("run-old", RunStatus::Running);
+        older.updated_at = 10;
+
+        thread.apply_run_projection(&newer);
+        thread.apply_run_projection(&older);
+
+        assert_eq!(thread.latest_run_id.as_deref(), Some("run-new"));
+        assert_eq!(thread.active_run_id.as_deref(), Some("run-new"));
+        assert_eq!(thread.open_run_id.as_deref(), Some("run-new"));
     }
 
     #[test]

--- a/crates/awaken-runtime/src/backend/mod.rs
+++ b/crates/awaken-runtime/src/backend/mod.rs
@@ -497,7 +497,7 @@ pub async fn execute_remote_root_lifecycle(
                         &run_identity.run_id,
                         previous_state.clone(),
                     )
-                    .await;
+                    .await?;
                     return finish_remote_root_run(
                         checkpoint_store,
                         &run_identity.thread_id,
@@ -529,7 +529,7 @@ pub async fn execute_remote_root_lifecycle(
                 &run_identity.run_id,
                 previous_state.clone(),
             )
-            .await;
+            .await?;
             if backend.capabilities().cancellation.supports_remote_abort()
                 && let Err(error) = backend
                     .abort(BackendAbortRequest {
@@ -634,17 +634,18 @@ async fn load_checkpoint_state(
     storage: Option<&dyn RuntimeCheckpointStore>,
     run_id: &str,
     fallback: Option<PersistedState>,
-) -> Option<PersistedState> {
+) -> Result<Option<PersistedState>, AgentLoopError> {
     let Some(storage) = storage else {
-        return fallback;
+        return Ok(fallback);
     };
     match storage.load_run(run_id).await {
-        Ok(Some(run)) => run.state.or(fallback),
-        Ok(None) => fallback,
-        Err(error) => {
-            tracing::warn!(run_id, error = %error, "failed to load latest checkpoint state");
-            fallback
-        }
+        Ok(Some(run)) => Ok(run.state),
+        Ok(None) => Err(AgentLoopError::StorageError(format!(
+            "checkpoint state for run '{run_id}' was not found"
+        ))),
+        Err(error) => Err(AgentLoopError::StorageError(format!(
+            "failed to load latest checkpoint state for run '{run_id}': {error}"
+        ))),
     }
 }
 
@@ -769,6 +770,39 @@ fn run_status_label(status: RunStatus) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use awaken_runtime_contract::contract::storage::{RunRecord, StorageError};
+    use awaken_runtime_contract::thread::Thread;
+
+    struct FailingCheckpointStore;
+
+    #[async_trait::async_trait]
+    impl RuntimeCheckpointStore for FailingCheckpointStore {
+        async fn load_thread(&self, _thread_id: &str) -> Result<Option<Thread>, StorageError> {
+            Ok(None)
+        }
+
+        async fn load_messages(
+            &self,
+            _thread_id: &str,
+        ) -> Result<Option<Vec<Message>>, StorageError> {
+            Ok(None)
+        }
+
+        async fn load_committed_messages(
+            &self,
+            _thread_id: &str,
+        ) -> Result<Option<Vec<Message>>, StorageError> {
+            Ok(None)
+        }
+
+        async fn load_run(&self, _run_id: &str) -> Result<Option<RunRecord>, StorageError> {
+            Err(StorageError::Io("injected read failure".into()))
+        }
+
+        async fn latest_run(&self, _thread_id: &str) -> Result<Option<RunRecord>, StorageError> {
+            Ok(None)
+        }
+    }
 
     #[test]
     fn backend_status_timeout_is_first_class_at_runtime_boundary() {
@@ -808,6 +842,68 @@ mod tests {
         assert_eq!(
             status.result_status_label(&TerminationReason::Error("should not win".into())),
             "waiting_input"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_checkpoint_state_propagates_durable_read_errors() {
+        let error = load_checkpoint_state(Some(&FailingCheckpointStore), "run-1", None)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, AgentLoopError::StorageError(ref message)
+                if message.contains("failed to load latest checkpoint state")
+                    && message.contains("injected read failure")),
+            "unexpected error: {error}"
+        );
+    }
+
+    struct MissingCheckpointStore;
+
+    #[async_trait]
+    impl RuntimeCheckpointStore for MissingCheckpointStore {
+        async fn load_thread(&self, _thread_id: &str) -> Result<Option<Thread>, StorageError> {
+            Ok(None)
+        }
+
+        async fn load_messages(
+            &self,
+            _thread_id: &str,
+        ) -> Result<Option<Vec<Message>>, StorageError> {
+            Ok(None)
+        }
+
+        async fn load_committed_messages(
+            &self,
+            _thread_id: &str,
+        ) -> Result<Option<Vec<Message>>, StorageError> {
+            Ok(None)
+        }
+
+        async fn load_run(&self, _run_id: &str) -> Result<Option<RunRecord>, StorageError> {
+            Ok(None)
+        }
+
+        async fn latest_run(&self, _thread_id: &str) -> Result<Option<RunRecord>, StorageError> {
+            Ok(None)
+        }
+    }
+
+    #[tokio::test]
+    async fn load_checkpoint_state_rejects_missing_durable_run_even_with_fallback() {
+        let fallback = PersistedState {
+            revision: 9,
+            extensions: std::collections::HashMap::new(),
+        };
+        let error = load_checkpoint_state(Some(&MissingCheckpointStore), "run-1", Some(fallback))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, AgentLoopError::StorageError(ref message)
+                if message.contains("checkpoint state for run 'run-1' was not found")),
+            "unexpected error: {error}"
         );
     }
 }

--- a/crates/awaken-runtime/src/builder_tests.rs
+++ b/crates/awaken-runtime/src/builder_tests.rs
@@ -725,21 +725,20 @@ async fn builder_runtime_resolves_persistent_activation_as_replayable() {
         )],
     )
     .with_agent_id("test-agent");
-    // A server-issued resolution id pins the run: the runtime echoes it into a
-    // Replayable plan. The runtime never mints the id itself — pinning is a
-    // server-side concern carried via `RegistryResolutionScope::Pinned`.
-    let plan = runtime
+    // A server-issued resolution id must be resolved by a server-owned
+    // materialized snapshot resolver. The embedded dynamic registry cannot
+    // prove snapshot provenance and must fail closed.
+    let result = runtime
         .resolve_activation_in_scope(
             &activation,
             crate::resolution::ResolutionPolicy::PersistentServer,
             crate::resolution::RegistryResolutionScope::Pinned("resolution-test".into()),
         )
-        .await
-        .expect("pinned persistent resolution");
-    let crate::ResolvedRunPlan::Replayable(plan) = plan else {
-        panic!("a pinned persistent resolution must yield a Replayable plan");
-    };
-    assert_eq!(plan.artifact.resolution_id, "resolution-test");
+        .await;
+    assert!(matches!(
+        result,
+        Err(crate::resolution::ResolveError::UnsupportedPersistence(_))
+    ));
 
     // Without a resolution id the runtime resolves the live registry into a
     // LiveOnly plan, which cannot satisfy a persistent (server) policy.

--- a/crates/awaken-runtime/src/credentials/material.rs
+++ b/crates/awaken-runtime/src/credentials/material.rs
@@ -194,18 +194,52 @@ fn compatible_adapters(kind: CredentialKind) -> &'static [&'static str] {
 ///
 /// Returns:
 /// - `Ok(Some(material))` — material is configured; register with the broker.
-/// - `Ok(None)` — `kind == Bearer` AND `api_key` is absent/empty. The runtime
-///   should skip broker registration and let genai's adapter fall back to
-///   its default env var (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`).
-///   This preserves 0.4.0 behaviour where omitting `api_key` means "use
-///   the host environment".
+/// - `Ok(None)` — only from [`build_material_allowing_env_fallback`] when
+///   `kind == Bearer` and `api_key` is absent/empty. The runtime should skip
+///   broker registration and let genai's adapter fall back to its default env
+///   var (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). Callers must opt in
+///   explicitly so managed provider configs do not silently borrow host
+///   credentials.
 /// - `Err(_)` — incompatible (kind × adapter), missing required api_key for
-///   non-bearer kinds, the `credentials-google` feature disabled but a
+///   bearer/non-bearer kinds, the `credentials-google` feature disabled but a
 ///   service-account configuration was supplied, or unparseable material.
 pub fn build_material(
     adapter: &str,
     kind: CredentialKind,
     api_key: Option<&RedactedString>,
+) -> Result<Option<CredentialMaterial>, String> {
+    build_material_inner(adapter, kind, api_key, false)
+}
+
+/// Build credential material while explicitly allowing bearer env fallback.
+///
+/// Server-managed provider configs should call this only when their parsed
+/// adapter options contain `allow_env_credentials = true`.
+pub fn build_material_allowing_env_fallback(
+    adapter: &str,
+    kind: CredentialKind,
+    api_key: Option<&RedactedString>,
+) -> Result<Option<CredentialMaterial>, String> {
+    build_material_inner(adapter, kind, api_key, true)
+}
+
+/// Parse the explicit env-credential opt-in from provider adapter options.
+pub fn allow_env_credentials_from_options(
+    options: &BTreeMap<String, Value>,
+) -> Result<bool, String> {
+    let Some(value) = options.get("allow_env_credentials") else {
+        return Ok(false);
+    };
+    value.as_bool().ok_or_else(|| {
+        "adapter_options.allow_env_credentials must be a boolean when present".to_string()
+    })
+}
+
+fn build_material_inner(
+    adapter: &str,
+    kind: CredentialKind,
+    api_key: Option<&RedactedString>,
+    allow_env_fallback: bool,
 ) -> Result<Option<CredentialMaterial>, String> {
     // (kind × adapter) compatibility
     let allowed = compatible_adapters(kind);
@@ -219,10 +253,14 @@ pub fn build_material(
 
     match kind {
         CredentialKind::Bearer => {
-            // Bearer is the back-compat path: missing api_key is allowed
-            // and signals "fall back to genai's env var default".
             let Some(key) = api_key.filter(|k| !k.is_empty()) else {
-                return Ok(None);
+                return if allow_env_fallback {
+                    Ok(None)
+                } else {
+                    Err("credentials_kind 'bearer' requires api_key unless \
+                         adapter_options.allow_env_credentials is true"
+                        .to_string())
+                };
             };
             Ok(Some(CredentialMaterial::static_bearer(key.clone())))
         }
@@ -331,25 +369,27 @@ mod tests {
     }
 
     #[test]
-    fn build_material_bearer_without_key_returns_none_for_env_fallback() {
-        // 0.4.0 contract: omitting api_key is allowed and means "use the
-        // adapter's env var default". Material returns None so the broker
-        // is bypassed entirely.
+    fn build_material_bearer_without_key_is_rejected_by_default() {
+        let err = build_material("openai", CredentialKind::Bearer, None)
+            .expect_err("missing bearer api_key must fail closed");
+        assert!(err.contains("api_key"));
+    }
+
+    #[test]
+    fn build_material_bearer_env_fallback_requires_explicit_opt_in() {
         assert!(
-            build_material("openai", CredentialKind::Bearer, None)
+            build_material_allowing_env_fallback("openai", CredentialKind::Bearer, None)
                 .unwrap()
                 .is_none()
         );
     }
 
     #[test]
-    fn build_material_bearer_with_empty_key_returns_none_not_error() {
+    fn build_material_bearer_with_empty_key_is_rejected_by_default() {
         let key = RedactedString::new("");
-        assert!(
-            build_material("openai", CredentialKind::Bearer, Some(&key))
-                .unwrap()
-                .is_none()
-        );
+        let err = build_material("openai", CredentialKind::Bearer, Some(&key))
+            .expect_err("empty bearer api_key must fail closed");
+        assert!(err.contains("api_key"));
     }
 
     #[test]

--- a/crates/awaken-runtime/src/credentials/mod.rs
+++ b/crates/awaken-runtime/src/credentials/mod.rs
@@ -18,7 +18,7 @@
 //!
 //! Static bearers bypass the broker on the production hot path (see
 //! `awaken_server::services::config_runtime::build_genai_provider_executor`)
-//! because there is no token to refresh — it is identical to 0.4.0 wiring.
+//! because there is no token to refresh.
 //! The broker still accepts static-bearer material for embedders that
 //! want everything funnelled through one chokepoint and for tests.
 //!
@@ -30,6 +30,11 @@
 //! |----------------------------|------------------------------------|-----------------|
 //! | absent / `"bearer"`        | OAuth bearer or static API key     | operator-managed|
 //! | `"service_account_json"`   | full Google service-account JSON   | broker, automatic|
+//!
+//! Bearer providers without `api_key` fail closed by default. Set
+//! `ProviderSpec.adapter_options.allow_env_credentials = true` only when the
+//! provider should intentionally use the host environment's adapter-specific
+//! credential variable.
 //!
 //! Compatibility rules and validation live in [`material::build_material`].
 //!
@@ -51,5 +56,8 @@ mod token;
 
 pub use broker::{AwakenCredentialBroker, CredentialBroker, CredentialRetryPolicy};
 pub use error::CredentialError;
-pub use material::{CredentialKind, CredentialMaterial, GoogleServiceAccountKey, build_material};
+pub use material::{
+    CredentialKind, CredentialMaterial, GoogleServiceAccountKey,
+    allow_env_credentials_from_options, build_material, build_material_allowing_env_fallback,
+};
 pub use token::IssuedToken;

--- a/crates/awaken-runtime/src/extensions/a2a/a2a_backend.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/a2a_backend.rs
@@ -21,25 +21,29 @@ use awaken_runtime_contract::contract::event_sink::EventSink;
 use awaken_runtime_contract::contract::identity::RunIdentity;
 use awaken_runtime_contract::contract::lifecycle::TerminationReason;
 use awaken_runtime_contract::contract::message::{Message, Role, Visibility};
-use awaken_runtime_contract::now_ms;
 use awaken_runtime_contract::registry_spec::RemoteEndpoint;
 use awaken_runtime_contract::state::PersistedState;
 use futures::StreamExt;
 use parking_lot::Mutex;
-use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::{sync::Arc, time::Duration};
 
 mod checkpoint;
+mod remote_state;
 use checkpoint::persist_accepted_checkpoint;
+#[cfg(test)]
+use remote_state::{PersistedA2aThreadState, REMOTE_STATE_KEY, REMOTE_STATE_SCHEMA_VERSION};
+use remote_state::{
+    persisted_abort_task_id, read_remote_state_entry, reusable_prior_task_id,
+    update_persisted_state, update_persisted_state_from_direct,
+};
 
 const A2A_VERSION: &str = "1.0";
 const A2A_BACKEND: &str = "a2a";
 const A2A_TASK_PROGRESS_ACTIVITY_TYPE: &str = "a2a-task-progress";
 const HISTORY_LENGTH_OPTION_KEY: &str = "history_length";
 const POLL_INTERVAL_OPTION_KEY: &str = "poll_interval_ms";
-const REMOTE_STATE_KEY: &str = "__runtime_remote_backend";
 const RETURN_IMMEDIATELY_OPTION_KEY: &str = "return_immediately";
 const WAIT_REASON_AUTH_REQUIRED: &str = "auth_required";
 const WAIT_REASON_INPUT_REQUIRED: &str = "input_required";
@@ -235,38 +239,10 @@ impl ExecutionBackendFactory for A2aBackendFactory {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-struct PersistedRemoteBackendState {
-    #[serde(default = "remote_state_schema_version")]
-    version: u32,
-    #[serde(default)]
-    targets: BTreeMap<String, PersistedA2aThreadState>,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-struct PersistedA2aThreadState {
-    #[serde(default = "remote_state_schema_version")]
-    version: u32,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    task_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    context_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    last_state: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    updated_at_ms: Option<u64>,
-}
-
 #[derive(Debug)]
 enum SubmissionOutcome {
     DirectMessage(DirectMessageSnapshot),
     Task(TaskSnapshot),
-}
-
-const REMOTE_STATE_SCHEMA_VERSION: u32 = 1;
-
-fn remote_state_schema_version() -> u32 {
-    REMOTE_STATE_SCHEMA_VERSION
 }
 
 enum A2aExecutionRequest<'a> {
@@ -403,8 +379,10 @@ impl A2aBackend {
         request: &A2aExecutionRequest<'_>,
         persisted: Option<&PersistedState>,
     ) -> Result<A2aMessage, ExecutionBackendError> {
-        let prior_state =
-            persisted.and_then(|state| read_remote_state_entry(state, &self.remote_target_key()));
+        let prior_state = persisted
+            .map(|state| read_remote_state_entry(state, &self.remote_target_key()))
+            .transpose()?
+            .flatten();
         let parts = request
             .turn_messages()
             .iter()
@@ -671,12 +649,13 @@ impl ExecutionBackend for A2aBackend {
     }
 
     async fn abort(&self, request: BackendAbortRequest<'_>) -> Result<(), ExecutionBackendError> {
+        let persisted_task_id = persisted_abort_task_id(&request, &self.remote_target_key())?;
         let Some(task_id) = self
             .in_flight_tasks
             .lock()
             .get(&request.run_identity.run_id)
             .cloned()
-            .or_else(|| persisted_abort_task_id(&request, &self.remote_target_key()))
+            .or(persisted_task_id)
         else {
             return Ok(());
         };
@@ -748,7 +727,7 @@ impl A2aBackend {
                         persisted_state,
                         &self.remote_target_key(),
                         &snapshot,
-                    ),
+                    )?,
                     thread_state: None, // A2A state is opaque; all keys ride on `state` (C4).
                 })
             }
@@ -763,7 +742,7 @@ impl A2aBackend {
                     persisted_state,
                     &self.remote_target_key(),
                     &submitted_snapshot,
-                );
+                )?;
                 persist_accepted_checkpoint(&request, accepted_state.clone()).await?;
                 emit_task_progress(&sink, &submitted_snapshot).await;
                 let completion = self.observe_to_completion(submitted_snapshot, &sink).await;
@@ -789,7 +768,7 @@ impl A2aBackend {
                         accepted_state,
                         &self.remote_target_key(),
                         &snapshot,
-                    ),
+                    )?,
                     thread_state: None,
                 })
             }
@@ -1178,119 +1157,6 @@ fn task_progress_content(snapshot: &TaskSnapshot) -> Value {
         "failure_message": snapshot.failure_message.clone(),
     })
 }
-fn update_persisted_state(
-    state: Option<PersistedState>,
-    target_key: &str,
-    snapshot: &TaskSnapshot,
-) -> Option<PersistedState> {
-    let mut persisted = state.unwrap_or(PersistedState {
-        revision: 0,
-        extensions: HashMap::new(),
-    });
-    let mut remote_state = persisted
-        .extensions
-        .remove(REMOTE_STATE_KEY)
-        .and_then(|value| serde_json::from_value::<PersistedRemoteBackendState>(value).ok())
-        .unwrap_or_default();
-    remote_state.version = REMOTE_STATE_SCHEMA_VERSION;
-    remote_state.targets.insert(
-        target_key.to_string(),
-        PersistedA2aThreadState {
-            version: REMOTE_STATE_SCHEMA_VERSION,
-            task_id: Some(snapshot.task_id.clone()),
-            context_id: snapshot.context_id.clone(),
-            last_state: Some(task_state_name(snapshot.state).to_string()),
-            updated_at_ms: Some(now_ms()),
-        },
-    );
-    persisted.extensions.insert(
-        REMOTE_STATE_KEY.to_string(),
-        serde_json::to_value(remote_state).ok()?,
-    );
-    Some(persisted)
-}
-
-fn update_persisted_state_from_direct(
-    state: Option<PersistedState>,
-    target_key: &str,
-    snapshot: &DirectMessageSnapshot,
-) -> Option<PersistedState> {
-    if snapshot.task_id.is_none() && snapshot.context_id.is_none() {
-        return state;
-    }
-
-    let mut persisted = state.unwrap_or(PersistedState {
-        revision: 0,
-        extensions: HashMap::new(),
-    });
-    let mut remote_state = persisted
-        .extensions
-        .remove(REMOTE_STATE_KEY)
-        .and_then(|value| serde_json::from_value::<PersistedRemoteBackendState>(value).ok())
-        .unwrap_or_default();
-    let prior = remote_state
-        .targets
-        .get(target_key)
-        .cloned()
-        .unwrap_or_default();
-
-    remote_state.version = REMOTE_STATE_SCHEMA_VERSION;
-    remote_state.targets.insert(
-        target_key.to_string(),
-        PersistedA2aThreadState {
-            version: REMOTE_STATE_SCHEMA_VERSION,
-            task_id: snapshot.task_id.clone().or(prior.task_id),
-            context_id: snapshot.context_id.clone().or(prior.context_id),
-            last_state: Some("DIRECT_MESSAGE".to_string()),
-            updated_at_ms: Some(now_ms()),
-        },
-    );
-
-    persisted.extensions.insert(
-        REMOTE_STATE_KEY.to_string(),
-        serde_json::to_value(remote_state).ok()?,
-    );
-    Some(persisted)
-}
-
-fn read_remote_state_entry(
-    state: &PersistedState,
-    target_key: &str,
-) -> Option<PersistedA2aThreadState> {
-    state
-        .extensions
-        .get(REMOTE_STATE_KEY)
-        .cloned()
-        .and_then(|value| serde_json::from_value::<PersistedRemoteBackendState>(value).ok())
-        .and_then(|state| state.targets.get(target_key).cloned())
-}
-
-fn persisted_abort_task_id(request: &BackendAbortRequest<'_>, target_key: &str) -> Option<String> {
-    request
-        .persisted_state
-        .and_then(|state| read_remote_state_entry(state, target_key))
-        .and_then(|state| reusable_prior_task_id(&state))
-}
-
-fn reusable_prior_task_id(state: &PersistedA2aThreadState) -> Option<String> {
-    if state
-        .last_state
-        .as_deref()
-        .is_some_and(is_interrupted_remote_state)
-    {
-        state.task_id.clone()
-    } else {
-        None
-    }
-}
-
-fn is_interrupted_remote_state(state: &str) -> bool {
-    matches!(
-        state,
-        "TASK_STATE_INPUT_REQUIRED" | "TASK_STATE_AUTH_REQUIRED"
-    )
-}
-
 fn extract_output_text(task: &Task) -> Option<String> {
     for artifact in &task.artifacts {
         if let Some(text) = extract_text_from_parts(&artifact.parts) {
@@ -1900,16 +1766,33 @@ mod tests {
                 failure_message: None,
             },
         )
-        .expect("state should serialize");
+        .expect("state should serialize")
+        .expect("state should be present");
 
         let remote =
             read_remote_state_entry(&persisted, "a2a:https://gateway.example.com/v1/a2a/worker")
+                .expect("remote state should decode")
                 .expect("remote state entry");
         assert_eq!(remote.task_id.as_deref(), Some("task-1"));
         assert_eq!(remote.context_id.as_deref(), Some("ctx-1"));
         assert_eq!(remote.last_state.as_deref(), Some("TASK_STATE_COMPLETED"));
         assert_eq!(remote.version, REMOTE_STATE_SCHEMA_VERSION);
         assert!(remote.updated_at_ms.is_some());
+    }
+
+    #[test]
+    fn corrupt_persisted_remote_state_is_not_treated_as_missing() {
+        let mut extensions = HashMap::new();
+        extensions.insert(REMOTE_STATE_KEY.to_string(), json!({"targets": []}));
+        let persisted = PersistedState {
+            revision: 0,
+            extensions,
+        };
+
+        let error =
+            read_remote_state_entry(&persisted, "a2a:https://gateway.example.com/v1/a2a/worker")
+                .expect_err("corrupt persisted remote state must fail closed");
+        assert!(error.to_string().contains(REMOTE_STATE_KEY));
     }
 
     #[test]
@@ -1966,7 +1849,8 @@ mod tests {
                 failure_message: None,
             },
         )
-        .expect("persisted remote state");
+        .expect("persisted remote state")
+        .expect("persisted remote state must be present");
         let run_identity = RunIdentity::new(
             "thread-1".into(),
             None,
@@ -1984,7 +1868,9 @@ mod tests {
         };
 
         assert_eq!(
-            persisted_abort_task_id(&request, target_key).as_deref(),
+            persisted_abort_task_id(&request, target_key)
+                .expect("persisted abort state should decode")
+                .as_deref(),
             Some("waiting-task")
         );
     }
@@ -2004,7 +1890,8 @@ mod tests {
                 failure_message: None,
             },
         )
-        .expect("persisted remote state");
+        .expect("persisted remote state")
+        .expect("persisted remote state must be present");
         let run_identity = RunIdentity::new(
             "thread-1".into(),
             None,
@@ -2021,7 +1908,11 @@ mod tests {
             is_continuation: false,
         };
 
-        assert_eq!(persisted_abort_task_id(&request, target_key), None);
+        assert_eq!(
+            persisted_abort_task_id(&request, target_key)
+                .expect("persisted abort state should decode"),
+            None
+        );
     }
 
     #[test]
@@ -2035,10 +1926,12 @@ mod tests {
                 output: BackendRunOutput::from_text(Some("done".into())),
             },
         )
-        .expect("direct message state should serialize");
+        .expect("direct message state should serialize")
+        .expect("direct message state should be present");
 
         let remote =
             read_remote_state_entry(&persisted, "a2a:https://gateway.example.com/v1/a2a/worker")
+                .expect("remote state should decode")
                 .expect("remote state entry");
         assert_eq!(remote.task_id.as_deref(), Some("task-direct"));
         assert_eq!(remote.context_id.as_deref(), Some("ctx-direct"));
@@ -2063,7 +1956,7 @@ mod tests {
         )
         .expect("state should pass through");
 
-        assert_eq!(persisted, original);
+        assert_eq!(persisted, Some(original));
     }
 
     #[tokio::test]
@@ -2084,7 +1977,8 @@ mod tests {
                 failure_message: None,
             },
         )
-        .expect("continued state");
+        .expect("continued state")
+        .expect("continued state must be present");
         let newer_state = update_persisted_state(
             None,
             &target_key,
@@ -2097,7 +1991,8 @@ mod tests {
                 failure_message: None,
             },
         )
-        .expect("newer state");
+        .expect("newer state")
+        .expect("newer state must be present");
 
         let store = InMemoryStore::new();
         store
@@ -2114,7 +2009,7 @@ mod tests {
                     request: None,
                     input: None,
                     output: None,
-                    status: RunStatus::Waiting,
+                    status: RunStatus::Created,
                     termination_reason: None,
                     final_output: None,
                     error_payload: None,
@@ -2149,7 +2044,7 @@ mod tests {
                     request: None,
                     input: None,
                     output: None,
-                    status: RunStatus::Done,
+                    status: RunStatus::Created,
                     termination_reason: None,
                     final_output: None,
                     error_payload: None,
@@ -2204,7 +2099,9 @@ mod tests {
             .await
             .expect("load state")
             .expect("state");
-        let remote = read_remote_state_entry(&state, &target_key).expect("remote state");
+        let remote = read_remote_state_entry(&state, &target_key)
+            .expect("remote state should decode")
+            .expect("remote state");
         assert_eq!(remote.task_id.as_deref(), Some("continued-task"));
         assert_eq!(remote.context_id.as_deref(), Some("continued-context"));
     }

--- a/crates/awaken-runtime/src/extensions/a2a/a2a_backend/remote_state.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/a2a_backend/remote_state.rs
@@ -1,0 +1,176 @@
+use std::collections::{BTreeMap, HashMap};
+
+use awaken_runtime_contract::now_ms;
+use awaken_runtime_contract::state::PersistedState;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::backend::{BackendAbortRequest, ExecutionBackendError};
+
+use super::{DirectMessageSnapshot, TaskSnapshot, task_state_name};
+
+pub(super) const REMOTE_STATE_KEY: &str = "__runtime_remote_backend";
+pub(super) const REMOTE_STATE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct PersistedRemoteBackendState {
+    #[serde(default = "remote_state_schema_version")]
+    version: u32,
+    #[serde(default)]
+    targets: BTreeMap<String, PersistedA2aThreadState>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) struct PersistedA2aThreadState {
+    #[serde(default = "remote_state_schema_version")]
+    pub(super) version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) context_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) last_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) updated_at_ms: Option<u64>,
+}
+
+fn remote_state_schema_version() -> u32 {
+    REMOTE_STATE_SCHEMA_VERSION
+}
+
+pub(super) fn update_persisted_state(
+    state: Option<PersistedState>,
+    target_key: &str,
+    snapshot: &TaskSnapshot,
+) -> Result<Option<PersistedState>, ExecutionBackendError> {
+    let mut persisted = state.unwrap_or(PersistedState {
+        revision: 0,
+        extensions: HashMap::new(),
+    });
+    let mut remote_state =
+        decode_persisted_remote_state(persisted.extensions.remove(REMOTE_STATE_KEY))?;
+    remote_state.version = REMOTE_STATE_SCHEMA_VERSION;
+    remote_state.targets.insert(
+        target_key.to_string(),
+        PersistedA2aThreadState {
+            version: REMOTE_STATE_SCHEMA_VERSION,
+            task_id: Some(snapshot.task_id.clone()),
+            context_id: snapshot.context_id.clone(),
+            last_state: Some(task_state_name(snapshot.state).to_string()),
+            updated_at_ms: Some(now_ms()),
+        },
+    );
+    persisted.extensions.insert(
+        REMOTE_STATE_KEY.to_string(),
+        encode_persisted_remote_state(remote_state)?,
+    );
+    Ok(Some(persisted))
+}
+
+pub(super) fn update_persisted_state_from_direct(
+    state: Option<PersistedState>,
+    target_key: &str,
+    snapshot: &DirectMessageSnapshot,
+) -> Result<Option<PersistedState>, ExecutionBackendError> {
+    if snapshot.task_id.is_none() && snapshot.context_id.is_none() {
+        return Ok(state);
+    }
+
+    let mut persisted = state.unwrap_or(PersistedState {
+        revision: 0,
+        extensions: HashMap::new(),
+    });
+    let mut remote_state =
+        decode_persisted_remote_state(persisted.extensions.remove(REMOTE_STATE_KEY))?;
+    let prior = remote_state
+        .targets
+        .get(target_key)
+        .cloned()
+        .unwrap_or_default();
+
+    remote_state.version = REMOTE_STATE_SCHEMA_VERSION;
+    remote_state.targets.insert(
+        target_key.to_string(),
+        PersistedA2aThreadState {
+            version: REMOTE_STATE_SCHEMA_VERSION,
+            task_id: snapshot.task_id.clone().or(prior.task_id),
+            context_id: snapshot.context_id.clone().or(prior.context_id),
+            last_state: Some("DIRECT_MESSAGE".to_string()),
+            updated_at_ms: Some(now_ms()),
+        },
+    );
+
+    persisted.extensions.insert(
+        REMOTE_STATE_KEY.to_string(),
+        encode_persisted_remote_state(remote_state)?,
+    );
+    Ok(Some(persisted))
+}
+
+pub(super) fn read_remote_state_entry(
+    state: &PersistedState,
+    target_key: &str,
+) -> Result<Option<PersistedA2aThreadState>, ExecutionBackendError> {
+    Ok(
+        decode_persisted_remote_state(state.extensions.get(REMOTE_STATE_KEY).cloned())?
+            .targets
+            .get(target_key)
+            .cloned(),
+    )
+}
+
+pub(super) fn persisted_abort_task_id(
+    request: &BackendAbortRequest<'_>,
+    target_key: &str,
+) -> Result<Option<String>, ExecutionBackendError> {
+    Ok(request
+        .persisted_state
+        .map(|state| read_remote_state_entry(state, target_key))
+        .transpose()?
+        .flatten()
+        .and_then(|state| reusable_prior_task_id(&state)))
+}
+
+pub(super) fn reusable_prior_task_id(state: &PersistedA2aThreadState) -> Option<String> {
+    if state
+        .last_state
+        .as_deref()
+        .is_some_and(is_interrupted_remote_state)
+    {
+        state.task_id.clone()
+    } else {
+        None
+    }
+}
+
+fn decode_persisted_remote_state(
+    value: Option<Value>,
+) -> Result<PersistedRemoteBackendState, ExecutionBackendError> {
+    match value {
+        Some(value) => {
+            serde_json::from_value::<PersistedRemoteBackendState>(value).map_err(|error| {
+                ExecutionBackendError::ExecutionFailed(format!(
+                    "corrupt A2A persisted remote state at {REMOTE_STATE_KEY}: {error}"
+                ))
+            })
+        }
+        None => Ok(PersistedRemoteBackendState::default()),
+    }
+}
+
+fn encode_persisted_remote_state(
+    state: PersistedRemoteBackendState,
+) -> Result<Value, ExecutionBackendError> {
+    serde_json::to_value(state).map_err(|error| {
+        ExecutionBackendError::ExecutionFailed(format!(
+            "failed to encode A2A persisted remote state: {error}"
+        ))
+    })
+}
+
+fn is_interrupted_remote_state(state: &str) -> bool {
+    matches!(
+        state,
+        "TASK_STATE_INPUT_REQUIRED" | "TASK_STATE_AUTH_REQUIRED"
+    )
+}

--- a/crates/awaken-runtime/src/extensions/background/cancel_task_tool.rs
+++ b/crates/awaken-runtime/src/extensions/background/cancel_task_tool.rs
@@ -177,8 +177,15 @@ impl Tool for CancelTaskTool {
     }
 
     async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
+        self.validate_args(&args)?;
         let current_scope = self.current_scope(ctx);
-        let relation = args["target"]["relation"].as_str().unwrap_or_default();
+        let target = args
+            .get("target")
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'target'".into()))?;
+        let relation = target
+            .get("relation")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'target.relation'".into()))?;
         let (root_task_id, cancelled_count) = match relation {
             "self" => {
                 let scope = current_scope.clone().ok_or_else(|| {
@@ -207,12 +214,16 @@ impl Tool for CancelTaskTool {
                 let scope = current_scope.clone().ok_or_else(|| {
                     ToolError::ExecutionFailed(CancelTaskError::CurrentTaskUnavailable.to_string())
                 })?;
-                let name = args["target"]["name"].as_str().unwrap_or_default();
+                let name = target
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| ToolError::InvalidArguments("child requires 'name'".into()))?;
                 let Some(child_task_id) = self.resolve_child(&scope, name) else {
                     let receipt = Self::make_error(name.to_string(), CancelTaskError::TaskNotFound);
                     return Ok(ToolResult::success(
                         CANCEL_TASK_TOOL_ID,
-                        serde_json::to_value(receipt).unwrap_or_default(),
+                        serde_json::to_value(receipt)
+                            .map_err(|e| ToolError::Internal(e.to_string()))?,
                     )
                     .into());
                 };
@@ -234,7 +245,7 @@ impl Tool for CancelTaskTool {
 
         Ok(ToolResult::success(
             CANCEL_TASK_TOOL_ID,
-            serde_json::to_value(receipt).unwrap_or_default(),
+            serde_json::to_value(receipt).map_err(|e| ToolError::Internal(e.to_string()))?,
         )
         .into())
     }
@@ -321,6 +332,20 @@ mod tests {
             tool.validate_args(&json!({"target": {"relation": "child"}}))
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_invalid_args() {
+        let (manager, store) = make_manager_and_store();
+        let tool = CancelTaskTool::new(manager);
+        let ctx = make_ctx_with_store_and_task("thread-1", "agent-1", &store, None);
+
+        let error = tool
+            .execute(json!({"target": {"relation": "child"}}), &ctx)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ToolError::InvalidArguments(_)));
     }
 
     #[tokio::test]

--- a/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
+++ b/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
@@ -255,9 +255,18 @@ impl Tool for SendMessageTool {
     }
 
     async fn execute(&self, args: Value, ctx: &ToolCallContext) -> Result<ToolOutput, ToolError> {
-        let to = &args["to"];
-        let relation = to["relation"].as_str().unwrap_or_default();
-        let message = args["message"].as_str().unwrap_or_default();
+        self.validate_args(&args)?;
+        let to = args
+            .get("to")
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'to'".into()))?;
+        let relation = to
+            .get("relation")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'to.relation'".into()))?;
+        let message = args
+            .get("message")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'message'".into()))?;
         let sender = &ctx.run_identity.agent_id;
         let thread_id = &ctx.run_identity.thread_id;
         let msg_id = uuid::Uuid::now_v7().to_string();
@@ -268,7 +277,10 @@ impl Tool for SendMessageTool {
         //   agent  → durable mailbox (cross-thread)
         let receipt = match relation {
             "child" => {
-                let name = to["name"].as_str().unwrap_or_default();
+                let name = to
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| ToolError::InvalidArguments("child requires 'name'".into()))?;
                 match self.resolve_child(name, thread_id, ctx) {
                     Some(task_id) => {
                         match self
@@ -306,8 +318,14 @@ impl Tool for SendMessageTool {
                 None => Self::make_error(MessageError::RecipientUnavailable),
             },
             "agent" => {
-                let target_thread = to["thread_id"].as_str().unwrap_or_default();
-                let target_agent = to["agent_id"].as_str().unwrap_or_default();
+                let target_thread =
+                    to.get("thread_id").and_then(Value::as_str).ok_or_else(|| {
+                        ToolError::InvalidArguments("agent requires 'thread_id'".into())
+                    })?;
+                let target_agent = to
+                    .get("agent_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
                 match self
                     .send_durable(target_thread, target_agent, sender, message)
                     .await
@@ -321,7 +339,7 @@ impl Tool for SendMessageTool {
 
         Ok(ToolResult::success(
             SEND_MESSAGE_TOOL_ID,
-            serde_json::to_value(&receipt).unwrap_or_default(),
+            serde_json::to_value(&receipt).map_err(|e| ToolError::Internal(e.to_string()))?,
         )
         .into())
     }
@@ -582,6 +600,20 @@ mod tests {
             t.validate_args(&json!({"to": {"relation": "agent"}, "message": "hi"}))
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_invalid_args() {
+        let (manager, _store) = make_manager_and_store();
+        let tool = make_tool(manager);
+        let ctx = make_ctx("thread-1", "agent-1");
+
+        let error = tool
+            .execute(json!({"to": {"relation": "child"}, "message": "hi"}), &ctx)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ToolError::InvalidArguments(_)));
     }
 
     #[test]

--- a/crates/awaken-runtime/src/inbox.rs
+++ b/crates/awaken-runtime/src/inbox.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use awaken_runtime_contract::contract::message::{Message, Visibility};
 use futures::channel::mpsc;
+use thiserror::Error;
 
 /// Callback invoked when [`InboxSender::send`] detects the receiver is gone.
 ///
@@ -167,25 +168,46 @@ pub fn is_pending_boundary_wake_payload(json: &serde_json::Value) -> bool {
     json.get("kind").and_then(|kind| kind.as_str()) == Some("pending_boundary_wake")
 }
 
+#[derive(Debug, Error)]
+pub enum InboxPayloadError {
+    #[error("inbox messages payload is missing a messages array")]
+    MissingMessagesArray,
+    #[error("invalid inbox message at index {index}: {source}")]
+    InvalidMessage {
+        index: usize,
+        source: serde_json::Error,
+    },
+}
+
+/// Convert any inbox payload into messages, rejecting malformed direct-message
+/// payloads instead of dropping entries.
+pub fn try_inbox_payload_messages(
+    json: &serde_json::Value,
+) -> Result<Vec<Message>, InboxPayloadError> {
+    if json.get("kind").and_then(|kind| kind.as_str()) != Some("messages") {
+        return Ok(vec![inbox_event_message(json)]);
+    }
+    let values = json
+        .get("messages")
+        .and_then(|messages| messages.as_array())
+        .ok_or(InboxPayloadError::MissingMessagesArray)?;
+
+    values
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            serde_json::from_value::<Message>(value.clone())
+                .map_err(|source| InboxPayloadError::InvalidMessage { index, source })
+        })
+        .collect()
+}
+
 /// Convert any inbox payload into messages for the owner agent.
 ///
 /// Unknown payloads are treated as background-task events to preserve the
 /// historical inbox behavior.
 pub fn inbox_payload_messages(json: &serde_json::Value) -> Vec<Message> {
-    if json.get("kind").and_then(|kind| kind.as_str()) == Some("messages")
-        && let Some(values) = json
-            .get("messages")
-            .and_then(|messages| messages.as_array())
-    {
-        let messages = values
-            .iter()
-            .filter_map(|value| serde_json::from_value::<Message>(value.clone()).ok())
-            .collect::<Vec<_>>();
-        if !messages.is_empty() {
-            return messages;
-        }
-    }
-    vec![inbox_event_message(json)]
+    try_inbox_payload_messages(json).unwrap_or_else(|_| vec![inbox_event_message(json)])
 }
 
 /// Create a new `(InboxSender, InboxReceiver)` pair.
@@ -340,6 +362,25 @@ mod tests {
         );
         assert_eq!(messages[0].visibility, Visibility::All);
         assert_eq!(messages[0].text(), "live steering");
+    }
+
+    #[test]
+    fn try_inbox_payload_messages_rejects_malformed_direct_message() {
+        let mut payload = inbox_messages_payload(vec![Message::user("valid")]);
+        payload["messages"]
+            .as_array_mut()
+            .expect("messages array")
+            .push(serde_json::json!({"role": 7}));
+        let error = try_inbox_payload_messages(&payload)
+            .expect_err("malformed direct inbox message must fail closed");
+        assert!(matches!(
+            error,
+            InboxPayloadError::InvalidMessage { index: 1, .. }
+        ));
+
+        let fallback = inbox_payload_messages(&payload);
+        assert_eq!(fallback.len(), 1);
+        assert_eq!(fallback[0].visibility, Visibility::Internal);
     }
 
     #[test]

--- a/crates/awaken-runtime/src/loop_runner/mod.rs
+++ b/crates/awaken-runtime/src/loop_runner/mod.rs
@@ -101,6 +101,8 @@ pub enum AgentLoopError {
     PhaseError(#[from] awaken_runtime_contract::StateError),
     #[error("runtime error: {0}")]
     RuntimeError(#[from] crate::error::RuntimeError),
+    #[error("invalid activation: {0}")]
+    InvalidActivation(String),
     #[error("invalid resume: {0}")]
     InvalidResume(String),
 }

--- a/crates/awaken-runtime/src/loop_runner/orchestrator.rs
+++ b/crates/awaken-runtime/src/loop_runner/orchestrator.rs
@@ -1,7 +1,7 @@
 //! Main agent loop orchestration.
 
 use crate::context::{TruncationState, try_consume_compaction_event};
-use crate::inbox::{inbox_payload_messages, is_pending_boundary_wake_payload};
+use crate::inbox::{is_pending_boundary_wake_payload, try_inbox_payload_messages};
 use crate::state::StateStore;
 use awaken_runtime_contract::contract::event::AgentEvent;
 use awaken_runtime_contract::contract::lifecycle::{RunStatus, TerminationReason};
@@ -57,7 +57,10 @@ async fn apply_inbox_payloads_at_boundary(
             changed = true;
             continue;
         }
-        inbox_messages.extend(inbox_payload_messages(&payload));
+        inbox_messages.extend(
+            try_inbox_payload_messages(&payload)
+                .map_err(|error| AgentLoopError::InvalidResume(error.to_string()))?,
+        );
     }
     if inbox_messages.is_empty() {
         if wake_pending {

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/mod.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/mod.rs
@@ -16,10 +16,8 @@ use crate::plugins::Plugin;
 use crate::registry::ResolvedBackendAgent;
 use crate::registry::{AgentResolver, ResolvedAgent};
 use crate::resolution::{
-    BackendProfile, BackendRequirements, ExecutionPlan, ExecutionRole, LiveOnlyScope,
-    RegistryResolutionScope, ReplayableResolvedRun, ReplayableScope, ResolutionArtifact,
-    ResolutionRequest, ResolutionTarget, ResolveError as RunResolveError, ResolvedModelBinding,
-    ResolvedRun, ResolvedRunPlan, ResolvedTool, Resolver,
+    ExecutionPlan, ExecutionRole, RegistryResolutionScope, ResolutionRequest, ResolutionTarget,
+    ResolveError as RunResolveError, ResolvedRunPlan, Resolver,
 };
 use async_trait::async_trait;
 use awaken_runtime_contract::contract::executor::LlmExecutor;
@@ -529,12 +527,24 @@ fn resolve_delegate_tools(
 /// resolution logic. `RegistrySet` stays a pure data container.
 pub struct RegistrySetResolver {
     registries: RegistrySet,
+    replayable_snapshot: bool,
 }
 
 impl RegistrySetResolver {
     #[must_use]
     pub fn new(registries: RegistrySet) -> Self {
-        Self { registries }
+        Self {
+            registries,
+            replayable_snapshot: false,
+        }
+    }
+
+    #[must_use]
+    pub fn new_replayable_snapshot(registries: RegistrySet) -> Self {
+        Self {
+            registries,
+            replayable_snapshot: true,
+        }
     }
 }
 
@@ -564,21 +574,18 @@ impl Resolver for RegistrySetResolver {
         &self,
         request: ResolutionRequest,
     ) -> Result<ResolvedRunPlan, RunResolveError> {
+        if matches!(request.resolution_scope, RegistryResolutionScope::Pinned(_))
+            && !self.replayable_snapshot
+        {
+            return Err(RunResolveError::UnsupportedPersistence(
+                "pinned registry resolution requires a materialized replayable snapshot".into(),
+            ));
+        }
         let (agent_id, role) = target_agent_and_role(&request.target);
         let agent_id = agent_id.to_string();
         let execution = resolve_execution_registry_set(&self.registries, &agent_id)
             .map_err(|error| RunResolveError::Runtime(error.to_string()))?;
-        let requirements = BackendRequirements::from_features(&request.features);
-        let profile = backend_profile_for_execution(&execution)?;
-        let plan = resolved_run(
-            execution,
-            role,
-            request.overrides,
-            requirements,
-            profile,
-            request.resolution_scope,
-        )?;
-        Ok(plan)
+        ResolvedRunPlan::from_execution_for_request(execution, role, request)
     }
 }
 
@@ -587,72 +594,6 @@ fn target_agent_and_role(target: &ResolutionTarget) -> (&str, ExecutionRole) {
         ResolutionTarget::Root { agent_id, .. } => (agent_id.as_str(), ExecutionRole::Root),
         ResolutionTarget::Delegate { agent_id, .. } => (agent_id.as_str(), ExecutionRole::Delegate),
         ResolutionTarget::Handoff { agent_id, .. } => (agent_id.as_str(), ExecutionRole::Handoff),
-    }
-}
-
-fn backend_profile_for_execution(
-    execution: &ExecutionPlan,
-) -> Result<BackendProfile, RunResolveError> {
-    match execution {
-        ExecutionPlan::Local(_) => Ok(BackendProfile::full_local()),
-        ExecutionPlan::Remote(agent) => Ok(agent.backend()?.capabilities()),
-    }
-}
-
-fn resolved_run(
-    execution: ExecutionPlan,
-    role: ExecutionRole,
-    overrides: Option<awaken_runtime_contract::contract::inference::InferenceOverride>,
-    requirements: BackendRequirements,
-    backend_profile: BackendProfile,
-    resolution_scope: RegistryResolutionScope,
-) -> Result<ResolvedRunPlan, RunResolveError> {
-    let agent_spec = execution.spec().clone();
-    let upstream_model = match &execution {
-        ExecutionPlan::Local(agent) => agent.upstream_model.clone(),
-        ExecutionPlan::Remote(agent) => agent.spec.model_id.clone(),
-    };
-    let tools = match &execution {
-        ExecutionPlan::Local(agent) => agent
-            .tool_descriptors()
-            .into_iter()
-            .map(|descriptor| ResolvedTool { descriptor })
-            .collect(),
-        ExecutionPlan::Remote(_) => Vec::new(),
-    };
-    match resolution_scope {
-        RegistryResolutionScope::Pinned(resolution_id) => {
-            Ok(ResolvedRunPlan::Replayable(ReplayableResolvedRun {
-                execution: ResolvedRun {
-                    agent_spec,
-                    role,
-                    execution,
-                    model: ResolvedModelBinding { upstream_model },
-                    tools,
-                    overrides,
-                    backend_profile,
-                    requirements,
-                    scope: ReplayableScope,
-                },
-                artifact: ResolutionArtifact { resolution_id },
-            }))
-        }
-        RegistryResolutionScope::Live => {
-            // No server-issued resolution id: the run resolves against the live
-            // registry. Persistent runs are best-effort (resume re-resolves
-            // live); deterministic replay requires a `Pinned` resolution id.
-            Ok(ResolvedRunPlan::LiveOnly(ResolvedRun {
-                agent_spec,
-                role,
-                execution,
-                model: ResolvedModelBinding { upstream_model },
-                tools,
-                overrides,
-                backend_profile,
-                requirements,
-                scope: LiveOnlyScope,
-            }))
-        }
     }
 }
 

--- a/crates/awaken-runtime/src/registry/resolve/pipeline/tests.rs
+++ b/crates/awaken-runtime/src/registry/resolve/pipeline/tests.rs
@@ -13,6 +13,7 @@ use crate::registry::memory::{
     MapAgentSpecRegistry, MapModelRegistry, MapPluginSource, MapProviderRegistry, MapToolRegistry,
 };
 use crate::registry::traits::ModelRegistry;
+use crate::resolution::{RegistryResolutionScope, ResolvedModelBinding, ResolvedTool};
 use async_trait::async_trait;
 use awaken_runtime_contract::contract::executor::{InferenceExecutionError, InferenceRequest};
 use awaken_runtime_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
@@ -1025,6 +1026,263 @@ fn registry_set_resolver_not_found() {
     let resolver = RegistrySetResolver::new(regs);
     let err = AgentResolver::resolve(&resolver, "missing").unwrap_err();
     assert!(matches!(err, RuntimeError::ResolveFailed { .. }));
+}
+
+fn root_request(agent_id: &str, scope: RegistryResolutionScope) -> ResolutionRequest {
+    ResolutionRequest {
+        target: ResolutionTarget::Root {
+            agent_id: agent_id.to_string(),
+            thread_id: "thread-1".to_string(),
+        },
+        resolution_scope: scope,
+        overrides: None,
+        frontend_tools: Vec::new(),
+        features: crate::RunFeatureSet::default(),
+    }
+}
+
+fn plan_model(plan: &ResolvedRunPlan) -> &ResolvedModelBinding {
+    match plan {
+        ResolvedRunPlan::Replayable(plan) => &plan.execution.model,
+        ResolvedRunPlan::LiveOnly(plan) => &plan.model,
+    }
+}
+
+fn plan_tools(plan: &ResolvedRunPlan) -> &[ResolvedTool] {
+    match plan {
+        ResolvedRunPlan::Replayable(plan) => &plan.execution.tools,
+        ResolvedRunPlan::LiveOnly(plan) => &plan.tools,
+    }
+}
+
+#[tokio::test]
+async fn registry_set_resolver_resolves_live_root_plan() {
+    let regs = build_registries(
+        vec![("read", Arc::new(MockTool { id: "read".into() }))],
+        "test-model",
+        ModelSpec::new("test-model", "p", "upstream-live"),
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        make_spec("agent-live"),
+    );
+    let resolver = RegistrySetResolver::new(regs);
+
+    let plan = Resolver::resolve(
+        &resolver,
+        root_request("agent-live", RegistryResolutionScope::Live),
+    )
+    .await
+    .expect("live root resolves");
+
+    assert!(matches!(plan, ResolvedRunPlan::LiveOnly(_)));
+    assert_eq!(plan.resolution_id(), None);
+    assert_eq!(plan.agent_spec().id, "agent-live");
+    assert_eq!(plan.role(), ExecutionRole::Root);
+    assert!(matches!(plan.execution(), ExecutionPlan::Local(_)));
+    assert_eq!(plan_tools(&plan).len(), 1);
+    assert_eq!(plan_model(&plan).upstream_model, "upstream-live");
+}
+
+#[tokio::test]
+async fn registry_set_resolver_rejects_pinned_root_without_snapshot_provenance() {
+    let regs = build_registries(
+        vec![],
+        "test-model",
+        ModelSpec::new("test-model", "p", "upstream-pinned"),
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        make_spec("agent-pinned"),
+    );
+    let resolver = RegistrySetResolver::new(regs);
+
+    let result = Resolver::resolve(
+        &resolver,
+        root_request(
+            "agent-pinned",
+            RegistryResolutionScope::Pinned("publication-42".to_string()),
+        ),
+    )
+    .await;
+    let Err(err) = result else {
+        panic!("ordinary registry set must not claim pinned replayability");
+    };
+
+    assert!(matches!(
+        err,
+        crate::resolution::ResolveError::UnsupportedPersistence(_)
+    ));
+}
+
+#[tokio::test]
+async fn registry_set_resolver_resolves_materialized_pinned_root_as_replayable() {
+    let regs = build_registries(
+        vec![],
+        "test-model",
+        ModelSpec::new("test-model", "p", "upstream-pinned"),
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        make_spec("agent-pinned"),
+    );
+    let resolver = RegistrySetResolver::new_replayable_snapshot(regs);
+
+    let plan = Resolver::resolve(
+        &resolver,
+        root_request(
+            "agent-pinned",
+            RegistryResolutionScope::Pinned("publication-42".to_string()),
+        ),
+    )
+    .await
+    .expect("materialized pinned root resolves");
+
+    assert!(matches!(plan, ResolvedRunPlan::Replayable(_)));
+    assert_eq!(plan.resolution_id(), Some("publication-42"));
+    assert_eq!(plan.agent_spec().id, "agent-pinned");
+    assert_eq!(plan.role(), ExecutionRole::Root);
+    assert_eq!(plan_model(&plan).upstream_model, "upstream-pinned");
+}
+
+#[tokio::test]
+async fn registry_set_agent_resolver_and_run_resolver_share_local_resolution() {
+    use crate::registry::AgentResolver;
+
+    let regs = build_registries(
+        vec![("read", Arc::new(MockTool { id: "read".into() }))],
+        "test-model",
+        ModelSpec::new("test-model", "p", "shared-upstream"),
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        make_spec("agent-shared"),
+    );
+    let resolver = RegistrySetResolver::new(regs);
+
+    let agent = AgentResolver::resolve(&resolver, "agent-shared").expect("agent resolves");
+    let plan = Resolver::resolve(
+        &resolver,
+        root_request("agent-shared", RegistryResolutionScope::Live),
+    )
+    .await
+    .expect("run plan resolves");
+
+    assert_eq!(agent.id(), plan.agent_spec().id);
+    assert_eq!(agent.upstream_model, plan_model(&plan).upstream_model);
+    assert_eq!(agent.tool_descriptors().len(), plan_tools(&plan).len());
+}
+
+#[tokio::test]
+async fn dynamic_registry_resolver_uses_current_snapshot_for_run_plan() {
+    let initial = build_registries(
+        vec![],
+        "test-model",
+        ModelSpec::new("test-model", "p", "upstream-v1"),
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        make_spec("agent-v1"),
+    );
+    let replacement = build_registries(
+        vec![],
+        "test-model",
+        ModelSpec::new("test-model", "p", "upstream-v2"),
+        "p",
+        Arc::new(MockExecutor),
+        vec![],
+        make_spec("agent-v2"),
+    );
+    let handle = RegistryHandle::new(initial);
+    let resolver = DynamicRegistryResolver::new(handle.clone());
+
+    let v1 = Resolver::resolve(
+        &resolver,
+        root_request("agent-v1", RegistryResolutionScope::Live),
+    )
+    .await
+    .expect("initial snapshot resolves");
+    assert_eq!(v1.agent_spec().id, "agent-v1");
+
+    handle.replace(replacement);
+    let v2 = Resolver::resolve(
+        &resolver,
+        root_request("agent-v2", RegistryResolutionScope::Live),
+    )
+    .await
+    .expect("replacement snapshot resolves");
+    assert_eq!(v2.agent_spec().id, "agent-v2");
+    assert_eq!(plan_model(&v2).upstream_model, "upstream-v2");
+}
+
+#[cfg(feature = "a2a")]
+#[tokio::test]
+async fn registry_set_resolver_resolves_remote_root_plan() {
+    let validate_count = Arc::new(AtomicUsize::new(0));
+    let build_count = Arc::new(AtomicUsize::new(0));
+    let remote = AgentSpec {
+        id: "remote-root".into(),
+        endpoint: Some(RemoteEndpoint {
+            backend: "test-backend".into(),
+            base_url: "https://remote.example.com".into(),
+            ..Default::default()
+        }),
+        ..make_spec("remote-root")
+    };
+
+    let mut model_reg = MapModelRegistry::new();
+    model_reg
+        .register_model(ModelSpec::new("test-model", "p", "n"))
+        .unwrap();
+    let mut provider_reg = MapProviderRegistry::new();
+    provider_reg
+        .register_provider("p", Arc::new(MockExecutor))
+        .unwrap();
+    let mut agent_reg = MapAgentSpecRegistry::new();
+    agent_reg.register_spec(remote).unwrap();
+    let mut backends = MapBackendRegistry::with_default_remote_backends();
+    backends
+        .register_backend_factory(Arc::new(StaticBackendFactory {
+            backend: "test-backend",
+            result: DelegateRunResult {
+                agent_id: "remote-root".into(),
+                status: DelegateRunStatus::Completed,
+                termination: TerminationReason::NaturalEnd,
+                status_reason: None,
+                response: Some("ok".into()),
+                output: crate::backend::BackendRunOutput::from_text(Some("ok".into())),
+                steps: 1,
+                run_id: None,
+                inbox: None,
+                state: None,
+                thread_state: None,
+            },
+            validate_count: validate_count.clone(),
+            build_count: build_count.clone(),
+        }))
+        .unwrap();
+
+    let regs = RegistrySet {
+        agents: Arc::new(agent_reg),
+        tools: Arc::new(MapToolRegistry::new()),
+        models: Arc::new(model_reg),
+        providers: Arc::new(provider_reg),
+        plugins: Arc::new(MapPluginSource::new()),
+        backends: Arc::new(backends) as Arc<dyn BackendRegistry>,
+    };
+    let resolver = RegistrySetResolver::new(regs);
+
+    let plan = Resolver::resolve(
+        &resolver,
+        root_request("remote-root", RegistryResolutionScope::Live),
+    )
+    .await
+    .expect("remote root resolves");
+
+    assert!(matches!(plan.execution(), ExecutionPlan::Remote(_)));
+    assert_eq!(plan.agent_spec().id, "remote-root");
+    assert_eq!(validate_count.load(Ordering::SeqCst), 1);
+    assert_eq!(build_count.load(Ordering::SeqCst), 1);
 }
 
 // -- Config validation tests --

--- a/crates/awaken-runtime/src/resolution/local_registry.rs
+++ b/crates/awaken-runtime/src/resolution/local_registry.rs
@@ -1,14 +1,12 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use awaken_runtime_contract::contract::inference::InferenceOverride;
 
-use crate::registry::{AgentResolver, ResolvedAgent};
+use crate::registry::AgentResolver;
 
 use super::{
-    BackendProfile, BackendRequirements, ExecutionPlan, ExecutionRole, LiveOnlyScope,
-    RegistryResolutionScope, ResolutionRequest, ResolutionTarget, ResolveError,
-    ResolvedModelBinding, ResolvedRun, ResolvedRunPlan, ResolvedTool, Resolver,
+    ExecutionRole, RegistryResolutionScope, ResolutionRequest, ResolutionTarget, ResolveError,
+    ResolvedRunPlan, Resolver,
 };
 
 /// `Resolver` backed by an `AgentResolver` registry. Handles root local /
@@ -40,56 +38,6 @@ impl Resolver for LocalRegistryResolver {
             ));
         }
         let execution = self.inner.resolve_execution(agent_id)?;
-        let requirements = BackendRequirements::from_features(&req.features);
-        match execution {
-            ExecutionPlan::Local(agent) => Ok(ResolvedRunPlan::LiveOnly(resolved_local_live(
-                *agent,
-                ExecutionRole::Root,
-                req.overrides,
-                requirements,
-            ))),
-            ExecutionPlan::Remote(agent) => {
-                let backend = agent.backend()?;
-                let profile = backend.capabilities();
-                let upstream_model = agent.spec.model_id.clone();
-                Ok(ResolvedRunPlan::LiveOnly(ResolvedRun {
-                    agent_spec: (*agent.spec).clone(),
-                    role: ExecutionRole::Root,
-                    execution: ExecutionPlan::Remote(agent),
-                    model: ResolvedModelBinding { upstream_model },
-                    tools: Vec::new(),
-                    overrides: req.overrides,
-                    backend_profile: profile,
-                    requirements,
-                    scope: LiveOnlyScope,
-                }))
-            }
-        }
-    }
-}
-
-fn resolved_local_live(
-    agent: ResolvedAgent,
-    role: ExecutionRole,
-    overrides: Option<InferenceOverride>,
-    requirements: BackendRequirements,
-) -> ResolvedRun<LiveOnlyScope> {
-    let tools = agent
-        .tool_descriptors()
-        .into_iter()
-        .map(|descriptor| ResolvedTool { descriptor })
-        .collect();
-    ResolvedRun {
-        agent_spec: (*agent.spec).clone(),
-        role,
-        execution: ExecutionPlan::from_resolved_agent(&agent),
-        model: ResolvedModelBinding {
-            upstream_model: agent.upstream_model.clone(),
-        },
-        tools,
-        overrides,
-        backend_profile: BackendProfile::full_local(),
-        requirements,
-        scope: LiveOnlyScope,
+        ResolvedRunPlan::from_execution_for_request(execution, ExecutionRole::Root, req)
     }
 }

--- a/crates/awaken-runtime/src/resolution/types.rs
+++ b/crates/awaken-runtime/src/resolution/types.rs
@@ -161,6 +161,65 @@ pub enum RootScopeKind {
 }
 
 impl ResolvedRunPlan {
+    pub(crate) fn from_execution_for_request(
+        execution: ExecutionPlan,
+        role: ExecutionRole,
+        request: ResolutionRequest,
+    ) -> Result<Self, ResolveError> {
+        let requirements = BackendRequirements::from_features(&request.features);
+        let backend_profile = execution.backend_profile()?;
+        Ok(Self::from_execution(
+            execution,
+            role,
+            request.overrides,
+            requirements,
+            backend_profile,
+            request.resolution_scope,
+        ))
+    }
+
+    #[must_use]
+    pub(crate) fn from_execution(
+        execution: ExecutionPlan,
+        role: ExecutionRole,
+        overrides: Option<InferenceOverride>,
+        requirements: BackendRequirements,
+        backend_profile: BackendProfile,
+        resolution_scope: RegistryResolutionScope,
+    ) -> Self {
+        let agent_spec = execution.spec().clone();
+        let (upstream_model, tools) = execution_model_and_tools(&execution);
+        match resolution_scope {
+            RegistryResolutionScope::Pinned(resolution_id) => {
+                Self::Replayable(ReplayableResolvedRun {
+                    execution: ResolvedRun {
+                        agent_spec,
+                        role,
+                        execution,
+                        model: ResolvedModelBinding { upstream_model },
+                        tools,
+                        overrides,
+                        backend_profile,
+                        requirements,
+                        scope: ReplayableScope,
+                    },
+                    artifact: ResolutionArtifact { resolution_id },
+                })
+            }
+            RegistryResolutionScope::Live => Self::LiveOnly(ResolvedRun {
+                agent_spec,
+                role,
+                execution,
+                model: ResolvedModelBinding { upstream_model },
+                tools,
+                overrides,
+                backend_profile,
+                requirements,
+                scope: LiveOnlyScope,
+            }),
+        }
+    }
+
     pub fn into_replayable(self) -> Result<ReplayableResolvedRun, ResolveError> {
         match self {
             Self::Replayable(plan) => Ok(plan),
@@ -227,6 +286,20 @@ impl ResolvedRunPlan {
     }
 }
 
+fn execution_model_and_tools(execution: &ExecutionPlan) -> (String, Vec<ResolvedTool>) {
+    match execution {
+        ExecutionPlan::Local(agent) => (
+            agent.upstream_model.clone(),
+            agent
+                .tool_descriptors()
+                .into_iter()
+                .map(|descriptor| ResolvedTool { descriptor })
+                .collect(),
+        ),
+        ExecutionPlan::Remote(agent) => (agent.spec.model_id.clone(), Vec::new()),
+    }
+}
+
 #[derive(Clone)]
 pub struct ReplayableScope;
 
@@ -270,6 +343,13 @@ impl ExecutionPlan {
         match self {
             Self::Local(agent) => agent.spec.as_ref(),
             Self::Remote(agent) => agent.spec.as_ref(),
+        }
+    }
+
+    pub(crate) fn backend_profile(&self) -> Result<BackendProfile, ResolveError> {
+        match self {
+            Self::Local(_) => Ok(BackendProfile::full_local()),
+            Self::Remote(agent) => Ok(agent.backend()?.capabilities()),
         }
     }
 }

--- a/crates/awaken-runtime/src/run.rs
+++ b/crates/awaken-runtime/src/run.rs
@@ -7,7 +7,7 @@ use awaken_runtime_contract::contract::commit_coordinator::CommitCoordinator;
 use awaken_runtime_contract::contract::run::{
     RunInput, RunInputSnapshot, RunIntent, RunKind, RunOptions, RunTraceContext,
 };
-use awaken_runtime_contract::contract::storage::{RunRecord, RunRequestOrigin};
+use awaken_runtime_contract::contract::storage::{RunRecord, RunRequestOrigin, StorageError};
 use awaken_runtime_contract::contract::suspension::ToolCallResume;
 use awaken_runtime_contract::contract::tool_intercept::{AdapterKind, RunMode};
 use awaken_runtime_contract::contract::{
@@ -247,6 +247,7 @@ impl RunActivation {
         self.intent.kind = RunKind::HitlResume {
             run_id: run_id.into(),
         };
+        self.persistence.is_continuation = true;
         self.trace.run_mode = RunMode::Resume;
         self
     }
@@ -364,12 +365,86 @@ impl RunActivation {
         self.capture.thread_context_cache = Some(cache);
         self
     }
+
+    /// Validate activation invariants before runtime execution starts.
+    ///
+    /// This keeps the owned runtime boundary aligned with the persisted
+    /// `RunActivationSnapshot` contract without forcing user-authored
+    /// `NewMessages` to already carry persistence ids.
+    pub fn validate(&self) -> Result<(), RunActivationError> {
+        self.intent.validate()?;
+        self.trace.validate()?;
+
+        match self.intent.kind {
+            RunKind::NewIntent if self.persistence.is_continuation => {
+                return Err(RunActivationError::Validation(
+                    "persistence.is_continuation requires a resume or continuation run kind"
+                        .to_string(),
+                ));
+            }
+            RunKind::HitlResume { .. } | RunKind::ContinuationFromRun { .. }
+                if !self.persistence.is_continuation =>
+            {
+                return Err(RunActivationError::Validation(
+                    "resume and continuation run kinds require persistence.is_continuation"
+                        .to_string(),
+                ));
+            }
+            _ => {}
+        }
+
+        if let RunInput::AlreadyPersisted(snapshot) = &self.input {
+            snapshot.validate()?;
+            if snapshot.thread_id != self.intent.thread_id {
+                return Err(RunActivationError::Validation(format!(
+                    "run activation intent.thread_id '{}' must match input.thread_id '{}'",
+                    self.intent.thread_id, snapshot.thread_id
+                )));
+            }
+        }
+
+        for (idx, (call_id, _)) in self.control.seeded_decisions.iter().enumerate() {
+            require_non_empty(
+                &format!("run activation seeded_decisions[{idx}].call_id"),
+                call_id,
+            )?;
+        }
+        require_optional_non_empty(
+            "run activation run_id_hint",
+            self.persistence.run_id_hint.as_deref(),
+        )?;
+        require_optional_non_empty(
+            "run activation dispatch_id_hint",
+            self.persistence.dispatch_id_hint.as_deref(),
+        )?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum RunActivationError {
     #[error("run activation is missing thread_id")]
     MissingThreadId,
+    #[error("run activation validation failed: {0}")]
+    Validation(String),
+    #[error(transparent)]
+    Contract(#[from] StorageError),
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), RunActivationError> {
+    if value.trim().is_empty() {
+        return Err(RunActivationError::Validation(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+fn require_optional_non_empty(field: &str, value: Option<&str>) -> Result<(), RunActivationError> {
+    if let Some(value) = value {
+        require_non_empty(field, value)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -421,6 +496,57 @@ mod tests {
     fn activation_is_owned_send_static() {
         let activation = RunActivation::new("thread", vec![Message::user("hi")]);
         assert_send_static(activation);
+    }
+
+    #[test]
+    fn activation_validation_rejects_blank_identity_fields() {
+        let activation = RunActivation::new("thread", vec![Message::user("hi")])
+            .with_agent_id(" ")
+            .with_run_id_hint("run-1");
+
+        let err = activation.validate().unwrap_err();
+        assert!(err.to_string().contains("agent_id"));
+    }
+
+    #[test]
+    fn activation_validation_rejects_mismatched_persisted_input_thread() {
+        let activation = RunActivation::new("thread-a", Vec::new()).with_already_persisted_input(
+            RunInputSnapshot {
+                thread_id: "thread-b".into(),
+                ..RunInputSnapshot::default()
+            },
+        );
+
+        let err = activation.validate().unwrap_err();
+        assert!(err.to_string().contains("intent.thread_id"));
+    }
+
+    #[test]
+    fn activation_validation_rejects_orphaned_continuation_hint() {
+        let mut activation = RunActivation::new("thread", Vec::new());
+        activation.persistence.is_continuation = true;
+
+        let err = activation.validate().unwrap_err();
+        assert!(err.to_string().contains("is_continuation"));
+    }
+
+    #[test]
+    fn hitl_resume_builder_sets_continuation_hint() {
+        let activation = RunActivation::new("thread", Vec::new()).with_hitl_resume_run_id("run-1");
+
+        assert!(activation.persistence.is_continuation);
+        activation.validate().unwrap();
+    }
+
+    #[test]
+    fn activation_validation_rejects_resume_without_continuation_hint() {
+        let mut activation = RunActivation::new("thread", Vec::new());
+        activation.intent.kind = RunKind::HitlResume {
+            run_id: "run-1".into(),
+        };
+
+        let err = activation.validate().unwrap_err();
+        assert!(err.to_string().contains("is_continuation"));
     }
 
     /// Pins the routing between builder methods and the three split

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -1,25 +1,34 @@
 //! AgentRuntime::run() implementation.
-use super::AgentRuntime;
+use super::{AgentRuntime, DecisionBatch};
 use crate::backend::{
     BackendControl, BackendLocalRootContext, BackendRootRunRequest, ExecutionBackendError,
     LocalBackend, execute_remote_root_lifecycle, execution_capabilities,
     validate_root_execution_request,
 };
-use crate::loop_runner::{AgentLoopError, AgentRunResult, CommitWiring};
-use crate::registry::AgentResolver;
-use crate::resolution::{ExecutionPlan, ExecutionRole, ResolvedRunPlan};
+use crate::cancellation::CancellationToken;
+use crate::checkpoint_store::RuntimeCheckpointStore;
+use crate::loop_runner::{AgentLoopError, AgentRunResult, CommitWiring, PendingBoundaryHandler};
+use crate::registry::{AgentResolver, RegistrySet};
+use crate::resolution::{
+    BackendProfile, ExecutionPlan, ExecutionRole, PersistenceRequirement, RegistryResolutionScope,
+    ResolutionRequest, ResolutionTarget, ResolvedRunPlan, RunFeatureSet,
+};
 use crate::run::{RunActivation, RunInbox, ThreadContextSnapshot};
 use awaken_runtime_contract::contract::active_agent::ActiveAgentIdKey;
+use awaken_runtime_contract::contract::commit_coordinator::CommitCoordinator;
 use awaken_runtime_contract::contract::event_sink::EventSink;
 use awaken_runtime_contract::contract::identity::{RunIdentity, RunOrigin};
+use awaken_runtime_contract::contract::inference::InferenceOverride;
 use awaken_runtime_contract::contract::message::{
     Message, Role, Visibility, strip_unpaired_tool_calls_from_view,
 };
 use awaken_runtime_contract::contract::run::{RunInput, RunKind};
 use awaken_runtime_contract::contract::storage::RunRecord;
-use awaken_runtime_contract::contract::suspension::ToolCallStatus;
+use awaken_runtime_contract::contract::suspension::{ToolCallResume, ToolCallStatus};
+use awaken_runtime_contract::contract::tool::ToolDescriptor;
 use awaken_runtime_contract::now_ms;
 use awaken_runtime_contract::state::PersistedState;
+use futures::channel::mpsc;
 use std::sync::Arc;
 const DEFAULT_AGENT_ID: &str = "default";
 /// RAII guard that unregisters the active run on drop, ensuring cleanup
@@ -43,6 +52,72 @@ struct PreparedLocalRootExecution {
     /// not already attached a manager + summarizer.
     compaction: Option<CompactionRuntime>,
 }
+struct PreparedRootExecution {
+    messages: Vec<Message>,
+    phase_runtime: Option<crate::phase::PhaseRuntime>,
+    inbox: Option<crate::inbox::InboxReceiver>,
+    live_inbox_sender: Option<crate::inbox::InboxSender>,
+    previous_non_local_state: Option<PersistedState>,
+    compaction: Option<CompactionRuntime>,
+}
+
+struct RootRunSetup {
+    agent_id: String,
+    execution_resolver: Arc<dyn AgentResolver>,
+    resolved_execution: ExecutionPlan,
+    capabilities: BackendProfile,
+    resolution_id_seed: Option<String>,
+}
+
+struct RootRunSetupInput<'a> {
+    requested_agent_id: Option<String>,
+    thread_id: &'a str,
+    thread_ctx: &'a Option<ThreadContextSnapshot>,
+    pinned_registry_set: Option<RegistrySet>,
+    inherited_run_resolver: Option<Arc<dyn crate::resolution::Resolver>>,
+    resolved_plan: Option<ResolvedRunPlan>,
+    overrides: &'a Option<InferenceOverride>,
+    frontend_tools: &'a [ToolDescriptor],
+    has_seeded_decisions: bool,
+    has_live_decision_channel: bool,
+    is_human_resume: bool,
+    is_continuation: bool,
+}
+
+struct RootRunIdentityInput {
+    thread_id: String,
+    parent_thread_id: Option<String>,
+    run_id: String,
+    parent_run_id: Option<String>,
+    agent_id: String,
+    origin: RunOrigin,
+    run_mode: awaken_runtime_contract::contract::tool_intercept::RunMode,
+    adapter: awaken_runtime_contract::contract::tool_intercept::AdapterKind,
+    dispatch_id: Option<String>,
+    session_id: Option<String>,
+    transport_request_id: Option<String>,
+}
+
+struct BackendRequestInput<'a> {
+    agent_id: &'a str,
+    messages: Vec<Message>,
+    new_messages: Vec<Message>,
+    sink: Arc<dyn EventSink>,
+    resolver: &'a dyn AgentResolver,
+    run_identity: RunIdentity,
+    storage: Option<&'a dyn RuntimeCheckpointStore>,
+    commit_coordinator: Option<&'a dyn CommitCoordinator>,
+    resolution_id_seed: Option<&'a str>,
+    resolved_execution: &'a ExecutionPlan,
+    phase_runtime: Option<&'a crate::phase::PhaseRuntime>,
+    control: BackendControl,
+    decisions: Vec<(String, ToolCallResume)>,
+    overrides: Option<InferenceOverride>,
+    frontend_tools: Vec<ToolDescriptor>,
+    inbox: Option<crate::inbox::InboxReceiver>,
+    is_continuation: bool,
+}
+
 /// Per-run context auto-compaction wiring: shared manager + summarizer that
 /// the loop's resolver-wrapper grafts onto every `ResolvedAgent` it produces.
 #[derive(Clone)]
@@ -167,6 +242,9 @@ impl AgentRuntime {
         thread_ctx: Option<ThreadContextSnapshot>,
         resolved_plan: Option<ResolvedRunPlan>,
     ) -> Result<AgentRunResult, AgentLoopError> {
+        activation
+            .validate()
+            .map_err(|error| AgentLoopError::InvalidActivation(error.to_string()))?;
         let RunActivation {
             intent,
             input,
@@ -182,6 +260,7 @@ impl AgentRuntime {
         // the commit by that coordinator, so the runtime carries no buffer.
         let commit_coordinator_override = control.commit_coordinator_override.clone();
         let pinned_registry_set = inherited.pinned_registry_set;
+        let inherited_run_resolver = inherited.run_resolver;
         let run_id_hint = persistence.run_id_hint;
         let dispatch_id_hint = persistence.dispatch_id_hint;
         let (request_messages, input_already_persisted) = match input {
@@ -190,15 +269,16 @@ impl AgentRuntime {
         };
         let messages_already_persisted =
             persistence.messages_already_persisted || input_already_persisted;
-        let (continue_run_id, intent_is_continuation) = match intent.kind {
-            RunKind::NewIntent => (None, false),
-            RunKind::HitlResume { run_id } => (Some(run_id), false),
-            RunKind::ContinuationFromRun { run_id } => (Some(run_id), true),
+        let (continue_run_id, is_human_resume, intent_is_continuation) = match intent.kind {
+            RunKind::NewIntent => (None, false, false),
+            RunKind::HitlResume { run_id } => (Some(run_id), true, false),
+            RunKind::ContinuationFromRun { run_id } => (Some(run_id), false, true),
         };
         let thread_id = intent.thread_id;
         let agent_id = intent.agent_id;
         let overrides = options.overrides;
         let frontend_tools = options.frontend_tools;
+        let has_live_decision_channel = control.decision_rx.is_some();
         let decisions = control.seeded_decisions;
         let (req_origin, run_mode, adapter) = (trace.origin, trace.run_mode, trace.adapter);
         let (req_parent_run_id, req_parent_thread_id) =
@@ -208,29 +288,29 @@ impl AgentRuntime {
         let run_inbox = control.inbox;
         let new_messages = request_messages.clone();
         let requested_continue_run_id = continue_run_id.clone();
-        let agent_id = self
-            .resolve_agent_id(agent_id, &thread_id, &thread_ctx)
+        let root_setup = self
+            .resolve_root_run_setup(RootRunSetupInput {
+                requested_agent_id: agent_id,
+                thread_id: &thread_id,
+                thread_ctx: &thread_ctx,
+                pinned_registry_set,
+                inherited_run_resolver,
+                resolved_plan,
+                overrides: &overrides,
+                frontend_tools: &frontend_tools,
+                has_seeded_decisions: !decisions.is_empty(),
+                has_live_decision_channel,
+                is_human_resume,
+                is_continuation: intent_is_continuation,
+            })
             .await?;
-        let resolver_set =
-            pinned_registry_set.or_else(|| self.registry_snapshot().map(|s| s.into_registries()));
-        let run_resolver: Arc<dyn AgentResolver> = if let Some(set) = resolver_set {
-            Arc::new(crate::registry::resolve::RegistrySetResolver::new(set))
-        } else {
-            self.execution_resolver_arc()
-        };
-        let resolution_id_seed = resolved_plan
-            .as_ref()
-            .and_then(|plan| plan.resolution_id().map(str::to_string));
-        let resolved_execution = if let Some(plan) = resolved_plan {
-            validate_resolved_root_plan(&plan, &agent_id)?;
-            plan.execution().clone()
-        } else {
-            run_resolver
-                .resolve_execution(&agent_id)
-                .map_err(AgentLoopError::RuntimeError)?
-        };
-        let capabilities =
-            execution_capabilities(&resolved_execution).map_err(local_root_execution_error)?;
+        let RootRunSetup {
+            agent_id,
+            execution_resolver,
+            resolved_execution,
+            capabilities,
+            resolution_id_seed,
+        } = root_setup;
         let (run_id, is_continuation) = self
             .next_root_run_id(
                 &thread_id,
@@ -241,74 +321,39 @@ impl AgentRuntime {
                 &thread_ctx,
             )
             .await?;
-        let run_origin: RunOrigin = req_origin;
-        let mut run_identity = RunIdentity::new(
-            thread_id.clone(),
-            req_parent_thread_id,
-            run_id.clone(),
-            req_parent_run_id,
-            agent_id.clone(),
-            run_origin,
-        )
-        .with_run_mode(run_mode)
-        .with_adapter(adapter);
-        if let Some(dispatch_id) = dispatch_id {
-            run_identity = run_identity.with_dispatch_id(dispatch_id);
-        }
-        if let Some(session_id) = session_id {
-            run_identity = run_identity.with_session_id(session_id);
-        }
-        if let Some(transport_request_id) = transport_request_id {
-            run_identity = run_identity.with_transport_request_id(transport_request_id);
-        }
-        let mut run_inbox = run_inbox;
-        let mut compaction_runtime: Option<CompactionRuntime> = None;
-        let (messages, phase_runtime, inbox, live_inbox_sender, previous_non_local_state) =
-            match &resolved_execution {
-                ExecutionPlan::Local(preflight_resolved) => {
-                    let prepared = self
-                        .prepare_local_root_execution(
-                            preflight_resolved,
-                            &thread_id,
-                            request_messages,
-                            messages_already_persisted,
-                            &decisions,
-                            run_inbox.take(),
-                            &thread_ctx,
-                        )
-                        .await?;
-                    compaction_runtime = prepared.compaction;
-                    (
-                        prepared.messages,
-                        Some(prepared.phase_runtime),
-                        Some(prepared.inbox),
-                        Some(prepared.inbox_sender),
-                        None,
-                    )
-                }
-                ExecutionPlan::Remote(_) => {
-                    let live_inbox_sender =
-                        run_inbox.as_ref().map(|run_inbox| run_inbox.sender.clone());
-                    (
-                        self.load_non_local_messages(
-                            &thread_id,
-                            request_messages,
-                            messages_already_persisted,
-                            &thread_ctx,
-                        )
-                        .await?,
-                        None,
-                        run_inbox.take().map(|run_inbox| run_inbox.receiver),
-                        live_inbox_sender,
-                        self.load_non_local_state(
-                            &thread_id,
-                            requested_continue_run_id.as_deref(),
-                            &thread_ctx,
-                        )
-                        .await?,
-                    )
-                }
-            };
+        let run_identity = build_root_run_identity(RootRunIdentityInput {
+            thread_id: thread_id.clone(),
+            parent_thread_id: req_parent_thread_id,
+            run_id: run_id.clone(),
+            parent_run_id: req_parent_run_id,
+            agent_id: agent_id.clone(),
+            origin: req_origin,
+            run_mode,
+            adapter,
+            dispatch_id,
+            session_id,
+            transport_request_id,
+        });
+        let prepared_execution = self
+            .prepare_root_execution(
+                &resolved_execution,
+                &thread_id,
+                request_messages,
+                messages_already_persisted,
+                &decisions,
+                run_inbox,
+                requested_continue_run_id.as_deref(),
+                &thread_ctx,
+            )
+            .await?;
+        let PreparedRootExecution {
+            messages,
+            phase_runtime,
+            inbox,
+            live_inbox_sender,
+            previous_non_local_state,
+            compaction,
+        } = prepared_execution;
         let run_created_at = now_ms();
         let (handle, cancellation_token, raw_decision_rx) = self.create_run_channels_with_inbox(
             run_id.clone(),
@@ -316,22 +361,22 @@ impl AgentRuntime {
             live_inbox_sender,
         );
         let runtime_cancellation_token = cancellation_token.clone();
-        let decisions_live = matches!(
-            capabilities.decisions,
-            crate::resolution::DecisionCapability::LiveOnly
-                | crate::resolution::DecisionCapability::LiveAndDurable
+        let backend_control = build_backend_control(
+            &capabilities,
+            cancellation_token,
+            raw_decision_rx,
+            control.pending_boundary,
         );
-        let decision_rx = decisions_live.then_some(raw_decision_rx);
         // Wrap the resolver so every `ResolvedAgent` it produces during this
         // run carries the per-run compaction manager + summarizer when the
         // agent opted in via `autocompact_threshold`. Lifetime is tied to
         // `backend_request`, which is consumed before this scope ends.
-        let compaction_resolver = compaction_runtime
+        let compaction_resolver = compaction
             .clone()
-            .map(|runtime| CompactionResolver::new(run_resolver.as_ref(), runtime));
+            .map(|runtime| CompactionResolver::new(execution_resolver.as_ref(), runtime));
         let resolver_for_backend: &dyn AgentResolver = match compaction_resolver.as_ref() {
             Some(wrapper) => wrapper,
-            None => run_resolver.as_ref(),
+            None => execution_resolver.as_ref(),
         };
         let effective_coordinator: Option<
             Arc<dyn awaken_runtime_contract::contract::commit_coordinator::CommitCoordinator>,
@@ -341,36 +386,25 @@ impl AgentRuntime {
             .checkpoint_storage
             .as_deref()
             .or(coord_reader.as_deref());
-        let backend_request = BackendRootRunRequest {
-            agent_id: &agent_id,
+        let backend_request = build_backend_root_run_request(BackendRequestInput {
+            agent_id: agent_id.as_str(),
             messages,
             new_messages,
             sink: sink.clone(),
             resolver: resolver_for_backend,
             run_identity: run_identity.clone(),
-            checkpoint_store: match &resolved_execution {
-                ExecutionPlan::Local(_) => phase_runtime.as_ref().and(storage),
-                ExecutionPlan::Remote(_) => storage,
-            },
-            commit: CommitWiring::new(effective_coordinator.as_deref())
-                .with_resolution_id_seed(resolution_id_seed.as_deref()),
-            control: BackendControl {
-                cancellation_token: capabilities
-                    .cancellation
-                    .supports_cooperative_token()
-                    .then_some(cancellation_token),
-                decision_rx,
-                pending_boundary: control.pending_boundary,
-            },
+            storage,
+            commit_coordinator: effective_coordinator.as_deref(),
+            resolution_id_seed: resolution_id_seed.as_deref(),
+            resolved_execution: &resolved_execution,
+            phase_runtime: phase_runtime.as_ref(),
+            control: backend_control,
             decisions,
             overrides,
             frontend_tools,
-            local: phase_runtime
-                .as_ref()
-                .map(|phase_runtime| BackendLocalRootContext { phase_runtime }),
             inbox,
             is_continuation: is_continuation || intent_is_continuation,
-        };
+        });
         validate_root_execution_request(&resolved_execution, &backend_request).map_err(
             |error| match error {
                 ExecutionBackendError::Loop(loop_error) => loop_error,
@@ -387,28 +421,140 @@ impl AgentRuntime {
             run_id: run_id.clone(),
         };
 
-        match &resolved_execution {
-            ExecutionPlan::Local(_) => {
-                let result = LocalBackend::new()
-                    .execute_root_with_thread_context(backend_request, thread_ctx)
-                    .await
-                    .map_err(local_root_execution_error)?;
-                Ok(AgentRunResult {
-                    run_id: run_id.clone(),
-                    response: result.response.unwrap_or_default(),
-                    termination: result.termination,
-                    steps: result.steps,
+        execute_resolved_root(
+            &resolved_execution,
+            backend_request,
+            thread_ctx,
+            &run_id,
+            run_created_at,
+            runtime_cancellation_token,
+            previous_non_local_state,
+        )
+        .await
+    }
+
+    async fn resolve_root_run_setup(
+        &self,
+        input: RootRunSetupInput<'_>,
+    ) -> Result<RootRunSetup, AgentLoopError> {
+        let agent_id = self
+            .resolve_agent_id(input.requested_agent_id, input.thread_id, input.thread_ctx)
+            .await?;
+        let resolver_set = input
+            .pinned_registry_set
+            .or_else(|| self.registry_snapshot().map(|s| s.into_registries()));
+        let execution_resolver: Arc<dyn AgentResolver> = if let Some(set) = resolver_set.clone() {
+            Arc::new(crate::registry::resolve::RegistrySetResolver::new(set))
+        } else {
+            self.execution_resolver_arc()
+        };
+        let resolved_plan = if let Some(plan) = input.resolved_plan {
+            plan
+        } else {
+            let root_resolver: Arc<dyn crate::resolution::Resolver> =
+                if let Some(resolver) = input.inherited_run_resolver {
+                    resolver
+                } else if let Some(set) = resolver_set {
+                    Arc::new(crate::registry::resolve::RegistrySetResolver::new(set))
+                } else {
+                    self.run_resolver_arc()
+                };
+            let request = ResolutionRequest {
+                target: ResolutionTarget::Root {
+                    agent_id: agent_id.clone(),
+                    thread_id: input.thread_id.to_string(),
+                },
+                resolution_scope: RegistryResolutionScope::Live,
+                overrides: input.overrides.clone(),
+                frontend_tools: input.frontend_tools.to_vec(),
+                features: RunFeatureSet {
+                    has_seeded_decisions: input.has_seeded_decisions,
+                    has_live_decision_channel: input.has_live_decision_channel,
+                    has_overrides: input.overrides.is_some(),
+                    has_frontend_tools: !input.frontend_tools.is_empty(),
+                    is_human_resume: input.is_human_resume,
+                    is_continuation: input.is_continuation,
+                    requested_persistence: PersistenceRequirement::NotRequired,
+                },
+            };
+            root_resolver.resolve(request).await.map_err(|error| {
+                AgentLoopError::RuntimeError(crate::RuntimeError::ResolveFailed {
+                    message: error.to_string(),
+                })
+            })?
+        };
+        validate_resolved_root_plan(&resolved_plan, &agent_id)?;
+        let resolution_id_seed = resolved_plan.resolution_id().map(str::to_string);
+        let resolved_execution = resolved_plan.execution().clone();
+        let capabilities =
+            execution_capabilities(&resolved_execution).map_err(local_root_execution_error)?;
+
+        Ok(RootRunSetup {
+            agent_id,
+            execution_resolver,
+            resolved_execution,
+            capabilities,
+            resolution_id_seed,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn prepare_root_execution(
+        &self,
+        resolved_execution: &ExecutionPlan,
+        thread_id: &str,
+        request_messages: Vec<Message>,
+        messages_already_persisted: bool,
+        decisions: &[(
+            String,
+            awaken_runtime_contract::contract::suspension::ToolCallResume,
+        )],
+        run_inbox: Option<RunInbox>,
+        requested_continue_run_id: Option<&str>,
+        thread_ctx: &Option<ThreadContextSnapshot>,
+    ) -> Result<PreparedRootExecution, AgentLoopError> {
+        match resolved_execution {
+            ExecutionPlan::Local(preflight_resolved) => {
+                let prepared = self
+                    .prepare_local_root_execution(
+                        preflight_resolved,
+                        thread_id,
+                        request_messages,
+                        messages_already_persisted,
+                        decisions,
+                        run_inbox,
+                        thread_ctx,
+                    )
+                    .await?;
+                Ok(PreparedRootExecution {
+                    messages: prepared.messages,
+                    phase_runtime: Some(prepared.phase_runtime),
+                    inbox: Some(prepared.inbox),
+                    live_inbox_sender: Some(prepared.inbox_sender),
+                    previous_non_local_state: None,
+                    compaction: prepared.compaction,
                 })
             }
-            ExecutionPlan::Remote(non_local) => {
-                execute_remote_root_lifecycle(
-                    non_local,
-                    backend_request,
-                    run_created_at,
-                    runtime_cancellation_token,
-                    previous_non_local_state,
-                )
-                .await
+            ExecutionPlan::Remote(_) => {
+                let live_inbox_sender =
+                    run_inbox.as_ref().map(|run_inbox| run_inbox.sender.clone());
+                Ok(PreparedRootExecution {
+                    messages: self
+                        .load_non_local_messages(
+                            thread_id,
+                            request_messages,
+                            messages_already_persisted,
+                            thread_ctx,
+                        )
+                        .await?,
+                    phase_runtime: None,
+                    inbox: run_inbox.map(|run_inbox| run_inbox.receiver),
+                    live_inbox_sender,
+                    previous_non_local_state: self
+                        .load_non_local_state(thread_id, requested_continue_run_id, thread_ctx)
+                        .await?,
+                    compaction: None,
+                })
             }
         }
     }
@@ -554,8 +700,9 @@ impl AgentRuntime {
         if let Some(run_id) = continue_run_id {
             // Check cache first for continue_run_id.
             if let Some(ctx) = thread_ctx
-                && ctx.run_cache.contains_key(&run_id)
+                && let Some(existing) = ctx.run_cache.get(&run_id)
             {
+                ensure_continuation_run_thread(thread_id, &run_id, existing)?;
                 return Ok((run_id, true));
             }
             let Some(ref ts) = self.checkpoint_storage else {
@@ -563,12 +710,12 @@ impl AgentRuntime {
                     "continue_run_id '{run_id}' requires run storage"
                 )));
             };
-            if ts
+            let existing = ts
                 .load_run(&run_id)
                 .await
-                .map_err(|e| AgentLoopError::StorageError(e.to_string()))?
-                .is_some()
-            {
+                .map_err(|e| AgentLoopError::StorageError(e.to_string()))?;
+            if let Some(existing) = existing {
+                ensure_continuation_run_thread(thread_id, &run_id, &existing)?;
                 return Ok((run_id, true));
             }
             return Err(AgentLoopError::InvalidResume(format!(
@@ -766,6 +913,131 @@ fn local_root_execution_error(error: ExecutionBackendError) -> AgentLoopError {
         other => AgentLoopError::RuntimeError(crate::RuntimeError::ResolveFailed {
             message: other.to_string(),
         }),
+    }
+}
+
+fn ensure_continuation_run_thread(
+    expected_thread_id: &str,
+    continue_run_id: &str,
+    existing: &RunRecord,
+) -> Result<(), AgentLoopError> {
+    if existing.thread_id != expected_thread_id {
+        return Err(AgentLoopError::InvalidResume(format!(
+            "continue_run_id '{continue_run_id}' belongs to thread '{}' but activation targets thread '{expected_thread_id}'",
+            existing.thread_id
+        )));
+    }
+    Ok(())
+}
+
+fn build_root_run_identity(input: RootRunIdentityInput) -> RunIdentity {
+    let mut identity = RunIdentity::new(
+        input.thread_id,
+        input.parent_thread_id,
+        input.run_id,
+        input.parent_run_id,
+        input.agent_id,
+        input.origin,
+    )
+    .with_run_mode(input.run_mode)
+    .with_adapter(input.adapter);
+
+    if let Some(dispatch_id) = input.dispatch_id {
+        identity = identity.with_dispatch_id(dispatch_id);
+    }
+    if let Some(session_id) = input.session_id {
+        identity = identity.with_session_id(session_id);
+    }
+    if let Some(transport_request_id) = input.transport_request_id {
+        identity = identity.with_transport_request_id(transport_request_id);
+    }
+
+    identity
+}
+
+fn build_backend_root_run_request<'a>(input: BackendRequestInput<'a>) -> BackendRootRunRequest<'a> {
+    let checkpoint_store = match input.resolved_execution {
+        ExecutionPlan::Local(_) => input.phase_runtime.and(input.storage),
+        ExecutionPlan::Remote(_) => input.storage,
+    };
+    let local = input
+        .phase_runtime
+        .map(|phase_runtime| BackendLocalRootContext { phase_runtime });
+
+    BackendRootRunRequest {
+        agent_id: input.agent_id,
+        messages: input.messages,
+        new_messages: input.new_messages,
+        sink: input.sink,
+        resolver: input.resolver,
+        run_identity: input.run_identity,
+        checkpoint_store,
+        commit: CommitWiring::new(input.commit_coordinator)
+            .with_resolution_id_seed(input.resolution_id_seed),
+        control: input.control,
+        decisions: input.decisions,
+        overrides: input.overrides,
+        frontend_tools: input.frontend_tools,
+        local,
+        inbox: input.inbox,
+        is_continuation: input.is_continuation,
+    }
+}
+
+fn build_backend_control(
+    capabilities: &BackendProfile,
+    cancellation_token: CancellationToken,
+    raw_decision_rx: mpsc::UnboundedReceiver<DecisionBatch>,
+    pending_boundary: Option<Arc<dyn PendingBoundaryHandler>>,
+) -> BackendControl {
+    let decisions_live = matches!(
+        capabilities.decisions,
+        crate::resolution::DecisionCapability::LiveOnly
+            | crate::resolution::DecisionCapability::LiveAndDurable
+    );
+
+    BackendControl {
+        cancellation_token: capabilities
+            .cancellation
+            .supports_cooperative_token()
+            .then_some(cancellation_token),
+        decision_rx: decisions_live.then_some(raw_decision_rx),
+        pending_boundary,
+    }
+}
+
+async fn execute_resolved_root(
+    resolved_execution: &ExecutionPlan,
+    backend_request: BackendRootRunRequest<'_>,
+    thread_ctx: Option<ThreadContextSnapshot>,
+    run_id: &str,
+    run_created_at: u64,
+    runtime_cancellation_token: CancellationToken,
+    previous_non_local_state: Option<PersistedState>,
+) -> Result<AgentRunResult, AgentLoopError> {
+    match resolved_execution {
+        ExecutionPlan::Local(_) => {
+            let result = LocalBackend::new()
+                .execute_root_with_thread_context(backend_request, thread_ctx)
+                .await
+                .map_err(local_root_execution_error)?;
+            Ok(AgentRunResult {
+                run_id: run_id.to_string(),
+                response: result.response.unwrap_or_default(),
+                termination: result.termination,
+                steps: result.steps,
+            })
+        }
+        ExecutionPlan::Remote(non_local) => {
+            execute_remote_root_lifecycle(
+                non_local,
+                backend_request,
+                run_created_at,
+                runtime_cancellation_token,
+                previous_non_local_state,
+            )
+            .await
+        }
     }
 }
 

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner/tests.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner/tests.rs
@@ -1,7 +1,12 @@
 #![allow(deprecated)]
 
 use super::super::*;
-use super::build_compaction_runtime;
+use super::{
+    BackendRequestInput, RootRunIdentityInput, build_backend_control,
+    build_backend_root_run_request, build_compaction_runtime, build_root_run_identity,
+};
+use crate::backend::BackendControl;
+use crate::cancellation::CancellationToken;
 #[cfg(feature = "a2a")]
 use crate::extensions::a2a::{
     AgentBackend, AgentBackendError, AgentBackendFactory, AgentBackendFactoryError,
@@ -19,6 +24,11 @@ use crate::registry::snapshot::RegistryHandle;
 #[cfg(feature = "a2a")]
 use crate::registry::traits::{BackendRegistry, RegistrySet};
 use crate::registry::{AgentResolver, ResolvedAgent};
+use crate::resolution::{
+    BackendProfile, BackendRequirements, ExecutionPlan, ExecutionRole, LiveOnlyScope,
+    ResolutionRequest, ResolveError, ResolvedModelBinding, ResolvedRun, ResolvedRunPlan,
+    ResolvedTool, Resolver,
+};
 use crate::state::{KeyScope, StateCommand, StateKey, StateKeyOptions};
 use crate::{PhaseContext, PhaseHook, RunActivation, ToolPolicyHook};
 use async_trait::async_trait;
@@ -30,10 +40,13 @@ use awaken_runtime_contract::contract::event_sink::{EventSink, NullEventSink, Ve
 use awaken_runtime_contract::contract::executor::{
     InferenceExecutionError, InferenceRequest, LlmExecutor,
 };
+use awaken_runtime_contract::contract::identity::{RunIdentity, RunOrigin};
 use awaken_runtime_contract::contract::inference::{InferenceOverride, StopReason, StreamResult};
 use awaken_runtime_contract::contract::lifecycle::{RunStatus, TerminationReason};
 use awaken_runtime_contract::contract::message::Message;
-use awaken_runtime_contract::contract::storage::{RunRecord, RunWaitingState, WaitingReason};
+use awaken_runtime_contract::contract::storage::{
+    RunOutcome, RunRecord, RunWaitingState, WaitingReason,
+};
 use awaken_runtime_contract::contract::suspension::ResumeDecisionAction;
 use awaken_runtime_contract::contract::suspension::ToolCallResume;
 use awaken_runtime_contract::contract::tool::{
@@ -647,6 +660,50 @@ async fn run_rejects_unknown_continue_run_id() {
 }
 
 #[tokio::test]
+async fn next_root_run_id_rejects_continue_run_from_other_thread() {
+    let store = Arc::new(InMemoryStore::new());
+    let runtime = AgentRuntime::new(Arc::new(FixedResolver {
+        agent: ResolvedAgent::new("agent", "m", "sys", Arc::new(ScriptedLlm::new(Vec::new()))),
+        plugins: vec![],
+    }))
+    .with_in_memory_thread_run_store(store.clone());
+
+    store
+        .checkpoint(
+            "thread-b",
+            &[Message::user("previous")],
+            &RunRecord {
+                run_id: "run-b".into(),
+                thread_id: "thread-b".into(),
+                agent_id: "agent".into(),
+                status: RunStatus::Done,
+                termination_reason: Some(TerminationReason::NaturalEnd),
+                outcome: Some(RunOutcome {
+                    termination_reason: TerminationReason::NaturalEnd,
+                    final_output: None,
+                    error_payload: None,
+                }),
+                created_at: 1,
+                finished_at: Some(2),
+                updated_at: 2,
+                ..RunRecord::default()
+            },
+        )
+        .await
+        .expect("seed run on another thread");
+
+    let error = runtime
+        .next_root_run_id("thread-a", Some("run-b".into()), None, None, true, &None)
+        .await
+        .expect_err("continuation must not cross thread boundaries");
+
+    assert!(
+        error.to_string().contains("belongs to thread 'thread-b'"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
 async fn run_uses_dispatch_id_hint_for_new_run_identity() {
     let (runtime, store) = build_remote_runtime(
         RemoteEndpoint {
@@ -1220,6 +1277,166 @@ impl AgentResolver for FixedResolver {
     }
 }
 
+struct ResolveOnlyAgentResolver {
+    agent: ResolvedAgent,
+}
+
+impl AgentResolver for ResolveOnlyAgentResolver {
+    fn resolve(&self, _agent_id: &str) -> Result<ResolvedAgent, crate::error::RuntimeError> {
+        let mut agent = self.agent.clone();
+        agent.env = build_agent_env(&[], &agent)?;
+        Ok(agent)
+    }
+
+    fn resolve_execution(
+        &self,
+        _agent_id: &str,
+    ) -> Result<ExecutionPlan, crate::error::RuntimeError> {
+        Err(crate::error::RuntimeError::ResolveFailed {
+            message: "legacy execution resolver should not be used for root preflight".into(),
+        })
+    }
+}
+
+struct FixedRunPlanResolver {
+    agent: ResolvedAgent,
+}
+
+#[async_trait]
+impl Resolver for FixedRunPlanResolver {
+    async fn resolve(&self, req: ResolutionRequest) -> Result<ResolvedRunPlan, ResolveError> {
+        let requirements = BackendRequirements::from_features(&req.features);
+        let tools = self
+            .agent
+            .tool_descriptors()
+            .into_iter()
+            .map(|descriptor| ResolvedTool { descriptor })
+            .collect();
+        Ok(ResolvedRunPlan::LiveOnly(ResolvedRun {
+            agent_spec: (*self.agent.spec).clone(),
+            role: ExecutionRole::Root,
+            execution: ExecutionPlan::from_resolved_agent(&self.agent),
+            model: ResolvedModelBinding {
+                upstream_model: self.agent.upstream_model.clone(),
+            },
+            tools,
+            overrides: req.overrides,
+            backend_profile: BackendProfile::full_local(),
+            requirements,
+            scope: LiveOnlyScope,
+        }))
+    }
+}
+
+#[test]
+fn build_root_run_identity_preserves_trace_fields() {
+    let identity = build_root_run_identity(RootRunIdentityInput {
+        thread_id: "thread-1".into(),
+        parent_thread_id: Some("parent-thread".into()),
+        run_id: "run-1".into(),
+        parent_run_id: Some("parent-run".into()),
+        agent_id: "agent-1".into(),
+        origin: RunOrigin::Mcp,
+        run_mode: RunMode::Resume,
+        adapter: AdapterKind::AiSdk,
+        dispatch_id: Some("dispatch-1".into()),
+        session_id: Some("session-1".into()),
+        transport_request_id: Some("transport-1".into()),
+    });
+
+    assert_eq!(identity.thread_id, "thread-1");
+    assert_eq!(identity.parent_thread_id.as_deref(), Some("parent-thread"));
+    assert_eq!(identity.run_id, "run-1");
+    assert_eq!(identity.parent_run_id.as_deref(), Some("parent-run"));
+    assert_eq!(identity.agent_id, "agent-1");
+    assert_eq!(identity.origin(), RunOrigin::Mcp);
+    assert_eq!(identity.run_mode(), RunMode::Resume);
+    assert_eq!(identity.adapter(), AdapterKind::AiSdk);
+    assert_eq!(identity.trace.dispatch_id.as_deref(), Some("dispatch-1"));
+    assert_eq!(identity.trace.session_id.as_deref(), Some("session-1"));
+    assert_eq!(
+        identity.trace.transport_request_id.as_deref(),
+        Some("transport-1")
+    );
+}
+
+#[test]
+fn build_backend_request_wires_local_checkpoint_and_resolution_seed() {
+    let agent = ResolvedAgent::new(
+        "agent",
+        "model",
+        "system",
+        Arc::new(ScriptedLlm::new(Vec::new())),
+    );
+    let execution = ExecutionPlan::from_resolved_agent(&agent);
+    let resolver = FixedResolver {
+        agent,
+        plugins: vec![],
+    };
+    let phase_store = crate::state::StateStore::new();
+    let phase_runtime = crate::phase::PhaseRuntime::new(phase_store).unwrap();
+    let durable_store = Arc::new(InMemoryStore::new());
+    let checkpoint_reader =
+        awaken_server_contract::contract::store_traits::ThreadRunCheckpointStore::new(
+            durable_store as Arc<dyn ThreadRunStore>,
+        );
+
+    let request = build_backend_root_run_request(BackendRequestInput {
+        agent_id: "agent",
+        messages: vec![Message::user("hello").with_id("msg-1".to_string())],
+        new_messages: vec![Message::user("hello").with_id("msg-2".to_string())],
+        sink: Arc::new(NullEventSink),
+        resolver: &resolver,
+        run_identity: RunIdentity::new(
+            "thread".into(),
+            None,
+            "run".into(),
+            None,
+            "agent".into(),
+            RunOrigin::User,
+        ),
+        storage: Some(&checkpoint_reader),
+        commit_coordinator: None,
+        resolution_id_seed: Some("resolution-1"),
+        resolved_execution: &execution,
+        phase_runtime: Some(&phase_runtime),
+        control: BackendControl::default(),
+        decisions: Vec::new(),
+        overrides: None,
+        frontend_tools: Vec::new(),
+        inbox: None,
+        is_continuation: true,
+    });
+
+    assert!(request.local.is_some());
+    assert!(request.checkpoint_store.is_some());
+    assert_eq!(request.commit.resolution_id_seed, Some("resolution-1"));
+    assert!(request.is_continuation);
+}
+
+#[test]
+fn build_backend_control_honors_backend_capabilities() {
+    let (_tx, rx) = futures::channel::mpsc::unbounded();
+    let local = build_backend_control(
+        &BackendProfile::full_local(),
+        CancellationToken::new(),
+        rx,
+        None,
+    );
+    assert!(local.cancellation_token.is_some());
+    assert!(local.decision_rx.is_some());
+
+    let (_tx, rx) = futures::channel::mpsc::unbounded();
+    let remote = build_backend_control(
+        &BackendProfile::remote_stateless_text(),
+        CancellationToken::new(),
+        rx,
+        None,
+    );
+    assert!(remote.cancellation_token.is_none());
+    assert!(remote.decision_rx.is_none());
+}
+
 struct ThreadCounterKey;
 
 impl StateKey for ThreadCounterKey {
@@ -1420,6 +1637,32 @@ async fn run_to_completion_returns_final_result() {
         result.termination,
         awaken_runtime_contract::contract::lifecycle::TerminationReason::NaturalEnd
     );
+}
+
+#[tokio::test]
+async fn run_uses_run_resolver_for_root_preflight() {
+    let llm = Arc::new(ScriptedLlm::new(vec![StreamResult {
+        content: vec![ContentBlock::text("ok")],
+        tool_calls: vec![],
+        usage: None,
+        stop_reason: Some(StopReason::EndTurn),
+        has_incomplete_tool_calls: false,
+    }]));
+    let agent = ResolvedAgent::new("agent", "m", "sys", llm);
+    let runtime = AgentRuntime::new(Arc::new(ResolveOnlyAgentResolver {
+        agent: agent.clone(),
+    }))
+    .with_run_resolver(Arc::new(FixedRunPlanResolver { agent }));
+
+    let result = runtime
+        .run_to_completion(
+            RunActivation::new("thread-run-resolver", vec![Message::user("hi")])
+                .with_agent_id("agent"),
+        )
+        .await
+        .expect("run should use the configured run resolver");
+
+    assert_eq!(result.response, "ok");
 }
 
 #[tokio::test]

--- a/crates/awaken-server-contract/src/contract/mailbox.rs
+++ b/crates/awaken-server-contract/src/contract/mailbox.rs
@@ -87,65 +87,649 @@ pub struct RunDispatchResult {
 pub struct RunDispatch {
     // ── identity ──
     /// UUID v7, globally unique.
-    pub dispatch_id: String,
+    dispatch_id: String,
     /// Thread ID, routing anchor.
-    pub thread_id: String,
+    thread_id: String,
     /// Canonical runtime run ID this dispatch activates.
-    pub run_id: String,
+    run_id: String,
 
     // ── queue semantics ──
     /// 0 = highest, 255 = lowest, default 128.
-    pub priority: u8,
+    priority: u8,
     /// Idempotent delivery key.
-    pub dedupe_key: Option<String>,
+    dedupe_key: Option<String>,
     /// Thread dispatch epoch captured when this dispatch was created.
-    pub dispatch_epoch: u64,
+    dispatch_epoch: u64,
 
     // ── lifecycle ──
     /// Current status.
-    pub status: RunDispatchStatus,
+    status: RunDispatchStatus,
     /// Unix millis; future value = delayed delivery.
-    pub available_at: u64,
+    available_at: u64,
     /// Number of claim attempts so far.
-    pub attempt_count: u32,
+    attempt_count: u32,
     /// Maximum attempts before dead-lettering (default 5).
-    pub max_attempts: u32,
+    max_attempts: u32,
     /// Last error message.
-    pub last_error: Option<String>,
+    last_error: Option<String>,
 
     // ── lease ──
     /// UUID set on claim.
-    pub claim_token: Option<String>,
+    claim_token: Option<String>,
     /// Consumer identifier (process) that claimed this dispatch.
-    pub claimed_by: Option<String>,
+    claimed_by: Option<String>,
     /// Unix millis, extended by heartbeat.
-    pub lease_until: Option<u64>,
+    lease_until: Option<u64>,
 
     // ── runtime trace ──
     /// Dispatch attempt ID associated with the current/latest claim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dispatch_instance_id: Option<String>,
+    dispatch_instance_id: Option<String>,
     /// Runtime status associated with this dispatch's current/latest run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub run_status: Option<RunStatus>,
+    run_status: Option<RunStatus>,
     /// Structured terminal reason for the current/latest run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub termination: Option<TerminationReason>,
+    termination: Option<TerminationReason>,
     /// Final response text for the current/latest run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub run_response: Option<String>,
+    run_response: Option<String>,
     /// Runtime error text for the current/latest run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub run_error: Option<String>,
+    run_error: Option<String>,
     /// Unix millis when the runtime result was recorded.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub completed_at: Option<u64>,
+    completed_at: Option<u64>,
 
     // ── timestamps ──
     /// Unix millis when the dispatch was created.
-    pub created_at: u64,
+    created_at: u64,
     /// Unix millis of the last update.
+    updated_at: u64,
+}
+
+/// Explicit persisted representation used by store codecs.
+///
+/// This bag keeps deserialization and backend row decoding possible without
+/// reopening `RunDispatch` to arbitrary field mutation. Convert it with
+/// [`RunDispatch::from_persisted_parts`], which validates lifecycle
+/// invariants before returning a dispatch.
+#[derive(Debug, Clone)]
+pub struct RunDispatchParts {
+    pub dispatch_id: String,
+    pub thread_id: String,
+    pub run_id: String,
+    pub priority: u8,
+    pub dedupe_key: Option<String>,
+    pub dispatch_epoch: u64,
+    pub status: RunDispatchStatus,
+    pub available_at: u64,
+    pub attempt_count: u32,
+    pub max_attempts: u32,
+    pub last_error: Option<String>,
+    pub claim_token: Option<String>,
+    pub claimed_by: Option<String>,
+    pub lease_until: Option<u64>,
+    pub dispatch_instance_id: Option<String>,
+    pub run_status: Option<RunStatus>,
+    pub termination: Option<TerminationReason>,
+    pub run_response: Option<String>,
+    pub run_error: Option<String>,
+    pub completed_at: Option<u64>,
+    pub created_at: u64,
     pub updated_at: u64,
+}
+
+impl RunDispatch {
+    /// Build a queued dispatch. The result is validateable for enqueue and is
+    /// the only public constructor for new mailbox records.
+    #[must_use]
+    pub fn queued(
+        dispatch_id: impl Into<String>,
+        thread_id: impl Into<String>,
+        run_id: impl Into<String>,
+        created_at: u64,
+    ) -> Self {
+        Self {
+            dispatch_id: dispatch_id.into(),
+            thread_id: thread_id.into(),
+            run_id: run_id.into(),
+            priority: 128,
+            dedupe_key: None,
+            dispatch_epoch: 0,
+            status: RunDispatchStatus::Queued,
+            available_at: created_at,
+            attempt_count: 0,
+            max_attempts: 5,
+            last_error: None,
+            claim_token: None,
+            claimed_by: None,
+            lease_until: None,
+            dispatch_instance_id: None,
+            run_status: None,
+            termination: None,
+            run_response: None,
+            run_error: None,
+            completed_at: None,
+            created_at,
+            updated_at: created_at,
+        }
+    }
+
+    #[must_use]
+    pub fn with_priority(mut self, priority: u8) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    #[must_use]
+    pub fn with_dedupe_key(mut self, dedupe_key: impl Into<Option<String>>) -> Self {
+        self.dedupe_key = dedupe_key.into();
+        self
+    }
+
+    #[must_use]
+    pub fn with_available_at(mut self, available_at: u64) -> Self {
+        self.available_at = available_at;
+        self
+    }
+
+    #[must_use]
+    pub fn with_created_at(mut self, created_at: u64) -> Self {
+        self.created_at = created_at;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_attempts(mut self, max_attempts: u32) -> Self {
+        self.max_attempts = max_attempts;
+        self
+    }
+
+    #[must_use]
+    pub fn with_attempt_count(mut self, attempt_count: u32) -> Self {
+        self.attempt_count = attempt_count;
+        self
+    }
+
+    #[must_use]
+    pub fn with_dispatch_epoch(mut self, dispatch_epoch: u64) -> Self {
+        self.dispatch_epoch = dispatch_epoch;
+        self
+    }
+
+    pub fn from_persisted_parts(parts: RunDispatchParts) -> Result<Self, StorageError> {
+        let dispatch = Self {
+            dispatch_id: parts.dispatch_id,
+            thread_id: parts.thread_id,
+            run_id: parts.run_id,
+            priority: parts.priority,
+            dedupe_key: parts.dedupe_key,
+            dispatch_epoch: parts.dispatch_epoch,
+            status: parts.status,
+            available_at: parts.available_at,
+            attempt_count: parts.attempt_count,
+            max_attempts: parts.max_attempts,
+            last_error: parts.last_error,
+            claim_token: parts.claim_token,
+            claimed_by: parts.claimed_by,
+            lease_until: parts.lease_until,
+            dispatch_instance_id: parts.dispatch_instance_id,
+            run_status: parts.run_status,
+            termination: parts.termination,
+            run_response: parts.run_response,
+            run_error: parts.run_error,
+            completed_at: parts.completed_at,
+            created_at: parts.created_at,
+            updated_at: parts.updated_at,
+        };
+        dispatch.validate_for_persist()?;
+        Ok(dispatch)
+    }
+
+    #[must_use]
+    pub fn to_persisted_parts(&self) -> RunDispatchParts {
+        RunDispatchParts {
+            dispatch_id: self.dispatch_id.clone(),
+            thread_id: self.thread_id.clone(),
+            run_id: self.run_id.clone(),
+            priority: self.priority,
+            dedupe_key: self.dedupe_key.clone(),
+            dispatch_epoch: self.dispatch_epoch,
+            status: self.status,
+            available_at: self.available_at,
+            attempt_count: self.attempt_count,
+            max_attempts: self.max_attempts,
+            last_error: self.last_error.clone(),
+            claim_token: self.claim_token.clone(),
+            claimed_by: self.claimed_by.clone(),
+            lease_until: self.lease_until,
+            dispatch_instance_id: self.dispatch_instance_id.clone(),
+            run_status: self.run_status,
+            termination: self.termination.clone(),
+            run_response: self.run_response.clone(),
+            run_error: self.run_error.clone(),
+            completed_at: self.completed_at,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+
+    #[must_use]
+    pub fn dispatch_id(&self) -> &String {
+        &self.dispatch_id
+    }
+
+    #[must_use]
+    pub fn thread_id(&self) -> &String {
+        &self.thread_id
+    }
+
+    #[must_use]
+    pub fn run_id(&self) -> &String {
+        &self.run_id
+    }
+
+    #[must_use]
+    pub fn priority(&self) -> u8 {
+        self.priority
+    }
+
+    #[must_use]
+    pub fn dedupe_key(&self) -> Option<&str> {
+        self.dedupe_key.as_deref()
+    }
+
+    #[must_use]
+    pub fn dispatch_epoch(&self) -> u64 {
+        self.dispatch_epoch
+    }
+
+    #[must_use]
+    pub fn status(&self) -> RunDispatchStatus {
+        self.status
+    }
+
+    #[must_use]
+    pub fn available_at(&self) -> u64 {
+        self.available_at
+    }
+
+    #[must_use]
+    pub fn attempt_count(&self) -> u32 {
+        self.attempt_count
+    }
+
+    #[must_use]
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    #[must_use]
+    pub fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
+    #[must_use]
+    pub fn claim_token(&self) -> Option<&str> {
+        self.claim_token.as_deref()
+    }
+
+    #[must_use]
+    pub fn claimed_by(&self) -> Option<&str> {
+        self.claimed_by.as_deref()
+    }
+
+    #[must_use]
+    pub fn lease_until(&self) -> Option<u64> {
+        self.lease_until
+    }
+
+    #[must_use]
+    pub fn dispatch_instance_id(&self) -> Option<&str> {
+        self.dispatch_instance_id.as_deref()
+    }
+
+    #[must_use]
+    pub fn run_status(&self) -> Option<RunStatus> {
+        self.run_status
+    }
+
+    #[must_use]
+    pub fn termination(&self) -> Option<&TerminationReason> {
+        self.termination.as_ref()
+    }
+
+    #[must_use]
+    pub fn run_response(&self) -> Option<&str> {
+        self.run_response.as_deref()
+    }
+
+    #[must_use]
+    pub fn run_error(&self) -> Option<&str> {
+        self.run_error.as_deref()
+    }
+
+    #[must_use]
+    pub fn completed_at(&self) -> Option<u64> {
+        self.completed_at
+    }
+
+    #[must_use]
+    pub fn created_at(&self) -> u64 {
+        self.created_at
+    }
+
+    #[must_use]
+    pub fn updated_at(&self) -> u64 {
+        self.updated_at
+    }
+
+    /// Store enqueue normalization: bind the dispatch to the current thread
+    /// epoch and clear all runtime/terminal state.
+    pub fn prepare_for_enqueue(&mut self, dispatch_epoch: u64) {
+        self.dispatch_epoch = dispatch_epoch;
+        self.status = RunDispatchStatus::Queued;
+        self.claim_token = None;
+        self.claimed_by = None;
+        self.lease_until = None;
+        self.dispatch_instance_id = None;
+        self.run_status = None;
+        self.termination = None;
+        self.run_response = None;
+        self.run_error = None;
+        self.completed_at = None;
+    }
+
+    /// Transition a queued dispatch to claimed.
+    pub fn claim(
+        &mut self,
+        consumer_id: impl Into<String>,
+        claim_token: impl Into<String>,
+        lease_until: u64,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Queued, "claim")?;
+        self.status = RunDispatchStatus::Claimed;
+        self.claim_token = Some(claim_token.into());
+        self.claimed_by = Some(consumer_id.into());
+        self.lease_until = Some(lease_until);
+        self.updated_at = now;
+        self.validate_for_persist()
+    }
+
+    pub fn extend_lease(&mut self, lease_until: u64, now: u64) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Claimed, "lease extension")?;
+        self.lease_until = Some(lease_until);
+        self.updated_at = now;
+        self.validate_for_persist()
+    }
+
+    pub fn record_dispatch_start(
+        &mut self,
+        dispatch_instance_id: impl Into<String>,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Claimed, "recording runtime start")?;
+        self.dispatch_instance_id = Some(dispatch_instance_id.into());
+        self.run_status = Some(RunStatus::Running);
+        self.termination = None;
+        self.run_response = None;
+        self.run_error = None;
+        self.completed_at = None;
+        self.updated_at = now;
+        self.validate_for_persist()
+    }
+
+    pub fn record_run_result(
+        &mut self,
+        result: &RunDispatchResult,
+        now: u64,
+    ) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Claimed, "recording runtime result")?;
+        if result.run_id != self.run_id {
+            return Err(StorageError::Validation(format!(
+                "dispatch '{}' result run_id '{}' does not match '{}'",
+                self.dispatch_id, result.run_id, self.run_id
+            )));
+        }
+        self.dispatch_instance_id = Some(result.dispatch_instance_id.clone());
+        self.run_status = Some(result.status);
+        self.termination = result.termination.clone();
+        self.run_response = result.response.clone();
+        self.run_error = result.error.clone();
+        self.completed_at = Some(now);
+        self.updated_at = now;
+        self.validate_for_persist()
+    }
+
+    pub fn mark_acked(&mut self, now: u64) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Claimed, "ack")?;
+        self.status = RunDispatchStatus::Acked;
+        self.completed_at = Some(now);
+        self.updated_at = now;
+        self.clear_claim_fields();
+        self.validate_for_persist()
+    }
+
+    pub fn mark_cancelled(&mut self, now: u64) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Queued, "cancel")?;
+        self.status = RunDispatchStatus::Cancelled;
+        self.completed_at = Some(now);
+        self.updated_at = now;
+        self.clear_claim_fields();
+        self.validate_for_persist()
+    }
+
+    pub fn mark_superseded(&mut self, now: u64, reason: Option<&str>) -> Result<(), StorageError> {
+        self.status = RunDispatchStatus::Superseded;
+        self.completed_at = Some(now);
+        self.updated_at = now;
+        if let Some(reason) = reason {
+            self.last_error = Some(reason.to_string());
+        }
+        self.clear_claim_fields();
+        self.validate_for_persist()
+    }
+
+    pub fn mark_superseded_at_epoch(
+        &mut self,
+        now: u64,
+        epoch: u64,
+        reason: Option<&str>,
+    ) -> Result<(), StorageError> {
+        self.dispatch_epoch = epoch;
+        self.mark_superseded(now, reason)
+    }
+
+    pub fn mark_dead_letter(&mut self, now: u64, error: &str) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Claimed, "dead letter")?;
+        self.status = RunDispatchStatus::DeadLetter;
+        self.last_error = Some(error.to_string());
+        self.completed_at = Some(now);
+        self.updated_at = now;
+        self.clear_claim_fields();
+        self.validate_for_persist()
+    }
+
+    pub fn mark_nack_result(
+        &mut self,
+        now: u64,
+        retry_at: u64,
+        error: &str,
+    ) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Claimed, "nack")?;
+        self.attempt_count = self.attempt_count.saturating_add(1);
+        self.last_error = Some(error.to_string());
+        self.updated_at = now;
+        self.clear_claim_fields();
+        if self.attempt_count >= self.max_attempts {
+            self.status = RunDispatchStatus::DeadLetter;
+            self.completed_at = Some(now);
+        } else {
+            self.status = RunDispatchStatus::Queued;
+            self.available_at = retry_at;
+            self.completed_at = None;
+        }
+        self.validate_for_persist()
+    }
+
+    pub fn mark_expired_lease(
+        &mut self,
+        now: u64,
+        max_attempts_error: &str,
+    ) -> Result<(), StorageError> {
+        self.require_status(RunDispatchStatus::Claimed, "lease expiration")?;
+        self.attempt_count = self.attempt_count.saturating_add(1);
+        self.available_at = now;
+        self.updated_at = now;
+        self.clear_claim_fields();
+        if self.attempt_count >= self.max_attempts {
+            self.status = RunDispatchStatus::DeadLetter;
+            self.last_error = Some(max_attempts_error.to_string());
+            self.completed_at = Some(now);
+        } else {
+            self.status = RunDispatchStatus::Queued;
+            self.completed_at = None;
+        }
+        self.validate_for_persist()
+    }
+
+    pub fn remap_identity(
+        &mut self,
+        dispatch_id: impl Into<String>,
+        thread_id: impl Into<String>,
+        run_id: impl Into<String>,
+        dedupe_key: Option<String>,
+    ) {
+        self.dispatch_id = dispatch_id.into();
+        self.thread_id = thread_id.into();
+        self.run_id = run_id.into();
+        self.dedupe_key = dedupe_key;
+    }
+
+    fn clear_claim_fields(&mut self) {
+        self.claim_token = None;
+        self.claimed_by = None;
+        self.lease_until = None;
+    }
+
+    fn require_status(
+        &self,
+        expected: RunDispatchStatus,
+        transition: &str,
+    ) -> Result<(), StorageError> {
+        if self.status != expected {
+            return Err(StorageError::Validation(format!(
+                "dispatch '{}' must be {:?} before {transition}",
+                self.dispatch_id, expected
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate an externally supplied dispatch before queue admission.
+    pub fn validate_for_enqueue(&self) -> Result<(), StorageError> {
+        self.validate_identity_and_retry()?;
+        if self.status != RunDispatchStatus::Queued {
+            return Err(StorageError::Validation(format!(
+                "enqueued dispatch '{}' must start as Queued",
+                self.dispatch_id
+            )));
+        }
+        self.validate_queued()
+    }
+
+    /// Validate persisted dispatch lifecycle invariants.
+    pub fn validate_for_persist(&self) -> Result<(), StorageError> {
+        self.validate_identity_and_retry()?;
+        match self.status {
+            RunDispatchStatus::Queued => self.validate_queued(),
+            RunDispatchStatus::Claimed => {
+                if self
+                    .claim_token
+                    .as_deref()
+                    .is_none_or(|value| value.trim().is_empty())
+                    || self
+                        .claimed_by
+                        .as_deref()
+                        .is_none_or(|value| value.trim().is_empty())
+                    || self.lease_until.is_none()
+                {
+                    return Err(StorageError::Validation(format!(
+                        "Claimed dispatch '{}' must carry claim_token, claimed_by, and lease_until",
+                        self.dispatch_id
+                    )));
+                }
+                Ok(())
+            }
+            RunDispatchStatus::Acked
+            | RunDispatchStatus::Cancelled
+            | RunDispatchStatus::Superseded
+            | RunDispatchStatus::DeadLetter => {
+                if self.claim_token.is_some()
+                    || self.claimed_by.is_some()
+                    || self.lease_until.is_some()
+                {
+                    return Err(StorageError::Validation(format!(
+                        "{:?} dispatch '{}' must not carry active lease fields",
+                        self.status, self.dispatch_id
+                    )));
+                }
+                if self.completed_at.is_none() {
+                    return Err(StorageError::Validation(format!(
+                        "{:?} dispatch '{}' must carry completed_at",
+                        self.status, self.dispatch_id
+                    )));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn validate_identity_and_retry(&self) -> Result<(), StorageError> {
+        require_non_empty("dispatch_id", &self.dispatch_id)?;
+        require_non_empty("thread_id", &self.thread_id)?;
+        require_non_empty("run_id", &self.run_id)?;
+        if self.max_attempts == 0 {
+            return Err(StorageError::Validation(format!(
+                "dispatch '{}' max_attempts must be greater than zero",
+                self.dispatch_id
+            )));
+        }
+        if self.attempt_count > self.max_attempts {
+            return Err(StorageError::Validation(format!(
+                "dispatch '{}' attempt_count must not exceed max_attempts",
+                self.dispatch_id
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_queued(&self) -> Result<(), StorageError> {
+        if self.claim_token.is_some() || self.claimed_by.is_some() || self.lease_until.is_some() {
+            return Err(StorageError::Validation(format!(
+                "Queued dispatch '{}' must not carry claim fields",
+                self.dispatch_id
+            )));
+        }
+        if self.completed_at.is_some() {
+            return Err(StorageError::Validation(format!(
+                "Queued dispatch '{}' must not carry completed_at",
+                self.dispatch_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn require_non_empty(field: &str, value: &str) -> Result<(), StorageError> {
+    if value.trim().is_empty() {
+        return Err(StorageError::Validation(format!(
+            "{field} must not be empty"
+        )));
+    }
+    Ok(())
 }
 
 // ── MailboxInterrupt ────────────────────────────────────────────────
@@ -1209,21 +1793,117 @@ mod tests {
         use super::super::lifecycle::TerminationReason;
 
         let mut dispatch = make_run_dispatch();
-        dispatch.dispatch_instance_id = Some("dispatch-1".into());
-        dispatch.run_status = Some(RunStatus::Done);
-        dispatch.termination = Some(TerminationReason::NaturalEnd);
-        dispatch.run_response = Some("done".into());
-        dispatch.completed_at = Some(2000);
+        dispatch
+            .claim("worker", "token", 1500, 1000)
+            .expect("claim should be valid");
+        dispatch
+            .record_run_result(
+                &RunDispatchResult {
+                    run_id: "run-001".into(),
+                    dispatch_instance_id: "dispatch-1".into(),
+                    status: RunStatus::Done,
+                    termination: Some(TerminationReason::NaturalEnd),
+                    response: Some("done".into()),
+                    error: None,
+                },
+                2000,
+            )
+            .expect("run result should be valid");
 
         let json = serde_json::to_string(&dispatch).unwrap();
         let parsed: RunDispatch = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.run_id, "run-001");
-        assert_eq!(parsed.dispatch_instance_id.as_deref(), Some("dispatch-1"));
-        assert_eq!(parsed.run_status, Some(RunStatus::Done));
-        assert_eq!(parsed.termination, Some(TerminationReason::NaturalEnd));
-        assert_eq!(parsed.run_response.as_deref(), Some("done"));
-        assert_eq!(parsed.completed_at, Some(2000));
-        assert_eq!(parsed.status, RunDispatchStatus::Queued);
+        assert_eq!(parsed.run_id(), "run-001");
+        assert_eq!(parsed.dispatch_instance_id(), Some("dispatch-1"));
+        assert_eq!(parsed.run_status(), Some(RunStatus::Done));
+        assert_eq!(parsed.termination(), Some(&TerminationReason::NaturalEnd));
+        assert_eq!(parsed.run_response(), Some("done"));
+        assert_eq!(parsed.completed_at(), Some(2000));
+        assert_eq!(parsed.status(), RunDispatchStatus::Claimed);
+    }
+
+    #[test]
+    fn run_dispatch_transition_api_enforces_lifecycle_shape() {
+        let mut dispatch = RunDispatch::queued("dispatch-001", "thread-abc", "run-001", 1000)
+            .with_dedupe_key(Some("req-xyz".to_string()));
+
+        assert_eq!(dispatch.status(), RunDispatchStatus::Queued);
+        assert!(dispatch.claim_token().is_none());
+
+        dispatch
+            .claim("consumer-1", "claim-1", 2000, 1100)
+            .expect("queued dispatch can be claimed");
+        assert_eq!(dispatch.status(), RunDispatchStatus::Claimed);
+        assert_eq!(dispatch.claimed_by(), Some("consumer-1"));
+        assert_eq!(dispatch.claim_token(), Some("claim-1"));
+        assert_eq!(dispatch.lease_until(), Some(2000));
+
+        dispatch.mark_acked(3000).expect("claimed dispatch can ack");
+        assert_eq!(dispatch.status(), RunDispatchStatus::Acked);
+        assert!(dispatch.claim_token().is_none());
+        assert!(dispatch.claimed_by().is_none());
+        assert!(dispatch.lease_until().is_none());
+        assert_eq!(dispatch.completed_at(), Some(3000));
+    }
+
+    #[test]
+    fn run_dispatch_transition_api_rejects_claiming_terminal_dispatch() {
+        let mut dispatch = RunDispatch::queued("dispatch-001", "thread-abc", "run-001", 1000);
+        dispatch
+            .mark_cancelled(2000)
+            .expect("queued dispatch can be cancelled");
+
+        let error = dispatch
+            .claim("consumer-1", "claim-1", 3000, 2500)
+            .unwrap_err();
+        assert!(
+            matches!(error, StorageError::Validation(ref message) if message.contains("must be Queued")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn run_dispatch_transition_api_rejects_terminalizing_unclaimed_dispatch() {
+        let mut dispatch = RunDispatch::queued("dispatch-001", "thread-abc", "run-001", 1000);
+
+        let error = dispatch.mark_acked(2000).unwrap_err();
+        assert!(
+            matches!(error, StorageError::Validation(ref message) if message.contains("must be Claimed")),
+            "unexpected ack error: {error}"
+        );
+
+        let error = dispatch.mark_dead_letter(2000, "failed").unwrap_err();
+        assert!(
+            matches!(error, StorageError::Validation(ref message) if message.contains("must be Claimed")),
+            "unexpected dead-letter error: {error}"
+        );
+
+        let error = dispatch
+            .mark_nack_result(2000, 3000, "retry later")
+            .unwrap_err();
+        assert!(
+            matches!(error, StorageError::Validation(ref message) if message.contains("must be Claimed")),
+            "unexpected nack error: {error}"
+        );
+
+        let error = dispatch.mark_expired_lease(2000, "expired").unwrap_err();
+        assert!(
+            matches!(error, StorageError::Validation(ref message) if message.contains("must be Claimed")),
+            "unexpected expired-lease error: {error}"
+        );
+    }
+
+    #[test]
+    fn run_dispatch_transition_api_rejects_cancelling_claimed_dispatch() {
+        let mut dispatch = RunDispatch::queued("dispatch-001", "thread-abc", "run-001", 1000);
+        dispatch
+            .claim("consumer-1", "claim-1", 2000, 1100)
+            .expect("queued dispatch can be claimed");
+
+        let error = dispatch.mark_cancelled(2000).unwrap_err();
+        assert!(
+            matches!(error, StorageError::Validation(ref message) if message.contains("must be Queued")),
+            "unexpected cancel error: {error}"
+        );
     }
 
     #[test]

--- a/crates/awaken-server-contract/src/contract/store_traits.rs
+++ b/crates/awaken-server-contract/src/contract/store_traits.rs
@@ -388,6 +388,14 @@ pub trait RunStore: Send + Sync {
 /// and coordinator-internal use.
 #[async_trait]
 pub trait ThreadRunStore: ThreadStore + RunStore + Send + Sync {
+    /// Return an identity for the backing thread/run store, when the
+    /// implementation can prove it. This is intentionally narrower than a
+    /// coordinator transaction scope: it only identifies the thread/run read
+    /// and write backend used by mailbox/server code.
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        None
+    }
+
     #[deprecated(since = "0.6.0", note = "use CommitCoordinator (ADR-0038 D7)")]
     async fn checkpoint(
         &self,

--- a/crates/awaken-server/src/app/modules.rs
+++ b/crates/awaken-server/src/app/modules.rs
@@ -158,9 +158,11 @@ impl RunModuleState {
 
     #[must_use]
     pub fn unscope_dispatch(&self, mut dispatch: RunDispatch) -> RunDispatch {
-        dispatch.dispatch_id = self.unscoped_id(&dispatch.dispatch_id);
-        dispatch.thread_id = self.unscoped_id(&dispatch.thread_id);
-        dispatch.run_id = self.unscoped_id(&dispatch.run_id);
+        let dispatch_id = self.unscoped_id(dispatch.dispatch_id());
+        let thread_id = self.unscoped_id(dispatch.thread_id());
+        let run_id = self.unscoped_id(dispatch.run_id());
+        let dedupe_key = dispatch.dedupe_key().map(|key| self.unscoped_id(key));
+        dispatch.remap_identity(dispatch_id, thread_id, run_id, dedupe_key);
         dispatch
     }
 

--- a/crates/awaken-server/src/error.rs
+++ b/crates/awaken-server/src/error.rs
@@ -26,6 +26,8 @@ pub enum ApiError {
     /// `--features permission`. Distinct from 404 so callers can
     /// differentiate "no such resource" from "feature not available".
     ServiceUnavailable(String),
+    /// Request cannot be executed by the resolved backend capabilities.
+    CapabilityMismatch(String),
     Internal(String),
     /// Storage promised a row that is missing inside retention. Distinct from
     /// `Internal` so operators can alert on integrity violations (ADR-0034 D8:
@@ -46,6 +48,7 @@ impl fmt::Display for ApiError {
             | ApiError::Gone(msg)
             | ApiError::NotFound(msg)
             | ApiError::ServiceUnavailable(msg)
+            | ApiError::CapabilityMismatch(msg)
             | ApiError::Internal(msg)
             | ApiError::DataIntegrity(msg) => f.write_str(msg),
             ApiError::ThreadNotFound(id) => write!(f, "thread not found: {id}"),
@@ -71,6 +74,9 @@ impl IntoResponse for ApiError {
                 (StatusCode::NOT_FOUND, format!("run not found: {id}"), None)
             }
             ApiError::ServiceUnavailable(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg, None),
+            ApiError::CapabilityMismatch(msg) => {
+                (StatusCode::BAD_REQUEST, msg, Some("capability_mismatch"))
+            }
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg, None),
             ApiError::DataIntegrity(msg) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -99,6 +105,17 @@ mod tests {
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(value["error"], "row missing");
         assert_eq!(value["code"], "data_integrity");
+    }
+
+    #[tokio::test]
+    async fn capability_mismatch_carries_user_visible_code() {
+        let response =
+            ApiError::CapabilityMismatch("backend lacks durable resume".into()).into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["error"], "backend lacks durable resume");
+        assert_eq!(value["code"], "capability_mismatch");
     }
 
     #[tokio::test]

--- a/crates/awaken-server/src/lib.rs
+++ b/crates/awaken-server/src/lib.rs
@@ -36,3 +36,16 @@ pub mod services;
 pub(crate) mod system_routes;
 pub mod time;
 pub mod transport;
+
+pub mod prelude {
+    pub use awaken_server_contract::contract::mailbox::MailboxStore;
+    pub use awaken_server_contract::contract::storage::ThreadRunStore;
+    pub use awaken_server_contract::{
+        RequestSurface, ScopeContext, ScopeId, ScopedConfigStore, ScopedMailboxStore,
+        ScopedOutboxStore, ScopedProtocolReplayLog, ScopedThreadRunStore, ScopedVersionedRegistry,
+    };
+
+    pub use crate::app::{ServerConfig, ServerState, ShutdownConfig, serve, serve_with_shutdown};
+    pub use crate::mailbox::{Mailbox, MailboxConfig};
+    pub use crate::routes::build_router;
+}

--- a/crates/awaken-server/src/mailbox.rs
+++ b/crates/awaken-server/src/mailbox.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 
-use awaken_runtime::RunActivation;
+use awaken_runtime::{ResolveError, RunActivation};
 use awaken_server_contract::contract::commit_coordinator::CommitCoordinator;
 use awaken_server_contract::contract::event::AgentEvent;
 use awaken_server_contract::contract::event_sink::EventSink;
@@ -354,6 +354,11 @@ pub enum MailboxError {
     Validation(String),
     #[error("store error: {0}")]
     Store(#[from] StorageError),
+    #[error("resolution error while {context}: {source}")]
+    Resolution {
+        context: &'static str,
+        source: ResolveError,
+    },
     #[error("internal error: {0}")]
     Internal(String),
     /// A foreground submit cannot be consumed because a barrier pending entry
@@ -734,16 +739,16 @@ impl Mailbox {
         config: MailboxConfig,
     ) -> Self {
         Self::try_new(executor, store, run_store, consumer_id, config)
-            .expect("Mailbox requires a CommitCoordinator outside debug/test fallback")
+            .expect("Mailbox requires a CommitCoordinator outside unit-test fallback")
     }
 
     /// Fallible constructor for production wiring that must fail closed.
     ///
     /// ADR-0038 D7: the mailbox adopts `executor.commit_coordinator()` and
-    /// derives its `ThreadRunStore` from that coordinator. Debug/test builds
-    /// retain the legacy implicit run-store coordinator for embedded unit
-    /// callers; release builds return an error instead of silently taking a
-    /// partial durable path with no canonical events/outbox writes.
+    /// derives its `ThreadRunStore` from that coordinator. Unit tests retain
+    /// the legacy implicit run-store coordinator for small harnesses; every
+    /// non-test build returns an error instead of silently taking a partial
+    /// durable path with no canonical events/outbox writes.
     pub fn try_new(
         executor: impl IntoDispatchExecutor,
         store: Arc<dyn MailboxStore>,
@@ -755,20 +760,30 @@ impl Mailbox {
         let staged_coordinator = executor.staged_commit_coordinator();
         let coordinator = if let Some(coordinator) = executor.commit_coordinator() {
             coordinator
-        } else if cfg!(debug_assertions) {
+        } else if cfg!(test) {
             tracing::warn!(
-                "using dev/test MailboxRunStoreCoordinator fallback; production executors must \
+                "using unit-test MailboxRunStoreCoordinator fallback; non-test executors must \
                  provide a CommitCoordinator"
             );
             Arc::new(MailboxRunStoreCoordinator::new(Arc::clone(&run_store)))
                 as Arc<dyn CommitCoordinator>
         } else {
             return Err(MailboxError::Internal(
-                "Mailbox requires a CommitCoordinator in release builds; wire a durable \
+                "Mailbox requires a CommitCoordinator; wire a durable \
                  Memory/File/Pg coordinator through the runtime"
                     .to_string(),
             ));
         };
+        if let (Some(coordinator_identity), Some(run_store_identity)) = (
+            coordinator.thread_run_storage_identity(),
+            run_store.thread_run_storage_identity(),
+        ) && coordinator_identity != run_store_identity
+        {
+            return Err(MailboxError::Validation(format!(
+                "mailbox run_store must match executor CommitCoordinator thread/run store \
+                 (coordinator={coordinator_identity}, run_store={run_store_identity})"
+            )));
+        }
         Ok(Self {
             executor,
             store,
@@ -799,21 +814,27 @@ impl Mailbox {
     /// `RegistrySet` via `with_pinned_registry_set`.
     #[must_use]
     pub fn with_pinned_registry(
-        mut self,
+        self,
         store: Arc<dyn awaken_server_contract::VersionedRegistryStore>,
         scope: impl Into<String>,
     ) -> Self {
-        let scope = awaken_server_contract::ScopeId::new(scope.into())
-            .expect("pinned registry scope_id must be valid");
+        self.try_with_pinned_registry(store, scope)
+            .expect("pinned registry scope_id must be valid")
+    }
+
+    pub fn try_with_pinned_registry(
+        mut self,
+        store: Arc<dyn awaken_server_contract::VersionedRegistryStore>,
+        scope: impl Into<String>,
+    ) -> Result<Self, awaken_server_contract::ScopeError> {
+        let scope = awaken_server_contract::ScopeId::new(scope.into())?;
         self.pinned_registry = Some(PinnedRegistrySource { store, scope });
-        self
+        Ok(self)
     }
 
     /// Materialize the pinned `RegistrySet` for a run's resolution_id
     /// (publication snapshot_version), overlaying live runtime objects. Returns
-    /// `Ok(None)` only when no pinned-registry source is wired or the id is not
-    /// a snapshot_version; once a numeric snapshot id is recognized, failures
-    /// are terminal so replay/resume cannot silently drift to the live registry.
+    /// `Ok(None)` only when no pinned-registry source is wired.
     async fn materialize_pinned_registry_set(
         &self,
         resolution_id: &str,
@@ -821,29 +842,31 @@ impl Mailbox {
         let Some(source) = self.pinned_registry.as_ref() else {
             return Ok(None);
         };
-        let Ok(snapshot_version) = resolution_id.parse::<u64>() else {
-            return Ok(None);
-        };
-        let live = self.executor.live_registry_set().ok_or_else(|| {
+        let snapshot_version = resolution_id.parse::<u64>().map_err(|error| {
             MailboxError::Internal(format!(
-                "pinned registry snapshot {snapshot_version} cannot be materialized: live registry unavailable"
+                "invalid pinned registry resolution id '{resolution_id}': {error}"
             ))
+        })?;
+        let live = self.executor.live_registry_set().ok_or_else(|| {
+            MailboxError::Internal(
+                "pinned registry materialization requires a live registry snapshot".to_string(),
+            )
         })?;
         let materializer = crate::services::frozen_registry::FrozenAgentRegistryMaterializer::new(
             source.store.clone(),
         );
-        match materializer
+        let frozen = materializer
             .materialize(awaken_server_contract::VersionSelector::Publication {
                 scope_id: source.scope.as_str().to_string(),
                 snapshot_version,
             })
             .await
-        {
-            Ok(frozen) => Ok(Some(frozen.to_registry_set(&live))),
-            Err(error) => Err(MailboxError::Internal(format!(
-                "pinned registry snapshot {snapshot_version} cannot be materialized: {error}"
-            ))),
-        }
+            .map_err(|error| {
+                MailboxError::Internal(format!(
+                    "failed to materialize pinned registry publication {snapshot_version}: {error}"
+                ))
+            })?;
+        Ok(Some(frozen.to_registry_set(&live)))
     }
 
     /// Number of stripes for `lock_thread_append` (defined in `submit`).

--- a/crates/awaken-server/src/mailbox/cancel.rs
+++ b/crates/awaken-server/src/mailbox/cancel.rs
@@ -49,7 +49,7 @@ impl Mailbox {
         }
 
         if let Some(dispatch) = self.store.load_dispatch(id).await?
-            && dispatch.status == RunDispatchStatus::Claimed
+            && dispatch.status() == RunDispatchStatus::Claimed
         {
             return self
                 .deliver_live_cancel(&live_target_for_dispatch(&dispatch))
@@ -126,14 +126,14 @@ impl Mailbox {
         if wait_for_release {
             if self.executor.cancel_and_wait_by_thread(thread_id).await {
                 if self
-                    .wait_for_dispatch_not_claimed(&active_dispatch.dispatch_id)
+                    .wait_for_dispatch_not_claimed(&active_dispatch.dispatch_id())
                     .await?
                 {
                     return Ok(true);
                 }
                 tracing::warn!(
                     thread_id,
-                    dispatch_id = %active_dispatch.dispatch_id,
+                    dispatch_id = %active_dispatch.dispatch_id(),
                     "local cancel completed but active dispatch did not release before foreground submit"
                 );
                 self.record_mailbox_timeout(
@@ -157,12 +157,12 @@ impl Mailbox {
 
         if wait_for_release
             && !self
-                .wait_for_dispatch_not_claimed(&active_dispatch.dispatch_id)
+                .wait_for_dispatch_not_claimed(&active_dispatch.dispatch_id())
                 .await?
         {
             tracing::warn!(
                 thread_id,
-                dispatch_id = %active_dispatch.dispatch_id,
+                dispatch_id = %active_dispatch.dispatch_id(),
                 "remote cancel delivered but active dispatch did not release before foreground submit"
             );
             self.record_mailbox_timeout(
@@ -226,9 +226,9 @@ impl Mailbox {
         }
         if let Err(error) = result {
             tracing::warn!(
-                dispatch_id = %dispatch.dispatch_id,
-                run_id = %dispatch.run_id,
-                thread_id = %dispatch.thread_id,
+                dispatch_id = %dispatch.dispatch_id(),
+                run_id = %dispatch.run_id(),
+                thread_id = %dispatch.thread_id(),
                 reason,
                 error = %error,
                 "failed to mark terminal mailbox run as cancelled"
@@ -241,10 +241,10 @@ impl Mailbox {
         dispatch: &RunDispatch,
         _reason: &str,
     ) -> Result<bool, MailboxError> {
-        let Some(mut run) = self.run_store.load_run(&dispatch.run_id).await? else {
+        let Some(mut run) = self.run_store.load_run(&dispatch.run_id()).await? else {
             return Ok(false);
         };
-        if run.thread_id != dispatch.thread_id || run.status == RunStatus::Done {
+        if run.thread_id != *dispatch.thread_id() || run.status == RunStatus::Done {
             return Ok(false);
         }
 
@@ -252,8 +252,8 @@ impl Mailbox {
         run.status = RunStatus::Done;
         run.termination_reason = Some(TerminationReason::Cancelled);
         run.error_payload = None;
-        run.dispatch_id = Some(dispatch.dispatch_id.clone());
-        run.session_id = dispatch.dispatch_instance_id.clone();
+        run.dispatch_id = Some(dispatch.dispatch_id().clone());
+        run.session_id = dispatch.dispatch_instance_id().map(str::to_string);
         run.waiting = None;
         run.finished_at = Some(now);
         run.updated_at = now;
@@ -274,9 +274,9 @@ impl Mailbox {
         }
         if let Err(error) = result {
             tracing::warn!(
-                dispatch_id = %dispatch.dispatch_id,
-                run_id = %dispatch.run_id,
-                thread_id = %dispatch.thread_id,
+                dispatch_id = %dispatch.dispatch_id(),
+                run_id = %dispatch.run_id(),
+                thread_id = %dispatch.thread_id(),
                 error = %error,
                 "failed to mark dead-lettered mailbox run as errored"
             );
@@ -284,7 +284,7 @@ impl Mailbox {
     }
 
     pub(super) async fn reconcile_terminal_dispatch(&self, dispatch: &RunDispatch) {
-        match dispatch.status {
+        match dispatch.status() {
             RunDispatchStatus::DeadLetter => {
                 self.mark_dead_letter_dispatch_run_error(dispatch).await;
             }
@@ -352,24 +352,24 @@ impl Mailbox {
         &self,
         dispatch: &RunDispatch,
     ) -> Result<bool, MailboxError> {
-        let Some(mut run) = self.run_store.load_run(&dispatch.run_id).await? else {
+        let Some(mut run) = self.run_store.load_run(&dispatch.run_id()).await? else {
             return Ok(false);
         };
-        if run.thread_id != dispatch.thread_id || run.status == RunStatus::Done {
+        if run.thread_id != *dispatch.thread_id() || run.status == RunStatus::Done {
             return Ok(false);
         }
 
         let reason = dispatch
-            .run_error
-            .clone()
-            .or_else(|| dispatch.last_error.clone())
+            .run_error()
+            .map(str::to_string)
+            .or_else(|| dispatch.last_error().map(str::to_string))
             .unwrap_or_else(|| "mailbox dispatch dead-lettered".to_string());
         let now = now_ms() / 1000;
         run.status = RunStatus::Done;
         run.termination_reason = Some(TerminationReason::Error(reason.clone()));
         run.error_payload = Some(serde_json::json!({ "message": reason }));
-        run.dispatch_id = Some(dispatch.dispatch_id.clone());
-        run.session_id = dispatch.dispatch_instance_id.clone();
+        run.dispatch_id = Some(dispatch.dispatch_id().clone());
+        run.session_id = dispatch.dispatch_instance_id().map(str::to_string);
         run.waiting = None;
         run.finished_at = Some(now);
         run.updated_at = now;
@@ -388,22 +388,22 @@ impl Mailbox {
         for _ in 0..MAX_APPEND_ATTEMPTS {
             let messages = self
                 .run_store
-                .load_committed_messages(&dispatch.thread_id)
+                .load_committed_messages(&dispatch.thread_id())
                 .await?
                 .unwrap_or_default();
             let expected_version = messages.len() as u64;
             if self
-                .commit_run_append(&dispatch.thread_id, &[], Some(expected_version), run)
+                .commit_run_append(&dispatch.thread_id(), &[], Some(expected_version), run)
                 .await?
             {
-                self.refresh_worker_checkpoint_cache(&dispatch.thread_id, &messages, run)
+                self.refresh_worker_checkpoint_cache(&dispatch.thread_id(), &messages, run)
                     .await;
                 return Ok(());
             }
         }
         Err(MailboxError::Internal(format!(
             "terminal dispatch run checkpoint exhausted {MAX_APPEND_ATTEMPTS} retries under version conflict for thread '{}'",
-            dispatch.thread_id
+            dispatch.thread_id()
         )))
     }
 }

--- a/crates/awaken-server/src/mailbox/checkpoint_repair.rs
+++ b/crates/awaken-server/src/mailbox/checkpoint_repair.rs
@@ -67,7 +67,16 @@ impl Mailbox {
         };
         for task in tasks {
             let messages = match self.run_store.load_messages(&task.thread_id).await {
-                Ok(messages) => messages.unwrap_or_default(),
+                Ok(Some(messages)) => messages,
+                Ok(None) => {
+                    tracing::warn!(
+                        thread_id = %task.thread_id,
+                        run_id = %task.run_id,
+                        "checkpoint repair retry found no committed messages; re-queued"
+                    );
+                    self.enqueue_checkpoint_repair(task);
+                    continue;
+                }
                 Err(error) => {
                     tracing::warn!(
                         thread_id = %task.thread_id,

--- a/crates/awaken-server/src/mailbox/coordinator_facade.rs
+++ b/crates/awaken-server/src/mailbox/coordinator_facade.rs
@@ -5,9 +5,9 @@
 //!   the trait object the mailbox stores internally so `Mailbox::new`
 //!   accepts both shapes through one signature.
 //! - [`MailboxRunStoreCoordinator`] is the implicit coordinator the mailbox
-//!   builds when the supplied executor exposes none. It delegates straight
-//!   to `ThreadRunStore::checkpoint` and is intended for embedded/test
-//!   callers; production deployments wire a full coordinator
+//!   builds only in unit tests when the supplied executor exposes none. It
+//!   delegates straight to `ThreadRunStore::checkpoint`; non-test callers wire
+//!   a full coordinator
 //!   (`MemoryCommitCoordinator` / `FileCommitCoordinator` /
 //!   `PgCommitCoordinator`) through the runtime instead.
 
@@ -43,13 +43,12 @@ impl IntoDispatchExecutor for Arc<dyn RunDispatchExecutor> {
 }
 
 /// Minimal [`CommitCoordinator`] that delegates straight to
-/// [`ThreadRunStore::checkpoint`]. Used by `Mailbox::new` when the
-/// executor does not supply its own coordinator (embedded callers / unit
-/// tests where the runtime never carries persistence wiring). It does not
-/// publish canonical events or outbox drafts — only checkpoint commits —
-/// so it is **not** a replacement for `MemoryCommitCoordinator` /
-/// `FileCommitCoordinator` / `PgCommitCoordinator` in deployments that
-/// need full transactional event capture.
+/// [`ThreadRunStore::checkpoint`]. Used by `Mailbox::new` only in unit tests
+/// where the runtime never carries persistence wiring. It does not publish
+/// canonical events or outbox drafts — only checkpoint commits — so it is
+/// **not** a replacement for `MemoryCommitCoordinator` /
+/// `FileCommitCoordinator` / `PgCommitCoordinator` in deployments that need
+/// full transactional event capture.
 pub(super) struct MailboxRunStoreCoordinator {
     store: Arc<dyn ThreadRunStore>,
     scope: TransactionScopeId,

--- a/crates/awaken-server/src/mailbox/decision.rs
+++ b/crates/awaken-server/src/mailbox/decision.rs
@@ -34,7 +34,7 @@ impl Mailbox {
         }
 
         if let Some(dispatch) = self.store.load_dispatch(id).await?
-            && dispatch.status == RunDispatchStatus::Claimed
+            && dispatch.status() == RunDispatchStatus::Claimed
         {
             let delivered = self
                 .deliver_live_decision(

--- a/crates/awaken-server/src/mailbox/dispatch_execution.rs
+++ b/crates/awaken-server/src/mailbox/dispatch_execution.rs
@@ -13,9 +13,11 @@ use awaken_runtime::ThreadContextSnapshot;
 use awaken_runtime::{EventBuffer, ResolutionPolicy, RuntimeError};
 use awaken_server_contract::contract::event::AgentEvent;
 use awaken_server_contract::contract::event_sink::EventSink;
+use awaken_server_contract::contract::lifecycle::RunStatus;
 use awaken_server_contract::contract::mailbox::{
     RunDispatch, RunDispatchResult, RunDispatchStatus,
 };
+use awaken_server_contract::contract::storage::StorageError;
 use awaken_server_contract::now_ms;
 
 use crate::transport::channel_sink::ReconnectableEventSink;
@@ -38,7 +40,7 @@ pub(super) async fn run_claimed_dispatch(
     thread_id: String,
     suspended: Arc<AtomicBool>,
 ) {
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     crate::metrics::inc_active_runs();
     let _guard = ActiveRunGuard;
     // Dispatch epoch check: if this dispatch was superseded between claim and
@@ -63,11 +65,11 @@ pub(super) async fn run_claimed_dispatch(
             return;
         }
     };
-    if current_dispatch.status != RunDispatchStatus::Claimed
-        || current_dispatch.claim_token.as_deref() != Some(claim_token.as_str())
+    if current_dispatch.status() != RunDispatchStatus::Claimed
+        || current_dispatch.claim_token().as_deref() != Some(claim_token.as_str())
     {
-        tracing::info!(dispatch_id, status = ?current_dispatch.status, "dispatch no longer owned by this worker, skipping execution");
-        if current_dispatch.status == RunDispatchStatus::Superseded {
+        tracing::info!(dispatch_id, status = ?current_dispatch.status(), "dispatch no longer owned by this worker, skipping execution");
+        if current_dispatch.status() == RunDispatchStatus::Superseded {
             this.mark_superseded_dispatch_run_cancelled(
                 &current_dispatch,
                 "dispatch superseded before execution start",
@@ -85,11 +87,11 @@ pub(super) async fn run_claimed_dispatch(
         epoch_start,
     );
     match current_epoch_result {
-        Ok(current_epoch) if current_dispatch.dispatch_epoch < current_epoch => {
+        Ok(current_epoch) if current_dispatch.dispatch_epoch() < current_epoch => {
             tracing::info!(
                 dispatch_id,
                 thread_id,
-                dispatch_epoch = current_dispatch.dispatch_epoch,
+                dispatch_epoch = current_dispatch.dispatch_epoch(),
                 current_epoch,
                 "dispatch superseded before execution start"
             );
@@ -136,7 +138,7 @@ pub(super) async fn run_claimed_dispatch(
             );
             let msg = error.to_string();
             let run_result = RunDispatchResult {
-                run_id: dispatch.run_id.clone(),
+                run_id: dispatch.run_id().clone(),
                 dispatch_instance_id: dispatch_instance_id.clone(),
                 status: awaken_server_contract::contract::lifecycle::RunStatus::Done,
                 termination: Some(
@@ -160,7 +162,7 @@ pub(super) async fn run_claimed_dispatch(
             if let Err(error) = record_result {
                 tracing::warn!(dispatch_id, error = %error, "failed to record dispatch start for reconstruction failure");
                 if let Ok(Some(latest_dispatch)) = this.store.load_dispatch(&dispatch_id).await
-                    && latest_dispatch.status == RunDispatchStatus::Superseded
+                    && latest_dispatch.status() == RunDispatchStatus::Superseded
                 {
                     this.mark_superseded_dispatch_run_cancelled(
                         &latest_dispatch,
@@ -194,7 +196,7 @@ pub(super) async fn run_claimed_dispatch(
             if dead_letter_result.is_ok() {
                 this.refresh_dispatch_depth_metrics().await;
                 if let Ok(Some(dead_letter_dispatch)) = this.store.load_dispatch(&dispatch_id).await
-                    && dead_letter_dispatch.status == RunDispatchStatus::DeadLetter
+                    && dead_letter_dispatch.status() == RunDispatchStatus::DeadLetter
                 {
                     this.mark_dead_letter_dispatch_run_error(&dead_letter_dispatch)
                         .await;
@@ -211,9 +213,10 @@ pub(super) async fn run_claimed_dispatch(
     // checkpoint commit). The runtime itself never sees the buffer. Capture
     // requires a staged coordinator (one that can append canonical events
     // atomically with the checkpoint); `with_runtime_event_capture` validated
-    // a commit coordinator is present, and the staged variant is the one that
-    // does the atomic event write.
-    let event_buffer = (this.runtime_event_capture.is_some() && this.staged_coordinator.is_some())
+    // the staged coordinator is present before capture can be enabled.
+    let event_buffer = this
+        .runtime_event_capture
+        .is_some()
         .then(|| Arc::new(EventBuffer::new()));
     let sink = Arc::new(SuspensionAwareSink {
         inner: this.wrap_dispatch_runtime_event_sink(
@@ -226,13 +229,41 @@ pub(super) async fn run_claimed_dispatch(
         suspended,
     });
     normalize_mailbox_run_mode(&mut request, false);
-    let run_id = dispatch.run_id.clone();
+    let run_id = dispatch.run_id().clone();
     request = request
         .with_dispatch_id(dispatch_id.clone())
         .with_session_id(dispatch_instance_id.clone());
-    if let Some(buffer) = event_buffer
-        && let Some(staged) = this.staged_coordinator.as_ref()
-    {
+    if let Some(buffer) = event_buffer {
+        let Some(staged) = this.staged_coordinator.as_ref() else {
+            let msg = "runtime event capture requires staged commit coordinator";
+            tracing::error!(
+                dispatch_id,
+                run_id,
+                "mailbox runtime event capture misconfigured"
+            );
+            let now = now_ms();
+            let dead_letter_start = Instant::now();
+            let dead_letter_result = this
+                .store
+                .dead_letter(&dispatch_id, &claim_token, msg, now)
+                .await;
+            record_mailbox_operation_result(
+                "dead_letter",
+                result_label(&dead_letter_result),
+                dead_letter_start,
+            );
+            if dead_letter_result.is_ok() {
+                this.refresh_dispatch_depth_metrics().await;
+                if let Ok(Some(dead_letter_dispatch)) = this.store.load_dispatch(&dispatch_id).await
+                    && dead_letter_dispatch.status() == RunDispatchStatus::DeadLetter
+                {
+                    this.mark_dead_letter_dispatch_run_error(&dead_letter_dispatch)
+                        .await;
+                }
+            }
+            this.finish_execution(&thread_id, &dispatch_id).await;
+            return;
+        };
         // Fold staged canonical drafts into the run's checkpoint commits via a
         // per-run coordinator wrapping the mailbox's durable staged coordinator.
         let staging =
@@ -252,7 +283,7 @@ pub(super) async fn run_claimed_dispatch(
     if let Err(e) = record_start_result {
         tracing::warn!(dispatch_id, run_id, error = %e, "failed to record mailbox dispatch start; skipping execution");
         if let Ok(Some(latest_dispatch)) = this.store.load_dispatch(&dispatch_id).await
-            && latest_dispatch.status == RunDispatchStatus::Superseded
+            && latest_dispatch.status() == RunDispatchStatus::Superseded
         {
             this.mark_superseded_dispatch_run_cancelled(
                 &latest_dispatch,
@@ -282,7 +313,7 @@ pub(super) async fn run_claimed_dispatch(
     let (inbox_sender, inbox_receiver) =
         awaken_runtime::inbox::inbox_channel_with_fallback(Arc::new(TaskDoneMailboxNotify::new(
             this.clone(),
-            dispatch.thread_id.clone(),
+            dispatch.thread_id().clone(),
             continue_run_id,
         )));
     request = request.with_inbox(inbox_sender, inbox_receiver);
@@ -308,10 +339,13 @@ pub(super) async fn run_claimed_dispatch(
             // RegistrySet so the run loop resolves against it (e.g. an unsaved
             // sandbox draft) instead of falling back to the live registry. The
             // runtime stays pin-agnostic — it only receives a RegistrySet.
-            let resolved = match this.materialize_pinned_registry_set(&resolution_id).await {
-                Ok(Some(set)) => {
-                    request = request.with_pinned_registry_set(set);
-                    this.executor
+            match this.materialize_pinned_registry_set(&resolution_id).await {
+                Ok(pinned_set) => {
+                    if let Some(set) = pinned_set {
+                        request = request.with_pinned_registry_set(set);
+                    }
+                    match this
+                        .executor
                         .resolve_activation_in_scope(
                             &request,
                             ResolutionPolicy::PersistentServer,
@@ -319,30 +353,32 @@ pub(super) async fn run_claimed_dispatch(
                         )
                         .await
                         .and_then(|plan| plan.into_replayable())
-                }
-                Ok(None) => this
-                    .executor
-                    .resolve_activation_in_scope(
-                        &request,
-                        ResolutionPolicy::PersistentServer,
-                        RegistryResolutionScope::Pinned(resolution_id),
-                    )
-                    .await
-                    .and_then(|plan| plan.into_replayable()),
-                Err(error) => Err(awaken_runtime::ResolveError::Runtime(error.to_string())),
-            };
-            match resolved {
-                Ok(plan) => {
-                    if let Some(handler) = this.pending_boundary_handler(
-                        &request,
-                        &run_id,
-                        plan.artifact.resolution_id.as_str(),
-                    ) {
-                        request = request.with_pending_boundary_handler(handler);
+                    {
+                        Ok(plan) => {
+                            if let Some(handler) = this.pending_boundary_handler(
+                                &request,
+                                &run_id,
+                                plan.artifact.resolution_id.as_str(),
+                            ) {
+                                request = request.with_pending_boundary_handler(handler);
+                            }
+                            this.executor
+                                .run_replayable_with_thread_context(
+                                    request,
+                                    plan,
+                                    sink.clone(),
+                                    thread_ctx,
+                                )
+                                .await
+                        }
+                        Err(error) => {
+                            Err(awaken_runtime::loop_runner::AgentLoopError::RuntimeError(
+                                RuntimeError::ResolveFailed {
+                                    message: error.to_string(),
+                                },
+                            ))
+                        }
                     }
-                    this.executor
-                        .run_replayable_with_thread_context(request, plan, sink.clone(), thread_ctx)
-                        .await
                 }
                 Err(error) => Err(awaken_runtime::loop_runner::AgentLoopError::RuntimeError(
                     RuntimeError::ResolveFailed {
@@ -362,12 +398,13 @@ pub(super) async fn run_claimed_dispatch(
         .store
         .record_run_result(&dispatch_id, &claim_token, &run_result, now)
         .await;
+    let run_result_recorded = record_run_result.is_ok();
     record_mailbox_operation_result(
         "record_run_result",
         result_label(&record_run_result),
         record_result_start,
     );
-    if let Err(e) = record_run_result {
+    if let Err(e) = &record_run_result {
         tracing::warn!(dispatch_id, run_id, error = %e, "failed to record mailbox run result");
     }
     let outcome = classify_error(&result);
@@ -379,6 +416,27 @@ pub(super) async fn run_claimed_dispatch(
             record_mailbox_operation_result("ack", result_label(&ack_result), ack_start);
             if let Err(e) = ack_result {
                 tracing::warn!(dispatch_id, error = %e, "ack failed");
+                if run_result_recorded {
+                    let recovery_start = Instant::now();
+                    let recovery_result = recover_completed_ack_after_result_recorded(
+                        &this,
+                        &dispatch_id,
+                        &claim_token,
+                        now,
+                    )
+                    .await;
+                    record_mailbox_operation_result(
+                        "ack_recovery",
+                        result_label(&recovery_result),
+                        recovery_start,
+                    );
+                    match recovery_result {
+                        Ok(()) => this.refresh_dispatch_depth_metrics().await,
+                        Err(error) => {
+                            tracing::warn!(dispatch_id, error = %error, "ack recovery failed");
+                        }
+                    }
+                }
             } else {
                 this.refresh_dispatch_depth_metrics().await;
             }
@@ -388,7 +446,7 @@ pub(super) async fn run_claimed_dispatch(
             // Emit error event so the SSE stream terminates with a proper
             // RUN_ERROR instead of silently closing.
             sink.emit(AgentEvent::RunFinish {
-                thread_id: dispatch.thread_id.clone(),
+                thread_id: dispatch.thread_id().clone(),
                 run_id: run_id.clone(),
                 identity: Some(mailbox_run_identity(
                     &dispatch,
@@ -401,7 +459,7 @@ pub(super) async fn run_claimed_dispatch(
                 ),
             })
             .await;
-            let backoff_factor = 2u64.pow(dispatch.attempt_count.saturating_sub(1).min(6));
+            let backoff_factor = 2u64.pow(dispatch.attempt_count().saturating_sub(1).min(6));
             let retry_at = now
                 + (this.config.default_retry_delay_ms * backoff_factor)
                     .min(this.config.max_retry_delay_ms);
@@ -425,7 +483,7 @@ pub(super) async fn run_claimed_dispatch(
             // RUN_ERROR. The runtime did not reach the loop, so no
             // RunFinish was emitted — we must do it here.
             sink.emit(AgentEvent::RunFinish {
-                thread_id: dispatch.thread_id.clone(),
+                thread_id: dispatch.thread_id().clone(),
                 run_id: run_id.clone(),
                 identity: Some(mailbox_run_identity(
                     &dispatch,
@@ -454,7 +512,7 @@ pub(super) async fn run_claimed_dispatch(
             } else {
                 this.refresh_dispatch_depth_metrics().await;
                 if let Ok(Some(dead_letter_dispatch)) = this.store.load_dispatch(&dispatch_id).await
-                    && dead_letter_dispatch.status == RunDispatchStatus::DeadLetter
+                    && dead_letter_dispatch.status() == RunDispatchStatus::DeadLetter
                 {
                     this.mark_dead_letter_dispatch_run_error(&dead_letter_dispatch)
                         .await;
@@ -463,4 +521,36 @@ pub(super) async fn run_claimed_dispatch(
         }
     }
     this.finish_execution(&thread_id, &dispatch_id).await;
+}
+
+async fn recover_completed_ack_after_result_recorded(
+    this: &Mailbox,
+    dispatch_id: &str,
+    claim_token: &str,
+    now: u64,
+) -> Result<(), StorageError> {
+    let Some(dispatch) = this.store.load_dispatch(dispatch_id).await? else {
+        return Err(StorageError::NotFound(dispatch_id.to_string()));
+    };
+    match dispatch.status() {
+        RunDispatchStatus::Acked => return Ok(()),
+        RunDispatchStatus::Claimed => {}
+        status => {
+            return Err(StorageError::Validation(format!(
+                "cannot recover ack for dispatch '{dispatch_id}' in status {status:?}"
+            )));
+        }
+    }
+    if dispatch.claim_token() != Some(claim_token) {
+        return Err(StorageError::VersionConflict {
+            expected: 0,
+            actual: 1,
+        });
+    }
+    if dispatch.run_status() != Some(RunStatus::Done) {
+        return Err(StorageError::Validation(format!(
+            "cannot recover ack for dispatch '{dispatch_id}' without recorded Done result"
+        )));
+    }
+    this.store.ack(dispatch_id, claim_token, now).await
 }

--- a/crates/awaken-server/src/mailbox/helpers.rs
+++ b/crates/awaken-server/src/mailbox/helpers.rs
@@ -142,8 +142,8 @@ pub(super) fn normalize_message_ids(messages: &[Message]) -> Vec<Message> {
 }
 
 pub(super) fn live_target_for_dispatch(dispatch: &RunDispatch) -> LiveRunTarget {
-    LiveRunTarget::new(dispatch.thread_id.clone(), dispatch.run_id.clone())
-        .with_dispatch_id(dispatch.dispatch_id.clone())
+    LiveRunTarget::new(dispatch.thread_id().clone(), dispatch.run_id().clone())
+        .with_dispatch_id(dispatch.dispatch_id().clone())
 }
 
 pub(super) fn live_target_for_run(run: &RunRecord) -> LiveRunTarget {
@@ -196,14 +196,14 @@ pub(super) fn mailbox_run_identity(
     dispatch_instance_id: &str,
 ) -> awaken_server_contract::contract::identity::RunIdentity {
     awaken_server_contract::contract::identity::RunIdentity::new(
-        dispatch.thread_id.clone(),
+        dispatch.thread_id().clone(),
         None,
         run_id.to_string(),
         None,
         String::new(),
         awaken_server_contract::contract::identity::RunOrigin::Internal,
     )
-    .with_dispatch_id(dispatch.dispatch_id.clone())
+    .with_dispatch_id(dispatch.dispatch_id().clone())
     .with_session_id(dispatch_instance_id.to_string())
 }
 
@@ -212,9 +212,9 @@ pub(super) fn millis_to_seconds(ms: u64) -> f64 {
 }
 
 pub(super) fn record_mailbox_dispatch_start_metrics(dispatch: &RunDispatch, start_now: u64) {
-    let enqueue_to_start_ms = start_now.saturating_sub(dispatch.created_at);
-    let eligible_to_start_ms = start_now.saturating_sub(dispatch.available_at);
-    let claim_to_start_ms = start_now.saturating_sub(dispatch.updated_at);
+    let enqueue_to_start_ms = start_now.saturating_sub(dispatch.created_at());
+    let eligible_to_start_ms = start_now.saturating_sub(dispatch.available_at());
+    let claim_to_start_ms = start_now.saturating_sub(dispatch.updated_at());
 
     crate::metrics::record_mailbox_dispatch_enqueue_to_start(millis_to_seconds(
         enqueue_to_start_ms,
@@ -225,9 +225,9 @@ pub(super) fn record_mailbox_dispatch_start_metrics(dispatch: &RunDispatch, star
     crate::metrics::record_mailbox_dispatch_claim_to_start(millis_to_seconds(claim_to_start_ms));
 
     tracing::info!(
-        dispatch_id = %dispatch.dispatch_id,
-        run_id = %dispatch.run_id,
-        thread_id = %dispatch.thread_id,
+        dispatch_id = %dispatch.dispatch_id(),
+        run_id = %dispatch.run_id(),
+        thread_id = %dispatch.thread_id(),
         enqueue_to_start_ms,
         eligible_to_start_ms,
         claim_to_start_ms,
@@ -242,7 +242,7 @@ pub(super) fn record_mailbox_dispatch_completion_metrics(
     outcome: &str,
 ) {
     let runtime_ms = completed_now.saturating_sub(start_now);
-    let enqueue_to_complete_ms = completed_now.saturating_sub(dispatch.created_at);
+    let enqueue_to_complete_ms = completed_now.saturating_sub(dispatch.created_at());
 
     crate::metrics::record_mailbox_dispatch_runtime(millis_to_seconds(runtime_ms), outcome);
     crate::metrics::record_mailbox_dispatch_enqueue_to_complete(
@@ -252,9 +252,9 @@ pub(super) fn record_mailbox_dispatch_completion_metrics(
     crate::metrics::record_run_completion(millis_to_seconds(runtime_ms), outcome);
 
     tracing::info!(
-        dispatch_id = %dispatch.dispatch_id,
-        run_id = %dispatch.run_id,
-        thread_id = %dispatch.thread_id,
+        dispatch_id = %dispatch.dispatch_id(),
+        run_id = %dispatch.run_id(),
+        thread_id = %dispatch.thread_id(),
         outcome,
         runtime_ms,
         enqueue_to_complete_ms,
@@ -263,7 +263,7 @@ pub(super) fn record_mailbox_dispatch_completion_metrics(
 }
 
 pub(super) fn record_mailbox_dispatch_terminal_metrics(dispatch: &RunDispatch, outcome: &str) {
-    let completed_now = dispatch.completed_at.unwrap_or_else(now_ms);
+    let completed_now = dispatch.completed_at().unwrap_or_else(now_ms);
     record_mailbox_dispatch_completion_metrics(dispatch, completed_now, completed_now, outcome);
 }
 
@@ -385,6 +385,9 @@ pub(super) fn classify_error(
                 // transient to preserve prior behavior.
                 AgentLoopError::InferenceFailed(_) => {
                     MailboxRunOutcome::TransientError(e.to_string())
+                }
+                AgentLoopError::InvalidActivation(_) => {
+                    MailboxRunOutcome::PermanentError(e.to_string())
                 }
                 // Agent-level failures (phase error, invalid resume) are not infra errors.
                 _ => MailboxRunOutcome::Completed,

--- a/crates/awaken-server/src/mailbox/lifecycle.rs
+++ b/crates/awaken-server/src/mailbox/lifecycle.rs
@@ -360,30 +360,13 @@ impl Mailbox {
                 continue;
             }
             let now = now_ms();
-            let dispatch = RunDispatch {
-                dispatch_id: dispatch_id.clone(),
-                thread_id: run.thread_id.clone(),
-                run_id: run.run_id.clone(),
-                priority: 128,
-                dedupe_key: None,
-                dispatch_epoch: 0,
-                status: RunDispatchStatus::Queued,
-                available_at: now,
-                attempt_count: 0,
-                max_attempts: self.config.default_max_attempts,
-                last_error: None,
-                claim_token: None,
-                claimed_by: None,
-                lease_until: None,
-                dispatch_instance_id: None,
-                run_status: None,
-                termination: None,
-                run_response: None,
-                run_error: None,
-                completed_at: None,
-                created_at: now,
-                updated_at: now,
-            };
+            let dispatch = RunDispatch::queued(
+                dispatch_id.clone(),
+                run.thread_id.clone(),
+                run.run_id.clone(),
+                now,
+            )
+            .with_max_attempts(self.config.default_max_attempts);
             if let Err(error) = self.store.enqueue(&dispatch).await {
                 match error {
                     StorageError::AlreadyExists(id) if id == dispatch_id => {
@@ -532,8 +515,8 @@ impl Mailbox {
                         self.record_run_rescheduled_dispatch(&dispatch, "expired_lease_reclaimed")
                             .await;
                         self.reconcile_terminal_dispatch(&dispatch).await;
-                        if dispatch.status == RunDispatchStatus::Queued {
-                            let thread_id = dispatch.thread_id.clone();
+                        if dispatch.status() == RunDispatchStatus::Queued {
+                            let thread_id = dispatch.thread_id().clone();
                             self.get_or_create_worker(&thread_id).await;
                             self.try_dispatch_next(&thread_id).await;
                         }

--- a/crates/awaken-server/src/mailbox/live_delivery.rs
+++ b/crates/awaken-server/src/mailbox/live_delivery.rs
@@ -187,17 +187,22 @@ impl Mailbox {
         }
     }
 
-    pub(super) async fn reusable_waiting_run_id(&self, thread_id: &str) -> Option<String> {
-        if let Some(thread) = self.run_store.load_thread(thread_id).await.ok().flatten()
+    pub(super) async fn reusable_waiting_run_id(
+        &self,
+        thread_id: &str,
+    ) -> Result<Option<String>, MailboxError> {
+        if let Some(thread) = self.run_store.load_thread(thread_id).await?
             && let Some(open_run_id) = thread.open_run_id.as_deref()
-            && let Some(run) = self.run_store.load_run(open_run_id).await.ok().flatten()
+            && let Some(run) = self.run_store.load_run(open_run_id).await?
             && run.thread_id == thread_id
             && run.is_resumable_waiting()
         {
-            return Some(run.run_id);
+            return Ok(Some(run.run_id));
         }
-        let run = self.run_store.latest_run(thread_id).await.ok().flatten()?;
-        run.is_resumable_waiting().then_some(run.run_id)
+        let Some(run) = self.run_store.latest_run(thread_id).await? else {
+            return Ok(None);
+        };
+        Ok(run.is_resumable_waiting().then_some(run.run_id))
     }
 
     // ── Query ────────────────────────────────────────────────────────

--- a/crates/awaken-server/src/mailbox/runtime_event_capture.rs
+++ b/crates/awaken-server/src/mailbox/runtime_event_capture.rs
@@ -38,6 +38,12 @@ impl Mailbox {
                 "runtime event capture requires an executor with CommitCoordinator".to_string(),
             ));
         }
+        if self.staged_coordinator.is_none() {
+            return Err(MailboxError::Validation(
+                "runtime event capture requires an executor with StagedCommitCoordinator"
+                    .to_string(),
+            ));
+        }
         AgentEventNormalizationContext::new("validation-thread", "validation-run", &origin)
             .map_err(|error| MailboxError::Validation(error.to_string()))?;
         self.runtime_event_capture = Some(RuntimeEventCaptureConfig { mode, origin });
@@ -122,8 +128,8 @@ impl Mailbox {
     ) -> Arc<dyn EventSink> {
         self.wrap_reconnectable_runtime_event_sink(
             inner,
-            &dispatch.thread_id,
-            &dispatch.run_id,
+            &dispatch.thread_id(),
+            &dispatch.run_id(),
             correlation_id,
             resumed,
             event_buffer,

--- a/crates/awaken-server/src/mailbox/server_event_capture.rs
+++ b/crates/awaken-server/src/mailbox/server_event_capture.rs
@@ -57,8 +57,8 @@ impl Mailbox {
         };
         let origin = self.server_event_origin.clone();
         let payload = match serde_json::to_value(AgentEvent::RunFinish {
-            thread_id: dispatch.thread_id.clone(),
-            run_id: dispatch.run_id.clone(),
+            thread_id: dispatch.thread_id().clone(),
+            run_id: dispatch.run_id().clone(),
             identity: None,
             result: None,
             termination: awaken_server_contract::contract::lifecycle::TerminationReason::Error(
@@ -67,14 +67,14 @@ impl Mailbox {
         }) {
             Ok(payload) => payload,
             Err(error) => {
-                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "invalid run errored event payload");
+                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id(), "invalid run errored event payload");
                 return;
             }
         };
         let mut draft = match CanonicalEventDraft::new(
             vec![
-                EventScope::thread(dispatch.thread_id.clone()),
-                EventScope::run(dispatch.run_id.clone()),
+                EventScope::thread(dispatch.thread_id().clone()),
+                EventScope::run(dispatch.run_id().clone()),
             ],
             match CanonicalEventKind::new("RunErrored") {
                 Ok(kind) => kind,
@@ -88,22 +88,23 @@ impl Mailbox {
         ) {
             Ok(draft) => draft,
             Err(error) => {
-                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "invalid run errored event draft");
+                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id(), "invalid run errored event draft");
                 return;
             }
         };
         draft.visibility = EventVisibility::Public;
-        draft.correlation_id = Some(dispatch.dispatch_id.clone());
+        draft.correlation_id = Some(dispatch.dispatch_id().clone());
         let options = AppendOptions {
             writer_id: Some("mailbox".to_string()),
             idempotency_key: Some(format!(
                 "RunErrored/{}/{}",
-                dispatch.dispatch_id, dispatch.attempt_count
+                dispatch.dispatch_id(),
+                dispatch.attempt_count()
             )),
             expected_prior_cursors: Default::default(),
         };
         if let Err(error) = publisher.publish(draft, options).await {
-            tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "failed to record run errored event");
+            tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id(), "failed to record run errored event");
         }
     }
 
@@ -131,20 +132,20 @@ impl Mailbox {
             })
             .collect::<Vec<_>>();
         let payload = json!({
-            "thread_id": dispatch.thread_id,
-            "run_id": dispatch.run_id,
-            "dispatch_id": dispatch.dispatch_id,
-            "dispatch_epoch": dispatch.dispatch_epoch,
-            "attempt_count": dispatch.attempt_count,
-            "status": dispatch_status_label(dispatch.status),
+            "thread_id": dispatch.thread_id(),
+            "run_id": dispatch.run_id(),
+            "dispatch_id": dispatch.dispatch_id(),
+            "dispatch_epoch": dispatch.dispatch_epoch(),
+            "attempt_count": dispatch.attempt_count(),
+            "status": dispatch_status_label(dispatch.status()),
             "reason": reason,
             "error": error.to_string(),
             "decisions": decisions,
         });
         let mut draft = match CanonicalEventDraft::new(
             vec![
-                EventScope::thread(dispatch.thread_id.clone()),
-                EventScope::run(dispatch.run_id.clone()),
+                EventScope::thread(dispatch.thread_id().clone()),
+                EventScope::run(dispatch.run_id().clone()),
             ],
             match CanonicalEventKind::new("MailboxResumeFailed") {
                 Ok(kind) => kind,
@@ -158,22 +159,23 @@ impl Mailbox {
         ) {
             Ok(draft) => draft,
             Err(error) => {
-                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "invalid mailbox resume failed event draft");
+                tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id(), "invalid mailbox resume failed event draft");
                 return;
             }
         };
         draft.visibility = EventVisibility::Public;
-        draft.correlation_id = Some(dispatch.dispatch_id.clone());
+        draft.correlation_id = Some(dispatch.dispatch_id().clone());
         let options = AppendOptions {
             writer_id: Some("mailbox".to_string()),
             idempotency_key: Some(format!(
                 "MailboxResumeFailed/{}/{}",
-                dispatch.dispatch_id, dispatch.attempt_count
+                dispatch.dispatch_id(),
+                dispatch.attempt_count()
             )),
             expected_prior_cursors: Default::default(),
         };
         if let Err(error) = publisher.publish(draft, options).await {
-            tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id, "failed to record mailbox resume failed event");
+            tracing::error!(error = %error, dispatch_id = %dispatch.dispatch_id(), "failed to record mailbox resume failed event");
         }
     }
 
@@ -182,7 +184,7 @@ impl Mailbox {
         dispatch: &RunDispatch,
         reason: &'static str,
     ) {
-        if dispatch.status == RunDispatchStatus::Queued {
+        if dispatch.status() == RunDispatchStatus::Queued {
             self.record_mailbox_dispatch_event_inner(
                 "RunRescheduled",
                 dispatch,
@@ -224,15 +226,15 @@ impl Mailbox {
         };
         let origin = self.server_event_origin.clone();
         let mut payload = json!({
-            "thread_id": dispatch.thread_id,
-            "run_id": dispatch.run_id,
-            "dispatch_id": dispatch.dispatch_id,
-            "dispatch_epoch": dispatch.dispatch_epoch,
-            "attempt_count": dispatch.attempt_count,
-            "status": dispatch_status_label(dispatch.status),
-            "available_at": dispatch.available_at,
-            "created_at": dispatch.created_at,
-            "updated_at": dispatch.updated_at,
+            "thread_id": dispatch.thread_id(),
+            "run_id": dispatch.run_id(),
+            "dispatch_id": dispatch.dispatch_id(),
+            "dispatch_epoch": dispatch.dispatch_epoch(),
+            "attempt_count": dispatch.attempt_count(),
+            "status": dispatch_status_label(dispatch.status()),
+            "available_at": dispatch.available_at(),
+            "created_at": dispatch.created_at(),
+            "updated_at": dispatch.updated_at(),
         });
         if let Some(reason) = reason
             && let Some(payload) = payload.as_object_mut()
@@ -251,8 +253,8 @@ impl Mailbox {
         }
         let mut draft = match CanonicalEventDraft::new(
             vec![
-                EventScope::thread(dispatch.thread_id.clone()),
-                EventScope::run(dispatch.run_id.clone()),
+                EventScope::thread(dispatch.thread_id().clone()),
+                EventScope::run(dispatch.run_id().clone()),
             ],
             match CanonicalEventKind::new(event_kind) {
                 Ok(kind) => kind,
@@ -266,22 +268,24 @@ impl Mailbox {
         ) {
             Ok(draft) => draft,
             Err(error) => {
-                tracing::error!(error = %error, event_kind, dispatch_id = %dispatch.dispatch_id, "invalid mailbox event draft");
+                tracing::error!(error = %error, event_kind, dispatch_id = %dispatch.dispatch_id(), "invalid mailbox event draft");
                 return;
             }
         };
         draft.visibility = EventVisibility::Public;
-        draft.correlation_id = Some(dispatch.dispatch_id.clone());
+        draft.correlation_id = Some(dispatch.dispatch_id().clone());
         let options = AppendOptions {
             writer_id: Some("mailbox".to_string()),
             idempotency_key: Some(format!(
                 "{}/{}/{}",
-                event_kind, dispatch.dispatch_id, dispatch.attempt_count
+                event_kind,
+                dispatch.dispatch_id(),
+                dispatch.attempt_count()
             )),
             expected_prior_cursors: Default::default(),
         };
         if let Err(error) = publisher.publish(draft, options).await {
-            tracing::error!(error = %error, event_kind, dispatch_id = %dispatch.dispatch_id, "failed to record mailbox event");
+            tracing::error!(error = %error, event_kind, dispatch_id = %dispatch.dispatch_id(), "failed to record mailbox event");
         }
     }
 
@@ -306,6 +310,7 @@ impl Mailbox {
         if first_new_seq > last_new_seq {
             return Ok(());
         }
+        validate_checkpoint_event_range(thread_id, run_id, messages, first_new_seq, last_new_seq)?;
         for seq in first_new_seq..=last_new_seq {
             self.record_message_committed(thread_id, run_id, messages, seq)
                 .await?;
@@ -398,9 +403,9 @@ impl Mailbox {
         delivery_path: &'static str,
     ) {
         self.record_mailbox_decision_received(
-            &dispatch.thread_id,
-            &dispatch.run_id,
-            Some(&dispatch.dispatch_id),
+            &dispatch.thread_id(),
+            &dispatch.run_id(),
+            Some(&dispatch.dispatch_id()),
             tool_call_id,
             resume,
             delivery_path,
@@ -739,6 +744,32 @@ impl Mailbox {
         })?;
         Ok(())
     }
+}
+
+fn validate_checkpoint_event_range(
+    thread_id: &str,
+    run_id: &str,
+    messages: &[Message],
+    first_new_seq: u64,
+    last_new_seq: u64,
+) -> Result<(), MailboxError> {
+    for seq in first_new_seq..=last_new_seq {
+        let Some(message) = seq
+            .checked_sub(1)
+            .and_then(|index| messages.get(index as usize))
+        else {
+            return Err(MailboxError::Internal(format!(
+                "checkpoint event range {first_new_seq}-{last_new_seq} for thread '{thread_id}' run '{run_id}' exceeds committed message count {}",
+                messages.len()
+            )));
+        };
+        if message.id.as_deref().is_none_or(|id| id.trim().is_empty()) {
+            return Err(MailboxError::Internal(format!(
+                "checkpoint event message seq {seq} for thread '{thread_id}' run '{run_id}' is missing message id"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn message_kind(message: &Message) -> &'static str {

--- a/crates/awaken-server/src/mailbox/signal_loop.rs
+++ b/crates/awaken-server/src/mailbox/signal_loop.rs
@@ -72,7 +72,7 @@ impl Mailbox {
         let deadline = tokio::time::Instant::now() + Duration::from_millis(REMOTE_CANCEL_WAIT_MS);
         loop {
             match self.store.load_dispatch(dispatch_id).await? {
-                Some(dispatch) if dispatch.status == RunDispatchStatus::Claimed => {}
+                Some(dispatch) if dispatch.status() == RunDispatchStatus::Claimed => {}
                 _ => return Ok(true),
             }
             if tokio::time::Instant::now() >= deadline {
@@ -209,7 +209,7 @@ impl Mailbox {
         let Some(dispatch) = self.store.load_dispatch(&entry.dispatch_id).await? else {
             return Ok(false);
         };
-        Ok(dispatch.status == RunDispatchStatus::Queued && dispatch.available_at <= now)
+        Ok(dispatch.status() == RunDispatchStatus::Queued && dispatch.available_at() <= now)
     }
 
     // ── Internal: dispatch ───────────────────────────────────────────
@@ -247,8 +247,11 @@ impl Mailbox {
             return DispatchAttempt::NoEligible;
         };
 
-        let dispatch_id = dispatch.dispatch_id.clone();
-        let claim_token = dispatch.claim_token.clone().unwrap_or_default();
+        let dispatch_id = dispatch.dispatch_id().clone();
+        let claim_token = dispatch
+            .claim_token()
+            .map(str::to_string)
+            .unwrap_or_default();
 
         // Shared flag: set by the event sink when a tool call is suspended.
         let suspended = Arc::new(AtomicBool::new(false));
@@ -281,7 +284,7 @@ impl Mailbox {
             w.thread_ctx = thread_ctx;
             w.status = MailboxWorkerStatus::Running {
                 dispatch_id: dispatch_id.clone(),
-                run_id: dispatch.run_id.clone(),
+                run_id: dispatch.run_id().clone(),
                 lease_handle,
                 sink: Arc::clone(&reconnectable_sink),
             };
@@ -376,7 +379,7 @@ impl Mailbox {
     }
 
     /// Spawn the actual execution task for a claimed dispatch.
-    #[tracing::instrument(skip(self, reconnectable_sink, suspended), fields(dispatch_id = %dispatch.dispatch_id, thread_id = %thread_id))]
+    #[tracing::instrument(skip(self, reconnectable_sink, suspended), fields(dispatch_id = %dispatch.dispatch_id(), thread_id = %thread_id))]
     pub(super) fn spawn_execution(
         self: &Arc<Self>,
         dispatch: RunDispatch,

--- a/crates/awaken-server/src/mailbox/submit.rs
+++ b/crates/awaken-server/src/mailbox/submit.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 use awaken_runtime::{RegistryResolutionScope, ResolutionPolicy, RunActivation};
 use awaken_server_contract::contract::event::AgentEvent;
 use awaken_server_contract::contract::lifecycle::RunStatus;
-use awaken_server_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_server_contract::contract::mailbox::RunDispatch;
 use awaken_server_contract::contract::message::Message;
 use awaken_server_contract::contract::run::{RunInput, RunInputSnapshot, RunKind};
 use awaken_server_contract::contract::storage::{MessageSeqRange, RunRecord, RunRequestSnapshot};
@@ -130,14 +130,13 @@ impl Mailbox {
             .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
             .await?;
         let dispatch = self.build_dispatch(&request, &thread_id)?;
-        let dispatch_id = dispatch.dispatch_id.clone();
-        let thread_id = dispatch.thread_id.clone();
+        let dispatch_id = dispatch.dispatch_id().clone();
+        let thread_id = dispatch.thread_id().clone();
 
         // WAL: persist after the prepared checkpoint; startup recovery reconciles
         // the crash window. available_at is set slightly ahead so the sweep does not
         // grab the dispatch during the inline claim window (reclaimed after the guard).
-        let mut wal_dispatch = dispatch;
-        wal_dispatch.available_at = now_ms() + INLINE_CLAIM_GUARD_MS;
+        let wal_dispatch = dispatch.with_available_at(now_ms() + INLINE_CLAIM_GUARD_MS);
         self.enqueue_dispatch_for_request(&request, &wal_dispatch)
             .await?;
         self.record_mailbox_dispatch_event("RunQueued", &wal_dispatch)
@@ -162,7 +161,15 @@ impl Mailbox {
         let (event_tx, event_rx) = mpsc::channel(Self::EVENT_CHANNEL_CAPACITY);
 
         if let Some(claimed_dispatch) = claimed {
-            let claim_token = claimed_dispatch.claim_token.clone().unwrap_or_default();
+            let claim_token = claimed_dispatch
+                .claim_token()
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    MailboxError::Internal(format!(
+                        "claimed dispatch '{}' is missing claim token",
+                        claimed_dispatch.dispatch_id()
+                    ))
+                })?;
 
             // Shared flag: set by the event sink when a tool call is suspended.
             let suspended = Arc::new(AtomicBool::new(false));
@@ -270,8 +277,8 @@ impl Mailbox {
             .prepare_run_for_dispatch(&mut request, &thread_id, &messages)
             .await?;
         let dispatch = self.build_dispatch(&request, &thread_id)?;
-        let dispatch_id = dispatch.dispatch_id.clone();
-        let thread_id = dispatch.thread_id.clone();
+        let dispatch_id = dispatch.dispatch_id().clone();
+        let thread_id = dispatch.thread_id().clone();
 
         // WAL: persist with available_at = now; startup recovery reconstructs
         // the row if the process crashed after preparing the run checkpoint.
@@ -355,7 +362,7 @@ impl Mailbox {
         let _append_guard = lock_thread_append(&self.thread_append_locks, thread_id).await;
         if request.resume_run_id().is_none()
             && request.persistence.run_id_hint.is_none()
-            && let Some(waiting_run_id) = self.reusable_waiting_run_id(thread_id).await
+            && let Some(waiting_run_id) = self.reusable_waiting_run_id(thread_id).await?
         {
             request.intent.kind = RunKind::HitlResume {
                 run_id: waiting_run_id,
@@ -580,10 +587,9 @@ impl Mailbox {
             .await
             .and_then(|plan| plan.into_replayable())
             .map(|plan| plan.artifact.resolution_id)
-            .map_err(|error| {
-                MailboxError::Validation(format!(
-                    "persistent mailbox dispatch requires a replayable resolved run: {error}"
-                ))
+            .map_err(|source| MailboxError::Resolution {
+                context: "resolving persistent mailbox dispatch to a replayable run",
+                source,
             })
     }
 
@@ -599,34 +605,17 @@ impl Mailbox {
             .or_else(|| request.persistence.run_id_hint.clone())
             .ok_or_else(|| MailboxError::Internal("run_id missing after preparation".into()))?;
         let now = now_ms();
-        Ok(RunDispatch {
-            dispatch_id: request
+        Ok(RunDispatch::queued(
+            request
                 .persistence
                 .dispatch_id_hint
                 .clone()
                 .unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
-            thread_id: thread_id.to_string(),
+            thread_id.to_string(),
             run_id,
-            priority: 128,
-            dedupe_key: None,
-            dispatch_epoch: 0,
-            status: RunDispatchStatus::Queued,
-            available_at: now,
-            attempt_count: 0,
-            max_attempts: self.config.default_max_attempts,
-            last_error: None,
-            claim_token: None,
-            claimed_by: None,
-            lease_until: None,
-            dispatch_instance_id: None,
-            run_status: None,
-            termination: None,
-            run_response: None,
-            run_error: None,
-            completed_at: None,
-            created_at: now,
-            updated_at: now,
-        })
+            now,
+        )
+        .with_max_attempts(self.config.default_max_attempts))
     }
 
     pub(super) async fn reconstruct_run_request(
@@ -636,31 +625,34 @@ impl Mailbox {
         let run = {
             let cached = {
                 let workers = self.workers.read().await;
-                workers.get(&dispatch.thread_id).and_then(|w| {
+                workers.get(dispatch.thread_id()).and_then(|w| {
                     let w = w.lock();
                     w.thread_ctx
                         .as_ref()
-                        .and_then(|ctx| ctx.get_run(&dispatch.run_id).cloned())
+                        .and_then(|ctx| ctx.get_run(&dispatch.run_id()).cloned())
                 })
             };
             if let Some(run) = cached {
                 run
             } else {
                 self.run_store
-                    .load_run(&dispatch.run_id)
+                    .load_run(&dispatch.run_id())
                     .await?
                     .ok_or_else(|| {
                         MailboxError::Validation(format!(
                             "run '{}' not found for dispatch '{}'",
-                            dispatch.run_id, dispatch.dispatch_id
+                            dispatch.run_id(),
+                            dispatch.dispatch_id()
                         ))
                     })?
             }
         };
-        if run.thread_id != dispatch.thread_id {
+        if run.thread_id != *dispatch.thread_id() {
             return Err(MailboxError::Validation(format!(
                 "run '{}' belongs to thread '{}', not dispatch thread '{}'",
-                run.run_id, run.thread_id, dispatch.thread_id
+                run.run_id,
+                run.thread_id,
+                dispatch.thread_id()
             )));
         }
         if let Some(snapshot) = run.activation.clone() {
@@ -734,7 +726,7 @@ impl Mailbox {
         } else {
             request.with_run_id_hint(run.run_id.clone())
         };
-        Ok(request.with_trace_dispatch_id(dispatch.dispatch_id.clone()))
+        Ok(request.with_trace_dispatch_id(dispatch.dispatch_id().clone()))
     }
 
     async fn activation_messages_for_snapshot(

--- a/crates/awaken-server/src/mailbox/tests.rs
+++ b/crates/awaken-server/src/mailbox/tests.rs
@@ -445,6 +445,7 @@ struct SignalMailboxStore {
     nacked_count: Arc<AtomicUsize>,
     enqueue_failures_remaining: AtomicUsize,
     claim_failures_remaining: AtomicUsize,
+    ack_failures_remaining: AtomicUsize,
     claim_dispatch_empty_once: AtomicBool,
 }
 
@@ -463,6 +464,12 @@ impl SignalMailboxStore {
         store
     }
 
+    fn with_ack_failures(ack_failures: usize) -> Self {
+        let mut store = Self::with_failures_and_empty_claim_dispatch(0, false);
+        store.ack_failures_remaining = AtomicUsize::new(ack_failures);
+        store
+    }
+
     fn with_empty_claim_dispatch_once() -> Self {
         Self::with_failures_and_empty_claim_dispatch(0, true)
     }
@@ -478,6 +485,7 @@ impl SignalMailboxStore {
             nacked_count: Arc::new(AtomicUsize::new(0)),
             enqueue_failures_remaining: AtomicUsize::new(0),
             claim_failures_remaining: AtomicUsize::new(claim_failures),
+            ack_failures_remaining: AtomicUsize::new(0),
             claim_dispatch_empty_once: AtomicBool::new(claim_dispatch_empty_once),
         }
     }
@@ -505,8 +513,8 @@ impl MailboxStore for SignalMailboxStore {
         }
         self.inner.enqueue(dispatch).await?;
         self.signals.lock().await.push_back(TestDispatchSignal {
-            thread_id: dispatch.thread_id.clone(),
-            dispatch_id: dispatch.dispatch_id.clone(),
+            thread_id: dispatch.thread_id().clone(),
+            dispatch_id: dispatch.dispatch_id().clone(),
         });
         Ok(())
     }
@@ -554,6 +562,15 @@ impl MailboxStore for SignalMailboxStore {
         claim_token: &str,
         now: u64,
     ) -> Result<(), StorageError> {
+        let remaining = self.ack_failures_remaining.load(Ordering::SeqCst);
+        if remaining > 0
+            && self
+                .ack_failures_remaining
+                .compare_exchange(remaining, remaining - 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+        {
+            return Err(StorageError::Io("injected ack failure".into()));
+        }
         self.inner.ack(dispatch_id, claim_token, now).await
     }
 
@@ -881,10 +898,12 @@ impl MailboxStore for InterruptOnLoadMailboxStore {
     async fn load_dispatch(&self, dispatch_id: &str) -> Result<Option<RunDispatch>, StorageError> {
         let loaded = self.inner.load_dispatch(dispatch_id).await?;
         if let Some(dispatch) = loaded.as_ref()
-            && dispatch.status == RunDispatchStatus::Claimed
+            && dispatch.status() == RunDispatchStatus::Claimed
             && self.interrupt_once.swap(false, Ordering::SeqCst)
         {
-            self.inner.interrupt(&dispatch.thread_id, now_ms()).await?;
+            self.inner
+                .interrupt(&dispatch.thread_id(), now_ms())
+                .await?;
         }
         Ok(loaded)
     }
@@ -959,6 +978,49 @@ fn make_mailbox_with_run_store(
         "test-consumer".to_string(),
         MailboxConfig::default(),
     ))
+}
+
+#[test]
+fn try_with_pinned_registry_rejects_invalid_scope() {
+    let mailbox = Mailbox::new(
+        make_runtime(),
+        Arc::new(InMemoryMailboxStore::new()),
+        Arc::new(InMemoryStore::new()),
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    );
+
+    let result =
+        mailbox.try_with_pinned_registry(Arc::new(InMemoryVersionedRegistryStore::new()), " ");
+
+    assert!(result.is_err(), "invalid scope id must be surfaced");
+}
+
+#[tokio::test]
+async fn materialize_pinned_registry_rejects_invalid_resolution_id() {
+    let mailbox = Mailbox::new(
+        make_runtime(),
+        Arc::new(InMemoryMailboxStore::new()),
+        Arc::new(InMemoryStore::new()),
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    )
+    .with_pinned_registry(Arc::new(InMemoryVersionedRegistryStore::new()), "default");
+
+    let error = match mailbox
+        .materialize_pinned_registry_set("not-a-version")
+        .await
+    {
+        Ok(_) => panic!("invalid resolution id must fail"),
+        Err(error) => error,
+    };
+
+    assert!(
+        error
+            .to_string()
+            .contains("invalid pinned registry resolution id"),
+        "unexpected error: {error}"
+    );
 }
 
 struct NoopMailboxRuntime;
@@ -1815,9 +1877,9 @@ async fn enqueue_prepared_dispatch(
 ) -> MailboxSubmitResult {
     let dispatch = prepare_queued_dispatch(mailbox, thread_id, content).await;
     let result = MailboxSubmitResult {
-        dispatch_id: dispatch.dispatch_id.clone(),
-        run_id: dispatch.run_id.clone(),
-        thread_id: dispatch.thread_id.clone(),
+        dispatch_id: dispatch.dispatch_id().clone(),
+        run_id: dispatch.run_id().clone(),
+        thread_id: dispatch.thread_id().clone(),
         status: MailboxDispatchStatus::Queued,
     };
     store
@@ -1973,7 +2035,7 @@ async fn start_lifecycle_ready_retries_startup_recovery_until_ready() {
     let dispatch = mailbox
         .build_dispatch(&request, &thread_id)
         .expect("build queued dispatch");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store
         .enqueue(&dispatch)
         .await
@@ -1991,10 +2053,10 @@ async fn start_lifecycle_ready_retries_startup_recovery_until_ready() {
         .expect("ready lifecycle should retry startup recovery");
 
     let recovered = wait_for_dispatch(&store.inner, &dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::DeadLetter
+        dispatch.status() == RunDispatchStatus::DeadLetter
     })
     .await;
-    assert_eq!(recovered.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(recovered.status(), RunDispatchStatus::DeadLetter);
     handle.shutdown().await.expect("shutdown lifecycle");
 }
 
@@ -2017,8 +2079,8 @@ async fn reconstruct_failure_dead_letters_once_without_repolling() {
     ));
 
     let dispatch = prepare_queued_dispatch(&mailbox, "thread-gc", "hi").await;
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let thread_id = dispatch.thread_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let thread_id = dispatch.thread_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     // Simulate durable corruption: the run record survives but its activation
@@ -2034,16 +2096,16 @@ async fn reconstruct_failure_dead_letters_once_without_repolling() {
     mailbox.try_dispatch_next(&thread_id).await;
 
     let dead = wait_for_dispatch(&store, &dispatch_id, |d| {
-        d.status == RunDispatchStatus::DeadLetter
+        d.status() == RunDispatchStatus::DeadLetter
     })
     .await;
-    assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(dead.status(), RunDispatchStatus::DeadLetter);
     assert!(
-        dead.last_error
+        dead.last_error()
             .as_deref()
             .is_some_and(|e| e.contains("not found")),
         "expected missing-message error, got: {:?}",
-        dead.last_error
+        dead.last_error()
     );
     // Reconstruct failure must short-circuit before the runtime is entered.
     assert_eq!(
@@ -2054,7 +2116,7 @@ async fn reconstruct_failure_dead_letters_once_without_repolling() {
 
     // No double-poll: a subsequent dispatch poll must not re-claim the
     // terminal row. attempt_count and run_count stay frozen.
-    let attempts_after_dead_letter = dead.attempt_count;
+    let attempts_after_dead_letter = dead.attempt_count();
     mailbox.try_dispatch_next(&thread_id).await;
     sleep(Duration::from_millis(50)).await;
     let after = store
@@ -2063,12 +2125,13 @@ async fn reconstruct_failure_dead_letters_once_without_repolling() {
         .unwrap()
         .expect("dispatch remains inspectable");
     assert_eq!(
-        after.status,
+        after.status(),
         RunDispatchStatus::DeadLetter,
         "dead-lettered row must stay terminal"
     );
     assert_eq!(
-        after.attempt_count, attempts_after_dead_letter,
+        after.attempt_count(),
+        attempts_after_dead_letter,
         "terminal row must not be re-claimed / re-attempted"
     );
     assert_eq!(
@@ -2150,18 +2213,14 @@ async fn run_gc_auto_vacuums_old_terminal_dispatches() {
 
     // Drive a dispatch to a terminal (Acked) state with a past completed_at.
     let mut dispatch = prepare_queued_dispatch(&mailbox, "thread-gc-vacuum", "done").await;
-    dispatch.available_at = 1000;
-    let dispatch_id = dispatch.dispatch_id.clone();
+    dispatch = dispatch.with_available_at(1000);
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
     let claimed = store
         .claim("thread-gc-vacuum", "p3-gc-consumer", 30_000, 1000, 1)
         .await
         .expect("claim dispatch");
-    let token = claimed[0]
-        .claim_token
-        .as_deref()
-        .expect("claim token")
-        .to_string();
+    let token = claimed[0].claim_token().expect("claim token").to_string();
     store.ack(&dispatch_id, &token, 2000).await.expect("ack");
     assert_eq!(
         store
@@ -2169,7 +2228,7 @@ async fn run_gc_auto_vacuums_old_terminal_dispatches() {
             .await
             .unwrap()
             .expect("acked dispatch is inspectable")
-            .status,
+            .status(),
         RunDispatchStatus::Acked
     );
 
@@ -2202,24 +2261,24 @@ async fn permanent_inference_error_dead_letters_after_single_run() {
     ));
 
     let dispatch = prepare_queued_dispatch(&mailbox, "thread-perm", "go").await;
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let thread_id = dispatch.thread_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let thread_id = dispatch.thread_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     mailbox.get_or_create_worker(&thread_id).await;
     mailbox.try_dispatch_next(&thread_id).await;
 
     let dead = wait_for_dispatch(&store, &dispatch_id, |d| {
-        d.status == RunDispatchStatus::DeadLetter
+        d.status() == RunDispatchStatus::DeadLetter
     })
     .await;
-    assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(dead.status(), RunDispatchStatus::DeadLetter);
     assert!(
-        dead.last_error
+        dead.last_error()
             .as_deref()
             .is_some_and(|e| e.contains("unauthorized")),
         "expected unauthorized error, got: {:?}",
-        dead.last_error
+        dead.last_error()
     );
     // The decisive assertion: the runtime ran exactly once. A pre-fix build
     // nacked and re-ran up to max_attempts (5) before dead-lettering.
@@ -2229,9 +2288,9 @@ async fn permanent_inference_error_dead_letters_after_single_run() {
         "permanent fault must not be retried"
     );
     assert!(
-        dead.attempt_count < 5,
+        dead.attempt_count() < 5,
         "permanent fault must not exhaust the retry budget, attempt_count={}",
-        dead.attempt_count
+        dead.attempt_count()
     );
 }
 
@@ -2259,8 +2318,8 @@ async fn transient_inference_error_nacks_for_retry() {
     ));
 
     let dispatch = prepare_queued_dispatch(&mailbox, "thread-transient", "go").await;
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let thread_id = dispatch.thread_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let thread_id = dispatch.thread_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     mailbox.get_or_create_worker(&thread_id).await;
@@ -2269,11 +2328,11 @@ async fn transient_inference_error_nacks_for_retry() {
     // Nacked back to Queued (eligible later, after backoff) with one attempt
     // recorded — not dead-lettered.
     let requeued = wait_for_dispatch(&store, &dispatch_id, |d| {
-        d.status == RunDispatchStatus::Queued && d.attempt_count == 1
+        d.status() == RunDispatchStatus::Queued && d.attempt_count() == 1
     })
     .await;
-    assert_eq!(requeued.status, RunDispatchStatus::Queued);
-    assert_eq!(requeued.attempt_count, 1);
+    assert_eq!(requeued.status(), RunDispatchStatus::Queued);
+    assert_eq!(requeued.attempt_count(), 1);
     assert_eq!(
         runtime.run_count(),
         1,
@@ -2281,11 +2340,11 @@ async fn transient_inference_error_nacks_for_retry() {
     );
     assert!(
         requeued
-            .last_error
+            .last_error()
             .as_deref()
             .is_some_and(|e| e.contains("rate limited")),
         "expected rate-limit error, got: {:?}",
-        requeued.last_error
+        requeued.last_error()
     );
 }
 
@@ -2307,25 +2366,30 @@ async fn reconstruct_failure_missing_run_dead_letters_once() {
 
     let mut dispatch = prepare_queued_dispatch(&mailbox, "thread-missing-run", "hi").await;
     // Point the dispatch at a run that was never persisted.
-    dispatch.run_id = "nonexistent-run".to_string();
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let thread_id = dispatch.thread_id.clone();
+    dispatch.remap_identity(
+        dispatch.dispatch_id().clone(),
+        dispatch.thread_id().clone(),
+        "nonexistent-run".to_string(),
+        dispatch.dedupe_key().map(str::to_string),
+    );
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let thread_id = dispatch.thread_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     mailbox.get_or_create_worker(&thread_id).await;
     mailbox.try_dispatch_next(&thread_id).await;
 
     let dead = wait_for_dispatch(&store, &dispatch_id, |d| {
-        d.status == RunDispatchStatus::DeadLetter
+        d.status() == RunDispatchStatus::DeadLetter
     })
     .await;
-    assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(dead.status(), RunDispatchStatus::DeadLetter);
     assert!(
-        dead.last_error
+        dead.last_error()
             .as_deref()
             .is_some_and(|e| e.contains("not found")),
         "expected run-not-found error, got: {:?}",
-        dead.last_error
+        dead.last_error()
     );
     assert_eq!(
         runtime.run_count(),
@@ -2351,8 +2415,8 @@ async fn run_sweep_reclaims_expired_lease_and_completes_work() {
     ));
 
     let mut dispatch = prepare_queued_dispatch(&mailbox, "thread-sweep-reclaim", "x").await;
-    dispatch.available_at = 1000;
-    let dispatch_id = dispatch.dispatch_id.clone();
+    dispatch = dispatch.with_available_at(1000);
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
     // A consumer claims then "crashes": short lease far in the past.
     store
@@ -2365,7 +2429,7 @@ async fn run_sweep_reclaims_expired_lease_and_completes_work() {
             .await
             .unwrap()
             .expect("claimed dispatch is inspectable")
-            .status,
+            .status(),
         RunDispatchStatus::Claimed
     );
 
@@ -2373,12 +2437,13 @@ async fn run_sweep_reclaims_expired_lease_and_completes_work() {
     mailbox.run_sweep().await;
 
     let done = wait_for_dispatch(&store, &dispatch_id, |d| {
-        d.status == RunDispatchStatus::Acked
+        d.status() == RunDispatchStatus::Acked
     })
     .await;
-    assert_eq!(done.status, RunDispatchStatus::Acked);
+    assert_eq!(done.status(), RunDispatchStatus::Acked);
     assert_eq!(
-        done.attempt_count, 1,
+        done.attempt_count(),
+        1,
         "reclaim records exactly one recovery attempt"
     );
     assert!(
@@ -2415,7 +2480,7 @@ async fn quota_storm_drains_with_bounded_work() {
     for i in 0..DISPATCHES {
         let thread_id = format!("storm-thread-{i}");
         let dispatch = prepare_queued_dispatch(&mailbox, &thread_id, "go").await;
-        dispatch_ids.push(dispatch.dispatch_id.clone());
+        dispatch_ids.push(dispatch.dispatch_id().clone());
         store.enqueue(&dispatch).await.expect("enqueue dispatch");
         mailbox.get_or_create_worker(&thread_id).await;
         mailbox.try_dispatch_next(&thread_id).await;
@@ -2424,10 +2489,10 @@ async fn quota_storm_drains_with_bounded_work() {
     // Every dispatch must reach DeadLetter (the storm fully drains).
     for dispatch_id in &dispatch_ids {
         let dead = wait_for_dispatch(&store, dispatch_id, |d| {
-            d.status == RunDispatchStatus::DeadLetter
+            d.status() == RunDispatchStatus::DeadLetter
         })
         .await;
-        assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+        assert_eq!(dead.status(), RunDispatchStatus::DeadLetter);
     }
 
     // Bounded work: each dispatch ran exactly once. A pre-fix build would have
@@ -2481,8 +2546,8 @@ async fn permanent_error_recovers_from_transient_dead_letter_fault() {
     ));
 
     let dispatch = prepare_queued_dispatch(&mailbox, "thread-dl-fault", "go").await;
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let thread_id = dispatch.thread_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let thread_id = dispatch.thread_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     mailbox.get_or_create_worker(&thread_id).await;
@@ -2498,13 +2563,13 @@ async fn permanent_error_recovers_from_transient_dead_letter_fault() {
             .await
             .unwrap()
             .expect("dispatch is inspectable");
-        if current.status == RunDispatchStatus::DeadLetter {
+        if current.status() == RunDispatchStatus::DeadLetter {
             break;
         }
         assert!(
             Instant::now() < deadline,
             "dispatch never recovered to DeadLetter (stuck at {:?})",
-            current.status
+            current.status()
         );
         sleep(Duration::from_millis(50)).await;
         mailbox.run_sweep().await;
@@ -2515,13 +2580,13 @@ async fn permanent_error_recovers_from_transient_dead_letter_fault() {
         .await
         .unwrap()
         .expect("dispatch is inspectable");
-    assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(dead.status(), RunDispatchStatus::DeadLetter);
     assert!(
-        dead.last_error
+        dead.last_error()
             .as_deref()
             .is_some_and(|e| e.contains("unauthorized")),
         "expected unauthorized error, got: {:?}",
-        dead.last_error
+        dead.last_error()
     );
     // The injected fault forced exactly one recovery cycle: the run executed
     // twice (the failed-dead_letter attempt and the successful one).
@@ -2807,7 +2872,7 @@ async fn start_lifecycle_is_idempotent_and_drop_does_not_abort_recovery() {
     let dispatch = mailbox
         .build_dispatch(&request, &thread_id)
         .expect("build queued dispatch");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store
         .enqueue(&dispatch)
         .await
@@ -2829,7 +2894,7 @@ async fn start_lifecycle_is_idempotent_and_drop_does_not_abort_recovery() {
     drop(duplicate);
 
     wait_for_dispatch(&store, &dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::DeadLetter
+        dispatch.status() == RunDispatchStatus::DeadLetter
     })
     .await;
 
@@ -3012,7 +3077,7 @@ async fn start_lifecycle_runs_startup_recovery_for_existing_queued_dispatches() 
     let dispatch = mailbox
         .build_dispatch(&request, &thread_id)
         .expect("build queued dispatch");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store
         .enqueue(&dispatch)
         .await
@@ -3023,14 +3088,14 @@ async fn start_lifecycle_runs_startup_recovery_for_existing_queued_dispatches() 
         .expect("lifecycle should start");
 
     let recovered = wait_for_dispatch(&store, &dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::DeadLetter
+        dispatch.status() == RunDispatchStatus::DeadLetter
     })
     .await;
 
-    assert_eq!(recovered.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(recovered.status(), RunDispatchStatus::DeadLetter);
     assert!(
         recovered
-            .last_error
+            .last_error()
             .as_deref()
             .is_some_and(|error| error.contains("missing-agent")),
         "dead-letter error should preserve the runtime failure: {recovered:?}"
@@ -3059,8 +3124,8 @@ async fn start_lifecycle_reclaims_expired_claimed_dispatches_and_executes_them()
     let dispatch = mailbox
         .build_dispatch(&request, &thread_id)
         .expect("build stale claimed dispatch");
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let claim_now = dispatch.available_at;
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let claim_now = dispatch.available_at();
     store
         .enqueue(&dispatch)
         .await
@@ -3070,8 +3135,8 @@ async fn start_lifecycle_reclaims_expired_claimed_dispatches_and_executes_them()
         .await
         .expect("claim dispatch before simulated crash");
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].status, RunDispatchStatus::Claimed);
-    assert_eq!(claimed[0].lease_until, Some(claim_now + 1));
+    assert_eq!(claimed[0].status(), RunDispatchStatus::Claimed);
+    assert_eq!(claimed[0].lease_until(), Some(claim_now + 1));
     sleep(Duration::from_millis(2)).await;
 
     let handle = mailbox
@@ -3079,27 +3144,26 @@ async fn start_lifecycle_reclaims_expired_claimed_dispatches_and_executes_them()
         .expect("lifecycle should start");
 
     let recovered = wait_for_dispatch(&store, &dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::DeadLetter
-            && dispatch.run_status == Some(RunStatus::Done)
+        dispatch.status() == RunDispatchStatus::DeadLetter
+            && dispatch.run_status() == Some(RunStatus::Done)
     })
     .await;
 
-    assert_eq!(recovered.status, RunDispatchStatus::DeadLetter);
-    assert_eq!(recovered.attempt_count, 1);
-    let run_id = recovered.run_id.as_str();
+    assert_eq!(recovered.status(), RunDispatchStatus::DeadLetter);
+    assert_eq!(recovered.attempt_count(), 1);
+    let run_id = recovered.run_id().as_str();
     assert_ne!(
         run_id, dispatch_id,
         "recovered stale dispatches should also keep run id separate from mailbox dispatch id"
     );
-    assert!(recovered.dispatch_instance_id.is_some());
+    assert!(recovered.dispatch_instance_id().is_some());
     assert!(matches!(
-        recovered.termination,
-        Some(TerminationReason::Error(ref message)) if message.contains("missing-agent")
+        recovered.termination(),
+        Some(TerminationReason::Error(message)) if message.contains("missing-agent")
     ));
     assert!(
         recovered
-            .run_error
-            .as_deref()
+            .run_error()
             .is_some_and(|error| error.contains("missing-agent"))
     );
     handle.shutdown().await.expect("shutdown lifecycle");
@@ -3131,7 +3195,7 @@ async fn multi_instance_ready_lifecycle_executes_shared_dispatch_once() {
         "shared startup dispatch",
     )
     .await;
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     mailbox_store
         .enqueue(&dispatch)
         .await
@@ -3145,10 +3209,10 @@ async fn multi_instance_ready_lifecycle_executes_shared_dispatch_once() {
     let handle_b = handle_b.expect("instance b lifecycle should start");
 
     let acked = wait_for_dispatch(&mailbox_store, &dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Acked
+        dispatch.status() == RunDispatchStatus::Acked
     })
     .await;
-    assert_eq!(acked.status, RunDispatchStatus::Acked);
+    assert_eq!(acked.status(), RunDispatchStatus::Acked);
     assert_eq!(
         runtime_a.run_count() + runtime_b.run_count(),
         1,
@@ -3187,7 +3251,7 @@ async fn dispatch_signal_loop_claims_and_executes_queued_dispatch() {
     let dispatch = mailbox
         .build_dispatch(&request, &thread_id)
         .expect("build dispatch");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     let signal_loop = tokio::spawn(Arc::clone(&mailbox).run_dispatch_signal_loop());
@@ -3197,7 +3261,7 @@ async fn dispatch_signal_loop_claims_and_executes_queued_dispatch() {
             .load_dispatch(&dispatch_id)
             .await
             .expect("dispatch lookup should succeed")
-            && dispatch.status == RunDispatchStatus::Acked
+            && dispatch.status() == RunDispatchStatus::Acked
         {
             break dispatch;
         }
@@ -3209,7 +3273,7 @@ async fn dispatch_signal_loop_claims_and_executes_queued_dispatch() {
     };
     signal_loop.abort();
 
-    assert_eq!(acked.status, RunDispatchStatus::Acked);
+    assert_eq!(acked.status(), RunDispatchStatus::Acked);
     assert_eq!(store.acked_signal_count(), 1);
 }
 
@@ -3241,7 +3305,7 @@ async fn dispatch_signal_loop_nacks_and_redelivers_after_claim_error() {
     let dispatch = mailbox
         .build_dispatch(&request, &thread_id)
         .expect("build dispatch");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     let signal_loop = tokio::spawn(Arc::clone(&mailbox).run_dispatch_signal_loop());
@@ -3252,7 +3316,7 @@ async fn dispatch_signal_loop_nacks_and_redelivers_after_claim_error() {
             .await
             .expect("dispatch lookup should succeed")
             .expect("dispatch should exist");
-        if dispatch.status == RunDispatchStatus::Acked {
+        if dispatch.status() == RunDispatchStatus::Acked {
             break;
         }
         assert!(
@@ -3295,7 +3359,7 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
     let active_dispatch = mailbox
         .build_dispatch(&active, &thread_id)
         .expect("build active dispatch");
-    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    let active_dispatch_id = active_dispatch.dispatch_id().clone();
     store
         .enqueue(&active_dispatch)
         .await
@@ -3305,7 +3369,7 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
         .await
         .expect("claim active dispatch");
     assert_eq!(claimed.len(), 1);
-    let active_claim_token = claimed[0].claim_token.clone().unwrap();
+    let active_claim_token = claimed[0].claim_token().unwrap().to_string();
 
     let mut queued = RunActivation::new("thread-signal-blocked", vec![Message::user("queued")])
         .with_agent_id("agent");
@@ -3322,7 +3386,7 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
     let queued_dispatch = mailbox
         .build_dispatch(&queued, &thread_id)
         .expect("build queued dispatch");
-    let queued_dispatch_id = queued_dispatch.dispatch_id.clone();
+    let queued_dispatch_id = queued_dispatch.dispatch_id().clone();
     store
         .enqueue(&queued_dispatch)
         .await
@@ -3346,7 +3410,7 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
         .await
         .expect("queued dispatch lookup")
         .expect("queued dispatch exists");
-    assert_eq!(queued_before_release.status, RunDispatchStatus::Queued);
+    assert_eq!(queued_before_release.status(), RunDispatchStatus::Queued);
 
     store
         .ack(&active_dispatch_id, &active_claim_token, now_ms())
@@ -3360,7 +3424,7 @@ async fn dispatch_signal_loop_nacks_when_signal_is_blocked_by_active_claim() {
             .await
             .expect("queued dispatch lookup")
             .expect("queued dispatch exists");
-        if dispatch.status == RunDispatchStatus::Acked {
+        if dispatch.status() == RunDispatchStatus::Acked {
             break;
         }
         assert!(
@@ -3467,7 +3531,7 @@ async fn submit_background_enqueues_dispatch() {
         .await
         .unwrap();
     assert!(!dispatches.is_empty());
-    assert_eq!(dispatches[0].run_id, result.run_id);
+    assert_eq!(dispatches[0].run_id(), &result.run_id);
 }
 
 #[tokio::test]
@@ -3786,7 +3850,7 @@ async fn cancel_queued_dispatch_works() {
     assert!(cancelled);
 
     let after = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(after.status, RunDispatchStatus::Cancelled);
+    assert_eq!(after.status(), RunDispatchStatus::Cancelled);
 
     let run = run_store
         .load_run(&result.run_id)
@@ -3990,6 +4054,18 @@ fn classify_error_inference_failed_is_transient() {
     assert!(matches!(
         classify_error(&result),
         MailboxRunOutcome::TransientError(_)
+    ));
+}
+
+#[test]
+fn classify_error_invalid_activation_is_permanent() {
+    use awaken_runtime::loop_runner::AgentLoopError;
+    let result = Err(AgentLoopError::InvalidActivation(
+        "blank thread".to_string(),
+    ));
+    assert!(matches!(
+        classify_error(&result),
+        MailboxRunOutcome::PermanentError(_)
     ));
 }
 
@@ -4240,17 +4316,17 @@ async fn build_dispatch_sets_correct_fields() {
         RunActivation::new("thread-42", vec![Message::user("test")]).with_run_id_hint("run-42");
     let dispatch = mailbox.build_dispatch(&request, "thread-42").unwrap();
 
-    assert_eq!(dispatch.thread_id, "thread-42");
-    assert_eq!(dispatch.run_id, "run-42");
-    assert_eq!(dispatch.status, RunDispatchStatus::Queued);
-    assert_eq!(dispatch.attempt_count, 0);
-    assert_eq!(dispatch.max_attempts, 5); // default
-    assert_eq!(dispatch.priority, 128);
-    assert_eq!(dispatch.dispatch_epoch, 0);
-    assert!(dispatch.claim_token.is_none());
-    assert!(dispatch.claimed_by.is_none());
-    assert!(dispatch.lease_until.is_none());
-    assert!(dispatch.last_error.is_none());
+    assert_eq!(dispatch.thread_id(), "thread-42");
+    assert_eq!(dispatch.run_id(), "run-42");
+    assert_eq!(dispatch.status(), RunDispatchStatus::Queued);
+    assert_eq!(dispatch.attempt_count(), 0);
+    assert_eq!(dispatch.max_attempts(), 5); // default
+    assert_eq!(dispatch.priority(), 128);
+    assert_eq!(dispatch.dispatch_epoch(), 0);
+    assert!(dispatch.claim_token().is_none());
+    assert!(dispatch.claimed_by().is_none());
+    assert!(dispatch.lease_until().is_none());
+    assert!(dispatch.last_error().is_none());
 }
 
 #[test]
@@ -4543,7 +4619,7 @@ async fn mailbox_execution_records_dispatch_latency_metrics() {
         .expect("submit should succeed");
 
     wait_for_dispatch(&mailbox_store, &submitted.dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Acked
+        dispatch.status() == RunDispatchStatus::Acked
     })
     .await;
 
@@ -4604,7 +4680,7 @@ async fn mailbox_lease_renewal_is_wired_and_prevents_reclaim() {
         .await
         .expect("load dispatch")
         .expect("dispatch should exist")
-        .lease_until
+        .lease_until()
         .expect("claimed dispatch should have a lease");
 
     tokio::time::timeout(Duration::from_secs(2), async {
@@ -4615,7 +4691,7 @@ async fn mailbox_lease_renewal_is_wired_and_prevents_reclaim() {
                 .expect("load dispatch")
                 .expect("dispatch should exist");
             if dispatch
-                .lease_until
+                .lease_until()
                 .is_some_and(|lease| lease > initial_lease)
             {
                 break;
@@ -4637,7 +4713,7 @@ async fn mailbox_lease_renewal_is_wired_and_prevents_reclaim() {
 
     release_first.notify_one();
     wait_for_dispatch(&mailbox_store, &submitted.dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Acked
+        dispatch.status() == RunDispatchStatus::Acked
     })
     .await;
 
@@ -4679,20 +4755,66 @@ async fn background_success_records_run_result_and_keeps_dispatch_id_separate_fr
         .expect("submit should succeed");
 
     let acked = wait_for_dispatch(&mailbox_store, &submitted.dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Acked && dispatch.run_status == Some(RunStatus::Done)
+        dispatch.status() == RunDispatchStatus::Acked
+            && dispatch.run_status() == Some(RunStatus::Done)
     })
     .await;
 
-    let run_id = acked.run_id.as_str();
+    let run_id = acked.run_id().as_str();
     assert_ne!(
         run_id, submitted.dispatch_id,
         "default mailbox dispatch IDs must not be used as canonical run IDs"
     );
-    assert!(acked.dispatch_instance_id.is_some());
-    assert_eq!(acked.termination, Some(TerminationReason::NaturalEnd));
-    assert_eq!(acked.run_response.as_deref(), Some("finished"));
-    assert!(acked.run_error.is_none());
-    assert!(acked.completed_at.is_some());
+    assert!(acked.dispatch_instance_id().is_some());
+    assert_eq!(acked.termination(), Some(&TerminationReason::NaturalEnd));
+    assert_eq!(acked.run_response(), Some("finished"));
+    assert!(acked.run_error().is_none());
+    assert!(acked.completed_at().is_some());
+}
+
+#[tokio::test]
+async fn background_success_recovers_ack_after_result_was_recorded() {
+    let mailbox_store = Arc::new(SignalMailboxStore::with_ack_failures(1));
+    let run_store = Arc::new(InMemoryStore::new());
+    let llm = Arc::new(ScriptedLlm::new(vec![StreamResult {
+        content: vec![ContentBlock::text("finished")],
+        tool_calls: vec![],
+        usage: None,
+        stop_reason: Some(StopReason::EndTurn),
+        has_incomplete_tool_calls: false,
+    }]));
+    let resolver = Arc::new(FixedResolver {
+        agent: ResolvedAgent::new("agent", "m", "sys", llm),
+        plugins: vec![],
+    });
+    let runtime = Arc::new(AgentRuntime::new(resolver));
+    let mailbox = Arc::new(Mailbox::new(
+        runtime,
+        mailbox_store.clone(),
+        run_store,
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    ));
+
+    let submitted = mailbox
+        .submit_background(
+            RunActivation::new("thread-run-result-ack-recover", vec![Message::user("go")])
+                .with_agent_id("agent"),
+        )
+        .await
+        .expect("submit should succeed");
+
+    let acked = wait_for_dispatch(&mailbox_store.inner, &submitted.dispatch_id, |dispatch| {
+        dispatch.status() == RunDispatchStatus::Acked
+            && dispatch.run_status() == Some(RunStatus::Done)
+    })
+    .await;
+
+    assert_eq!(acked.run_response(), Some("finished"));
+    assert_eq!(
+        mailbox_store.ack_failures_remaining.load(Ordering::SeqCst),
+        0
+    );
 }
 
 #[tokio::test]
@@ -4710,33 +4832,32 @@ async fn background_permanent_error_records_run_result_before_dead_letter() {
         .expect("submit should succeed");
 
     let dead = wait_for_dispatch(&store, &submitted.dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::DeadLetter
-            && dispatch.run_status == Some(RunStatus::Done)
-            && dispatch.run_error.is_some()
+        dispatch.status() == RunDispatchStatus::DeadLetter
+            && dispatch.run_status() == Some(RunStatus::Done)
+            && dispatch.run_error().is_some()
     })
     .await;
 
-    let run_id = dead.run_id.as_str();
+    let run_id = dead.run_id().as_str();
     assert_ne!(
         run_id, submitted.dispatch_id,
         "synthetic terminal events must preserve canonical run id instead of reusing dispatch id"
     );
-    assert!(dead.dispatch_instance_id.is_some());
+    assert!(dead.dispatch_instance_id().is_some());
     assert!(matches!(
-        dead.termination,
-        Some(TerminationReason::Error(ref message)) if message.contains("missing-agent")
+        dead.termination(),
+        Some(TerminationReason::Error(message)) if message.contains("missing-agent")
     ));
     assert!(
-        dead.last_error
+        dead.last_error()
             .as_deref()
             .is_some_and(|error| error.contains("missing-agent"))
     );
     assert!(
-        dead.run_error
-            .as_deref()
+        dead.run_error()
             .is_some_and(|error| error.contains("missing-agent"))
     );
-    assert!(dead.completed_at.is_some());
+    assert!(dead.completed_at().is_some());
 }
 
 #[tokio::test]
@@ -4754,30 +4875,14 @@ async fn reconstruct_failure_cleans_worker_and_dispatches_next_queued() {
     let thread_id = "thread-reconstruct-next";
     let now = now_ms();
 
-    let missing = RunDispatch {
-        dispatch_id: "dispatch-missing-run".to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: "missing-run".to_string(),
-        priority: 10,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: now,
-        attempt_count: 0,
-        max_attempts: 3,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: now,
-        updated_at: now,
-    };
+    let missing = RunDispatch::queued(
+        "dispatch-missing-run".to_string(),
+        thread_id.to_string(),
+        "missing-run".to_string(),
+        now,
+    )
+    .with_priority(10)
+    .with_max_attempts(3);
     store.enqueue(&missing).await.expect("enqueue missing run");
 
     let mut next_request =
@@ -4795,10 +4900,10 @@ async fn reconstruct_failure_cleans_worker_and_dispatches_next_queued() {
     let mut next = mailbox
         .build_dispatch(&next_request, thread_id)
         .expect("build next dispatch");
-    next.priority = 20;
-    next.created_at = now.saturating_add(1);
-    next.updated_at = next.created_at;
-    let next_dispatch_id = next.dispatch_id.clone();
+    next = next
+        .with_priority(20)
+        .with_created_at(now.saturating_add(1));
+    let next_dispatch_id = next.dispatch_id().clone();
     store.enqueue(&next).await.expect("enqueue next");
 
     mailbox.get_or_create_worker(thread_id).await;
@@ -4808,16 +4913,16 @@ async fn reconstruct_failure_cleans_worker_and_dispatches_next_queued() {
     );
 
     let dead = wait_for_dispatch(&store, "dispatch-missing-run", |dispatch| {
-        dispatch.status == RunDispatchStatus::DeadLetter
+        dispatch.status() == RunDispatchStatus::DeadLetter
     })
     .await;
-    assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(dead.status(), RunDispatchStatus::DeadLetter);
 
     let acked = wait_for_dispatch(&store, &next_dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Acked
+        dispatch.status() == RunDispatchStatus::Acked
     })
     .await;
-    assert_eq!(acked.status, RunDispatchStatus::Acked);
+    assert_eq!(acked.status(), RunDispatchStatus::Acked);
 }
 
 #[tokio::test]
@@ -4835,30 +4940,14 @@ async fn reconstruct_failure_dead_letters_once_and_is_not_polled_again() {
     let thread_id = "thread-reconstruct-once";
     let now = now_ms();
 
-    let missing = RunDispatch {
-        dispatch_id: "dispatch-reconstruct-once".to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: "missing-run".to_string(),
-        priority: 10,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: now,
-        attempt_count: 0,
-        max_attempts: 3,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: now,
-        updated_at: now,
-    };
+    let missing = RunDispatch::queued(
+        "dispatch-reconstruct-once".to_string(),
+        thread_id.to_string(),
+        "missing-run".to_string(),
+        now,
+    )
+    .with_priority(10)
+    .with_max_attempts(3);
     store.enqueue(&missing).await.expect("enqueue missing run");
 
     mailbox.get_or_create_worker(thread_id).await;
@@ -4868,10 +4957,10 @@ async fn reconstruct_failure_dead_letters_once_and_is_not_polled_again() {
     );
 
     let dead = wait_for_dispatch(&store.inner, "dispatch-reconstruct-once", |dispatch| {
-        dispatch.status == RunDispatchStatus::DeadLetter
+        dispatch.status() == RunDispatchStatus::DeadLetter
     })
     .await;
-    assert_eq!(dead.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(dead.status(), RunDispatchStatus::DeadLetter);
 
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
@@ -4954,7 +5043,7 @@ async fn interrupt_marks_superseded_queued_runs_cancelled() {
             .await
             .unwrap()
             .expect("superseded dispatch should remain inspectable");
-        assert_eq!(dispatch.status, RunDispatchStatus::Superseded);
+        assert_eq!(dispatch.status(), RunDispatchStatus::Superseded);
 
         let run = run_store
             .load_run(&submitted.run_id)
@@ -4996,7 +5085,7 @@ async fn runtime_event_capture_records_run_interrupted_on_thread_interrupt() {
     );
     let thread_id = "thread-interrupt-event";
     let active_dispatch = prepare_queued_dispatch(&mailbox, thread_id, "active").await;
-    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    let active_dispatch_id = active_dispatch.dispatch_id().clone();
     mailbox_store
         .enqueue(&active_dispatch)
         .await
@@ -5016,7 +5105,7 @@ async fn runtime_event_capture_records_run_interrupted_on_thread_interrupt() {
         result
             .active_dispatch
             .as_ref()
-            .map(|dispatch| dispatch.dispatch_id.as_str()),
+            .map(|dispatch| dispatch.dispatch_id().as_str()),
         Some(active_dispatch_id.as_str())
     );
     let page = event_store
@@ -5030,7 +5119,7 @@ async fn runtime_event_capture_records_run_interrupted_on_thread_interrupt() {
         .expect("run interrupted event should be recorded");
     assert_eq!(
         event.run_id.as_deref(),
-        Some(active_dispatch.run_id.as_str())
+        Some(active_dispatch.run_id().as_str())
     );
     assert_eq!(
         event.correlation_id.as_deref(),
@@ -5072,7 +5161,7 @@ async fn runtime_event_capture_records_run_rescheduled_on_retry_backoff() {
         .await
         .expect("background submit should succeed");
     let queued = wait_for_dispatch(&mailbox_store, &submitted.dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Queued && dispatch.attempt_count == 1
+        dispatch.status() == RunDispatchStatus::Queued && dispatch.attempt_count() == 1
     })
     .await;
 
@@ -5095,7 +5184,7 @@ async fn runtime_event_capture_records_run_rescheduled_on_retry_backoff() {
     assert_eq!(event.payload["attempt_count"].as_u64(), Some(1));
     assert_eq!(
         event.payload["available_at"].as_u64(),
-        Some(queued.available_at)
+        Some(queued.available_at())
     );
 }
 
@@ -5121,8 +5210,8 @@ async fn runtime_event_capture_records_run_rescheduled_on_expired_lease_reclaim(
     );
     let thread_id = "thread-reschedule-reclaim";
     let mut dispatch = prepare_queued_dispatch(&mailbox, thread_id, "reclaim").await;
-    dispatch.available_at = 1_000;
-    let dispatch_id = dispatch.dispatch_id.clone();
+    dispatch = dispatch.with_available_at(1_000);
+    let dispatch_id = dispatch.dispatch_id().clone();
     mailbox_store
         .enqueue(&dispatch)
         .await
@@ -5184,7 +5273,7 @@ async fn foreground_submit_marks_prior_queued_run_cancelled() {
         .await
         .unwrap()
         .expect("old dispatch should remain inspectable");
-    assert_eq!(old_dispatch.status, RunDispatchStatus::Superseded);
+    assert_eq!(old_dispatch.status(), RunDispatchStatus::Superseded);
 
     let old_run = run_store
         .load_run(&old.run_id)
@@ -5235,10 +5324,10 @@ async fn submit_inline_claim_empty_cancels_precreated_run() {
         .expect("list inline cleanup dispatches");
     assert_eq!(dispatches.len(), 1);
     let dispatch = &dispatches[0];
-    assert_eq!(dispatch.status, RunDispatchStatus::Cancelled);
+    assert_eq!(dispatch.status(), RunDispatchStatus::Cancelled);
 
     let run = run_store
-        .load_run(&dispatch.run_id)
+        .load_run(&dispatch.run_id())
         .await
         .unwrap()
         .expect("inline cleanup should keep run inspectable");
@@ -5246,7 +5335,7 @@ async fn submit_inline_claim_empty_cancels_precreated_run() {
     assert_eq!(run.termination_reason, Some(TerminationReason::Cancelled));
     assert_eq!(
         run.dispatch_id.as_deref(),
-        Some(dispatch.dispatch_id.as_str())
+        Some(dispatch.dispatch_id().as_str())
     );
 
     let output = crate::metrics::render().unwrap_or_default();
@@ -5342,10 +5431,10 @@ async fn reclaim_dead_letter_marks_run_error() {
     ));
 
     let mut dispatch = prepare_queued_dispatch(&mailbox, "thread-reclaim-dead", "expire").await;
-    dispatch.max_attempts = 1;
-    dispatch.available_at = 1000;
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let run_id = dispatch.run_id.clone();
+    dispatch = dispatch.with_max_attempts(1);
+    dispatch = dispatch.with_available_at(1000);
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let run_id = dispatch.run_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
     let claimed = store
         .claim("thread-reclaim-dead", "stale-consumer", 100, 1000, 1)
@@ -5363,7 +5452,7 @@ async fn reclaim_dead_letter_marks_run_error() {
         .await
         .unwrap()
         .expect("dead-lettered dispatch should remain inspectable");
-    assert_eq!(dead_letter.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(dead_letter.status(), RunDispatchStatus::DeadLetter);
 
     let run = run_store
         .load_run(&run_id)
@@ -5397,9 +5486,9 @@ async fn sweep_reconciles_dead_letter_dispatch_after_crash() {
 
     let mut dispatch =
         prepare_queued_dispatch(&mailbox, "thread-sweep-reconcile-dead", "dead").await;
-    dispatch.available_at = 1;
-    let dispatch_id = dispatch.dispatch_id.clone();
-    let run_id = dispatch.run_id.clone();
+    dispatch = dispatch.with_available_at(1);
+    let dispatch_id = dispatch.dispatch_id().clone();
+    let run_id = dispatch.run_id().clone();
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
     let claimed = store
         .claim(
@@ -5412,8 +5501,7 @@ async fn sweep_reconciles_dead_letter_dispatch_after_crash() {
         .await
         .expect("claim dispatch");
     let claim_token = claimed[0]
-        .claim_token
-        .as_deref()
+        .claim_token()
         .expect("claimed dispatch should have a claim token")
         .to_string();
     store
@@ -5697,6 +5785,73 @@ async fn maintenance_drain_republishes_enqueued_checkpoint_repair() {
         .await
         .unwrap();
     assert_eq!(page.events.len(), 2, "re-publish must be idempotent");
+}
+
+#[tokio::test]
+async fn maintenance_drain_requeues_checkpoint_repair_when_messages_missing() {
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let mailbox = Arc::new(
+        Mailbox::new(
+            Arc::new(NoopMailboxRuntime),
+            make_store(),
+            thread_store,
+            "test-consumer".to_string(),
+            MailboxConfig::default(),
+        )
+        .with_server_event_publisher(
+            test_server_event_publisher(Arc::clone(&event_store)),
+            "server",
+        )
+        .unwrap(),
+    );
+
+    mailbox.enqueue_checkpoint_repair(super::checkpoint_repair::CheckpointRepairTask {
+        thread_id: "thread-missing".to_string(),
+        run_id: "run-missing".to_string(),
+        first_seq: 1,
+        last_seq: 1,
+    });
+    mailbox.run_sweep().await;
+
+    let page = event_store
+        .list(EventScope::thread("thread-missing"), None, 10)
+        .await
+        .unwrap();
+    assert!(page.events.is_empty());
+    let queued = mailbox.checkpoint_repair_queue.lock().unwrap();
+    assert_eq!(queued.len(), 1);
+}
+
+#[tokio::test]
+async fn checkpoint_event_recording_rejects_out_of_range_message_seq() {
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let thread_store = Arc::new(InMemoryStore::new());
+    let mailbox = Mailbox::new(
+        Arc::new(NoopMailboxRuntime),
+        make_store(),
+        thread_store,
+        "test-consumer".to_string(),
+        MailboxConfig::default(),
+    )
+    .with_server_event_publisher(
+        test_server_event_publisher(Arc::clone(&event_store)),
+        "server",
+    )
+    .unwrap();
+
+    let message = Message::user("hi").with_id("msg-1".to_string());
+    let error = mailbox
+        .record_thread_message_checkpoint_events("thread-range", "run-range", &[message], 1, 2)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, MailboxError::Internal(_)));
+    let page = event_store
+        .list(EventScope::thread("thread-range"), None, 10)
+        .await
+        .unwrap();
+    assert!(page.events.is_empty());
 }
 
 #[tokio::test]
@@ -6226,7 +6381,7 @@ async fn live_then_queue_steers_active_run_without_new_dispatch() {
     assert_eq!(
         dispatches
             .iter()
-            .filter(|dispatch| dispatch.run_id == first.run_id)
+            .filter(|dispatch| dispatch.run_id() == &first.run_id)
             .count(),
         1,
         "live steering must not create an extra dispatch"
@@ -6261,7 +6416,7 @@ async fn live_then_queue_falls_back_to_durable_dispatch_when_receiver_unavailabl
     let active_dispatch = mailbox
         .build_dispatch(&active_request, thread_id)
         .expect("build active dispatch");
-    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    let active_dispatch_id = active_dispatch.dispatch_id().clone();
     mailbox_store
         .enqueue(&active_dispatch)
         .await
@@ -6276,7 +6431,7 @@ async fn live_then_queue_falls_back_to_durable_dispatch_when_receiver_unavailabl
         let mut worker = worker.lock();
         worker.status = MailboxWorkerStatus::Running {
             dispatch_id: active_dispatch_id.clone(),
-            run_id: active_dispatch.run_id.clone(),
+            run_id: active_dispatch.run_id().clone(),
             lease_handle: tokio::spawn(async {}),
             sink: Arc::new(ReconnectableEventSink::new(mpsc::channel(16).0)),
         };
@@ -6310,7 +6465,7 @@ async fn live_then_queue_falls_back_to_durable_dispatch_when_receiver_unavailabl
         .await
         .expect("list queued");
     assert_eq!(queued.len(), 1);
-    assert_eq!(queued[0].dispatch_id, result.dispatch_id);
+    assert_eq!(queued[0].dispatch_id(), &result.dispatch_id);
 }
 
 #[tokio::test]
@@ -6353,7 +6508,7 @@ async fn foreground_submit_sends_live_cancel_for_remote_active_dispatch() {
     let active_dispatch = mailbox
         .build_dispatch(&active_request, thread_id)
         .expect("build active dispatch");
-    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    let active_dispatch_id = active_dispatch.dispatch_id().clone();
     mailbox_store
         .enqueue(&active_dispatch)
         .await
@@ -6363,7 +6518,7 @@ async fn foreground_submit_sends_live_cancel_for_remote_active_dispatch() {
         .await
         .expect("claim active dispatch")
         .expect("active dispatch should be claimed");
-    let active_claim_token = claimed.claim_token.clone().expect("claim token");
+    let active_claim_token = claimed.claim_token().expect("claim token").to_string();
 
     let subscriber = mailbox_store
         .open_live_channel_for(&live_target_for_dispatch(&active_dispatch))
@@ -6469,7 +6624,7 @@ async fn foreground_submit_does_not_prepare_replacement_when_remote_cancel_times
     let active_dispatch = mailbox
         .build_dispatch(&active_request, thread_id)
         .expect("build active dispatch");
-    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    let active_dispatch_id = active_dispatch.dispatch_id().clone();
     mailbox_store.enqueue(&active_dispatch).await.unwrap();
     mailbox_store
         .claim_dispatch(&active_dispatch_id, "remote-consumer", 30_000, now_ms())
@@ -6517,8 +6672,8 @@ async fn foreground_submit_does_not_prepare_replacement_when_remote_cancel_times
         .await
         .expect("list dispatches");
     assert_eq!(all.len(), 1);
-    assert_eq!(all[0].dispatch_id, active_dispatch_id);
-    assert_eq!(all[0].status, RunDispatchStatus::Claimed);
+    assert_eq!(all[0].dispatch_id(), &active_dispatch_id);
+    assert_eq!(all[0].status(), RunDispatchStatus::Claimed);
 }
 
 #[tokio::test]
@@ -6558,7 +6713,7 @@ async fn foreground_submit_does_not_prepare_replacement_when_local_cancel_times_
     let active_dispatch = mailbox
         .build_dispatch(&active_request, thread_id)
         .expect("build active dispatch");
-    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    let active_dispatch_id = active_dispatch.dispatch_id().clone();
     mailbox_store.enqueue(&active_dispatch).await.unwrap();
     mailbox_store
         .claim_dispatch(&active_dispatch_id, "foreground-consumer", 30_000, now_ms())
@@ -6590,8 +6745,8 @@ async fn foreground_submit_does_not_prepare_replacement_when_local_cancel_times_
         .await
         .expect("list dispatches");
     assert_eq!(all.len(), 1);
-    assert_eq!(all[0].dispatch_id, active_dispatch_id);
-    assert_eq!(all[0].status, RunDispatchStatus::Claimed);
+    assert_eq!(all[0].dispatch_id(), &active_dispatch_id);
+    assert_eq!(all[0].status(), RunDispatchStatus::Claimed);
 
     let page = event_store
         .list(EventScope::thread(thread_id), None, 10)
@@ -6639,7 +6794,7 @@ async fn foreground_submit_waits_for_local_cancelled_dispatch_to_release_claim()
     let active_dispatch = mailbox
         .build_dispatch(&active_request, thread_id)
         .expect("build active dispatch");
-    let active_dispatch_id = active_dispatch.dispatch_id.clone();
+    let active_dispatch_id = active_dispatch.dispatch_id().clone();
     mailbox_store.enqueue(&active_dispatch).await.unwrap();
     mailbox_store
         .claim_dispatch(&active_dispatch_id, "foreground-consumer", 30_000, now_ms())
@@ -6671,8 +6826,8 @@ async fn foreground_submit_waits_for_local_cancelled_dispatch_to_release_claim()
         .await
         .expect("list dispatches");
     assert_eq!(all.len(), 1);
-    assert_eq!(all[0].dispatch_id, active_dispatch_id);
-    assert_eq!(all[0].status, RunDispatchStatus::Claimed);
+    assert_eq!(all[0].dispatch_id(), &active_dispatch_id);
+    assert_eq!(all[0].status(), RunDispatchStatus::Claimed);
 }
 
 /// Cross-node live delivery: no local worker, but the thread has an
@@ -6919,7 +7074,7 @@ async fn live_then_queue_falls_back_when_subscriber_drops_receipt() {
         1,
         "unacked receipt must force a durable dispatch"
     );
-    assert_eq!(result.dispatch_id, dispatches[0].dispatch_id);
+    assert_eq!(&result.dispatch_id, dispatches[0].dispatch_id());
 }
 
 /// Contract test documenting the `submit_live_then_queue` at-least-once
@@ -6997,7 +7152,7 @@ async fn live_then_queue_is_at_least_once_when_ack_lost() {
         .await
         .expect("list dispatches");
     assert_eq!(dispatches.len(), 1);
-    assert_eq!(result.dispatch_id, dispatches[0].dispatch_id);
+    assert_eq!(&result.dispatch_id, dispatches[0].dispatch_id());
 }
 
 /// expected_run_id mismatch against a remote Running run must abort
@@ -7207,7 +7362,7 @@ async fn live_then_queue_falls_back_to_queue_when_no_remote_subscriber() {
         1,
         "no-subscriber cross-node must fall back to durable queue"
     );
-    assert_eq!(result.dispatch_id, all_dispatches[0].dispatch_id);
+    assert_eq!(&result.dispatch_id, all_dispatches[0].dispatch_id());
 }
 
 #[tokio::test]
@@ -7533,8 +7688,8 @@ async fn recover_reconstructs_dispatch_for_prepared_run_missing_wal() {
         .await
         .expect("load reconstructed dispatch")
         .expect("dispatch reconstructed");
-    assert_eq!(dispatch.run_id, run_id);
-    assert_eq!(dispatch.thread_id, "thread-prepared-crash");
+    assert_eq!(dispatch.run_id(), &run_id);
+    assert_eq!(dispatch.thread_id(), "thread-prepared-crash");
 }
 
 #[tokio::test]
@@ -7585,8 +7740,8 @@ async fn recover_reconstructs_dispatch_for_prepared_waiting_resume_missing_wal()
         .await
         .expect("load reconstructed dispatch")
         .expect("dispatch reconstructed");
-    assert_eq!(dispatch.run_id, "run-waiting-crash");
-    assert_eq!(dispatch.thread_id, "thread-waiting-crash");
+    assert_eq!(dispatch.run_id(), "run-waiting-crash");
+    assert_eq!(dispatch.thread_id(), "thread-waiting-crash");
 }
 
 #[tokio::test]
@@ -7679,9 +7834,9 @@ async fn distributed_claim_same_dispatch_allows_exactly_one_consumer() {
         .await
         .expect("load dispatch")
         .expect("dispatch exists");
-    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
-    assert_eq!(loaded.claimed_by, winners[0].claimed_by);
-    assert_eq!(loaded.claim_token, winners[0].claim_token);
+    assert_eq!(loaded.status(), RunDispatchStatus::Claimed);
+    assert_eq!(loaded.claimed_by(), winners[0].claimed_by());
+    assert_eq!(loaded.claim_token(), winners[0].claim_token());
 }
 
 #[tokio::test]
@@ -7689,7 +7844,7 @@ async fn distributed_expired_lease_reclaim_rejects_late_old_owner_ack() {
     let store = make_store();
     let mut dispatch =
         sample_dispatch("thread-lease-race", "run-lease-race", "dispatch-lease-race");
-    dispatch.available_at = 0;
+    dispatch = dispatch.with_available_at(0);
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     let claimed_by_a = store
@@ -7697,22 +7852,22 @@ async fn distributed_expired_lease_reclaim_rejects_late_old_owner_ack() {
         .await
         .expect("claim by a")
         .expect("a owns dispatch");
-    let old_token = claimed_by_a.claim_token.clone().expect("old token");
+    let old_token = claimed_by_a.claim_token().expect("old token");
 
     let reclaimed = store
         .reclaim_expired_leases(1_101, 10)
         .await
         .expect("reclaim expired lease");
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
-    assert_eq!(reclaimed[0].attempt_count, 1);
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::Queued);
+    assert_eq!(reclaimed[0].attempt_count(), 1);
 
     let claimed_by_b = store
         .claim_dispatch("dispatch-lease-race", "consumer-b", 30_000, 1_102)
         .await
         .expect("claim by b")
         .expect("b owns dispatch after reclaim");
-    let new_token = claimed_by_b.claim_token.clone().expect("new token");
+    let new_token = claimed_by_b.claim_token().expect("new token");
 
     assert!(
         store
@@ -7726,8 +7881,8 @@ async fn distributed_expired_lease_reclaim_rejects_late_old_owner_ack() {
         .await
         .expect("load after old ack")
         .expect("dispatch exists");
-    assert_eq!(still_claimed_by_b.status, RunDispatchStatus::Claimed);
-    assert_eq!(still_claimed_by_b.claimed_by.as_deref(), Some("consumer-b"));
+    assert_eq!(still_claimed_by_b.status(), RunDispatchStatus::Claimed);
+    assert_eq!(still_claimed_by_b.claimed_by(), Some("consumer-b"));
 
     store
         .ack("dispatch-lease-race", &new_token, 1_104)
@@ -7738,7 +7893,7 @@ async fn distributed_expired_lease_reclaim_rejects_late_old_owner_ack() {
         .await
         .expect("load delivered")
         .expect("dispatch exists");
-    assert_eq!(delivered.status, RunDispatchStatus::Acked);
+    assert_eq!(delivered.status(), RunDispatchStatus::Acked);
 }
 
 #[tokio::test]
@@ -7749,7 +7904,7 @@ async fn distributed_lease_reclaim_uses_strict_expiry_boundary() {
         "run-lease-boundary",
         "dispatch-lease-boundary",
     );
-    dispatch.available_at = 0;
+    dispatch = dispatch.with_available_at(0);
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     store
@@ -7785,7 +7940,7 @@ async fn distributed_lease_reclaim_uses_strict_expiry_boundary() {
         1,
         "lease should only be reclaimed after the boundary has passed"
     );
-    assert_eq!(after_expiry[0].status, RunDispatchStatus::Queued);
+    assert_eq!(after_expiry[0].status(), RunDispatchStatus::Queued);
 }
 
 #[tokio::test]
@@ -7796,7 +7951,7 @@ async fn distributed_nack_retry_window_respects_retry_at_boundary() {
         "run-retry-boundary",
         "dispatch-retry-boundary",
     );
-    dispatch.available_at = 0;
+    dispatch = dispatch.with_available_at(0);
     store.enqueue(&dispatch).await.expect("enqueue dispatch");
 
     let claimed = store
@@ -7804,7 +7959,7 @@ async fn distributed_nack_retry_window_respects_retry_at_boundary() {
         .await
         .expect("claim dispatch")
         .expect("claim exists");
-    let token = claimed.claim_token.expect("claim token");
+    let token = claimed.claim_token().expect("claim token");
 
     store
         .nack(
@@ -7833,7 +7988,7 @@ async fn distributed_nack_retry_window_respects_retry_at_boundary() {
     assert!(
         at_retry
             .first()
-            .is_some_and(|dispatch| dispatch.dispatch_id == "dispatch-retry-boundary"),
+            .is_some_and(|dispatch| dispatch.dispatch_id() == "dispatch-retry-boundary"),
         "dispatch must become claimable at retry_at"
     );
 }
@@ -7884,7 +8039,7 @@ async fn distributed_recover_prepared_run_missing_wal_is_idempotent_across_insta
         .await
         .expect("list dispatches");
     assert_eq!(dispatches.len(), 1);
-    assert_eq!(dispatches[0].dispatch_id, "dispatch-distributed-recover");
+    assert_eq!(dispatches[0].dispatch_id(), "dispatch-distributed-recover");
 }
 
 #[tokio::test]
@@ -8111,7 +8266,7 @@ async fn interrupt_between_claim_and_execution_supersedes_without_runtime_start(
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             if let Some(dispatch) = store.load_dispatch(&result.dispatch_id).await.unwrap()
-                && dispatch.status == RunDispatchStatus::Superseded
+                && dispatch.status() == RunDispatchStatus::Superseded
             {
                 break;
             }
@@ -8131,9 +8286,9 @@ async fn interrupt_between_claim_and_execution_supersedes_without_runtime_start(
         .await
         .unwrap()
         .expect("dispatch should remain inspectable");
-    assert_eq!(loaded.status, RunDispatchStatus::Superseded);
-    assert!(loaded.claim_token.is_none());
-    assert!(loaded.lease_until.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Superseded);
+    assert!(loaded.claim_token().is_none());
+    assert!(loaded.lease_until().is_none());
 
     let run = run_store
         .load_run(&result.run_id)
@@ -8187,7 +8342,7 @@ async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finis
     let first_dispatch = mailbox
         .build_dispatch(&first, &thread_id)
         .expect("build first dispatch");
-    let first_dispatch_id = first_dispatch.dispatch_id.clone();
+    let first_dispatch_id = first_dispatch.dispatch_id().clone();
     store.enqueue(&first_dispatch).await.expect("enqueue first");
 
     let mut second = RunActivation::new("thread-signal-busy", vec![Message::user("second")])
@@ -8205,7 +8360,7 @@ async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finis
     let second_dispatch = mailbox
         .build_dispatch(&second, &thread_id)
         .expect("build second dispatch");
-    let second_dispatch_id = second_dispatch.dispatch_id.clone();
+    let second_dispatch_id = second_dispatch.dispatch_id().clone();
     store
         .enqueue(&second_dispatch)
         .await
@@ -8243,7 +8398,7 @@ async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finis
         .expect("load queued dispatch")
         .expect("queued dispatch exists");
     assert_eq!(
-        queued_before_release.status,
+        queued_before_release.status(),
         RunDispatchStatus::Queued,
         "busy signal ack must not claim the other dispatch before the first finishes"
     );
@@ -8257,17 +8412,17 @@ async fn dispatch_signal_busy_ack_still_runs_queued_dispatch_after_current_finis
     assert_eq!(dispatch_id.as_deref(), Some(queued_dispatch_id));
 
     let first_done = wait_for_dispatch(&store.inner, &first_dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Acked
+        dispatch.status() == RunDispatchStatus::Acked
     })
     .await;
     let second_done = wait_for_dispatch(&store.inner, &second_dispatch_id, |dispatch| {
-        dispatch.status == RunDispatchStatus::Acked
+        dispatch.status() == RunDispatchStatus::Acked
     })
     .await;
     signal_loop.abort();
 
-    assert_eq!(first_done.status, RunDispatchStatus::Acked);
-    assert_eq!(second_done.status, RunDispatchStatus::Acked);
+    assert_eq!(first_done.status(), RunDispatchStatus::Acked);
+    assert_eq!(second_done.status(), RunDispatchStatus::Acked);
     assert_eq!(store.acked_signal_count(), 2);
     assert_eq!(store.nacked_signal_count(), 0);
 }
@@ -8505,7 +8660,7 @@ fn nack_backoff_progression() {
     // Formula from execute_dispatch: 2^(attempt_count.saturating_sub(1).min(6))
     // attempt_count is 0-based on the dispatch at nack time, but incremented
     // by the store before re-queue. The backoff in execute_dispatch uses
-    // dispatch.attempt_count which is the pre-nack value.
+    // dispatch.attempt_count() which is the pre-nack value.
     for (attempt_count, expected_ms) in [
         (1, 250),   // 2^0 * 250 = 250
         (2, 500),   // 2^1 * 250 = 500
@@ -8648,6 +8803,7 @@ async fn gc_idle_workers_noop_when_empty() {
 // ── ThreadContext cache tests ───────────────────────────────────
 
 fn make_run_record(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecord {
+    let finished_at = (status == RunStatus::Done).then_some(2);
     RunRecord {
         run_id: run_id.to_string(),
         thread_id: thread_id.to_string(),
@@ -8669,7 +8825,7 @@ fn make_run_record(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecor
         outcome: None,
         created_at: 1,
         started_at: None,
-        finished_at: None,
+        finished_at,
         updated_at: 1,
         steps: 0,
         input_tokens: 0,
@@ -8725,7 +8881,7 @@ async fn thread_context_cache_used_by_reusable_waiting_run_id() {
         w.thread_ctx = Some(ctx);
     }
 
-    let result = mailbox.reusable_waiting_run_id(thread_id).await;
+    let result = mailbox.reusable_waiting_run_id(thread_id).await.unwrap();
     assert_eq!(result, Some("run-waiting".to_string()));
 }
 
@@ -8882,7 +9038,10 @@ async fn reusable_waiting_run_id_ignores_stale_worker_cache() {
         .await
         .unwrap();
 
-    assert_eq!(mailbox.reusable_waiting_run_id(thread_id).await, None);
+    assert_eq!(
+        mailbox.reusable_waiting_run_id(thread_id).await.unwrap(),
+        None
+    );
 }
 
 #[tokio::test]
@@ -8975,7 +9134,7 @@ async fn reusable_waiting_run_id_returns_none_for_done_cached_run() {
         w.thread_ctx = Some(ctx);
     }
 
-    let result = mailbox.reusable_waiting_run_id(thread_id).await;
+    let result = mailbox.reusable_waiting_run_id(thread_id).await.unwrap();
     assert_eq!(result, None, "Done run should not be reusable");
 }
 
@@ -9008,30 +9167,14 @@ impl RunDispatchExecutor for CoordinatorAwareNoopRuntime {
 
 fn sample_dispatch(thread_id: &str, run_id: &str, dispatch_id: &str) -> RunDispatch {
     let now = now_ms();
-    RunDispatch {
-        dispatch_id: dispatch_id.to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: run_id.to_string(),
-        priority: 0,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: now,
-        attempt_count: 0,
-        max_attempts: 3,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: now,
-        updated_at: now,
-    }
+    RunDispatch::queued(
+        dispatch_id.to_string(),
+        thread_id.to_string(),
+        run_id.to_string(),
+        now,
+    )
+    .with_priority(0)
+    .with_max_attempts(3)
 }
 
 /// ADR-0036 D9: when a per-run `EventBuffer` is supplied to
@@ -9045,7 +9188,10 @@ async fn wrap_dispatch_with_buffer_stages_into_buffer_not_writer() {
     let event_store = Arc::new(InMemoryEventStore::new());
     let mailbox_store = make_store();
     let thread_store = Arc::new(InMemoryStore::new());
-    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(CoordinatorAwareNoopRuntime);
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(CommittingEmittingMailboxRuntime::new(
+        Arc::clone(&thread_store),
+        Arc::clone(&event_store),
+    ));
     let mailbox = Arc::new(
         Mailbox::new(
             runtime,
@@ -9111,5 +9257,58 @@ fn runtime_event_capture_requires_commit_coordinator() {
     assert_eq!(
         error.to_string(),
         "validation error: runtime event capture requires an executor with CommitCoordinator"
+    );
+}
+
+#[test]
+fn runtime_event_capture_requires_staged_commit_coordinator() {
+    let mailbox_store = make_store();
+    let thread_store = Arc::new(InMemoryStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(CoordinatorAwareNoopRuntime);
+    let result = Mailbox::new(
+        runtime,
+        mailbox_store,
+        thread_store,
+        "c".into(),
+        MailboxConfig::default(),
+    )
+    .with_runtime_event_capture(RuntimeEventDurability::Compacted, "test");
+    let error = match result {
+        Ok(_) => panic!("capture without a staged coordinator must be rejected"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.to_string(),
+        "validation error: runtime event capture requires an executor with StagedCommitCoordinator"
+    );
+}
+
+#[test]
+fn mailbox_try_new_rejects_coordinator_run_store_mismatch() {
+    let coordinator_store = Arc::new(InMemoryStore::new());
+    let mailbox_run_store = Arc::new(InMemoryStore::new());
+    let event_store = Arc::new(InMemoryEventStore::new());
+    let runtime: Arc<dyn RunDispatchExecutor> = Arc::new(CommittingEmittingMailboxRuntime::new(
+        coordinator_store,
+        event_store,
+    ));
+
+    let result = Mailbox::try_new(
+        runtime,
+        make_store(),
+        mailbox_run_store,
+        "c".into(),
+        MailboxConfig::default(),
+    );
+
+    let error = match result {
+        Ok(_) => panic!("mailbox must reject mismatched coordinator and run_store"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("mailbox run_store must match executor CommitCoordinator"),
+        "unexpected error: {error}"
     );
 }

--- a/crates/awaken-server/src/protocols/a2a/message.rs
+++ b/crates/awaken-server/src/protocols/a2a/message.rs
@@ -23,8 +23,8 @@ use super::push_config::{
 };
 use super::stream_projector::{InitialStreamEvent, TaskStreamProjector};
 use super::task::{
-    load_task_snapshot, record_task_binding, resolve_task, run_is_a2a_resumable, submitted_task,
-    task_context_id, wait_for_task,
+    decode_task_bindings_metadata, load_task_snapshot, record_task_binding, resolve_task,
+    run_is_a2a_resumable, submitted_task, task_context_id, wait_for_task,
 };
 use super::types::{BLOCKING_POLL_INTERVAL, PreparedRequest, SUPPORTED_OUTPUT_MODE, TaskSnapshot};
 
@@ -493,16 +493,15 @@ async fn thread_has_prior_context(
     if thread.active_run_id.is_some() || thread.open_run_id.is_some() {
         return Ok(true);
     }
-    if thread
+    if let Some(value) = thread
         .metadata
         .custom
         .get(super::types::TASK_BINDINGS_METADATA_KEY)
-        .and_then(|value| {
-            serde_json::from_value::<super::types::StoredTaskBindings>(value.clone()).ok()
-        })
-        .is_some_and(|bindings| !bindings.tasks.is_empty())
     {
-        return Ok(true);
+        let bindings = decode_task_bindings_metadata(value.clone())?;
+        if !bindings.tasks.is_empty() {
+            return Ok(true);
+        }
     }
 
     let messages = store

--- a/crates/awaken-server/src/protocols/a2a/push_config.rs
+++ b/crates/awaken-server/src/protocols/a2a/push_config.rs
@@ -339,11 +339,8 @@ fn load_thread_push_notification_configs(
         return Ok(Vec::new());
     };
 
-    if let Ok(stored) = serde_json::from_value::<StoredPushConfigs>(value.clone()) {
-        Ok(stored.tasks.get(task_id).cloned().unwrap_or_default())
-    } else {
-        serde_json::from_value(value.clone()).map_err(|err| A2aError::Internal(err.to_string()))
-    }
+    let stored = decode_push_configs_metadata(value.clone(), task_id)?;
+    Ok(stored.tasks.get(task_id).cloned().unwrap_or_default())
 }
 
 async fn save_thread_push_notification_configs(
@@ -354,12 +351,10 @@ async fn save_thread_push_notification_configs(
     task_id: &str,
     configs: Vec<PushNotificationConfig>,
 ) -> Result<(), A2aError> {
-    let mut stored = thread
-        .metadata
-        .custom
-        .remove(PUSH_CONFIGS_METADATA_KEY)
-        .and_then(|value| serde_json::from_value::<StoredPushConfigs>(value).ok())
-        .unwrap_or_default();
+    let mut stored = match thread.metadata.custom.remove(PUSH_CONFIGS_METADATA_KEY) {
+        Some(value) => decode_push_configs_metadata(value, task_id)?,
+        None => StoredPushConfigs::default(),
+    };
     if configs.is_empty() {
         stored.tasks.remove(task_id);
     } else {
@@ -376,6 +371,29 @@ async fn save_thread_push_notification_configs(
     persist_thread_metadata(st, thread_id, exists, thread).await?;
 
     Ok(())
+}
+
+fn decode_push_configs_metadata(
+    value: serde_json::Value,
+    task_id: &str,
+) -> Result<StoredPushConfigs, A2aError> {
+    match serde_json::from_value::<StoredPushConfigs>(value.clone()) {
+        Ok(stored) => Ok(stored),
+        Err(stored_error) => {
+            let legacy_configs = serde_json::from_value::<Vec<PushNotificationConfig>>(value)
+                .map_err(|legacy_error| {
+                    A2aError::Internal(format!(
+                        "corrupt A2A push config metadata at {PUSH_CONFIGS_METADATA_KEY}: \
+                         stored format error: {stored_error}; legacy format error: {legacy_error}"
+                    ))
+                })?;
+            let mut stored = StoredPushConfigs::default();
+            if !legacy_configs.is_empty() {
+                stored.tasks.insert(task_id.to_string(), legacy_configs);
+            }
+            Ok(stored)
+        }
+    }
 }
 
 /// Releases the single-flight dedupe key for an A2A push driver when the driver
@@ -490,6 +508,8 @@ async fn drive_push_notification(
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     fn config(id: &str, tenant: Option<&str>, url: &str) -> PushNotificationConfig {
@@ -537,6 +557,28 @@ mod tests {
             .find(|c| c.agent_id.as_deref() == Some("b"))
             .unwrap();
         assert_eq!(b.url, "http://b/1");
+    }
+
+    #[test]
+    fn decode_push_configs_metadata_rejects_malformed_state() {
+        let error = decode_push_configs_metadata(json!({"tasks": []}), "task-1")
+            .expect_err("malformed push config metadata must fail closed");
+        match error {
+            A2aError::Internal(message) => {
+                assert!(message.contains(PUSH_CONFIGS_METADATA_KEY));
+                assert!(message.contains("stored format error"));
+                assert!(message.contains("legacy format error"));
+            }
+            other => panic!("expected internal corruption error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_push_configs_metadata_preserves_legacy_task_list() {
+        let stored =
+            decode_push_configs_metadata(json!([config("cfg-1", None, "http://a/1")]), "task-1")
+                .expect("legacy push config list must remain readable");
+        assert_eq!(stored.tasks["task-1"][0].id.as_deref(), Some("cfg-1"));
     }
 
     #[test]

--- a/crates/awaken-server/src/protocols/a2a/task.rs
+++ b/crates/awaken-server/src/protocols/a2a/task.rs
@@ -95,7 +95,7 @@ pub(super) async fn cancel_task(
     let mut cancelled = false;
     for dispatch in queued_dispatches {
         cancelled |= mailbox
-            .cancel(&dispatch.dispatch_id)
+            .cancel(&dispatch.dispatch_id())
             .await
             .map_err(|e| A2aError::Internal(e.to_string()))?;
     }
@@ -252,7 +252,7 @@ pub(super) async fn resolve_task(
         return Ok(None);
     };
     Ok(Some(ResolvedTask {
-        thread_id: dispatch.thread_id.clone(),
+        thread_id: dispatch.thread_id().clone(),
         run: None,
         dispatch: Some(dispatch),
     }))
@@ -269,12 +269,10 @@ pub(super) async fn record_task_binding(
     start_message_id: &str,
 ) -> Result<(), A2aError> {
     let (exists, mut thread) = load_thread_metadata_projection(st, thread_id).await?;
-    let mut bindings = thread
-        .metadata
-        .custom
-        .remove(TASK_BINDINGS_METADATA_KEY)
-        .and_then(|value| serde_json::from_value::<StoredTaskBindings>(value).ok())
-        .unwrap_or_default();
+    let mut bindings = match thread.metadata.custom.remove(TASK_BINDINGS_METADATA_KEY) {
+        Some(value) => decode_task_bindings_metadata(value)?,
+        None => StoredTaskBindings::default(),
+    };
     bindings.tasks.insert(
         task_id.to_string(),
         StoredTaskBinding {
@@ -311,12 +309,23 @@ async fn load_task_binding(
         return Ok(None);
     };
 
-    Ok(thread
-        .metadata
-        .custom
-        .get(TASK_BINDINGS_METADATA_KEY)
-        .and_then(|value| serde_json::from_value::<StoredTaskBindings>(value.clone()).ok())
-        .and_then(|bindings| bindings.tasks.get(task_id).cloned()))
+    let Some(value) = thread.metadata.custom.get(TASK_BINDINGS_METADATA_KEY) else {
+        return Ok(None);
+    };
+    Ok(decode_task_bindings_metadata(value.clone())?
+        .tasks
+        .get(task_id)
+        .cloned())
+}
+
+pub(super) fn decode_task_bindings_metadata(
+    value: serde_json::Value,
+) -> Result<StoredTaskBindings, A2aError> {
+    serde_json::from_value::<StoredTaskBindings>(value).map_err(|error| {
+        A2aError::Internal(format!(
+            "corrupt A2A task binding metadata at {TASK_BINDINGS_METADATA_KEY}: {error}"
+        ))
+    })
 }
 
 pub(super) async fn task_context_id(
@@ -380,8 +389,8 @@ pub(super) async fn load_task_snapshot(
             .map_err(|e| A2aError::Internal(e.to_string()))?
             .into_iter()
             .map(|dispatch| st.run.unscope_dispatch(dispatch))
-            .filter(|dispatch| dispatch.run_id == task_id || dispatch.dispatch_id == task_id)
-            .max_by_key(|dispatch| dispatch.updated_at)
+            .filter(|dispatch| dispatch.run_id() == task_id || dispatch.dispatch_id() == task_id)
+            .max_by_key(|dispatch| dispatch.updated_at())
     };
 
     let history = st
@@ -435,8 +444,8 @@ pub(super) async fn load_task_snapshot(
         current_agent_id: Some(record.agent_id.clone()),
     });
     let dispatch_source = latest_dispatch.as_ref().map(|dispatch| TaskSource {
-        state: dispatch_to_task_state(dispatch.status),
-        updated_at_ms: dispatch.updated_at,
+        state: dispatch_to_task_state(dispatch.status()),
+        updated_at_ms: dispatch.updated_at(),
         current_agent_id: latest_run.as_ref().map(|record| record.agent_id.clone()),
     });
 
@@ -444,7 +453,7 @@ pub(super) async fn load_task_snapshot(
         (Some(run), Some(dispatch)) if dispatch.updated_at_ms >= run.updated_at_ms => {
             if latest_dispatch
                 .as_ref()
-                .is_some_and(|dispatch| dispatch.status != RunDispatchStatus::Acked)
+                .is_some_and(|dispatch| dispatch.status() != RunDispatchStatus::Acked)
             {
                 dispatch_source
             } else {
@@ -643,9 +652,29 @@ pub(super) async fn collect_task_ids(st: &ProtocolRoutesState) -> Result<Vec<Str
             ids.extend(
                 dispatches
                     .into_iter()
-                    .map(|dispatch| st.run.unscope_dispatch(dispatch).dispatch_id),
+                    .map(|dispatch| st.run.unscope_dispatch(dispatch).dispatch_id().clone()),
             );
         }
     }
     Ok(ids.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn decode_task_bindings_metadata_rejects_malformed_state() {
+        let error = decode_task_bindings_metadata(json!({"tasks": []}))
+            .expect_err("malformed task binding metadata must fail closed");
+        match error {
+            A2aError::Internal(message) => {
+                assert!(message.contains(TASK_BINDINGS_METADATA_KEY));
+                assert!(message.contains("invalid type"));
+            }
+            other => panic!("expected internal corruption error, got {other:?}"),
+        }
+    }
 }

--- a/crates/awaken-server/src/routes.rs
+++ b/crates/awaken-server/src/routes.rs
@@ -18,7 +18,7 @@ use crate::query::{self, MessageQueryParams, ThreadQueryParams};
 use crate::services::run_control_service::{
     InputMode, InterruptMode, RunControlError, RunControlService,
 };
-use awaken_runtime::RunActivation;
+use awaken_runtime::{ResolveError, RunActivation};
 use awaken_server_contract::ScopeContext;
 use awaken_server_contract::contract::message::Message;
 use awaken_server_contract::contract::storage::{ChildThreadDeleteStrategy, StorageError};
@@ -36,6 +36,7 @@ pub(crate) fn map_mailbox_error(error: MailboxError) -> ApiError {
             err @ StorageError::AlreadyExists(_) | err @ StorageError::VersionConflict { .. },
         ) => ApiError::Conflict(err.to_string()),
         MailboxError::Store(err) => ApiError::Internal(err.to_string()),
+        MailboxError::Resolution { context, source } => map_resolve_error(context, source),
         MailboxError::Internal(msg) => ApiError::Internal(msg),
         // A barrier ahead in pending must be consumed first: a client-resolvable
         // conflict, not a server fault.
@@ -44,6 +45,28 @@ pub(crate) fn map_mailbox_error(error: MailboxError) -> ApiError {
         } => ApiError::Conflict(format!(
             "delivery blocked by barrier: pending '{blocking_pending_id}' must be consumed first"
         )),
+    }
+}
+
+fn map_resolve_error(context: &'static str, error: ResolveError) -> ApiError {
+    match error {
+        ResolveError::CapabilityMismatch(mismatches) => ApiError::CapabilityMismatch(format!(
+            "{context}: {}",
+            mismatches
+                .into_iter()
+                .map(|mismatch| format!(
+                    "{} required {}, actual {}",
+                    mismatch.capability, mismatch.required, mismatch.actual
+                ))
+                .collect::<Vec<_>>()
+                .join("; ")
+        )),
+        ResolveError::UnsupportedTarget(message)
+        | ResolveError::UnsupportedPersistence(message)
+        | ResolveError::NestedScopeMismatch(message) => {
+            ApiError::BadRequest(format!("{context}: {message}"))
+        }
+        ResolveError::Runtime(message) => ApiError::Internal(format!("{context}: {message}")),
     }
 }
 

--- a/crates/awaken-server/src/routes_test.rs
+++ b/crates/awaken-server/src/routes_test.rs
@@ -330,6 +330,19 @@ async fn api_error_internal_body() {
 }
 
 #[tokio::test]
+async fn api_error_capability_mismatch_body_has_code() {
+    let err = ApiError::CapabilityMismatch("backend mismatch".into());
+    let resp = err.into_response();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let value: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["error"], "backend mismatch");
+    assert_eq!(value["code"], "capability_mismatch");
+}
+
+#[tokio::test]
 async fn api_error_bad_request_body() {
     let err = ApiError::BadRequest("invalid input".into());
     let resp = err.into_response();

--- a/crates/awaken-server/src/services/audit_log.rs
+++ b/crates/awaken-server/src/services/audit_log.rs
@@ -205,7 +205,7 @@ impl AuditLogger {
     /// Returns `Ok(None)` when the event is not found (either never existed or was pruned).
     pub async fn get_event(&self, id: &str) -> Result<Option<AuditEvent>, StorageError> {
         let value = self.store.get(AUDIT_NAMESPACE, id).await?;
-        Ok(value.and_then(|v| serde_json::from_value::<AuditEvent>(v).ok()))
+        value.map(|value| decode_audit_event(id, value)).transpose()
     }
 
     /// Emit a restore audit event with the `restored_from` field set.
@@ -354,17 +354,19 @@ impl AuditLogger {
             .await
             .map_err(AuditQueryError::Storage)?;
 
-        // Deserialize and filter.
-        let mut events: Vec<AuditEvent> = all
+        let mut events = Vec::new();
+        for (id, value) in all {
+            // Cursor: only include entries with id < cursor_id (older pages).
+            // We're serving newest-first so we reverse later.
+            if cursor_id.as_deref().is_some_and(|cid| id.as_str() >= cid) {
+                continue;
+            }
+            events.push(decode_audit_event(&id, value).map_err(AuditQueryError::Storage)?);
+        }
+
+        // Filter decoded events.
+        let mut events: Vec<AuditEvent> = events
             .into_iter()
-            .filter_map(|(id, value)| {
-                // Cursor: only include entries with id < cursor_id (older pages).
-                // We're serving newest-first so we reverse later.
-                if cursor_id.as_deref().is_some_and(|cid| id.as_str() >= cid) {
-                    return None;
-                }
-                serde_json::from_value::<AuditEvent>(value).ok()
-            })
             .filter(|event| {
                 if let Some(ref since) = filter.since
                     && let Ok(ts) = event.ts.parse::<DateTime<Utc>>()
@@ -439,6 +441,11 @@ impl AuditLogger {
         }
         Ok(pruned)
     }
+}
+
+fn decode_audit_event(id: &str, value: Value) -> Result<AuditEvent, StorageError> {
+    serde_json::from_value::<AuditEvent>(value)
+        .map_err(|error| StorageError::Serialization(format!("corrupt audit event {id}: {error}")))
 }
 
 /// Derive the actor string from request headers.
@@ -782,6 +789,34 @@ mod tests {
         assert_eq!(event.action, AuditAction::Create);
         assert_eq!(event.resource, "agents/my-agent");
         assert_eq!(event.actor, "anonymous");
+    }
+
+    #[tokio::test]
+    async fn corrupt_audit_event_fails_closed_on_read() {
+        let store = Arc::new(MemStore::default());
+        store
+            .put(AUDIT_NAMESPACE, "bad-event", &json!({"id": 1}))
+            .await
+            .unwrap();
+        let logger = AuditLogger::new(store);
+
+        let get_error = logger
+            .get_event("bad-event")
+            .await
+            .expect_err("corrupt audit event must not look missing");
+        assert!(matches!(get_error, StorageError::Serialization(_)));
+        assert!(get_error.to_string().contains("bad-event"));
+
+        let query_error = logger
+            .query(AuditQuery::default())
+            .await
+            .expect_err("corrupt audit event must not be skipped");
+        match query_error {
+            AuditQueryError::Storage(StorageError::Serialization(message)) => {
+                assert!(message.contains("bad-event"));
+            }
+            other => panic!("expected serialization storage error, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/awaken-server/src/services/config_runtime.rs
+++ b/crates/awaken-server/src/services/config_runtime.rs
@@ -30,6 +30,8 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
+#[cfg(test)]
+mod credential_tests;
 mod managed_config;
 mod provider_cache;
 mod provider_capability_discovery;
@@ -1163,13 +1165,12 @@ impl ConfigRuntimeManager {
 ///
 /// Auth wiring branches on credential kind:
 ///
-/// - **Static bearer / env-fallback** (0.4.0 default): the api_key (or
-///   genai's per-adapter env var, when api_key is absent) is handed
-///   directly to genai's synchronous `with_auth_resolver_fn`. The broker
-///   is **not** consulted — there is no token to refresh and no token
-///   endpoint to single-flight against. This keeps the inference hot path
-///   identical to 0.4.0 and avoids the cache / lock churn the broker
-///   would otherwise add per request.
+/// - **Static bearer / explicit env fallback**: the api_key is handed directly
+///   to genai's synchronous `with_auth_resolver_fn`. If api_key is absent,
+///   callers must set `adapter_options.allow_env_credentials = true` to let
+///   genai use its per-adapter env var. The broker is **not** consulted —
+///   there is no token to refresh and no token endpoint to single-flight
+///   against.
 ///
 /// - **Dynamic** (`service_account_json`, future cloud creds): material
 ///   is registered with the broker, and an async auth resolver consults
@@ -1184,10 +1185,15 @@ pub fn build_genai_provider_executor_with_broker(
     spec: &ProviderSpec,
     broker: Arc<dyn awaken_runtime::credentials::CredentialBroker>,
 ) -> Result<Arc<dyn LlmExecutor>, ConfigRuntimeError> {
-    use awaken_runtime::credentials::{CredentialKind, build_material};
+    use awaken_runtime::credentials::{
+        CredentialKind, allow_env_credentials_from_options, build_material,
+        build_material_allowing_env_fallback,
+    };
 
     let adapter_kind = parse_adapter_kind(&spec.adapter)?;
     let kind = CredentialKind::from_options(&spec.adapter_options)
+        .map_err(ConfigRuntimeError::InvalidConfig)?;
+    let allow_env_credentials = allow_env_credentials_from_options(&spec.adapter_options)
         .map_err(ConfigRuntimeError::InvalidConfig)?;
 
     // Eager-validate material shape (malformed SA JSON, kind/adapter
@@ -1197,15 +1203,19 @@ pub fn build_genai_provider_executor_with_broker(
     // because the bearer wiring reads `spec.api_key` directly to bypass
     // the broker entirely. Non-bearer kinds *do* register the returned
     // material with the broker.
-    let material = build_material(&spec.adapter, kind, spec.api_key.as_ref())
-        .map_err(ConfigRuntimeError::InvalidConfig)?;
+    let material = if allow_env_credentials {
+        build_material_allowing_env_fallback(&spec.adapter, kind, spec.api_key.as_ref())
+    } else {
+        build_material(&spec.adapter, kind, spec.api_key.as_ref())
+    }
+    .map_err(ConfigRuntimeError::InvalidConfig)?;
 
     let mut builder = Client::builder().with_model_mapper_fn(move |model: ModelIden| {
         Ok(ModelIden::new(adapter_kind, model.model_name.to_string()))
     });
 
     if matches!(kind, CredentialKind::Bearer) {
-        // Static bearer / env-fallback path — identical wiring to 0.4.0.
+        // Static bearer / explicit env-fallback path.
         // Broker is bypassed entirely: there's no token to refresh and no
         // token endpoint to single-flight against, so cache/lock churn
         // would be pure overhead.
@@ -1214,7 +1224,7 @@ pub fn build_genai_provider_executor_with_broker(
             builder = builder
                 .with_auth_resolver_fn(move |_| Ok(Some(AuthData::from_single(key.clone()))));
         }
-        // else: env-fallback — leave genai's default resolver
+        // else: explicit env fallback — leave genai's default resolver
         // (VENDOR_API_KEY env var) in place.
     } else if let Some(material) = material {
         // Dynamic kind: register with the broker; the async resolver
@@ -1580,6 +1590,7 @@ mod tests {
         ProviderSpec {
             id: "test".into(),
             adapter: "openai".into(),
+            api_key: Some("test-secret-key".to_string().into()),
             adapter_options,
             ..ProviderSpec::default()
         }
@@ -1877,370 +1888,6 @@ mod tests {
                 "as_lower_str round-trip mismatch for {name}"
             );
         }
-    }
-
-    // -- credential broker integration tests ---------------------------------
-    //
-    // These tests exercise the path: ProviderSpec → build_material →
-    // broker.register → executor build. They cover the eager-validation
-    // contract (bad credentials_kind, bad SA JSON, missing api_key) and
-    // backward compatibility (no api_key + bearer = silent fallback to
-    // genai env vars).
-
-    fn provider_spec_with_kind_and_key(
-        adapter: &str,
-        kind: Option<&str>,
-        api_key: Option<&str>,
-    ) -> ProviderSpec {
-        let mut options: BTreeMap<String, Value> = BTreeMap::new();
-        if let Some(k) = kind {
-            options.insert("credentials_kind".into(), json!(k));
-        }
-        ProviderSpec {
-            id: format!("test-{adapter}"),
-            adapter: adapter.into(),
-            api_key: api_key.map(|k| k.to_string().into()),
-            adapter_options: options,
-            ..ProviderSpec::default()
-        }
-    }
-
-    #[test]
-    fn supported_adapters_includes_recent_additions() {
-        let names: std::collections::HashSet<&str> = supported_adapters().into_iter().collect();
-        for required in ["vertex", "github_copilot", "ollama_cloud"] {
-            assert!(
-                names.contains(required),
-                "expected adapter {required} to be exposed via supported_adapters()"
-            );
-        }
-    }
-
-    #[test]
-    fn supported_adapters_filters_unknown_candidates() {
-        // Forward-looking candidates that genai 0.6 does not yet recognise must
-        // be dropped, not passed through as broken options to the admin UI.
-        let names: std::collections::HashSet<&str> = supported_adapters().into_iter().collect();
-        for speculative in ["bedrock", "azure", "azure_openai", "mistral", "perplexity"] {
-            if AdapterKind::from_lower_str(speculative).is_none() {
-                assert!(
-                    !names.contains(speculative),
-                    "speculative candidate {speculative} leaked into supported_adapters() despite genai not supporting it"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn unsupported_adapter_error_points_at_genai_docs() {
-        let err = parse_adapter_kind("definitely-not-a-real-adapter").unwrap_err();
-        let display = err.to_string();
-        assert!(
-            display.contains("definitely-not-a-real-adapter"),
-            "error must echo the offending name, got: {display}"
-        );
-        assert!(
-            display.contains("docs.rs/genai"),
-            "error must point operators at genai's AdapterKind docs, got: {display}"
-        );
-    }
-
-    #[test]
-    fn build_genai_executor_for_every_supported_adapter() {
-        // Stronger than the parse round-trip: every adapter exposed via
-        // supported_adapters() must successfully construct an LlmExecutor end
-        // to end (parse → AdapterKind → genai builder chain → wrapper). No
-        // network calls happen at build time, so this is safe and offline.
-        for name in supported_adapters() {
-            let spec = ProviderSpec {
-                id: format!("test-{name}"),
-                adapter: name.to_string(),
-                ..ProviderSpec::default()
-            };
-            build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
-                panic!("supported adapter `{name}` failed to build executor: {err:?}")
-            });
-        }
-    }
-
-    #[test]
-    fn build_genai_executor_with_api_key_for_every_supported_adapter() {
-        // Same as above but exercising the auth_resolver path (api_key set).
-        // Catches any adapter that rejects a static key at builder time.
-        for name in supported_adapters() {
-            let spec = ProviderSpec {
-                id: format!("test-{name}"),
-                adapter: name.to_string(),
-                api_key: Some("test-secret-key".to_string().into()),
-                ..ProviderSpec::default()
-            };
-            build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
-                panic!("supported adapter `{name}` (with api_key) failed to build: {err:?}")
-            });
-        }
-    }
-
-    #[test]
-    fn build_genai_executor_with_base_url_override_for_every_supported_adapter() {
-        // Cover the third resolver path: base_url override (proxy / self-hosted).
-        // Use a syntactically valid URL — genai validates the form at build time.
-        for name in supported_adapters() {
-            let spec = ProviderSpec {
-                id: format!("test-{name}"),
-                adapter: name.to_string(),
-                base_url: Some("https://example.invalid/v1".to_string()),
-                ..ProviderSpec::default()
-            };
-            build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
-                panic!("supported adapter `{name}` (with base_url) failed to build: {err:?}")
-            });
-        }
-    }
-
-    #[test]
-    fn build_genai_executor_with_full_options_for_every_supported_adapter() {
-        // All resolver paths simultaneously: api_key + base_url + headers +
-        // an unknown forward-compat option key. Every adapter must accept the
-        // combination without breaking the builder chain.
-        for name in supported_adapters() {
-            let mut adapter_options = BTreeMap::new();
-            adapter_options.insert(
-                "headers".into(),
-                json!({ "X-Awaken-Trace": "regression-test" }),
-            );
-            adapter_options.insert("future_extension_key".into(), json!({ "ignored": true }));
-            let spec = ProviderSpec {
-                id: format!("test-{name}"),
-                adapter: name.to_string(),
-                api_key: Some("test-secret-key".to_string().into()),
-                base_url: Some("https://example.invalid/v1".to_string()),
-                timeout_secs: 60,
-                adapter_options,
-            };
-            build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
-                panic!("supported adapter `{name}` (full options) failed to build: {err:?}")
-            });
-        }
-    }
-
-    #[test]
-    fn build_genai_executor_clamps_zero_timeout_for_every_supported_adapter() {
-        // Boundary: timeout_secs = 0 must be clamped to >=1 instead of producing
-        // a Duration that breaks the executor. Same protection for every adapter.
-        for name in supported_adapters() {
-            let spec = ProviderSpec {
-                id: format!("test-{name}"),
-                adapter: name.to_string(),
-                timeout_secs: 0,
-                ..ProviderSpec::default()
-            };
-            build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
-                panic!("supported adapter `{name}` (zero timeout) failed to build: {err:?}")
-            });
-        }
-    }
-
-    #[test]
-    fn parse_adapter_kind_is_case_insensitive_for_every_supported_adapter() {
-        // Every supported adapter must parse regardless of casing variations.
-        // Guards against silent regressions in the to_ascii_lowercase normalisation.
-        for name in supported_adapters() {
-            let upper = name.to_ascii_uppercase();
-            let mixed: String = name
-                .chars()
-                .enumerate()
-                .map(|(i, c)| {
-                    if i % 2 == 0 {
-                        c.to_ascii_uppercase()
-                    } else {
-                        c
-                    }
-                })
-                .collect();
-            for variant in [name.to_string(), upper, mixed, format!("  {name}  ")] {
-                parse_adapter_kind(&variant).unwrap_or_else(|err| {
-                    panic!("`{variant}` (canonical: {name}) failed to parse: {err:?}")
-                });
-            }
-        }
-    }
-
-    #[test]
-    fn supported_adapters_unique_no_duplicate_names() {
-        // Detect copy-paste mistakes in ADAPTER_CANDIDATES that would silently
-        // duplicate an entry in the admin UI dropdown.
-        let names: Vec<&'static str> = supported_adapters();
-        let mut seen = std::collections::HashSet::with_capacity(names.len());
-        for name in &names {
-            assert!(
-                seen.insert(*name),
-                "duplicate entry `{name}` in supported_adapters()"
-            );
-        }
-        // Sanity floor: PR opens with 19 known adapters, never expect to ship
-        // fewer (would mean we lost coverage of an upstream-supported adapter).
-        assert!(
-            names.len() >= 19,
-            "supported_adapters() shrank below floor of 19 (got {}): {names:?}",
-            names.len()
-        );
-    }
-
-    #[test]
-    fn vertex_anthropic_namespaces_parse_when_routed_through_adapter_string() {
-        // Vertex routes Gemini and Claude via the same adapter string; only
-        // genai's namespace routing inside `from_model` discriminates publishers.
-        // Ensure the adapter-name level still resolves to AdapterKind::Vertex
-        // regardless of which model the caller eventually sends.
-        let kind = parse_adapter_kind("vertex").expect("vertex must parse");
-        assert_eq!(kind, AdapterKind::Vertex);
-        // GitHub Copilot is the same shape: one adapter, multi-publisher routing.
-        let kind = parse_adapter_kind("github_copilot").expect("github_copilot must parse");
-        assert_eq!(kind, AdapterKind::GithubCopilot);
-        // Ollama Cloud must not collide with vanilla Ollama.
-        let cloud = parse_adapter_kind("ollama_cloud").expect("ollama_cloud must parse");
-        let local = parse_adapter_kind("ollama").expect("ollama must parse");
-        assert_ne!(
-            cloud, local,
-            "ollama_cloud and ollama must map to distinct kinds"
-        );
-        assert_eq!(cloud, AdapterKind::OllamaCloud);
-        assert_eq!(local, AdapterKind::Ollama);
-    }
-
-    #[test]
-    fn parse_adapter_kind_accepts_legacy_aliases() {
-        assert_eq!(
-            parse_adapter_kind("openai-resp").unwrap(),
-            AdapterKind::OpenAIResp
-        );
-        assert_eq!(
-            parse_adapter_kind("responses").unwrap(),
-            AdapterKind::OpenAIResp
-        );
-        assert_eq!(
-            parse_adapter_kind("  Anthropic ").unwrap(),
-            AdapterKind::Anthropic
-        );
-    }
-
-    #[test]
-    fn build_genai_omitted_api_key_falls_back_to_env_default() {
-        // 0.4.0 behaviour: a provider with no api_key should still build —
-        // genai's adapter will read VENDOR_API_KEY at request time. The
-        // broker integration must not break this.
-        let spec = provider_spec_with_kind_and_key("openai", None, None);
-        build_genai_provider_executor_with_broker(&spec, test_broker())
-            .expect("env-fallback bearer must build");
-    }
-
-    #[test]
-    fn build_genai_explicit_bearer_succeeds() {
-        let spec = provider_spec_with_kind_and_key("openai", Some("bearer"), Some("sk-test-123"));
-        build_genai_provider_executor_with_broker(&spec, test_broker())
-            .expect("explicit bearer must build");
-    }
-
-    #[test]
-    fn build_genai_unknown_credentials_kind_rejected_with_clear_error() {
-        let spec = provider_spec_with_kind_and_key(
-            "openai",
-            Some("never-heard-of-it"),
-            Some("sk-test-123"),
-        );
-        let err = build_genai_provider_executor_with_broker(&spec, test_broker())
-            .err()
-            .expect("expected error");
-        assert!(
-            matches!(err, ConfigRuntimeError::InvalidConfig(ref m) if m.contains("never-heard-of-it")),
-            "expected InvalidConfig naming the bad kind, got: {err:?}"
-        );
-    }
-
-    #[test]
-    fn build_genai_service_account_kind_with_non_vertex_adapter_rejected() {
-        let spec = provider_spec_with_kind_and_key(
-            "openai",
-            Some("service_account_json"),
-            Some(r#"{"client_email":"x@y","private_key":"-----BEGIN PRIVATE KEY-----"}"#),
-        );
-        let err = build_genai_provider_executor_with_broker(&spec, test_broker())
-            .err()
-            .expect("expected error");
-        assert!(
-            matches!(err, ConfigRuntimeError::InvalidConfig(ref m)
-                if m.contains("service_account_json") && m.contains("vertex") && m.contains("openai")),
-            "expected InvalidConfig naming the kind/adapter mismatch, got: {err:?}"
-        );
-    }
-
-    // Note: deeper service_account_json shape tests live in
-    // `awaken_runtime::credentials::material::tests` so they don't depend
-    // on `parse_adapter_kind` recognising the "vertex" adapter (which is
-    // gated on the upstream genai version actually shipping it).
-
-    /// Broker double that records every `register` / `deregister` call so
-    /// tests can assert what was (or wasn't) handed to the broker.
-    #[derive(Default)]
-    struct RecordingBroker {
-        registered: parking_lot::Mutex<Vec<String>>,
-    }
-
-    #[async_trait::async_trait]
-    impl awaken_runtime::credentials::CredentialBroker for RecordingBroker {
-        fn register(
-            &self,
-            provider_id: String,
-            _material: awaken_runtime::credentials::CredentialMaterial,
-        ) {
-            self.registered.lock().push(provider_id);
-        }
-        async fn token_for(
-            &self,
-            _provider_id: &str,
-            _scope: &str,
-        ) -> Result<
-            awaken_runtime::credentials::IssuedToken,
-            awaken_runtime::credentials::CredentialError,
-        > {
-            unreachable!("static-bearer build must not call token_for");
-        }
-    }
-
-    #[test]
-    fn build_genai_static_bearer_does_not_register_with_broker() {
-        // Item 2: static bearers go straight into genai's sync resolver,
-        // bypassing the broker. If we ever regress and register them, the
-        // broker would unnecessarily cache, single-flight, and lock on
-        // every chat call.
-        let recording: Arc<RecordingBroker> = Arc::new(RecordingBroker::default());
-        let broker: Arc<dyn awaken_runtime::credentials::CredentialBroker> =
-            Arc::clone(&recording) as _;
-
-        let spec = provider_spec_with_kind_and_key("openai", Some("bearer"), Some("sk-x"));
-        build_genai_provider_executor_with_broker(&spec, broker).expect("static bearer must build");
-
-        assert!(
-            recording.registered.lock().is_empty(),
-            "static bearer must not register with the broker"
-        );
-    }
-
-    #[test]
-    fn build_genai_omitted_api_key_does_not_register_with_broker() {
-        // Env-var fallback — same expectation as the static bearer case:
-        // there's no material to register and no token to mint.
-        let recording: Arc<RecordingBroker> = Arc::new(RecordingBroker::default());
-        let broker: Arc<dyn awaken_runtime::credentials::CredentialBroker> =
-            Arc::clone(&recording) as _;
-
-        let spec = provider_spec_with_kind_and_key("openai", None, None);
-        build_genai_provider_executor_with_broker(&spec, broker).expect("env-fallback must build");
-
-        assert!(
-            recording.registered.lock().is_empty(),
-            "env-fallback must not register with the broker"
-        );
     }
 
     #[test]

--- a/crates/awaken-server/src/services/config_runtime/credential_tests.rs
+++ b/crates/awaken-server/src/services/config_runtime/credential_tests.rs
@@ -1,0 +1,351 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use awaken_server_contract::ProviderSpec;
+use serde_json::{Value, json};
+
+use super::*;
+
+fn provider_spec_with_kind_and_key(
+    adapter: &str,
+    kind: Option<&str>,
+    api_key: Option<&str>,
+) -> ProviderSpec {
+    let mut options: BTreeMap<String, Value> = BTreeMap::new();
+    if let Some(kind) = kind {
+        options.insert("credentials_kind".into(), json!(kind));
+    }
+    ProviderSpec {
+        id: format!("test-{adapter}"),
+        adapter: adapter.into(),
+        api_key: api_key.map(|key| key.to_string().into()),
+        adapter_options: options,
+        ..ProviderSpec::default()
+    }
+}
+
+fn provider_spec_with_env_credentials(adapter: &str, kind: Option<&str>) -> ProviderSpec {
+    let mut spec = provider_spec_with_kind_and_key(adapter, kind, None);
+    spec.adapter_options
+        .insert("allow_env_credentials".into(), json!(true));
+    spec
+}
+
+fn test_broker() -> Arc<dyn awaken_runtime::credentials::CredentialBroker> {
+    Arc::new(awaken_runtime::credentials::AwakenCredentialBroker::new())
+}
+
+#[test]
+fn supported_adapters_includes_recent_additions() {
+    let names: std::collections::HashSet<&str> = supported_adapters().into_iter().collect();
+    for required in ["vertex", "github_copilot", "ollama_cloud"] {
+        assert!(
+            names.contains(required),
+            "expected adapter {required} to be exposed via supported_adapters()"
+        );
+    }
+}
+
+#[test]
+fn supported_adapters_filters_unknown_candidates() {
+    let names: std::collections::HashSet<&str> = supported_adapters().into_iter().collect();
+    for speculative in ["bedrock", "azure", "azure_openai", "mistral", "perplexity"] {
+        if AdapterKind::from_lower_str(speculative).is_none() {
+            assert!(
+                !names.contains(speculative),
+                "speculative candidate {speculative} leaked into supported_adapters() despite genai not supporting it"
+            );
+        }
+    }
+}
+
+#[test]
+fn unsupported_adapter_error_points_at_genai_docs() {
+    let err = parse_adapter_kind("definitely-not-a-real-adapter").unwrap_err();
+    let display = err.to_string();
+    assert!(
+        display.contains("definitely-not-a-real-adapter"),
+        "error must echo the offending name, got: {display}"
+    );
+    assert!(
+        display.contains("docs.rs/genai"),
+        "error must point operators at genai's AdapterKind docs, got: {display}"
+    );
+}
+
+#[test]
+fn build_genai_executor_for_every_supported_adapter() {
+    for name in supported_adapters() {
+        let mut adapter_options = BTreeMap::new();
+        adapter_options.insert("allow_env_credentials".into(), json!(true));
+        let spec = ProviderSpec {
+            id: format!("test-{name}"),
+            adapter: name.to_string(),
+            adapter_options,
+            ..ProviderSpec::default()
+        };
+        build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
+            panic!("supported adapter `{name}` failed to build executor: {err:?}")
+        });
+    }
+}
+
+#[test]
+fn build_genai_executor_with_api_key_for_every_supported_adapter() {
+    for name in supported_adapters() {
+        let spec = ProviderSpec {
+            id: format!("test-{name}"),
+            adapter: name.to_string(),
+            api_key: Some("test-secret-key".to_string().into()),
+            ..ProviderSpec::default()
+        };
+        build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
+            panic!("supported adapter `{name}` (with api_key) failed to build: {err:?}")
+        });
+    }
+}
+
+#[test]
+fn build_genai_executor_with_base_url_override_for_every_supported_adapter() {
+    for name in supported_adapters() {
+        let spec = ProviderSpec {
+            id: format!("test-{name}"),
+            adapter: name.to_string(),
+            api_key: Some("test-secret-key".to_string().into()),
+            base_url: Some("https://example.invalid/v1".to_string()),
+            ..ProviderSpec::default()
+        };
+        build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
+            panic!("supported adapter `{name}` (with base_url) failed to build: {err:?}")
+        });
+    }
+}
+
+#[test]
+fn build_genai_executor_with_full_options_for_every_supported_adapter() {
+    for name in supported_adapters() {
+        let mut adapter_options = BTreeMap::new();
+        adapter_options.insert(
+            "headers".into(),
+            json!({ "X-Awaken-Trace": "regression-test" }),
+        );
+        adapter_options.insert("future_extension_key".into(), json!({ "ignored": true }));
+        let spec = ProviderSpec {
+            id: format!("test-{name}"),
+            adapter: name.to_string(),
+            api_key: Some("test-secret-key".to_string().into()),
+            base_url: Some("https://example.invalid/v1".to_string()),
+            timeout_secs: 60,
+            adapter_options,
+        };
+        build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
+            panic!("supported adapter `{name}` (full options) failed to build: {err:?}")
+        });
+    }
+}
+
+#[test]
+fn build_genai_executor_clamps_zero_timeout_for_every_supported_adapter() {
+    for name in supported_adapters() {
+        let spec = ProviderSpec {
+            id: format!("test-{name}"),
+            adapter: name.to_string(),
+            api_key: Some("test-secret-key".to_string().into()),
+            timeout_secs: 0,
+            ..ProviderSpec::default()
+        };
+        build_genai_provider_executor_with_broker(&spec, test_broker()).unwrap_or_else(|err| {
+            panic!("supported adapter `{name}` (zero timeout) failed to build: {err:?}")
+        });
+    }
+}
+
+#[test]
+fn parse_adapter_kind_is_case_insensitive_for_every_supported_adapter() {
+    for name in supported_adapters() {
+        let upper = name.to_ascii_uppercase();
+        let mixed: String = name
+            .chars()
+            .enumerate()
+            .map(|(index, character)| {
+                if index % 2 == 0 {
+                    character.to_ascii_uppercase()
+                } else {
+                    character
+                }
+            })
+            .collect();
+        for variant in [name.to_string(), upper, mixed, format!("  {name}  ")] {
+            parse_adapter_kind(&variant).unwrap_or_else(|err| {
+                panic!("`{variant}` (canonical: {name}) failed to parse: {err:?}")
+            });
+        }
+    }
+}
+
+#[test]
+fn supported_adapters_unique_no_duplicate_names() {
+    let names: Vec<&'static str> = supported_adapters();
+    let mut seen = std::collections::HashSet::with_capacity(names.len());
+    for name in &names {
+        assert!(
+            seen.insert(*name),
+            "duplicate entry `{name}` in supported_adapters()"
+        );
+    }
+    assert!(
+        names.len() >= 19,
+        "supported_adapters() shrank below floor of 19 (got {}): {names:?}",
+        names.len()
+    );
+}
+
+#[test]
+fn vertex_anthropic_namespaces_parse_when_routed_through_adapter_string() {
+    let kind = parse_adapter_kind("vertex").expect("vertex must parse");
+    assert_eq!(kind, AdapterKind::Vertex);
+    let kind = parse_adapter_kind("github_copilot").expect("github_copilot must parse");
+    assert_eq!(kind, AdapterKind::GithubCopilot);
+    let cloud = parse_adapter_kind("ollama_cloud").expect("ollama_cloud must parse");
+    let local = parse_adapter_kind("ollama").expect("ollama must parse");
+    assert_ne!(
+        cloud, local,
+        "ollama_cloud and ollama must map to distinct kinds"
+    );
+    assert_eq!(cloud, AdapterKind::OllamaCloud);
+    assert_eq!(local, AdapterKind::Ollama);
+}
+
+#[test]
+fn parse_adapter_kind_accepts_legacy_aliases() {
+    assert_eq!(
+        parse_adapter_kind("openai-resp").unwrap(),
+        AdapterKind::OpenAIResp
+    );
+    assert_eq!(
+        parse_adapter_kind("responses").unwrap(),
+        AdapterKind::OpenAIResp
+    );
+    assert_eq!(
+        parse_adapter_kind("  Anthropic ").unwrap(),
+        AdapterKind::Anthropic
+    );
+}
+
+#[test]
+fn build_genai_omitted_api_key_is_rejected_by_default() {
+    let spec = provider_spec_with_kind_and_key("openai", None, None);
+    let err = match build_genai_provider_executor_with_broker(&spec, test_broker()) {
+        Ok(_) => panic!("missing bearer api_key must fail closed"),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(err, ConfigRuntimeError::InvalidConfig(ref message) if message.contains("api_key")),
+        "expected InvalidConfig naming api_key, got: {err:?}"
+    );
+}
+
+#[test]
+fn build_genai_env_credentials_requires_explicit_opt_in() {
+    let spec = provider_spec_with_env_credentials("openai", None);
+    build_genai_provider_executor_with_broker(&spec, test_broker())
+        .expect("explicit env-credential bearer must build");
+}
+
+#[test]
+fn build_genai_explicit_bearer_succeeds() {
+    let spec = provider_spec_with_kind_and_key("openai", Some("bearer"), Some("sk-test-123"));
+    build_genai_provider_executor_with_broker(&spec, test_broker())
+        .expect("explicit bearer must build");
+}
+
+#[test]
+fn build_genai_unknown_credentials_kind_rejected_with_clear_error() {
+    let spec =
+        provider_spec_with_kind_and_key("openai", Some("never-heard-of-it"), Some("sk-test-123"));
+    let err = build_genai_provider_executor_with_broker(&spec, test_broker())
+        .err()
+        .expect("expected error");
+    assert!(
+        matches!(err, ConfigRuntimeError::InvalidConfig(ref message) if message.contains("never-heard-of-it")),
+        "expected InvalidConfig naming the bad kind, got: {err:?}"
+    );
+}
+
+#[test]
+fn build_genai_service_account_kind_with_non_vertex_adapter_rejected() {
+    let spec = provider_spec_with_kind_and_key(
+        "openai",
+        Some("service_account_json"),
+        Some(r#"{"client_email":"x@y","private_key":"-----BEGIN PRIVATE KEY-----"}"#),
+    );
+    let err = build_genai_provider_executor_with_broker(&spec, test_broker())
+        .err()
+        .expect("expected error");
+    assert!(
+        matches!(err, ConfigRuntimeError::InvalidConfig(ref message)
+            if message.contains("service_account_json")
+                && message.contains("vertex")
+                && message.contains("openai")),
+        "expected InvalidConfig naming the kind/adapter mismatch, got: {err:?}"
+    );
+}
+
+#[derive(Default)]
+struct RecordingBroker {
+    registered: parking_lot::Mutex<Vec<String>>,
+}
+
+#[async_trait]
+impl awaken_runtime::credentials::CredentialBroker for RecordingBroker {
+    fn register(
+        &self,
+        provider_id: String,
+        _material: awaken_runtime::credentials::CredentialMaterial,
+    ) {
+        self.registered.lock().push(provider_id);
+    }
+
+    async fn token_for(
+        &self,
+        _provider_id: &str,
+        _scope: &str,
+    ) -> Result<
+        awaken_runtime::credentials::IssuedToken,
+        awaken_runtime::credentials::CredentialError,
+    > {
+        unreachable!("static-bearer build must not call token_for");
+    }
+}
+
+#[test]
+fn build_genai_static_bearer_does_not_register_with_broker() {
+    let recording: Arc<RecordingBroker> = Arc::new(RecordingBroker::default());
+    let broker: Arc<dyn awaken_runtime::credentials::CredentialBroker> =
+        Arc::clone(&recording) as _;
+
+    let spec = provider_spec_with_kind_and_key("openai", Some("bearer"), Some("sk-x"));
+    build_genai_provider_executor_with_broker(&spec, broker).expect("static bearer must build");
+
+    assert!(
+        recording.registered.lock().is_empty(),
+        "static bearer must not register with the broker"
+    );
+}
+
+#[test]
+fn build_genai_env_credentials_do_not_register_with_broker() {
+    let recording: Arc<RecordingBroker> = Arc::new(RecordingBroker::default());
+    let broker: Arc<dyn awaken_runtime::credentials::CredentialBroker> =
+        Arc::clone(&recording) as _;
+
+    let spec = provider_spec_with_env_credentials("openai", None);
+    build_genai_provider_executor_with_broker(&spec, broker)
+        .expect("explicit env fallback must build");
+
+    assert!(
+        recording.registered.lock().is_empty(),
+        "explicit env fallback must not register with the broker"
+    );
+}

--- a/crates/awaken-server/src/services/config_runtime/publish.rs
+++ b/crates/awaken-server/src/services/config_runtime/publish.rs
@@ -49,7 +49,7 @@ impl ConfigRuntimeManager {
             return Err(error);
         }
 
-        let runtime_set = self.published_or_candidate_registry_set(candidate).await;
+        let runtime_set = self.published_or_candidate_registry_set(candidate).await?;
         let version = match self.runtime.replace_registry_set(runtime_set) {
             Some(version) => version,
             None => {

--- a/crates/awaken-server/src/services/config_runtime/versioned_publish.rs
+++ b/crates/awaken-server/src/services/config_runtime/versioned_publish.rs
@@ -66,35 +66,24 @@ impl ConfigRuntimeManager {
         self.versioned_registry.is_some()
     }
 
-    /// Pick the `RegistrySet` to install via runtime hot-swap: prefer
-    /// the materialized `RegistryPublication`, fall back to the editing
-    /// candidate when no versioned store is wired or materialization
-    /// fails (ADR-0035 D8/D11). Takes ownership of `candidate` so the
-    /// caller never accidentally hot-swaps with stale editing data after
-    /// a successful publication.
+    /// Pick the `RegistrySet` to install via runtime hot-swap. When a
+    /// versioned store is wired, the published registry must materialize; the
+    /// editing candidate is only valid for unversioned runtimes.
     pub(super) async fn published_or_candidate_registry_set(
         &self,
         candidate: RegistrySet,
-    ) -> RegistrySet {
+    ) -> Result<RegistrySet, ConfigRuntimeError> {
         let Some(target) = self.versioned_registry.as_ref() else {
-            return candidate;
+            return Ok(candidate);
         };
         let materializer = FrozenAgentRegistryMaterializer::new(target.store.clone());
-        match materializer
+        let frozen = materializer
             .materialize(VersionSelector::LatestPublication {
                 scope_id: target.scope_id.as_str().to_string(),
             })
             .await
-        {
-            Ok(frozen) => frozen.to_registry_set(&candidate),
-            Err(error) => {
-                tracing::warn!(
-                    error = %error,
-                    "failed to materialize published registry set; falling back to candidate"
-                );
-                candidate
-            }
-        }
+            .map_err(|error| ConfigRuntimeError::VersionedRegistry(error.to_string()))?;
+        Ok(frozen.to_registry_set(&candidate))
     }
 
     /// Publish a ONE-OFF ephemeral publication = the current managed config
@@ -431,6 +420,27 @@ mod tests {
         assert!(publication.source_config_revisions.iter().any(|revision| {
             revision.namespace == "agents" && revision.id == "agent-1" && revision.revision > 0
         }));
+    }
+
+    #[tokio::test]
+    async fn published_registry_materialization_failure_does_not_use_candidate() {
+        let (manager, _, _) = make_manager_with_versioned_store().await;
+        let candidate = manager
+            .runtime
+            .registry_handle()
+            .expect("runtime registry handle")
+            .snapshot()
+            .into_registries();
+
+        let error = match manager.published_or_candidate_registry_set(candidate).await {
+            Ok(_) => panic!("missing latest publication must fail"),
+            Err(error) => error,
+        };
+        assert!(
+            matches!(error, ConfigRuntimeError::VersionedRegistry(ref message)
+                if message.contains("publication") && message.contains("latest")),
+            "unexpected error: {error:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/awaken-server/src/services/config_service/normalization.rs
+++ b/crates/awaken-server/src/services/config_service/normalization.rs
@@ -87,12 +87,25 @@ impl ConfigService {
                     &spec.adapter_options,
                 )
                 .map_err(ConfigServiceError::InvalidPayload)?;
-                awaken_runtime::credentials::build_material(
-                    &spec.adapter,
-                    kind,
-                    spec.api_key.as_ref(),
-                )
-                .map_err(ConfigServiceError::InvalidPayload)?;
+                let allow_env_credentials =
+                    awaken_runtime::credentials::allow_env_credentials_from_options(
+                        &spec.adapter_options,
+                    )
+                    .map_err(ConfigServiceError::InvalidPayload)?;
+                let material_result = if allow_env_credentials {
+                    awaken_runtime::credentials::build_material_allowing_env_fallback(
+                        &spec.adapter,
+                        kind,
+                        spec.api_key.as_ref(),
+                    )
+                } else {
+                    awaken_runtime::credentials::build_material(
+                        &spec.adapter,
+                        kind,
+                        spec.api_key.as_ref(),
+                    )
+                };
+                material_result.map_err(ConfigServiceError::InvalidPayload)?;
             }
             ConfigNamespace::McpServers => {
                 let spec: McpServerSpec = from_value(body)?;

--- a/crates/awaken-server/src/services/config_service/tests.rs
+++ b/crates/awaken-server/src/services/config_service/tests.rs
@@ -345,7 +345,8 @@ async fn create_waits_for_in_flight_apply_before_writing_store() {
                     ConfigNamespace::Providers,
                     json!({
                         "id": "serialized",
-                        "adapter": "stub"
+                        "adapter": "stub",
+                        "api_key": "test-key"
                     }),
                     &axum::http::HeaderMap::new(),
                 )
@@ -391,6 +392,27 @@ async fn create_waits_for_in_flight_apply_before_writing_store() {
             .and_then(|spec| spec.get("id"))
             .and_then(Value::as_str),
         Some("serialized")
+    );
+}
+
+#[tokio::test]
+async fn create_provider_rejects_missing_bearer_api_key_by_default() {
+    let config_store = Arc::new(awaken_stores::InMemoryStore::new());
+    let (state, _manager) = build_state(config_store).await;
+    let service = ConfigService::new(&state).expect("config service");
+
+    let error = service
+        .create_with_headers(
+            ConfigNamespace::Providers,
+            json!({ "id": "missing-key", "adapter": "stub" }),
+            &axum::http::HeaderMap::new(),
+        )
+        .await
+        .expect_err("missing bearer api_key must fail closed");
+
+    assert!(
+        matches!(error, ConfigServiceError::InvalidPayload(ref message) if message.contains("api_key")),
+        "expected InvalidPayload naming api_key, got {error:?}"
     );
 }
 
@@ -516,7 +538,7 @@ async fn find_dependents_model_uses_effective_agent_model_override() {
     service
         .create_with_headers(
             ConfigNamespace::Providers,
-            json!({ "id": "prov-b", "adapter": "stub" }),
+            json!({ "id": "prov-b", "adapter": "stub", "api_key": "test-key" }),
             &axum::http::HeaderMap::new(),
         )
         .await
@@ -612,7 +634,7 @@ async fn provider_removal_preview_ignores_effective_remote_endpoint_agents() {
     service
         .create_with_headers(
             ConfigNamespace::Providers,
-            json!({ "id": "prov-remote", "adapter": "stub" }),
+            json!({ "id": "prov-remote", "adapter": "stub", "api_key": "test-key" }),
             &axum::http::HeaderMap::new(),
         )
         .await
@@ -667,7 +689,7 @@ async fn provider_removal_preview_collects_dependents_across_multiple_models() {
         service
             .create_with_headers(
                 ConfigNamespace::Providers,
-                json!({ "id": provider_id, "adapter": "stub" }),
+                json!({ "id": provider_id, "adapter": "stub", "api_key": "test-key" }),
                 &axum::http::HeaderMap::new(),
             )
             .await
@@ -859,7 +881,7 @@ async fn delete_without_force_returns_blocked_when_dependents_exist() {
     service
         .create_with_headers(
             ConfigNamespace::Providers,
-            json!({ "id": "prov-b", "adapter": "stub" }),
+            json!({ "id": "prov-b", "adapter": "stub", "api_key": "test-key" }),
             &axum::http::HeaderMap::new(),
         )
         .await
@@ -903,7 +925,7 @@ async fn delete_with_force_cascades_unused_provider_models() {
     service
         .create_with_headers(
             ConfigNamespace::Providers,
-            json!({ "id": "prov-c", "adapter": "stub" }),
+            json!({ "id": "prov-c", "adapter": "stub", "api_key": "test-key" }),
             &axum::http::HeaderMap::new(),
         )
         .await
@@ -953,7 +975,7 @@ async fn delete_with_force_rolls_back_cascade_when_model_delete_fails() {
     service
         .create_with_headers(
             ConfigNamespace::Providers,
-            json!({ "id": "prov-e", "adapter": "stub" }),
+            json!({ "id": "prov-e", "adapter": "stub", "api_key": "test-key" }),
             &axum::http::HeaderMap::new(),
         )
         .await
@@ -1009,7 +1031,7 @@ async fn delete_provider_with_force_blocks_when_agents_use_provider_models() {
     service
         .create_with_headers(
             ConfigNamespace::Providers,
-            json!({ "id": "prov-d", "adapter": "stub" }),
+            json!({ "id": "prov-d", "adapter": "stub", "api_key": "test-key" }),
             &axum::http::HeaderMap::new(),
         )
         .await
@@ -1083,7 +1105,7 @@ async fn delete_rollback_re_emits_envelope() {
     service
         .create_with_headers(
             ConfigNamespace::Providers,
-            json!({ "id": "rollback-prov", "adapter": "stub" }),
+            json!({ "id": "rollback-prov", "adapter": "stub", "api_key": "test-key" }),
             &axum::http::HeaderMap::new(),
         )
         .await
@@ -1303,7 +1325,7 @@ mod audit_integration {
         service
             .create_with_headers(
                 ConfigNamespace::Providers,
-                json!({ "id": "audit-prov", "adapter": "stub" }),
+                json!({ "id": "audit-prov", "adapter": "stub", "api_key": "test-key" }),
                 &HeaderMap::new(),
             )
             .await
@@ -1418,7 +1440,7 @@ mod audit_integration {
         service
             .create_with_headers(
                 ConfigNamespace::Providers,
-                json!({ "id": "audit-cascade-prov", "adapter": "stub" }),
+                json!({ "id": "audit-cascade-prov", "adapter": "stub", "api_key": "test-key" }),
                 &HeaderMap::new(),
             )
             .await

--- a/crates/awaken-server/src/services/frozen_registry.rs
+++ b/crates/awaken-server/src/services/frozen_registry.rs
@@ -170,16 +170,17 @@ impl Resolver for ScopedServerResolver {
                 scope_id: self.scope_id.as_str().to_string(),
             },
             // The runtime carries an opaque resolution id; for the published
-            // path it is the publication snapshot version. Anything else falls
-            // back to the latest publication.
+            // path it is the publication snapshot version.
             RegistryResolutionScope::Pinned(resolution_id) => match resolution_id.parse::<u64>() {
                 Ok(snapshot_version) => VersionSelector::Publication {
                     scope_id: self.scope_id.as_str().to_string(),
                     snapshot_version,
                 },
-                Err(_) => VersionSelector::LatestPublication {
-                    scope_id: self.scope_id.as_str().to_string(),
-                },
+                Err(error) => {
+                    return Err(ResolveError::Runtime(format!(
+                        "invalid pinned registry resolution id '{resolution_id}': {error}"
+                    )));
+                }
             },
         };
         let frozen = self
@@ -187,16 +188,17 @@ impl Resolver for ScopedServerResolver {
             .materialize(selector)
             .await
             .map_err(|error| ResolveError::Runtime(error.to_string()))?;
-        request.resolution_scope = RegistryResolutionScope::Pinned(
-            frozen
-                .manifest
-                .registry_snapshot_version
-                .map(|version| version.to_string())
-                .unwrap_or_default(),
-        );
-        awaken_runtime::registry::resolve::RegistrySetResolver::new(frozen.to_registry_set(&live))
-            .resolve(request)
-            .await
+        let snapshot_version = frozen.manifest.registry_snapshot_version.ok_or_else(|| {
+            ResolveError::Runtime(
+                "published registry manifest is missing registry_snapshot_version".to_string(),
+            )
+        })?;
+        request.resolution_scope = RegistryResolutionScope::Pinned(snapshot_version.to_string());
+        awaken_runtime::registry::resolve::RegistrySetResolver::new_replayable_snapshot(
+            frozen.to_registry_set(&live),
+        )
+        .resolve(request)
+        .await
     }
 }
 
@@ -661,6 +663,47 @@ mod tests {
         let resumed = resolver.resolve(resume).await.unwrap();
         assert_eq!(resumed.resolution_id(), Some(resolution_id.as_str()));
         assert_eq!(resumed.agent_spec().id, "root");
+    }
+
+    #[tokio::test]
+    async fn scoped_server_resolver_rejects_invalid_pinned_resolution_id() {
+        let store = InMemoryVersionedRegistryStore::new();
+        let provider = publish_provider(&store, "provider-1").await;
+        let model = publish_model(&store, "model-1", "provider-1").await;
+        let root = publish_agent(&store, agent("root", "model-1", [])).await;
+        store
+            .create_publication(
+                "default",
+                "pub-1",
+                refs([&provider, &model, &root]),
+                Vec::new(),
+                None,
+                json!({}),
+            )
+            .await
+            .unwrap();
+
+        let resolver = ScopedServerResolver::new(
+            ScopeId::default_scope(),
+            Arc::new(store),
+            live_registry_handle(),
+        );
+        let mut resume = nested_request(ResolutionTarget::Root {
+            agent_id: "root".into(),
+            thread_id: "thread-1".into(),
+        });
+        resume.resolution_scope = RegistryResolutionScope::Pinned("not-a-version".into());
+
+        let error = match resolver.resolve(resume).await {
+            Ok(_) => panic!("invalid pinned resolution id must fail"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("invalid pinned registry resolution id"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/awaken-server/tests/fault_injection.rs
+++ b/crates/awaken-server/tests/fault_injection.rs
@@ -245,30 +245,14 @@ impl MailboxStore for FailingMailboxStore {
 }
 
 fn make_dispatch(dispatch_id: &str, thread_id: &str) -> RunDispatch {
-    RunDispatch {
-        dispatch_id: dispatch_id.to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: format!("run-{dispatch_id}"),
-        priority: 128,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: 1000,
-        attempt_count: 0,
-        max_attempts: 5,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: 1000,
-        updated_at: 1000,
-    }
+    RunDispatch::queued(
+        dispatch_id.to_string(),
+        thread_id.to_string(),
+        format!("run-{dispatch_id}"),
+        1000,
+    )
+    .with_priority(128)
+    .with_max_attempts(5)
 }
 
 struct ImmediateLlm;
@@ -434,7 +418,7 @@ async fn ack_failure_leaves_dispatch_claimed_for_reclaim() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    let claim_token = claimed[0].claim_token.clone().unwrap();
+    let claim_token = claimed[0].claim_token().unwrap().to_string();
 
     // Make ack fail
     store.fail_ack.store(true, Ordering::SeqCst);
@@ -443,19 +427,19 @@ async fn ack_failure_leaves_dispatch_claimed_for_reclaim() {
 
     // Dispatch should still be in Claimed state
     let loaded = store.load_dispatch("j-1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
+    assert_eq!(loaded.status(), RunDispatchStatus::Claimed);
 
     // After lease expiry, reclaim should recover the dispatch
     store.fail_ack.store(false, Ordering::SeqCst);
-    let lease_expiry = loaded.lease_until.unwrap() + 1;
+    let lease_expiry = loaded.lease_until().unwrap() + 1;
     let reclaimed = store
         .reclaim_expired_leases(lease_expiry, 10)
         .await
         .unwrap();
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].dispatch_id, "j-1");
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
-    assert_eq!(reclaimed[0].attempt_count, 1);
+    assert_eq!(reclaimed[0].dispatch_id(), "j-1");
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::Queued);
+    assert_eq!(reclaimed[0].attempt_count(), 1);
 }
 
 // ============================================================================
@@ -472,7 +456,7 @@ async fn nack_failure_leaves_dispatch_claimed() {
         .claim("thread-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let claim_token = claimed[0].claim_token.clone().unwrap();
+    let claim_token = claimed[0].claim_token().unwrap().to_string();
 
     store.fail_nack.store(true, Ordering::SeqCst);
     let result = store
@@ -482,7 +466,7 @@ async fn nack_failure_leaves_dispatch_claimed() {
 
     // Dispatch remains Claimed
     let loaded = store.load_dispatch("j-1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
+    assert_eq!(loaded.status(), RunDispatchStatus::Claimed);
 }
 
 // ============================================================================
@@ -504,8 +488,8 @@ async fn enqueue_failure_does_not_corrupt_existing_dispatches() {
 
     // First dispatch is still intact
     let loaded = store.load_dispatch("j-1").await.unwrap().unwrap();
-    assert_eq!(loaded.dispatch_id, "j-1");
-    assert_eq!(loaded.status, RunDispatchStatus::Queued);
+    assert_eq!(loaded.dispatch_id(), "j-1");
+    assert_eq!(loaded.status(), RunDispatchStatus::Queued);
 
     // Second dispatch was never persisted
     assert!(store.load_dispatch("j-2").await.unwrap().is_none());
@@ -538,7 +522,7 @@ async fn dispatch_remains_claimable_after_claim_failure_recovery() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "j-1");
+    assert_eq!(claimed[0].dispatch_id(), "j-1");
 }
 
 // ============================================================================

--- a/crates/awaken-server/tests/http_api.rs
+++ b/crates/awaken-server/tests/http_api.rs
@@ -1558,7 +1558,7 @@ mod integration {
             .await
             .unwrap();
         assert_eq!(dispatches.len(), 1);
-        assert_eq!(dispatches[0].run_id, "run-open-input");
+        assert_eq!(dispatches[0].run_id(), "run-open-input");
     }
 
     #[tokio::test]
@@ -1591,7 +1591,7 @@ mod integration {
             .await
             .unwrap();
         assert_eq!(dispatches.len(), 1);
-        assert_eq!(dispatches[0].run_id, "run-durable-decision");
+        assert_eq!(dispatches[0].run_id(), "run-durable-decision");
     }
 
     #[tokio::test]

--- a/crates/awaken-server/tests/run_api.rs
+++ b/crates/awaken-server/tests/run_api.rs
@@ -13,10 +13,11 @@ use awaken_runtime::extensions::a2a::{
     AgentBackend, AgentBackendError, AgentBackendFactory, AgentBackendFactoryError,
     DelegateRunResult, DelegateRunStatus,
 };
-use awaken_server::app::{ServerConfig, ServerState};
+use awaken_server::app::{ConfigModuleState, ServerConfig, ServerState};
 use awaken_server::routes::build_router;
 use awaken_server::scope::{HttpScopeProvider, ScopeResolveError};
-use awaken_server_contract::ModelSpec;
+use awaken_server::services::config_runtime::ConfigRuntimeManager;
+use awaken_server_contract::contract::config_store::ConfigStore;
 use awaken_server_contract::contract::content::extract_text;
 use awaken_server_contract::contract::executor::{InferenceExecutionError, InferenceRequest};
 use awaken_server_contract::contract::inference::{StopReason, StreamResult, TokenUsage};
@@ -24,7 +25,9 @@ use awaken_server_contract::contract::lifecycle::{RunStatus, TerminationReason};
 use awaken_server_contract::contract::storage::{RunRecord, RunStore, ThreadStore};
 use awaken_server_contract::registry_spec::AgentSpec;
 use awaken_server_contract::registry_spec::RemoteEndpoint;
+use awaken_server_contract::{BuiltinSeedSet, BuiltinSpec, ModelSpec, ProviderSpec};
 use awaken_server_contract::{RequestSurface, ScopeContext, ScopeId, scoped_key};
+use awaken_stores::InMemoryVersionedRegistryStore;
 use awaken_stores::memory::InMemoryStore;
 use axum::body::to_bytes;
 use axum::http::request::Parts;
@@ -375,6 +378,80 @@ fn make_test_app_with_executor(
             .expect("build runtime"),
     );
     make_test_app_with_runtime(runtime, store)
+}
+
+async fn make_test_app_with_unpublishable_versioned_config() -> TestApp {
+    let store = Arc::new(InMemoryStore::new());
+    let runtime = Arc::new(
+        AgentRuntimeBuilder::new()
+            .with_model(ModelSpec::new("test-model", "mock", "mock-model"))
+            .with_provider("mock", Arc::new(ImmediateExecutor))
+            .with_agent_spec(AgentSpec {
+                id: "test-agent".into(),
+                model_id: "test-model".into(),
+                system_prompt: "test".into(),
+                max_rounds: 0,
+                ..Default::default()
+            })
+            .with_in_memory_thread_run_store(store.clone())
+            .build()
+            .expect("build runtime"),
+    );
+    runtime.set_run_resolver(Arc::new(TestRunResolver {
+        inner: runtime.resolver_arc(),
+    }));
+    let mailbox_store = Arc::new(awaken_stores::InMemoryMailboxStore::new());
+    let mailbox = Arc::new(awaken_server::mailbox::Mailbox::new(
+        runtime.clone(),
+        mailbox_store,
+        store.clone(),
+        "test".to_string(),
+        awaken_server::mailbox::MailboxConfig::default(),
+    ));
+    let config_store = store.clone() as Arc<dyn ConfigStore>;
+    let manager = Arc::new(
+        ConfigRuntimeManager::new(runtime.clone(), config_store.clone())
+            .expect("config runtime manager")
+            .with_versioned_registry_store(
+                "default",
+                Arc::new(InMemoryVersionedRegistryStore::new()),
+            ),
+    );
+    manager
+        .apply_seed(&BuiltinSeedSet {
+            binary_version: "test".to_string(),
+            specs: vec![
+                BuiltinSpec::Provider(ProviderSpec {
+                    id: "provider-1".into(),
+                    adapter: "openai".into(),
+                    api_key: Some("sk-test-secret".into()),
+                    ..Default::default()
+                }),
+                BuiltinSpec::Model(ModelSpec::new("model-1", "provider-1", "upstream")),
+                BuiltinSpec::Agent(Box::new(AgentSpec {
+                    id: "agent-1".into(),
+                    model_id: "model-1".into(),
+                    system_prompt: "test".into(),
+                    max_rounds: 0,
+                    ..Default::default()
+                })),
+            ],
+        })
+        .await
+        .expect("seed unpublishable managed config");
+    let mut state = ServerState::new(
+        runtime.clone(),
+        mailbox,
+        store.clone(),
+        runtime.resolver_arc(),
+        ServerConfig::default(),
+    );
+    state.config = Some(ConfigModuleState::new(config_store, manager));
+    state.admin.admin_api_config.bearer_token = Some(TEST_ADMIN_TOKEN.into());
+    TestApp {
+        router: build_router(&state),
+        store,
+    }
 }
 
 fn make_test_app_with_local_components() -> TestApp {
@@ -1124,6 +1201,37 @@ async fn ai_sdk_agent_preview_runs_with_draft_system_prompt_and_history() {
     assert!(
         body.contains("roles=system,user,assistant,user"),
         "preview should preserve assistant history: {body}"
+    );
+}
+
+#[tokio::test]
+async fn ai_sdk_agent_preview_returns_error_when_durable_publish_fails() {
+    let test = make_test_app_with_unpublishable_versioned_config().await;
+    let (status, body) = post_json(
+        test.router,
+        "/v1/ai-sdk/agent-previews/runs",
+        json!({
+            "agent": {
+                "id": "preview",
+                "model_id": "model-1",
+                "system_prompt": "draft system prompt",
+                "max_rounds": 0
+            },
+            "messages": [
+                {
+                    "id": "u1",
+                    "role": "user",
+                    "parts": [{ "type": "text", "text": "hello" }]
+                }
+            ]
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "body={body}");
+    assert!(
+        body.contains("failed to publish durable preview"),
+        "durable publish failure must not fall back to ephemeral preview: {body}"
     );
 }
 

--- a/crates/awaken-stores/src/file.rs
+++ b/crates/awaken-stores/src/file.rs
@@ -20,6 +20,9 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
+use crate::message_validation::{validate_committed_message_records, validate_committed_messages};
+use crate::pending_message_store::validate_pending_message_records;
+
 mod pending;
 
 /// File-system storage backend.
@@ -47,6 +50,10 @@ impl FileStore {
             config_cas_lock: shared_config_cas_lock(&base_path),
             base_path,
         }
+    }
+
+    pub(crate) fn thread_run_storage_identity_descriptor(&self) -> String {
+        format!("file-thread-run::{}", hierarchy_lock_key(&self.base_path))
     }
 
     fn threads_dir(&self) -> PathBuf {
@@ -287,6 +294,7 @@ impl FileStore {
             }
             records.sort_by_key(|record| record.seq);
             if !records.is_empty() {
+                validate_committed_message_records(thread_id, &records)?;
                 return Ok(Some(records));
             }
         }
@@ -295,6 +303,7 @@ impl FileStore {
         else {
             return Ok(None);
         };
+        validate_committed_messages(&messages)?;
         Ok(Some(
             messages
                 .into_iter()
@@ -337,6 +346,7 @@ impl FileStore {
         messages: &[Message],
         ops: &mut Vec<StagedFileOp>,
     ) -> Result<(), StorageError> {
+        validate_committed_messages(messages)?;
         // Write the replacement records first, then remove stale records only when the new
         // message set is shorter than the existing set. This avoids staging duplicate
         // delete+write operations on the same target path in one transaction.
@@ -440,9 +450,12 @@ impl FileStore {
         &self,
         thread_id: &str,
     ) -> Result<Vec<PendingMessageRecord>, StorageError> {
-        read_json::<Vec<PendingMessageRecord>>(&self.pending_messages_path(thread_id))
-            .await
-            .map(|records| records.unwrap_or_default())
+        let records =
+            read_json::<Vec<PendingMessageRecord>>(&self.pending_messages_path(thread_id))
+                .await
+                .map(|records| records.unwrap_or_default())?;
+        validate_pending_message_records(&records)?;
+        Ok(records)
     }
 
     async fn write_pending_messages_locked(
@@ -450,6 +463,7 @@ impl FileStore {
         thread_id: &str,
         records: &[PendingMessageRecord],
     ) -> Result<StagedWrite, StorageError> {
+        validate_pending_message_records(records)?;
         let payload = serde_json::to_string_pretty(records)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         stage_write(
@@ -1081,6 +1095,7 @@ impl ThreadStore for FileStore {
         validate_id(&thread.id, "thread id")?;
         let mut normalized = thread.clone();
         normalized.normalize_lineage();
+        normalized.validate_for_persist()?;
         let payload = serde_json::to_string_pretty(&normalized)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         atomic_write(
@@ -1334,6 +1349,7 @@ impl ThreadStore for FileStore {
 impl RunStore for FileStore {
     async fn create_run(&self, record: &RunRecord) -> Result<(), StorageError> {
         validate_id(&record.run_id, "run id")?;
+        record.validate_for_persist()?;
         let payload = serde_json::to_string_pretty(record)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         atomic_write_exclusive(
@@ -1628,6 +1644,10 @@ impl ConfigStore for FileStore {
 
 #[async_trait]
 impl ThreadRunStore for FileStore {
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        Some(self.thread_run_storage_identity_descriptor())
+    }
+
     async fn checkpoint(
         &self,
         thread_id: &str,
@@ -1636,6 +1656,7 @@ impl ThreadRunStore for FileStore {
     ) -> Result<(), StorageError> {
         validate_id(thread_id, "thread id")?;
         validate_id(&run.run_id, "run id")?;
+        run.validate_for_persist()?;
         let _guard = self.hierarchy_lock.lock().await;
         self.checkpoint_locked(thread_id, messages, run).await
     }
@@ -1649,6 +1670,7 @@ impl ThreadRunStore for FileStore {
     ) -> Result<u64, StorageError> {
         validate_id(thread_id, "thread id")?;
         validate_id(&run.run_id, "run id")?;
+        run.validate_for_persist()?;
         let _guard = self.hierarchy_lock.lock().await;
 
         let committed = self

--- a/crates/awaken-stores/src/file/pending.rs
+++ b/crates/awaken-stores/src/file/pending.rs
@@ -342,6 +342,7 @@ impl PendingMessageStore for FileStore {
     ) -> Result<Vec<MessageRecord>, StorageError> {
         validate_id(thread_id, "thread id")?;
         validate_id(&run.run_id, "run id")?;
+        run.validate_for_persist()?;
         let _guard = self.hierarchy_lock.lock().await;
         let committed = self
             .load_committed_message_records_locked(thread_id)
@@ -446,6 +447,7 @@ impl PendingMessageStore for FileStore {
     ) -> Result<Vec<MessageRecord>, StorageError> {
         validate_id(thread_id, "thread id")?;
         validate_id(&run.run_id, "run id")?;
+        run.validate_for_persist()?;
         let _guard = self.hierarchy_lock.lock().await;
         let committed = self
             .load_committed_message_records_locked(thread_id)

--- a/crates/awaken-stores/src/file_commit_coordinator.rs
+++ b/crates/awaken-stores/src/file_commit_coordinator.rs
@@ -99,6 +99,10 @@ impl CommitCoordinator for FileCommitCoordinator {
         self.scope.clone()
     }
 
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        Some(self.thread_run.thread_run_storage_identity_descriptor())
+    }
+
     fn reader(&self) -> Arc<dyn awaken_server_contract::contract::storage::RuntimeCheckpointStore> {
         Arc::new(
             awaken_server_contract::contract::storage::ThreadRunCheckpointStore::new(Arc::clone(

--- a/crates/awaken-stores/src/lib.rs
+++ b/crates/awaken-stores/src/lib.rs
@@ -21,6 +21,7 @@ pub mod memory_mailbox;
 pub mod memory_outbox;
 pub mod memory_protocol_replay_log;
 pub mod memory_versioned_registry;
+mod message_validation;
 pub mod pending_message_store;
 
 /// Wall-clock time in milliseconds since the UNIX epoch.

--- a/crates/awaken-stores/src/mailbox_state.rs
+++ b/crates/awaken-stores/src/mailbox_state.rs
@@ -1,4 +1,4 @@
-use awaken_server_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_server_contract::contract::mailbox::RunDispatch;
 
 pub(crate) const REASON_CLAIMED_SUPERSEDED_BY_EPOCH: &str =
     "claimed dispatch superseded by newer dispatch epoch";
@@ -23,20 +23,10 @@ pub(crate) const REASON_QUEUED_SUPERSEDED_BY_EPOCH: &str =
     "queued dispatch superseded by newer dispatch epoch";
 pub(crate) const REASON_LEASE_EXPIRED_MAX_ATTEMPTS: &str = "lease expired; max attempts reached";
 
-pub(crate) fn clear_claim_fields(dispatch: &mut RunDispatch) {
-    dispatch.claim_token = None;
-    dispatch.claimed_by = None;
-    dispatch.lease_until = None;
-}
-
 pub(crate) fn mark_superseded(dispatch: &mut RunDispatch, now: u64, reason: Option<&str>) {
-    dispatch.status = RunDispatchStatus::Superseded;
-    dispatch.completed_at = Some(now);
-    dispatch.updated_at = now;
-    if let Some(reason) = reason {
-        dispatch.last_error = Some(reason.to_string());
-    }
-    clear_claim_fields(dispatch);
+    dispatch
+        .mark_superseded(now, reason)
+        .expect("superseded dispatch transition must preserve invariants");
 }
 
 #[cfg_attr(not(feature = "nats"), allow(dead_code))]
@@ -46,89 +36,59 @@ pub(crate) fn mark_superseded_at_epoch(
     epoch: u64,
     reason: Option<&str>,
 ) {
-    dispatch.dispatch_epoch = epoch;
-    mark_superseded(dispatch, now, reason);
+    dispatch
+        .mark_superseded_at_epoch(now, epoch, reason)
+        .expect("superseded dispatch transition must preserve invariants");
 }
 
 pub(crate) fn mark_acked(dispatch: &mut RunDispatch, now: u64) {
-    dispatch.status = RunDispatchStatus::Acked;
-    dispatch.completed_at = Some(now);
-    dispatch.updated_at = now;
-    clear_claim_fields(dispatch);
+    dispatch
+        .mark_acked(now)
+        .expect("acked dispatch transition must preserve invariants");
 }
 
 pub(crate) fn mark_cancelled(dispatch: &mut RunDispatch, now: u64) {
-    dispatch.status = RunDispatchStatus::Cancelled;
-    dispatch.completed_at = Some(now);
-    dispatch.updated_at = now;
-    clear_claim_fields(dispatch);
+    dispatch
+        .mark_cancelled(now)
+        .expect("cancelled dispatch transition must preserve invariants");
 }
 
 pub(crate) fn mark_dead_letter(dispatch: &mut RunDispatch, now: u64, error: &str) {
-    dispatch.status = RunDispatchStatus::DeadLetter;
-    dispatch.last_error = Some(error.to_string());
-    dispatch.completed_at = Some(now);
-    dispatch.updated_at = now;
-    clear_claim_fields(dispatch);
+    dispatch
+        .mark_dead_letter(now, error)
+        .expect("dead-letter dispatch transition must preserve invariants");
 }
 
 pub(crate) fn mark_nack_result(dispatch: &mut RunDispatch, now: u64, retry_at: u64, error: &str) {
-    dispatch.attempt_count += 1;
-    dispatch.last_error = Some(error.to_string());
-    dispatch.updated_at = now;
-    clear_claim_fields(dispatch);
-    if dispatch.attempt_count >= dispatch.max_attempts {
-        dispatch.status = RunDispatchStatus::DeadLetter;
-        dispatch.completed_at = Some(now);
-    } else {
-        dispatch.status = RunDispatchStatus::Queued;
-        dispatch.available_at = retry_at;
-    }
+    dispatch
+        .mark_nack_result(now, retry_at, error)
+        .expect("nack dispatch transition must preserve invariants");
 }
 
 pub(crate) fn mark_expired_lease(dispatch: &mut RunDispatch, now: u64) {
-    dispatch.attempt_count = dispatch.attempt_count.saturating_add(1);
-    dispatch.available_at = now;
-    dispatch.updated_at = now;
-    clear_claim_fields(dispatch);
-    if dispatch.attempt_count >= dispatch.max_attempts {
-        dispatch.status = RunDispatchStatus::DeadLetter;
-        dispatch.last_error = Some(REASON_LEASE_EXPIRED_MAX_ATTEMPTS.to_string());
-        dispatch.completed_at = Some(now);
-    } else {
-        dispatch.status = RunDispatchStatus::Queued;
-    }
+    dispatch
+        .mark_expired_lease(now, REASON_LEASE_EXPIRED_MAX_ATTEMPTS)
+        .expect("expired-lease dispatch transition must preserve invariants");
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use awaken_server_contract::contract::mailbox::RunDispatchStatus;
 
     fn dispatch() -> RunDispatch {
-        RunDispatch {
-            dispatch_id: "dispatch-1".to_string(),
-            thread_id: "thread-1".to_string(),
-            run_id: "run-1".to_string(),
-            priority: 128,
-            dedupe_key: None,
-            dispatch_epoch: 1,
-            status: RunDispatchStatus::Claimed,
-            available_at: 1000,
-            attempt_count: 0,
-            max_attempts: 2,
-            last_error: None,
-            claim_token: Some("token".to_string()),
-            claimed_by: Some("worker".to_string()),
-            lease_until: Some(2000),
-            dispatch_instance_id: None,
-            run_status: None,
-            termination: None,
-            run_response: None,
-            run_error: None,
-            completed_at: None,
-            created_at: 1000,
-            updated_at: 1000,
-        }
+        let mut dispatch = RunDispatch::queued(
+            "dispatch-1".to_string(),
+            "thread-1".to_string(),
+            "run-1".to_string(),
+            1000,
+        )
+        .with_dispatch_epoch(1)
+        .with_max_attempts(2);
+        dispatch
+            .claim("worker", "token", 2000, 1000)
+            .expect("test dispatch claim is valid");
+        dispatch
     }
 
     #[test]
@@ -136,11 +96,11 @@ mod tests {
         let mut dispatch = dispatch();
         mark_acked(&mut dispatch, 3000);
 
-        assert_eq!(dispatch.status, RunDispatchStatus::Acked);
-        assert_eq!(dispatch.completed_at, Some(3000));
-        assert!(dispatch.claim_token.is_none());
-        assert!(dispatch.claimed_by.is_none());
-        assert!(dispatch.lease_until.is_none());
+        assert_eq!(dispatch.status(), RunDispatchStatus::Acked);
+        assert_eq!(dispatch.completed_at(), Some(3000));
+        assert!(dispatch.claim_token().is_none());
+        assert!(dispatch.claimed_by().is_none());
+        assert!(dispatch.lease_until().is_none());
     }
 
     #[test]
@@ -148,31 +108,31 @@ mod tests {
         let mut dispatch = dispatch();
         mark_nack_result(&mut dispatch, 3000, 4000, "temporary failure");
 
-        assert_eq!(dispatch.status, RunDispatchStatus::Queued);
-        assert_eq!(dispatch.attempt_count, 1);
-        assert_eq!(dispatch.available_at, 4000);
-        assert_eq!(dispatch.last_error.as_deref(), Some("temporary failure"));
+        assert_eq!(dispatch.status(), RunDispatchStatus::Queued);
+        assert_eq!(dispatch.attempt_count(), 1);
+        assert_eq!(dispatch.available_at(), 4000);
+        assert_eq!(dispatch.last_error(), Some("temporary failure"));
 
-        dispatch.claim_token = Some("token-2".to_string());
-        dispatch.claimed_by = Some("worker".to_string());
-        dispatch.lease_until = Some(5000);
+        dispatch
+            .claim("worker", "token-2", 5000, 5000)
+            .expect("requeued dispatch can be claimed again");
         mark_nack_result(&mut dispatch, 6000, 7000, "final failure");
 
-        assert_eq!(dispatch.status, RunDispatchStatus::DeadLetter);
-        assert_eq!(dispatch.attempt_count, 2);
-        assert_eq!(dispatch.completed_at, Some(6000));
-        assert!(dispatch.claim_token.is_none());
+        assert_eq!(dispatch.status(), RunDispatchStatus::DeadLetter);
+        assert_eq!(dispatch.attempt_count(), 2);
+        assert_eq!(dispatch.completed_at(), Some(6000));
+        assert!(dispatch.claim_token().is_none());
     }
 
     #[test]
     fn expired_lease_records_dead_letter_reason() {
         let mut dispatch = dispatch();
-        dispatch.attempt_count = 1;
+        dispatch = dispatch.with_attempt_count(1);
         mark_expired_lease(&mut dispatch, 3000);
 
-        assert_eq!(dispatch.status, RunDispatchStatus::DeadLetter);
+        assert_eq!(dispatch.status(), RunDispatchStatus::DeadLetter);
         assert_eq!(
-            dispatch.last_error.as_deref(),
+            dispatch.last_error(),
             Some(REASON_LEASE_EXPIRED_MAX_ATTEMPTS)
         );
     }

--- a/crates/awaken-stores/src/memory/mod.rs
+++ b/crates/awaken-stores/src/memory/mod.rs
@@ -20,6 +20,8 @@ use awaken_server_contract::thread::{Thread, normalize_lineage_id};
 use serde_json::Value;
 use tokio::sync::RwLock;
 
+use crate::message_validation::{validate_committed_message_records, validate_committed_messages};
+
 mod pending;
 
 /// In-memory storage implementing all four store traits.
@@ -143,14 +145,16 @@ impl ThreadStore for InMemoryStore {
     async fn save_thread(&self, thread: &Thread) -> Result<(), StorageError> {
         let mut normalized = thread.clone();
         normalized.normalize_lineage();
+        normalized.validate_for_persist()?;
         let mut guard = self.threads.write().await;
-        guard.insert(thread.id.clone(), normalized);
+        guard.insert(normalized.id.clone(), normalized);
         Ok(())
     }
 
     async fn save_thread_validated(&self, thread: &Thread) -> Result<(), StorageError> {
         let mut normalized = thread.clone();
         normalized.normalize_lineage();
+        normalized.validate_for_persist()?;
         let mut guard = self.threads.write().await;
         validate_thread_hierarchy_map(
             &guard,
@@ -284,10 +288,12 @@ impl ThreadStore for InMemoryStore {
 
     async fn load_messages(&self, thread_id: &str) -> Result<Option<Vec<Message>>, StorageError> {
         let guard = self.messages.read().await;
-        Ok(guard.get(thread_id).cloned().map(|mut messages| {
-            strip_unpaired_tool_calls_from_view(&mut messages);
-            messages
-        }))
+        let Some(mut messages) = guard.get(thread_id).cloned() else {
+            return Ok(None);
+        };
+        validate_committed_messages(&messages)?;
+        strip_unpaired_tool_calls_from_view(&mut messages);
+        Ok(Some(messages))
     }
 
     async fn load_committed_messages(
@@ -295,7 +301,11 @@ impl ThreadStore for InMemoryStore {
         thread_id: &str,
     ) -> Result<Option<Vec<Message>>, StorageError> {
         let guard = self.messages.read().await;
-        Ok(guard.get(thread_id).cloned())
+        let Some(messages) = guard.get(thread_id).cloned() else {
+            return Ok(None);
+        };
+        validate_committed_messages(&messages)?;
+        Ok(Some(messages))
     }
 
     async fn list_message_records(
@@ -307,6 +317,7 @@ impl ThreadStore for InMemoryStore {
         let Some(messages) = guard.get(thread_id) else {
             return Ok(MessagePage::empty());
         };
+        validate_committed_messages(messages)?;
         let mut messages = messages.clone();
         strip_unpaired_tool_calls_from_view(&mut messages);
         let records = messages
@@ -320,7 +331,8 @@ impl ThreadStore for InMemoryStore {
                     message,
                 )
             })
-            .collect();
+            .collect::<Vec<_>>();
+        validate_committed_message_records(thread_id, &records)?;
         Ok(paginate_message_records(records, query))
     }
 
@@ -329,6 +341,7 @@ impl ThreadStore for InMemoryStore {
         thread_id: &str,
         messages: &[Message],
     ) -> Result<(), StorageError> {
+        validate_committed_messages(messages)?;
         let mut guard = self.messages.write().await;
         guard.insert(thread_id.to_owned(), messages.to_vec());
         Ok(())
@@ -392,6 +405,7 @@ impl ThreadStore for InMemoryStore {
 #[async_trait]
 impl RunStore for InMemoryStore {
     async fn create_run(&self, record: &RunRecord) -> Result<(), StorageError> {
+        record.validate_for_persist()?;
         let mut guard = self.runs.write().await;
         if guard.contains_key(&record.run_id) {
             return Err(StorageError::AlreadyExists(record.run_id.clone()));
@@ -448,12 +462,18 @@ impl RunStore for InMemoryStore {
 
 #[async_trait]
 impl ThreadRunStore for InMemoryStore {
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        Some(format!("memory-thread-run::{:p}", self))
+    }
+
     async fn checkpoint(
         &self,
         thread_id: &str,
         messages: &[Message],
         run: &RunRecord,
     ) -> Result<(), StorageError> {
+        run.validate_for_persist()?;
+        validate_committed_messages(messages)?;
         let now = current_millis();
         let mut thread_guard = self.threads.write().await;
         let existing_thread = thread_guard.get(thread_id).cloned();
@@ -493,6 +513,7 @@ impl ThreadRunStore for InMemoryStore {
         expected_version: Option<u64>,
         run: &RunRecord,
     ) -> Result<u64, StorageError> {
+        run.validate_for_persist()?;
         let now = current_millis();
         let mut thread_guard = self.threads.write().await;
         let existing_thread = thread_guard.get(thread_id).cloned();

--- a/crates/awaken-stores/src/memory/pending.rs
+++ b/crates/awaken-stores/src/memory/pending.rs
@@ -12,6 +12,9 @@ use awaken_server_contract::contract::storage::{
 use awaken_server_contract::thread::Thread;
 
 use crate::PendingMessageStore;
+use crate::pending_message_store::{
+    validate_pending_message_record, validate_pending_message_records,
+};
 
 use super::validate_thread_hierarchy_map;
 use super::{InMemoryStore, current_millis};
@@ -70,7 +73,9 @@ impl PendingMessageStore for InMemoryStore {
         thread_id: &str,
     ) -> Result<Vec<PendingMessageRecord>, StorageError> {
         let guard = self.pending_messages.read().await;
-        Ok(guard.get(thread_id).cloned().unwrap_or_default())
+        let records = guard.get(thread_id).cloned().unwrap_or_default();
+        validate_pending_message_records(&records)?;
+        Ok(records)
     }
 
     async fn list_threads_with_pending_messages(
@@ -124,6 +129,7 @@ impl PendingMessageStore for InMemoryStore {
             .map(|record| record.pending_id.as_str())
             .collect::<HashSet<_>>();
         for record in &records {
+            validate_pending_message_record(record)?;
             if !seen.insert(record.pending_id.as_str()) {
                 return Err(duplicate_pending_id(&record.pending_id));
             }
@@ -169,7 +175,10 @@ impl PendingMessageStore for InMemoryStore {
                 Some(_) => {}
                 None => message.id = Some(pending_id.to_owned()),
             }
-            record.message = message;
+            let mut updated = record.clone();
+            updated.message = message;
+            validate_pending_message_record(&updated)?;
+            record.message = updated.message;
             record.revision += 1;
             record.updated_at = Some(current_millis() / 1000);
             return Ok(record.clone());
@@ -343,6 +352,7 @@ impl PendingMessageStore for InMemoryStore {
         expected_pending_ids: &[String],
         run: &RunRecord,
     ) -> Result<Vec<MessageRecord>, StorageError> {
+        run.validate_for_persist()?;
         let now = current_millis();
         let mut thread_guard = self.threads.write().await;
         let existing_thread = thread_guard.get(thread_id).cloned();
@@ -419,6 +429,7 @@ impl PendingMessageStore for InMemoryStore {
         expected_pending_ids: &[String],
         run: &RunRecord,
     ) -> Result<Vec<MessageRecord>, StorageError> {
+        run.validate_for_persist()?;
         let now = current_millis();
         let mut thread_guard = self.threads.write().await;
         let existing_thread = thread_guard.get(thread_id).cloned();
@@ -458,6 +469,7 @@ impl PendingMessageStore for InMemoryStore {
             );
             record.created_at = Some(append_now);
             record.updated_at = Some(append_now);
+            validate_pending_message_record(&record)?;
             if !seen.insert(record.pending_id.clone()) {
                 return Err(duplicate_pending_id(&record.pending_id));
             }

--- a/crates/awaken-stores/src/memory/tests.rs
+++ b/crates/awaken-stores/src/memory/tests.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tokio::sync::Barrier;
 
 fn make_run(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecord {
-    RunRecord {
+    let mut run = RunRecord {
         run_id: run_id.to_string(),
         thread_id: thread_id.to_string(),
         agent_id: "agent".to_string(),
@@ -39,7 +39,11 @@ fn make_run(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecord {
         input_tokens: 0,
         output_tokens: 0,
         state: None,
+    };
+    if status == RunStatus::Done {
+        run.finished_at = Some(run.updated_at);
     }
+    run
 }
 
 // ── ThreadStore ──
@@ -51,6 +55,20 @@ async fn thread_save_and_load() {
     store.save_thread(&thread).await.unwrap();
     let loaded = store.load_thread(&thread.id).await.unwrap().unwrap();
     assert_eq!(loaded.id, thread.id);
+}
+
+#[tokio::test]
+async fn thread_save_rejects_empty_id() {
+    let store = InMemoryStore::new();
+    let thread = Thread::with_id(" ");
+
+    let err = store
+        .save_thread(&thread)
+        .await
+        .expect_err("thread id must be non-empty");
+
+    assert!(matches!(err, StorageError::Validation(message) if message.contains("thread id")));
+    assert!(store.threads.read().await.is_empty());
 }
 
 #[tokio::test]
@@ -134,6 +152,20 @@ async fn messages_save_and_load() {
 }
 
 #[tokio::test]
+async fn messages_save_rejects_invalid_committed_message_shape() {
+    let store = InMemoryStore::new();
+    let mut invalid = Message::user("invalid").with_id("msg-invalid".to_string());
+    invalid.tool_call_id = Some("tool-call".to_string());
+
+    let error = store
+        .save_messages("t-invalid", &[invalid])
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, StorageError::Validation(_)));
+}
+
+#[tokio::test]
 async fn messages_load_missing_returns_none() {
     let store = InMemoryStore::new();
     assert!(store.load_messages("no-such").await.unwrap().is_none());
@@ -208,6 +240,37 @@ async fn pending_messages_append_edit_reorder_and_retract() {
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].pending_id, "pending-1");
     assert_eq!(pending[0].position, 1);
+}
+
+#[tokio::test]
+async fn pending_messages_reject_invalid_message_shape() {
+    let store = InMemoryStore::new();
+    let mode = DeliveryMode::new_run(DeliveryGranularity::Batch);
+    let mut invalid = Message::user("invalid").with_id("pending-invalid".to_string());
+    invalid.tool_call_id = Some("tool-call".to_string());
+
+    let error = store
+        .append_pending_message_records("thread-invalid-pending", &[invalid], mode.clone())
+        .await
+        .unwrap_err();
+    assert!(matches!(error, StorageError::Validation(_)));
+
+    store
+        .append_pending_message_records(
+            "thread-invalid-pending",
+            &[Message::user("valid").with_id("pending-valid".to_string())],
+            mode,
+        )
+        .await
+        .unwrap();
+
+    let mut invalid_edit = Message::tool("", "missing call id");
+    invalid_edit.id = Some("pending-valid".to_string());
+    let error = store
+        .update_pending_message_record("thread-invalid-pending", "pending-valid", invalid_edit)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, StorageError::Validation(_)));
 }
 
 #[tokio::test]

--- a/crates/awaken-stores/src/memory_commit_coordinator.rs
+++ b/crates/awaken-stores/src/memory_commit_coordinator.rs
@@ -131,6 +131,13 @@ impl CommitCoordinator for MemoryCommitCoordinator {
         self.scope.clone()
     }
 
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        Some(format!(
+            "memory-thread-run::{:p}",
+            Arc::as_ptr(&self.thread_run)
+        ))
+    }
+
     fn reader(&self) -> Arc<dyn awaken_server_contract::contract::storage::RuntimeCheckpointStore> {
         Arc::new(
             awaken_server_contract::contract::storage::ThreadRunCheckpointStore::new(Arc::clone(
@@ -225,6 +232,7 @@ mod tests {
             thread_id: thread_id.to_string(),
             status: RunStatus::Done,
             agent_id: "agent-1".to_string(),
+            finished_at: Some(1),
             ..Default::default()
         }
     }

--- a/crates/awaken-stores/src/memory_mailbox.rs
+++ b/crates/awaken-stores/src/memory_mailbox.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use awaken_server_contract::contract::lifecycle::RunStatus;
 use awaken_server_contract::contract::mailbox::{
     LiveCommandReceipt, LiveDeliveryOutcome, LiveRunCommand, LiveRunCommandEntry,
     LiveRunCommandStream, LiveRunTarget, MailboxInterrupt, MailboxInterruptDetails, MailboxStore,
@@ -130,15 +129,16 @@ impl InMemoryMailboxStore {
 #[async_trait]
 impl MailboxStore for InMemoryMailboxStore {
     async fn enqueue(&self, dispatch: &RunDispatch) -> Result<(), StorageError> {
+        dispatch.validate_for_enqueue()?;
         let mut dispatches = self.dispatches.write().await;
         let mut state = self.state.write().await;
 
         // Dedupe check: reject if dedupe_key matches an existing non-terminal dispatch.
-        if let Some(ref dk) = dispatch.dedupe_key {
+        if let Some(dk) = dispatch.dedupe_key() {
             let duplicate = dispatches.values().any(|j| {
-                j.thread_id == dispatch.thread_id
-                    && j.dedupe_key.as_deref() == Some(dk)
-                    && !j.status.is_terminal()
+                j.thread_id() == dispatch.thread_id()
+                    && j.dedupe_key() == Some(dk)
+                    && !j.status().is_terminal()
             });
             if duplicate {
                 return Err(StorageError::AlreadyExists(format!("dedupe_key={dk}")));
@@ -147,22 +147,16 @@ impl MailboxStore for InMemoryMailboxStore {
 
         // Auto-create MailboxState if needed, get current dispatch epoch.
         let ms = state
-            .entry(dispatch.thread_id.clone())
+            .entry(dispatch.thread_id().to_string())
             .or_insert(MailboxState {
                 current_dispatch_epoch: 0,
             });
 
         let mut dispatch = dispatch.clone();
-        dispatch.dispatch_epoch = ms.current_dispatch_epoch;
-        dispatch.status = RunDispatchStatus::Queued;
-        dispatch.dispatch_instance_id = None;
-        dispatch.run_status = None;
-        dispatch.termination = None;
-        dispatch.run_response = None;
-        dispatch.run_error = None;
-        dispatch.completed_at = None;
+        dispatch.prepare_for_enqueue(ms.current_dispatch_epoch);
+        dispatch.validate_for_persist()?;
 
-        dispatches.insert(dispatch.dispatch_id.clone(), dispatch);
+        dispatches.insert(dispatch.dispatch_id().to_string(), dispatch);
         Ok(())
     }
 
@@ -181,14 +175,14 @@ impl MailboxStore for InMemoryMailboxStore {
         };
 
         for dispatch in dispatches.values_mut() {
-            if dispatch.thread_id == thread_id
-                && dispatch.status == RunDispatchStatus::Queued
-                && dispatch.dispatch_epoch < current_epoch
+            if dispatch.thread_id() == thread_id
+                && dispatch.status() == RunDispatchStatus::Queued
+                && dispatch.dispatch_epoch() < current_epoch
             {
-                dispatch.dispatch_epoch = current_epoch;
-                mailbox_state::mark_superseded(
+                mailbox_state::mark_superseded_at_epoch(
                     dispatch,
                     now,
+                    current_epoch,
                     Some(mailbox_state::REASON_QUEUED_SUPERSEDED_BY_EPOCH),
                 );
             }
@@ -197,7 +191,7 @@ impl MailboxStore for InMemoryMailboxStore {
         // Same thread must not have two Claimed dispatches concurrently.
         let has_claimed = dispatches
             .values()
-            .any(|j| j.thread_id == thread_id && j.status == RunDispatchStatus::Claimed);
+            .any(|j| j.thread_id() == thread_id && j.status() == RunDispatchStatus::Claimed);
         if has_claimed {
             return Ok(vec![]);
         }
@@ -206,9 +200,9 @@ impl MailboxStore for InMemoryMailboxStore {
         let mut eligible: Vec<&String> = dispatches
             .iter()
             .filter(|(_, j)| {
-                j.thread_id == thread_id
-                    && j.status == RunDispatchStatus::Queued
-                    && j.available_at <= now
+                j.thread_id() == thread_id
+                    && j.status() == RunDispatchStatus::Queued
+                    && j.available_at() <= now
             })
             .map(|(id, _)| id)
             .collect();
@@ -217,9 +211,9 @@ impl MailboxStore for InMemoryMailboxStore {
         eligible.sort_by(|a, b| {
             let ja = &dispatches[*a];
             let jb = &dispatches[*b];
-            ja.priority
-                .cmp(&jb.priority)
-                .then(ja.created_at.cmp(&jb.created_at))
+            ja.priority()
+                .cmp(&jb.priority())
+                .then(ja.created_at().cmp(&jb.created_at()))
         });
 
         eligible.truncate(limit);
@@ -232,11 +226,7 @@ impl MailboxStore for InMemoryMailboxStore {
             let dispatch = dispatches
                 .get_mut(&id)
                 .ok_or_else(|| StorageError::NotFound(id.clone()))?;
-            dispatch.status = RunDispatchStatus::Claimed;
-            dispatch.claim_token = Some(token.clone());
-            dispatch.claimed_by = Some(consumer_id.to_string());
-            dispatch.lease_until = Some(now + lease_ms);
-            dispatch.updated_at = now;
+            dispatch.claim(consumer_id, token.clone(), now + lease_ms, now)?;
             claimed.push(dispatch.clone());
         }
 
@@ -253,7 +243,7 @@ impl MailboxStore for InMemoryMailboxStore {
         let mut dispatches = self.dispatches.write().await;
 
         let thread_id = match dispatches.get(dispatch_id) {
-            Some(j) if j.status == RunDispatchStatus::Queued => j.thread_id.clone(),
+            Some(j) if j.status() == RunDispatchStatus::Queued => j.thread_id().to_string(),
             _ => return Ok(None),
         };
         let current_epoch = {
@@ -261,20 +251,20 @@ impl MailboxStore for InMemoryMailboxStore {
             Self::current_epoch_from_state(&state, &thread_id)
         };
         if let Some(dispatch) = dispatches.get_mut(dispatch_id)
-            && dispatch.dispatch_epoch < current_epoch
+            && dispatch.dispatch_epoch() < current_epoch
         {
-            dispatch.dispatch_epoch = current_epoch;
-            mailbox_state::mark_superseded(
+            mailbox_state::mark_superseded_at_epoch(
                 dispatch,
                 now,
+                current_epoch,
                 Some(mailbox_state::REASON_QUEUED_SUPERSEDED_BY_EPOCH),
             );
             return Ok(None);
         }
         let has_other_claimed = dispatches.values().any(|j| {
-            j.thread_id == thread_id
-                && j.dispatch_id != dispatch_id
-                && j.status == RunDispatchStatus::Claimed
+            j.thread_id() == &thread_id
+                && j.dispatch_id() != dispatch_id
+                && j.status() == RunDispatchStatus::Claimed
         });
         if has_other_claimed {
             return Ok(None);
@@ -286,11 +276,7 @@ impl MailboxStore for InMemoryMailboxStore {
             .get_mut(dispatch_id)
             .ok_or_else(|| StorageError::Io("dispatch disappeared during claim".into()))?;
         let token = Uuid::now_v7().to_string();
-        dispatch.status = RunDispatchStatus::Claimed;
-        dispatch.claim_token = Some(token);
-        dispatch.claimed_by = Some(consumer_id.to_string());
-        dispatch.lease_until = Some(now + lease_ms);
-        dispatch.updated_at = now;
+        dispatch.claim(consumer_id, token, now + lease_ms, now)?;
 
         Ok(Some(dispatch.clone()))
     }
@@ -307,7 +293,7 @@ impl MailboxStore for InMemoryMailboxStore {
             .get_mut(dispatch_id)
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
@@ -315,14 +301,14 @@ impl MailboxStore for InMemoryMailboxStore {
         }
         let current_epoch = {
             let state = self.state.read().await;
-            Self::current_epoch_from_state(&state, &dispatch.thread_id)
+            Self::current_epoch_from_state(&state, dispatch.thread_id())
         };
-        if dispatch.dispatch_epoch < current_epoch {
-            let stale_epoch = dispatch.dispatch_epoch;
-            dispatch.dispatch_epoch = current_epoch;
-            mailbox_state::mark_superseded(
+        if dispatch.dispatch_epoch() < current_epoch {
+            let stale_epoch = dispatch.dispatch_epoch();
+            mailbox_state::mark_superseded_at_epoch(
                 dispatch,
                 now,
+                current_epoch,
                 Some(mailbox_state::REASON_CLAIMED_SUPERSEDED_BY_EPOCH),
             );
             return Err(StorageError::VersionConflict {
@@ -348,8 +334,8 @@ impl MailboxStore for InMemoryMailboxStore {
             .get_mut(dispatch_id)
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.status != RunDispatchStatus::Claimed
-            || dispatch.claim_token.as_deref() != Some(claim_token)
+        if dispatch.status() != RunDispatchStatus::Claimed
+            || dispatch.claim_token() != Some(claim_token)
         {
             return Err(StorageError::VersionConflict {
                 expected: 0,
@@ -358,14 +344,14 @@ impl MailboxStore for InMemoryMailboxStore {
         }
         let current_epoch = {
             let state = self.state.read().await;
-            Self::current_epoch_from_state(&state, &dispatch.thread_id)
+            Self::current_epoch_from_state(&state, dispatch.thread_id())
         };
-        if dispatch.dispatch_epoch < current_epoch {
-            let stale_epoch = dispatch.dispatch_epoch;
-            dispatch.dispatch_epoch = current_epoch;
-            mailbox_state::mark_superseded(
+        if dispatch.dispatch_epoch() < current_epoch {
+            let stale_epoch = dispatch.dispatch_epoch();
+            mailbox_state::mark_superseded_at_epoch(
                 dispatch,
                 now,
+                current_epoch,
                 Some(mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_START),
             );
             return Err(StorageError::VersionConflict {
@@ -374,13 +360,7 @@ impl MailboxStore for InMemoryMailboxStore {
             });
         }
 
-        dispatch.dispatch_instance_id = Some(dispatch_instance_id.to_string());
-        dispatch.run_status = Some(RunStatus::Running);
-        dispatch.termination = None;
-        dispatch.run_response = None;
-        dispatch.run_error = None;
-        dispatch.completed_at = None;
-        dispatch.updated_at = now;
+        dispatch.record_dispatch_start(dispatch_instance_id, now)?;
         Ok(())
     }
 
@@ -397,8 +377,8 @@ impl MailboxStore for InMemoryMailboxStore {
             .get_mut(dispatch_id)
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.status != RunDispatchStatus::Claimed
-            || dispatch.claim_token.as_deref() != Some(claim_token)
+        if dispatch.status() != RunDispatchStatus::Claimed
+            || dispatch.claim_token() != Some(claim_token)
         {
             return Err(StorageError::VersionConflict {
                 expected: 0,
@@ -407,14 +387,14 @@ impl MailboxStore for InMemoryMailboxStore {
         }
         let current_epoch = {
             let state = self.state.read().await;
-            Self::current_epoch_from_state(&state, &dispatch.thread_id)
+            Self::current_epoch_from_state(&state, dispatch.thread_id())
         };
-        if dispatch.dispatch_epoch < current_epoch {
-            let stale_epoch = dispatch.dispatch_epoch;
-            dispatch.dispatch_epoch = current_epoch;
-            mailbox_state::mark_superseded(
+        if dispatch.dispatch_epoch() < current_epoch {
+            let stale_epoch = dispatch.dispatch_epoch();
+            mailbox_state::mark_superseded_at_epoch(
                 dispatch,
                 now,
+                current_epoch,
                 Some(mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_RESULT),
             );
             return Err(StorageError::VersionConflict {
@@ -423,13 +403,7 @@ impl MailboxStore for InMemoryMailboxStore {
             });
         }
 
-        dispatch.dispatch_instance_id = Some(result.dispatch_instance_id.clone());
-        dispatch.run_status = Some(result.status);
-        dispatch.termination = result.termination.clone();
-        dispatch.run_response = result.response.clone();
-        dispatch.run_error = result.error.clone();
-        dispatch.completed_at = Some(now);
-        dispatch.updated_at = now;
+        dispatch.record_run_result(result, now)?;
         Ok(())
     }
 
@@ -447,7 +421,7 @@ impl MailboxStore for InMemoryMailboxStore {
             .get_mut(dispatch_id)
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
@@ -455,14 +429,14 @@ impl MailboxStore for InMemoryMailboxStore {
         }
         let current_epoch = {
             let state = self.state.read().await;
-            Self::current_epoch_from_state(&state, &dispatch.thread_id)
+            Self::current_epoch_from_state(&state, dispatch.thread_id())
         };
-        if dispatch.dispatch_epoch < current_epoch {
-            let stale_epoch = dispatch.dispatch_epoch;
-            dispatch.dispatch_epoch = current_epoch;
-            mailbox_state::mark_superseded(
+        if dispatch.dispatch_epoch() < current_epoch {
+            let stale_epoch = dispatch.dispatch_epoch();
+            mailbox_state::mark_superseded_at_epoch(
                 dispatch,
                 now,
+                current_epoch,
                 Some(mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_NACK),
             );
             return Err(StorageError::VersionConflict {
@@ -489,7 +463,7 @@ impl MailboxStore for InMemoryMailboxStore {
             .get_mut(dispatch_id)
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
@@ -497,14 +471,14 @@ impl MailboxStore for InMemoryMailboxStore {
         }
         let current_epoch = {
             let state = self.state.read().await;
-            Self::current_epoch_from_state(&state, &dispatch.thread_id)
+            Self::current_epoch_from_state(&state, dispatch.thread_id())
         };
-        if dispatch.dispatch_epoch < current_epoch {
-            let stale_epoch = dispatch.dispatch_epoch;
-            dispatch.dispatch_epoch = current_epoch;
-            mailbox_state::mark_superseded(
+        if dispatch.dispatch_epoch() < current_epoch {
+            let stale_epoch = dispatch.dispatch_epoch();
+            mailbox_state::mark_superseded_at_epoch(
                 dispatch,
                 now,
+                current_epoch,
                 Some(mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_DEAD_LETTER),
             );
             return Err(StorageError::VersionConflict {
@@ -525,7 +499,7 @@ impl MailboxStore for InMemoryMailboxStore {
         let mut dispatches = self.dispatches.write().await;
 
         let dispatch = match dispatches.get_mut(dispatch_id) {
-            Some(j) if j.status == RunDispatchStatus::Queued => j,
+            Some(j) if j.status() == RunDispatchStatus::Queued => j,
             _ => return Ok(None),
         };
 
@@ -544,8 +518,8 @@ impl MailboxStore for InMemoryMailboxStore {
 
         let dispatch = match dispatches.get_mut(dispatch_id) {
             Some(j)
-                if j.status == RunDispatchStatus::Claimed
-                    && j.claim_token.as_deref() == Some(claim_token) =>
+                if j.status() == RunDispatchStatus::Claimed
+                    && j.claim_token() == Some(claim_token) =>
             {
                 j
             }
@@ -553,20 +527,19 @@ impl MailboxStore for InMemoryMailboxStore {
         };
         let current_epoch = {
             let state = self.state.read().await;
-            Self::current_epoch_from_state(&state, &dispatch.thread_id)
+            Self::current_epoch_from_state(&state, dispatch.thread_id())
         };
-        if dispatch.dispatch_epoch < current_epoch {
-            dispatch.dispatch_epoch = current_epoch;
-            mailbox_state::mark_superseded(
+        if dispatch.dispatch_epoch() < current_epoch {
+            mailbox_state::mark_superseded_at_epoch(
                 dispatch,
                 now,
+                current_epoch,
                 Some(mailbox_state::REASON_CLAIMED_SUPERSEDED_DURING_LEASE_RENEWAL),
             );
             return Ok(false);
         }
 
-        dispatch.lease_until = Some(now + extension_ms);
-        dispatch.updated_at = now;
+        dispatch.extend_lease(now + extension_ms, now)?;
         Ok(true)
     }
 
@@ -597,11 +570,11 @@ impl MailboxStore for InMemoryMailboxStore {
         let mut active_dispatch = None;
 
         for dispatch in dispatches.values_mut() {
-            if dispatch.thread_id != thread_id {
+            if dispatch.thread_id() != thread_id {
                 continue;
             }
-            match dispatch.status {
-                RunDispatchStatus::Queued if dispatch.dispatch_epoch <= old_dispatch_epoch => {
+            match dispatch.status() {
+                RunDispatchStatus::Queued if dispatch.dispatch_epoch() <= old_dispatch_epoch => {
                     mailbox_state::mark_superseded(
                         dispatch,
                         now,
@@ -641,10 +614,10 @@ impl MailboxStore for InMemoryMailboxStore {
         let Some(dispatch) = dispatches.get_mut(dispatch_id) else {
             return Ok(None);
         };
-        if dispatch.status != RunDispatchStatus::Claimed {
+        if dispatch.status() != RunDispatchStatus::Claimed {
             return Ok(None);
         }
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
@@ -652,10 +625,14 @@ impl MailboxStore for InMemoryMailboxStore {
         }
         let current_epoch = {
             let state = self.state.read().await;
-            Self::current_epoch_from_state(&state, &dispatch.thread_id)
+            Self::current_epoch_from_state(&state, dispatch.thread_id())
         };
-        dispatch.dispatch_epoch = dispatch.dispatch_epoch.max(current_epoch);
-        mailbox_state::mark_superseded(dispatch, now, Some(reason));
+        mailbox_state::mark_superseded_at_epoch(
+            dispatch,
+            now,
+            dispatch.dispatch_epoch().max(current_epoch),
+            Some(reason),
+        );
         Ok(Some(dispatch.clone()))
     }
 
@@ -676,17 +653,17 @@ impl MailboxStore for InMemoryMailboxStore {
         let mut matched: Vec<&RunDispatch> = dispatches
             .values()
             .filter(|j| {
-                j.thread_id == thread_id
+                j.thread_id() == thread_id
                     && status_filter
-                        .map(|sf| sf.contains(&j.status))
+                        .map(|sf| sf.contains(&j.status()))
                         .unwrap_or(true)
             })
             .collect();
 
         matched.sort_by(|a, b| {
-            a.priority
-                .cmp(&b.priority)
-                .then(a.created_at.cmp(&b.created_at))
+            a.priority()
+                .cmp(&b.priority())
+                .then(a.created_at().cmp(&b.created_at()))
         });
 
         Ok(matched
@@ -704,7 +681,7 @@ impl MailboxStore for InMemoryMailboxStore {
         let dispatches = self.dispatches.read().await;
         Ok(dispatches
             .values()
-            .filter(|dispatch| dispatch.status == status)
+            .filter(|dispatch| dispatch.status() == status)
             .count())
     }
 
@@ -716,14 +693,14 @@ impl MailboxStore for InMemoryMailboxStore {
         let dispatches = self.dispatches.read().await;
         let mut terminal = dispatches
             .values()
-            .filter(|dispatch| dispatch.status.is_terminal())
+            .filter(|dispatch| dispatch.status().is_terminal())
             .cloned()
             .collect::<Vec<_>>();
         terminal.sort_by(|a, b| {
-            a.updated_at
-                .cmp(&b.updated_at)
-                .then(a.created_at.cmp(&b.created_at))
-                .then(a.dispatch_id.cmp(&b.dispatch_id))
+            a.updated_at()
+                .cmp(&b.updated_at())
+                .then(a.created_at().cmp(&b.created_at()))
+                .then(a.dispatch_id().cmp(b.dispatch_id()))
         });
         Ok(terminal.into_iter().skip(offset).take(limit).collect())
     }
@@ -739,10 +716,11 @@ impl MailboxStore for InMemoryMailboxStore {
         let expired_ids: Vec<String> = dispatches
             .values()
             .filter(|j| {
-                j.status == RunDispatchStatus::Claimed && j.lease_until.is_some_and(|lu| lu < now)
+                j.status() == RunDispatchStatus::Claimed
+                    && j.lease_until().is_some_and(|lu| lu < now)
             })
             .take(limit)
-            .map(|j| j.dispatch_id.clone())
+            .map(|j| j.dispatch_id().to_string())
             .collect();
 
         let mut reclaimed = Vec::with_capacity(expired_ids.len());
@@ -751,12 +729,12 @@ impl MailboxStore for InMemoryMailboxStore {
             let dispatch = dispatches
                 .get_mut(&id)
                 .ok_or_else(|| StorageError::NotFound(id.clone()))?;
-            let current_epoch = Self::current_epoch_from_state(&state, &dispatch.thread_id);
-            if dispatch.dispatch_epoch < current_epoch {
-                dispatch.dispatch_epoch = current_epoch;
-                mailbox_state::mark_superseded(
+            let current_epoch = Self::current_epoch_from_state(&state, dispatch.thread_id());
+            if dispatch.dispatch_epoch() < current_epoch {
+                mailbox_state::mark_superseded_at_epoch(
                     dispatch,
                     now,
+                    current_epoch,
                     Some(mailbox_state::REASON_CLAIMED_LEASE_EXPIRED_AFTER_INTERRUPT),
                 );
                 continue;
@@ -771,15 +749,17 @@ impl MailboxStore for InMemoryMailboxStore {
     async fn purge_terminal(&self, older_than: u64) -> Result<usize, StorageError> {
         let mut dispatches = self.dispatches.write().await;
         let before = dispatches.len();
-        dispatches.retain(|_, j| !(j.status.is_terminal() && j.updated_at < older_than));
+        dispatches.retain(|_, j| !(j.status().is_terminal() && j.updated_at() < older_than));
         // Drop per-thread dispatch-epoch state for threads that no longer have
         // any dispatch. Without this the `state` map grows unbounded across
         // every thread id ever seen. A later enqueue recreates the entry at a
         // fresh epoch, which is correct because no dispatch survives to be
         // superseded. Lock order matches the rest of the store (dispatches then
         // state) to avoid deadlock.
-        let live_threads: std::collections::HashSet<&str> =
-            dispatches.values().map(|j| j.thread_id.as_str()).collect();
+        let live_threads: std::collections::HashSet<&str> = dispatches
+            .values()
+            .map(|j| j.thread_id().as_str())
+            .collect();
         let mut state = self.state.write().await;
         state.retain(|thread_id, _| live_threads.contains(thread_id.as_str()));
         Ok(before - dispatches.len())
@@ -789,8 +769,8 @@ impl MailboxStore for InMemoryMailboxStore {
         let dispatches = self.dispatches.read().await;
         let mut ids: Vec<String> = dispatches
             .values()
-            .filter(|j| j.status == RunDispatchStatus::Queued)
-            .map(|j| j.thread_id.clone())
+            .filter(|j| j.status() == RunDispatchStatus::Queued)
+            .map(|j| j.thread_id().to_string())
             .collect::<std::collections::HashSet<_>>()
             .into_iter()
             .collect();

--- a/crates/awaken-stores/src/memory_mailbox/tests.rs
+++ b/crates/awaken-stores/src/memory_mailbox/tests.rs
@@ -1,31 +1,14 @@
 use super::*;
+use awaken_server_contract::contract::lifecycle::RunStatus;
 use std::sync::Arc;
 
 fn make_dispatch(thread_id: &str, agent_id: &str) -> RunDispatch {
-    RunDispatch {
-        dispatch_id: Uuid::now_v7().to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: format!("run-{agent_id}"),
-        priority: 128,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: 1000,
-        attempt_count: 0,
-        max_attempts: 5,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: 1000,
-        updated_at: 1000,
-    }
+    RunDispatch::queued(
+        Uuid::now_v7().to_string(),
+        thread_id.to_string(),
+        format!("run-{agent_id}"),
+        1000,
+    )
 }
 
 #[tokio::test]
@@ -36,14 +19,29 @@ async fn enqueue_and_list() {
 
     let listed = store.list_dispatches("m-1", None, 100, 0).await.unwrap();
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].status, RunDispatchStatus::Queued);
+    assert_eq!(listed[0].status(), RunDispatchStatus::Queued);
+}
+
+#[tokio::test]
+async fn enqueue_rejects_non_queued_dispatch() {
+    let store = InMemoryMailboxStore::new();
+    let mut dispatch = make_dispatch("m-1", "agent-1");
+    dispatch.claim("worker", "stale-token", 2000, 1000).unwrap();
+
+    let err = store
+        .enqueue(&dispatch)
+        .await
+        .expect_err("enqueue must only accept queued dispatches");
+
+    assert!(matches!(err, StorageError::Validation(message)
+        if message.contains("must start as Queued")));
 }
 
 #[tokio::test]
 async fn claim_returns_queued_dispatch() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
@@ -51,16 +49,16 @@ async fn claim_returns_queued_dispatch() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, dispatch_id);
-    assert_eq!(claimed[0].status, RunDispatchStatus::Claimed);
-    assert!(claimed[0].claim_token.is_some());
+    assert_eq!(claimed[0].dispatch_id(), &dispatch_id);
+    assert_eq!(claimed[0].status(), RunDispatchStatus::Claimed);
+    assert!(claimed[0].claim_token().is_some());
 }
 
 #[tokio::test]
 async fn claim_respects_available_at() {
     let store = InMemoryMailboxStore::new();
     let mut dispatch = make_dispatch("m-1", "agent-1");
-    dispatch.available_at = 5000; // future
+    dispatch = dispatch.with_available_at(5000); // future
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
@@ -112,7 +110,7 @@ async fn claim_honors_batch_limit_without_active_claim() {
     assert!(
         claimed
             .iter()
-            .all(|dispatch| dispatch.status == RunDispatchStatus::Claimed)
+            .all(|dispatch| dispatch.status() == RunDispatchStatus::Claimed)
     );
 }
 
@@ -120,19 +118,19 @@ async fn claim_honors_batch_limit_without_active_claim() {
 async fn claim_priority_ordering() {
     let store = InMemoryMailboxStore::new();
 
-    let mut low = make_dispatch("m-1", "agent-1");
-    low.priority = 200;
-    low.created_at = 900;
+    let low = make_dispatch("m-1", "agent-1")
+        .with_priority(200)
+        .with_created_at(900);
     store.enqueue(&low).await.unwrap();
 
-    let mut high = make_dispatch("m-1", "agent-1");
-    high.priority = 10;
-    high.created_at = 1000;
+    let high = make_dispatch("m-1", "agent-1")
+        .with_priority(10)
+        .with_created_at(1000);
     store.enqueue(&high).await.unwrap();
 
-    let mut mid = make_dispatch("m-1", "agent-1");
-    mid.priority = 128;
-    mid.created_at = 950;
+    let mid = make_dispatch("m-1", "agent-1")
+        .with_priority(128)
+        .with_created_at(950);
     store.enqueue(&mid).await.unwrap();
 
     let claimed = store
@@ -140,10 +138,10 @@ async fn claim_priority_ordering() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].priority, 10);
-    let token = claimed[0].claim_token.clone().unwrap();
+    assert_eq!(claimed[0].priority(), 10);
+    let token = claimed[0].claim_token().clone().unwrap();
     store
-        .ack(&claimed[0].dispatch_id, &token, 1100)
+        .ack(&claimed[0].dispatch_id(), &token, 1100)
         .await
         .unwrap();
 
@@ -152,10 +150,10 @@ async fn claim_priority_ordering() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].priority, 128);
-    let token = claimed[0].claim_token.clone().unwrap();
+    assert_eq!(claimed[0].priority(), 128);
+    let token = claimed[0].claim_token().clone().unwrap();
     store
-        .ack(&claimed[0].dispatch_id, &token, 1300)
+        .ack(&claimed[0].dispatch_id(), &token, 1300)
         .await
         .unwrap();
 
@@ -164,33 +162,33 @@ async fn claim_priority_ordering() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].priority, 200);
+    assert_eq!(claimed[0].priority(), 200);
 }
 
 #[tokio::test]
 async fn ack_transitions_to_acked() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
         .claim("m-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store.ack(&dispatch_id, &token, 2000).await.unwrap();
 
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Acked);
+    assert_eq!(loaded.status(), RunDispatchStatus::Acked);
 }
 
 #[tokio::test]
 async fn ack_rejects_wrong_claim_token() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     store
@@ -208,29 +206,29 @@ async fn records_dispatch_start_and_run_result_separately_from_ack() {
 
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
         .claim("m-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store
         .record_dispatch_start(&dispatch_id, &token, "dispatch-1", 1500)
         .await
         .unwrap();
     let running = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(running.status, RunDispatchStatus::Claimed);
-    assert_eq!(running.run_id, dispatch.run_id);
-    assert_eq!(running.dispatch_instance_id.as_deref(), Some("dispatch-1"));
-    assert_eq!(running.run_status, Some(RunStatus::Running));
-    assert!(running.termination.is_none());
-    assert!(running.completed_at.is_none());
+    assert_eq!(running.status(), RunDispatchStatus::Claimed);
+    assert_eq!(running.run_id(), dispatch.run_id());
+    assert_eq!(running.dispatch_instance_id(), Some("dispatch-1"));
+    assert_eq!(running.run_status(), Some(RunStatus::Running));
+    assert!(running.termination().is_none());
+    assert!(running.completed_at().is_none());
 
     let result = RunDispatchResult {
-        run_id: "run-1".into(),
+        run_id: dispatch.run_id().clone(),
         dispatch_instance_id: "dispatch-1".into(),
         status: RunStatus::Done,
         termination: Some(TerminationReason::NaturalEnd),
@@ -242,24 +240,27 @@ async fn records_dispatch_start_and_run_result_separately_from_ack() {
         .await
         .unwrap();
     let completed = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(completed.status, RunDispatchStatus::Claimed);
-    assert_eq!(completed.run_status, Some(RunStatus::Done));
-    assert_eq!(completed.termination, Some(TerminationReason::NaturalEnd));
-    assert_eq!(completed.run_response.as_deref(), Some("done"));
-    assert_eq!(completed.completed_at, Some(1800));
+    assert_eq!(completed.status(), RunDispatchStatus::Claimed);
+    assert_eq!(completed.run_status(), Some(RunStatus::Done));
+    assert_eq!(
+        completed.termination(),
+        Some(&TerminationReason::NaturalEnd)
+    );
+    assert_eq!(completed.run_response(), Some("done"));
+    assert_eq!(completed.completed_at(), Some(1800));
 
     store.ack(&dispatch_id, &token, 2000).await.unwrap();
     let acked = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(acked.status, RunDispatchStatus::Acked);
-    assert_eq!(acked.run_status, Some(RunStatus::Done));
-    assert_eq!(acked.run_response.as_deref(), Some("done"));
+    assert_eq!(acked.status(), RunDispatchStatus::Acked);
+    assert_eq!(acked.run_status(), Some(RunStatus::Done));
+    assert_eq!(acked.run_response(), Some("done"));
 }
 
 #[tokio::test]
 async fn record_run_result_rejects_stale_claim_token() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     store
@@ -268,7 +269,7 @@ async fn record_run_result_rejects_stale_claim_token() {
         .unwrap();
 
     let result = RunDispatchResult {
-        run_id: "run-1".into(),
+        run_id: dispatch.run_id().clone(),
         dispatch_instance_id: "dispatch-1".into(),
         status: RunStatus::Done,
         termination: None,
@@ -283,22 +284,22 @@ async fn record_run_result_rejects_stale_claim_token() {
     );
 
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert!(loaded.run_status.is_none());
-    assert!(loaded.run_error.is_none());
+    assert!(loaded.run_status().is_none());
+    assert!(loaded.run_error().is_none());
 }
 
 #[tokio::test]
 async fn nack_returns_to_queued() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
         .claim("m-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store
         .nack(&dispatch_id, &token, 3000, "transient error", 2000)
@@ -306,25 +307,25 @@ async fn nack_returns_to_queued() {
         .unwrap();
 
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Queued);
-    assert_eq!(loaded.attempt_count, 1);
-    assert_eq!(loaded.available_at, 3000);
-    assert!(loaded.claim_token.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Queued);
+    assert_eq!(loaded.attempt_count(), 1);
+    assert_eq!(loaded.available_at(), 3000);
+    assert!(loaded.claim_token().is_none());
 }
 
 #[tokio::test]
 async fn nack_dead_letters_after_max_attempts() {
     let store = InMemoryMailboxStore::new();
     let mut dispatch = make_dispatch("m-1", "agent-1");
-    dispatch.max_attempts = 1;
-    let dispatch_id = dispatch.dispatch_id.clone();
+    dispatch = dispatch.with_max_attempts(1);
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
         .claim("m-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store
         .nack(&dispatch_id, &token, 3000, "final error", 2000)
@@ -332,21 +333,21 @@ async fn nack_dead_letters_after_max_attempts() {
         .unwrap();
 
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
+    assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
 }
 
 #[tokio::test]
 async fn dead_letter_is_terminal() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
         .claim("m-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store
         .dead_letter(&dispatch_id, &token, "permanent failure", 2000)
@@ -354,37 +355,37 @@ async fn dead_letter_is_terminal() {
         .unwrap();
 
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
-    assert!(loaded.status.is_terminal());
+    assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
+    assert!(loaded.status().is_terminal());
 }
 
 #[tokio::test]
 async fn cancel_queued_dispatch() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let cancelled = store.cancel(&dispatch_id, 2000).await.unwrap();
     assert!(cancelled.is_some());
-    assert_eq!(cancelled.unwrap().status, RunDispatchStatus::Cancelled);
+    assert_eq!(cancelled.unwrap().status(), RunDispatchStatus::Cancelled);
 
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Cancelled);
+    assert_eq!(loaded.status(), RunDispatchStatus::Cancelled);
 }
 
 #[tokio::test]
 async fn extend_lease_success() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
         .claim("m-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     let ok = store
         .extend_lease(&dispatch_id, &token, 60_000, 15_000)
@@ -393,14 +394,14 @@ async fn extend_lease_success() {
     assert!(ok);
 
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(loaded.lease_until, Some(75_000));
+    assert_eq!(loaded.lease_until(), Some(75_000));
 }
 
 #[tokio::test]
 async fn extend_lease_wrong_token() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     store
@@ -460,7 +461,7 @@ async fn interrupt_returns_active_claimed() {
     let result = store.interrupt("m-1", 2000).await.unwrap();
     assert!(result.active_dispatch.is_some());
     assert_eq!(
-        result.active_dispatch.unwrap().status,
+        result.active_dispatch.unwrap().status(),
         RunDispatchStatus::Claimed
     );
     // The second (Queued) dispatch should be superseded.
@@ -471,11 +472,11 @@ async fn interrupt_returns_active_claimed() {
 async fn dedupe_key_rejects_duplicate() {
     let store = InMemoryMailboxStore::new();
     let mut dispatch1 = make_dispatch("m-1", "agent-1");
-    dispatch1.dedupe_key = Some("unique-key".to_string());
+    dispatch1 = dispatch1.with_dedupe_key(Some("unique-key".to_string()));
     store.enqueue(&dispatch1).await.unwrap();
 
     let mut dispatch2 = make_dispatch("m-1", "agent-1");
-    dispatch2.dedupe_key = Some("unique-key".to_string());
+    dispatch2 = dispatch2.with_dedupe_key(Some("unique-key".to_string()));
     let result = store.enqueue(&dispatch2).await;
     assert!(result.is_err());
 }
@@ -484,7 +485,7 @@ async fn dedupe_key_rejects_duplicate() {
 async fn reclaim_expired_leases() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     // Claim with a short lease.
@@ -496,9 +497,9 @@ async fn reclaim_expired_leases() {
     // Advance time past lease expiry (lease_until = 1100).
     let reclaimed = store.reclaim_expired_leases(2000, 10).await.unwrap();
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].dispatch_id, dispatch_id);
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
-    assert_eq!(reclaimed[0].attempt_count, 1);
+    assert_eq!(reclaimed[0].dispatch_id(), &dispatch_id);
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::Queued);
+    assert_eq!(reclaimed[0].attempt_count(), 1);
 }
 
 #[tokio::test]
@@ -512,9 +513,9 @@ async fn purge_terminal() {
         .claim("m-1", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store
-        .ack(&claimed[0].dispatch_id, &token, 1500)
+        .ack(&claimed[0].dispatch_id(), &token, 1500)
         .await
         .unwrap();
 
@@ -531,7 +532,7 @@ async fn purge_terminal() {
     // The non-terminal dispatch should remain.
     let listed = store.list_dispatches("m-1", None, 100, 0).await.unwrap();
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].status, RunDispatchStatus::Queued);
+    assert_eq!(listed[0].status(), RunDispatchStatus::Queued);
 }
 
 #[tokio::test]
@@ -545,9 +546,9 @@ async fn purge_terminal_drops_state_only_for_fully_drained_threads() {
         .claim("thread-a", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.as_ref().unwrap().clone();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store
-        .ack(&claimed[0].dispatch_id, &token, 1500)
+        .ack(&claimed[0].dispatch_id(), &token, 1500)
         .await
         .unwrap();
 
@@ -595,7 +596,7 @@ async fn purge_terminal_drops_state_only_for_fully_drained_threads() {
         .await
         .unwrap();
     assert_eq!(revived.len(), 1);
-    assert_eq!(revived[0].status, RunDispatchStatus::Queued);
+    assert_eq!(revived[0].status(), RunDispatchStatus::Queued);
 }
 
 #[tokio::test]
@@ -608,9 +609,9 @@ async fn purge_terminal_with_no_remaining_dispatches_clears_all_state() {
             .claim(thread, "consumer-1", 30_000, 1000, 1)
             .await
             .unwrap();
-        let token = claimed[0].claim_token.as_ref().unwrap().clone();
+        let token = claimed[0].claim_token().unwrap().to_string();
         store
-            .ack(&claimed[0].dispatch_id, &token, 1500)
+            .ack(&claimed[0].dispatch_id(), &token, 1500)
             .await
             .unwrap();
     }
@@ -648,7 +649,7 @@ async fn queued_thread_ids() {
 async fn claim_dispatch_by_id() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
@@ -657,9 +658,9 @@ async fn claim_dispatch_by_id() {
         .unwrap();
     assert!(claimed.is_some());
     let claimed = claimed.unwrap();
-    assert_eq!(claimed.dispatch_id, dispatch_id);
-    assert_eq!(claimed.status, RunDispatchStatus::Claimed);
-    assert!(claimed.claim_token.is_some());
+    assert_eq!(claimed.dispatch_id(), &dispatch_id);
+    assert_eq!(claimed.status(), RunDispatchStatus::Claimed);
+    assert!(claimed.claim_token().is_some());
 }
 
 #[tokio::test]
@@ -684,8 +685,8 @@ async fn claim_dispatch_rejects_if_thread_already_has_claimed() {
     let store = InMemoryMailboxStore::new();
     let dispatch1 = make_dispatch("m-1", "agent-1");
     let dispatch2 = make_dispatch("m-1", "agent-1");
-    let id1 = dispatch1.dispatch_id.clone();
-    let id2 = dispatch2.dispatch_id.clone();
+    let id1 = dispatch1.dispatch_id().clone();
+    let id2 = dispatch2.dispatch_id().clone();
     store.enqueue(&dispatch1).await.unwrap();
     store.enqueue(&dispatch2).await.unwrap();
 
@@ -715,8 +716,8 @@ async fn claim_resumes_after_ack() {
     // Claim first (whichever the store picks).
     let claimed = store.claim("m-1", "c-1", 30_000, 1000, 1).await.unwrap();
     assert_eq!(claimed.len(), 1);
-    let claimed_id = claimed[0].dispatch_id.clone();
-    let claimed_token = claimed[0].claim_token.clone().unwrap();
+    let claimed_id = claimed[0].dispatch_id().clone();
+    let claimed_token = claimed[0].claim_token().clone().unwrap();
 
     // Ack the claimed dispatch → Acked.
     store.ack(&claimed_id, &claimed_token, 2000).await.unwrap();
@@ -724,7 +725,7 @@ async fn claim_resumes_after_ack() {
     // Now claim should succeed for the other dispatch.
     let claimed2 = store.claim("m-1", "c-1", 30_000, 2000, 1).await.unwrap();
     assert_eq!(claimed2.len(), 1);
-    assert_ne!(claimed2[0].dispatch_id, claimed_id);
+    assert_ne!(claimed2[0].dispatch_id(), &claimed_id);
 }
 
 // ── Concurrency & parallelism tests ─────────────────────────────
@@ -737,10 +738,11 @@ async fn fifo_ordering_within_same_priority() {
     let mut dispatch_ids = Vec::new();
     for i in 0u64..5 {
         let mut dispatch = make_dispatch("thread-1", "agent-1");
-        dispatch.priority = 0;
-        dispatch.created_at = 1000 + i;
-        dispatch.available_at = 1000;
-        dispatch_ids.push(dispatch.dispatch_id.clone());
+        dispatch = dispatch
+            .with_priority(0)
+            .with_created_at(1000 + i)
+            .with_available_at(1000);
+        dispatch_ids.push(dispatch.dispatch_id().clone());
         store.enqueue(&dispatch).await.unwrap();
     }
 
@@ -753,12 +755,12 @@ async fn fifo_ordering_within_same_priority() {
             .unwrap();
         assert_eq!(claimed.len(), 1, "expected exactly 1 dispatch per claim");
         let dispatch = &claimed[0];
-        claimed_order.push(dispatch.dispatch_id.clone());
+        claimed_order.push(dispatch.dispatch_id().clone());
         // Ack so it becomes terminal and won't be claimed again.
         store
             .ack(
-                &dispatch.dispatch_id,
-                dispatch.claim_token.as_ref().unwrap(),
+                dispatch.dispatch_id(),
+                dispatch.claim_token().unwrap(),
                 2000,
             )
             .await
@@ -780,7 +782,7 @@ async fn concurrent_enqueue_no_lost_dispatches() {
         let store = std::sync::Arc::clone(&store);
         handles.push(tokio::spawn(async move {
             let mut dispatch = make_dispatch("thread-1", "agent-1");
-            dispatch.dedupe_key = Some(format!("dedupe-{i}"));
+            dispatch = dispatch.with_dedupe_key(Some(format!("dedupe-{i}")));
             store.enqueue(&dispatch).await.unwrap();
         }));
     }
@@ -806,7 +808,7 @@ async fn concurrent_claim_only_one_wins() {
 
     // Enqueue exactly 1 dispatch.
     let dispatch = make_dispatch("thread-1", "agent-1");
-    let dispatch_id = dispatch.dispatch_id.clone();
+    let dispatch_id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     // Use a barrier so all tasks start claiming at roughly the same time.
@@ -834,7 +836,7 @@ async fn concurrent_claim_only_one_wins() {
         } else {
             winners += 1;
             assert_eq!(claimed.len(), 1);
-            assert_eq!(claimed[0].dispatch_id, dispatch_id);
+            assert_eq!(claimed[0].dispatch_id(), &dispatch_id);
         }
     }
 
@@ -843,8 +845,8 @@ async fn concurrent_claim_only_one_wins() {
 
     // Verify the dispatch has a single claim_token.
     let loaded = store.load_dispatch(&dispatch_id).await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
-    assert!(loaded.claim_token.is_some());
+    assert_eq!(loaded.status(), RunDispatchStatus::Claimed);
+    assert!(loaded.claim_token().is_some());
 }
 
 #[tokio::test]
@@ -852,11 +854,11 @@ async fn claim_respects_per_thread_isolation() {
     let store = InMemoryMailboxStore::new();
 
     let dispatch1 = make_dispatch("thread-1", "agent-1");
-    let dispatch1_id = dispatch1.dispatch_id.clone();
+    let dispatch1_id = dispatch1.dispatch_id().clone();
     store.enqueue(&dispatch1).await.unwrap();
 
     let dispatch2 = make_dispatch("thread-2", "agent-1");
-    let dispatch2_id = dispatch2.dispatch_id.clone();
+    let dispatch2_id = dispatch2.dispatch_id().clone();
     store.enqueue(&dispatch2).await.unwrap();
 
     // Claim from thread-1.
@@ -865,7 +867,7 @@ async fn claim_respects_per_thread_isolation() {
         .await
         .unwrap();
     assert_eq!(claimed1.len(), 1);
-    assert_eq!(claimed1[0].dispatch_id, dispatch1_id);
+    assert_eq!(claimed1[0].dispatch_id(), &dispatch1_id);
 
     // Claim from thread-2 should succeed independently.
     let claimed2 = store
@@ -873,15 +875,16 @@ async fn claim_respects_per_thread_isolation() {
         .await
         .unwrap();
     assert_eq!(claimed2.len(), 1);
-    assert_eq!(claimed2[0].dispatch_id, dispatch2_id);
+    assert_eq!(claimed2[0].dispatch_id(), &dispatch2_id);
 
     // Both are independently Claimed.
     let loaded1 = store.load_dispatch(&dispatch1_id).await.unwrap().unwrap();
     let loaded2 = store.load_dispatch(&dispatch2_id).await.unwrap().unwrap();
-    assert_eq!(loaded1.status, RunDispatchStatus::Claimed);
-    assert_eq!(loaded2.status, RunDispatchStatus::Claimed);
+    assert_eq!(loaded1.status(), RunDispatchStatus::Claimed);
+    assert_eq!(loaded2.status(), RunDispatchStatus::Claimed);
     assert_ne!(
-        loaded1.claim_token, loaded2.claim_token,
+        loaded1.claim_token(),
+        loaded2.claim_token(),
         "each thread should get its own claim token"
     );
 }
@@ -920,8 +923,8 @@ async fn concurrent_claim_dispatch_only_one_wins() {
     let inner = InMemoryMailboxStore::new();
     let dispatch1 = make_dispatch("m-1", "agent-1");
     let dispatch2 = make_dispatch("m-1", "agent-1");
-    let id1 = dispatch1.dispatch_id.clone();
-    let id2 = dispatch2.dispatch_id.clone();
+    let id1 = dispatch1.dispatch_id().clone();
+    let id2 = dispatch2.dispatch_id().clone();
     inner.enqueue(&dispatch1).await.unwrap();
     inner.enqueue(&dispatch2).await.unwrap();
 
@@ -955,8 +958,8 @@ async fn claim_dispatch_different_thread_both_succeed() {
     let store = InMemoryMailboxStore::new();
     let dispatch1 = make_dispatch("m-1", "agent-1");
     let dispatch2 = make_dispatch("m-2", "agent-1");
-    let id1 = dispatch1.dispatch_id.clone();
-    let id2 = dispatch2.dispatch_id.clone();
+    let id1 = dispatch1.dispatch_id().clone();
+    let id2 = dispatch2.dispatch_id().clone();
     store.enqueue(&dispatch1).await.unwrap();
     store.enqueue(&dispatch2).await.unwrap();
 
@@ -976,7 +979,7 @@ async fn claim_dispatch_different_thread_both_succeed() {
 async fn claim_after_nack_works() {
     let store = InMemoryMailboxStore::new();
     let dispatch = make_dispatch("m-1", "agent-1");
-    let id = dispatch.dispatch_id.clone();
+    let id = dispatch.dispatch_id().clone();
     store.enqueue(&dispatch).await.unwrap();
 
     // Claim then nack.
@@ -985,7 +988,7 @@ async fn claim_after_nack_works() {
         .await
         .unwrap()
         .unwrap();
-    let token = claimed.claim_token.unwrap();
+    let token = claimed.claim_token().unwrap().to_string();
     store.nack(&id, &token, 1000, "retry", 2000).await.unwrap();
 
     // Should be claimable again.
@@ -1250,18 +1253,19 @@ mod proptest_memory_mailbox {
             rt.block_on(async {
                 let store = InMemoryMailboxStore::new();
                 let mut dispatch = make_dispatch("m-prop", "agent-prop");
-                dispatch.priority = priority;
-                dispatch.max_attempts = max_attempts;
+                dispatch = dispatch
+                    .with_priority(priority)
+                    .with_max_attempts(max_attempts);
                 store.enqueue(&dispatch).await.unwrap();
 
                 let claimed = store.claim("m-prop", "consumer-1", 30_000, 1000, 1).await.unwrap();
                 assert_eq!(claimed.len(), 1);
                 let cj = &claimed[0];
-                assert_eq!(cj.priority, priority);
-                assert_eq!(cj.max_attempts, max_attempts);
-                assert_eq!(cj.status, RunDispatchStatus::Claimed);
-                assert!(cj.claim_token.is_some());
-                assert_eq!(cj.claimed_by.as_deref(), Some("consumer-1"));
+                assert_eq!(cj.priority(), priority);
+                assert_eq!(cj.max_attempts(), max_attempts);
+                assert_eq!(cj.status(), RunDispatchStatus::Claimed);
+                assert!(cj.claim_token().is_some());
+                assert_eq!(cj.claimed_by(), Some("consumer-1"));
             });
         }
     }

--- a/crates/awaken-stores/src/message_validation.rs
+++ b/crates/awaken-stores/src/message_validation.rs
@@ -1,0 +1,48 @@
+use awaken_server_contract::contract::message::{Message, MessageRecord};
+use awaken_server_contract::contract::storage::{StorageError, message_append};
+
+pub(crate) fn validate_committed_messages(messages: &[Message]) -> Result<(), StorageError> {
+    message_append::validate_append_only_delta(&[], messages)
+}
+
+pub(crate) fn validate_committed_message_records(
+    thread_id: &str,
+    records: &[MessageRecord],
+) -> Result<(), StorageError> {
+    for (index, record) in records.iter().enumerate() {
+        let expected_seq = index as u64 + 1;
+        if record.thread_id != thread_id {
+            return Err(StorageError::Validation(format!(
+                "committed message '{}' belongs to thread '{}', expected '{}'",
+                record.message_id, record.thread_id, thread_id
+            )));
+        }
+        if record.seq != expected_seq {
+            return Err(StorageError::Serialization(format!(
+                "committed message seq must be continuous: expected {expected_seq}, got {}",
+                record.seq
+            )));
+        }
+        match record.message.id.as_deref() {
+            Some(message_id) if message_id == record.message_id => {}
+            Some(message_id) => {
+                return Err(StorageError::Validation(format!(
+                    "committed message record '{}' cannot carry message id '{}'",
+                    record.message_id, message_id
+                )));
+            }
+            None => {
+                return Err(StorageError::Validation(format!(
+                    "committed message record '{}' must carry message id",
+                    record.message_id
+                )));
+            }
+        }
+    }
+    validate_committed_messages(
+        &records
+            .iter()
+            .map(|record| record.message.clone())
+            .collect::<Vec<_>>(),
+    )
+}

--- a/crates/awaken-stores/src/nats_buffered_thread/writer.rs
+++ b/crates/awaken-stores/src/nats_buffered_thread/writer.rs
@@ -89,6 +89,7 @@ pub async fn checkpoint<T: ThreadRunStore + Send + Sync + 'static>(
     messages: &[Message],
     run: &RunRecord,
 ) -> Result<(), StorageError> {
+    run.validate_for_persist()?;
     let existing_thread = reader::load_thread_overlay(store, thread_id).await?;
     reader::validate_thread_hierarchy_overlay(
         store,

--- a/crates/awaken-stores/src/nats_mailbox/codec.rs
+++ b/crates/awaken-stores/src/nats_mailbox/codec.rs
@@ -12,7 +12,10 @@ pub fn encode(dispatch: &RunDispatch) -> Result<Bytes, StorageError> {
 }
 
 pub fn decode(bytes: &[u8]) -> Result<RunDispatch, StorageError> {
-    serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))
+    let dispatch: RunDispatch =
+        serde_json::from_slice(bytes).map_err(|e| StorageError::Serialization(e.to_string()))?;
+    dispatch.validate_for_persist()?;
+    Ok(dispatch)
 }
 
 pub fn encode_thread_index(ids: &[String]) -> Result<Bytes, StorageError> {
@@ -88,33 +91,10 @@ pub fn decode_epoch(bytes: &[u8]) -> Result<u64, StorageError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use awaken_server_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+    use awaken_server_contract::contract::mailbox::RunDispatch;
 
     fn sample_dispatch() -> RunDispatch {
-        RunDispatch {
-            dispatch_id: "d1".to_string(),
-            thread_id: "t1".to_string(),
-            run_id: "r1".to_string(),
-            priority: 128,
-            dedupe_key: None,
-            dispatch_epoch: 0,
-            status: RunDispatchStatus::Queued,
-            available_at: 0,
-            attempt_count: 0,
-            max_attempts: 3,
-            last_error: None,
-            claim_token: None,
-            claimed_by: None,
-            lease_until: None,
-            dispatch_instance_id: None,
-            run_status: None,
-            termination: None,
-            run_response: None,
-            run_error: None,
-            completed_at: None,
-            created_at: 0,
-            updated_at: 0,
-        }
+        RunDispatch::queued("d1", "t1", "r1", 0).with_max_attempts(3)
     }
 
     #[test]
@@ -122,7 +102,7 @@ mod tests {
         let dispatch = sample_dispatch();
         let encoded = encode(&dispatch).unwrap();
         let decoded = decode(&encoded).unwrap();
-        assert_eq!(decoded.dispatch_id, "d1");
+        assert_eq!(decoded.dispatch_id(), "d1");
     }
 
     #[test]

--- a/crates/awaken-stores/src/nats_mailbox/index.rs
+++ b/crates/awaken-stores/src/nats_mailbox/index.rs
@@ -39,7 +39,7 @@ impl DispatchIndex {
     }
 
     fn upsert_inner(&mut self, dispatch: RunDispatch, revision: Option<u64>, force: bool) {
-        let id = dispatch.dispatch_id.clone();
+        let id = dispatch.dispatch_id().to_string();
         if let Some(prev) = self.by_id.get(&id) {
             if !force {
                 if let (Some(prev_revision), Some(incoming_revision)) = (prev.revision, revision)
@@ -47,21 +47,21 @@ impl DispatchIndex {
                 {
                     return;
                 }
-                if revision.is_none() && dispatch.updated_at < prev.dispatch.updated_at {
+                if revision.is_none() && dispatch.updated_at() < prev.dispatch.updated_at() {
                     return;
                 }
             }
-            if let Some(set) = self.by_status.get_mut(&status_key(prev.dispatch.status)) {
+            if let Some(set) = self.by_status.get_mut(&status_key(prev.dispatch.status())) {
                 set.remove(&id);
             }
         } else {
             self.by_thread
-                .entry(dispatch.thread_id.clone())
+                .entry(dispatch.thread_id().to_string())
                 .or_default()
                 .push(id.clone());
         }
         self.by_status
-            .entry(status_key(dispatch.status))
+            .entry(status_key(dispatch.status()))
             .or_default()
             .insert(id.clone());
         self.by_id
@@ -86,13 +86,13 @@ impl DispatchIndex {
         }
         if let Some(indexed) = self.by_id.remove(dispatch_id) {
             let dispatch = indexed.dispatch;
-            if let Some(set) = self.by_status.get_mut(&status_key(dispatch.status)) {
+            if let Some(set) = self.by_status.get_mut(&status_key(dispatch.status())) {
                 set.remove(dispatch_id);
             }
-            if let Some(ids) = self.by_thread.get_mut(&dispatch.thread_id) {
+            if let Some(ids) = self.by_thread.get_mut(dispatch.thread_id()) {
                 ids.retain(|id| id != dispatch_id);
                 if ids.is_empty() {
-                    self.by_thread.remove(&dispatch.thread_id);
+                    self.by_thread.remove(dispatch.thread_id());
                 }
             }
         }
@@ -119,7 +119,7 @@ impl DispatchIndex {
         ids.iter()
             .filter_map(|id| self.by_id.get(id).map(|indexed| indexed.dispatch.clone()))
             .filter(|d| match status_filter {
-                Some(filter) => filter.contains(&d.status),
+                Some(filter) => filter.contains(&d.status()),
                 None => true,
             })
             .collect()
@@ -139,16 +139,16 @@ impl DispatchIndex {
             let Some(dispatch) = self.by_id.get(id).map(|indexed| &indexed.dispatch) else {
                 continue;
             };
-            if dispatch.status != RunDispatchStatus::Queued || dispatch.available_at > now {
+            if dispatch.status() != RunDispatchStatus::Queued || dispatch.available_at() > now {
                 continue;
             }
             eligible_count += 1;
             if best.is_none_or(|current| {
                 dispatch
-                    .priority
-                    .cmp(&current.priority)
-                    .then(dispatch.created_at.cmp(&current.created_at))
-                    .then(dispatch.dispatch_id.cmp(&current.dispatch_id))
+                    .priority()
+                    .cmp(&current.priority())
+                    .then(dispatch.created_at().cmp(&current.created_at()))
+                    .then(dispatch.dispatch_id().cmp(current.dispatch_id()))
                     .is_lt()
             }) {
                 best = Some(dispatch);
@@ -162,15 +162,15 @@ impl DispatchIndex {
         ids.iter()
             .filter_map(|id| self.by_id.get(id).map(|indexed| &indexed.dispatch))
             .filter(|dispatch| {
-                dispatch.status == RunDispatchStatus::Claimed
+                dispatch.status() == RunDispatchStatus::Claimed
                     && dispatch
-                        .lease_until
+                        .lease_until()
                         .is_some_and(|lease_until| lease_until >= now)
             })
             .min_by(|left, right| {
-                left.lease_until
-                    .cmp(&right.lease_until)
-                    .then(left.dispatch_id.cmp(&right.dispatch_id))
+                left.lease_until()
+                    .cmp(&right.lease_until())
+                    .then(left.dispatch_id().cmp(right.dispatch_id()))
             })
             .cloned()
     }
@@ -187,13 +187,13 @@ impl DispatchIndex {
             .filter_map(|id| self.by_id.get(id).map(|indexed| &indexed.dispatch))
             .filter(|dispatch| {
                 dispatch
-                    .lease_until
+                    .lease_until()
                     .is_some_and(|lease_until| lease_until < now)
             })
             .map(|dispatch| {
                 (
-                    dispatch.lease_until.unwrap_or(0),
-                    dispatch.dispatch_id.clone(),
+                    dispatch.lease_until().unwrap_or(0),
+                    dispatch.dispatch_id().to_string(),
                 )
             })
             .collect::<Vec<_>>();
@@ -212,7 +212,7 @@ impl DispatchIndex {
         let mut threads: HashSet<String> = HashSet::new();
         for id in queued_ids {
             if let Some(indexed) = self.by_id.get(id) {
-                threads.insert(indexed.dispatch.thread_id.clone());
+                threads.insert(indexed.dispatch.thread_id().to_string());
             }
         }
         threads.into_iter().collect()
@@ -231,7 +231,7 @@ impl DispatchIndex {
         queued_ids
             .iter()
             .filter_map(|id| self.by_id.get(id).map(|indexed| &indexed.dispatch))
-            .filter(|d| d.available_at <= now)
+            .filter(|d| d.available_at() <= now)
             .cloned()
             .collect()
     }
@@ -312,12 +312,12 @@ async fn initial_scan(
             && !kv_helpers::is_tombstone(&entry)
             && let Ok(dispatch) = codec::decode(&entry.value)
         {
-            seen_threads.insert(dispatch.thread_id.clone());
-            if !is_terminal(dispatch.status) {
+            seen_threads.insert(dispatch.thread_id().to_string());
+            if !is_terminal(dispatch.status()) {
                 active_by_thread
-                    .entry(dispatch.thread_id.clone())
+                    .entry(dispatch.thread_id().to_string())
                     .or_default()
-                    .push(dispatch.dispatch_id.clone());
+                    .push(dispatch.dispatch_id().to_string());
             }
             index
                 .write()
@@ -355,8 +355,8 @@ async fn apply_entry(
     if let Ok(dispatch) = codec::decode(&entry.value) {
         if let Err(error) = reconcile_thread_index(kv_thread_index, &dispatch).await {
             tracing::warn!(
-                thread_id = %dispatch.thread_id,
-                dispatch_id = %dispatch.dispatch_id,
+                thread_id = %dispatch.thread_id(),
+                dispatch_id = %dispatch.dispatch_id(),
                 error = %error,
                 "failed to maintain nats_mailbox thread index from watcher"
             );
@@ -372,18 +372,18 @@ async fn reconcile_thread_index(
     kv_thread_index: &async_nats::jetstream::kv::Store,
     dispatch: &RunDispatch,
 ) -> Result<(), StorageError> {
-    if is_terminal(dispatch.status) {
+    if is_terminal(dispatch.status()) {
         ops_write::remove_thread_index_from_bucket(
             kv_thread_index,
-            &dispatch.thread_id,
-            &dispatch.dispatch_id,
+            dispatch.thread_id(),
+            dispatch.dispatch_id(),
         )
         .await
     } else {
         ops_write::append_thread_index_to_bucket(
             kv_thread_index,
-            &dispatch.thread_id,
-            &dispatch.dispatch_id,
+            dispatch.thread_id(),
+            dispatch.dispatch_id(),
         )
         .await
     }
@@ -404,7 +404,7 @@ mod tests {
     use super::*;
 
     fn dispatch(id: &str, status: RunDispatchStatus, updated_at: u64) -> RunDispatch {
-        RunDispatch {
+        let parts = awaken_server_contract::contract::mailbox::RunDispatchParts {
             dispatch_id: id.to_string(),
             thread_id: "thread".to_string(),
             run_id: format!("{id}-run"),
@@ -416,18 +416,19 @@ mod tests {
             attempt_count: 0,
             max_attempts: 3,
             last_error: None,
-            claim_token: None,
-            claimed_by: None,
-            lease_until: None,
+            claim_token: (status == RunDispatchStatus::Claimed).then(|| "token".to_string()),
+            claimed_by: (status == RunDispatchStatus::Claimed).then(|| "worker".to_string()),
+            lease_until: (status == RunDispatchStatus::Claimed).then_some(10_000),
             dispatch_instance_id: None,
             run_status: None,
             termination: None,
             run_response: None,
             run_error: None,
-            completed_at: None,
+            completed_at: status.is_terminal().then_some(updated_at),
             created_at: 0,
             updated_at,
-        }
+        };
+        RunDispatch::from_persisted_parts(parts).expect("test dispatch must be valid")
     }
 
     #[test]
@@ -437,7 +438,7 @@ mod tests {
         index.upsert_with_revision(dispatch("d1", RunDispatchStatus::Queued, 10), 10);
 
         assert_eq!(
-            index.get("d1").map(|dispatch| dispatch.status),
+            index.get("d1").map(|dispatch| dispatch.status()),
             Some(RunDispatchStatus::Claimed)
         );
         assert_eq!(index.count_by_status(RunDispatchStatus::Claimed), 1);

--- a/crates/awaken-stores/src/nats_mailbox/metrics.rs
+++ b/crates/awaken-stores/src/nats_mailbox/metrics.rs
@@ -30,7 +30,7 @@ pub(crate) fn record_authoritative_scan(keys: usize, elapsed: Duration) {
 
 pub(crate) fn record_queued_without_signal_age(dispatch: &RunDispatch, now: u64) {
     ::metrics::histogram!("awaken_mailbox_queued_without_signal_age_ms")
-        .record(now.saturating_sub(dispatch.available_at) as f64);
+        .record(now.saturating_sub(dispatch.available_at()) as f64);
 }
 
 pub(crate) fn inc_dispatch_signal_republish() {

--- a/crates/awaken-stores/src/nats_mailbox/mod.rs
+++ b/crates/awaken-stores/src/nats_mailbox/mod.rs
@@ -316,9 +316,9 @@ impl NatsMailboxStore {
         dispatch: &RunDispatch,
     ) -> Result<(), StorageError> {
         let mut stamped = dispatch.clone();
-        stamped.dispatch_epoch = match self
+        let epoch = match self
             .kv_epoch
-            .entry(&keys::epoch_key(&stamped.thread_id))
+            .entry(&keys::epoch_key(stamped.thread_id()))
             .await
             .map_err(|e| StorageError::Io(format!("kv entry: {e}")))?
         {
@@ -326,11 +326,12 @@ impl NatsMailboxStore {
             Some(entry) => codec::decode_epoch(&entry.value)?,
             None => 0,
         };
-        ops_write::append_thread_index(self, &stamped.thread_id, &stamped.dispatch_id).await?;
+        stamped.prepare_for_enqueue(epoch);
+        ops_write::append_thread_index(self, stamped.thread_id(), stamped.dispatch_id()).await?;
         let bytes = codec::encode(&stamped)?;
         let revision = self
             .kv_dispatch
-            .put(keys::dispatch_key(&stamped.dispatch_id), bytes)
+            .put(keys::dispatch_key(stamped.dispatch_id()), bytes)
             .await
             .map_err(|e| StorageError::Io(format!("kv put: {e}")))?;
         self.index
@@ -348,11 +349,11 @@ impl NatsMailboxStore {
         &self,
         dispatch: &RunDispatch,
     ) -> Result<(), StorageError> {
-        ops_write::append_thread_index(self, &dispatch.thread_id, &dispatch.dispatch_id).await?;
+        ops_write::append_thread_index(self, dispatch.thread_id(), dispatch.dispatch_id()).await?;
         let bytes = codec::encode(dispatch)?;
         let revision = self
             .kv_dispatch
-            .put(keys::dispatch_key(&dispatch.dispatch_id), bytes)
+            .put(keys::dispatch_key(dispatch.dispatch_id()), bytes)
             .await
             .map_err(|e| StorageError::Io(format!("kv put: {e}")))?;
         self.index
@@ -557,15 +558,15 @@ impl MailboxStore for NatsMailboxStore {
                 let _ = message.ack().await;
                 continue;
             };
-            if dispatch.status.is_terminal() {
+            if dispatch.status().is_terminal() {
                 ops_write::cleanup_thread_index(self, &dispatch).await;
             } else {
-                ops_write::append_thread_index(self, &dispatch.thread_id, &dispatch.dispatch_id)
+                ops_write::append_thread_index(self, dispatch.thread_id(), dispatch.dispatch_id())
                     .await?;
             }
             self.index.write().await.upsert(dispatch.clone());
             entries.push(DispatchSignalEntry {
-                thread_id: dispatch.thread_id,
+                thread_id: dispatch.thread_id().to_string(),
                 dispatch_id,
                 receipt: Box::new(NatsDispatchSignalReceipt { message }),
             });

--- a/crates/awaken-stores/src/nats_mailbox/ops_claim.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_claim.rs
@@ -31,19 +31,19 @@ async fn active_local_claim_blocks(
     else {
         return Ok(false);
     };
-    if except_dispatch_id == Some(local_active.dispatch_id.as_str()) {
+    if except_dispatch_id == Some(local_active.dispatch_id()) {
         return Ok(false);
     }
 
-    let Some(authoritative) = ops_query::load_dispatch(store, &local_active.dispatch_id).await?
+    let Some(authoritative) = ops_query::load_dispatch(store, local_active.dispatch_id()).await?
     else {
-        store.index.write().await.remove(&local_active.dispatch_id);
+        store.index.write().await.remove(local_active.dispatch_id());
         return Ok(false);
     };
     store.index.write().await.upsert(authoritative.clone());
-    Ok(authoritative.status == RunDispatchStatus::Claimed
+    Ok(authoritative.status() == RunDispatchStatus::Claimed
         && authoritative
-            .lease_until
+            .lease_until()
             .is_some_and(|lease_until| lease_until >= now))
 }
 
@@ -105,10 +105,11 @@ async fn claim_dispatch_inner(
         }
         let mut dispatch = codec::decode(&entry.value)?;
 
-        if dispatch.status != RunDispatchStatus::Queued {
+        if dispatch.status() != RunDispatchStatus::Queued {
             return Ok(None);
         }
-        if matches!(available_at_policy, AvailableAtPolicy::Respect) && dispatch.available_at > now
+        if matches!(available_at_policy, AvailableAtPolicy::Respect)
+            && dispatch.available_at() > now
         {
             return Ok(None);
         }
@@ -118,8 +119,8 @@ async fn claim_dispatch_inner(
         // cross-node guarantee for `interrupt()` — a node whose local
         // index hasn't caught up may see a stale Queued dispatch; the
         // KV read here is strongly consistent and rejects it.
-        let thread_epoch = ops_write::current_thread_epoch(store, &dispatch.thread_id).await?;
-        if dispatch.dispatch_epoch < thread_epoch {
+        let thread_epoch = ops_write::current_thread_epoch(store, dispatch.thread_id()).await?;
+        if dispatch.dispatch_epoch() < thread_epoch {
             mailbox_state::mark_superseded_at_epoch(&mut dispatch, now, thread_epoch, None);
             let bytes = codec::encode(&dispatch)?;
             if let Ok(revision) = store
@@ -132,12 +133,12 @@ async fn claim_dispatch_inner(
                     .write()
                     .await
                     .upsert_with_revision(dispatch.clone(), revision);
-                if let Some(ref dedupe_key) = dispatch.dedupe_key {
+                if let Some(dedupe_key) = dispatch.dedupe_key() {
                     ops_write::release_dedupe_lock(
                         store,
-                        &dispatch.thread_id,
+                        dispatch.thread_id(),
                         dedupe_key,
-                        &dispatch.dispatch_id,
+                        dispatch.dispatch_id(),
                     )
                     .await;
                 }
@@ -147,21 +148,22 @@ async fn claim_dispatch_inner(
             continue;
         }
 
-        if active_local_claim_blocks(store, &dispatch.thread_id, Some(dispatch_id), now).await? {
+        if active_local_claim_blocks(store, dispatch.thread_id(), Some(dispatch_id), now).await? {
             return Ok(None);
         }
 
         let Some(thread_claim) =
-            claim_guard::acquire(store, &dispatch.thread_id, dispatch_id, lease_ms, now).await?
+            claim_guard::acquire(store, dispatch.thread_id(), dispatch_id, lease_ms, now).await?
         else {
             return Ok(None);
         };
 
-        dispatch.status = RunDispatchStatus::Claimed;
-        dispatch.claim_token = Some(thread_claim.claim_token.clone());
-        dispatch.claimed_by = Some(consumer_id.to_string());
-        dispatch.lease_until = Some(thread_claim.lease_until);
-        dispatch.updated_at = now;
+        dispatch.claim(
+            consumer_id,
+            thread_claim.claim_token.clone(),
+            thread_claim.lease_until,
+            now,
+        )?;
 
         let bytes = codec::encode(&dispatch)?;
         let result = store
@@ -180,7 +182,7 @@ async fn claim_dispatch_inner(
             Err(_e) => {
                 claim_guard::release(
                     store,
-                    &dispatch.thread_id,
+                    dispatch.thread_id(),
                     dispatch_id,
                     &thread_claim.claim_token,
                 )
@@ -222,7 +224,7 @@ pub async fn claim(
     if local_candidate_count >= LOCAL_CLAIM_FAST_PATH_MIN_CANDIDATES
         && let Some(candidate) = local_candidate
     {
-        match claim_available_dispatch(store, &candidate.dispatch_id, consumer_id, lease_ms, now)
+        match claim_available_dispatch(store, candidate.dispatch_id(), consumer_id, lease_ms, now)
             .await
         {
             Ok(Some(d)) => {
@@ -245,19 +247,19 @@ pub async fn claim(
         }
     }
     .into_iter()
-    .filter(|dispatch| dispatch.status == RunDispatchStatus::Queued)
+    .filter(|dispatch| dispatch.status() == RunDispatchStatus::Queued)
     .collect::<Vec<_>>();
-    candidates.retain(|d| d.available_at <= now);
+    candidates.retain(|d| d.available_at() <= now);
     let available_candidates = candidates.len();
     candidates.sort_by(|a, b| {
-        a.priority
-            .cmp(&b.priority)
-            .then(a.created_at.cmp(&b.created_at))
+        a.priority()
+            .cmp(&b.priority())
+            .then(a.created_at().cmp(&b.created_at()))
     });
 
     let mut claimed = Vec::new();
     for candidate in candidates {
-        match claim_available_dispatch(store, &candidate.dispatch_id, consumer_id, lease_ms, now)
+        match claim_available_dispatch(store, candidate.dispatch_id(), consumer_id, lease_ms, now)
             .await
         {
             Ok(Some(d)) => {

--- a/crates/awaken-stores/src/nats_mailbox/ops_interrupt.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_interrupt.rs
@@ -28,13 +28,13 @@ pub async fn interrupt(
     let guard_active_dispatch_id = claim_guard::active_dispatch_id(store, thread_id, now).await?;
     if let Some(active_dispatch_id) = guard_active_dispatch_id.as_deref()
         && let Some(authoritative) = ops_query::load_dispatch(store, active_dispatch_id).await?
-        && authoritative.thread_id == thread_id
-        && authoritative.status == RunDispatchStatus::Claimed
+        && authoritative.thread_id() == thread_id
+        && authoritative.status() == RunDispatchStatus::Claimed
     {
         store.index.write().await.upsert(authoritative.clone());
         if !dispatches
             .iter()
-            .any(|dispatch| dispatch.dispatch_id == authoritative.dispatch_id)
+            .any(|dispatch| dispatch.dispatch_id() == authoritative.dispatch_id())
         {
             dispatches.push(authoritative.clone());
         }
@@ -42,19 +42,19 @@ pub async fn interrupt(
     }
 
     for dispatch in dispatches {
-        match dispatch.status {
+        match dispatch.status() {
             RunDispatchStatus::Queued => {
-                match supersede(store, &dispatch.dispatch_id, new_epoch, now).await {
+                match supersede(store, dispatch.dispatch_id(), new_epoch, now).await {
                     Ok(SupersedeOutcome::Superseded(superseded)) => {
                         superseded_count += 1;
                         // Terminal → release any dedupe lock so a subsequent
                         // enqueue with the same key can take over.
-                        if let Some(ref dedupe_key) = superseded.dedupe_key {
+                        if let Some(dedupe_key) = superseded.dedupe_key() {
                             ops_write::release_dedupe_lock(
                                 store,
-                                &superseded.thread_id,
+                                superseded.thread_id(),
                                 dedupe_key,
-                                &superseded.dispatch_id,
+                                superseded.dispatch_id(),
                             )
                             .await;
                         }
@@ -67,7 +67,7 @@ pub async fn interrupt(
                     Err(error) => {
                         tracing::warn!(
                             thread_id,
-                            dispatch_id = %dispatch.dispatch_id,
+                            dispatch_id = %dispatch.dispatch_id(),
                             error = %error,
                             "failed to supersede queued dispatch during interrupt"
                         );
@@ -77,7 +77,7 @@ pub async fn interrupt(
             RunDispatchStatus::Claimed => {
                 if guard_active_dispatch_id
                     .as_deref()
-                    .is_none_or(|active_id| active_id == dispatch.dispatch_id)
+                    .is_none_or(|active_id| active_id == dispatch.dispatch_id())
                 {
                     active_dispatch = Some(dispatch);
                 }
@@ -140,13 +140,13 @@ async fn supersede(
             return Err(StorageError::NotFound(dispatch_id.to_string()));
         }
         let mut dispatch = codec::decode(&entry.value)?;
-        if dispatch.status != RunDispatchStatus::Queued {
-            if dispatch.status == RunDispatchStatus::Claimed {
+        if dispatch.status() != RunDispatchStatus::Queued {
+            if dispatch.status() == RunDispatchStatus::Claimed {
                 return Ok(SupersedeOutcome::Claimed(Box::new(dispatch)));
             }
             return Ok(SupersedeOutcome::NotQueued);
         }
-        if dispatch.dispatch_epoch >= new_epoch {
+        if dispatch.dispatch_epoch() >= new_epoch {
             return Ok(SupersedeOutcome::NotQueued);
         }
         mailbox_state::mark_superseded_at_epoch(&mut dispatch, now, new_epoch, None);

--- a/crates/awaken-stores/src/nats_mailbox/ops_maintenance.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_maintenance.rs
@@ -70,18 +70,18 @@ async fn reclaim_one(
             return Ok(None);
         }
         let mut dispatch = codec::decode(&entry.value)?;
-        if dispatch.status != RunDispatchStatus::Claimed {
+        if dispatch.status() != RunDispatchStatus::Claimed {
             return Ok(None);
         }
-        if dispatch.lease_until.map(|u| u >= now).unwrap_or(true) {
+        if dispatch.lease_until().map(|u| u >= now).unwrap_or(true) {
             return Ok(None);
         }
-        if let Some(lease_until) = dispatch.lease_until {
+        if let Some(lease_until) = dispatch.lease_until() {
             metrics::record_claimed_dispatch_lease_age(now, lease_until);
         }
-        let old_claim_token = dispatch.claim_token.clone();
-        let thread_epoch = ops_write::current_thread_epoch(store, &dispatch.thread_id).await?;
-        if dispatch.dispatch_epoch < thread_epoch {
+        let old_claim_token = dispatch.claim_token().map(str::to_string);
+        let thread_epoch = ops_write::current_thread_epoch(store, dispatch.thread_id()).await?;
+        if dispatch.dispatch_epoch() < thread_epoch {
             mailbox_state::mark_superseded_at_epoch(
                 &mut dispatch,
                 now,
@@ -100,15 +100,15 @@ async fn reclaim_one(
                     .await
                     .upsert_with_revision(dispatch.clone(), revision);
                 if let Some(ref claim_token) = old_claim_token {
-                    claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token)
+                    claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token)
                         .await?;
                 }
-                if let Some(ref dedupe_key) = dispatch.dedupe_key {
+                if let Some(dedupe_key) = dispatch.dedupe_key() {
                     ops_write::release_dedupe_lock(
                         store,
-                        &dispatch.thread_id,
+                        dispatch.thread_id(),
                         dedupe_key,
-                        &dispatch.dispatch_id,
+                        dispatch.dispatch_id(),
                     )
                     .await;
                 }
@@ -131,20 +131,20 @@ async fn reclaim_one(
                 .await
                 .upsert_with_revision(dispatch.clone(), revision);
             if let Some(ref claim_token) = old_claim_token {
-                claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+                claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token).await?;
             }
-            if dispatch.status == RunDispatchStatus::DeadLetter
-                && let Some(ref dedupe_key) = dispatch.dedupe_key
+            if dispatch.status() == RunDispatchStatus::DeadLetter
+                && let Some(dedupe_key) = dispatch.dedupe_key()
             {
                 ops_write::release_dedupe_lock(
                     store,
-                    &dispatch.thread_id,
+                    dispatch.thread_id(),
                     dedupe_key,
-                    &dispatch.dispatch_id,
+                    dispatch.dispatch_id(),
                 )
                 .await;
             }
-            if dispatch.status == RunDispatchStatus::DeadLetter {
+            if dispatch.status() == RunDispatchStatus::DeadLetter {
                 ops_write::cleanup_thread_index(store, &dispatch).await;
             }
             metrics::inc_expired_claim_reclaimed();
@@ -162,9 +162,9 @@ pub async fn purge_terminal(
         .await?
         .into_iter()
         .filter(|dispatch| {
-            dispatch.status.is_terminal()
+            dispatch.status().is_terminal()
                 && dispatch
-                    .completed_at
+                    .completed_at()
                     .is_some_and(|completed_at| completed_at < older_than)
         })
         .collect::<Vec<_>>();
@@ -172,11 +172,11 @@ pub async fn purge_terminal(
     for dispatch in dispatches {
         if store
             .kv_dispatch
-            .delete(&keys::dispatch_key(&dispatch.dispatch_id))
+            .delete(&keys::dispatch_key(dispatch.dispatch_id()))
             .await
             .is_ok()
         {
-            store.index.write().await.remove(&dispatch.dispatch_id);
+            store.index.write().await.remove(dispatch.dispatch_id());
             ops_write::cleanup_thread_index(store, &dispatch).await;
             purged += 1;
         }

--- a/crates/awaken-stores/src/nats_mailbox/ops_query.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_query.rs
@@ -37,7 +37,7 @@ pub(crate) async fn load_thread_dispatches(
         let Some(dispatch) = load_dispatch(store, &dispatch_id).await? else {
             continue;
         };
-        if dispatch.thread_id == thread_id {
+        if dispatch.thread_id() == thread_id {
             store.index.write().await.upsert(dispatch.clone());
             dispatches.push(dispatch);
         }
@@ -62,9 +62,9 @@ pub(crate) async fn load_claim_candidates(
     for dispatch_id in ids {
         let cached = store.index.read().await.get_cloned(&dispatch_id);
         if let Some(dispatch) = cached
-            && dispatch.thread_id == thread_id
-            && dispatch.status == RunDispatchStatus::Queued
-            && dispatch.available_at <= now
+            && dispatch.thread_id() == thread_id
+            && dispatch.status() == RunDispatchStatus::Queued
+            && dispatch.available_at() <= now
         {
             dispatches.push(dispatch);
             continue;
@@ -73,7 +73,7 @@ pub(crate) async fn load_claim_candidates(
         let Some(dispatch) = load_dispatch(store, &dispatch_id).await? else {
             continue;
         };
-        if dispatch.thread_id == thread_id {
+        if dispatch.thread_id() == thread_id {
             store.index.write().await.upsert(dispatch.clone());
             dispatches.push(dispatch);
         }
@@ -169,9 +169,9 @@ pub async fn list_dispatches(
         .await
         .list_by_thread(thread_id, status_filter);
     items.sort_by(|a, b| {
-        a.priority
-            .cmp(&b.priority)
-            .then(a.created_at.cmp(&b.created_at))
+        a.priority()
+            .cmp(&b.priority())
+            .then(a.created_at().cmp(&b.created_at()))
     });
     Ok(items.into_iter().skip(offset).take(limit).collect())
 }
@@ -195,13 +195,13 @@ pub async fn list_terminal_dispatches(
     let mut dispatches = load_all_dispatches(store)
         .await?
         .into_iter()
-        .filter(|dispatch| dispatch.status.is_terminal())
+        .filter(|dispatch| dispatch.status().is_terminal())
         .collect::<Vec<_>>();
     dispatches.sort_by(|a, b| {
-        a.updated_at
-            .cmp(&b.updated_at)
-            .then(a.created_at.cmp(&b.created_at))
-            .then(a.dispatch_id.cmp(&b.dispatch_id))
+        a.updated_at()
+            .cmp(&b.updated_at())
+            .then(a.created_at().cmp(&b.created_at()))
+            .then(a.dispatch_id().cmp(b.dispatch_id()))
     });
     Ok(dispatches.into_iter().skip(offset).take(limit).collect())
 }

--- a/crates/awaken-stores/src/nats_mailbox/ops_write.rs
+++ b/crates/awaken-stores/src/nats_mailbox/ops_write.rs
@@ -2,7 +2,6 @@
 
 use async_nats::HeaderMap;
 use async_nats::jetstream::kv::CreateErrorKind;
-use awaken_server_contract::contract::lifecycle::RunStatus;
 use awaken_server_contract::contract::mailbox::{
     RunDispatch, RunDispatchResult, RunDispatchStatus,
 };
@@ -14,6 +13,7 @@ use crate::mailbox_state;
 const DEDUPE_ORPHAN_GRACE_MS: u64 = 5_000;
 
 pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result<(), StorageError> {
+    dispatch.validate_for_enqueue()?;
     // ── Stamp dispatch_epoch from authoritative KV state ──
     //
     // The `MailboxStore` trait contract states "sets dispatch epoch from
@@ -23,7 +23,8 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
     // rejects it as stale, so every foreground submit after any interrupt
     // would fail.
     let mut dispatch = dispatch.clone();
-    dispatch.dispatch_epoch = current_thread_epoch(store, &dispatch.thread_id).await?;
+    dispatch.prepare_for_enqueue(current_thread_epoch(store, dispatch.thread_id()).await?);
+    dispatch.validate_for_persist()?;
 
     // ── Authoritative dedupe (race-free across nodes) ──
     //
@@ -33,12 +34,12 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
     // holder crashed between lock create and dispatch put, or if the
     // holding dispatch has become terminal/stale-by-epoch, the acquire
     // path reconciles by purging the orphan lock and retrying.
-    if let Some(ref dedupe_key) = dispatch.dedupe_key {
+    if let Some(dedupe_key) = dispatch.dedupe_key() {
         acquire_dedupe_lock(
             store,
-            &dispatch.thread_id,
+            dispatch.thread_id(),
             dedupe_key,
-            &dispatch.dispatch_id,
+            dispatch.dispatch_id(),
         )
         .await?;
     }
@@ -47,13 +48,13 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
     // makes queue scans O(thread dispatches) without introducing a
     // stranded-dispatch gap: if the later dispatch put fails, the index
     // entry is a harmless dangling id that strong loads skip.
-    if let Err(e) = append_thread_index(store, &dispatch.thread_id, &dispatch.dispatch_id).await {
-        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+    if let Err(e) = append_thread_index(store, dispatch.thread_id(), dispatch.dispatch_id()).await {
+        if let Some(dedupe_key) = dispatch.dedupe_key() {
             release_dedupe_lock(
                 store,
-                &dispatch.thread_id,
+                dispatch.thread_id(),
                 dedupe_key,
-                &dispatch.dispatch_id,
+                dispatch.dispatch_id(),
             )
             .await;
         }
@@ -69,18 +70,18 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
     let bytes = codec::encode(&dispatch)?;
     let revision = match store
         .kv_dispatch
-        .put(keys::dispatch_key(&dispatch.dispatch_id), bytes)
+        .put(keys::dispatch_key(dispatch.dispatch_id()), bytes)
         .await
     {
         Ok(revision) => revision,
         // Roll back the dedupe lock so a retry isn't permanently blocked.
         Err(e) => {
-            if let Some(ref dedupe_key) = dispatch.dedupe_key {
+            if let Some(dedupe_key) = dispatch.dedupe_key() {
                 release_dedupe_lock(
                     store,
-                    &dispatch.thread_id,
+                    dispatch.thread_id(),
                     dedupe_key,
-                    &dispatch.dispatch_id,
+                    dispatch.dispatch_id(),
                 )
                 .await;
             }
@@ -99,13 +100,13 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
     // Best-effort: JetStream delivery signal. Failure is recovered by the
     // sweeper, which re-publishes for every Queued dispatch still missing
     // its notification.
-    let subject = keys::dispatch_subject(&dispatch.thread_id);
-    let payload = bytes::Bytes::from(dispatch.dispatch_id.clone().into_bytes());
-    let publish_result = if let Some(ref dedupe_key) = dispatch.dedupe_key {
+    let subject = keys::dispatch_subject(dispatch.thread_id());
+    let payload = bytes::Bytes::from(dispatch.dispatch_id().as_bytes().to_vec());
+    let publish_result = if let Some(dedupe_key) = dispatch.dedupe_key() {
         let mut headers = HeaderMap::new();
         headers.insert(
             "Nats-Msg-Id",
-            keys::dedupe_msg_id(&dispatch.thread_id, dedupe_key, &dispatch.dispatch_id).as_str(),
+            keys::dedupe_msg_id(dispatch.thread_id(), dedupe_key, dispatch.dispatch_id()).as_str(),
         );
         store
             .jetstream
@@ -118,8 +119,8 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
         Ok(future) => {
             if let Err(e) = future.await {
                 tracing::warn!(
-                    thread_id = dispatch.thread_id,
-                    dispatch_id = dispatch.dispatch_id,
+                    thread_id = %dispatch.thread_id(),
+                    dispatch_id = %dispatch.dispatch_id(),
                     error = %e,
                     "JetStream publish ack failed; sweeper will retry"
                 );
@@ -127,8 +128,8 @@ pub async fn enqueue(store: &NatsMailboxStore, dispatch: &RunDispatch) -> Result
         }
         Err(e) => {
             tracing::warn!(
-                thread_id = dispatch.thread_id,
-                dispatch_id = dispatch.dispatch_id,
+                thread_id = %dispatch.thread_id(),
+                dispatch_id = %dispatch.dispatch_id(),
                 error = %e,
                 "JetStream publish failed; sweeper will retry"
             );
@@ -227,7 +228,7 @@ async fn reconcile_dedupe_lock(
     }
     let holder = codec::decode(&holder_entry.value)?;
     if matches!(
-        holder.status,
+        holder.status(),
         RunDispatchStatus::Acked
             | RunDispatchStatus::Cancelled
             | RunDispatchStatus::DeadLetter
@@ -245,12 +246,12 @@ async fn reconcile_dedupe_lock(
         Some(e) => codec::decode_epoch(&e.value)?,
         None => 0,
     };
-    if holder.dispatch_epoch < thread_epoch {
+    if holder.dispatch_epoch() < thread_epoch {
         // Holder wasn't seen by interrupt's local-index sweep but is
         // stale by authoritative epoch. Queued holders can be released so a
         // fresh enqueue can proceed; Claimed holders are still active and keep
         // their dedupe lock until their terminal transition releases it.
-        if holder.status == RunDispatchStatus::Queued {
+        if holder.status() == RunDispatchStatus::Queued {
             return purge_lock_if_revision(store, &key, entry.revision).await;
         }
         return Ok(false);
@@ -538,14 +539,14 @@ pub(crate) async fn replace_thread_index_bucket(
 pub(super) async fn cleanup_thread_index(store: &NatsMailboxStore, dispatch: &RunDispatch) {
     if let Err(error) = remove_thread_index_from_bucket(
         &store.kv_thread_index,
-        &dispatch.thread_id,
-        &dispatch.dispatch_id,
+        dispatch.thread_id(),
+        dispatch.dispatch_id(),
     )
     .await
     {
         tracing::warn!(
-            thread_id = %dispatch.thread_id,
-            dispatch_id = %dispatch.dispatch_id,
+            thread_id = %dispatch.thread_id(),
+            dispatch_id = %dispatch.dispatch_id(),
             error = %error,
             "failed to remove terminal dispatch from thread index"
         );
@@ -633,14 +634,14 @@ pub async fn extend_lease(
             return Ok(false);
         }
         let mut dispatch = codec::decode(&entry.value)?;
-        if dispatch.status != RunDispatchStatus::Claimed {
+        if dispatch.status() != RunDispatchStatus::Claimed {
             return Ok(false);
         }
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Ok(false);
         }
-        let thread_epoch = current_thread_epoch(store, &dispatch.thread_id).await?;
-        if dispatch.dispatch_epoch < thread_epoch {
+        let thread_epoch = current_thread_epoch(store, dispatch.thread_id()).await?;
+        if dispatch.dispatch_epoch() < thread_epoch {
             mailbox_state::mark_superseded_at_epoch(
                 &mut dispatch,
                 now,
@@ -658,13 +659,13 @@ pub async fn extend_lease(
                     .write()
                     .await
                     .upsert_with_revision(dispatch.clone(), revision);
-                claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
-                if let Some(ref dedupe_key) = dispatch.dedupe_key {
+                claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token).await?;
+                if let Some(dedupe_key) = dispatch.dedupe_key() {
                     release_dedupe_lock(
                         store,
-                        &dispatch.thread_id,
+                        dispatch.thread_id(),
                         dedupe_key,
-                        &dispatch.dispatch_id,
+                        dispatch.dispatch_id(),
                     )
                     .await;
                 }
@@ -676,7 +677,7 @@ pub async fn extend_lease(
         let lease_until = now.saturating_add(extension_ms);
         if !claim_guard::extend(
             store,
-            &dispatch.thread_id,
+            dispatch.thread_id(),
             dispatch_id,
             claim_token,
             lease_until,
@@ -685,8 +686,7 @@ pub async fn extend_lease(
         {
             return Ok(false);
         }
-        dispatch.lease_until = Some(lease_until);
-        dispatch.updated_at = now;
+        dispatch.extend_lease(lease_until, now)?;
         let bytes = codec::encode(&dispatch)?;
         if let Ok(revision) = store
             .kv_dispatch
@@ -731,12 +731,12 @@ where
         }
         let mut dispatch = codec::decode(&entry.value)?;
         if let Some(now) = stale_check_now
-            && dispatch.status == RunDispatchStatus::Claimed
+            && dispatch.status() == RunDispatchStatus::Claimed
         {
-            let thread_epoch = current_thread_epoch(store, &dispatch.thread_id).await?;
-            if dispatch.dispatch_epoch < thread_epoch {
-                let stale_epoch = dispatch.dispatch_epoch;
-                let old_claim_token = dispatch.claim_token.clone();
+            let thread_epoch = current_thread_epoch(store, dispatch.thread_id()).await?;
+            if dispatch.dispatch_epoch() < thread_epoch {
+                let stale_epoch = dispatch.dispatch_epoch();
+                let old_claim_token = dispatch.claim_token().map(str::to_string);
                 mailbox_state::mark_superseded_at_epoch(
                     &mut dispatch,
                     now,
@@ -755,15 +755,15 @@ where
                         .await
                         .upsert_with_revision(dispatch.clone(), revision);
                     if let Some(ref claim_token) = old_claim_token {
-                        claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token)
+                        claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token)
                             .await?;
                     }
-                    if let Some(ref dedupe_key) = dispatch.dedupe_key {
+                    if let Some(dedupe_key) = dispatch.dedupe_key() {
                         release_dedupe_lock(
                             store,
-                            &dispatch.thread_id,
+                            dispatch.thread_id(),
                             dedupe_key,
-                            &dispatch.dispatch_id,
+                            dispatch.dispatch_id(),
                         )
                         .await;
                     }
@@ -801,13 +801,13 @@ pub async fn ack(
     now: u64,
 ) -> Result<(), StorageError> {
     let result = cas_update(store, dispatch_id, Some(now), |d| {
-        if d.status != RunDispatchStatus::Claimed {
+        if d.status() != RunDispatchStatus::Claimed {
             return Err(StorageError::NotFound(format!(
                 "dispatch {dispatch_id} not claimed (status={:?})",
-                d.status
+                d.status()
             )));
         }
-        if d.claim_token.as_deref() != Some(claim_token) {
+        if d.claim_token() != Some(claim_token) {
             return Err(StorageError::NotFound(format!(
                 "claim_token mismatch for {dispatch_id}"
             )));
@@ -820,15 +820,15 @@ pub async fn ack(
         return Err(StorageError::NotFound(dispatch_id.to_string()));
     }
     if let Some((dispatch, _)) = result {
-        claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+        claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token).await?;
         // Terminal state — release the dedupe lock so a future request
         // with the same key can succeed.
-        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+        if let Some(dedupe_key) = dispatch.dedupe_key() {
             release_dedupe_lock(
                 store,
-                &dispatch.thread_id,
+                dispatch.thread_id(),
                 dedupe_key,
-                &dispatch.dispatch_id,
+                dispatch.dispatch_id(),
             )
             .await;
         }
@@ -846,12 +846,12 @@ pub async fn nack(
     now: u64,
 ) -> Result<(), StorageError> {
     let result = cas_update(store, dispatch_id, Some(now), |d| {
-        if d.status != RunDispatchStatus::Claimed {
+        if d.status() != RunDispatchStatus::Claimed {
             return Err(StorageError::NotFound(format!(
                 "dispatch {dispatch_id} not claimed"
             )));
         }
-        if d.claim_token.as_deref() != Some(claim_token) {
+        if d.claim_token() != Some(claim_token) {
             return Err(StorageError::NotFound(format!(
                 "claim_token mismatch for {dispatch_id}"
             )));
@@ -864,21 +864,21 @@ pub async fn nack(
         return Err(StorageError::NotFound(dispatch_id.to_string()));
     }
     if let Some((dispatch, _)) = result {
-        claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+        claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token).await?;
         // Only release the dedupe lock if THIS attempt was actually
         // terminal (nack can either retry-queue or dead-letter).
-        if dispatch.status == RunDispatchStatus::DeadLetter
-            && let Some(ref dedupe_key) = dispatch.dedupe_key
+        if dispatch.status() == RunDispatchStatus::DeadLetter
+            && let Some(dedupe_key) = dispatch.dedupe_key()
         {
             release_dedupe_lock(
                 store,
-                &dispatch.thread_id,
+                dispatch.thread_id(),
                 dedupe_key,
-                &dispatch.dispatch_id,
+                dispatch.dispatch_id(),
             )
             .await;
         }
-        if dispatch.status == RunDispatchStatus::DeadLetter {
+        if dispatch.status() == RunDispatchStatus::DeadLetter {
             cleanup_thread_index(store, &dispatch).await;
         }
     }
@@ -893,12 +893,12 @@ pub async fn dead_letter(
     now: u64,
 ) -> Result<(), StorageError> {
     let result = cas_update(store, dispatch_id, Some(now), |d| {
-        if d.status != RunDispatchStatus::Claimed {
+        if d.status() != RunDispatchStatus::Claimed {
             return Err(StorageError::NotFound(format!(
                 "dispatch {dispatch_id} not claimed"
             )));
         }
-        if d.claim_token.as_deref() != Some(claim_token) {
+        if d.claim_token() != Some(claim_token) {
             return Err(StorageError::NotFound(format!(
                 "claim_token mismatch for {dispatch_id}"
             )));
@@ -911,13 +911,13 @@ pub async fn dead_letter(
         return Err(StorageError::NotFound(dispatch_id.to_string()));
     }
     if let Some((dispatch, _)) = result {
-        claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
-        if let Some(ref dedupe_key) = dispatch.dedupe_key {
+        claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token).await?;
+        if let Some(dedupe_key) = dispatch.dedupe_key() {
             release_dedupe_lock(
                 store,
-                &dispatch.thread_id,
+                dispatch.thread_id(),
                 dedupe_key,
-                &dispatch.dispatch_id,
+                dispatch.dispatch_id(),
             )
             .await;
         }
@@ -946,19 +946,19 @@ pub async fn supersede_claimed(
             return Ok(None);
         }
         let mut dispatch = codec::decode(&entry.value)?;
-        if dispatch.status != RunDispatchStatus::Claimed {
+        if dispatch.status() != RunDispatchStatus::Claimed {
             return Ok(None);
         }
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
             });
         }
-        let thread_epoch = current_thread_epoch(store, &dispatch.thread_id).await?;
-        let old_claim_token = dispatch.claim_token.clone();
-        dispatch.dispatch_epoch = dispatch.dispatch_epoch.max(thread_epoch);
-        mailbox_state::mark_superseded(&mut dispatch, now, Some(reason));
+        let thread_epoch = current_thread_epoch(store, dispatch.thread_id()).await?;
+        let old_claim_token = dispatch.claim_token().map(str::to_string);
+        let epoch = dispatch.dispatch_epoch().max(thread_epoch);
+        mailbox_state::mark_superseded_at_epoch(&mut dispatch, now, epoch, Some(reason));
         let bytes = codec::encode(&dispatch)?;
         if let Ok(revision) = store
             .kv_dispatch
@@ -971,14 +971,14 @@ pub async fn supersede_claimed(
                 .await
                 .upsert_with_revision(dispatch.clone(), revision);
             if let Some(ref claim_token) = old_claim_token {
-                claim_guard::release(store, &dispatch.thread_id, dispatch_id, claim_token).await?;
+                claim_guard::release(store, dispatch.thread_id(), dispatch_id, claim_token).await?;
             }
-            if let Some(ref dedupe_key) = dispatch.dedupe_key {
+            if let Some(dedupe_key) = dispatch.dedupe_key() {
                 release_dedupe_lock(
                     store,
-                    &dispatch.thread_id,
+                    dispatch.thread_id(),
                     dedupe_key,
-                    &dispatch.dispatch_id,
+                    dispatch.dispatch_id(),
                 )
                 .await;
             }
@@ -997,10 +997,10 @@ pub async fn cancel(
     now: u64,
 ) -> Result<Option<RunDispatch>, StorageError> {
     let result = match cas_update(store, dispatch_id, None, |d| {
-        if d.status != RunDispatchStatus::Queued {
+        if d.status() != RunDispatchStatus::Queued {
             return Err(StorageError::NotFound(format!(
                 "dispatch {dispatch_id} not cancellable (status={:?})",
-                d.status
+                d.status()
             )));
         }
         mailbox_state::mark_cancelled(d, now);
@@ -1014,13 +1014,13 @@ pub async fn cancel(
     };
     let result = result.map(|(dispatch, _)| dispatch);
     if let Some(ref dispatch) = result
-        && let Some(ref dedupe_key) = dispatch.dedupe_key
+        && let Some(dedupe_key) = dispatch.dedupe_key()
     {
         release_dedupe_lock(
             store,
-            &dispatch.thread_id,
+            dispatch.thread_id(),
             dedupe_key,
-            &dispatch.dispatch_id,
+            dispatch.dispatch_id(),
         )
         .await;
     }
@@ -1038,24 +1038,17 @@ pub async fn record_dispatch_start(
     now: u64,
 ) -> Result<(), StorageError> {
     let result = cas_update(store, dispatch_id, Some(now), |d| {
-        if d.claim_token.as_deref() != Some(claim_token) {
+        if d.claim_token() != Some(claim_token) {
             return Err(StorageError::NotFound(format!(
                 "claim_token mismatch for {dispatch_id}"
             )));
         }
-        if d.status != RunDispatchStatus::Claimed {
+        if d.status() != RunDispatchStatus::Claimed {
             return Err(StorageError::NotFound(format!(
                 "dispatch {dispatch_id} not claimed"
             )));
         }
-        d.dispatch_instance_id = Some(dispatch_instance_id.to_string());
-        d.run_status = Some(RunStatus::Running);
-        d.termination = None;
-        d.run_response = None;
-        d.run_error = None;
-        d.completed_at = None;
-        d.updated_at = now;
-        Ok(())
+        d.record_dispatch_start(dispatch_instance_id, now)
     })
     .await?;
     if result.is_none() {
@@ -1072,24 +1065,17 @@ pub async fn record_run_result(
     now: u64,
 ) -> Result<(), StorageError> {
     let updated = cas_update(store, dispatch_id, Some(now), |d| {
-        if d.claim_token.as_deref() != Some(claim_token) {
+        if d.claim_token() != Some(claim_token) {
             return Err(StorageError::NotFound(format!(
                 "claim_token mismatch for {dispatch_id}"
             )));
         }
-        if d.status != RunDispatchStatus::Claimed {
+        if d.status() != RunDispatchStatus::Claimed {
             return Err(StorageError::NotFound(format!(
                 "dispatch {dispatch_id} not claimed"
             )));
         }
-        d.dispatch_instance_id = Some(result.dispatch_instance_id.clone());
-        d.run_status = Some(result.status);
-        d.termination = result.termination.clone();
-        d.run_response = result.response.clone();
-        d.run_error = result.error.clone();
-        d.completed_at = Some(now);
-        d.updated_at = now;
-        Ok(())
+        d.record_run_result(result, now)
     })
     .await?;
     if updated.is_none() {

--- a/crates/awaken-stores/src/nats_mailbox/sweeper.rs
+++ b/crates/awaken-stores/src/nats_mailbox/sweeper.rs
@@ -61,7 +61,7 @@ async fn tick(
             .read()
             .await
             .published
-            .get(&candidate.dispatch_id)
+            .get(candidate.dispatch_id())
             .is_some_and(|published| {
                 now.saturating_sub(published.last_published_at) < republish_after_ms
             });
@@ -72,7 +72,7 @@ async fn tick(
             let mut state_w = state.write().await;
             let entry = state_w
                 .published
-                .entry(candidate.dispatch_id.clone())
+                .entry(candidate.dispatch_id().to_string())
                 .or_insert(PublishedSignal {
                     last_published_at: 0,
                     publish_count: 0,
@@ -82,8 +82,8 @@ async fn tick(
             if entry.publish_count > 1 {
                 metrics::inc_dispatch_signal_republish();
                 tracing::warn!(
-                    thread_id = %candidate.thread_id,
-                    dispatch_id = %candidate.dispatch_id,
+                    thread_id = %candidate.thread_id(),
+                    dispatch_id = %candidate.dispatch_id(),
                     publish_count = entry.publish_count,
                     "republished queued dispatch signal"
                 );
@@ -95,14 +95,14 @@ async fn tick(
     let idx = index.read().await;
     state_w.published.retain(|id, _| {
         idx.get(id)
-            .is_some_and(|d| d.status == RunDispatchStatus::Queued)
+            .is_some_and(|d| d.status() == RunDispatchStatus::Queued)
     });
 }
 
 async fn publish(jetstream: &async_nats::jetstream::Context, dispatch: &RunDispatch) -> bool {
-    let payload = bytes::Bytes::from(dispatch.dispatch_id.clone().into_bytes());
+    let payload = bytes::Bytes::from(dispatch.dispatch_id().as_bytes().to_vec());
     match jetstream
-        .publish(keys::dispatch_subject(&dispatch.thread_id), payload)
+        .publish(keys::dispatch_subject(dispatch.thread_id()), payload)
         .await
     {
         Ok(ack_future) => ack_future.await.is_ok(),

--- a/crates/awaken-stores/src/pending_message_store.rs
+++ b/crates/awaken-stores/src/pending_message_store.rs
@@ -2,7 +2,62 @@ use async_trait::async_trait;
 use awaken_server_contract::contract::message::{
     DeliveryBoundary, DeliveryMode, Message, MessageRecord, PendingMessageRecord,
 };
-use awaken_server_contract::contract::storage::{RunRecord, StorageError, ThreadRunStore};
+use awaken_server_contract::contract::storage::{
+    RunRecord, StorageError, ThreadRunStore, message_append,
+};
+
+pub(crate) fn validate_pending_message_record(
+    record: &PendingMessageRecord,
+) -> Result<(), StorageError> {
+    if record.pending_id.trim().is_empty() {
+        return Err(StorageError::Validation(
+            "pending message id must not be empty".to_string(),
+        ));
+    }
+    if record.thread_id.trim().is_empty() {
+        return Err(StorageError::Validation(format!(
+            "pending message '{}' thread id must not be empty",
+            record.pending_id
+        )));
+    }
+    if record.position == 0 {
+        return Err(StorageError::Validation(format!(
+            "pending message '{}' position must be 1-based",
+            record.pending_id
+        )));
+    }
+    if record.revision == 0 {
+        return Err(StorageError::Validation(format!(
+            "pending message '{}' revision must be 1-based",
+            record.pending_id
+        )));
+    }
+    match record.message.id.as_deref() {
+        Some(message_id) if message_id == record.pending_id => {}
+        Some(message_id) => {
+            return Err(StorageError::Validation(format!(
+                "pending message '{}' cannot carry message id '{}'",
+                record.pending_id, message_id
+            )));
+        }
+        None => {
+            return Err(StorageError::Validation(format!(
+                "pending message '{}' must carry message id",
+                record.pending_id
+            )));
+        }
+    }
+    message_append::validate_message_shape(&record.message, "pending")
+}
+
+pub(crate) fn validate_pending_message_records(
+    records: &[PendingMessageRecord],
+) -> Result<(), StorageError> {
+    for record in records {
+        validate_pending_message_record(record)?;
+    }
+    Ok(())
+}
 
 /// Store-local extension for delivered-but-unconsumed thread messages.
 #[async_trait]

--- a/crates/awaken-stores/src/postgres.rs
+++ b/crates/awaken-stores/src/postgres.rs
@@ -84,6 +84,10 @@ impl PostgresStore {
             self.configs_table,
         )
     }
+
+    pub(crate) fn thread_run_storage_identity_descriptor(&self) -> String {
+        format!("pg-thread-run::{}", self.transaction_scope_descriptor())
+    }
 }
 
 mod config;

--- a/crates/awaken-stores/src/postgres/pending.rs
+++ b/crates/awaken-stores/src/postgres/pending.rs
@@ -4,10 +4,11 @@ use awaken_server_contract::contract::message::{
     pending_queue_revision, select_pending_for_freeze, select_pending_for_freeze_for_run,
 };
 use awaken_server_contract::contract::storage::{RunRecord, StorageError, message_append};
-use sqlx::{Postgres, Row, Transaction};
+use sqlx::{Postgres, Row, Transaction, postgres::PgRow};
 use std::collections::HashSet;
 
 use crate::PendingMessageStore;
+use crate::pending_message_store::validate_pending_message_record;
 
 use super::PostgresStore;
 
@@ -25,6 +26,70 @@ fn already_consumed(pending_id: &str) -> StorageError {
 
 fn duplicate_pending_id(pending_id: &str) -> StorageError {
     StorageError::Validation(format!("pending message '{pending_id}' already exists"))
+}
+
+fn pending_row_decode_error(column: &str, error: impl std::fmt::Display) -> StorageError {
+    StorageError::Serialization(format!(
+        "failed to decode pending message column '{column}': {error}"
+    ))
+}
+
+fn optional_i64(row: &PgRow, column: &str) -> Result<Option<i64>, StorageError> {
+    row.try_get::<Option<i64>, _>(column)
+        .map_err(|error| pending_row_decode_error(column, error))
+}
+
+fn optional_string(row: &PgRow, column: &str) -> Result<Option<String>, StorageError> {
+    row.try_get::<Option<String>, _>(column)
+        .map_err(|error| pending_row_decode_error(column, error))
+}
+
+fn optional_json(row: &PgRow, column: &str) -> Result<Option<serde_json::Value>, StorageError> {
+    row.try_get::<Option<serde_json::Value>, _>(column)
+        .map_err(|error| pending_row_decode_error(column, error))
+}
+
+fn required_nonnegative_u64(row: &PgRow, column: &str, label: &str) -> Result<u64, StorageError> {
+    let value = optional_i64(row, column)?.ok_or_else(|| {
+        StorageError::Serialization(format!("pending message row missing {label}"))
+    })?;
+    u64::try_from(value).map_err(|_| {
+        StorageError::Serialization(format!(
+            "pending message {label} must be non-negative, got {value}"
+        ))
+    })
+}
+
+fn optional_epoch_u64(row: &PgRow, column: &str, unit: &str) -> Result<Option<u64>, StorageError> {
+    optional_i64(row, column)?
+        .map(|value| {
+            u64::try_from(value).map_err(|_| {
+                StorageError::Serialization(format!(
+                    "pending message {column} {unit} must be non-negative, got {value}"
+                ))
+            })
+        })
+        .transpose()
+}
+
+fn decode_delivery_mode(row: &PgRow) -> Result<DeliveryMode, StorageError> {
+    optional_json(row, "delivery_mode")?
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|e| StorageError::Serialization(e.to_string()))
+        .map(|mode| mode.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_row_decode_error_includes_column_name() {
+        let error = pending_row_decode_error("position", "wrong type");
+        assert!(matches!(error, StorageError::Serialization(_)));
+        assert!(error.to_string().contains("position"));
+    }
 }
 
 impl PostgresStore {
@@ -49,53 +114,34 @@ impl PostgresStore {
             .map(|row| {
                 let message: Message = serde_json::from_value(row.get("data"))
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
-                let delivery_mode = row
-                    .try_get::<Option<serde_json::Value>, _>("delivery_mode")
-                    .ok()
-                    .flatten()
-                    .map(serde_json::from_value)
-                    .transpose()
-                    .map_err(|e| StorageError::Serialization(e.to_string()))?
-                    .unwrap_or_default();
-                let position = row
-                    .try_get::<Option<i64>, _>("position")
-                    .ok()
-                    .flatten()
-                    .unwrap_or(0) as u64;
-                let pending_id = row
-                    .try_get::<Option<String>, _>("message_id")
-                    .ok()
-                    .flatten()
+                let delivery_mode = decode_delivery_mode(&row)?;
+                let position = required_nonnegative_u64(&row, "position", "position")?;
+                let pending_id = optional_string(&row, "message_id")?
                     .or_else(|| message.id.clone())
                     .ok_or_else(|| {
                         StorageError::Serialization(
                             "pending message row has no message_id or message.id".to_string(),
                         )
                     })?;
-                let created_at = row
-                    .try_get::<Option<i64>, _>("created_at_ms")
-                    .ok()
-                    .flatten()
-                    .map(|ms| (ms as u64) / 1000);
-                let updated_at = row
-                    .try_get::<Option<i64>, _>("updated_at_s")
-                    .ok()
-                    .flatten()
-                    .map(|seconds| seconds as u64);
-                Ok(PendingMessageRecord {
+                let created_at =
+                    optional_epoch_u64(&row, "created_at_ms", "milliseconds")?.map(|ms| ms / 1000);
+                let updated_at = optional_epoch_u64(&row, "updated_at_s", "seconds")?;
+                let record = PendingMessageRecord {
                     pending_id,
                     thread_id: thread_id.to_owned(),
                     position,
                     message,
-                    revision: row
-                        .try_get::<Option<i64>, _>("pending_revision")
-                        .ok()
-                        .flatten()
-                        .unwrap_or(1) as u64,
+                    revision: required_nonnegative_u64(
+                        &row,
+                        "pending_revision",
+                        "pending_revision",
+                    )?,
                     delivery_mode,
                     created_at,
                     updated_at,
-                })
+                };
+                validate_pending_message_record(&record)?;
+                Ok(record)
             })
             .collect()
     }
@@ -124,6 +170,7 @@ impl PostgresStore {
         tx: &mut Transaction<'_, Postgres>,
         record: &PendingMessageRecord,
     ) -> Result<(), StorageError> {
+        validate_pending_message_record(record)?;
         let data = serde_json::to_value(&record.message)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         let delivery_mode = serde_json::to_value(record.delivery_mode.clone())
@@ -230,6 +277,7 @@ impl PendingMessageStore for PostgresStore {
             .map(|record| record.pending_id.as_str())
             .collect::<HashSet<_>>();
         for record in &records {
+            validate_pending_message_record(record)?;
             if !seen.insert(record.pending_id.as_str()) {
                 return Err(duplicate_pending_id(&record.pending_id));
             }
@@ -266,6 +314,17 @@ impl PendingMessageStore for PostgresStore {
             Some(_) => {}
             None => message.id = Some(pending_id.to_owned()),
         }
+        let pending_message = PendingMessageRecord {
+            pending_id: pending_id.to_owned(),
+            thread_id: thread_id.to_owned(),
+            position: 1,
+            message: message.clone(),
+            revision: 1,
+            delivery_mode: DeliveryMode::default(),
+            created_at: None,
+            updated_at: None,
+        };
+        validate_pending_message_record(&pending_message)?;
         let mut tx = self
             .pool
             .begin()
@@ -310,36 +369,15 @@ impl PendingMessageStore for PostgresStore {
         let record = PendingMessageRecord {
             pending_id: pending_id.to_owned(),
             thread_id: thread_id.to_owned(),
-            position: row
-                .try_get::<Option<i64>, _>("position")
-                .ok()
-                .flatten()
-                .unwrap_or(0) as u64,
-            revision: row
-                .try_get::<Option<i64>, _>("pending_revision")
-                .ok()
-                .flatten()
-                .unwrap_or(1) as u64,
+            position: required_nonnegative_u64(&row, "position", "position")?,
+            revision: required_nonnegative_u64(&row, "pending_revision", "pending_revision")?,
             message,
-            delivery_mode: row
-                .try_get::<Option<serde_json::Value>, _>("delivery_mode")
-                .ok()
-                .flatten()
-                .map(serde_json::from_value)
-                .transpose()
-                .map_err(|e| StorageError::Serialization(e.to_string()))?
-                .unwrap_or_default(),
-            created_at: row
-                .try_get::<Option<i64>, _>("created_at_ms")
-                .ok()
-                .flatten()
-                .map(|ms| (ms as u64) / 1000),
-            updated_at: row
-                .try_get::<Option<i64>, _>("updated_at_s")
-                .ok()
-                .flatten()
-                .map(|seconds| seconds as u64),
+            delivery_mode: decode_delivery_mode(&row)?,
+            created_at: optional_epoch_u64(&row, "created_at_ms", "milliseconds")?
+                .map(|ms| ms / 1000),
+            updated_at: optional_epoch_u64(&row, "updated_at_s", "seconds")?,
         };
+        validate_pending_message_record(&record)?;
         tx.commit()
             .await
             .map_err(|e| StorageError::Io(e.to_string()))?;
@@ -605,6 +643,7 @@ impl PostgresStore {
                 );
                 record.created_at = Some(now);
                 record.updated_at = Some(now);
+                validate_pending_message_record(&record)?;
                 if !seen.insert(record.pending_id.clone()) {
                     return Err(duplicate_pending_id(&record.pending_id));
                 }

--- a/crates/awaken-stores/src/postgres/run.rs
+++ b/crates/awaken-stores/src/postgres/run.rs
@@ -5,6 +5,7 @@ use awaken_server_contract::contract::storage::{
     checkpoint_parent_thread_id, message_append,
 };
 use awaken_server_contract::thread::Thread;
+use serde::de::DeserializeOwned;
 use sqlx::Row;
 use sqlx::postgres::PgRow;
 
@@ -17,48 +18,33 @@ const RUN_COLUMNS: &str = concat!(
     "started_at, finished_at, updated_at, steps, input_tokens, output_tokens, state"
 );
 
+fn optional_json<T: serde::Serialize>(
+    field: &str,
+    value: Option<&T>,
+) -> Result<Option<serde_json::Value>, StorageError> {
+    value
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|error| StorageError::Serialization(format!("serialize run {field}: {error}")))
+}
+
 // ── RunStore ────────────────────────────────────────────────────────
 
 #[async_trait]
 impl RunStore for PostgresStore {
     async fn create_run(&self, record: &RunRecord) -> Result<(), StorageError> {
+        record.validate_for_persist()?;
         self.ensure_schema().await?;
-        let state_json = record
-            .state
-            .as_ref()
-            .and_then(|s| serde_json::to_value(s).ok());
-        let termination_reason_json = record
-            .termination_reason
-            .as_ref()
-            .and_then(|reason| serde_json::to_value(reason).ok());
-        let activation_json = record
-            .activation
-            .as_ref()
-            .and_then(|activation| serde_json::to_value(activation).ok());
-        let request_json = record
-            .request
-            .as_ref()
-            .and_then(|request| serde_json::to_value(request).ok());
-        let input_json = record
-            .input
-            .as_ref()
-            .and_then(|input| serde_json::to_value(input).ok());
-        let output_json = record
-            .output
-            .as_ref()
-            .and_then(|output| serde_json::to_value(output).ok());
-        let waiting_json = record
-            .waiting
-            .as_ref()
-            .and_then(|waiting| serde_json::to_value(waiting).ok());
-        let outcome_json = record
-            .outcome
-            .as_ref()
-            .and_then(|outcome| serde_json::to_value(outcome).ok());
-        let resolution_id_json = record
-            .resolution_id
-            .as_ref()
-            .and_then(|manifest| serde_json::to_value(manifest).ok());
+        let state_json = optional_json("state", record.state.as_ref())?;
+        let termination_reason_json =
+            optional_json("termination_reason", record.termination_reason.as_ref())?;
+        let activation_json = optional_json("activation", record.activation.as_ref())?;
+        let request_json = optional_json("request", record.request.as_ref())?;
+        let input_json = optional_json("input", record.input.as_ref())?;
+        let output_json = optional_json("output", record.output.as_ref())?;
+        let waiting_json = optional_json("waiting", record.waiting.as_ref())?;
+        let outcome_json = optional_json("outcome", record.outcome.as_ref())?;
+        let resolution_id_json = optional_json("resolution_id", record.resolution_id.as_ref())?;
         let sql = format!(
             "INSERT INTO {} (run_id, thread_id, agent_id, parent_run_id, resolution_id, activation, request, run_input, run_output, status, termination_reason, final_output, error_payload, dispatch_id, session_id, transport_request_id, waiting, outcome, created_at, started_at, finished_at, updated_at, steps, input_tokens, output_tokens, state)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)",
@@ -117,7 +103,7 @@ impl RunStore for PostgresStore {
             .await
             .map_err(|e| StorageError::Io(e.to_string()))?;
 
-        Ok(row.map(run_record_from_pg_row))
+        row.map(try_run_record_from_pg_row).transpose()
     }
 
     async fn latest_run(&self, thread_id: &str) -> Result<Option<RunRecord>, StorageError> {
@@ -132,7 +118,7 @@ impl RunStore for PostgresStore {
             .await
             .map_err(|e| StorageError::Io(e.to_string()))?;
 
-        Ok(row.map(run_record_from_pg_row))
+        row.map(try_run_record_from_pg_row).transpose()
     }
 
     async fn list_runs(&self, query: &RunQuery) -> Result<RunPage, StorageError> {
@@ -208,7 +194,10 @@ impl RunStore for PostgresStore {
                 .map_err(|e| StorageError::Io(e.to_string()))?
         };
 
-        let items: Vec<RunRecord> = rows.into_iter().map(run_record_from_pg_row).collect();
+        let items: Vec<RunRecord> = rows
+            .into_iter()
+            .map(try_run_record_from_pg_row)
+            .collect::<Result<_, _>>()?;
 
         let has_more = (query.offset + items.len()) < total as usize;
         Ok(RunPage {
@@ -331,43 +320,18 @@ impl PostgresStore {
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         run: &RunRecord,
     ) -> Result<(), StorageError> {
+        run.validate_for_persist()?;
         // Upsert run record
-        let state_json = run
-            .state
-            .as_ref()
-            .and_then(|s| serde_json::to_value(s).ok());
-        let termination_reason_json = run
-            .termination_reason
-            .as_ref()
-            .and_then(|reason| serde_json::to_value(reason).ok());
-        let activation_json = run
-            .activation
-            .as_ref()
-            .and_then(|activation| serde_json::to_value(activation).ok());
-        let request_json = run
-            .request
-            .as_ref()
-            .and_then(|request| serde_json::to_value(request).ok());
-        let input_json = run
-            .input
-            .as_ref()
-            .and_then(|input| serde_json::to_value(input).ok());
-        let output_json = run
-            .output
-            .as_ref()
-            .and_then(|output| serde_json::to_value(output).ok());
-        let waiting_json = run
-            .waiting
-            .as_ref()
-            .and_then(|waiting| serde_json::to_value(waiting).ok());
-        let outcome_json = run
-            .outcome
-            .as_ref()
-            .and_then(|outcome| serde_json::to_value(outcome).ok());
-        let resolution_id_json = run
-            .resolution_id
-            .as_ref()
-            .and_then(|manifest| serde_json::to_value(manifest).ok());
+        let state_json = optional_json("state", run.state.as_ref())?;
+        let termination_reason_json =
+            optional_json("termination_reason", run.termination_reason.as_ref())?;
+        let activation_json = optional_json("activation", run.activation.as_ref())?;
+        let request_json = optional_json("request", run.request.as_ref())?;
+        let input_json = optional_json("input", run.input.as_ref())?;
+        let output_json = optional_json("output", run.output.as_ref())?;
+        let waiting_json = optional_json("waiting", run.waiting.as_ref())?;
+        let outcome_json = optional_json("outcome", run.outcome.as_ref())?;
+        let resolution_id_json = optional_json("resolution_id", run.resolution_id.as_ref())?;
         let run_sql = format!(
             "INSERT INTO {} (run_id, thread_id, agent_id, parent_run_id, resolution_id, activation, request, run_input, run_output, status, termination_reason, final_output, error_payload, dispatch_id, session_id, transport_request_id, waiting, outcome, created_at, started_at, finished_at, updated_at, steps, input_tokens, output_tokens, state)
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
@@ -430,6 +394,10 @@ impl PostgresStore {
 
 #[async_trait]
 impl ThreadRunStore for PostgresStore {
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        Some(self.thread_run_storage_identity_descriptor())
+    }
+
     async fn checkpoint(
         &self,
         thread_id: &str,
@@ -499,7 +467,8 @@ impl ThreadRunStore for PostgresStore {
             .fetch_optional(&mut *tx)
             .await
             .map_err(|e| StorageError::Io(e.to_string()))?
-            .map(run_record_from_pg_row);
+            .map(try_run_record_from_pg_row)
+            .transpose()?;
 
         if records.is_empty() && latest_run.is_none() {
             return Ok(None);
@@ -551,7 +520,17 @@ pub(super) fn like_prefix_pattern(prefix: &str) -> String {
     pattern
 }
 
-fn run_record_from_pg_row(row: PgRow) -> RunRecord {
+fn optional_row_json<T: DeserializeOwned>(
+    field: &str,
+    value: Option<serde_json::Value>,
+) -> Result<Option<T>, StorageError> {
+    value
+        .map(serde_json::from_value)
+        .transpose()
+        .map_err(|error| StorageError::Serialization(format!("decode run {field}: {error}")))
+}
+
+fn try_run_record_from_pg_row(row: PgRow) -> Result<RunRecord, StorageError> {
     let status: String = row.get("status");
     let state: Option<serde_json::Value> = row.get("state");
     let resolution_id: Option<serde_json::Value> = row.get("resolution_id");
@@ -570,25 +549,25 @@ fn run_record_from_pg_row(row: PgRow) -> RunRecord {
     let input_tokens: i64 = row.get("input_tokens");
     let output_tokens: i64 = row.get("output_tokens");
 
-    RunRecord {
+    let record = RunRecord {
         run_id: row.get("run_id"),
         thread_id: row.get("thread_id"),
         agent_id: row.get("agent_id"),
         parent_run_id: row.get("parent_run_id"),
-        resolution_id: resolution_id.and_then(|value| serde_json::from_value(value).ok()),
-        activation: activation.and_then(|value| serde_json::from_value(value).ok()),
-        request: request.and_then(|value| serde_json::from_value(value).ok()),
-        input: input.and_then(|value| serde_json::from_value(value).ok()),
-        output: output.and_then(|value| serde_json::from_value(value).ok()),
-        status: parse_run_status(&status),
-        termination_reason: termination_reason.and_then(|value| serde_json::from_value(value).ok()),
+        resolution_id: optional_row_json("resolution_id", resolution_id)?,
+        activation: optional_row_json("activation", activation)?,
+        request: optional_row_json("request", request)?,
+        input: optional_row_json("run_input", input)?,
+        output: optional_row_json("run_output", output)?,
+        status: parse_run_status(&status)?,
+        termination_reason: optional_row_json("termination_reason", termination_reason)?,
         final_output: row.get("final_output"),
         error_payload: row.get("error_payload"),
         dispatch_id: row.get("dispatch_id"),
         session_id: row.get("session_id"),
         transport_request_id: row.get("transport_request_id"),
-        waiting: waiting.and_then(|value| serde_json::from_value(value).ok()),
-        outcome: outcome.and_then(|value| serde_json::from_value(value).ok()),
+        waiting: optional_row_json("waiting", waiting)?,
+        outcome: optional_row_json("outcome", outcome)?,
         created_at: created_at as u64,
         started_at: started_at.map(|value| value as u64),
         finished_at: finished_at.map(|value| value as u64),
@@ -596,17 +575,102 @@ fn run_record_from_pg_row(row: PgRow) -> RunRecord {
         steps: steps as usize,
         input_tokens: input_tokens as u64,
         output_tokens: output_tokens as u64,
-        state: state.and_then(|value| serde_json::from_value(value).ok()),
+        state: optional_row_json("state", state)?,
+    };
+    validate_decoded_run_record(record)
+}
+
+fn validate_decoded_run_record(record: RunRecord) -> Result<RunRecord, StorageError> {
+    record.validate_for_persist()?;
+    Ok(record)
+}
+
+pub(super) fn parse_run_status(
+    s: &str,
+) -> Result<awaken_server_contract::contract::lifecycle::RunStatus, StorageError> {
+    use awaken_server_contract::contract::lifecycle::RunStatus;
+    match s {
+        "created" => Ok(RunStatus::Created),
+        "running" => Ok(RunStatus::Running),
+        "waiting" => Ok(RunStatus::Waiting),
+        "done" => Ok(RunStatus::Done),
+        other => Err(StorageError::Validation(format!(
+            "unknown run status '{other}'"
+        ))),
     }
 }
 
-pub(super) fn parse_run_status(s: &str) -> awaken_server_contract::contract::lifecycle::RunStatus {
-    use awaken_server_contract::contract::lifecycle::RunStatus;
-    match s {
-        "created" => RunStatus::Created,
-        "running" => RunStatus::Running,
-        "waiting" => RunStatus::Waiting,
-        "done" => RunStatus::Done,
-        _ => RunStatus::Running,
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::ser::Error as _;
+
+    struct FailingSerialize;
+
+    impl serde::Serialize for FailingSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(S::Error::custom("injected serialization failure"))
+        }
+    }
+
+    #[test]
+    fn optional_json_propagates_serialization_errors() {
+        let error = optional_json("state", Some(&FailingSerialize)).unwrap_err();
+
+        assert!(
+            matches!(error, StorageError::Serialization(ref message)
+                if message.contains("serialize run state")
+                    && message.contains("injected serialization failure")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn decoded_run_record_validation_rejects_corrupt_activation() {
+        let record = RunRecord {
+            run_id: "run-1".to_string(),
+            thread_id: "thread-1".to_string(),
+            agent_id: "agent-1".to_string(),
+            status: awaken_server_contract::contract::lifecycle::RunStatus::Running,
+            created_at: 1,
+            updated_at: 1,
+            activation: Some(
+                awaken_server_contract::contract::run::RunActivationSnapshot {
+                    intent: awaken_server_contract::contract::run::RunIntent::new("other-thread"),
+                    input: awaken_server_contract::contract::run::RunInputSnapshot {
+                        thread_id: "other-thread".to_string(),
+                        ..Default::default()
+                    },
+                    options: awaken_server_contract::contract::run::RunOptions::default(),
+                    trace: awaken_server_contract::contract::run::RunTraceContext::default(),
+                    seeded_decisions: Vec::new(),
+                    resolution_id: None,
+                },
+            ),
+            ..Default::default()
+        };
+
+        let error = validate_decoded_run_record(record).unwrap_err();
+
+        assert!(
+            matches!(error, StorageError::Validation(ref message)
+                if message.contains("activation thread_id")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn optional_row_json_propagates_decode_errors() {
+        let error: StorageError =
+            optional_row_json::<String>("resolution_id", Some(serde_json::json!({}))).unwrap_err();
+
+        assert!(
+            matches!(error, StorageError::Serialization(ref message)
+                if message.contains("decode run resolution_id")),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/awaken-stores/src/postgres/tests.rs
+++ b/crates/awaken-stores/src/postgres/tests.rs
@@ -15,17 +15,31 @@ use super::run::parse_run_status;
 #[test]
 fn parse_run_status_known_values() {
     use awaken_server_contract::contract::lifecycle::RunStatus;
-    assert!(matches!(parse_run_status("created"), RunStatus::Created));
-    assert!(matches!(parse_run_status("running"), RunStatus::Running));
-    assert!(matches!(parse_run_status("waiting"), RunStatus::Waiting));
-    assert!(matches!(parse_run_status("done"), RunStatus::Done));
+    assert!(matches!(
+        parse_run_status("created").unwrap(),
+        RunStatus::Created
+    ));
+    assert!(matches!(
+        parse_run_status("running").unwrap(),
+        RunStatus::Running
+    ));
+    assert!(matches!(
+        parse_run_status("waiting").unwrap(),
+        RunStatus::Waiting
+    ));
+    assert!(matches!(parse_run_status("done").unwrap(), RunStatus::Done));
 }
 
 #[test]
-fn parse_run_status_unknown_defaults_to_running() {
-    use awaken_server_contract::contract::lifecycle::RunStatus;
-    assert!(matches!(parse_run_status("unknown"), RunStatus::Running));
-    assert!(matches!(parse_run_status(""), RunStatus::Running));
+fn parse_run_status_unknown_returns_validation_error() {
+    assert!(matches!(
+        parse_run_status("unknown"),
+        Err(StorageError::Validation(message)) if message.contains("unknown run status")
+    ));
+    assert!(matches!(
+        parse_run_status(""),
+        Err(StorageError::Validation(message)) if message.contains("unknown run status")
+    ));
 }
 
 #[test]

--- a/crates/awaken-stores/src/postgres/thread.rs
+++ b/crates/awaken-stores/src/postgres/thread.rs
@@ -4,14 +4,37 @@ use awaken_server_contract::contract::message::{
 };
 use awaken_server_contract::contract::storage::{
     ChildThreadDeleteStrategy, MessagePage, MessageQuery, StorageError, ThreadPage,
-    ThreadParentFilter, ThreadQuery, ThreadStore, paginate_message_records,
+    ThreadParentFilter, ThreadQuery, ThreadStore, message_append, paginate_message_records,
 };
 use awaken_server_contract::thread::{Thread, normalize_lineage_id_owned};
 use sqlx::{Postgres, Row, Transaction};
 
+use crate::message_validation::validate_committed_message_records;
+
 use super::PostgresStore;
 
+fn committed_seq_to_u64(value: i64) -> Result<u64, StorageError> {
+    u64::try_from(value).map_err(|_| {
+        StorageError::Serialization(format!(
+            "committed message seq must be non-negative, got {value}"
+        ))
+    })
+}
+
 impl PostgresStore {
+    fn decode_committed_message(
+        thread_id: &str,
+        seq: u64,
+        message: Message,
+    ) -> Result<MessageRecord, StorageError> {
+        message_append::validate_message_shape(&message, "committed")?;
+        Ok(MessageRecord::from_message(
+            thread_id.to_owned(),
+            seq,
+            message,
+        ))
+    }
+
     pub(super) fn decode_committed_message_rows(
         rows: Vec<sqlx::postgres::PgRow>,
         thread_id: &str,
@@ -19,26 +42,32 @@ impl PostgresStore {
         let mut records = Vec::new();
         for row in rows {
             let data: serde_json::Value = row.get("data");
-            let seq: Option<i64> = row.try_get("seq").ok().flatten();
+            let seq: Option<i64> = row.try_get("seq").map_err(|error| {
+                StorageError::Serialization(format!(
+                    "failed to decode committed message seq: {error}"
+                ))
+            })?;
             if seq.is_none() && data.is_array() {
                 let messages: Vec<Message> = serde_json::from_value(data)
                     .map_err(|e| StorageError::Serialization(e.to_string()))?;
-                records.extend(messages.into_iter().enumerate().map(|(index, message)| {
-                    MessageRecord::from_message(thread_id.to_owned(), index as u64 + 1, message)
-                }));
+                for (index, message) in messages.into_iter().enumerate() {
+                    records.push(Self::decode_committed_message(
+                        thread_id,
+                        index as u64 + 1,
+                        message,
+                    )?);
+                }
                 continue;
             }
             let message: Message = serde_json::from_value(data)
                 .map_err(|e| StorageError::Serialization(e.to_string()))?;
             let seq = seq
-                .map(|value| value as u64)
+                .map(committed_seq_to_u64)
+                .transpose()?
                 .unwrap_or(records.len() as u64 + 1);
-            records.push(MessageRecord::from_message(
-                thread_id.to_owned(),
-                seq,
-                message,
-            ));
+            records.push(Self::decode_committed_message(thread_id, seq, message)?);
         }
+        validate_committed_message_records(thread_id, &records)?;
         Ok(records)
     }
 
@@ -167,6 +196,7 @@ impl PostgresStore {
     ) -> Result<(), StorageError> {
         let mut normalized = thread.clone();
         normalized.normalize_lineage();
+        normalized.validate_for_persist()?;
         let data = serde_json::to_value(&normalized)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         let sql = format!(
@@ -319,6 +349,49 @@ impl PostgresStore {
             };
             current_thread_id = next_parent_thread_id;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn committed_seq_to_u64_rejects_negative_values() {
+        let error = committed_seq_to_u64(-1).expect_err("negative seq must fail");
+        assert!(matches!(error, StorageError::Serialization(_)));
+        assert!(error.to_string().contains("-1"));
+    }
+
+    #[test]
+    fn committed_message_decode_rejects_missing_message_id() {
+        let mut message = Message::user("missing id");
+        message.id = None;
+
+        let error = PostgresStore::decode_committed_message("thread-1", 1, message)
+            .expect_err("missing id must fail");
+
+        assert!(matches!(error, StorageError::Validation(_)));
+    }
+
+    #[test]
+    fn committed_message_records_must_be_continuous() {
+        let first = MessageRecord::from_message(
+            "thread-1",
+            1,
+            Message::user("one").with_id("msg-1".to_string()),
+        );
+        let third = MessageRecord::from_message(
+            "thread-1",
+            3,
+            Message::user("three").with_id("msg-3".to_string()),
+        );
+
+        let error = validate_committed_message_records("thread-1", &[first, third])
+            .expect_err("gap must fail");
+
+        assert!(matches!(error, StorageError::Serialization(_)));
+        assert!(error.to_string().contains("continuous"));
     }
 }
 

--- a/crates/awaken-stores/src/postgres_commit_coordinator.rs
+++ b/crates/awaken-stores/src/postgres_commit_coordinator.rs
@@ -60,6 +60,10 @@ impl CommitCoordinator for PgCommitCoordinator {
         self.scope.clone()
     }
 
+    fn thread_run_storage_identity(&self) -> Option<String> {
+        Some(self.store.thread_run_storage_identity_descriptor())
+    }
+
     fn reader(&self) -> Arc<dyn awaken_server_contract::contract::storage::RuntimeCheckpointStore> {
         Arc::new(
             awaken_server_contract::contract::storage::ThreadRunCheckpointStore::new(Arc::clone(

--- a/crates/awaken-stores/src/postgres_versioned_registry.rs
+++ b/crates/awaken-stores/src/postgres_versioned_registry.rs
@@ -69,7 +69,7 @@ impl VersionedRegistryStore for PostgresStore {
             .fetch_optional(&self.pool)
             .await
             .map_err(to_registry_error)?;
-        Ok(row.map(resource_from_row))
+        row.map(resource_from_row).transpose()
     }
 
     async fn current(
@@ -99,7 +99,7 @@ impl VersionedRegistryStore for PostgresStore {
             .fetch_optional(&self.pool)
             .await
             .map_err(to_registry_error)?;
-        Ok(row.map(record_from_row))
+        row.map(record_from_row).transpose()
     }
 
     async fn get(
@@ -126,7 +126,7 @@ impl VersionedRegistryStore for PostgresStore {
             .fetch_optional(&self.pool)
             .await
             .map_err(to_registry_error)?;
-        Ok(row.map(record_from_row))
+        row.map(record_from_row).transpose()
     }
 
     async fn list_versions(
@@ -152,7 +152,7 @@ impl VersionedRegistryStore for PostgresStore {
             .fetch_all(&self.pool)
             .await
             .map_err(to_registry_error)?;
-        Ok(rows.into_iter().map(record_from_row).collect())
+        rows.into_iter().map(record_from_row).collect()
     }
 
     async fn publish_resource(
@@ -429,7 +429,10 @@ impl VersionedRegistryStore for PostgresStore {
             .fetch_one(&mut *tx)
             .await
             .map_err(to_registry_error)?;
-        let snapshot_version = i64_to_u64(snapshot_row.get("snapshot_version"));
+        let snapshot_version = checked_i64_to_u64(
+            "registry_publications.next_snapshot_version",
+            snapshot_row.get("snapshot_version"),
+        )?;
         let source_revisions = serde_json::to_value(&source_config_revisions)
             .map_err(|error| VersionedRegistryError::Serialization(error.to_string()))?;
         let insert_pub_sql = format!(
@@ -574,7 +577,10 @@ impl VersionedRegistryStore for PostgresStore {
             .fetch_one(&mut *tx)
             .await
             .map_err(to_registry_error)?;
-        let snapshot_version = i64_to_u64(snapshot_row.get("snapshot_version"));
+        let snapshot_version = checked_i64_to_u64(
+            "registry_publications.next_snapshot_version",
+            snapshot_row.get("snapshot_version"),
+        )?;
         let source_revisions = serde_json::to_value(&source_config_revisions)
             .map_err(|error| VersionedRegistryError::Serialization(error.to_string()))?;
         let insert_pub_sql = format!(

--- a/crates/awaken-stores/src/postgres_versioned_registry/helpers.rs
+++ b/crates/awaken-stores/src/postgres_versioned_registry/helpers.rs
@@ -36,7 +36,7 @@ pub(super) async fn load_resource_state_tx(
         .fetch_optional(&mut **tx)
         .await
         .map_err(to_registry_error)?;
-    Ok(row.map(resource_from_row))
+    row.map(resource_from_row).transpose()
 }
 
 pub(super) async fn load_version_tx(
@@ -62,7 +62,7 @@ pub(super) async fn load_version_tx(
         .fetch_optional(&mut **tx)
         .await
         .map_err(to_registry_error)?;
-    Ok(row.map(record_from_row))
+    row.map(record_from_row).transpose()
 }
 
 pub(super) async fn next_version_tx(
@@ -86,7 +86,7 @@ pub(super) async fn next_version_tx(
         .await
         .map_err(to_registry_error)?;
     let next_version: i64 = row.get("next_version");
-    Ok(next_version as u64)
+    checked_i64_to_u64("next_version", next_version)
 }
 
 pub(super) async fn insert_version_tx(
@@ -219,24 +219,33 @@ pub(super) async fn load_publication_with_entries(
         .await
         .map_err(to_registry_error)?
         .into_iter()
-        .map(|entry| VersionRef {
-            kind: entry.get("kind"),
-            id: entry.get("id"),
-            version: i64_to_u64(entry.get("version")),
+        .map(|entry| {
+            Ok(VersionRef {
+                kind: entry.get("kind"),
+                id: entry.get("id"),
+                version: checked_i64_to_u64("publication_entries.version", entry.get("version"))?,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, VersionedRegistryError>>()?;
     let source_config_revisions: Value = row.get("source_config_revisions_json");
     let source_config_revisions =
         serde_json::from_value::<Vec<ConfigRevisionRef>>(source_config_revisions)
             .map_err(|error| VersionedRegistryError::Serialization(error.to_string()))?;
+    let snapshot_version = checked_i64_to_u64(
+        "registry_publications.snapshot_version",
+        snapshot_version_i64,
+    )?;
     Ok(Some(RegistryPublication {
         publication_id: row.get("publication_id"),
         scope_id,
-        snapshot_version: snapshot_version_i64 as u64,
+        snapshot_version,
         entries,
         source_config_revisions,
         created_by: row.get("created_by"),
-        created_at_ms: i64_to_u64(row.get("created_at_ms")),
+        created_at_ms: checked_i64_to_u64(
+            "registry_publications.created_at_ms",
+            row.get("created_at_ms"),
+        )?,
         metadata: row.get("metadata_json"),
     }))
 }
@@ -304,32 +313,51 @@ pub(super) fn validate_publication_request(
     Ok(())
 }
 
-pub(super) fn resource_from_row(row: PgRow) -> VersionedResourceState {
-    VersionedResourceState {
+pub(super) fn resource_from_row(
+    row: PgRow,
+) -> Result<VersionedResourceState, VersionedRegistryError> {
+    Ok(VersionedResourceState {
         scope_id: row.get("scope_id"),
         kind: row.get("kind"),
         id: row.get("id"),
-        current_version: row.get::<Option<i64>, _>("current_version").map(i64_to_u64),
-        archived_at_ms: row.get::<Option<i64>, _>("archived_at_ms").map(i64_to_u64),
-        created_at_ms: i64_to_u64(row.get("created_at_ms")),
-        updated_at_ms: i64_to_u64(row.get("updated_at_ms")),
+        current_version: row
+            .get::<Option<i64>, _>("current_version")
+            .map(|value| checked_i64_to_u64("registry_resources.current_version", value))
+            .transpose()?,
+        archived_at_ms: row
+            .get::<Option<i64>, _>("archived_at_ms")
+            .map(|value| checked_i64_to_u64("registry_resources.archived_at_ms", value))
+            .transpose()?,
+        created_at_ms: checked_i64_to_u64(
+            "registry_resources.created_at_ms",
+            row.get("created_at_ms"),
+        )?,
+        updated_at_ms: checked_i64_to_u64(
+            "registry_resources.updated_at_ms",
+            row.get("updated_at_ms"),
+        )?,
         metadata: row.get("metadata_json"),
-    }
+    })
 }
 
-pub(super) fn record_from_row(row: PgRow) -> VersionedRecord<Value> {
+pub(super) fn record_from_row(
+    row: PgRow,
+) -> Result<VersionedRecord<Value>, VersionedRegistryError> {
     let canonical_value_json: String = row.get("canonical_value_json");
-    VersionedRecord {
+    Ok(VersionedRecord {
         kind: row.get("kind"),
         id: row.get("id"),
-        version: i64_to_u64(row.get("version")),
+        version: checked_i64_to_u64("registry_versions.version", row.get("version"))?,
         content_hash: row.get("content_hash"),
         value_schema_version: row.get::<i32, _>("value_schema_version") as u32,
         value: row.get("value_json"),
         canonical_json_bytes: canonical_value_json.into_bytes(),
-        created_at_ms: i64_to_u64(row.get("created_at_ms")),
+        created_at_ms: checked_i64_to_u64(
+            "registry_versions.created_at_ms",
+            row.get("created_at_ms"),
+        )?,
         metadata: row.get("metadata_json"),
-    }
+    })
 }
 
 pub(super) fn canonical_json_string(bytes: &[u8]) -> Result<String, VersionedRegistryError> {
@@ -337,8 +365,22 @@ pub(super) fn canonical_json_string(bytes: &[u8]) -> Result<String, VersionedReg
         .map_err(|error| VersionedRegistryError::Serialization(error.to_string()))
 }
 
-pub(super) fn i64_to_u64(value: i64) -> u64 {
-    value.try_into().unwrap_or_default()
+pub(super) fn checked_i64_to_u64(field: &str, value: i64) -> Result<u64, VersionedRegistryError> {
+    value.try_into().map_err(|_| {
+        VersionedRegistryError::Serialization(format!("{field} contains negative value {value}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn i64_to_u64_rejects_negative_values() {
+        let error = checked_i64_to_u64("field", -1).expect_err("negative values must fail");
+        assert!(matches!(error, VersionedRegistryError::Serialization(_)));
+        assert!(error.to_string().contains("negative value -1"));
+    }
 }
 
 pub(super) fn from_storage_error(error: StorageError) -> VersionedRegistryError {

--- a/crates/awaken-stores/src/postgres_versioned_registry_schema.rs
+++ b/crates/awaken-stores/src/postgres_versioned_registry_schema.rs
@@ -15,10 +15,10 @@ pub(crate) async fn ensure_versioned_registry_schema(
                 scope_id TEXT NOT NULL DEFAULT 'default',
                 kind TEXT NOT NULL,
                 id TEXT NOT NULL,
-                current_version BIGINT,
-                archived_at_ms BIGINT,
-                created_at_ms BIGINT NOT NULL,
-                updated_at_ms BIGINT NOT NULL,
+                current_version BIGINT CHECK (current_version IS NULL OR current_version > 0),
+                archived_at_ms BIGINT CHECK (archived_at_ms IS NULL OR archived_at_ms >= 0),
+                created_at_ms BIGINT NOT NULL CHECK (created_at_ms >= 0),
+                updated_at_ms BIGINT NOT NULL CHECK (updated_at_ms >= 0),
                 metadata_json JSONB NOT NULL DEFAULT '{{}}',
                 PRIMARY KEY (scope_id, kind, id)
             )",
@@ -29,13 +29,13 @@ pub(crate) async fn ensure_versioned_registry_schema(
                 scope_id TEXT NOT NULL DEFAULT 'default',
                 kind TEXT NOT NULL,
                 id TEXT NOT NULL,
-                version BIGINT NOT NULL,
+                version BIGINT NOT NULL CHECK (version > 0),
                 content_hash TEXT NOT NULL,
                 value_schema_version INTEGER NOT NULL,
                 canonical_value_json TEXT NOT NULL,
                 value_json JSONB NOT NULL,
                 metadata_json JSONB NOT NULL DEFAULT '{{}}',
-                created_at_ms BIGINT NOT NULL,
+                created_at_ms BIGINT NOT NULL CHECK (created_at_ms >= 0),
                 PRIMARY KEY (scope_id, kind, id, version)
             )",
             tables.versions
@@ -48,12 +48,12 @@ pub(crate) async fn ensure_versioned_registry_schema(
         format!(
             "CREATE TABLE IF NOT EXISTS {} (
                 scope_id TEXT NOT NULL DEFAULT 'default',
-                snapshot_version BIGINT NOT NULL,
+                snapshot_version BIGINT NOT NULL CHECK (snapshot_version > 0),
                 publication_id TEXT NOT NULL,
                 source_config_revisions_json JSONB NOT NULL DEFAULT '[]',
                 created_by TEXT,
                 metadata_json JSONB NOT NULL DEFAULT '{{}}',
-                created_at_ms BIGINT NOT NULL,
+                created_at_ms BIGINT NOT NULL CHECK (created_at_ms >= 0),
                 PRIMARY KEY (scope_id, snapshot_version),
                 UNIQUE (scope_id, publication_id)
             )",
@@ -62,10 +62,10 @@ pub(crate) async fn ensure_versioned_registry_schema(
         format!(
             "CREATE TABLE IF NOT EXISTS {} (
                 scope_id TEXT NOT NULL DEFAULT 'default',
-                snapshot_version BIGINT NOT NULL,
+                snapshot_version BIGINT NOT NULL CHECK (snapshot_version > 0),
                 kind TEXT NOT NULL,
                 id TEXT NOT NULL,
-                version BIGINT NOT NULL,
+                version BIGINT NOT NULL CHECK (version > 0),
                 content_hash TEXT NOT NULL,
                 PRIMARY KEY (scope_id, snapshot_version, kind, id),
                 FOREIGN KEY (scope_id, snapshot_version)

--- a/crates/awaken-stores/src/sqlite_mailbox.rs
+++ b/crates/awaken-stores/src/sqlite_mailbox.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use awaken_server_contract::contract::lifecycle::{RunStatus, TerminationReason};
 use awaken_server_contract::contract::mailbox::{
-    MailboxInterrupt, MailboxInterruptDetails, MailboxStore, RunDispatch, RunDispatchResult,
-    RunDispatchStatus,
+    MailboxInterrupt, MailboxInterruptDetails, MailboxStore, RunDispatch, RunDispatchParts,
+    RunDispatchResult, RunDispatchStatus,
 };
 use awaken_server_contract::contract::storage::StorageError;
 use rusqlite::{Connection, Row, params};
@@ -222,7 +222,7 @@ fn row_to_dispatch(row: &Row<'_>) -> Result<RunDispatch, rusqlite::Error> {
     let created_at_i64: i64 = row.get("created_at")?;
     let updated_at_i64: i64 = row.get("updated_at")?;
 
-    Ok(RunDispatch {
+    RunDispatch::from_persisted_parts(RunDispatchParts {
         dispatch_id: row.get("dispatch_id")?,
         thread_id: row.get("thread_id")?,
         run_id: row.get("run_id")?,
@@ -246,6 +246,9 @@ fn row_to_dispatch(row: &Row<'_>) -> Result<RunDispatch, rusqlite::Error> {
         created_at: created_at_i64 as u64,
         updated_at: updated_at_i64 as u64,
     })
+    .map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+    })
 }
 
 fn current_epoch_for_conn(conn: &Connection, thread_id: &str) -> Result<u64, StorageError> {
@@ -265,17 +268,17 @@ fn supersede_claimed_loaded(
     now: u64,
     reason: &str,
 ) -> Result<Option<RunDispatch>, StorageError> {
-    if dispatch.status != RunDispatchStatus::Claimed {
+    if dispatch.status() != RunDispatchStatus::Claimed {
         return Ok(None);
     }
-    if dispatch.claim_token.as_deref() != Some(claim_token) {
+    if dispatch.claim_token() != Some(claim_token) {
         return Err(StorageError::VersionConflict {
             expected: 0,
             actual: 1,
         });
     }
-    let current_epoch = current_epoch_for_conn(conn, &dispatch.thread_id)?;
-    let terminal_epoch = dispatch.dispatch_epoch.max(current_epoch);
+    let current_epoch = current_epoch_for_conn(conn, &dispatch.thread_id())?;
+    let terminal_epoch = dispatch.dispatch_epoch().max(current_epoch);
     let changed = conn
         .execute(
             "UPDATE run_dispatches
@@ -295,7 +298,7 @@ fn supersede_claimed_loaded(
                 reason,
                 now as i64,
                 now as i64,
-                &dispatch.dispatch_id,
+                &dispatch.dispatch_id(),
                 claim_token
             ],
         )
@@ -305,7 +308,7 @@ fn supersede_claimed_loaded(
     }
     conn.prepare_cached("SELECT * FROM run_dispatches WHERE dispatch_id = ?1")
         .map_err(|e| StorageError::Io(format!("prepare supersede claimed reload: {e}")))?
-        .query_row(params![&dispatch.dispatch_id], row_to_dispatch)
+        .query_row(params![&dispatch.dispatch_id()], row_to_dispatch)
         .optional()
         .map_err(|e| StorageError::Io(format!("supersede claimed reload: {e}")))
 }
@@ -348,8 +351,8 @@ fn supersede_stale_claimed_if_needed(
     now: u64,
     reason: &str,
 ) -> Result<bool, StorageError> {
-    let current_epoch = current_epoch_for_conn(conn, &dispatch.thread_id)?;
-    if dispatch.dispatch_epoch >= current_epoch {
+    let current_epoch = current_epoch_for_conn(conn, &dispatch.thread_id())?;
+    if dispatch.dispatch_epoch() >= current_epoch {
         return Ok(false);
     }
     supersede_claimed_loaded(conn, dispatch, claim_token, now, reason)?;
@@ -361,10 +364,10 @@ fn supersede_stale_claimed_if_needed(
 #[async_trait]
 impl MailboxStore for SqliteMailboxStore {
     async fn enqueue(&self, dispatch: &RunDispatch) -> Result<(), StorageError> {
+        dispatch.validate_for_enqueue()?;
         let conn = self.conn.lock().await;
-
         // Dedupe check.
-        if let Some(ref dk) = dispatch.dedupe_key {
+        if let Some(ref dk) = dispatch.dedupe_key() {
             let dup: bool = conn
                 .prepare_cached(
                     "SELECT EXISTS(
@@ -375,7 +378,9 @@ impl MailboxStore for SqliteMailboxStore {
                     )",
                 )
                 .map_err(|e| StorageError::Io(format!("prepare dedupe: {e}")))?
-                .query_row(params![dispatch.thread_id, dk], |row| row.get::<_, bool>(0))
+                .query_row(params![dispatch.thread_id(), dk], |row| {
+                    row.get::<_, bool>(0)
+                })
                 .map_err(|e| StorageError::Io(format!("dedupe check: {e}")))?;
 
             if dup {
@@ -388,14 +393,14 @@ impl MailboxStore for SqliteMailboxStore {
             "INSERT INTO thread_dispatch_epochs (thread_id, current_epoch)
              VALUES (?1, 0)
              ON CONFLICT (thread_id) DO NOTHING",
-            params![dispatch.thread_id],
+            params![dispatch.thread_id()],
         )
         .map_err(|e| StorageError::Io(format!("upsert dispatch_epoch: {e}")))?;
 
         let dispatch_epoch: i64 = conn
             .prepare_cached("SELECT current_epoch FROM thread_dispatch_epochs WHERE thread_id = ?1")
             .map_err(|e| StorageError::Io(format!("prepare dispatch_epoch select: {e}")))?
-            .query_row(params![dispatch.thread_id], |row| row.get(0))
+            .query_row(params![dispatch.thread_id()], |row| row.get(0))
             .map_err(|e| StorageError::Io(format!("dispatch_epoch select: {e}")))?;
 
         conn.execute(
@@ -413,22 +418,22 @@ impl MailboxStore for SqliteMailboxStore {
                 ?15, ?16
             )",
             params![
-                dispatch.dispatch_id,
-                dispatch.thread_id,
-                dispatch.run_id,
-                dispatch.priority as i64,
-                dispatch.dedupe_key,
+                dispatch.dispatch_id(),
+                dispatch.thread_id(),
+                dispatch.run_id(),
+                dispatch.priority() as i64,
+                dispatch.dedupe_key(),
                 dispatch_epoch,
                 status_to_str(RunDispatchStatus::Queued),
-                dispatch.available_at as i64,
-                dispatch.attempt_count as i64,
-                dispatch.max_attempts as i64,
-                dispatch.last_error,
-                dispatch.claim_token,
-                dispatch.claimed_by,
-                dispatch.lease_until.map(|v| v as i64),
-                dispatch.created_at as i64,
-                dispatch.updated_at as i64,
+                dispatch.available_at() as i64,
+                dispatch.attempt_count() as i64,
+                dispatch.max_attempts() as i64,
+                dispatch.last_error(),
+                dispatch.claim_token(),
+                dispatch.claimed_by(),
+                dispatch.lease_until().map(|v| v as i64),
+                dispatch.created_at() as i64,
+                dispatch.updated_at() as i64,
             ],
         )
         .map_err(|e| StorageError::Io(format!("insert dispatch: {e}")))?;
@@ -555,11 +560,11 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("claim_dispatch load: {e}")))?;
 
         let dispatch = match dispatch {
-            Some(j) if j.status == RunDispatchStatus::Queued => j,
+            Some(j) if j.status() == RunDispatchStatus::Queued => j,
             _ => return Ok(None),
         };
 
-        if dispatch.dispatch_epoch < current_epoch_for_conn(&conn, &dispatch.thread_id)? {
+        if dispatch.dispatch_epoch() < current_epoch_for_conn(&conn, &dispatch.thread_id())? {
             conn.execute(
                 "UPDATE run_dispatches
                  SET status = 'Superseded',
@@ -573,7 +578,7 @@ impl MailboxStore for SqliteMailboxStore {
                  WHERE dispatch_id = ?5
                    AND status = 'Queued'",
                 params![
-                    current_epoch_for_conn(&conn, &dispatch.thread_id)? as i64,
+                    current_epoch_for_conn(&conn, &dispatch.thread_id())? as i64,
                     mailbox_state::REASON_QUEUED_SUPERSEDED_BY_EPOCH,
                     now as i64,
                     now as i64,
@@ -595,7 +600,7 @@ impl MailboxStore for SqliteMailboxStore {
                 )",
             )
             .map_err(|e| StorageError::Io(format!("prepare claim_dispatch check: {e}")))?
-            .query_row(params![dispatch.thread_id, dispatch_id], |row| {
+            .query_row(params![dispatch.thread_id(), dispatch_id], |row| {
                 row.get::<_, bool>(0)
             })
             .map_err(|e| StorageError::Io(format!("claim_dispatch check: {e}")))?;
@@ -652,7 +657,7 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("ack load: {e}")))?
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
@@ -666,8 +671,8 @@ impl MailboxStore for SqliteMailboxStore {
             mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_ACK,
         )? {
             return Err(StorageError::VersionConflict {
-                expected: dispatch.dispatch_epoch,
-                actual: current_epoch_for_conn(&conn, &dispatch.thread_id)?,
+                expected: dispatch.dispatch_epoch(),
+                actual: current_epoch_for_conn(&conn, &dispatch.thread_id())?,
             });
         }
 
@@ -704,8 +709,8 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("record_dispatch_start load: {e}")))?
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.status != RunDispatchStatus::Claimed
-            || dispatch.claim_token.as_deref() != Some(claim_token)
+        if dispatch.status() != RunDispatchStatus::Claimed
+            || dispatch.claim_token() != Some(claim_token)
         {
             return Err(StorageError::VersionConflict {
                 expected: 0,
@@ -720,8 +725,8 @@ impl MailboxStore for SqliteMailboxStore {
             mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_START,
         )? {
             return Err(StorageError::VersionConflict {
-                expected: dispatch.dispatch_epoch,
-                actual: current_epoch_for_conn(&conn, &dispatch.thread_id)?,
+                expected: dispatch.dispatch_epoch(),
+                actual: current_epoch_for_conn(&conn, &dispatch.thread_id())?,
             });
         }
 
@@ -764,8 +769,8 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("record_run_result load: {e}")))?
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.status != RunDispatchStatus::Claimed
-            || dispatch.claim_token.as_deref() != Some(claim_token)
+        if dispatch.status() != RunDispatchStatus::Claimed
+            || dispatch.claim_token() != Some(claim_token)
         {
             return Err(StorageError::VersionConflict {
                 expected: 0,
@@ -780,8 +785,8 @@ impl MailboxStore for SqliteMailboxStore {
             mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_RESULT,
         )? {
             return Err(StorageError::VersionConflict {
-                expected: dispatch.dispatch_epoch,
-                actual: current_epoch_for_conn(&conn, &dispatch.thread_id)?,
+                expected: dispatch.dispatch_epoch(),
+                actual: current_epoch_for_conn(&conn, &dispatch.thread_id())?,
             });
         }
 
@@ -831,7 +836,7 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("nack load: {e}")))?
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
@@ -845,14 +850,14 @@ impl MailboxStore for SqliteMailboxStore {
             mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_NACK,
         )? {
             return Err(StorageError::VersionConflict {
-                expected: dispatch.dispatch_epoch,
-                actual: current_epoch_for_conn(&conn, &dispatch.thread_id)?,
+                expected: dispatch.dispatch_epoch(),
+                actual: current_epoch_for_conn(&conn, &dispatch.thread_id())?,
             });
         }
 
-        let new_attempt_count = dispatch.attempt_count + 1;
+        let new_attempt_count = dispatch.attempt_count() + 1;
 
-        if new_attempt_count >= dispatch.max_attempts {
+        if new_attempt_count >= dispatch.max_attempts() {
             // Dead letter.
             conn.execute(
                 "UPDATE run_dispatches
@@ -918,7 +923,7 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("dead_letter load: {e}")))?
             .ok_or_else(|| StorageError::NotFound(dispatch_id.to_string()))?;
 
-        if dispatch.claim_token.as_deref() != Some(claim_token) {
+        if dispatch.claim_token() != Some(claim_token) {
             return Err(StorageError::VersionConflict {
                 expected: 0,
                 actual: 1,
@@ -932,8 +937,8 @@ impl MailboxStore for SqliteMailboxStore {
             mailbox_state::REASON_CLAIMED_SUPERSEDED_BEFORE_DEAD_LETTER,
         )? {
             return Err(StorageError::VersionConflict {
-                expected: dispatch.dispatch_epoch,
-                actual: current_epoch_for_conn(&conn, &dispatch.thread_id)?,
+                expected: dispatch.dispatch_epoch(),
+                actual: current_epoch_for_conn(&conn, &dispatch.thread_id())?,
             });
         }
 
@@ -970,7 +975,7 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("cancel load: {e}")))?;
 
         match dispatch {
-            Some(j) if j.status == RunDispatchStatus::Queued => {}
+            Some(j) if j.status() == RunDispatchStatus::Queued => {}
             _ => return Ok(None),
         }
 
@@ -1014,8 +1019,8 @@ impl MailboxStore for SqliteMailboxStore {
         let Some(dispatch) = dispatch else {
             return Ok(false);
         };
-        if dispatch.status != RunDispatchStatus::Claimed
-            || dispatch.claim_token.as_deref() != Some(claim_token)
+        if dispatch.status() != RunDispatchStatus::Claimed
+            || dispatch.claim_token() != Some(claim_token)
         {
             return Ok(false);
         }
@@ -1348,7 +1353,7 @@ impl MailboxStore for SqliteMailboxStore {
             .map_err(|e| StorageError::Io(format!("prepare reclaim deadletter: {e}")))?;
 
         for dispatch in &expired {
-            let Some(claim_token) = dispatch.claim_token.as_deref() else {
+            let Some(claim_token) = dispatch.claim_token() else {
                 continue;
             };
             if supersede_stale_claimed_if_needed(
@@ -1361,14 +1366,14 @@ impl MailboxStore for SqliteMailboxStore {
                 continue;
             }
 
-            let new_attempt = dispatch.attempt_count + 1;
-            if new_attempt >= dispatch.max_attempts {
+            let new_attempt = dispatch.attempt_count() + 1;
+            if new_attempt >= dispatch.max_attempts() {
                 deadletter_stmt
                     .execute(params![
                         new_attempt as i64,
                         now as i64,
                         now as i64,
-                        &dispatch.dispatch_id
+                        &dispatch.dispatch_id()
                     ])
                     .map_err(|e| StorageError::Io(format!("reclaim deadletter: {e}")))?;
             } else {
@@ -1376,7 +1381,7 @@ impl MailboxStore for SqliteMailboxStore {
                     .execute(params![
                         new_attempt as i64,
                         now as i64,
-                        &dispatch.dispatch_id
+                        &dispatch.dispatch_id()
                     ])
                     .map_err(|e| StorageError::Io(format!("reclaim requeue: {e}")))?;
             }
@@ -1394,9 +1399,9 @@ impl MailboxStore for SqliteMailboxStore {
 
         for dispatch in &expired {
             let dispatch = load_stmt
-                .query_row(params![&dispatch.dispatch_id], row_to_dispatch)
+                .query_row(params![&dispatch.dispatch_id()], row_to_dispatch)
                 .map_err(|e| StorageError::Io(format!("reclaim reload: {e}")))?;
-            if dispatch.status != RunDispatchStatus::Superseded {
+            if dispatch.status() != RunDispatchStatus::Superseded {
                 result.push(dispatch);
             }
         }
@@ -1462,30 +1467,12 @@ mod tests {
     use super::*;
 
     fn make_dispatch(id: &str, thread_id: &str) -> RunDispatch {
-        RunDispatch {
-            dispatch_id: id.to_string(),
-            thread_id: thread_id.to_string(),
-            run_id: format!("run-{id}"),
-            priority: 128,
-            dedupe_key: None,
-            dispatch_epoch: 0,
-            status: RunDispatchStatus::Queued,
-            available_at: 0,
-            attempt_count: 0,
-            max_attempts: 5,
-            last_error: None,
-            claim_token: None,
-            claimed_by: None,
-            lease_until: None,
-            dispatch_instance_id: None,
-            run_status: None,
-            termination: None,
-            run_response: None,
-            run_error: None,
-            completed_at: None,
-            created_at: 1000,
-            updated_at: 1000,
-        }
+        RunDispatch::queued(
+            id.to_string(),
+            thread_id.to_string(),
+            format!("run-{id}"),
+            1000,
+        )
     }
 
     #[tokio::test]
@@ -1498,12 +1485,12 @@ mod tests {
         let loaded = store.load_dispatch("dispatch-1").await.unwrap();
         assert!(loaded.is_some());
         let loaded = loaded.unwrap();
-        assert_eq!(loaded.dispatch_id, "dispatch-1");
-        assert_eq!(loaded.thread_id, "thread-a");
-        assert_eq!(loaded.run_id, "run-dispatch-1");
-        assert_eq!(loaded.status, RunDispatchStatus::Queued);
-        assert_eq!(loaded.dispatch_epoch, 0);
-        assert_eq!(loaded.priority, 128);
+        assert_eq!(loaded.dispatch_id(), "dispatch-1");
+        assert_eq!(loaded.thread_id(), "thread-a");
+        assert_eq!(loaded.run_id(), "run-dispatch-1");
+        assert_eq!(loaded.status(), RunDispatchStatus::Queued);
+        assert_eq!(loaded.dispatch_epoch(), 0);
+        assert_eq!(loaded.priority(), 128);
 
         // Non-existent dispatch returns None.
         let missing = store.load_dispatch("no-such-dispatch").await.unwrap();
@@ -1514,13 +1501,13 @@ mod tests {
     async fn enqueue_dedupe_rejects_duplicate() {
         let store = SqliteMailboxStore::open_memory().unwrap();
 
-        let mut dispatch1 = make_dispatch("dispatch-1", "thread-a");
-        dispatch1.dedupe_key = Some("dk-1".to_string());
+        let dispatch1 =
+            make_dispatch("dispatch-1", "thread-a").with_dedupe_key(Some("dk-1".to_string()));
         store.enqueue(&dispatch1).await.unwrap();
 
         // Second enqueue with same dedupe_key should fail.
-        let mut dispatch2 = make_dispatch("dispatch-2", "thread-a");
-        dispatch2.dedupe_key = Some("dk-1".to_string());
+        let dispatch2 =
+            make_dispatch("dispatch-2", "thread-a").with_dedupe_key(Some("dk-1".to_string()));
         let result = store.enqueue(&dispatch2).await;
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -1529,13 +1516,13 @@ mod tests {
         }
 
         // Different dedupe_key should succeed.
-        let mut dispatch3 = make_dispatch("dispatch-3", "thread-a");
-        dispatch3.dedupe_key = Some("dk-2".to_string());
+        let dispatch3 =
+            make_dispatch("dispatch-3", "thread-a").with_dedupe_key(Some("dk-2".to_string()));
         store.enqueue(&dispatch3).await.unwrap();
 
         // Same dedupe_key in a different thread should succeed.
-        let mut dispatch4 = make_dispatch("dispatch-4", "thread-b");
-        dispatch4.dedupe_key = Some("dk-1".to_string());
+        let dispatch4 =
+            make_dispatch("dispatch-4", "thread-b").with_dedupe_key(Some("dk-1".to_string()));
         store.enqueue(&dispatch4).await.unwrap();
     }
 
@@ -1590,19 +1577,19 @@ mod tests {
     async fn list_dispatches_sorted_by_priority_then_created_at() {
         let store = SqliteMailboxStore::open_memory().unwrap();
 
-        let mut j1 = make_dispatch("dispatch-low", "thread-a");
-        j1.priority = 200;
-        j1.created_at = 100;
+        let j1 = make_dispatch("dispatch-low", "thread-a")
+            .with_priority(200)
+            .with_created_at(100);
         store.enqueue(&j1).await.unwrap();
 
-        let mut j2 = make_dispatch("dispatch-high", "thread-a");
-        j2.priority = 10;
-        j2.created_at = 200;
+        let j2 = make_dispatch("dispatch-high", "thread-a")
+            .with_priority(10)
+            .with_created_at(200);
         store.enqueue(&j2).await.unwrap();
 
-        let mut j3 = make_dispatch("dispatch-high-early", "thread-a");
-        j3.priority = 10;
-        j3.created_at = 50;
+        let j3 = make_dispatch("dispatch-high-early", "thread-a")
+            .with_priority(10)
+            .with_created_at(50);
         store.enqueue(&j3).await.unwrap();
 
         let list = store
@@ -1611,24 +1598,24 @@ mod tests {
             .unwrap();
         assert_eq!(list.len(), 3);
         // priority 10 created_at 50
-        assert_eq!(list[0].dispatch_id, "dispatch-high-early");
+        assert_eq!(list[0].dispatch_id(), "dispatch-high-early");
         // priority 10 created_at 200
-        assert_eq!(list[1].dispatch_id, "dispatch-high");
+        assert_eq!(list[1].dispatch_id(), "dispatch-high");
         // priority 200
-        assert_eq!(list[2].dispatch_id, "dispatch-low");
+        assert_eq!(list[2].dispatch_id(), "dispatch-low");
     }
 
     #[tokio::test]
     async fn enqueue_sets_dispatch_epoch_from_store() {
         let store = SqliteMailboxStore::open_memory().unwrap();
 
-        let mut dispatch = make_dispatch("dispatch-1", "thread-a");
-        dispatch.dispatch_epoch = 999; // should be overridden
+        let dispatch = make_dispatch("dispatch-1", "thread-a").with_dispatch_epoch(999);
         store.enqueue(&dispatch).await.unwrap();
 
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
         assert_eq!(
-            loaded.dispatch_epoch, 0,
+            loaded.dispatch_epoch(),
+            0,
             "dispatch_epoch should come from store, not from input"
         );
     }
@@ -1645,16 +1632,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(claimed.len(), 1);
-        assert_eq!(claimed[0].dispatch_id, "dispatch-1");
-        assert_eq!(claimed[0].status, RunDispatchStatus::Claimed);
-        assert!(claimed[0].claim_token.is_some());
-        assert_eq!(claimed[0].claimed_by.as_deref(), Some("consumer-1"));
-        assert_eq!(claimed[0].lease_until, Some(32_000));
+        assert_eq!(claimed[0].dispatch_id(), "dispatch-1");
+        assert_eq!(claimed[0].status(), RunDispatchStatus::Claimed);
+        assert!(claimed[0].claim_token().is_some());
+        assert_eq!(claimed[0].claimed_by(), Some("consumer-1"));
+        assert_eq!(claimed[0].lease_until(), Some(32_000));
 
         // Cannot double-claim while a dispatch is Claimed in this mailbox.
-        let mut dispatch2 = make_dispatch("dispatch-2", "thread-a");
-        dispatch2.created_at = 2000;
-        dispatch2.updated_at = 2000;
+        let dispatch2 = make_dispatch("dispatch-2", "thread-a").with_created_at(2000);
         store.enqueue(&dispatch2).await.unwrap();
         let double = store
             .claim("thread-a", "consumer-2", 30_000, 2000, 10)
@@ -1666,11 +1651,11 @@ mod tests {
         );
 
         // Ack the first dispatch.
-        let token = claimed[0].claim_token.as_ref().unwrap();
+        let token = claimed[0].claim_token().unwrap();
         store.ack("dispatch-1", token, 3000).await.unwrap();
 
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(loaded.status, RunDispatchStatus::Acked);
+        assert_eq!(loaded.status(), RunDispatchStatus::Acked);
     }
 
     #[tokio::test]
@@ -1688,15 +1673,14 @@ mod tests {
         assert!(
             claimed
                 .iter()
-                .all(|dispatch| dispatch.status == RunDispatchStatus::Claimed)
+                .all(|dispatch| dispatch.status() == RunDispatchStatus::Claimed)
         );
     }
 
     #[tokio::test]
     async fn nack_increments_attempt_and_requeues() {
         let store = SqliteMailboxStore::open_memory().unwrap();
-        let mut dispatch = make_dispatch("dispatch-1", "thread-a");
-        dispatch.max_attempts = 3;
+        let dispatch = make_dispatch("dispatch-1", "thread-a").with_max_attempts(3);
         store.enqueue(&dispatch).await.unwrap();
 
         // Claim then nack.
@@ -1704,7 +1688,7 @@ mod tests {
             .claim("thread-a", "c1", 30_000, 1000, 10)
             .await
             .unwrap();
-        let token = claimed[0].claim_token.as_ref().unwrap();
+        let token = claimed[0].claim_token().unwrap();
 
         store
             .nack("dispatch-1", token, 5000, "transient error", 2000)
@@ -1712,27 +1696,26 @@ mod tests {
             .unwrap();
 
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(loaded.status, RunDispatchStatus::Queued);
-        assert_eq!(loaded.attempt_count, 1);
-        assert_eq!(loaded.available_at, 5000);
-        assert_eq!(loaded.last_error.as_deref(), Some("transient error"));
-        assert!(loaded.claim_token.is_none());
-        assert!(loaded.claimed_by.is_none());
-        assert!(loaded.lease_until.is_none());
+        assert_eq!(loaded.status(), RunDispatchStatus::Queued);
+        assert_eq!(loaded.attempt_count(), 1);
+        assert_eq!(loaded.available_at(), 5000);
+        assert_eq!(loaded.last_error(), Some("transient error"));
+        assert!(loaded.claim_token().is_none());
+        assert!(loaded.claimed_by().is_none());
+        assert!(loaded.lease_until().is_none());
     }
 
     #[tokio::test]
     async fn nack_dead_letters_on_max_attempts() {
         let store = SqliteMailboxStore::open_memory().unwrap();
-        let mut dispatch = make_dispatch("dispatch-1", "thread-a");
-        dispatch.max_attempts = 1;
+        let dispatch = make_dispatch("dispatch-1", "thread-a").with_max_attempts(1);
         store.enqueue(&dispatch).await.unwrap();
 
         let claimed = store
             .claim("thread-a", "c1", 30_000, 1000, 10)
             .await
             .unwrap();
-        let token = claimed[0].claim_token.as_ref().unwrap();
+        let token = claimed[0].claim_token().unwrap();
 
         store
             .nack("dispatch-1", token, 5000, "fatal", 2000)
@@ -1740,9 +1723,9 @@ mod tests {
             .unwrap();
 
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
-        assert_eq!(loaded.attempt_count, 1);
-        assert_eq!(loaded.last_error.as_deref(), Some("fatal"));
+        assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
+        assert_eq!(loaded.attempt_count(), 1);
+        assert_eq!(loaded.last_error(), Some("fatal"));
     }
 
     #[tokio::test]
@@ -1755,7 +1738,7 @@ mod tests {
             .claim("thread-a", "c1", 30_000, 1000, 10)
             .await
             .unwrap();
-        let token = claimed[0].claim_token.as_ref().unwrap();
+        let token = claimed[0].claim_token().unwrap();
 
         store
             .dead_letter("dispatch-1", token, "permanent failure", 2000)
@@ -1763,11 +1746,11 @@ mod tests {
             .unwrap();
 
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
-        assert_eq!(loaded.last_error.as_deref(), Some("permanent failure"));
-        assert!(loaded.claim_token.is_none());
-        assert!(loaded.claimed_by.is_none());
-        assert!(loaded.lease_until.is_none());
+        assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
+        assert_eq!(loaded.last_error(), Some("permanent failure"));
+        assert!(loaded.claim_token().is_none());
+        assert!(loaded.claimed_by().is_none());
+        assert!(loaded.lease_until().is_none());
     }
 
     #[tokio::test]
@@ -1802,19 +1785,19 @@ mod tests {
             .claim("thread-a", "c1", 30_000, 1000, 1)
             .await
             .unwrap();
-        let token = claimed[0].claim_token.as_ref().unwrap();
+        let token = claimed[0].claim_token().unwrap();
 
         store
             .record_dispatch_start("dispatch-1", token, "dispatch-1", 1500)
             .await
             .unwrap();
         let running = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(running.status, RunDispatchStatus::Claimed);
-        assert_eq!(running.run_id, dispatch.run_id);
-        assert_eq!(running.dispatch_instance_id.as_deref(), Some("dispatch-1"));
-        assert_eq!(running.run_status, Some(RunStatus::Running));
-        assert!(running.termination.is_none());
-        assert!(running.completed_at.is_none());
+        assert_eq!(running.status(), RunDispatchStatus::Claimed);
+        assert_eq!(running.run_id(), dispatch.run_id());
+        assert_eq!(running.dispatch_instance_id(), Some("dispatch-1"));
+        assert_eq!(running.run_status(), Some(RunStatus::Running));
+        assert!(running.termination().is_none());
+        assert!(running.completed_at().is_none());
 
         let result = RunDispatchResult {
             run_id: "run-1".into(),
@@ -1829,20 +1812,20 @@ mod tests {
             .await
             .unwrap();
         let completed = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(completed.status, RunDispatchStatus::Claimed);
-        assert_eq!(completed.run_status, Some(RunStatus::Done));
+        assert_eq!(completed.status(), RunDispatchStatus::Claimed);
+        assert_eq!(completed.run_status(), Some(RunStatus::Done));
         assert_eq!(
-            completed.termination,
-            Some(TerminationReason::Blocked("policy".into()))
+            completed.termination(),
+            Some(&TerminationReason::Blocked("policy".into()))
         );
-        assert_eq!(completed.run_error.as_deref(), Some("policy"));
-        assert_eq!(completed.completed_at, Some(1800));
+        assert_eq!(completed.run_error(), Some("policy"));
+        assert_eq!(completed.completed_at(), Some(1800));
 
         store.ack("dispatch-1", token, 2000).await.unwrap();
         let acked = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(acked.status, RunDispatchStatus::Acked);
-        assert_eq!(acked.run_status, Some(RunStatus::Done));
-        assert_eq!(acked.run_error.as_deref(), Some("policy"));
+        assert_eq!(acked.status(), RunDispatchStatus::Acked);
+        assert_eq!(acked.run_status(), Some(RunStatus::Done));
+        assert_eq!(acked.run_error(), Some("policy"));
     }
 
     #[tokio::test]
@@ -1861,8 +1844,8 @@ mod tests {
         assert!(matches!(result, Err(StorageError::VersionConflict { .. })));
 
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(loaded.run_id, dispatch.run_id);
-        assert!(loaded.run_status.is_none());
+        assert_eq!(loaded.run_id(), dispatch.run_id());
+        assert!(loaded.run_status().is_none());
     }
 
     #[tokio::test]
@@ -1874,12 +1857,12 @@ mod tests {
         let cancelled = store.cancel("dispatch-1", 2000).await.unwrap();
         assert!(cancelled.is_some());
         let cancelled = cancelled.unwrap();
-        assert_eq!(cancelled.status, RunDispatchStatus::Cancelled);
-        assert_eq!(cancelled.updated_at, 2000);
+        assert_eq!(cancelled.status(), RunDispatchStatus::Cancelled);
+        assert_eq!(cancelled.updated_at(), 2000);
 
         // Verify persisted.
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(loaded.status, RunDispatchStatus::Cancelled);
+        assert_eq!(loaded.status(), RunDispatchStatus::Cancelled);
 
         // Cancel a non-Queued dispatch returns None.
         let again = store.cancel("dispatch-1", 3000).await.unwrap();
@@ -1938,7 +1921,7 @@ mod tests {
         assert_eq!(result.new_dispatch_epoch, 1);
         assert_eq!(result.superseded_count, 1); // only dispatch-2 was Queued
         assert!(result.active_dispatch.is_some());
-        assert_eq!(result.active_dispatch.unwrap().dispatch_id, "dispatch-1");
+        assert_eq!(result.active_dispatch.unwrap().dispatch_id(), "dispatch-1");
     }
 
     #[tokio::test]
@@ -1951,7 +1934,7 @@ mod tests {
             .claim("thread-a", "consumer-1", 30_000, 1000, 1)
             .await
             .unwrap();
-        let token = claimed[0].claim_token.as_ref().unwrap().clone();
+        let token = claimed[0].claim_token().unwrap();
 
         let ok = store
             .extend_lease("dispatch-1", &token, 60_000, 15_000)
@@ -1960,7 +1943,7 @@ mod tests {
         assert!(ok);
 
         let loaded = store.load_dispatch("dispatch-1").await.unwrap().unwrap();
-        assert_eq!(loaded.lease_until, Some(75_000));
+        assert_eq!(loaded.lease_until(), Some(75_000));
 
         // Wrong token returns false.
         let nope = store
@@ -1988,17 +1971,17 @@ mod tests {
             .claim("thread-a", "consumer-1", 1_000, 1000, 1)
             .await
             .unwrap();
-        assert_eq!(claimed[0].lease_until, Some(2_000));
+        assert_eq!(claimed[0].lease_until(), Some(2_000));
 
         // At now=3000, lease is expired.
         let reclaimed = store.reclaim_expired_leases(3000, 10).await.unwrap();
         assert_eq!(reclaimed.len(), 1);
-        assert_eq!(reclaimed[0].dispatch_id, "dispatch-1");
-        assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
-        assert_eq!(reclaimed[0].attempt_count, 1);
-        assert!(reclaimed[0].claim_token.is_none());
-        assert!(reclaimed[0].claimed_by.is_none());
-        assert!(reclaimed[0].lease_until.is_none());
+        assert_eq!(reclaimed[0].dispatch_id(), "dispatch-1");
+        assert_eq!(reclaimed[0].status(), RunDispatchStatus::Queued);
+        assert_eq!(reclaimed[0].attempt_count(), 1);
+        assert!(reclaimed[0].claim_token().is_none());
+        assert!(reclaimed[0].claimed_by().is_none());
+        assert!(reclaimed[0].lease_until().is_none());
 
         // Not expired yet: no reclaims.
         let claimed2 = store

--- a/crates/awaken-stores/tests/adr0036_mandatory.rs
+++ b/crates/awaken-stores/tests/adr0036_mandatory.rs
@@ -37,6 +37,7 @@ fn run_record(thread_id: &str, run_id: &str) -> RunRecord {
         run_id: run_id.to_string(),
         status: RunStatus::Done,
         agent_id: "agent-1".to_string(),
+        finished_at: Some(1),
         ..Default::default()
     }
 }

--- a/crates/awaken-stores/tests/mailbox_conformance.rs
+++ b/crates/awaken-stores/tests/mailbox_conformance.rs
@@ -25,36 +25,21 @@ pub fn make_dispatch(
     priority: u8,
     available_at: u64,
 ) -> RunDispatch {
-    RunDispatch {
-        dispatch_id: dispatch_id.to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: run_id.to_string(),
-        priority,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
+    RunDispatch::queued(
+        dispatch_id.to_string(),
+        thread_id.to_string(),
+        run_id.to_string(),
         available_at,
-        attempt_count: 0,
-        max_attempts: 5,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: available_at,
-        updated_at: available_at,
-    }
+    )
+    .with_priority(priority)
+    .with_available_at(available_at)
+    .with_max_attempts(5)
 }
 
 fn assert_claim_fields_clear(dispatch: &RunDispatch) {
-    assert!(dispatch.claim_token.is_none());
-    assert!(dispatch.claimed_by.is_none());
-    assert!(dispatch.lease_until.is_none());
+    assert!(dispatch.claim_token().is_none());
+    assert!(dispatch.claimed_by().is_none());
+    assert!(dispatch.lease_until().is_none());
 }
 
 /// Enqueue a single dispatch and verify it is returned by `list_dispatches`.
@@ -67,8 +52,8 @@ pub async fn enqueue_and_list<S: MailboxStore>(store: &S) {
         .await
         .unwrap();
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].dispatch_id, "d1");
-    assert_eq!(listed[0].status, RunDispatchStatus::Queued);
+    assert_eq!(listed[0].dispatch_id(), "d1");
+    assert_eq!(listed[0].status(), RunDispatchStatus::Queued);
 }
 
 /// `claim()` returns a previously queued dispatch with status Claimed and a
@@ -82,10 +67,10 @@ pub async fn claim_returns_queued_dispatch<S: MailboxStore>(store: &S) {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d1");
-    assert_eq!(claimed[0].status, RunDispatchStatus::Claimed);
-    assert!(claimed[0].claim_token.is_some());
-    assert_eq!(claimed[0].claimed_by.as_deref(), Some("consumer-1"));
+    assert_eq!(claimed[0].dispatch_id(), "d1");
+    assert_eq!(claimed[0].status(), RunDispatchStatus::Claimed);
+    assert!(claimed[0].claim_token().is_some());
+    assert_eq!(claimed[0].claimed_by(), Some("consumer-1"));
 }
 
 /// `claim()` must skip dispatches whose `available_at` is in the future.
@@ -105,17 +90,17 @@ pub async fn claim_respects_available_at<S: MailboxStore>(store: &S) {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d1");
+    assert_eq!(claimed[0].dispatch_id(), "d1");
 }
 
 /// Lower numeric priority wins before `created_at` ordering.
 pub async fn claim_respects_priority_before_created_at<S: MailboxStore>(store: &S) {
     let mut older_low_priority = make_dispatch("d-low", "t-priority", "r-low", 200, 1000);
-    older_low_priority.created_at = 10;
+    older_low_priority = older_low_priority.with_created_at(10);
     store.enqueue(&older_low_priority).await.unwrap();
 
     let mut newer_high_priority = make_dispatch("d-high", "t-priority", "r-high", 10, 1000);
-    newer_high_priority.created_at = 20;
+    newer_high_priority = newer_high_priority.with_created_at(20);
     store.enqueue(&newer_high_priority).await.unwrap();
 
     let claimed = store
@@ -123,8 +108,8 @@ pub async fn claim_respects_priority_before_created_at<S: MailboxStore>(store: &
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-high");
-    assert_eq!(claimed[0].priority, 10);
+    assert_eq!(claimed[0].dispatch_id(), "d-high");
+    assert_eq!(claimed[0].priority(), 10);
 }
 
 /// A second claim must not bypass same-thread execution ownership while a
@@ -134,7 +119,7 @@ pub async fn claim_limit_preserves_thread_exclusivity<S: MailboxStore>(store: &S
     store.enqueue(&older).await.unwrap();
 
     let mut newer = make_dispatch("d-two", "t-claim-limit", "r-two", 10, 1000);
-    newer.created_at = 2000;
+    newer = newer.with_created_at(2000);
     store.enqueue(&newer).await.unwrap();
 
     let claimed = store
@@ -142,7 +127,7 @@ pub async fn claim_limit_preserves_thread_exclusivity<S: MailboxStore>(store: &S
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-one");
+    assert_eq!(claimed[0].dispatch_id(), "d-one");
 
     let blocked = store
         .claim("t-claim-limit", "consumer-2", 30_000, 1100, 10)
@@ -153,7 +138,7 @@ pub async fn claim_limit_preserves_thread_exclusivity<S: MailboxStore>(store: &S
         "same thread must not claim a second dispatch while one is active"
     );
 
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store.ack("d-one", &token, 1200).await.unwrap();
 
     let next = store
@@ -161,21 +146,21 @@ pub async fn claim_limit_preserves_thread_exclusivity<S: MailboxStore>(store: &S
         .await
         .unwrap();
     assert_eq!(next.len(), 1);
-    assert_eq!(next[0].dispatch_id, "d-two");
+    assert_eq!(next[0].dispatch_id(), "d-two");
 }
 
 /// `list_dispatches()` must use the same priority/FIFO ordering as `claim()`.
 pub async fn list_dispatches_orders_by_priority_then_created_at<S: MailboxStore>(store: &S) {
     let mut low = make_dispatch("d-low", "t-list-order", "r-low", 200, 1000);
-    low.created_at = 10;
+    low = low.with_created_at(10);
     store.enqueue(&low).await.unwrap();
 
     let mut high_newer = make_dispatch("d-high-newer", "t-list-order", "r-high-newer", 10, 1000);
-    high_newer.created_at = 30;
+    high_newer = high_newer.with_created_at(30);
     store.enqueue(&high_newer).await.unwrap();
 
     let mut high_older = make_dispatch("d-high-older", "t-list-order", "r-high-older", 10, 1000);
-    high_older.created_at = 20;
+    high_older = high_older.with_created_at(20);
     store.enqueue(&high_older).await.unwrap();
 
     let listed = store
@@ -184,7 +169,7 @@ pub async fn list_dispatches_orders_by_priority_then_created_at<S: MailboxStore>
         .unwrap();
     let ids = listed
         .iter()
-        .map(|dispatch| dispatch.dispatch_id.as_str())
+        .map(|dispatch| dispatch.dispatch_id().as_str())
         .collect::<Vec<_>>();
     assert_eq!(ids, vec!["d-high-older", "d-high-newer", "d-low"]);
 }
@@ -198,12 +183,12 @@ pub async fn ack_transitions_to_acked<S: MailboxStore>(store: &S) {
         .claim("t-ack", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store.ack("d1", &token, 2000).await.unwrap();
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Acked);
+    assert_eq!(loaded.status(), RunDispatchStatus::Acked);
     assert_claim_fields_clear(&loaded);
 }
 
@@ -222,7 +207,7 @@ pub async fn ack_rejects_wrong_claim_token<S: MailboxStore>(store: &S) {
 
     // Dispatch stays Claimed.
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
+    assert_eq!(loaded.status(), RunDispatchStatus::Claimed);
 }
 
 /// `nack()` with attempts remaining returns the dispatch to Queued, bumping
@@ -235,7 +220,7 @@ pub async fn nack_returns_to_queued<S: MailboxStore>(store: &S) {
         .claim("t-nack", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store
         .nack("d1", &token, 3000, "transient error", 2000)
@@ -243,19 +228,19 @@ pub async fn nack_returns_to_queued<S: MailboxStore>(store: &S) {
         .unwrap();
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Queued);
-    assert_eq!(loaded.attempt_count, 1);
-    assert_eq!(loaded.available_at, 3000);
-    assert!(loaded.claim_token.is_none());
-    assert!(loaded.claimed_by.is_none());
-    assert!(loaded.lease_until.is_none());
-    assert_eq!(loaded.last_error.as_deref(), Some("transient error"));
+    assert_eq!(loaded.status(), RunDispatchStatus::Queued);
+    assert_eq!(loaded.attempt_count(), 1);
+    assert_eq!(loaded.available_at(), 3000);
+    assert!(loaded.claim_token().is_none());
+    assert!(loaded.claimed_by().is_none());
+    assert!(loaded.lease_until().is_none());
+    assert_eq!(loaded.last_error(), Some("transient error"));
 }
 
 /// `nack()` dead-letters a dispatch once `attempt_count` reaches `max_attempts`.
 pub async fn nack_dead_letters_after_max_attempts<S: MailboxStore>(store: &S) {
     let mut dispatch = make_dispatch("d1", "t-dead", "r1", 128, 1000);
-    dispatch.max_attempts = 2;
+    dispatch = dispatch.with_max_attempts(2);
     store.enqueue(&dispatch).await.unwrap();
 
     // First nack: attempt_count=1, back to Queued.
@@ -263,26 +248,26 @@ pub async fn nack_dead_letters_after_max_attempts<S: MailboxStore>(store: &S) {
         .claim("t-dead", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store.nack("d1", &token, 1500, "retry", 1100).await.unwrap();
     let after_first = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(after_first.status, RunDispatchStatus::Queued);
-    assert_eq!(after_first.attempt_count, 1);
+    assert_eq!(after_first.status(), RunDispatchStatus::Queued);
+    assert_eq!(after_first.attempt_count(), 1);
 
     // Second nack: attempt_count=2 == max_attempts → DeadLetter.
     let claimed = store
         .claim("t-dead", "consumer-1", 30_000, 1500, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store
         .nack("d1", &token, 2500, "final error", 2000)
         .await
         .unwrap();
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
-    assert_eq!(loaded.attempt_count, 2);
+    assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
+    assert_eq!(loaded.attempt_count(), 2);
     assert_claim_fields_clear(&loaded);
 }
 
@@ -293,10 +278,10 @@ pub async fn cancel_queued_dispatch<S: MailboxStore>(store: &S) {
 
     let cancelled = store.cancel("d1", 2000).await.unwrap();
     assert!(cancelled.is_some());
-    assert_eq!(cancelled.unwrap().status, RunDispatchStatus::Cancelled);
+    assert_eq!(cancelled.unwrap().status(), RunDispatchStatus::Cancelled);
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Cancelled);
+    assert_eq!(loaded.status(), RunDispatchStatus::Cancelled);
     assert_claim_fields_clear(&loaded);
 }
 
@@ -316,7 +301,7 @@ pub async fn cancel_claimed_dispatch_returns_none<S: MailboxStore>(store: &S) {
     assert!(cancelled.is_none());
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
+    assert_eq!(loaded.status(), RunDispatchStatus::Claimed);
 }
 
 /// `extend_lease()` with the right claim_token updates `lease_until`.
@@ -328,7 +313,7 @@ pub async fn extend_lease_success<S: MailboxStore>(store: &S) {
         .claim("t-extend", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     let ok = store
         .extend_lease("d1", &token, 60_000, 15_000)
@@ -337,7 +322,7 @@ pub async fn extend_lease_success<S: MailboxStore>(store: &S) {
     assert!(ok);
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.lease_until, Some(75_000));
+    assert_eq!(loaded.lease_until(), Some(75_000));
 }
 
 /// `extend_lease()` with a mismatched claim_token must return `false` and
@@ -350,7 +335,7 @@ pub async fn extend_lease_wrong_token<S: MailboxStore>(store: &S) {
         .claim("t-extend-wrong", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let original_lease = claimed[0].lease_until;
+    let original_lease = claimed[0].lease_until();
 
     let ok = store
         .extend_lease("d1", "wrong-token", 60_000, 15_000)
@@ -359,7 +344,7 @@ pub async fn extend_lease_wrong_token<S: MailboxStore>(store: &S) {
     assert!(!ok);
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.lease_until, original_lease);
+    assert_eq!(loaded.lease_until(), original_lease);
 }
 
 /// `interrupt()` supersedes all Queued dispatches in the thread.
@@ -382,8 +367,8 @@ pub async fn interrupt_supersedes_queued<S: MailboxStore>(store: &S) {
         .superseded_dispatches
         .iter()
         .map(|dispatch| {
-            assert_eq!(dispatch.status, RunDispatchStatus::Superseded);
-            dispatch.dispatch_id.as_str()
+            assert_eq!(dispatch.status(), RunDispatchStatus::Superseded);
+            dispatch.dispatch_id().as_str()
         })
         .collect::<Vec<_>>();
     returned_ids.sort_unstable();
@@ -415,7 +400,7 @@ pub async fn interrupt_returns_active_claimed<S: MailboxStore>(store: &S) {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    let claimed_id = claimed[0].dispatch_id.clone();
+    let claimed_id = claimed[0].dispatch_id().clone();
 
     // Enqueue another dispatch (will be Queued).
     store
@@ -430,13 +415,13 @@ pub async fn interrupt_returns_active_claimed<S: MailboxStore>(store: &S) {
     let active = result
         .active_dispatch
         .expect("interrupt must return active claimed dispatch");
-    assert_eq!(active.dispatch_id, claimed_id);
-    assert_eq!(active.status, RunDispatchStatus::Claimed);
+    assert_eq!(active.dispatch_id(), &claimed_id);
+    assert_eq!(active.status(), RunDispatchStatus::Claimed);
     assert_eq!(result.superseded_count, 1);
     assert_eq!(result.superseded_dispatches.len(), 1);
-    assert_eq!(result.superseded_dispatches[0].dispatch_id, "d2");
+    assert_eq!(result.superseded_dispatches[0].dispatch_id(), "d2");
     assert_eq!(
-        result.superseded_dispatches[0].status,
+        result.superseded_dispatches[0].status(),
         RunDispatchStatus::Superseded
     );
 }
@@ -467,7 +452,7 @@ pub async fn supersede_claimed_terminalizes_active_dispatch<S: MailboxStore>(sto
         .claim("t-supersede-claimed", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     let superseded = store
         .supersede_claimed("d1", &token, 2000, "test supersede")
@@ -475,15 +460,15 @@ pub async fn supersede_claimed_terminalizes_active_dispatch<S: MailboxStore>(sto
         .unwrap()
         .expect("claimed dispatch should be superseded");
 
-    assert_eq!(superseded.status, RunDispatchStatus::Superseded);
-    assert!(superseded.claim_token.is_none());
-    assert!(superseded.claimed_by.is_none());
-    assert!(superseded.lease_until.is_none());
-    assert_eq!(superseded.completed_at, Some(2000));
+    assert_eq!(superseded.status(), RunDispatchStatus::Superseded);
+    assert!(superseded.claim_token().is_none());
+    assert!(superseded.claimed_by().is_none());
+    assert!(superseded.lease_until().is_none());
+    assert_eq!(superseded.completed_at(), Some(2000));
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Superseded);
-    assert!(loaded.claim_token.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Superseded);
+    assert!(loaded.claim_token().is_none());
 }
 
 /// Once an interrupt bumps the thread epoch, a stale claimed dispatch must lose
@@ -497,7 +482,7 @@ pub async fn extend_lease_rejects_stale_claim_after_interrupt<S: MailboxStore>(s
         .claim("t-stale-lease", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store.interrupt("t-stale-lease", 1500).await.unwrap();
 
@@ -508,8 +493,8 @@ pub async fn extend_lease_rejects_stale_claim_after_interrupt<S: MailboxStore>(s
     assert!(!renewed, "stale claimed dispatch must not renew lease");
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Superseded);
-    assert!(loaded.claim_token.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Superseded);
+    assert!(loaded.claim_token().is_none());
 }
 
 /// Runtime-start projection must not resurrect a dispatch that became stale by
@@ -523,7 +508,7 @@ pub async fn record_dispatch_start_rejects_stale_claim_after_interrupt<S: Mailbo
         .claim("t-stale-start", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store.interrupt("t-stale-start", 1500).await.unwrap();
 
@@ -536,9 +521,9 @@ pub async fn record_dispatch_start_rejects_stale_claim_after_interrupt<S: Mailbo
     );
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Superseded);
-    assert!(loaded.dispatch_instance_id.is_none());
-    assert!(loaded.run_status.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Superseded);
+    assert!(loaded.dispatch_instance_id().is_none());
+    assert!(loaded.run_status().is_none());
 }
 
 /// Expired leases that became stale because of an interrupt must be
@@ -562,20 +547,20 @@ pub async fn reclaim_expired_stale_claim_supersedes<S: MailboxStore>(store: &S) 
     );
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Superseded);
-    assert!(loaded.claim_token.is_none());
-    assert!(loaded.lease_until.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Superseded);
+    assert!(loaded.claim_token().is_none());
+    assert!(loaded.lease_until().is_none());
 }
 
 /// `enqueue()` rejects a second dispatch that reuses a non-terminal
 /// dispatch's `dedupe_key`.
 pub async fn dedupe_key_rejects_duplicate<S: MailboxStore>(store: &S) {
     let mut first = make_dispatch("d1", "t-dedupe", "r1", 128, 1000);
-    first.dedupe_key = Some("unique-key".to_string());
+    first = first.with_dedupe_key(Some("unique-key".to_string()));
     store.enqueue(&first).await.unwrap();
 
     let mut second = make_dispatch("d2", "t-dedupe", "r2", 128, 1000);
-    second.dedupe_key = Some("unique-key".to_string());
+    second = second.with_dedupe_key(Some("unique-key".to_string()));
     let result = store.enqueue(&second).await;
     assert!(result.is_err(), "duplicate dedupe_key must be rejected");
 }
@@ -594,20 +579,20 @@ pub async fn reclaim_expired_leases_requeues<S: MailboxStore>(store: &S) {
     // Advance past lease expiry.
     let reclaimed = store.reclaim_expired_leases(2000, 10).await.unwrap();
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].dispatch_id, "d1");
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
-    assert_eq!(reclaimed[0].attempt_count, 1);
+    assert_eq!(reclaimed[0].dispatch_id(), "d1");
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::Queued);
+    assert_eq!(reclaimed[0].attempt_count(), 1);
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Queued);
-    assert!(loaded.claim_token.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Queued);
+    assert!(loaded.claim_token().is_none());
 }
 
 /// Expired lease reclaim follows `max_attempts` and dead-letters instead of
 /// retrying forever.
 pub async fn reclaim_expired_leases_dead_letters_at_max_attempts<S: MailboxStore>(store: &S) {
     let mut dispatch = make_dispatch("d1", "t-reclaim-max", "r1", 128, 1000);
-    dispatch.max_attempts = 1;
+    dispatch = dispatch.with_max_attempts(1);
     store.enqueue(&dispatch).await.unwrap();
 
     store
@@ -617,13 +602,13 @@ pub async fn reclaim_expired_leases_dead_letters_at_max_attempts<S: MailboxStore
 
     let reclaimed = store.reclaim_expired_leases(2000, 10).await.unwrap();
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].dispatch_id, "d1");
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::DeadLetter);
-    assert_eq!(reclaimed[0].attempt_count, 1);
+    assert_eq!(reclaimed[0].dispatch_id(), "d1");
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::DeadLetter);
+    assert_eq!(reclaimed[0].attempt_count(), 1);
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
-    assert_eq!(loaded.attempt_count, 1);
+    assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
+    assert_eq!(loaded.attempt_count(), 1);
     assert_claim_fields_clear(&loaded);
 }
 
@@ -634,7 +619,7 @@ pub async fn reclaim_expired_leases_dead_letter_is_idempotent_under_concurrency<
     store: &S,
 ) {
     let mut dispatch = make_dispatch("d1", "t-reclaim-idempotent", "r1", 128, 1000);
-    dispatch.max_attempts = 1;
+    dispatch = dispatch.with_max_attempts(1);
     store.enqueue(&dispatch).await.unwrap();
 
     store
@@ -655,12 +640,12 @@ pub async fn reclaim_expired_leases_dead_letter_is_idempotent_under_concurrency<
         1,
         "concurrent sweeps must observe a single terminal transition"
     );
-    assert_eq!(reclaimed[0].dispatch_id, "d1");
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::DeadLetter);
+    assert_eq!(reclaimed[0].dispatch_id(), "d1");
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::DeadLetter);
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
-    assert_eq!(loaded.attempt_count, 1);
+    assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
+    assert_eq!(loaded.attempt_count(), 1);
     assert_claim_fields_clear(&loaded);
 
     let later = store.reclaim_expired_leases(3000, 10).await.unwrap();
@@ -678,7 +663,7 @@ pub async fn purge_terminal_removes_old<S: MailboxStore>(store: &S) {
     // Cancel → Cancelled (terminal) with updated_at=1500.
     store.cancel("d1", 1500).await.unwrap();
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Cancelled);
+    assert_eq!(loaded.status(), RunDispatchStatus::Cancelled);
 
     // Cutoff > 1500 must purge the terminal dispatch.
     let purged = store.purge_terminal(2000).await.unwrap();
@@ -736,7 +721,7 @@ pub async fn count_dispatches_by_status_tracks_lifecycle<S: MailboxStore>(store:
         .claim("t-count-a", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let claim_token = claimed[0].claim_token.as_deref().unwrap();
+    let claim_token = claimed[0].claim_token().unwrap().to_string();
 
     assert_eq!(
         store
@@ -753,7 +738,7 @@ pub async fn count_dispatches_by_status_tracks_lifecycle<S: MailboxStore>(store:
         1
     );
 
-    store.ack("d1", claim_token, 1100).await.unwrap();
+    store.ack("d1", &claim_token, 1100).await.unwrap();
     store.cancel("d2", 1200).await.unwrap();
 
     assert_eq!(
@@ -807,7 +792,7 @@ pub async fn list_terminal_dispatches_returns_all_terminal<S: MailboxStore>(stor
     let listed = store.list_terminal_dispatches(10, 0).await.unwrap();
     let mut terminal = listed
         .iter()
-        .map(|dispatch| (dispatch.dispatch_id.as_str(), dispatch.status))
+        .map(|dispatch| (dispatch.dispatch_id().as_str(), dispatch.status()))
         .collect::<Vec<_>>();
     terminal.sort_unstable_by_key(|(dispatch_id, _)| *dispatch_id);
     assert_eq!(
@@ -820,7 +805,7 @@ pub async fn list_terminal_dispatches_returns_all_terminal<S: MailboxStore>(stor
 
     let paged = store.list_terminal_dispatches(1, 1).await.unwrap();
     assert_eq!(paged.len(), 1);
-    assert!(paged[0].status.is_terminal());
+    assert!(paged[0].status().is_terminal());
 }
 
 /// `claim_dispatch()` targets a specific dispatch_id and transitions it to
@@ -834,9 +819,9 @@ pub async fn claim_dispatch_by_id<S: MailboxStore>(store: &S) {
         .await
         .unwrap()
         .expect("claim_dispatch should return the dispatch");
-    assert_eq!(claimed.dispatch_id, "d1");
-    assert_eq!(claimed.status, RunDispatchStatus::Claimed);
-    assert!(claimed.claim_token.is_some());
+    assert_eq!(claimed.dispatch_id(), "d1");
+    assert_eq!(claimed.status(), RunDispatchStatus::Claimed);
+    assert!(claimed.claim_token().is_some());
 }
 
 /// `claim_dispatch(id)` MUST ignore `available_at` — it is the by-ID
@@ -846,7 +831,7 @@ pub async fn claim_dispatch_by_id<S: MailboxStore>(store: &S) {
 pub async fn claim_dispatch_ignores_available_at<S: MailboxStore>(store: &S) {
     // Submit with available_at far in the future.
     let mut dispatch = make_dispatch("d-guarded", "t-guarded", "r1", 128, 1000);
-    dispatch.available_at = 1_000_000;
+    dispatch = dispatch.with_available_at(1_000_000);
     store.enqueue(&dispatch).await.unwrap();
 
     // Queue scan at t=1000 must skip it (future available_at).
@@ -865,8 +850,8 @@ pub async fn claim_dispatch_ignores_available_at<S: MailboxStore>(store: &S) {
         .await
         .unwrap()
         .expect("claim_dispatch must ignore available_at");
-    assert_eq!(claimed.dispatch_id, "d-guarded");
-    assert_eq!(claimed.status, RunDispatchStatus::Claimed);
+    assert_eq!(claimed.dispatch_id(), "d-guarded");
+    assert_eq!(claimed.status(), RunDispatchStatus::Claimed);
 }
 
 /// `record_dispatch_start()` sets the active runtime projection and clears any
@@ -879,7 +864,7 @@ pub async fn record_dispatch_start_marks_running<S: MailboxStore>(store: &S) {
         .claim("t-start", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     store
         .record_dispatch_start("d1", &token, "attempt-1", 1500)
@@ -887,15 +872,15 @@ pub async fn record_dispatch_start_marks_running<S: MailboxStore>(store: &S) {
         .unwrap();
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.dispatch_instance_id.as_deref(), Some("attempt-1"));
+    assert_eq!(loaded.dispatch_instance_id(), Some("attempt-1"));
     assert_eq!(
-        loaded.run_status,
+        loaded.run_status(),
         Some(awaken_server_contract::contract::lifecycle::RunStatus::Running)
     );
-    assert!(loaded.termination.is_none());
-    assert!(loaded.run_response.is_none());
-    assert!(loaded.run_error.is_none());
-    assert!(loaded.completed_at.is_none());
+    assert!(loaded.termination().is_none());
+    assert!(loaded.run_response().is_none());
+    assert!(loaded.run_error().is_none());
+    assert!(loaded.completed_at().is_none());
 }
 
 /// `record_run_result()` requires the active claim and persists the full runtime
@@ -911,7 +896,7 @@ pub async fn record_run_result_sets_terminal_projection<S: MailboxStore>(store: 
         .claim("t-result", "consumer-1", 30_000, 1000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     let result = RunDispatchResult {
         run_id: "r1".to_string(),
         dispatch_instance_id: "attempt-1".to_string(),
@@ -927,12 +912,12 @@ pub async fn record_run_result_sets_terminal_projection<S: MailboxStore>(store: 
         .unwrap();
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.dispatch_instance_id.as_deref(), Some("attempt-1"));
-    assert_eq!(loaded.run_status, Some(RunStatus::Done));
-    assert_eq!(loaded.termination, Some(TerminationReason::NaturalEnd));
-    assert_eq!(loaded.run_response.as_deref(), Some("ok"));
-    assert!(loaded.run_error.is_none());
-    assert_eq!(loaded.completed_at, Some(2000));
+    assert_eq!(loaded.dispatch_instance_id(), Some("attempt-1"));
+    assert_eq!(loaded.run_status(), Some(RunStatus::Done));
+    assert_eq!(loaded.termination(), Some(&TerminationReason::NaturalEnd));
+    assert_eq!(loaded.run_response(), Some("ok"));
+    assert!(loaded.run_error().is_none());
+    assert_eq!(loaded.completed_at(), Some(2000));
 }
 
 /// Runtime projection writes must require an existing claimed dispatch.
@@ -979,9 +964,9 @@ pub async fn record_projection_rejects_missing_or_unclaimed_dispatch<S: MailboxS
     );
 
     let loaded = store.load_dispatch("d1").await.unwrap().unwrap();
-    assert_eq!(loaded.status, RunDispatchStatus::Queued);
-    assert!(loaded.run_status.is_none());
-    assert!(loaded.dispatch_instance_id.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::Queued);
+    assert!(loaded.run_status().is_none());
+    assert!(loaded.dispatch_instance_id().is_none());
 }
 
 /// For dispatches that share a priority, `claim()` must return them in
@@ -993,11 +978,11 @@ pub async fn fifo_ordering_within_same_priority<S: MailboxStore>(store: &S) {
     let newer_id = format!("newer-{}", Uuid::now_v7());
 
     let mut older = make_dispatch(&older_id, "t-fifo", "r1", 128, 1000);
-    older.created_at = 100;
+    older = older.with_created_at(100);
     store.enqueue(&older).await.unwrap();
 
     let mut newer = make_dispatch(&newer_id, "t-fifo", "r2", 128, 1000);
-    newer.created_at = 200;
+    newer = newer.with_created_at(200);
     store.enqueue(&newer).await.unwrap();
 
     // Claim them one at a time; the older dispatch must come first.
@@ -1006,11 +991,11 @@ pub async fn fifo_ordering_within_same_priority<S: MailboxStore>(store: &S) {
         .await
         .unwrap();
     assert_eq!(first.len(), 1);
-    assert_eq!(first[0].dispatch_id, older_id);
+    assert_eq!(first[0].dispatch_id(), &older_id);
 
-    let token = first[0].claim_token.clone().unwrap();
+    let token = first[0].claim_token().unwrap().to_string();
     store
-        .ack(&first[0].dispatch_id, &token, 1100)
+        .ack(first[0].dispatch_id(), &token, 1100)
         .await
         .unwrap();
 
@@ -1019,5 +1004,5 @@ pub async fn fifo_ordering_within_same_priority<S: MailboxStore>(store: &S) {
         .await
         .unwrap();
     assert_eq!(second.len(), 1);
-    assert_eq!(second[0].dispatch_id, newer_id);
+    assert_eq!(second[0].dispatch_id(), &newer_id);
 }

--- a/crates/awaken-stores/tests/memory_store.rs
+++ b/crates/awaken-stores/tests/memory_store.rs
@@ -332,6 +332,7 @@ async fn list_runs_filter_by_status() {
     let store = InMemoryStore::new();
     let mut done = make_run("r1", "t-1", 100);
     done.status = RunStatus::Done;
+    done.finished_at = Some(done.updated_at);
     store.create_run(&done).await.unwrap();
     store.create_run(&make_run("r2", "t-1", 200)).await.unwrap();
 
@@ -408,6 +409,7 @@ async fn run_record_with_termination_reason() {
     let store = InMemoryStore::new();
     let mut run = make_run("r1", "t-1", 100);
     run.status = RunStatus::Done;
+    run.finished_at = Some(run.updated_at);
     run.termination_reason = Some(TerminationReason::NaturalEnd);
     store.create_run(&run).await.unwrap();
 
@@ -822,12 +824,14 @@ async fn list_runs_combined_filter_thread_and_status() {
 
     let mut done = make_run("r1", "t-1", 100);
     done.status = RunStatus::Done;
+    done.finished_at = Some(done.updated_at);
     store.create_run(&done).await.unwrap();
 
     store.create_run(&make_run("r2", "t-1", 200)).await.unwrap();
 
     let mut done_other = make_run("r3", "t-2", 300);
     done_other.status = RunStatus::Done;
+    done_other.finished_at = Some(done_other.updated_at);
     store.create_run(&done_other).await.unwrap();
 
     let page = store
@@ -907,6 +911,7 @@ async fn full_agent_run_via_checkpoint() {
     // 4. Final assistant message
     let mut final_run = make_run("run-1", "t-1", 300);
     final_run.status = RunStatus::Done;
+    final_run.finished_at = Some(final_run.updated_at);
     final_run.termination_reason = Some(TerminationReason::NaturalEnd);
     final_run.steps = 2;
     final_run.input_tokens = 100;

--- a/crates/awaken-stores/tests/nats_mailbox_behavior.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_behavior.rs
@@ -7,35 +7,49 @@ use std::{
     time::{Duration, Instant},
 };
 
-use awaken_server_contract::contract::mailbox::{MailboxStore, RunDispatch, RunDispatchStatus};
+use awaken_server_contract::contract::mailbox::{
+    MailboxStore, RunDispatch, RunDispatchParts, RunDispatchStatus,
+};
 use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
 use nats_fixture::NatsFixture;
 
 fn test_dispatch(id: &str, thread_id: &str) -> RunDispatch {
-    RunDispatch {
-        dispatch_id: id.to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: format!("{id}-run"),
-        priority: 128,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: 0,
-        attempt_count: 0,
-        max_attempts: 3,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: 0,
-        updated_at: 0,
-    }
+    RunDispatch::queued(
+        id.to_string(),
+        thread_id.to_string(),
+        format!("{id}-run"),
+        0,
+    )
+    .with_max_attempts(3)
+}
+
+fn claimed_test_dispatch(
+    id: &str,
+    thread_id: &str,
+    consumer_id: &str,
+    claim_token: &str,
+    lease_until: u64,
+    now: u64,
+) -> RunDispatch {
+    let mut dispatch = test_dispatch(id, thread_id);
+    dispatch
+        .claim(
+            consumer_id.to_string(),
+            claim_token.to_string(),
+            lease_until,
+            now,
+        )
+        .expect("claimed test dispatch must be valid");
+    dispatch
+}
+
+fn dispatch_from_parts(
+    dispatch: RunDispatch,
+    mutate: impl FnOnce(&mut RunDispatchParts),
+) -> RunDispatch {
+    let mut parts = dispatch.to_persisted_parts();
+    mutate(&mut parts);
+    RunDispatch::from_persisted_parts(parts).expect("test dispatch parts must be valid")
 }
 
 async fn make_store(fixture: &NatsFixture) -> NatsMailboxStore {
@@ -111,7 +125,7 @@ async fn index_rebuilds_from_kv_on_restart() {
 
     let claimed = store2.claim("t1", "c2", 30_000, 1_000, 1).await.unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d1");
+    assert_eq!(claimed[0].dispatch_id(), "d1");
     store2.shutdown().await.unwrap();
 }
 
@@ -140,8 +154,8 @@ async fn index_rebuilds_hot_thread_from_kv_on_restart() {
         .await
         .expect("connect 1");
     for i in 0..2_000 {
-        let mut dispatch = test_dispatch(&format!("d-hot-restart-{i}"), "t-hot-restart");
-        dispatch.created_at = i;
+        let dispatch =
+            test_dispatch(&format!("d-hot-restart-{i}"), "t-hot-restart").with_created_at(i);
         store1.enqueue(&dispatch).await.unwrap();
     }
     store1
@@ -159,7 +173,7 @@ async fn index_rebuilds_hot_thread_from_kv_on_restart() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-hot-restart-0");
+    assert_eq!(claimed[0].dispatch_id(), "d-hot-restart-0");
 
     store2.shutdown().await.unwrap();
 }
@@ -173,7 +187,7 @@ async fn sweeper_republishes_available_dispatch() {
     store.enqueue(&d).await.unwrap();
     let claimed = store.claim("t1", "c1", 30_000, 100, 1).await.unwrap();
     assert_eq!(claimed.len(), 1);
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
 
     // Nack with retry_at in the past so sweeper picks it up on next tick.
     store
@@ -207,8 +221,9 @@ async fn load_dispatch_reads_authoritative_kv_not_stale_index() {
         .unwrap();
     assert_eq!(claimed.len(), 1);
 
-    let mut stale = dispatch;
-    stale.status = RunDispatchStatus::Queued;
+    let stale = dispatch_from_parts(dispatch, |parts| {
+        parts.status = RunDispatchStatus::Queued;
+    });
     store.__test_upsert_index_only(&stale).await;
 
     let loaded = store
@@ -216,8 +231,8 @@ async fn load_dispatch_reads_authoritative_kv_not_stale_index() {
         .await
         .unwrap()
         .expect("authoritative dispatch");
-    assert_eq!(loaded.status, RunDispatchStatus::Claimed);
-    assert_eq!(loaded.claimed_by.as_deref(), Some("consumer"));
+    assert_eq!(loaded.status(), RunDispatchStatus::Claimed);
+    assert_eq!(loaded.claimed_by(), Some("consumer"));
     store.shutdown().await.unwrap();
 }
 
@@ -257,7 +272,7 @@ async fn dispatch_signal_can_wake_a_different_store_instance() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-signal");
+    assert_eq!(claimed[0].dispatch_id(), "d-signal");
     signal.receipt.ack().await.unwrap();
 
     store1.shutdown().await.unwrap();
@@ -298,7 +313,7 @@ async fn pull_dispatch_signal_repairs_missing_thread_index_without_restart() {
         1,
         "pull_dispatch_signals should repair the authoritative thread index before claim"
     );
-    assert_eq!(claimed[0].dispatch_id, "d-signal-repairs-index");
+    assert_eq!(claimed[0].dispatch_id(), "d-signal-repairs-index");
     signal.receipt.ack().await.unwrap();
 
     store.shutdown().await.unwrap();
@@ -322,7 +337,7 @@ async fn interrupt_detects_authoritative_active_dispatch_when_local_index_is_sta
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    let claim_token = claimed[0].claim_token.clone().unwrap();
+    let claim_token = claimed[0].claim_token().unwrap().to_string();
 
     store2
         .__test_remove_dispatch_from_index("d-active-authoritative")
@@ -340,7 +355,7 @@ async fn interrupt_detects_authoritative_active_dispatch_when_local_index_is_sta
         interrupted
             .active_dispatch
             .as_ref()
-            .map(|dispatch| dispatch.dispatch_id.as_str()),
+            .map(|dispatch| dispatch.dispatch_id().as_str()),
         Some("d-active-authoritative")
     );
 
@@ -357,7 +372,7 @@ async fn interrupt_detects_authoritative_active_dispatch_when_local_index_is_sta
         .await
         .unwrap()
         .expect("dispatch remains recorded");
-    assert_eq!(stale.status, RunDispatchStatus::Superseded);
+    assert_eq!(stale.status(), RunDispatchStatus::Superseded);
 
     store1.shutdown().await.unwrap();
 }
@@ -377,13 +392,16 @@ async fn interrupt_keeps_claim_guard_active_dispatch_over_stale_claimed_records(
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "a-current-active");
+    assert_eq!(claimed[0].dispatch_id(), "a-current-active");
 
-    let mut stale = test_dispatch("z-stale-claimed", thread_id);
-    stale.status = RunDispatchStatus::Claimed;
-    stale.claim_token = Some("stale-token".to_string());
-    stale.claimed_by = Some("stale-consumer".to_string());
-    stale.lease_until = Some(500);
+    let stale = claimed_test_dispatch(
+        "z-stale-claimed",
+        thread_id,
+        "stale-consumer",
+        "stale-token",
+        500,
+        100,
+    );
     store
         .__test_plant_dispatch_exact(&stale)
         .await
@@ -394,7 +412,7 @@ async fn interrupt_keeps_claim_guard_active_dispatch_over_stale_claimed_records(
         interrupted
             .active_dispatch
             .as_ref()
-            .map(|dispatch| dispatch.dispatch_id.as_str()),
+            .map(|dispatch| dispatch.dispatch_id().as_str()),
         Some("a-current-active"),
         "claim-guard active dispatch must not be overwritten by stale claimed scan results"
     );
@@ -408,12 +426,12 @@ async fn claim_uses_authoritative_ordering_when_local_index_only_has_later_dispa
     let (store1, store2) = make_shared_stores(&fixture).await;
     store2.shutdown().await.unwrap();
 
-    let mut high = test_dispatch("d-high-priority", "t-authoritative-order");
-    high.priority = 10;
-    high.created_at = 1;
-    let mut low = test_dispatch("d-low-priority", "t-authoritative-order");
-    low.priority = 128;
-    low.created_at = 2;
+    let high = test_dispatch("d-high-priority", "t-authoritative-order")
+        .with_priority(10)
+        .with_created_at(1);
+    let low = test_dispatch("d-low-priority", "t-authoritative-order")
+        .with_priority(128)
+        .with_created_at(2);
 
     store1.enqueue(&high).await.unwrap();
     store1.enqueue(&low).await.unwrap();
@@ -437,7 +455,8 @@ async fn claim_uses_authoritative_ordering_when_local_index_only_has_later_dispa
         .unwrap();
     assert_eq!(claimed.len(), 1);
     assert_eq!(
-        claimed[0].dispatch_id, "d-high-priority",
+        claimed[0].dispatch_id(),
+        "d-high-priority",
         "claim must use authoritative ordering instead of the incomplete local watcher index"
     );
 
@@ -450,8 +469,8 @@ async fn reclaim_expired_leases_uses_authoritative_kv_and_clears_terminal_claim_
     let (store1, store2) = make_shared_stores(&fixture).await;
     store2.shutdown().await.unwrap();
 
-    let mut dispatch = test_dispatch("d-expired-authoritative", "t-expired-authoritative");
-    dispatch.max_attempts = 1;
+    let dispatch =
+        test_dispatch("d-expired-authoritative", "t-expired-authoritative").with_max_attempts(1);
     store1.enqueue(&dispatch).await.unwrap();
     let claimed = store1
         .claim("t-expired-authoritative", "consumer-1", 100, 1_000, 1)
@@ -469,21 +488,21 @@ async fn reclaim_expired_leases_uses_authoritative_kv_and_clears_terminal_claim_
 
     let reclaimed = store2.reclaim_expired_leases(2_000, 10).await.unwrap();
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].dispatch_id, "d-expired-authoritative");
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::DeadLetter);
-    assert!(reclaimed[0].claim_token.is_none());
-    assert!(reclaimed[0].claimed_by.is_none());
-    assert!(reclaimed[0].lease_until.is_none());
+    assert_eq!(reclaimed[0].dispatch_id(), "d-expired-authoritative");
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::DeadLetter);
+    assert!(reclaimed[0].claim_token().is_none());
+    assert!(reclaimed[0].claimed_by().is_none());
+    assert!(reclaimed[0].lease_until().is_none());
 
     let loaded = store1
         .load_dispatch("d-expired-authoritative")
         .await
         .unwrap()
         .expect("dispatch remains inspectable");
-    assert_eq!(loaded.status, RunDispatchStatus::DeadLetter);
-    assert!(loaded.claim_token.is_none());
-    assert!(loaded.claimed_by.is_none());
-    assert!(loaded.lease_until.is_none());
+    assert_eq!(loaded.status(), RunDispatchStatus::DeadLetter);
+    assert!(loaded.claim_token().is_none());
+    assert!(loaded.claimed_by().is_none());
+    assert!(loaded.lease_until().is_none());
 
     store1.shutdown().await.unwrap();
 }
@@ -530,7 +549,7 @@ async fn dispatch_signal_nack_redelivers_same_dispatch() {
         .await
         .unwrap()
         .expect("dispatch should still exist after signal nack");
-    assert_eq!(dispatch.status, RunDispatchStatus::Queued);
+    assert_eq!(dispatch.status(), RunDispatchStatus::Queued);
     redelivered.receipt.ack().await.unwrap();
     store.shutdown().await.unwrap();
 }
@@ -699,7 +718,7 @@ async fn dispatch_signal_nack_redelivers_to_other_store_instance() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-cross-redeliver");
+    assert_eq!(claimed[0].dispatch_id(), "d-cross-redeliver");
     redelivered.receipt.ack().await.unwrap();
 
     store1.shutdown().await.unwrap();
@@ -734,7 +753,7 @@ async fn enqueue_stamps_current_thread_epoch_after_interrupt() {
          enqueue should stamp current thread epoch"
     );
     assert!(
-        claimed.unwrap().dispatch_epoch >= 1,
+        claimed.unwrap().dispatch_epoch() >= 1,
         "stamped dispatch_epoch must be >= the post-interrupt epoch"
     );
 
@@ -750,8 +769,7 @@ async fn background_enqueue_after_interrupt_is_claimable_via_scan() {
 
     store.interrupt("t-bg", 1_000).await.unwrap();
 
-    let mut dispatch = test_dispatch("d-bg", "t-bg");
-    dispatch.available_at = 0; // claimable immediately
+    let dispatch = test_dispatch("d-bg", "t-bg").with_available_at(0);
     store.enqueue(&dispatch).await.unwrap();
 
     let claimed = store
@@ -781,7 +799,7 @@ async fn queue_claim_respects_retry_available_at_after_nack() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store
         .nack("d-retry-window", &token, 10_000, "retry later", 2_000)
         .await
@@ -819,18 +837,17 @@ async fn claim_skips_and_supersedes_stale_epoch_queue_head() {
 
     store.interrupt("t-stale-head", 1_000).await.unwrap();
 
-    let mut old = test_dispatch("d-old-stale", "t-stale-head");
-    old.dedupe_key = Some("stale-key".to_string());
-    old.dispatch_epoch = 0;
-    old.created_at = 1;
+    let old = test_dispatch("d-old-stale", "t-stale-head")
+        .with_dedupe_key(Some("stale-key".to_string()))
+        .with_dispatch_epoch(0)
+        .with_created_at(1);
     store.__test_plant_dispatch_exact(&old).await.unwrap();
     store
         .__test_force_dedupe_lock("t-stale-head", "stale-key", "d-old-stale")
         .await
         .unwrap();
 
-    let mut new = test_dispatch("d-new-valid", "t-stale-head");
-    new.created_at = 2;
+    let new = test_dispatch("d-new-valid", "t-stale-head").with_created_at(2);
     store.enqueue(&new).await.unwrap();
 
     let claimed = store
@@ -838,17 +855,17 @@ async fn claim_skips_and_supersedes_stale_epoch_queue_head() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-new-valid");
+    assert_eq!(claimed[0].dispatch_id(), "d-new-valid");
 
     let old_after = store
         .load_dispatch("d-old-stale")
         .await
         .unwrap()
         .expect("old dispatch should remain inspectable");
-    assert_eq!(old_after.status, RunDispatchStatus::Superseded);
+    assert_eq!(old_after.status(), RunDispatchStatus::Superseded);
 
-    let mut fresh = test_dispatch("d-fresh-dedupe", "t-stale-head");
-    fresh.dedupe_key = Some("stale-key".to_string());
+    let fresh = test_dispatch("d-fresh-dedupe", "t-stale-head")
+        .with_dedupe_key(Some("stale-key".to_string()));
     store
         .enqueue(&fresh)
         .await
@@ -865,8 +882,8 @@ async fn interrupt_does_not_release_dedupe_for_claimed_dispatch_from_stale_index
     let fixture = NatsFixture::start().await;
     let store = make_store(&fixture).await;
 
-    let mut indexed = test_dispatch("d-authoritative-claimed", "t-interrupt-race");
-    indexed.dedupe_key = Some("race-key".to_string());
+    let indexed = test_dispatch("d-authoritative-claimed", "t-interrupt-race")
+        .with_dedupe_key(Some("race-key".to_string()));
     store
         .__test_force_dedupe_lock("t-interrupt-race", "race-key", "d-authoritative-claimed")
         .await
@@ -881,10 +898,9 @@ async fn interrupt_does_not_release_dedupe_for_claimed_dispatch_from_stale_index
     );
 
     let mut claimed = indexed.clone();
-    claimed.status = RunDispatchStatus::Claimed;
-    claimed.claim_token = Some("claim-token".to_string());
-    claimed.claimed_by = Some("remote-consumer".to_string());
-    claimed.lease_until = Some(60_000);
+    claimed
+        .claim("remote-consumer", "claim-token", 60_000, 500)
+        .expect("claimed dispatch must be valid");
     store
         .__test_plant_dispatch_exact(&claimed)
         .await
@@ -900,8 +916,8 @@ async fn interrupt_does_not_release_dedupe_for_claimed_dispatch_from_stale_index
         Some("d-authoritative-claimed")
     );
 
-    let mut before_interrupt = test_dispatch("d-before-interrupt", "t-interrupt-race");
-    before_interrupt.dedupe_key = Some("race-key".to_string());
+    let before_interrupt = test_dispatch("d-before-interrupt", "t-interrupt-race")
+        .with_dedupe_key(Some("race-key".to_string()));
     assert!(
         store.enqueue(&before_interrupt).await.is_err(),
         "dedupe lock should be held before interrupt"
@@ -916,13 +932,13 @@ async fn interrupt_does_not_release_dedupe_for_claimed_dispatch_from_stale_index
         interrupted
             .active_dispatch
             .as_ref()
-            .map(|dispatch| dispatch.dispatch_id.as_str()),
+            .map(|dispatch| dispatch.dispatch_id().as_str()),
         Some("d-authoritative-claimed"),
         "interrupt should return the authoritative active dispatch"
     );
 
-    let mut next = test_dispatch("d-next-same-key", "t-interrupt-race");
-    next.dedupe_key = Some("race-key".to_string());
+    let next = test_dispatch("d-next-same-key", "t-interrupt-race")
+        .with_dedupe_key(Some("race-key".to_string()));
     let result = store.enqueue(&next).await;
     assert!(
         result.is_err(),
@@ -946,8 +962,7 @@ async fn dedupe_lock_orphan_is_reconciled_by_next_enqueue() {
         .await
         .unwrap();
 
-    let mut d1 = test_dispatch("d-recovers", "t-orphan");
-    d1.dedupe_key = Some("ghost-key".to_string());
+    let d1 = test_dispatch("d-recovers", "t-orphan").with_dedupe_key(Some("ghost-key".to_string()));
     store
         .enqueue(&d1)
         .await
@@ -972,8 +987,8 @@ async fn dedupe_lock_holder_delete_tombstone_is_reconciled_by_next_enqueue() {
         .await
         .unwrap();
 
-    let mut next = test_dispatch("d-after-tombstone", "t-tombstone");
-    next.dedupe_key = Some("same-key".to_string());
+    let next = test_dispatch("d-after-tombstone", "t-tombstone")
+        .with_dedupe_key(Some("same-key".to_string()));
     store
         .enqueue(&next)
         .await
@@ -996,7 +1011,7 @@ async fn thread_claim_tombstone_does_not_block_next_claim() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store
         .ack("d-claim-before-purge", &token, 2_000)
         .await
@@ -1019,7 +1034,7 @@ async fn thread_claim_tombstone_does_not_block_next_claim() {
         1,
         "thread claim Delete/Purge tombstones should be treated as absent"
     );
-    assert_eq!(claimed[0].dispatch_id, "d-claim-after-purge");
+    assert_eq!(claimed[0].dispatch_id(), "d-claim-after-purge");
 
     store.shutdown().await.unwrap();
 }
@@ -1029,10 +1044,8 @@ async fn purged_active_thread_claim_does_not_allow_second_active_claim() {
     let fixture = NatsFixture::start().await;
     let store = make_store(&fixture).await;
 
-    let mut first = test_dispatch("d-active-before-purge", "t-active-claim-purged");
-    first.created_at = 1;
-    let mut second = test_dispatch("d-queued-after-purge", "t-active-claim-purged");
-    second.created_at = 2;
+    let first = test_dispatch("d-active-before-purge", "t-active-claim-purged").with_created_at(1);
+    let second = test_dispatch("d-queued-after-purge", "t-active-claim-purged").with_created_at(2);
     store.enqueue(&first).await.unwrap();
     store.enqueue(&second).await.unwrap();
 
@@ -1041,7 +1054,7 @@ async fn purged_active_thread_claim_does_not_allow_second_active_claim() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-active-before-purge");
+    assert_eq!(claimed[0].dispatch_id(), "d-active-before-purge");
 
     store
         .__test_purge_thread_claim("t-active-claim-purged")
@@ -1071,13 +1084,13 @@ async fn purged_active_thread_claim_does_not_allow_second_active_claim() {
         .await
         .unwrap()
         .expect("active dispatch remains recorded");
-    assert_eq!(active.status, RunDispatchStatus::Claimed);
+    assert_eq!(active.status(), RunDispatchStatus::Claimed);
     let queued = store
         .load_dispatch("d-queued-after-purge")
         .await
         .unwrap()
         .expect("queued dispatch remains recorded");
-    assert_eq!(queued.status, RunDispatchStatus::Queued);
+    assert_eq!(queued.status(), RunDispatchStatus::Queued);
 
     store.shutdown().await.unwrap();
 }
@@ -1111,19 +1124,19 @@ async fn purged_expired_thread_claim_is_reclaimed_from_dispatch_index() {
         1,
         "expired claimed dispatches must be recoverable even when the thread-claim KV record is lost"
     );
-    assert_eq!(reclaimed[0].dispatch_id, "d-expired-claim-purged");
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
-    assert_eq!(reclaimed[0].attempt_count, 1);
-    assert!(reclaimed[0].claim_token.is_none());
-    assert!(reclaimed[0].claimed_by.is_none());
-    assert!(reclaimed[0].lease_until.is_none());
+    assert_eq!(reclaimed[0].dispatch_id(), "d-expired-claim-purged");
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::Queued);
+    assert_eq!(reclaimed[0].attempt_count(), 1);
+    assert!(reclaimed[0].claim_token().is_none());
+    assert!(reclaimed[0].claimed_by().is_none());
+    assert!(reclaimed[0].lease_until().is_none());
 
     let claimed_again = store
         .claim("t-expired-claim-purged", "consumer-2", 60_000, 3_000, 1)
         .await
         .unwrap();
     assert_eq!(claimed_again.len(), 1);
-    assert_eq!(claimed_again[0].dispatch_id, "d-expired-claim-purged");
+    assert_eq!(claimed_again[0].dispatch_id(), "d-expired-claim-purged");
 
     store.shutdown().await.unwrap();
 }
@@ -1149,8 +1162,8 @@ async fn dedupe_lock_tombstone_is_treated_as_absent() {
         None
     );
 
-    let mut next = test_dispatch("d-after-lock-tombstone", "t-lock-tombstone");
-    next.dedupe_key = Some("same-key".to_string());
+    let next = test_dispatch("d-after-lock-tombstone", "t-lock-tombstone")
+        .with_dedupe_key(Some("same-key".to_string()));
     store
         .enqueue(&next)
         .await
@@ -1173,7 +1186,7 @@ async fn purge_terminal_uses_authoritative_kv_when_local_index_is_missing() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store
         .ack("d-authoritative-gc", &token, 2_000)
         .await
@@ -1210,14 +1223,13 @@ async fn dedupe_key_reusable_after_cancel() {
     let fixture = NatsFixture::start().await;
     let store = make_store(&fixture).await;
 
-    let mut first = test_dispatch("d-first", "t-reuse");
-    first.dedupe_key = Some("reuse-key".to_string());
+    let first = test_dispatch("d-first", "t-reuse").with_dedupe_key(Some("reuse-key".to_string()));
     store.enqueue(&first).await.unwrap();
 
     store.cancel("d-first", 1_000).await.unwrap();
 
-    let mut second = test_dispatch("d-second", "t-reuse");
-    second.dedupe_key = Some("reuse-key".to_string());
+    let second =
+        test_dispatch("d-second", "t-reuse").with_dedupe_key(Some("reuse-key".to_string()));
     store
         .enqueue(&second)
         .await
@@ -1239,8 +1251,8 @@ async fn dedupe_key_reuse_publishes_distinct_dispatch_signals() {
     config.dedup_window = Duration::from_secs(120);
     let store = NatsMailboxStore::connect(config).await.expect("connect");
 
-    let mut first = test_dispatch("d-dedupe-signal-1", "t-dedupe-signal");
-    first.dedupe_key = Some("same-key".to_string());
+    let first = test_dispatch("d-dedupe-signal-1", "t-dedupe-signal")
+        .with_dedupe_key(Some("same-key".to_string()));
     store.enqueue(&first).await.unwrap();
     let first_signal = store
         .pull_dispatch_signals(8, Duration::from_secs(2))
@@ -1257,8 +1269,8 @@ async fn dedupe_key_reuse_publishes_distinct_dispatch_signals() {
         .unwrap()
         .expect("cancel first dispatch");
 
-    let mut second = test_dispatch("d-dedupe-signal-2", "t-dedupe-signal");
-    second.dedupe_key = Some("same-key".to_string());
+    let second = test_dispatch("d-dedupe-signal-2", "t-dedupe-signal")
+        .with_dedupe_key(Some("same-key".to_string()));
     store.enqueue(&second).await.unwrap();
 
     let second_signal = store
@@ -1302,9 +1314,12 @@ async fn concurrent_enqueue_same_thread_preserves_thread_index_entries() {
     for i in 0..total {
         let store = Arc::clone(&store);
         handles.push(tokio::spawn(async move {
-            let mut dispatch = test_dispatch(&format!("d-hot-index-{i}"), "t-hot-index");
-            dispatch.created_at = i as u64;
-            dispatch.updated_at = i as u64;
+            let dispatch = dispatch_from_parts(
+                test_dispatch(&format!("d-hot-index-{i}"), "t-hot-index").with_created_at(i as u64),
+                |parts| {
+                    parts.updated_at = i as u64;
+                },
+            );
             store.enqueue(&dispatch).await
         }));
     }
@@ -1329,12 +1344,12 @@ async fn concurrent_enqueue_same_thread_preserves_thread_index_entries() {
             "thread index should expose every concurrently enqueued dispatch"
         );
         let dispatch = got.into_iter().next().unwrap();
-        let token = dispatch.claim_token.clone().unwrap();
+        let token = dispatch.claim_token().unwrap().to_string();
         verifier
-            .ack(&dispatch.dispatch_id, &token, 20_000 + i as u64)
+            .ack(&dispatch.dispatch_id(), &token, 20_000 + i as u64)
             .await
             .unwrap();
-        claimed.push(dispatch.dispatch_id);
+        claimed.push(dispatch.dispatch_id().to_string());
     }
     claimed.sort();
     assert_eq!(claimed.len(), total);
@@ -1355,21 +1370,21 @@ async fn delayed_old_owner_release_does_not_delete_new_dedupe_lock() {
     let fixture = NatsFixture::start().await;
     let store = make_store(&fixture).await;
 
-    let mut first = test_dispatch("d-release-old", "t-release-race");
-    first.dedupe_key = Some("race-key".to_string());
+    let first = test_dispatch("d-release-old", "t-release-race")
+        .with_dedupe_key(Some("race-key".to_string()));
     store.enqueue(&first).await.unwrap();
     store.cancel("d-release-old", 1_000).await.unwrap();
 
-    let mut second = test_dispatch("d-release-new", "t-release-race");
-    second.dedupe_key = Some("race-key".to_string());
+    let second = test_dispatch("d-release-new", "t-release-race")
+        .with_dedupe_key(Some("race-key".to_string()));
     store.enqueue(&second).await.unwrap();
 
     store
         .__test_release_dedupe_lock_as("t-release-race", "race-key", "d-release-old")
         .await;
 
-    let mut third = test_dispatch("d-release-third", "t-release-race");
-    third.dedupe_key = Some("race-key".to_string());
+    let third = test_dispatch("d-release-third", "t-release-race")
+        .with_dedupe_key(Some("race-key".to_string()));
     let result = store.enqueue(&third).await;
     assert!(
         result.is_err(),
@@ -1391,10 +1406,10 @@ async fn concurrent_orphan_reconcile_admits_exactly_one_owner() {
         .await
         .unwrap();
 
-    let mut first = test_dispatch("d-race-a", "t-reconcile-race");
-    first.dedupe_key = Some("race-key".to_string());
-    let mut second = test_dispatch("d-race-b", "t-reconcile-race");
-    second.dedupe_key = Some("race-key".to_string());
+    let first =
+        test_dispatch("d-race-a", "t-reconcile-race").with_dedupe_key(Some("race-key".to_string()));
+    let second =
+        test_dispatch("d-race-b", "t-reconcile-race").with_dedupe_key(Some("race-key".to_string()));
 
     let store_a = store.clone();
     let store_b = store.clone();
@@ -1451,7 +1466,7 @@ async fn partial_failure_kv_put_without_publish_is_recovered_by_sweeper() {
         .await
         .expect("claim must not error")
         .expect("dispatch must be claimable after KV-only commit");
-    assert_eq!(claimed.dispatch_id, "d-partial");
+    assert_eq!(claimed.dispatch_id(), "d-partial");
 
     store.shutdown().await.unwrap();
 }
@@ -1461,12 +1476,10 @@ async fn dedup_rejects_duplicate_key_on_same_thread() {
     let fixture = NatsFixture::start().await;
     let store = make_store(&fixture).await;
 
-    let mut d1 = test_dispatch("d1", "t1");
-    d1.dedupe_key = Some("dup-key".to_string());
+    let d1 = test_dispatch("d1", "t1").with_dedupe_key(Some("dup-key".to_string()));
     store.enqueue(&d1).await.expect("first enqueue");
 
-    let mut d2 = test_dispatch("d2", "t1");
-    d2.dedupe_key = Some("dup-key".to_string());
+    let d2 = test_dispatch("d2", "t1").with_dedupe_key(Some("dup-key".to_string()));
     let result = store.enqueue(&d2).await;
     assert!(
         result.is_err(),

--- a/crates/awaken-stores/tests/nats_mailbox_connect.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_connect.rs
@@ -2,35 +2,18 @@
 
 mod nats_fixture;
 
-use awaken_server_contract::contract::mailbox::{RunDispatch, RunDispatchStatus};
+use awaken_server_contract::contract::mailbox::RunDispatch;
 use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
 use nats_fixture::NatsFixture;
 
 fn test_dispatch(id: &str, thread_id: &str) -> RunDispatch {
-    RunDispatch {
-        dispatch_id: id.to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: format!("{id}-run"),
-        priority: 128,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: 0,
-        attempt_count: 0,
-        max_attempts: 3,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: 0,
-        updated_at: 0,
-    }
+    RunDispatch::queued(
+        id.to_string(),
+        thread_id.to_string(),
+        format!("{id}-run"),
+        0,
+    )
+    .with_max_attempts(3)
 }
 
 fn unique_config(fixture: &NatsFixture) -> NatsMailboxConfig {

--- a/crates/awaken-stores/tests/nats_mailbox_distributed.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_distributed.rs
@@ -27,30 +27,13 @@ fn shared_config(fixture: &NatsFixture) -> (String, NatsMailboxConfig) {
 }
 
 fn test_dispatch(id: &str, thread_id: &str) -> RunDispatch {
-    RunDispatch {
-        dispatch_id: id.to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: format!("{id}-run"),
-        priority: 128,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: 0,
-        attempt_count: 0,
-        max_attempts: 3,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: 0,
-        updated_at: 0,
-    }
+    RunDispatch::queued(
+        id.to_string(),
+        thread_id.to_string(),
+        format!("{id}-run"),
+        0,
+    )
+    .with_max_attempts(3)
 }
 
 async fn wait_for_index(store: &NatsMailboxStore, dispatch_id: &str, timeout_ms: u64) -> bool {
@@ -102,7 +85,7 @@ async fn concurrent_claim_same_dispatch_only_one_wins() {
 
     // Verify winner's claim_token is unique.
     let winner_token = match (r_a, r_b) {
-        (Some(d), None) | (None, Some(d)) => d.claim_token.expect("claim_token set"),
+        (Some(d), None) | (None, Some(d)) => d.claim_token().expect("claim_token set").to_string(),
         _ => unreachable!("exactly one winner verified above"),
     };
     assert!(!winner_token.is_empty());
@@ -182,7 +165,7 @@ async fn expired_lease_reclaimable_by_other_instance() {
         .await
         .unwrap();
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].dispatch_id, "d1");
+    assert_eq!(reclaimed[0].dispatch_id(), "d1");
 
     // Now B can claim the re-queued dispatch.
     let b_claim = store_b
@@ -190,7 +173,7 @@ async fn expired_lease_reclaimable_by_other_instance() {
         .await
         .unwrap();
     assert!(b_claim.is_some());
-    assert_eq!(b_claim.unwrap().claimed_by.as_deref(), Some("consumer-b"));
+    assert_eq!(b_claim.unwrap().claimed_by(), Some("consumer-b"));
 
     store_b.shutdown().await.unwrap();
 }
@@ -215,7 +198,7 @@ async fn late_ack_after_cross_instance_reclaim_is_rejected() {
         .await
         .unwrap()
         .expect("a owns dispatch");
-    let token_a = claimed_a.claim_token.expect("a claim token");
+    let token_a = claimed_a.claim_token().expect("a claim token").to_string();
 
     let reclaimed = store_b.reclaim_expired_leases(1_101, 10).await.unwrap();
     assert_eq!(reclaimed.len(), 1);
@@ -224,7 +207,7 @@ async fn late_ack_after_cross_instance_reclaim_is_rejected() {
         .await
         .unwrap()
         .expect("b owns dispatch");
-    let token_b = claimed_b.claim_token.expect("b claim token");
+    let token_b = claimed_b.claim_token().expect("b claim token").to_string();
 
     assert!(
         store_a.ack("d-late-ack", &token_a, 1_103).await.is_err(),
@@ -235,8 +218,8 @@ async fn late_ack_after_cross_instance_reclaim_is_rejected() {
         .await
         .unwrap()
         .expect("dispatch");
-    assert_eq!(still_claimed.status, RunDispatchStatus::Claimed);
-    assert_eq!(still_claimed.claimed_by.as_deref(), Some("consumer-b"));
+    assert_eq!(still_claimed.status(), RunDispatchStatus::Claimed);
+    assert_eq!(still_claimed.claimed_by(), Some("consumer-b"));
 
     store_b.ack("d-late-ack", &token_b, 1_104).await.unwrap();
     store_a.shutdown().await.unwrap();
@@ -282,7 +265,7 @@ async fn cross_instance_lease_reclaim_uses_strict_expiry_boundary() {
     );
     let reclaimed = store_b.reclaim_expired_leases(1_101, 10).await.unwrap();
     assert_eq!(reclaimed.len(), 1);
-    assert_eq!(reclaimed[0].status, RunDispatchStatus::Queued);
+    assert_eq!(reclaimed[0].status(), RunDispatchStatus::Queued);
 
     store_a.shutdown().await.unwrap();
     store_b.shutdown().await.unwrap();
@@ -307,7 +290,7 @@ async fn cross_instance_nack_retry_window_respects_retry_at() {
         .claim("t-retry-boundary", "consumer-a", 30_000, 1_000, 1)
         .await
         .unwrap();
-    let token = claimed[0].claim_token.clone().expect("claim token");
+    let token = claimed[0].claim_token().expect("claim token").to_string();
     store_a
         .nack("d-retry-boundary", &token, 2_000, "retry later", 1_001)
         .await
@@ -326,7 +309,7 @@ async fn cross_instance_nack_retry_window_respects_retry_at() {
         .await
         .unwrap();
     assert_eq!(claimed_at_retry.len(), 1);
-    assert_eq!(claimed_at_retry[0].dispatch_id, "d-retry-boundary");
+    assert_eq!(claimed_at_retry[0].dispatch_id(), "d-retry-boundary");
 
     store_a.shutdown().await.unwrap();
     store_b.shutdown().await.unwrap();
@@ -388,10 +371,8 @@ async fn concurrent_enqueue_same_dedupe_key_only_one_wins() {
     let store_a = Arc::new(NatsMailboxStore::connect(cfg.clone()).await.expect("a"));
     let store_b = Arc::new(NatsMailboxStore::connect(cfg).await.expect("b"));
 
-    let mut d1 = test_dispatch("dedupe-a", "t-dedupe-race");
-    d1.dedupe_key = Some("same-key".into());
-    let mut d2 = test_dispatch("dedupe-b", "t-dedupe-race");
-    d2.dedupe_key = Some("same-key".into());
+    let d1 = test_dispatch("dedupe-a", "t-dedupe-race").with_dedupe_key(Some("same-key".into()));
+    let d2 = test_dispatch("dedupe-b", "t-dedupe-race").with_dedupe_key(Some("same-key".into()));
 
     let a = Arc::clone(&store_a);
     let b = Arc::clone(&store_b);

--- a/crates/awaken-stores/tests/nats_mailbox_stress.rs
+++ b/crates/awaken-stores/tests/nats_mailbox_stress.rs
@@ -8,35 +8,18 @@ use std::{
     time::{Duration, Instant},
 };
 
-use awaken_server_contract::contract::mailbox::{MailboxStore, RunDispatch, RunDispatchStatus};
+use awaken_server_contract::contract::mailbox::{MailboxStore, RunDispatch};
 use awaken_stores::{NatsMailboxConfig, NatsMailboxStore};
 use nats_fixture::NatsFixture;
 
 fn test_dispatch(id: &str, thread_id: &str) -> RunDispatch {
-    RunDispatch {
-        dispatch_id: id.to_string(),
-        thread_id: thread_id.to_string(),
-        run_id: format!("{id}-run"),
-        priority: 128,
-        dedupe_key: None,
-        dispatch_epoch: 0,
-        status: RunDispatchStatus::Queued,
-        available_at: 0,
-        attempt_count: 0,
-        max_attempts: 3,
-        last_error: None,
-        claim_token: None,
-        claimed_by: None,
-        lease_until: None,
-        dispatch_instance_id: None,
-        run_status: None,
-        termination: None,
-        run_response: None,
-        run_error: None,
-        completed_at: None,
-        created_at: 0,
-        updated_at: 0,
-    }
+    RunDispatch::queued(
+        id.to_string(),
+        thread_id.to_string(),
+        format!("{id}-run"),
+        0,
+    )
+    .with_max_attempts(3)
 }
 
 fn stress_records(default: usize) -> usize {
@@ -76,13 +59,12 @@ async fn claim_latency_uses_thread_index_under_large_global_kv() {
     let records = stress_records(10_000);
 
     for i in 0..records {
-        let mut dispatch = test_dispatch(&format!("d-global-{i}"), &format!("t-global-{i}"));
-        dispatch.created_at = i as u64;
+        let dispatch = test_dispatch(&format!("d-global-{i}"), &format!("t-global-{i}"))
+            .with_created_at(i as u64);
         store.enqueue(&dispatch).await.unwrap();
     }
 
-    let mut target = test_dispatch("d-target", "t-target");
-    target.priority = 1;
+    let target = test_dispatch("d-target", "t-target").with_priority(1);
     store.enqueue(&target).await.unwrap();
 
     let start = Instant::now();
@@ -91,7 +73,7 @@ async fn claim_latency_uses_thread_index_under_large_global_kv() {
         .await
         .unwrap();
     assert_eq!(claimed.len(), 1);
-    assert_eq!(claimed[0].dispatch_id, "d-target");
+    assert_eq!(claimed[0].dispatch_id(), "d-target");
     assert!(
         start.elapsed() < Duration::from_secs(5),
         "claim latency should not scale linearly with unrelated global dispatch records"
@@ -108,8 +90,8 @@ async fn concurrent_nodes_claim_same_thread_without_duplicate_owners() {
     let seed = NatsMailboxStore::connect(mk_config()).await.expect("seed");
     let total = stress_records(1_000).min(1_000);
     for i in 0..total {
-        let mut dispatch = test_dispatch(&format!("d-thread-{i}"), "t-hot-thread");
-        dispatch.created_at = i as u64;
+        let dispatch =
+            test_dispatch(&format!("d-thread-{i}"), "t-hot-thread").with_created_at(i as u64);
         seed.enqueue(&dispatch).await.unwrap();
     }
     seed.shutdown().await.unwrap();
@@ -139,12 +121,12 @@ async fn concurrent_nodes_claim_same_thread_without_duplicate_owners() {
                     break;
                 }
                 for dispatch in claimed {
-                    let token = dispatch.claim_token.clone().unwrap();
+                    let token = dispatch.claim_token().unwrap().to_string();
                     stores[worker]
-                        .ack(&dispatch.dispatch_id, &token, 100_001)
+                        .ack(dispatch.dispatch_id(), &token, 100_001)
                         .await
                         .unwrap();
-                    out.push(dispatch.dispatch_id);
+                    out.push(dispatch.dispatch_id().to_string());
                 }
             }
             out
@@ -182,8 +164,8 @@ async fn active_claim_with_many_queued_dispatches_remains_recoverable() {
     assert_eq!(claimed.len(), 1);
 
     for i in 0..stress_records(500) {
-        let mut dispatch = test_dispatch(&format!("d-queued-{i}"), "t-active");
-        dispatch.created_at = 10 + i as u64;
+        let dispatch =
+            test_dispatch(&format!("d-queued-{i}"), "t-active").with_created_at(10 + i as u64);
         store.enqueue(&dispatch).await.unwrap();
     }
 
@@ -199,7 +181,7 @@ async fn active_claim_with_many_queued_dispatches_remains_recoverable() {
             .unwrap();
     }
 
-    let token = claimed[0].claim_token.clone().unwrap();
+    let token = claimed[0].claim_token().unwrap().to_string();
     store.ack("d-active", &token, 2_000).await.unwrap();
     let recovered = store
         .claim("t-active", "next", 30_000, 3_000, 10)
@@ -228,8 +210,8 @@ async fn high_concurrency_dedupe_key_admits_exactly_one_owner() {
     for i in 0..total {
         let store = Arc::clone(&store);
         handles.push(tokio::spawn(async move {
-            let mut dispatch = test_dispatch(&format!("d-dedupe-{i}"), "t-dedupe-hot");
-            dispatch.dedupe_key = Some("same-key".to_string());
+            let dispatch = test_dispatch(&format!("d-dedupe-{i}"), "t-dedupe-hot")
+                .with_dedupe_key(Some("same-key".to_string()));
             store.enqueue(&dispatch).await
         }));
     }

--- a/crates/awaken-stores/tests/thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/thread_store_conformance.rs
@@ -10,7 +10,7 @@ use awaken_server_contract::contract::storage::{
 use awaken_server_contract::thread::Thread;
 
 pub fn make_run(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecord {
-    RunRecord {
+    let mut run = RunRecord {
         run_id: run_id.to_string(),
         thread_id: thread_id.to_string(),
         agent_id: "agent".to_string(),
@@ -37,7 +37,11 @@ pub fn make_run(run_id: &str, thread_id: &str, status: RunStatus) -> RunRecord {
         input_tokens: 0,
         output_tokens: 0,
         state: None,
+    };
+    if status == RunStatus::Done {
+        run.finished_at = Some(run.updated_at);
     }
+    run
 }
 
 pub async fn checkpoint_persists_messages_and_run<S: ThreadRunStore>(store: &S) {

--- a/crates/awaken/examples/multi_turn.rs
+++ b/crates/awaken/examples/multi_turn.rs
@@ -87,7 +87,8 @@ async fn main() {
     });
 
     let store = Arc::new(InMemoryStore::new());
-    let runtime = AgentRuntime::new(resolver).with_in_memory_thread_run_store(store);
+    let runtime = AgentRuntime::new(resolver)
+        .with_commit_coordinator(awaken::stores::MemoryCommitCoordinator::wrap(store));
 
     let thread_id = "conversation-1";
 

--- a/crates/awaken/src/prelude.rs
+++ b/crates/awaken/src/prelude.rs
@@ -68,14 +68,6 @@ pub use awaken_runtime_contract::contract::event_sink::EventSink;
 // ── Lifecycle ──
 pub use awaken_runtime_contract::contract::lifecycle::{RunStatus, TerminationReason};
 
-// ── Storage ──
-pub use awaken_server_contract::MailboxStore;
-pub use awaken_server_contract::contract::storage::ThreadRunStore;
-pub use awaken_server_contract::{
-    RequestSurface, ScopeContext, ScopeId, ScopedConfigStore, ScopedMailboxStore,
-    ScopedOutboxStore, ScopedProtocolReplayLog, ScopedThreadRunStore, ScopedVersionedRegistry,
-};
-
 // ── Stop policies ──
 pub use crate::policies::{StopConditionPlugin, StopDecision, StopPolicy, StopPolicyStats};
 
@@ -111,12 +103,3 @@ pub use awaken_ext_reminder::{
 pub use awaken_ext_generative_ui::{
     A2uiPlugin, A2uiPromptConfig, A2uiPromptConfigKey, DEFAULT_A2UI_CATALOG_ID,
 };
-
-#[cfg(feature = "server")]
-pub use awaken_server::app::{
-    ServerConfig, ServerState, ShutdownConfig, serve, serve_with_shutdown,
-};
-#[cfg(feature = "server")]
-pub use awaken_server::mailbox::{Mailbox, MailboxConfig};
-#[cfg(feature = "server")]
-pub use awaken_server::routes::build_router;

--- a/crates/awaken/tests/config_managed_skill_dialog_e2e.rs
+++ b/crates/awaken/tests/config_managed_skill_dialog_e2e.rs
@@ -114,7 +114,7 @@ async fn build_dialog_harness(responses: Vec<StreamResult>) -> DialogHarness {
 
     let runtime = Arc::new(
         AgentRuntimeBuilder::new()
-            .with_in_memory_thread_run_store(store.clone())
+            .with_commit_coordinator(awaken::stores::MemoryCommitCoordinator::wrap(store.clone()))
             .with_plugin(
                 "skills-discovery",
                 Arc::new(SkillDiscoveryPlugin::new(managed_skills.clone())) as Arc<dyn Plugin>,

--- a/crates/awaken/tests/skill_permission_e2e.rs
+++ b/crates/awaken/tests/skill_permission_e2e.rs
@@ -274,6 +274,7 @@ fn make_agent_spec_deny_all_with_extra_allowed_tools(extra_allowed_tools: &[&str
         system_prompt: "sys".into(),
         max_rounds: 16,
         max_continuation_retries: 2,
+        stop_conditions: Vec::new(),
         reasoning_effort: None,
         context_policy: None,
         plugin_ids: Vec::new(),

--- a/docs/adr/0010-registry-and-resolve.md
+++ b/docs/adr/0010-registry-and-resolve.md
@@ -138,6 +138,11 @@ policy passes through unchanged.
 - **Forward-compatible options.** Unknown keys in `adapter_options` are
   ignored at build time so older binaries do not reject newer specs.
 
+**Amendment: explicit environment credentials.** Bearer providers without
+`api_key` are rejected by default. `adapter_options.allow_env_credentials =
+true` may explicitly delegate bearer lookup to the host environment. The option
+is non-secret and must be a boolean.
+
 ### D4: resolve(agent_id) → ResolvedRun
 
 ```rust

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -149,6 +149,34 @@ pre-commit:
         fi
       stage_fixed: false
 
+    check-doc-links:
+      glob: "{AGENTS.md,CLAUDE.md,docs/**/*.md,scripts/ci/check-doc-links.py}"
+      run: |
+        python3 scripts/ci/check-doc-links.py --self-test
+        python3 scripts/ci/check-doc-links.py --staged
+      stage_fixed: false
+
+    check-adr-constraints:
+      glob: "{docs/adr/*.md,scripts/ci/check-adr-constraints.py}"
+      run: |
+        python3 scripts/ci/check-adr-constraints.py --self-test
+        python3 scripts/ci/check-adr-constraints.py --staged
+      stage_fixed: false
+
+    check-guardrails:
+      glob: "{AGENTS.md,docs/adr/*.md,scripts/ci/check-guardrails.py}"
+      run: |
+        python3 scripts/ci/check-guardrails.py --self-test
+        python3 scripts/ci/check-guardrails.py
+      stage_fixed: false
+
+    check-source-guardrails:
+      glob: "{crates/**/*.rs,scripts/ci/check-source-guardrails.py}"
+      run: |
+        python3 scripts/ci/check-source-guardrails.py --self-test
+        python3 scripts/ci/check-source-guardrails.py --staged
+      stage_fixed: false
+
     check-secrets:
       run: |
         # 检查常见的硬编码密钥模式

--- a/scripts/ci/check-adr-constraints.py
+++ b/scripts/ci/check-adr-constraints.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Validate staged ADR shape and append-mostly edits for accepted ADRs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ADR_PATH_RE = re.compile(r"^docs/adr/(?P<num>\d{4})-[^/]+\.md$")
+TITLE_RE = re.compile(r"^# ADR-(?P<num>\d{4}): .+", re.MULTILINE)
+STATUS_RE = re.compile(r"^- \*\*Status\*\*: (?P<status>.+)$", re.MULTILINE)
+ACCEPTED_RE = re.compile(r"\bAccepted\b|✅\s*Accepted")
+ALLOWED_REMOVAL_RE = re.compile(
+    r"^\s*$|^- \*\*(Status|Date|Depends on|Updates|Supersedes|Superseded by)\*\*:|^\[.*\]:\s*\S+|^<!-- awaken-allow: ADR-edit -->$"
+)
+
+
+@dataclass(frozen=True)
+class StagedAdr:
+    path: str
+    text: str
+    previous_text: str | None
+
+
+def _git(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=REPO_ROOT, text=True)
+
+
+def _staged_adrs() -> list[StagedAdr]:
+    out = _git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+    adrs: list[StagedAdr] = []
+    for path in out.splitlines():
+        if not path.startswith("docs/adr/") or not path.endswith(".md"):
+            continue
+        text = _git(["show", f":{path}"])
+        try:
+            previous = _git(["show", f"HEAD:{path}"])
+        except subprocess.CalledProcessError:
+            previous = None
+        adrs.append(StagedAdr(path=path, text=text, previous_text=previous))
+    return adrs
+
+
+def _removed_lines(path: str) -> list[tuple[int, str]]:
+    diff = _git(["diff", "--cached", "--unified=0", "--", path])
+    removed: list[tuple[int, str]] = []
+    old_line = 0
+    for raw in diff.splitlines():
+        if raw.startswith("@@ "):
+            match = re.search(r"@@ -(?P<start>\d+)(?:,\d+)? \+\d+(?:,\d+)? @@", raw)
+            old_line = int(match.group("start")) if match else 0
+            continue
+        if raw.startswith("-") and not raw.startswith("---"):
+            removed.append((old_line, raw[1:]))
+            old_line += 1
+        elif not raw.startswith("+"):
+            old_line += 1
+    return removed
+
+
+def validate_adrs(adrs: list[StagedAdr]) -> list[str]:
+    errors: list[str] = []
+    for adr in adrs:
+        path_match = ADR_PATH_RE.match(adr.path)
+        if not path_match:
+            continue
+        expected_num = path_match.group("num")
+        title_match = TITLE_RE.search(adr.text)
+        if not title_match:
+            errors.append(f"{adr.path}: missing '# ADR-{expected_num}: ...' title")
+        elif title_match.group("num") != expected_num:
+            errors.append(f"{adr.path}: title number ADR-{title_match.group('num')} does not match filename")
+
+        status_match = STATUS_RE.search(adr.text)
+        if not status_match:
+            errors.append(f"{adr.path}: missing '- **Status**:' metadata")
+
+        if adr.previous_text and STATUS_RE.search(adr.previous_text):
+            previous_status = STATUS_RE.search(adr.previous_text).group("status")
+            if ACCEPTED_RE.search(previous_status):
+                for line_no, line in _removed_lines(adr.path):
+                    if not ALLOWED_REMOVAL_RE.search(line):
+                        errors.append(
+                            f"{adr.path}:{line_no}: accepted ADRs are append-mostly; removed content requires a superseding ADR or explicit amendment"
+                        )
+                        break
+    return errors
+
+
+def self_test() -> int:
+    valid = StagedAdr(
+        "docs/adr/9999-example.md",
+        "# ADR-9999: Example\n\n- **Status**: Accepted\n",
+        None,
+    )
+    bad_title = StagedAdr(
+        "docs/adr/9998-example.md",
+        "# ADR-9999: Example\n\n- **Status**: Accepted\n",
+        None,
+    )
+    if validate_adrs([valid]):
+        sys.stderr.write("self-test rejected a valid ADR\n")
+        return 1
+    if not validate_adrs([bad_title]):
+        sys.stderr.write("self-test did not reject title/filename mismatch\n")
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--staged", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.staged:
+        sys.stderr.write("use --staged for ADR constraint checks\n")
+        return 2
+
+    errors = validate_adrs(_staged_adrs())
+    if errors:
+        sys.stderr.write("ERROR: ADR constraints failed:\n")
+        for error in errors:
+            sys.stderr.write(f"  - {error}\n")
+        sys.stderr.write("<system-reminder>→ Next: keep accepted ADRs append-mostly or add a superseding ADR</system-reminder>\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-doc-links.py
+++ b/scripts/ci/check-doc-links.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate relative links in staged Markdown files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LINK_RE = re.compile(r"!?\[[^\]]*\]\((?P<link>[^)\s]+)(?:\s+\"[^\"]*\")?\)")
+SKIP_SCHEMES = ("http://", "https://", "mailto:", "data:", "javascript:")
+DOC_FILE_RE = re.compile(r"(^AGENTS\.md$|^CLAUDE\.md$|^docs/.*\.md$)")
+
+
+@dataclass(frozen=True)
+class DocFile:
+    path: str
+    text: str
+
+
+def _staged_doc_files() -> list[DocFile]:
+    out = subprocess.check_output(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    docs: list[DocFile] = []
+    for path in out.splitlines():
+        if not DOC_FILE_RE.search(path):
+            continue
+        text = subprocess.check_output(["git", "show", f":{path}"], cwd=REPO_ROOT, text=True)
+        docs.append(DocFile(path=path, text=text))
+    return docs
+
+
+def _target_path(source_path: str, link: str) -> Path | None:
+    if not link or link.startswith(SKIP_SCHEMES) or link.startswith("#"):
+        return None
+    link = link.split("#", 1)[0].split("?", 1)[0]
+    if not link:
+        return None
+    link = unquote(link)
+    raw = Path(link.lstrip("/")) if link.startswith("/") else Path(source_path).parent / link
+    normalized = (REPO_ROOT / raw).resolve()
+    try:
+        normalized.relative_to(REPO_ROOT)
+    except ValueError:
+        return normalized
+    return normalized
+
+
+def validate_docs(docs: list[DocFile]) -> list[str]:
+    errors: list[str] = []
+    for doc in docs:
+        for match in LINK_RE.finditer(doc.text):
+            link = match.group("link").strip("<>")
+            target = _target_path(doc.path, link)
+            if target is None:
+                continue
+            line_no = doc.text.count("\n", 0, match.start()) + 1
+            if not target.exists():
+                errors.append(f"{doc.path}:{line_no}: broken relative link: {link}")
+    return errors
+
+
+def self_test() -> int:
+    ok = DocFile("AGENTS.md", "[ADR](docs/adr/0038-runtime-commit-boundary.md)\n")
+    broken = DocFile("AGENTS.md", "[Missing](docs/adr/no-such-adr.md)\n")
+    if validate_docs([ok]):
+        sys.stderr.write("self-test rejected a valid relative link\n")
+        return 1
+    if not validate_docs([broken]):
+        sys.stderr.write("self-test did not reject a missing relative link\n")
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--staged", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.staged:
+        sys.stderr.write("use --staged so legacy documentation links do not block unrelated changes\n")
+        return 2
+
+    errors = validate_docs(_staged_doc_files())
+    if errors:
+        sys.stderr.write("ERROR: broken staged Markdown links found:\n")
+        for error in errors:
+            sys.stderr.write(f"  - {error}\n")
+        sys.stderr.write("<system-reminder>→ Next: link to the canonical doc path or remove duplicated truth</system-reminder>\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-guardrails.py
+++ b/scripts/ci/check-guardrails.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Validate Awaken architecture guardrail entries.
+
+The check keeps AGENTS.md as a short guardrail index: each hard rule must name
+its ADR source, its mechanical enforcer, and its validation target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+GUARDRAIL_RE = re.compile(r"^- \*\*A-G(?P<num>\d+): (?P<title>[^*]+)\*\*", re.MULTILINE)
+ADR_LINK_RE = re.compile(r"\[ADR-(?P<num>\d{4})\]\((?P<path>docs/adr/[^)]+\.md)\)")
+PATH_RE = re.compile(r"`(?P<path>(?:crates|scripts|docs|apps)/[^`]+)`")
+DOC_SECTION_RE = re.compile(
+    r"^## Documentation Truth Sources\n(?P<body>.*?)(?=^## |\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+GUARDRAIL_SECTION_RE = re.compile(
+    r"^## Architecture Guardrails\n(?P<body>.*?)(?=^## |\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+REQUIRED_TRUTH_PATHS = (
+    "docs/adr/0035-published-versioned-registry-and-runtime-pinning.md",
+    "docs/adr/0036-runtime-commit-atomicity-and-event-buffer.md",
+    "docs/adr/0038-runtime-commit-boundary.md",
+    "docs/adr/0039-run-activation-layering.md",
+    "docs/adr/0040-resolver-resolved-run.md",
+    "docs/adr/0019-mailbox-architecture.md",
+    "docs/adr/0022-run-dispatch-data-model.md",
+    "docs/adr/protocol-object-model-mapping.md",
+)
+
+
+@dataclass(frozen=True)
+class Guardrail:
+    num: int
+    text: str
+
+
+def _section(pattern: re.Pattern[str], text: str, name: str, errors: list[str]) -> str:
+    match = pattern.search(text)
+    if not match:
+        errors.append(f"AGENTS.md missing required section: {name}")
+        return ""
+    return match.group("body")
+
+
+def _guardrail_blocks(section: str) -> list[Guardrail]:
+    matches = list(GUARDRAIL_RE.finditer(section))
+    blocks: list[Guardrail] = []
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(section)
+        blocks.append(Guardrail(num=int(match.group("num")), text=section[start:end].strip()))
+    return blocks
+
+
+def _validate_existing_path(repo: Path, rel_path: str, errors: list[str]) -> None:
+    if not (repo / rel_path).exists():
+        errors.append(f"referenced path does not exist: {rel_path}")
+
+
+def validate_text(repo: Path, text: str) -> list[str]:
+    errors: list[str] = []
+
+    doc_body = _section(DOC_SECTION_RE, text, "Documentation Truth Sources", errors)
+    for rel_path in REQUIRED_TRUTH_PATHS:
+        if rel_path not in doc_body:
+            errors.append(f"Documentation Truth Sources missing {rel_path}")
+        _validate_existing_path(repo, rel_path, errors)
+
+    guardrail_body = _section(GUARDRAIL_SECTION_RE, text, "Architecture Guardrails", errors)
+    guardrails = _guardrail_blocks(guardrail_body)
+    if len(guardrails) < 8:
+        errors.append("Architecture Guardrails must list at least 8 hard rules")
+        return errors
+
+    seen: set[int] = set()
+    for guardrail in guardrails:
+        if guardrail.num in seen:
+            errors.append(f"duplicate guardrail id A-G{guardrail.num}")
+        seen.add(guardrail.num)
+
+        for label in ("Source:", "Enforcer:", "Validation:"):
+            if label not in guardrail.text:
+                errors.append(f"A-G{guardrail.num} missing {label}")
+
+        adr_links = list(ADR_LINK_RE.finditer(guardrail.text))
+        if not adr_links:
+            errors.append(f"A-G{guardrail.num} must link at least one ADR source")
+        for link in adr_links:
+            _validate_existing_path(repo, link.group("path"), errors)
+
+        if "Enforcer:" in guardrail.text:
+            enforcer_text = guardrail.text.split("Enforcer:", 1)[1].split("Validation:", 1)[0].strip()
+            if len(enforcer_text) < 12:
+                errors.append(f"A-G{guardrail.num} has an empty enforcer")
+
+        if "Validation:" in guardrail.text:
+            validation_text = guardrail.text.split("Validation:", 1)[1].strip()
+            if len(validation_text) < 8:
+                errors.append(f"A-G{guardrail.num} has an empty validation target")
+            for path_match in PATH_RE.finditer(validation_text):
+                rel_path = path_match.group("path")
+                if rel_path.endswith(".rs") or rel_path.endswith(".py") or rel_path.endswith(".md"):
+                    _validate_existing_path(repo, rel_path, errors)
+
+    expected = list(range(1, max(seen) + 1))
+    actual = sorted(seen)
+    if actual != expected:
+        errors.append(f"guardrail ids must be contiguous from A-G1: got {actual}")
+
+    return errors
+
+
+def self_test() -> int:
+    repo = Path.cwd()
+    sample = """## Documentation Truth Sources
+- Registry pinning: docs/adr/0035-published-versioned-registry-and-runtime-pinning.md
+- Runtime events: docs/adr/0036-runtime-commit-atomicity-and-event-buffer.md
+- Commit boundary: docs/adr/0038-runtime-commit-boundary.md
+- Activation: docs/adr/0039-run-activation-layering.md
+- Resolution: docs/adr/0040-resolver-resolved-run.md
+- Mailbox: docs/adr/0019-mailbox-architecture.md
+- Dispatch: docs/adr/0022-run-dispatch-data-model.md
+- Protocols: docs/adr/protocol-object-model-mapping.md
+
+## Architecture Guardrails
+- **A-G1: One.** Source: [ADR-0038](docs/adr/0038-runtime-commit-boundary.md). Enforcer: validated entry point. Validation: existing checks.
+- **A-G2: Two.** Source: [ADR-0035](docs/adr/0035-published-versioned-registry-and-runtime-pinning.md). Enforcer: fail-closed materialization. Validation: existing checks.
+- **A-G3: Three.** Source: [ADR-0040](docs/adr/0040-resolver-resolved-run.md). Enforcer: typed run plan. Validation: existing checks.
+- **A-G4: Four.** Source: [ADR-0036](docs/adr/0036-runtime-commit-atomicity-and-event-buffer.md). Enforcer: staged capture. Validation: existing checks.
+- **A-G5: Five.** Source: [ADR-0019](docs/adr/0019-mailbox-architecture.md). Enforcer: state machine. Validation: existing checks.
+- **A-G6: Six.** Source: [ADR-0022](docs/adr/0022-run-dispatch-data-model.md). Enforcer: dispatch validator. Validation: existing checks.
+- **A-G7: Seven.** Source: [ADR-0039](docs/adr/0039-run-activation-layering.md). Enforcer: activation validator. Validation: existing checks.
+- **A-G8: Eight.** Source: [ADR-0038](docs/adr/0038-runtime-commit-boundary.md). Enforcer: dependency checks. Validation: existing checks.
+"""
+    errors = validate_text(repo, sample)
+    if errors:
+        sys.stderr.write("self-test unexpectedly failed:\n" + "\n".join(errors) + "\n")
+        return 1
+
+    broken = sample.replace("Enforcer: validated entry point. ", "")
+    broken_errors = validate_text(repo, broken)
+    if not any("A-G1 missing Enforcer" in error for error in broken_errors):
+        sys.stderr.write("self-test did not catch a missing enforcer\n")
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--repo", default=".")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    repo = Path(args.repo).resolve()
+    agents = repo / "AGENTS.md"
+    if not agents.exists():
+        sys.stderr.write("AGENTS.md not found\n")
+        return 1
+
+    errors = validate_text(repo, agents.read_text(encoding="utf-8"))
+    if errors:
+        sys.stderr.write("ERROR: architecture guardrail contract failed:\n")
+        for error in errors:
+            sys.stderr.write(f"  - {error}\n")
+        sys.stderr.write("<system-reminder>→ Next: add ADR source, enforcer, and validation for every guardrail</system-reminder>\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-source-guardrails.py
+++ b/scripts/ci/check-source-guardrails.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Block source additions that would weaken Awaken guardrails.
+
+The pre-commit path scans added lines only. This preserves legacy cleanup work
+while preventing new silent fallback, hidden downgrade, or facade widening code.
+Use `awaken-allow: A-GN` on the same line only for a deliberately reviewed
+exception.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ALLOW_RE = re.compile(r"awaken-allow:\s*A-G(?P<n>[0-9]+)")
+HUNK_RE = re.compile(r"@@ -\d+(?:,\d+)? \+(?P<start>\d+)(?:,\d+)? @@")
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    path: str
+    line_no: int
+    text: str
+
+
+@dataclass(frozen=True)
+class Rule:
+    code: str
+    description: str
+    pattern: re.Pattern[str]
+    path_predicate: Callable[[str], bool]
+    exclude_substrings: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _under(*prefixes: str) -> Callable[[str], bool]:
+    normalized = tuple(prefix.rstrip("/") + "/" for prefix in prefixes)
+
+    def check(path: str) -> bool:
+        return any(path.startswith(prefix) for prefix in normalized)
+
+    return check
+
+
+def _exact(*paths: str) -> Callable[[str], bool]:
+    allowed = set(paths)
+
+    def check(path: str) -> bool:
+        return path in allowed
+
+    return check
+
+
+def _or(*predicates: Callable[[str], bool]) -> Callable[[str], bool]:
+    def check(path: str) -> bool:
+        return any(predicate(path) for predicate in predicates)
+
+    return check
+
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        code="A-G2",
+        description="Postgres run-row decode must not hide corrupt JSON/status data",
+        pattern=re.compile(r"serde_json::from_value\([^\n]*\)\.ok\(\)|unwrap_or\(\s*RunStatus::Running\s*\)"),
+        path_predicate=_exact("crates/awaken-stores/src/postgres/run.rs"),
+    ),
+    Rule(
+        code="A-G5",
+        description="pinned registry resolution must not downgrade to latest/live scope",
+        pattern=re.compile(r"RegistryResolutionScope::Pinned.*LatestPublication|Pinned\([^)]*\).*LatestPublication|Pinned.*live_registry|live_registry.*Pinned"),
+        path_predicate=_or(
+            _under("crates/awaken-server/src"),
+            _under("crates/awaken-runtime/src/registry/resolve"),
+        ),
+    ),
+    Rule(
+        code="A-G5",
+        description="critical registry/durable-preview publication errors must not be converted to boolean success",
+        pattern=re.compile(r"(publish_ephemeral_with_extra_agent|materialize|materialize_pinned_registry)[^\n]*\.(is_ok|ok)\(\)"),
+        path_predicate=_under("crates/awaken-server/src"),
+    ),
+    Rule(
+        code="A-G6",
+        description="Replayable plans must be built through pinned snapshot provenance, not plain RegistrySetResolver::new",
+        pattern=re.compile(r"ResolvedRunPlan::Replayable|Replayability::Replayable"),
+        path_predicate=_under("crates/awaken-runtime/src/registry/resolve"),
+        exclude_substrings=("/tests.rs", "/tests/"),
+    ),
+    Rule(
+        code="A-G7",
+        description="runtime event capture must not depend on dispatch-time panic checks",
+        pattern=re.compile(r"expect\([^\n]*(runtime event capture|EventBuffer|staged commit coordinator)"),
+        path_predicate=_under("crates/awaken-server/src/mailbox"),
+    ),
+    Rule(
+        code="A-G10",
+        description="agent prelude must not export server or store integration surfaces",
+        pattern=re.compile(r"pub use .*(awaken_server|awaken_stores|crate::server|crate::stores|server_contract|ScopedThreadRunStore)"),
+        path_predicate=_exact("crates/awaken/src/prelude.rs"),
+    ),
+)
+
+
+def _staged_added_lines() -> list[AddedLine]:
+    diff = subprocess.check_output(
+        ["git", "diff", "--cached", "--unified=0", "--diff-filter=ACMR", "--", "*.rs"],
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    lines: list[AddedLine] = []
+    current_path: str | None = None
+    new_line = 0
+    for raw in diff.splitlines():
+        if raw.startswith("+++ b/"):
+            current_path = raw.removeprefix("+++ b/")
+            continue
+        if raw.startswith("@@ "):
+            match = HUNK_RE.search(raw)
+            new_line = int(match.group("start")) if match else 0
+            continue
+        if raw.startswith("+") and not raw.startswith("+++") and current_path:
+            lines.append(AddedLine(current_path, new_line, raw[1:]))
+            new_line += 1
+            continue
+        if not raw.startswith("-"):
+            new_line += 1
+    return lines
+
+
+def _line_allowed(line: AddedLine, rule: Rule) -> bool:
+    marker = ALLOW_RE.search(line.text)
+    return bool(marker and f"A-G{marker.group('n')}" == rule.code)
+
+
+def scan_added_lines(lines: list[AddedLine]) -> list[str]:
+    violations: list[str] = []
+    for line in lines:
+        for rule in RULES:
+            if not rule.path_predicate(line.path):
+                continue
+            decorated_path = f"/{line.path}"
+            if any(excluded in decorated_path for excluded in rule.exclude_substrings):
+                continue
+            if rule.pattern.search(line.text) and not _line_allowed(line, rule):
+                violations.append(
+                    f"{line.path}:{line.line_no}: [{rule.code}] {rule.description}: {line.text.strip()}"
+                )
+    return violations
+
+
+def self_test() -> int:
+    lines = [
+        AddedLine(
+            "crates/awaken-stores/src/postgres/run.rs",
+            12,
+            "let waiting = serde_json::from_value(value).ok();",
+        ),
+        AddedLine(
+            "crates/awaken-server/src/mailbox/runtime_event_capture.rs",
+            8,
+            'let buffer = event_buffer.expect("runtime event capture requires a per-run EventBuffer");',
+        ),
+        AddedLine(
+            "crates/awaken/src/prelude.rs",
+            4,
+            "pub use awaken_stores::MemoryCommitCoordinator;",
+        ),
+        AddedLine(
+            "crates/awaken/src/prelude.rs",
+            5,
+            "pub use awaken_stores::MemoryCommitCoordinator; // awaken-allow: A-G10",
+        ),
+    ]
+    violations = scan_added_lines(lines)
+    if len(violations) != 3:
+        sys.stderr.write("self-test expected exactly three violations\n")
+        sys.stderr.write("\n".join(violations) + "\n")
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--staged", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.staged:
+        sys.stderr.write("use --staged so existing legacy lines do not block unrelated changes\n")
+        return 2
+
+    violations = scan_added_lines(_staged_added_lines())
+    if violations:
+        sys.stderr.write("ERROR: source guardrail violations found:\n")
+        for violation in violations:
+            sys.stderr.write(f"  - {violation}\n")
+        sys.stderr.write("<system-reminder>→ Next: fail closed or route through the typed boundary; avoid silent fallback</system-reminder>\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- enforce runtime, message, run, and dispatch invariants across contracts and stores
- fail closed for pinned registry, config credentials, runtime event capture, and corrupt persisted records
- clean up resolution/run execution boundaries and narrow public API exports

## Validation
- cargo test --workspace --all-features --no-run
- pre-push admin-console CI
- pre-push workspace validate