### PR TITLE
🐛 fix(admin): surface absent capabilities route

### DIFF
--- a/apps/admin-console/src/lib/i18n/en.ts
+++ b/apps/admin-console/src/lib/i18n/en.ts
@@ -172,6 +172,11 @@ export const en = {
       toEnable: "To enable, {{hint}}",
       see: "see {{doc}}",
     },
+    capabilities: {
+      routeAbsentTitle: "Capabilities route not exposed",
+      routeAbsentHint:
+        "the server returned 404 on /v1/capabilities — older build, or the route layer is misconfigured. Capability counts are not authoritative.",
+    },
     agentActivity: {
       title: "Agent activity",
       window: "window: {{window}}",

--- a/apps/admin-console/src/lib/i18n/zh-CN.ts
+++ b/apps/admin-console/src/lib/i18n/zh-CN.ts
@@ -166,6 +166,11 @@ export const zhCN: Dict = {
       toEnable: "如需启用：{{hint}}",
       see: "参见 {{doc}}",
     },
+    capabilities: {
+      routeAbsentTitle: "未暴露能力接口",
+      routeAbsentHint:
+        "服务器对 /v1/capabilities 返回 404——可能是旧构建或路由配置异常；能力计数当前不可信。",
+    },
     agentActivity: {
       title: "智能体活动",
       window: "窗口：{{window}}",

--- a/apps/admin-console/src/lib/query/hooks/dashboard.ts
+++ b/apps/admin-console/src/lib/query/hooks/dashboard.ts
@@ -27,6 +27,7 @@ export const DASHBOARD_REFETCH_MS = 30_000;
  *  (typically a 5xx that returned an empty list). UI uses this to
  *  distinguish "configured empty" from "list endpoint failed". */
 export interface DegradedSlots {
+  capabilities?: boolean;
   mcpServers?: boolean;
   providers?: boolean;
   models?: boolean;
@@ -78,6 +79,7 @@ export function useDashboardQuery(range: TimeRange) {
       if (capabilitiesResult.kind === "registry_unavailable") {
         throw new Error(capabilitiesResult.message ?? "Capabilities registry unavailable");
       }
+      if (capabilitiesResult.kind === "route_absent") degraded.capabilities = true;
       if (mcp.degraded) degraded.mcpServers = true;
       if (providers.degraded) degraded.providers = true;
       if (models.degraded) degraded.models = true;

--- a/apps/admin-console/src/pages/dashboard-page.test.tsx
+++ b/apps/admin-console/src/pages/dashboard-page.test.tsx
@@ -505,6 +505,32 @@ describe("DashboardPage", () => {
     expect(degradedHints.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("renders a degraded notice when the capabilities route is absent", () => {
+    runtimeStatsState.value = { data: { kind: "ok", agents: [] }, error: null };
+    dashboardState.value = {
+      data: dashboardData({
+        degraded: { capabilities: true },
+        capabilities: {
+          agents: [],
+          skills: [],
+          tools: [],
+          plugins: [],
+          models: [],
+          providers: [],
+          namespaces: [],
+        },
+      }),
+      error: null,
+    };
+
+    renderDashboard();
+
+    expect(screen.getByText("dashboard.capabilities.routeAbsentTitle")).toBeTruthy();
+    expect(screen.getByText(/dashboard\.capabilities\.routeAbsentHint/)).toBeTruthy();
+    const ribbonQuestionMarks = screen.getAllByText("?");
+    expect(ribbonQuestionMarks.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("renders an empty-activity hint when runtime stats has no inferences", () => {
     runtimeStatsState.value = { data: { kind: "ok", agents: [] }, error: null };
     dashboardState.value = { data: dashboardData(), error: null };

--- a/apps/admin-console/src/pages/dashboard-page.tsx
+++ b/apps/admin-console/src/pages/dashboard-page.tsx
@@ -102,6 +102,7 @@ export function DashboardPage() {
                 label: t("dashboard.counters.skills"),
                 count: capabilities.skills.length,
                 to: adminRoutes.skills,
+                degraded: degraded.capabilities,
               },
               {
                 label: t("dashboard.counters.models"),
@@ -121,11 +122,22 @@ export function DashboardPage() {
                 to: adminRoutes.mcpServers,
                 degraded: degraded.mcpServers,
               },
-              { label: t("dashboard.counters.tools"), count: capabilities.tools.length },
+              {
+                label: t("dashboard.counters.tools"),
+                count: capabilities.tools.length,
+                degraded: degraded.capabilities,
+              },
             ]}
           />
         }
       />
+
+      {degraded.capabilities && (
+        <FeatureDisabledNotice
+          title={t("dashboard.capabilities.routeAbsentTitle")}
+          configHint={t("dashboard.capabilities.routeAbsentHint")}
+        />
+      )}
 
       <section className="mb-4">
         <WorkloadCard state={workloadState} />


### PR DESCRIPTION
## Summary
- carry capabilities route_absent through dashboard degraded state
- show an explicit dashboard notice instead of treating absent capabilities as a valid empty catalog
- mark skills/tools counters as unavailable when capabilities route is absent

## Validation
- pnpm vitest run src/pages/dashboard-page.test.tsx src/lib/i18n/i18n.test.ts
- pnpm lint
- pre-push: admin-console-ci + validate