### PR TITLE
♻️ refactor(runtime): tool/mechanism separation — send_message effect + AgentTool delegation port

### DIFF
--- a/crates/awaken-runtime/src/backend/local.rs
+++ b/crates/awaken-runtime/src/backend/local.rs
@@ -5,6 +5,8 @@ use awaken_runtime_contract::contract::identity::{RunIdentity, RunOrigin};
 use awaken_runtime_contract::contract::lifecycle::TerminationReason;
 
 use crate::loop_runner::{AgentLoopParams, CommitWiring, prepare_resume, run_agent_loop};
+#[cfg(feature = "background")]
+use crate::plugins::Plugin;
 use crate::registry::ResolvedAgent;
 use crate::state::StateStore;
 
@@ -298,23 +300,18 @@ impl LocalBackend {
         {
             None
         } else {
-            let manager = crate::extensions::background::BackgroundTaskManager::new();
-            let manager = std::sync::Arc::new(manager);
-            manager.set_store(store.clone());
+            // Bind the auto-created plugin through the same `bind_runtime_context`
+            // seam the resolved-env plugins use (see `bind_local_execution_env`),
+            // rather than re-setting store/owner_inbox by hand.
+            let manager =
+                std::sync::Arc::new(crate::extensions::background::BackgroundTaskManager::new());
+            let plugin = crate::extensions::background::BackgroundTaskPlugin::new(manager.clone());
+            plugin.bind_runtime_context(&store, owner_inbox.as_ref());
+            store
+                .install_plugin(plugin)
+                .map_err(|error| ExecutionBackendError::ExecutionFailed(error.to_string()))?;
             Some(manager)
         };
-
-        #[cfg(feature = "background")]
-        if let Some(manager) = &bg_manager {
-            if let Some(sender) = owner_inbox.clone() {
-                manager.set_owner_inbox(sender);
-            }
-            store
-                .install_plugin(crate::extensions::background::BackgroundTaskPlugin::new(
-                    manager.clone(),
-                ))
-                .map_err(|error| ExecutionBackendError::ExecutionFailed(error.to_string()))?;
-        }
 
         #[cfg(feature = "background")]
         let background_cancel_managers = {

--- a/crates/awaken-runtime/src/delegation.rs
+++ b/crates/awaken-runtime/src/delegation.rs
@@ -1,0 +1,161 @@
+//! Internal delegation port — the seam between delegation *tools* (UI) and the
+//! delegation *mechanism* (resolver + execution backend).
+//!
+//! [`AgentTool`](crate::extensions::a2a::AgentTool) and other delegation tools
+//! depend only on [`DelegateRunner`] and the backend-agnostic [`DelegateResult`]
+//! DTO; they never touch `backend::*` / `registry::*` / `resolution::*` on the
+//! hot path. [`ResolverDelegateRunner`] is the one place that maps the runtime's
+//! `BackendRunStatus`/`BackendRunResult` onto these DTOs.
+//!
+//! This is the in-crate precursor to a published `DelegateRunner` contract port:
+//! once the boundary proves out here, the trait + DTOs can move to
+//! `awaken-runtime-contract` and the tools can move to their own crate.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use awaken_runtime_contract::contract::event_sink::EventSink;
+use awaken_runtime_contract::contract::message::Message;
+
+use crate::backend::{
+    BackendControl, BackendDelegatePolicy, BackendDelegateRunRequest, BackendParentContext,
+    BackendRunResult, BackendRunStatus, execute_resolved_delegate_execution,
+};
+use crate::registry::AgentResolver;
+
+/// Parent lineage for a delegated child run.
+#[derive(Debug, Clone, Default)]
+pub struct DelegateParent {
+    pub run_id: Option<String>,
+    pub thread_id: Option<String>,
+    pub tool_call_id: Option<String>,
+}
+
+/// A request to run a child agent on behalf of a delegating tool.
+pub struct DelegateRequest {
+    pub agent_id: String,
+    pub messages: Vec<Message>,
+    pub parent: DelegateParent,
+    pub sink: Arc<dyn EventSink>,
+}
+
+/// Backend-agnostic terminal/waiting state of a delegated child run.
+///
+/// Mirrors the control-flow shape of `BackendRunStatus` without exposing the
+/// backend type to tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelegateOutcome {
+    Completed,
+    Cancelled,
+    Timeout,
+    Failed,
+    WaitingInput,
+    WaitingAuth,
+    Suspended,
+}
+
+/// Backend-agnostic result of a delegated child run.
+pub struct DelegateResult {
+    pub outcome: DelegateOutcome,
+    /// Stable status label, identical to `BackendRunStatus::to_string()`, kept
+    /// for wire/suspension compatibility.
+    pub status_label: String,
+    /// Inner message for waiting/suspended/failed states, if any.
+    pub status_message: Option<String>,
+    pub agent_id: String,
+    pub response: Option<String>,
+    /// Child output, pre-serialized so tools need not know the backend type.
+    pub output: Value,
+    pub steps: usize,
+    pub child_run_id: Option<String>,
+}
+
+/// Error surfaced when delegation cannot run (resolution or backend failure).
+#[derive(Debug, Clone)]
+pub struct DelegateError(pub String);
+
+impl std::fmt::Display for DelegateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for DelegateError {}
+
+/// The delegation mechanism, as seen by tools. Resolves a target agent and runs
+/// it to a terminal/waiting state, returning a backend-agnostic result.
+#[async_trait]
+pub trait DelegateRunner: Send + Sync {
+    async fn run(&self, request: DelegateRequest) -> Result<DelegateResult, DelegateError>;
+}
+
+/// Default mechanism: resolve via an [`AgentResolver`] and dispatch through the
+/// execution backend. This is the only code that depends on `BackendRunStatus`.
+pub struct ResolverDelegateRunner {
+    resolver: Arc<dyn AgentResolver>,
+}
+
+impl ResolverDelegateRunner {
+    pub fn new(resolver: Arc<dyn AgentResolver>) -> Self {
+        Self { resolver }
+    }
+}
+
+#[async_trait]
+impl DelegateRunner for ResolverDelegateRunner {
+    async fn run(&self, request: DelegateRequest) -> Result<DelegateResult, DelegateError> {
+        let resolved = self
+            .resolver
+            .resolve_execution(&request.agent_id)
+            .map_err(|error| DelegateError(error.to_string()))?;
+
+        let backend_request = BackendDelegateRunRequest {
+            agent_id: &request.agent_id,
+            new_messages: request.messages.clone(),
+            messages: request.messages,
+            sink: request.sink,
+            resolver: self.resolver.as_ref(),
+            parent: BackendParentContext {
+                parent_run_id: request.parent.run_id,
+                parent_thread_id: request.parent.thread_id,
+                parent_tool_call_id: request.parent.tool_call_id,
+            },
+            control: BackendControl::default(),
+            policy: BackendDelegatePolicy::default(),
+            state_seed: None,
+        };
+
+        let result = execute_resolved_delegate_execution(&resolved, backend_request)
+            .await
+            .map_err(|error| DelegateError(error.to_string()))?;
+
+        Ok(map_backend_result(result))
+    }
+}
+
+/// Map a `BackendRunResult` onto the backend-agnostic [`DelegateResult`].
+fn map_backend_result(result: BackendRunResult) -> DelegateResult {
+    let status_label = result.status.to_string();
+    let (outcome, status_message) = match result.status {
+        BackendRunStatus::Completed => (DelegateOutcome::Completed, None),
+        BackendRunStatus::Cancelled => (DelegateOutcome::Cancelled, None),
+        BackendRunStatus::Timeout => (DelegateOutcome::Timeout, None),
+        BackendRunStatus::Failed(message) => (DelegateOutcome::Failed, Some(message)),
+        BackendRunStatus::WaitingInput(message) => (DelegateOutcome::WaitingInput, message),
+        BackendRunStatus::WaitingAuth(message) => (DelegateOutcome::WaitingAuth, message),
+        BackendRunStatus::Suspended(message) => (DelegateOutcome::Suspended, message),
+    };
+
+    DelegateResult {
+        outcome,
+        status_label,
+        status_message,
+        agent_id: result.agent_id,
+        response: result.response,
+        output: serde_json::to_value(&result.output).unwrap_or(Value::Null),
+        steps: result.steps,
+        child_run_id: result.run_id,
+    }
+}

--- a/crates/awaken-runtime/src/extensions/a2a/agent_tool.rs
+++ b/crates/awaken-runtime/src/extensions/a2a/agent_tool.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use crate::backend::{
-    BackendControl, BackendDelegatePolicy, BackendDelegateRunRequest, BackendParentContext,
-    ExecutionBackend, execute_resolved_delegate_execution,
+use crate::backend::ExecutionBackend;
+use crate::delegation::{
+    DelegateOutcome, DelegateParent, DelegateRequest, DelegateResult, DelegateRunner,
+    ResolverDelegateRunner,
 };
 use crate::registry::{AgentResolver, ResolvedBackendAgent};
 use crate::resolution::ExecutionPlan;
@@ -32,8 +33,9 @@ pub struct AgentTool {
     agent_id: String,
     /// Human-readable description for the LLM.
     description: String,
-    /// Execution resolver used to build the canonical execution plan at call time.
-    resolver: Arc<dyn AgentResolver>,
+    /// Delegation mechanism (the narrow port). The tool never touches the
+    /// execution backend directly — it declares intent through this runner.
+    runner: Arc<dyn DelegateRunner>,
 }
 
 impl AgentTool {
@@ -73,15 +75,15 @@ impl AgentTool {
     ) -> Self {
         let agent_id = agent_id.into();
         let description = description.into();
-        Self {
-            agent_id: agent_id.clone(),
-            description: description.clone(),
-            resolver: Arc::new(FixedAgentResolver::non_local(
+        Self::with_execution_resolver(
+            agent_id.clone(),
+            description.clone(),
+            Arc::new(FixedAgentResolver::non_local(
                 &agent_id,
                 &description,
                 backend,
             )),
-        }
+        )
     }
 
     pub fn with_execution_resolver(
@@ -89,10 +91,27 @@ impl AgentTool {
         description: impl Into<String>,
         resolver: Arc<dyn AgentResolver>,
     ) -> Self {
+        Self::with_runner(
+            agent_id,
+            description,
+            Arc::new(ResolverDelegateRunner::new(resolver)),
+        )
+    }
+
+    /// Create a tool directly from a delegation runner (the narrow port).
+    ///
+    /// Crate-internal: the `DelegateRunner` seam is not part of the public
+    /// facade (A-G10). Public construction goes through the resolver/backend
+    /// constructors above.
+    pub(crate) fn with_runner(
+        agent_id: impl Into<String>,
+        description: impl Into<String>,
+        runner: Arc<dyn DelegateRunner>,
+    ) -> Self {
         Self {
             agent_id: agent_id.into(),
             description: description.into(),
-            resolver,
+            runner,
         }
     }
 
@@ -160,86 +179,72 @@ impl Tool for AgentTool {
             None => Arc::new(NullEventSink),
         };
 
-        let resolved = match self.resolver.resolve_execution(&self.agent_id) {
-            Ok(resolved) => resolved,
-            Err(error) => {
-                let message = format!("delegation to {} failed: {error}", self.agent_id);
-                ctx.report_progress(ProgressStatus::Failed, Some(&message), None)
-                    .await;
-                return Ok(ToolResult::error(&tool_id, error.to_string()).into());
-            }
-        };
-
-        let request = BackendDelegateRunRequest {
-            agent_id: &self.agent_id,
-            new_messages: messages.clone(),
+        let request = DelegateRequest {
+            agent_id: self.agent_id.clone(),
             messages,
-            sink,
-            resolver: self.resolver.as_ref(),
-            parent: BackendParentContext {
-                parent_run_id: Some(ctx.run_identity.run_id.clone()),
-                parent_thread_id: Some(ctx.run_identity.thread_id.clone()),
-                parent_tool_call_id: Some(ctx.call_id.clone()),
+            parent: DelegateParent {
+                run_id: Some(ctx.run_identity.run_id.clone()),
+                thread_id: Some(ctx.run_identity.thread_id.clone()),
+                tool_call_id: Some(ctx.call_id.clone()),
             },
-            control: BackendControl::default(),
-            policy: BackendDelegatePolicy::default(),
-            state_seed: None,
+            sink,
         };
 
-        let execution = execute_resolved_delegate_execution(&resolved, request).await;
-
-        match execution {
+        match self.runner.run(request).await {
             Ok(result) => {
-                let progress_status = match result.status {
-                    crate::backend::BackendRunStatus::Completed => ProgressStatus::Done,
-                    crate::backend::BackendRunStatus::Cancelled => ProgressStatus::Cancelled,
-                    crate::backend::BackendRunStatus::WaitingInput(_)
-                    | crate::backend::BackendRunStatus::WaitingAuth(_)
-                    | crate::backend::BackendRunStatus::Suspended(_) => ProgressStatus::Pending,
-                    crate::backend::BackendRunStatus::Timeout
-                    | crate::backend::BackendRunStatus::Failed(_) => ProgressStatus::Failed,
+                let progress_status = match result.outcome {
+                    DelegateOutcome::Completed => ProgressStatus::Done,
+                    DelegateOutcome::Cancelled => ProgressStatus::Cancelled,
+                    DelegateOutcome::WaitingInput
+                    | DelegateOutcome::WaitingAuth
+                    | DelegateOutcome::Suspended => ProgressStatus::Pending,
+                    DelegateOutcome::Timeout | DelegateOutcome::Failed => ProgressStatus::Failed,
                 };
-                let progress_message = match &result.status {
-                    crate::backend::BackendRunStatus::Completed => {
+                let progress_message = match result.outcome {
+                    DelegateOutcome::Completed => {
                         format!("delegation to {} completed", self.agent_id)
                     }
-                    crate::backend::BackendRunStatus::Cancelled => {
+                    DelegateOutcome::Cancelled => {
                         format!("delegation to {} cancelled", self.agent_id)
                     }
-                    crate::backend::BackendRunStatus::Failed(message) => {
-                        format!("delegation to {} failed: {message}", self.agent_id)
+                    DelegateOutcome::Failed => {
+                        format!(
+                            "delegation to {} failed: {}",
+                            self.agent_id,
+                            result.status_message.as_deref().unwrap_or("failed")
+                        )
                     }
-                    crate::backend::BackendRunStatus::WaitingInput(message) => {
+                    DelegateOutcome::WaitingInput => {
                         format!(
                             "delegation to {} waiting for input: {}",
                             self.agent_id,
-                            message.as_deref().unwrap_or("input required")
+                            result.status_message.as_deref().unwrap_or("input required")
                         )
                     }
-                    crate::backend::BackendRunStatus::WaitingAuth(message) => {
+                    DelegateOutcome::WaitingAuth => {
                         format!(
                             "delegation to {} waiting for auth: {}",
                             self.agent_id,
-                            message.as_deref().unwrap_or("auth required")
+                            result.status_message.as_deref().unwrap_or("auth required")
                         )
                     }
-                    crate::backend::BackendRunStatus::Suspended(message) => {
+                    DelegateOutcome::Suspended => {
                         format!(
                             "delegation to {} suspended: {}",
                             self.agent_id,
-                            message.as_deref().unwrap_or("suspended")
+                            result.status_message.as_deref().unwrap_or("suspended")
                         )
                     }
-                    crate::backend::BackendRunStatus::Timeout => {
+                    DelegateOutcome::Timeout => {
                         format!("delegation to {} timed out", self.agent_id)
                     }
                 };
                 ctx.report_progress(progress_status, Some(&progress_message), None)
                     .await;
 
-                let child_run_id = result.run_id.clone();
+                let child_run_id = result.child_run_id.clone();
                 let mut tool_result =
-                    tool_result_from_backend(&tool_id, result, progress_message, &args, ctx);
+                    tool_result_from_delegate(&tool_id, &result, progress_message, &args, ctx);
                 if let Some(ref child_run_id) = child_run_id {
                     tool_result = tool_result.with_metadata(
                         "child_run_id",
@@ -261,74 +266,68 @@ impl Tool for AgentTool {
     }
 }
 
-fn tool_result_from_backend(
+fn tool_result_from_delegate(
     tool_id: &str,
-    result: crate::backend::BackendRunResult,
+    result: &DelegateResult,
     message: String,
     args: &Value,
     ctx: &ToolCallContext,
 ) -> ToolResult {
-    let status = result.status.clone();
     let payload = json!({
         "agent_id": result.agent_id.clone(),
-        "status": status.to_string(),
+        "status": result.status_label.clone(),
         "response": result.response.clone(),
         "output": result.output.clone(),
         "steps": result.steps,
     });
 
-    match status {
-        crate::backend::BackendRunStatus::Completed => ToolResult::success(tool_id, payload),
-        crate::backend::BackendRunStatus::WaitingInput(_)
-        | crate::backend::BackendRunStatus::WaitingAuth(_)
-        | crate::backend::BackendRunStatus::Suspended(_) => ToolResult {
+    match result.outcome {
+        DelegateOutcome::Completed => ToolResult::success(tool_id, payload),
+        DelegateOutcome::WaitingInput
+        | DelegateOutcome::WaitingAuth
+        | DelegateOutcome::Suspended => ToolResult {
             tool_name: tool_id.to_string(),
             status: ToolStatus::Pending,
             data: payload,
             message: Some(message),
             suspension: Some(Box::new(delegate_suspend_ticket(
-                tool_id, &status, &result, args, ctx,
+                tool_id, result, args, ctx,
             ))),
             metadata: Default::default(),
         },
-        crate::backend::BackendRunStatus::Cancelled
-        | crate::backend::BackendRunStatus::Timeout
-        | crate::backend::BackendRunStatus::Failed(_) => ToolResult {
-            tool_name: tool_id.to_string(),
-            status: ToolStatus::Error,
-            data: payload,
-            message: Some(message),
-            suspension: None,
-            metadata: Default::default(),
-        },
+        DelegateOutcome::Cancelled | DelegateOutcome::Timeout | DelegateOutcome::Failed => {
+            ToolResult {
+                tool_name: tool_id.to_string(),
+                status: ToolStatus::Error,
+                data: payload,
+                message: Some(message),
+                suspension: None,
+                metadata: Default::default(),
+            }
+        }
     }
 }
 
 fn delegate_suspend_ticket(
     tool_id: &str,
-    status: &crate::backend::BackendRunStatus,
-    result: &crate::backend::BackendRunResult,
+    result: &DelegateResult,
     args: &Value,
     ctx: &ToolCallContext,
 ) -> SuspendTicket {
-    let (action, fallback_message) = match status {
-        crate::backend::BackendRunStatus::WaitingInput(_) => {
-            ("agent_delegate:input_required", "input required")
-        }
-        crate::backend::BackendRunStatus::WaitingAuth(_) => {
-            ("agent_delegate:auth_required", "auth required")
-        }
-        crate::backend::BackendRunStatus::Suspended(_) => ("agent_delegate:suspended", "suspended"),
+    let (action, fallback_message) = match result.outcome {
+        DelegateOutcome::WaitingInput => ("agent_delegate:input_required", "input required"),
+        DelegateOutcome::WaitingAuth => ("agent_delegate:auth_required", "auth required"),
+        DelegateOutcome::Suspended => ("agent_delegate:suspended", "suspended"),
         _ => ("agent_delegate:pending", "pending"),
     };
-    let reason = status_message(status).unwrap_or(fallback_message);
+    let reason = result.status_message.as_deref().unwrap_or(fallback_message);
     let pending_id = if ctx.call_id.trim().is_empty() {
         tool_id.to_string()
     } else {
         ctx.call_id.clone()
     };
     let suspension_id = result
-        .run_id
+        .child_run_id
         .as_ref()
         .filter(|run_id| !run_id.trim().is_empty())
         .map(|run_id| format!("delegate_run:{run_id}"))
@@ -340,8 +339,8 @@ fn delegate_suspend_ticket(
             message: reason.to_string(),
             parameters: json!({
                 "agent_id": result.agent_id.clone(),
-                "backend_status": status.to_string(),
-                "child_run_id": result.run_id.clone(),
+                "backend_status": result.status_label.clone(),
+                "child_run_id": result.child_run_id.clone(),
                 "tool_call_id": pending_id.clone(),
             }),
             response_schema: None,
@@ -349,15 +348,6 @@ fn delegate_suspend_ticket(
         PendingToolCall::new(pending_id, tool_id, args.clone()),
         ToolCallResumeMode::UseDecisionAsToolResult,
     )
-}
-
-fn status_message(status: &crate::backend::BackendRunStatus) -> Option<&str> {
-    match status {
-        crate::backend::BackendRunStatus::WaitingInput(message)
-        | crate::backend::BackendRunStatus::WaitingAuth(message)
-        | crate::backend::BackendRunStatus::Suspended(message) => message.as_deref(),
-        _ => None,
-    }
 }
 
 struct FixedAgentResolver {
@@ -400,5 +390,141 @@ impl AgentResolver for FixedAgentResolver {
 
     fn agent_ids(&self) -> Vec<String> {
         vec![self.execution.spec().id.clone()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::delegation::{DelegateError, DelegateOutcome, DelegateRequest, DelegateResult};
+    use awaken_runtime_contract::contract::identity::{RunIdentity, RunOrigin};
+    use awaken_runtime_contract::registry_spec::AgentSpec;
+
+    /// A `DelegateRunner` that returns a fixed outcome, so we can assert the
+    /// tool's `DelegateOutcome` → `ToolResult`/suspension mapping in isolation.
+    struct MockRunner {
+        outcome: DelegateOutcome,
+        status_label: &'static str,
+        status_message: Option<String>,
+        child_run_id: Option<String>,
+    }
+
+    #[async_trait]
+    impl DelegateRunner for MockRunner {
+        async fn run(&self, _request: DelegateRequest) -> Result<DelegateResult, DelegateError> {
+            Ok(DelegateResult {
+                outcome: self.outcome,
+                status_label: self.status_label.to_string(),
+                status_message: self.status_message.clone(),
+                agent_id: "child".into(),
+                response: Some("ok".into()),
+                output: Value::Null,
+                steps: 1,
+                child_run_id: self.child_run_id.clone(),
+            })
+        }
+    }
+
+    fn ctx() -> ToolCallContext {
+        ToolCallContext {
+            call_id: "call-1".into(),
+            tool_name: "agent_run_child".into(),
+            run_identity: RunIdentity::new(
+                "thread-1".into(),
+                None,
+                "run-1".into(),
+                None,
+                "parent".into(),
+                RunOrigin::User,
+            ),
+            agent_spec: Arc::new(AgentSpec::default()),
+            snapshot: crate::state::StateStore::new().snapshot(),
+            activity_sink: None,
+            cancellation_token: None,
+            resume_input: None,
+            suspension_id: None,
+            suspension_reason: None,
+        }
+    }
+
+    fn tool(outcome: DelegateOutcome, label: &'static str, msg: Option<&str>) -> AgentTool {
+        AgentTool::with_runner(
+            "child",
+            "desc",
+            Arc::new(MockRunner {
+                outcome,
+                status_label: label,
+                status_message: msg.map(str::to_string),
+                child_run_id: Some("run-7".into()),
+            }),
+        )
+    }
+
+    #[tokio::test]
+    async fn completed_maps_to_success() {
+        let out = tool(DelegateOutcome::Completed, "completed", None)
+            .execute(json!({"prompt": "hi"}), &ctx())
+            .await
+            .unwrap();
+        assert!(matches!(out.result.status, ToolStatus::Success));
+        assert_eq!(out.result.data["status"], "completed");
+        assert!(out.result.suspension.is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_maps_to_error() {
+        let out = tool(DelegateOutcome::Failed, "failed", Some("boom"))
+            .execute(json!({"prompt": "hi"}), &ctx())
+            .await
+            .unwrap();
+        assert!(matches!(out.result.status, ToolStatus::Error));
+        assert!(out.result.suspension.is_none());
+    }
+
+    #[tokio::test]
+    async fn waiting_input_maps_to_pending_suspension() {
+        let out = tool(
+            DelegateOutcome::WaitingInput,
+            "waiting_input",
+            Some("need x"),
+        )
+        .execute(json!({"prompt": "hi"}), &ctx())
+        .await
+        .unwrap();
+        assert!(matches!(out.result.status, ToolStatus::Pending));
+        let ticket = out.result.suspension.as_ref().expect("suspension ticket");
+        assert_eq!(ticket.suspension.action, "agent_delegate:input_required");
+        assert_eq!(ticket.suspension.id, "delegate_run:run-7");
+    }
+
+    #[tokio::test]
+    async fn suspended_maps_to_pending_suspension() {
+        let out = tool(DelegateOutcome::Suspended, "suspended", None)
+            .execute(json!({"prompt": "hi"}), &ctx())
+            .await
+            .unwrap();
+        assert!(matches!(out.result.status, ToolStatus::Pending));
+        let ticket = out.result.suspension.as_ref().expect("suspension ticket");
+        assert_eq!(ticket.suspension.action, "agent_delegate:suspended");
+    }
+
+    #[tokio::test]
+    async fn cancelled_maps_to_error() {
+        let out = tool(DelegateOutcome::Cancelled, "cancelled", None)
+            .execute(json!({"prompt": "hi"}), &ctx())
+            .await
+            .unwrap();
+        assert!(matches!(out.result.status, ToolStatus::Error));
+        assert!(out.result.suspension.is_none());
+    }
+
+    #[tokio::test]
+    async fn timeout_maps_to_error() {
+        let out = tool(DelegateOutcome::Timeout, "timeout", None)
+            .execute(json!({"prompt": "hi"}), &ctx())
+            .await
+            .unwrap();
+        assert!(matches!(out.result.status, ToolStatus::Error));
+        assert!(out.result.suspension.is_none());
     }
 }

--- a/crates/awaken-runtime/src/extensions/background/mod.rs
+++ b/crates/awaken-runtime/src/extensions/background/mod.rs
@@ -25,7 +25,11 @@ pub use plugin::BackgroundTaskPlugin;
 pub(crate) use run_cancellation::{
     dedup_managers, managers_for_resolved_agent, spawn_run_cancellation_guard,
 };
-pub use send_message_tool::SendMessageTool;
+pub use send_message_tool::{
+    DurableMessageRequest, DurableMessageSink, FailedDurableMessage, FailedDurableMessageKey,
+    FailedDurableMessageState, MessageDispatchHook, MessageOutbox, MessageOutboxKey, OutboxEntry,
+    OutboxRoute, SEND_MESSAGE_TOOL_ID, SendMessageReceipt, SendMessageTool,
+};
 pub use state::{
     BackgroundTaskStateKey, BackgroundTaskStateSnapshot, BackgroundTaskViewKey, PersistedTaskMeta,
 };

--- a/crates/awaken-runtime/src/extensions/background/plugin.rs
+++ b/crates/awaken-runtime/src/extensions/background/plugin.rs
@@ -9,6 +9,10 @@ use crate::state::{KeyScope, MutationBatch, StateKeyOptions, StateStore};
 use super::cancel_task_tool::{CANCEL_TASK_TOOL_ID, CancelTaskTool};
 use super::hook::BackgroundTaskSyncHook;
 use super::manager::BackgroundTaskManager;
+use super::send_message_tool::{
+    DurableMessageSink, FailedDurableMessageKey, MessageDispatchHook, MessageOutboxKey,
+    SEND_MESSAGE_TOOL_ID, SendMessageTool,
+};
 use super::state::{BackgroundTaskStateKey, BackgroundTaskViewKey};
 use super::types::BACKGROUND_TASKS_PLUGIN_ID;
 
@@ -30,17 +34,40 @@ use super::types::BACKGROUND_TASKS_PLUGIN_ID;
 /// throughout that path.
 pub struct BackgroundTaskPlugin {
     manager: Arc<BackgroundTaskManager>,
+    /// Host-provided durable transport, handed to [`MessageDispatchHook`]. When
+    /// absent, `send_message` still works for the live `child` route; durable
+    /// routes are dead-lettered by the dispatcher.
+    durable_sink: Option<Arc<dyn DurableMessageSink>>,
 }
 
 impl BackgroundTaskPlugin {
     pub fn new(manager: Arc<BackgroundTaskManager>) -> Self {
-        Self { manager }
+        Self {
+            manager,
+            durable_sink: None,
+        }
     }
 
     /// Create the plugin and wire the store into the manager.
     pub fn with_store(manager: Arc<BackgroundTaskManager>, store: StateStore) -> Self {
         manager.set_store(store);
-        Self { manager }
+        Self {
+            manager,
+            durable_sink: None,
+        }
+    }
+
+    /// Create the plugin with a host durable sink, enabling durable
+    /// (cross-thread) `send_message` delivery. Without it, only the live
+    /// `child` route is delivered.
+    pub fn with_messaging(
+        manager: Arc<BackgroundTaskManager>,
+        durable_sink: Arc<dyn DurableMessageSink>,
+    ) -> Self {
+        Self {
+            manager,
+            durable_sink: Some(durable_sink),
+        }
     }
 
     /// Return the manager for inbox wiring.
@@ -77,6 +104,25 @@ impl Plugin for BackgroundTaskPlugin {
         registrar.register_tool(
             CANCEL_TASK_TOOL_ID,
             Arc::new(CancelTaskTool::new(self.manager.clone())),
+        )?;
+
+        // `send_message` only commits an outbox entry — it holds no transport,
+        // so it is always available (the live `child` route needs no durable
+        // sink). The dispatcher is the sole holder of the transports and drains
+        // the committed outbox at StepEnd; with no durable sink, durable routes
+        // are dead-lettered rather than dropped.
+        let outbox_options = StateKeyOptions {
+            persistent: true,
+            scope: KeyScope::Thread,
+            ..StateKeyOptions::default()
+        };
+        registrar.register_key::<MessageOutboxKey>(outbox_options)?;
+        registrar.register_key::<FailedDurableMessageKey>(outbox_options)?;
+        registrar.register_tool(SEND_MESSAGE_TOOL_ID, Arc::new(SendMessageTool::new()))?;
+        registrar.register_phase_hook(
+            BACKGROUND_TASKS_PLUGIN_ID,
+            Phase::StepEnd,
+            MessageDispatchHook::new(self.manager.clone(), self.durable_sink.clone()),
         )?;
 
         // Sync task metadata into persisted state at run boundaries.

--- a/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
+++ b/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
@@ -1,10 +1,16 @@
 //! Unified `send_message` tool for agent-to-agent communication.
 //!
-//! Single agent-facing tool. Routing is automatic:
-//! - `child` → live inbox (low latency, in-process)
-//! - `parent` / `agent` → durable mailbox (persistent, cross-process)
+//! The tool can do exactly one thing: validate/resolve the recipient against the
+//! read-only snapshot and **commit an entry to the [`MessageOutboxKey`] outbox**.
+//! It holds no transport (manager/sink), so it cannot send through a lossy,
+//! uncommitted path — the "durable side effect on a non-durable channel" bug is
+//! unrepresentable here. The transports live solely in [`MessageDispatchHook`],
+//! the privileged dispatcher that drains the committed outbox at `StepEnd`.
 //!
-//! Transport selection is automatic — the caller does not specify delivery mode.
+//! Routing is automatic — the caller does not specify delivery mode; it is data
+//! the dispatcher acts on:
+//! - `child` → live inbox (in-process, best-effort)
+//! - `parent` / `agent` → durable mailbox (persistent, cross-process, at-least-once)
 
 use std::sync::Arc;
 
@@ -12,9 +18,13 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use awaken_runtime_contract::StateError;
 use awaken_runtime_contract::contract::tool::{
     Tool, ToolCallContext, ToolDescriptor, ToolError, ToolOutput, ToolResult,
 };
+
+use crate::hooks::{PhaseContext, PhaseHook};
+use crate::state::{StateCommand, StateKey};
 
 use super::manager::BackgroundTaskManager;
 use super::state::BackgroundTaskStateKey;
@@ -49,6 +59,16 @@ pub enum RecipientRef {
 }
 
 /// Result returned to the LLM after sending.
+///
+/// `status` is `"queued"` on success — the message was committed to the outbox
+/// (see [`MessageOutboxKey`]), **not** confirmed delivered. `message_id` is a
+/// client-side correlation id (an agent cannot act on a transport dispatch id,
+/// so none is returned).
+///
+/// The intent is committed with the run, so it survives a checkpoint/crash and
+/// is re-dispatched by [`MessageDispatchHook`] (at-least-once for durable
+/// routes; best-effort for the live `child` route). Durable rejections are
+/// dead-lettered to [`FailedDurableMessageKey`] rather than dropped.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendMessageReceipt {
     pub message_id: String,
@@ -83,8 +103,13 @@ impl std::fmt::Display for MessageError {
 /// The runtime does not know how this becomes durable work. A host can map it
 /// to a mailbox dispatch, an A2A submission, or another transport without
 /// making runtime depend on mailbox storage internals.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `message_id` is the stable, sender-side id of this message (the outbox entry
+/// id). Delivery is at-least-once, so the host/recipient MUST use it to
+/// deduplicate redelivered messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DurableMessageRequest {
+    pub message_id: String,
     pub recipient_thread_id: String,
     pub recipient_agent_id: Option<String>,
     pub sender_agent_id: String,
@@ -97,49 +122,273 @@ pub trait DurableMessageSink: Send + Sync {
     async fn send_agent_message(&self, request: DurableMessageRequest) -> Result<String, String>;
 }
 
-// ── Tool ─────────────────────────────────────────────────────────────
+// ── Outbox: the single committed channel for all message delivery ─────
+//
+// Feature code (the tool) can ONLY enqueue an entry here — a plain state
+// mutation committed with the run. It holds no transport (manager/sink), so it
+// cannot send through a lossy, uncommitted path. The transports live solely in
+// [`MessageDispatchHook`] below, which is the privileged dispatcher. This makes
+// the "durable side effect on a non-durable channel" bug unrepresentable in
+// feature code: there is no channel to choose and no sink to call.
 
-/// Unified message-sending tool exposed to LLMs.
-pub struct SendMessageTool {
-    manager: Arc<BackgroundTaskManager>,
-    durable_sink: Arc<dyn DurableMessageSink>,
+/// How a queued message is delivered. Resolved by the tool from the read-only
+/// snapshot; consumed only by [`MessageDispatchHook`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OutboxRoute {
+    /// Live in-process delivery to a child task's inbox (best-effort: the inbox
+    /// is ephemeral, so a dead target is dropped).
+    ChildInbox {
+        task_id: String,
+        owner_thread_id: String,
+        sender_agent_id: String,
+        message: String,
+    },
+    /// Durable cross-thread delivery via the host sink (at-least-once).
+    Durable(DurableMessageRequest),
 }
 
-impl SendMessageTool {
+/// A queued message awaiting delivery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutboxEntry {
+    pub id: String,
+    pub route: OutboxRoute,
+    /// Durable delivery attempts already made (for bounded retry).
+    #[serde(default)]
+    pub attempts: u32,
+}
+
+/// Persisted message outbox — the only way to send a message.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MessageOutbox {
+    pub pending: Vec<OutboxEntry>,
+}
+
+/// Reducer action for [`MessageOutboxKey`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MessageOutboxUpdate {
+    Enqueue(OutboxEntry),
+    Remove { id: String },
+}
+
+impl MessageOutbox {
+    pub(crate) fn reduce(&mut self, update: MessageOutboxUpdate) {
+        match update {
+            MessageOutboxUpdate::Enqueue(entry) => self.pending.push(entry),
+            MessageOutboxUpdate::Remove { id } => self.pending.retain(|entry| entry.id != id),
+        }
+    }
+}
+
+/// State key for the message outbox (Thread-scoped, persistent — so an entry
+/// undelivered at run end is re-dispatched by a later run on the thread).
+pub struct MessageOutboxKey;
+
+impl StateKey for MessageOutboxKey {
+    const KEY: &'static str = "background_message_outbox";
+    type Value = MessageOutbox;
+    type Update = MessageOutboxUpdate;
+
+    fn apply(value: &mut Self::Value, update: Self::Update) {
+        value.reduce(update);
+    }
+}
+
+/// A durable message whose delivery the sink rejected.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FailedDurableMessage {
+    pub request: DurableMessageRequest,
+    pub error: String,
+}
+
+/// Persisted dead-letter list for durable messages the sink rejected.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FailedDurableMessageState {
+    pub messages: Vec<FailedDurableMessage>,
+}
+
+/// Reducer action for [`FailedDurableMessageKey`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FailedDurableMessageUpdate {
+    Push(FailedDurableMessage),
+}
+
+impl FailedDurableMessageState {
+    pub(crate) fn reduce(&mut self, update: FailedDurableMessageUpdate) {
+        match update {
+            FailedDurableMessageUpdate::Push(message) => self.messages.push(message),
+        }
+    }
+}
+
+/// State key for the durable-message dead-letter list (Thread-scoped, persistent).
+///
+/// Each dead-letter is also logged (`tracing::warn` with `message_id`) so it is
+/// observable. A consumer/replay/cleanup surface and a metric counter are a
+/// tracked follow-up — without one this list will accumulate silently.
+pub struct FailedDurableMessageKey;
+
+impl StateKey for FailedDurableMessageKey {
+    const KEY: &'static str = "background_failed_durable_messages";
+    type Value = FailedDurableMessageState;
+    type Update = FailedDurableMessageUpdate;
+
+    fn apply(value: &mut Self::Value, update: Self::Update) {
+        value.reduce(update);
+    }
+}
+
+/// Durable delivery attempts before a message is dead-lettered.
+const MAX_DURABLE_ATTEMPTS: u32 = 5;
+
+/// Privileged message dispatcher — the only code that holds the delivery
+/// transports (live manager + optional host durable sink).
+///
+/// Runs at `StepEnd`, drains the committed [`MessageOutboxKey`], and delivers
+/// each entry by route:
+/// - `child` (live inbox): best-effort; a dead target is dropped.
+/// - `durable`: delivered through the sink. On a transient rejection the entry
+///   is kept (retried next `StepEnd`) up to [`MAX_DURABLE_ATTEMPTS`], then
+///   dead-lettered to [`FailedDurableMessageKey`]. With no sink configured,
+///   durable routes are dead-lettered immediately (child still works).
+///
+/// Delivered entries are removed in the returned command, so on a crash before
+/// that commit an undelivered entry stays in the outbox and is re-dispatched
+/// (at-least-once; the recipient deduplicates on `DurableMessageRequest.message_id`).
+pub struct MessageDispatchHook {
+    manager: Arc<BackgroundTaskManager>,
+    durable_sink: Option<Arc<dyn DurableMessageSink>>,
+}
+
+impl MessageDispatchHook {
     pub fn new(
         manager: Arc<BackgroundTaskManager>,
-        durable_sink: Arc<dyn DurableMessageSink>,
+        durable_sink: Option<Arc<dyn DurableMessageSink>>,
     ) -> Self {
         Self {
             manager,
             durable_sink,
         }
     }
+}
 
-    async fn send_durable(
-        &self,
-        recipient_thread_id: &str,
-        recipient_agent_id: &str,
-        sender_agent_id: &str,
-        message: &str,
-    ) -> Result<String, String> {
-        self.durable_sink
-            .send_agent_message(DurableMessageRequest {
-                recipient_thread_id: recipient_thread_id.to_string(),
-                recipient_agent_id: (!recipient_agent_id.is_empty())
-                    .then(|| recipient_agent_id.to_string()),
-                sender_agent_id: sender_agent_id.to_string(),
-                message: message.to_string(),
-            })
-            .await
+#[async_trait]
+impl PhaseHook for MessageDispatchHook {
+    async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, StateError> {
+        let outbox = ctx.state::<MessageOutboxKey>().cloned().unwrap_or_default();
+        let mut cmd = StateCommand::new();
+        for entry in outbox.pending {
+            let OutboxEntry {
+                id,
+                route,
+                attempts,
+            } = entry;
+            match route {
+                OutboxRoute::ChildInbox {
+                    task_id,
+                    owner_thread_id,
+                    sender_agent_id,
+                    message,
+                } => {
+                    if let Err(error) = self
+                        .manager
+                        .send_task_inbox_message(
+                            &task_id,
+                            &owner_thread_id,
+                            &sender_agent_id,
+                            &message,
+                        )
+                        .await
+                    {
+                        // The inbox is ephemeral; a dead target is best-effort dropped.
+                        tracing::debug!(?error, task_id, "child inbox delivery dropped");
+                    }
+                    cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Remove { id });
+                }
+                OutboxRoute::Durable(request) => {
+                    let Some(sink) = &self.durable_sink else {
+                        tracing::warn!(
+                            message_id = %request.message_id,
+                            "no durable transport configured; dead-lettering"
+                        );
+                        cmd.update::<FailedDurableMessageKey>(FailedDurableMessageUpdate::Push(
+                            FailedDurableMessage {
+                                request,
+                                error: "no durable transport configured".into(),
+                            },
+                        ));
+                        cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Remove { id });
+                        continue;
+                    };
+                    match sink.send_agent_message(request.clone()).await {
+                        Ok(dispatch_id) => {
+                            tracing::debug!(
+                                dispatch_id,
+                                message_id = %request.message_id,
+                                "durable message dispatched"
+                            );
+                            cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Remove { id });
+                        }
+                        Err(error) => {
+                            let next = attempts + 1;
+                            if next < MAX_DURABLE_ATTEMPTS {
+                                // Keep it for retry on a later StepEnd.
+                                tracing::warn!(
+                                    message_id = %request.message_id,
+                                    attempt = next,
+                                    %error,
+                                    "durable delivery failed; will retry"
+                                );
+                                cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Remove {
+                                    id: id.clone(),
+                                });
+                                cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Enqueue(
+                                    OutboxEntry {
+                                        id,
+                                        route: OutboxRoute::Durable(request),
+                                        attempts: next,
+                                    },
+                                ));
+                            } else {
+                                tracing::warn!(
+                                    message_id = %request.message_id,
+                                    attempts = next,
+                                    %error,
+                                    "durable delivery exhausted; dead-lettering"
+                                );
+                                cmd.update::<FailedDurableMessageKey>(
+                                    FailedDurableMessageUpdate::Push(FailedDurableMessage {
+                                        request,
+                                        error,
+                                    }),
+                                );
+                                cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Remove { id });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(cmd)
+    }
+}
+
+// ── Tool ─────────────────────────────────────────────────────────────
+
+/// Unified message-sending tool exposed to LLMs.
+///
+/// Stateless: delivery runs through [`SendMessageEffectHandler`], registered
+/// next to this tool by [`super::plugin::BackgroundTaskPlugin`].
+#[derive(Default)]
+pub struct SendMessageTool;
+
+impl SendMessageTool {
+    pub fn new() -> Self {
+        Self
     }
 
-    fn resolve_child(
-        &self,
-        name: &str,
-        owner_thread_id: &str,
-        ctx: &ToolCallContext,
-    ) -> Option<String> {
+    /// Resolve a live, same-thread child task by name or id against the
+    /// read-only snapshot. Returns the resolved `task_id`.
+    fn resolve_child(name: &str, owner_thread_id: &str, ctx: &ToolCallContext) -> Option<String> {
         let snap = ctx.state::<BackgroundTaskStateKey>()?;
         if let Some(meta) = snap.tasks.get(name)
             && meta.owner_thread_id == owner_thread_id
@@ -161,7 +410,9 @@ impl SendMessageTool {
     fn make_receipt(msg_id: String) -> SendMessageReceipt {
         SendMessageReceipt {
             message_id: msg_id,
-            status: "accepted",
+            // "queued", not "delivered": the effect is dispatched post-commit
+            // and not yet confirmed. See `SendMessageReceipt` docs.
+            status: "queued",
             error: None,
         }
     }
@@ -172,6 +423,17 @@ impl SendMessageTool {
             status: "failed",
             error: Some(code.to_string()),
         }
+    }
+
+    /// A failed receipt is reported to the LLM as a successful tool call
+    /// carrying a structured failure status (no effect is emitted).
+    fn failed_output(code: MessageError) -> Result<ToolOutput, ToolError> {
+        Ok(ToolResult::success(
+            SEND_MESSAGE_TOOL_ID,
+            serde_json::to_value(Self::make_error(code))
+                .map_err(|e| ToolError::Internal(e.to_string()))?,
+        )
+        .into())
     }
 }
 
@@ -266,56 +528,45 @@ impl Tool for SendMessageTool {
         let message = args
             .get("message")
             .and_then(Value::as_str)
-            .ok_or_else(|| ToolError::InvalidArguments("missing 'message'".into()))?;
-        let sender = &ctx.run_identity.agent_id;
-        let thread_id = &ctx.run_identity.thread_id;
+            .ok_or_else(|| ToolError::InvalidArguments("missing 'message'".into()))?
+            .to_string();
+        let sender = ctx.run_identity.agent_id.clone();
+        let thread_id = ctx.run_identity.thread_id.clone();
+        // Stable id for this message: it is the outbox entry id, carried into the
+        // durable request so the recipient can dedup an at-least-once redelivery.
         let msg_id = uuid::Uuid::now_v7().to_string();
 
-        // Routing is automatic — runtime picks the transport:
-        //   child  → live inbox (in-process)
-        //   parent → durable mailbox (cross-thread)
-        //   agent  → durable mailbox (cross-thread)
-        let receipt = match relation {
+        // Resolve the recipient from the read-only snapshot, then commit the
+        // delivery as an outbox entry. The tool holds no transport; routing
+        // (live vs durable) is data the dispatcher acts on, not a channel the
+        // tool picks.
+        let route = match relation {
             "child" => {
                 let name = to
                     .get("name")
                     .and_then(Value::as_str)
                     .ok_or_else(|| ToolError::InvalidArguments("child requires 'name'".into()))?;
-                match self.resolve_child(name, thread_id, ctx) {
-                    Some(task_id) => {
-                        match self
-                            .manager
-                            .send_task_inbox_message(&task_id, thread_id, sender, message)
-                            .await
-                        {
-                            Ok(()) => Self::make_receipt(msg_id.clone()),
-                            Err(e) => {
-                                use super::manager::SendError;
-                                Self::make_error(match e {
-                                    SendError::TaskNotFound => MessageError::RecipientNotFound,
-                                    SendError::NotOwner => MessageError::PermissionDenied,
-                                    SendError::TaskTerminated(_) | SendError::InboxClosed => {
-                                        MessageError::RecipientUnavailable
-                                    }
-                                    SendError::NoInbox => MessageError::RecipientUnavailable,
-                                })
-                            }
-                        }
-                    }
-                    None => Self::make_error(MessageError::RecipientNotFound),
+                match Self::resolve_child(name, &thread_id, ctx) {
+                    Some(task_id) => OutboxRoute::ChildInbox {
+                        task_id,
+                        owner_thread_id: thread_id,
+                        sender_agent_id: sender,
+                        message,
+                    },
+                    None => return Self::failed_output(MessageError::RecipientNotFound),
                 }
             }
             "parent" => match ctx.run_identity.parent_thread_id.as_deref() {
-                Some(parent_tid) => {
-                    // Leave agent_id empty — the runner will infer the correct
-                    // agent from the thread's latest run record. We don't have
-                    // parent_agent_id in RunIdentity yet.
-                    match self.send_durable(parent_tid, "", sender, message).await {
-                        Ok(dispatch_id) => Self::make_receipt(dispatch_id),
-                        Err(e) => Self::make_error(MessageError::TransportFailed(e)),
-                    }
-                }
-                None => Self::make_error(MessageError::RecipientUnavailable),
+                Some(parent_tid) => OutboxRoute::Durable(DurableMessageRequest {
+                    message_id: msg_id.clone(),
+                    recipient_thread_id: parent_tid.to_string(),
+                    // The runner infers the parent agent from the thread's
+                    // latest run record; we don't carry parent_agent_id here.
+                    recipient_agent_id: None,
+                    sender_agent_id: sender,
+                    message,
+                }),
+                None => return Self::failed_output(MessageError::RecipientUnavailable),
             },
             "agent" => {
                 let target_thread =
@@ -325,23 +576,37 @@ impl Tool for SendMessageTool {
                 let target_agent = to
                     .get("agent_id")
                     .and_then(Value::as_str)
-                    .unwrap_or_default();
-                match self
-                    .send_durable(target_thread, target_agent, sender, message)
-                    .await
-                {
-                    Ok(dispatch_id) => Self::make_receipt(dispatch_id),
-                    Err(e) => Self::make_error(MessageError::TransportFailed(e)),
-                }
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                OutboxRoute::Durable(DurableMessageRequest {
+                    message_id: msg_id.clone(),
+                    recipient_thread_id: target_thread.to_string(),
+                    recipient_agent_id: target_agent,
+                    sender_agent_id: sender,
+                    message,
+                })
             }
-            _ => Self::make_error(MessageError::RecipientNotFound),
+            other => {
+                return Err(ToolError::InvalidArguments(format!(
+                    "unknown relation '{other}'"
+                )));
+            }
         };
 
-        Ok(ToolResult::success(
-            SEND_MESSAGE_TOOL_ID,
-            serde_json::to_value(&receipt).map_err(|e| ToolError::Internal(e.to_string()))?,
-        )
-        .into())
+        let mut command = StateCommand::new();
+        command.update::<MessageOutboxKey>(MessageOutboxUpdate::Enqueue(OutboxEntry {
+            id: msg_id.clone(),
+            route,
+            attempts: 0,
+        }));
+        Ok(ToolOutput::with_command(
+            ToolResult::success(
+                SEND_MESSAGE_TOOL_ID,
+                serde_json::to_value(Self::make_receipt(msg_id))
+                    .map_err(|e| ToolError::Internal(e.to_string()))?,
+            ),
+            command,
+        ))
     }
 }
 
@@ -353,6 +618,7 @@ mod tests {
     };
     use crate::state::StateStore;
     use awaken_runtime_contract::contract::identity::RunIdentity;
+    use awaken_runtime_contract::model::Phase;
     use awaken_runtime_contract::registry_spec::AgentSpec;
     use tokio::sync::Mutex;
 
@@ -399,65 +665,117 @@ mod tests {
         make_ctx_with_store(thread_id, agent_id, &StateStore::new())
     }
 
-    fn make_manager_and_store() -> (Arc<BackgroundTaskManager>, StateStore) {
+    struct FailingSink;
+
+    #[async_trait]
+    impl DurableMessageSink for FailingSink {
+        async fn send_agent_message(
+            &self,
+            _request: DurableMessageRequest,
+        ) -> Result<String, String> {
+            Err("sink down".into())
+        }
+    }
+
+    /// Build a messaging-enabled env (registers the outbox + dead-letter keys)
+    /// and a store wired to the manager.
+    fn messaging_env() -> (
+        Arc<BackgroundTaskManager>,
+        Arc<RecordingDurableSink>,
+        StateStore,
+    ) {
         use crate::phase::ExecutionEnv;
         use crate::plugins::Plugin;
         let store = StateStore::new();
         let manager = Arc::new(BackgroundTaskManager::new());
         manager.set_store(store.clone());
-        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager.clone()));
+        let sink = Arc::new(RecordingDurableSink::default());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::with_messaging(
+            manager.clone(),
+            sink.clone(),
+        ));
         let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
         store.register_keys(&env.key_registrations).unwrap();
-        (manager, store)
+        (manager, sink, store)
     }
 
-    fn make_tool(manager: Arc<BackgroundTaskManager>) -> SendMessageTool {
-        SendMessageTool::new(manager, Arc::new(RecordingDurableSink::default()))
+    /// Commit a tool output's patch and read back the committed outbox.
+    fn outbox_of(store: &StateStore, out: ToolOutput) -> MessageOutbox {
+        store.commit(out.command.patch).unwrap();
+        store.read::<MessageOutboxKey>().unwrap_or_default()
     }
 
-    // -- child by name --
+    fn enqueue(store: &StateStore, id: &str, route: OutboxRoute) {
+        let mut cmd = StateCommand::new();
+        cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Enqueue(OutboxEntry {
+            id: id.into(),
+            route,
+            attempts: 0,
+        }));
+        store.commit(cmd.patch).unwrap();
+    }
+
+    fn durable_req(message_id: &str, recipient_thread_id: &str) -> DurableMessageRequest {
+        DurableMessageRequest {
+            message_id: message_id.into(),
+            recipient_thread_id: recipient_thread_id.into(),
+            recipient_agent_id: None,
+            sender_agent_id: "sender".into(),
+            message: "hello".into(),
+        }
+    }
+
+    // -- tool: enqueue child route --
 
     #[tokio::test]
-    async fn child_by_name_delivers_live() {
-        let (manager, store) = make_manager_and_store();
+    async fn child_enqueues_child_route() {
+        let (manager, _sink, store) = messaging_env();
         manager
             .spawn_agent(
                 "thread-1",
                 Some("researcher"),
                 "desc",
                 TaskParentContext::default(),
-                |cancel, _s, mut rx| async move {
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                    if rx.try_recv().is_some() {
-                        BgTaskResult::Success(json!({"got": true}))
-                    } else {
-                        cancel.cancelled().await;
-                        BgTaskResult::Cancelled
-                    }
+                |cancel, _s, _r| async move {
+                    cancel.cancelled().await;
+                    BgTaskResult::Cancelled
                 },
             )
             .await
             .unwrap();
 
-        let tool = make_tool(manager.clone());
-        // Take snapshot AFTER spawn so the task metadata is visible
+        let tool = SendMessageTool::new();
+        // Snapshot AFTER spawn so the task metadata is visible.
         let ctx = make_ctx_with_store("thread-1", "parent", &store);
-        let r = tool
+        let out = tool
             .execute(
                 json!({"to": {"relation": "child", "name": "researcher"}, "message": "hi"}),
                 &ctx,
             )
             .await
             .unwrap();
-        assert_eq!(r.result.data["status"], "accepted");
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(out.result.data["status"], "queued");
+        let outbox = outbox_of(&store, out);
+        assert_eq!(outbox.pending.len(), 1);
+        match &outbox.pending[0].route {
+            OutboxRoute::ChildInbox {
+                owner_thread_id,
+                sender_agent_id,
+                message,
+                ..
+            } => {
+                assert_eq!(owner_thread_id, "thread-1");
+                assert_eq!(sender_agent_id, "parent");
+                assert_eq!(message, "hi");
+            }
+            other => panic!("expected child route, got {other:?}"),
+        }
+        manager.cancel_all("thread-1").await;
     }
 
-    // -- child wrong thread --
-
     #[tokio::test]
-    async fn child_wrong_thread_permission_denied() {
-        let (manager, store) = make_manager_and_store();
+    async fn child_wrong_thread_fails_without_enqueue() {
+        let (manager, _sink, store) = messaging_env();
         manager
             .spawn_agent(
                 "thread-1",
@@ -472,226 +790,54 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = make_tool(manager.clone());
+        let tool = SendMessageTool::new();
         let ctx = make_ctx_with_store("thread-WRONG", "attacker", &store);
-        let r = tool
+        let out = tool
             .execute(
                 json!({"to": {"relation": "child", "name": "worker"}, "message": "x"}),
                 &ctx,
             )
             .await
             .unwrap();
-        assert_eq!(r.result.data["status"], "failed");
+        assert_eq!(out.result.data["status"], "failed");
+        assert!(outbox_of(&store, out).pending.is_empty());
         manager.cancel_all("thread-1").await;
     }
 
-    // -- child durable rejected --
-
-    // -- agent via mailbox --
+    // -- tool: enqueue durable route (agent/parent) --
 
     #[tokio::test]
-    async fn agent_delivers_durable() {
-        let (manager, _store) = make_manager_and_store();
-        let sink = Arc::new(RecordingDurableSink::default());
-        let tool = SendMessageTool::new(manager, sink.clone());
-        let ctx = make_ctx("thread-1", "sender");
-        let r = tool
+    async fn agent_enqueues_durable_route() {
+        let (_manager, _sink, store) = messaging_env();
+        let tool = SendMessageTool::new();
+        let ctx = make_ctx_with_store("thread-1", "sender", &store);
+        let out = tool
             .execute(
                 json!({"to": {"relation": "agent", "thread_id": "thread-2"}, "message": "hello"}),
                 &ctx,
             )
             .await
             .unwrap();
-        assert_eq!(r.result.data["status"], "accepted");
-
-        let requests = sink.requests.lock().await;
-        assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].recipient_thread_id, "thread-2");
-        assert_eq!(requests[0].recipient_agent_id, None);
-        assert_eq!(requests[0].sender_agent_id, "sender");
-        assert_eq!(requests[0].message, "hello");
+        assert_eq!(out.result.data["status"], "queued");
+        let outbox = outbox_of(&store, out);
+        assert_eq!(outbox.pending.len(), 1);
+        match &outbox.pending[0].route {
+            OutboxRoute::Durable(req) => {
+                assert_eq!(req.recipient_thread_id, "thread-2");
+                assert_eq!(req.recipient_agent_id, None);
+                assert_eq!(req.sender_agent_id, "sender");
+                assert_eq!(req.message, "hello");
+            }
+            other => panic!("expected durable route, got {other:?}"),
+        }
     }
-
-    // -- agent live rejected --
-
-    // -- parent --
-
-    #[tokio::test]
-    async fn parent_no_context_unavailable() {
-        let (manager, _store) = make_manager_and_store();
-        let tool = make_tool(manager);
-        let ctx = make_ctx("thread-1", "child");
-        let r = tool
-            .execute(
-                json!({"to": {"relation": "parent"}, "message": "done"}),
-                &ctx,
-            )
-            .await
-            .unwrap();
-        assert_eq!(r.result.data["status"], "failed");
-        assert!(
-            r.result.data["error"]
-                .as_str()
-                .unwrap()
-                .contains("recipient_unavailable")
-        );
-    }
-
-    #[tokio::test]
-    async fn parent_with_thread_id_delivers() {
-        let (manager, _store) = make_manager_and_store();
-        let sink = Arc::new(RecordingDurableSink::default());
-        let tool = SendMessageTool::new(manager, sink.clone());
-
-        let mut ctx = make_ctx("thread-child", "child-agent");
-        ctx.run_identity = awaken_runtime_contract::contract::identity::RunIdentity::new(
-            "thread-child".into(),
-            Some("thread-parent".into()),
-            "run-child".into(),
-            Some("run-parent".into()),
-            "child-agent".into(),
-            awaken_runtime_contract::contract::identity::RunOrigin::Subagent,
-        );
-
-        let r = tool
-            .execute(
-                json!({"to": {"relation": "parent"}, "message": "analysis complete"}),
-                &ctx,
-            )
-            .await
-            .unwrap();
-        assert_eq!(r.result.data["status"], "accepted");
-
-        let requests = sink.requests.lock().await;
-        assert_eq!(requests.len(), 1, "message should route to parent's thread");
-        assert_eq!(requests[0].recipient_thread_id, "thread-parent");
-        assert_eq!(requests[0].recipient_agent_id, None);
-        assert_eq!(requests[0].sender_agent_id, "child-agent");
-        assert_eq!(requests[0].message, "analysis complete");
-    }
-
-    // -- validation --
-
-    #[test]
-    fn rejects_missing_relation() {
-        let (m, _) = make_manager_and_store();
-        let t = make_tool(m);
-        assert!(
-            t.validate_args(&json!({"to": {}, "message": "hi"}))
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn rejects_child_without_name() {
-        let (m, _) = make_manager_and_store();
-        let t = make_tool(m);
-        assert!(
-            t.validate_args(&json!({"to": {"relation": "child"}, "message": "hi"}))
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn rejects_agent_without_thread_id() {
-        let (m, _) = make_manager_and_store();
-        let t = make_tool(m);
-        assert!(
-            t.validate_args(&json!({"to": {"relation": "agent"}, "message": "hi"}))
-                .is_err()
-        );
-    }
-
-    #[tokio::test]
-    async fn execute_rejects_invalid_args() {
-        let (manager, _store) = make_manager_and_store();
-        let tool = make_tool(manager);
-        let ctx = make_ctx("thread-1", "agent-1");
-
-        let error = tool
-            .execute(json!({"to": {"relation": "child"}, "message": "hi"}), &ctx)
-            .await
-            .unwrap_err();
-
-        assert!(matches!(error, ToolError::InvalidArguments(_)));
-    }
-
-    #[test]
-    fn accepts_valid_child() {
-        let (m, _) = make_manager_and_store();
-        let t = make_tool(m);
-        assert!(
-            t.validate_args(&json!({"to": {"relation": "child", "name": "r"}, "message": "hi"}))
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn accepts_valid_parent() {
-        let (m, _) = make_manager_and_store();
-        let t = make_tool(m);
-        assert!(
-            t.validate_args(&json!({"to": {"relation": "parent"}, "message": "hi"}))
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn accepts_valid_agent() {
-        let (m, _) = make_manager_and_store();
-        let t = make_tool(m);
-        assert!(
-            t.validate_args(
-                &json!({"to": {"relation": "agent", "thread_id": "t1"}, "message": "hi"})
-            )
-            .is_ok()
-        );
-    }
-
-    // -- parent routing returns unavailable (no parent_thread_id yet) --
-
-    #[tokio::test]
-    async fn parent_without_thread_id_returns_unavailable() {
-        let (manager, _store) = make_manager_and_store();
-        let tool = make_tool(manager);
-
-        // parent_run_id is set but parent_thread_id is None — routing fails.
-        let mut ctx = make_ctx("thread-1", "child");
-        ctx.run_identity = awaken_runtime_contract::contract::identity::RunIdentity::new(
-            "thread-1".into(),
-            None,
-            "run-child".into(),
-            Some("run-parent".into()), // parent_run_id exists
-            "child".into(),
-            awaken_runtime_contract::contract::identity::RunOrigin::Subagent,
-        );
-
-        let r = tool
-            .execute(
-                json!({"to": {"relation": "parent"}, "message": "hello parent"}),
-                &ctx,
-            )
-            .await
-            .unwrap();
-        assert_eq!(r.result.data["status"], "failed");
-        assert!(
-            r.result.data["error"]
-                .as_str()
-                .unwrap()
-                .contains("recipient_unavailable")
-        );
-    }
-
-    // -- agent routing includes agent_id in durable request --
 
     #[tokio::test]
     async fn agent_routing_includes_agent_id() {
-        let (manager, _store) = make_manager_and_store();
-        let sink = Arc::new(RecordingDurableSink::default());
-        let tool = SendMessageTool::new(manager, sink.clone());
-        let ctx = make_ctx("thread-1", "sender");
-
-        let r = tool
+        let (_manager, _sink, store) = messaging_env();
+        let tool = SendMessageTool::new();
+        let ctx = make_ctx_with_store("thread-1", "sender", &store);
+        let out = tool
             .execute(
                 json!({
                     "to": {"relation": "agent", "thread_id": "thread-target", "agent_id": "reviewer"},
@@ -701,10 +847,430 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(r.result.data["status"], "accepted");
+        assert_eq!(out.result.data["status"], "queued");
+        let outbox = outbox_of(&store, out);
+        match &outbox.pending[0].route {
+            OutboxRoute::Durable(req) => {
+                assert_eq!(req.recipient_agent_id.as_deref(), Some("reviewer"))
+            }
+            other => panic!("expected durable route, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parent_with_thread_id_enqueues_durable() {
+        let (_manager, _sink, store) = messaging_env();
+        let tool = SendMessageTool::new();
+        let mut ctx = make_ctx_with_store("thread-child", "child-agent", &store);
+        ctx.run_identity = RunIdentity::new(
+            "thread-child".into(),
+            Some("thread-parent".into()),
+            "run-child".into(),
+            Some("run-parent".into()),
+            "child-agent".into(),
+            awaken_runtime_contract::contract::identity::RunOrigin::Subagent,
+        );
+
+        let out = tool
+            .execute(
+                json!({"to": {"relation": "parent"}, "message": "analysis complete"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.result.data["status"], "queued");
+        let outbox = outbox_of(&store, out);
+        match &outbox.pending[0].route {
+            OutboxRoute::Durable(req) => {
+                assert_eq!(req.recipient_thread_id, "thread-parent");
+                assert_eq!(req.recipient_agent_id, None);
+                assert_eq!(req.sender_agent_id, "child-agent");
+                assert_eq!(req.message, "analysis complete");
+            }
+            other => panic!("expected durable route, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parent_without_thread_id_returns_unavailable() {
+        let (_manager, _sink, store) = messaging_env();
+        let tool = SendMessageTool::new();
+        let mut ctx = make_ctx_with_store("thread-1", "child", &store);
+        ctx.run_identity = RunIdentity::new(
+            "thread-1".into(),
+            None,
+            "run-child".into(),
+            Some("run-parent".into()),
+            "child".into(),
+            awaken_runtime_contract::contract::identity::RunOrigin::Subagent,
+        );
+
+        let out = tool
+            .execute(
+                json!({"to": {"relation": "parent"}, "message": "hello parent"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert_eq!(out.result.data["status"], "failed");
+        assert!(
+            out.result.data["error"]
+                .as_str()
+                .unwrap()
+                .contains("recipient_unavailable")
+        );
+        assert!(outbox_of(&store, out).pending.is_empty());
+    }
+
+    // -- dispatcher: drains the committed outbox --
+
+    #[tokio::test]
+    async fn dispatch_delivers_durable_and_clears_outbox() {
+        let (manager, sink, store) = messaging_env();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::Durable(durable_req("m1", "thread-2")),
+        );
+
+        let hook = MessageDispatchHook::new(manager.clone(), Some(sink.clone()));
+        let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+        let cmd = hook.run(&ctx).await.unwrap();
+        store.commit(cmd.patch).unwrap();
 
         let requests = sink.requests.lock().await;
         assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].recipient_agent_id.as_deref(), Some("reviewer"));
+        // The sender-side message id reaches the sink for dedup.
+        assert_eq!(requests[0].message_id, "m1");
+        assert!(
+            store
+                .read::<MessageOutboxKey>()
+                .unwrap_or_default()
+                .pending
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_retries_then_dead_letters_durable() {
+        let (manager, _sink, store) = messaging_env();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::Durable(durable_req("m1", "thread-2")),
+        );
+        let hook = MessageDispatchHook::new(manager.clone(), Some(Arc::new(FailingSink)));
+
+        // Each StepEnd: a transient failure keeps the entry (attempts++) until
+        // MAX_DURABLE_ATTEMPTS, then it is dead-lettered — not dropped, not retried forever.
+        for _ in 0..MAX_DURABLE_ATTEMPTS {
+            let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+            let cmd = hook.run(&ctx).await.unwrap();
+            store.commit(cmd.patch).unwrap();
+        }
+
+        assert!(
+            store
+                .read::<MessageOutboxKey>()
+                .unwrap_or_default()
+                .pending
+                .is_empty(),
+            "exhausted entry leaves the outbox"
+        );
+        assert_eq!(
+            store
+                .read::<FailedDurableMessageKey>()
+                .unwrap_or_default()
+                .messages
+                .len(),
+            1,
+            "exhausted entry is dead-lettered exactly once"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_dead_letters_durable_without_sink() {
+        // No durable transport: child still works, durable is dead-lettered.
+        let (manager, _sink, store) = messaging_env();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::Durable(durable_req("m1", "thread-2")),
+        );
+
+        let hook = MessageDispatchHook::new(manager.clone(), None);
+        let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+        let cmd = hook.run(&ctx).await.unwrap();
+        store.commit(cmd.patch).unwrap();
+
+        assert_eq!(
+            store
+                .read::<FailedDurableMessageKey>()
+                .unwrap_or_default()
+                .messages
+                .len(),
+            1
+        );
+        assert!(
+            store
+                .read::<MessageOutboxKey>()
+                .unwrap_or_default()
+                .pending
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn redelivery_after_crash_keeps_same_message_id() {
+        let (manager, sink, store) = messaging_env();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::Durable(durable_req("m1", "thread-2")),
+        );
+        let hook = MessageDispatchHook::new(manager.clone(), Some(sink.clone()));
+
+        // First dispatch delivers, but the returned remove is NOT committed
+        // (simulate a crash between sink delivery and the outbox commit).
+        let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+        let _dropped = hook.run(&ctx).await.unwrap();
+
+        // The entry is still committed in the outbox → it is redelivered.
+        let ctx2 = PhaseContext::new(Phase::StepEnd, store.snapshot());
+        let cmd = hook.run(&ctx2).await.unwrap();
+        store.commit(cmd.patch).unwrap();
+
+        let requests = sink.requests.lock().await;
+        assert_eq!(requests.len(), 2, "redelivered after the dropped commit");
+        assert!(
+            requests.iter().all(|r| r.message_id == "m1"),
+            "redelivery carries the same message_id so the recipient can dedup"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_delivers_child_without_sink() {
+        let (manager, _sink, store) = messaging_env();
+        let task_id = manager
+            .spawn_agent(
+                "thread-1",
+                Some("researcher"),
+                "desc",
+                TaskParentContext::default(),
+                |cancel, _s, _r| async move {
+                    cancel.cancelled().await;
+                    BgTaskResult::Cancelled
+                },
+            )
+            .await
+            .unwrap();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::ChildInbox {
+                task_id,
+                owner_thread_id: "thread-1".into(),
+                sender_agent_id: "parent".into(),
+                message: "hi".into(),
+            },
+        );
+
+        // No durable sink configured — child delivery must still work.
+        let hook = MessageDispatchHook::new(manager.clone(), None);
+        let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+        let cmd = hook.run(&ctx).await.unwrap();
+        store.commit(cmd.patch).unwrap();
+
+        assert!(
+            store
+                .read::<MessageOutboxKey>()
+                .unwrap_or_default()
+                .pending
+                .is_empty(),
+            "child entry delivered and removed even without a durable sink"
+        );
+        manager.cancel_all("thread-1").await;
+    }
+
+    // -- closed loop: enqueue, then the real StepEnd phase drives delivery --
+
+    #[tokio::test]
+    async fn closed_loop_dispatches_durable_at_step_end() {
+        use crate::phase::{ExecutionEnv, PhaseRuntime};
+        use crate::plugins::Plugin;
+        let store = StateStore::new();
+        let manager = Arc::new(BackgroundTaskManager::new());
+        manager.set_store(store.clone());
+        let sink = Arc::new(RecordingDurableSink::default());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::with_messaging(
+            manager.clone(),
+            sink.clone(),
+        ));
+        // LoopStatePlugin registers PendingWorkKey, which the background StepEnd
+        // sync hook writes — required for a full StepEnd phase run.
+        let loop_plugin: Arc<dyn Plugin> = Arc::new(crate::loop_runner::LoopStatePlugin);
+        let env = ExecutionEnv::from_plugins(&[plugin, loop_plugin], &Default::default()).unwrap();
+        store.register_keys(&env.key_registrations).unwrap();
+
+        // Enqueue as the tool would, then run the *real* StepEnd phase: the engine
+        // must invoke the registered dispatcher hook (not a direct call).
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::Durable(durable_req("m1", "thread-2")),
+        );
+        let runtime = PhaseRuntime::new(store.clone()).unwrap();
+        runtime.run_phase(&env, Phase::StepEnd).await.unwrap();
+
+        assert_eq!(
+            sink.requests.lock().await.len(),
+            1,
+            "dispatcher fired at StepEnd through the engine"
+        );
+        assert!(
+            store
+                .read::<MessageOutboxKey>()
+                .unwrap_or_default()
+                .pending
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_delivers_child_inbox() {
+        let (manager, sink, store) = messaging_env();
+        let task_id = manager
+            .spawn_agent(
+                "thread-1",
+                Some("researcher"),
+                "desc",
+                TaskParentContext::default(),
+                |cancel, _s, _r| async move {
+                    cancel.cancelled().await;
+                    BgTaskResult::Cancelled
+                },
+            )
+            .await
+            .unwrap();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::ChildInbox {
+                task_id,
+                owner_thread_id: "thread-1".into(),
+                sender_agent_id: "parent".into(),
+                message: "hi".into(),
+            },
+        );
+
+        let hook = MessageDispatchHook::new(manager.clone(), Some(sink.clone()));
+        let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+        let cmd = hook.run(&ctx).await.unwrap();
+        store.commit(cmd.patch).unwrap();
+
+        // Child delivery goes through the manager, not the durable sink.
+        assert!(sink.requests.lock().await.is_empty());
+        assert!(
+            store
+                .read::<MessageOutboxKey>()
+                .unwrap_or_default()
+                .pending
+                .is_empty()
+        );
+        manager.cancel_all("thread-1").await;
+    }
+
+    // -- validation --
+
+    #[test]
+    fn rejects_missing_relation() {
+        let t = SendMessageTool::new();
+        assert!(
+            t.validate_args(&json!({"to": {}, "message": "hi"}))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_child_without_name() {
+        let t = SendMessageTool::new();
+        assert!(
+            t.validate_args(&json!({"to": {"relation": "child"}, "message": "hi"}))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_agent_without_thread_id() {
+        let t = SendMessageTool::new();
+        assert!(
+            t.validate_args(&json!({"to": {"relation": "agent"}, "message": "hi"}))
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_invalid_args() {
+        let tool = SendMessageTool::new();
+        let ctx = make_ctx("thread-1", "agent-1");
+        let error = tool
+            .execute(json!({"to": {"relation": "child"}, "message": "hi"}), &ctx)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, ToolError::InvalidArguments(_)));
+    }
+
+    #[test]
+    fn accepts_valid_child() {
+        let t = SendMessageTool::new();
+        assert!(
+            t.validate_args(&json!({"to": {"relation": "child", "name": "r"}, "message": "hi"}))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn accepts_valid_parent() {
+        let t = SendMessageTool::new();
+        assert!(
+            t.validate_args(&json!({"to": {"relation": "parent"}, "message": "hi"}))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn accepts_valid_agent() {
+        let t = SendMessageTool::new();
+        assert!(
+            t.validate_args(
+                &json!({"to": {"relation": "agent", "thread_id": "t1"}, "message": "hi"})
+            )
+            .is_ok()
+        );
+    }
+
+    // -- registration: send_message is available with or without a sink --
+    // (the child route needs no durable transport; durable degrades to dead-letter)
+
+    #[test]
+    fn send_message_registered_with_sink() {
+        use crate::phase::ExecutionEnv;
+        use crate::plugins::Plugin;
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let sink: Arc<dyn DurableMessageSink> = Arc::new(RecordingDurableSink::default());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::with_messaging(manager, sink));
+        let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
+        assert!(env.tools.contains_key(SEND_MESSAGE_TOOL_ID));
+    }
+
+    #[test]
+    fn send_message_registered_without_sink() {
+        use crate::phase::ExecutionEnv;
+        use crate::plugins::Plugin;
+        let manager = Arc::new(BackgroundTaskManager::new());
+        let plugin: Arc<dyn Plugin> = Arc::new(BackgroundTaskPlugin::new(manager));
+        let env = ExecutionEnv::from_plugins(&[plugin], &Default::default()).unwrap();
+        // Child messaging works without a durable sink — the tool is still registered.
+        assert!(env.tools.contains_key(SEND_MESSAGE_TOOL_ID));
     }
 }

--- a/crates/awaken-runtime/src/lib.rs
+++ b/crates/awaken-runtime/src/lib.rs
@@ -15,6 +15,8 @@ pub mod checkpoint_store;
 pub mod child_agent;
 pub mod context;
 pub mod credentials;
+#[cfg(feature = "a2a")]
+pub(crate) mod delegation;
 pub mod engine;
 mod error;
 pub mod event_buffer;


### PR DESCRIPTION
Separates delegation/background **tools (UI)** from the **mechanism** inside `awaken-runtime`, in three atomic commits (each builds independently).

## 1. Bind the auto-created background plugin via the shared seam

The auto-created `BackgroundTaskPlugin` (in `LocalBackend`) is bound through the same `bind_runtime_context` seam as resolved-env plugins, deleting the parallel manual `set_store`/`set_owner_inbox` path.

## 2. Decouple AgentTool from the backend via an internal `DelegateRunner` port

New crate-internal port `crate::delegation::DelegateRunner` + backend-agnostic `DelegateResult`/`DelegateOutcome`. AgentTool's hot path no longer touches `backend::*`/`registry::*`/`resolution::*`; `ResolverDelegateRunner` is the sole mapper of `BackendRunStatus`/`BackendRunResult`. The port is `pub(crate)` (not public facade — A-G10).

**On "behavior preserved":** `main` already mapped `Completed→success`, `Waiting/Auth/Suspended→Pending`+suspension, `Failed/Cancelled/Timeout→Error` (in `tool_result_from_backend`). This commit preserves that mapping byte-for-byte (now keyed on `DelegateOutcome`), including suspension action strings (`agent_delegate:*`), the `backend_status` param, and `delegate_run:` id. So this is **not** a behavior change vs `main`; snapshot tests lock all five outcomes.

## 3. `send_message` via a committed outbox + a privileged dispatcher

The tool's only effect is committing an `OutboxEntry` to `MessageOutboxKey` (Thread-scoped, persistent); it holds **no transport**. `MessageDispatchHook` is the only holder of the transports and drains the outbox at `StepEnd`. Because the tool can never call a sink, "send a durable message through a non-durable channel" is unrepresentable in feature code.

Delivery semantics:
- **`child`** (live inbox): best-effort; works **without a durable sink** (tool + dispatcher are registered unconditionally; durable degrades).
- **`parent`/`agent`** (durable): at-least-once. Crash before the outbox `Remove` commits ⇒ redispatched. A transient sink rejection **keeps the entry and retries** on later `StepEnd`s up to `MAX_DURABLE_ATTEMPTS`, then dead-letters to `FailedDurableMessageKey`; with no sink, durable routes dead-letter. The sender-side `message_id` (= outbox entry id) is carried in `DurableMessageRequest` so the recipient deduplicates `(recipient_thread_id, message_id)`.

`cancel_task` is deliberately not converted (needs synchronous results + the current-run token).

## Tests (`cargo test -p awaken-runtime --features "a2a background"` — 1452 green; clippy + `cargo check --workspace --all-features` clean)

- tool enqueues the correct `OutboxRoute` per relation; nothing enqueued on failed routing
- dispatcher delivers durable→sink **carrying `message_id`**; retries-then-dead-letters on persistent failure; dead-letters when no sink; routes child→manager
- **redelivery-after-crash**: dropping the dispatcher's remove-commit redelivers and the sink sees the **same `message_id`** (dedup key)
- **child delivers without a durable sink**
- closed-loop test runs the real `StepEnd` phase via `PhaseRuntime` and asserts the registered dispatcher fires
- AgentTool `DelegateRunner` mock snapshots for **completed / failed / cancelled / timeout / waiting / suspended**

## Out of scope (follow-ups)

- **Host wiring**: no production caller of `with_messaging` yet; `ServerDurableMessageSink` over the mailbox is a follow-up (the runtime loop is proven by the closed-loop test).
- **Dead-letter recovery**: `FailedDurableMessageKey` is persisted + logged (`tracing::warn` with `message_id`); a replay/cleanup/metrics/admin surface is a follow-up.
- Backoff timing (`next_attempt_at_ms`): retry currently paces on the `StepEnd` cadence; explicit backoff is a possible refinement.
- Publishing `DelegateRunner` to `awaken-runtime-contract` + extracting tools to their own crate needs an ADR; plus a guardrail/lint that a delivery port never appears in a tool/handler constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
