### PR TITLE
✨ feat(server): wire durable send_message delivery through the mailbox

### DIFF
--- a/crates/awaken-contract/tests/contract_integration.rs
+++ b/crates/awaken-contract/tests/contract_integration.rs
@@ -439,6 +439,7 @@ fn stream_result_to_message_to_event_pipeline() {
                 run_id: Some("r1".into()),
                 step_index: Some(0),
                 compaction: None,
+                sender_agent_id: None,
             });
 
     assert_eq!(msg.role, Role::Assistant);

--- a/crates/awaken-runtime-contract/src/contract/message.rs
+++ b/crates/awaken-runtime-contract/src/contract/message.rs
@@ -49,6 +49,12 @@ pub struct MessageMetadata {
     /// Step (round) index within the run (0-based).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub step_index: Option<u32>,
+    /// Originating agent for a cross-agent durable message (`send_message`'s
+    /// `parent`/`agent` routes). Lets the recipient attribute, audit, or apply
+    /// sender-based logic instead of seeing an anonymous user message. `None`
+    /// for ordinary end-user/system messages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_agent_id: Option<String>,
     /// When set, this message is a compaction summary that logically replaces
     /// the committed interval `[from_seq, to_seq]` (ADR-0038 D11/C7). The mark
     /// rides in the message body so it persists through every store without a

--- a/crates/awaken-runtime-contract/src/contract/message/tests.rs
+++ b/crates/awaken-runtime-contract/src/contract/message/tests.rs
@@ -74,6 +74,7 @@ fn test_message_with_metadata_serialization() {
         run_id: Some("run-1".to_string()),
         step_index: Some(3),
         compaction: None,
+        sender_agent_id: None,
     });
     let json = serde_json::to_string(&msg).unwrap();
     assert!(json.contains("\"run_id\":\"run-1\""));
@@ -309,6 +310,7 @@ fn test_message_metadata_serde_roundtrip() {
         run_id: Some("run-1".into()),
         step_index: Some(5),
         compaction: None,
+        sender_agent_id: None,
     };
     let json = serde_json::to_string(&meta).unwrap();
     let parsed: MessageMetadata = serde_json::from_str(&json).unwrap();
@@ -331,6 +333,7 @@ fn message_record_projects_thread_sequence_and_producer() {
             run_id: Some("run-1".to_string()),
             step_index: Some(3),
             compaction: None,
+            sender_agent_id: None,
         });
 
     let record = MessageRecord::from_message("thread-1", 7, msg);
@@ -414,6 +417,7 @@ fn mark_produced_by_preserves_existing_metadata() {
         run_id: Some("existing-run".to_string()),
         step_index: Some(1),
         compaction: None,
+        sender_agent_id: None,
     });
 
     msg.mark_produced_by("new-run", Some(2));

--- a/crates/awaken-runtime-contract/tests/contract_integration.rs
+++ b/crates/awaken-runtime-contract/tests/contract_integration.rs
@@ -353,6 +353,7 @@ fn stream_result_to_message_to_event_pipeline() {
                 run_id: Some("r1".into()),
                 step_index: Some(0),
                 compaction: None,
+                sender_agent_id: None,
             });
 
     assert_eq!(msg.role, Role::Assistant);

--- a/crates/awaken-runtime/src/backend/local.rs
+++ b/crates/awaken-runtime/src/backend/local.rs
@@ -302,10 +302,18 @@ impl LocalBackend {
         } else {
             // Bind the auto-created plugin through the same `bind_runtime_context`
             // seam the resolved-env plugins use (see `bind_local_execution_env`),
-            // rather than re-setting store/owner_inbox by hand.
+            // rather than re-setting store/owner_inbox by hand. If the host
+            // scoped an ambient durable sink for this run, wire it so durable
+            // `send_message` routes deliver; otherwise child-only.
             let manager =
                 std::sync::Arc::new(crate::extensions::background::BackgroundTaskManager::new());
-            let plugin = crate::extensions::background::BackgroundTaskPlugin::new(manager.clone());
+            let plugin = match crate::extensions::background::current_durable_message_sink() {
+                Some(sink) => crate::extensions::background::BackgroundTaskPlugin::with_messaging(
+                    manager.clone(),
+                    sink,
+                ),
+                None => crate::extensions::background::BackgroundTaskPlugin::new(manager.clone()),
+            };
             plugin.bind_runtime_context(&store, owner_inbox.as_ref());
             store
                 .install_plugin(plugin)

--- a/crates/awaken-runtime/src/extensions/background/execution_context.rs
+++ b/crates/awaken-runtime/src/extensions/background/execution_context.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use super::send_message_tool::DurableMessageSink;
 use super::{BackgroundTaskManager, TaskId};
 
 tokio::task_local! {
@@ -8,6 +9,29 @@ tokio::task_local! {
 
 tokio::task_local! {
     static CURRENT_TOOL_LINEAGE_CONTEXT: ToolLineageContext;
+}
+
+tokio::task_local! {
+    /// Ambient durable message sink for the current run, scoped by the host
+    /// around run execution (e.g. the server). Read by the per-run background
+    /// plugin auto-creation in the local backend so `send_message`'s durable
+    /// routes deliver. Reuses the same task-local mechanism as the contexts
+    /// above; no new injection interface.
+    static CURRENT_DURABLE_MESSAGE_SINK: Arc<dyn DurableMessageSink>;
+}
+
+pub(crate) async fn scope_durable_message_sink<Fut>(
+    sink: Arc<dyn DurableMessageSink>,
+    future: Fut,
+) -> Fut::Output
+where
+    Fut: std::future::Future,
+{
+    CURRENT_DURABLE_MESSAGE_SINK.scope(sink, future).await
+}
+
+pub(crate) fn current_durable_message_sink() -> Option<Arc<dyn DurableMessageSink>> {
+    CURRENT_DURABLE_MESSAGE_SINK.try_with(Clone::clone).ok()
 }
 
 #[derive(Clone)]

--- a/crates/awaken-runtime/src/extensions/background/mod.rs
+++ b/crates/awaken-runtime/src/extensions/background/mod.rs
@@ -18,7 +18,8 @@ pub use cancel_task_tool::CancelTaskTool;
 pub use execution_context::current_background_task_id;
 pub(crate) use execution_context::{
     BackgroundTaskExecutionContext, ToolLineageContext, current_background_task_context,
-    current_tool_lineage_context, scope_background_task_context, scope_tool_lineage_context,
+    current_durable_message_sink, current_tool_lineage_context, scope_background_task_context,
+    scope_durable_message_sink, scope_tool_lineage_context,
 };
 pub use manager::{BackgroundTaskManager, SendError, SpawnError};
 pub use plugin::BackgroundTaskPlugin;

--- a/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
+++ b/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
@@ -274,6 +274,16 @@ impl MessageDispatchHook {
 #[async_trait]
 impl PhaseHook for MessageDispatchHook {
     async fn run(&self, ctx: &PhaseContext) -> Result<StateCommand, StateError> {
+        // Prefer the explicitly-wired sink; otherwise fall back to the host sink
+        // scoped as an ambient task-local around the run (see
+        // `scope_durable_message_sink`). This is what lets a plugin the host
+        // installed itself via `BackgroundTaskPlugin::new` (durable_sink: None) —
+        // not only the auto-created `with_messaging` plugin — still deliver
+        // durable routes once the runtime has a sink bound.
+        let durable_sink = self
+            .durable_sink
+            .clone()
+            .or_else(super::current_durable_message_sink);
         let outbox = ctx.state::<MessageOutboxKey>().cloned().unwrap_or_default();
         let mut cmd = StateCommand::new();
         for entry in outbox.pending {
@@ -305,7 +315,7 @@ impl PhaseHook for MessageDispatchHook {
                     cmd.update::<MessageOutboxKey>(MessageOutboxUpdate::Remove { id });
                 }
                 OutboxRoute::Durable(request) => {
-                    let Some(sink) = &self.durable_sink else {
+                    let Some(sink) = &durable_sink else {
                         tracing::warn!(
                             message_id = %request.message_id,
                             "no durable transport configured; dead-lettering"
@@ -1115,6 +1125,80 @@ mod tests {
         assert!(
             current_durable_message_sink().is_none(),
             "and is gone again once the scope ends"
+        );
+    }
+
+    /// Issue #3 regression: a dispatcher with NO explicitly-wired sink (as a
+    /// host-installed `BackgroundTaskPlugin::new` plugin would have) still
+    /// delivers durable routes via the host sink scoped ambiently around the run.
+    #[tokio::test]
+    async fn dispatcher_without_explicit_sink_delivers_via_ambient_sink() {
+        use crate::extensions::background::scope_durable_message_sink;
+        let (manager, _unused, store) = messaging_env();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::Durable(durable_req("m1", "thread-2")),
+        );
+
+        // durable_sink: None — mirrors a plugin built without `with_messaging`.
+        let hook = MessageDispatchHook::new(manager.clone(), None);
+        let ambient = Arc::new(RecordingDurableSink::default());
+        let ambient_dyn: Arc<dyn DurableMessageSink> = ambient.clone();
+
+        scope_durable_message_sink(ambient_dyn, async {
+            let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+            let cmd = hook.run(&ctx).await.unwrap();
+            store.commit(cmd.patch).unwrap();
+        })
+        .await;
+
+        assert_eq!(
+            ambient.requests.lock().await.len(),
+            1,
+            "durable route delivered through the ambient host sink, not dead-lettered"
+        );
+        assert!(
+            store
+                .read::<FailedDurableMessageKey>()
+                .unwrap_or_default()
+                .messages
+                .is_empty(),
+            "not dead-lettered when an ambient sink is available"
+        );
+        assert!(
+            store
+                .read::<MessageOutboxKey>()
+                .unwrap_or_default()
+                .pending
+                .is_empty()
+        );
+    }
+
+    /// Without any sink — neither explicit nor ambient — durable routes still
+    /// dead-letter (the existing degradation path is unchanged).
+    #[tokio::test]
+    async fn dispatcher_without_any_sink_dead_letters() {
+        let (manager, _unused, store) = messaging_env();
+        enqueue(
+            &store,
+            "m1",
+            OutboxRoute::Durable(durable_req("m1", "thread-2")),
+        );
+        let hook = MessageDispatchHook::new(manager.clone(), None);
+        // No scope_durable_message_sink wrapper → no ambient sink.
+        let ctx = PhaseContext::new(Phase::StepEnd, store.snapshot());
+        let cmd = hook.run(&ctx).await.unwrap();
+        store.commit(cmd.patch).unwrap();
+
+        assert_eq!(
+            store
+                .read::<FailedDurableMessageKey>()
+                .unwrap_or_default()
+                .messages
+                .len(),
+            1,
+            "dead-lettered when no sink is reachable at all"
         );
     }
 

--- a/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
+++ b/crates/awaken-runtime/src/extensions/background/send_message_tool.rs
@@ -1092,6 +1092,32 @@ mod tests {
         manager.cancel_all("thread-1").await;
     }
 
+    // -- ambient sink seam: scoped by the host, read by the per-run plugin --
+
+    #[tokio::test]
+    async fn ambient_durable_sink_seam_round_trips() {
+        use crate::extensions::background::{
+            current_durable_message_sink, scope_durable_message_sink,
+        };
+        let sink: Arc<dyn DurableMessageSink> = Arc::new(RecordingDurableSink::default());
+        assert!(
+            current_durable_message_sink().is_none(),
+            "unset outside any scope"
+        );
+        let visible = scope_durable_message_sink(sink.clone(), async {
+            current_durable_message_sink().is_some()
+        })
+        .await;
+        assert!(
+            visible,
+            "the scoped sink is visible to code running inside the run"
+        );
+        assert!(
+            current_durable_message_sink().is_none(),
+            "and is gone again once the scope ends"
+        );
+    }
+
     // -- closed loop: enqueue, then the real StepEnd phase drives delivery --
 
     #[tokio::test]

--- a/crates/awaken-runtime/src/loop_runner/checkpoint_tests.rs
+++ b/crates/awaken-runtime/src/loop_runner/checkpoint_tests.rs
@@ -105,6 +105,7 @@ fn materialize_message_log_preserves_output_across_same_run_resume() {
             run_id: Some("run-1".into()),
             step_index: Some(0),
             compaction: None,
+            sender_agent_id: None,
         },
     );
     let mut new_output = Message::assistant("after resume");
@@ -320,6 +321,7 @@ fn materialize_checkpoint_append_does_not_duplicate_committed_message_updates() 
             run_id: Some("run-1".into()),
             step_index: Some(0),
             compaction: None,
+            sender_agent_id: None,
         },
     );
     let previous = RunRecord {

--- a/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
@@ -132,9 +132,14 @@ pub struct AgentRuntime {
     /// built (the sink wraps the mailbox, which wraps this runtime). Scoped as an
     /// ambient task-local around run execution so the per-run background plugin
     /// can deliver `send_message`'s durable routes.
+    ///
+    /// Rebindable (`RwLock`, last-write-wins) — like [`Self::run_resolver`] — so a
+    /// new `ServerState`/mailbox reusing this runtime can repoint the sink instead
+    /// of being silently ignored (a first-write-wins `OnceLock` would pin a stale
+    /// `Weak<Mailbox>` that dangles once the original mailbox drops).
     #[cfg(feature = "background")]
     durable_message_sink:
-        std::sync::OnceLock<Arc<dyn crate::extensions::background::DurableMessageSink>>,
+        RwLock<Option<Arc<dyn crate::extensions::background::DurableMessageSink>>>,
 }
 
 impl AgentRuntime {
@@ -157,19 +162,23 @@ impl AgentRuntime {
             #[cfg(feature = "a2a")]
             composite_registry: None,
             #[cfg(feature = "background")]
-            durable_message_sink: std::sync::OnceLock::new(),
+            durable_message_sink: RwLock::new(None),
         }
     }
 
-    /// Late-bind the host durable message sink (see [`Self::durable_message_sink`]).
-    /// Idempotent: the first call wins. Reuses the same optional-host-capability
-    /// pattern as the other `set_*`/`with_*` wiring on this type.
+    /// Late-bind (or rebind) the host durable message sink (see
+    /// [`Self::durable_message_sink`]). Last-write-wins, mirroring
+    /// [`Self::set_run_resolver`], so a runtime reused by a new mailbox repoints
+    /// the sink rather than keeping a dangling `Weak<Mailbox>`.
     #[cfg(feature = "background")]
     pub fn set_durable_message_sink(
         &self,
         sink: Arc<dyn crate::extensions::background::DurableMessageSink>,
     ) {
-        let _ = self.durable_message_sink.set(sink);
+        *self
+            .durable_message_sink
+            .write()
+            .expect("durable message sink lock poisoned") = Some(sink);
     }
 
     #[must_use]
@@ -394,6 +403,18 @@ impl AgentRuntime {
     /// Create a run handle pair (handle + internal channels).
     ///
     /// Returns (RunHandle for caller, CancellationToken for loop, decision_rx for loop).
+    /// Test accessor for the currently-bound durable message sink, used to
+    /// assert last-write-wins rebinding.
+    #[cfg(all(test, feature = "background"))]
+    pub(crate) fn durable_message_sink_for_test(
+        &self,
+    ) -> Option<Arc<dyn crate::extensions::background::DurableMessageSink>> {
+        self.durable_message_sink
+            .read()
+            .expect("durable message sink lock poisoned")
+            .clone()
+    }
+
     #[cfg(test)]
     pub(crate) fn create_run_channels(
         &self,

--- a/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/mod.rs
@@ -128,6 +128,13 @@ pub struct AgentRuntime {
     missing_live_control_source_warned: std::sync::atomic::AtomicBool,
     #[cfg(feature = "a2a")]
     composite_registry: Option<Arc<CompositeAgentSpecRegistry>>,
+    /// Host-provided durable message transport, late-bound after the mailbox is
+    /// built (the sink wraps the mailbox, which wraps this runtime). Scoped as an
+    /// ambient task-local around run execution so the per-run background plugin
+    /// can deliver `send_message`'s durable routes.
+    #[cfg(feature = "background")]
+    durable_message_sink:
+        std::sync::OnceLock<Arc<dyn crate::extensions::background::DurableMessageSink>>,
 }
 
 impl AgentRuntime {
@@ -149,7 +156,20 @@ impl AgentRuntime {
             missing_live_control_source_warned: std::sync::atomic::AtomicBool::new(false),
             #[cfg(feature = "a2a")]
             composite_registry: None,
+            #[cfg(feature = "background")]
+            durable_message_sink: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Late-bind the host durable message sink (see [`Self::durable_message_sink`]).
+    /// Idempotent: the first call wins. Reuses the same optional-host-capability
+    /// pattern as the other `set_*`/`with_*` wiring on this type.
+    #[cfg(feature = "background")]
+    pub fn set_durable_message_sink(
+        &self,
+        sink: Arc<dyn crate::extensions::background::DurableMessageSink>,
+    ) {
+        let _ = self.durable_message_sink.set(sink);
     }
 
     #[must_use]

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -242,6 +242,28 @@ impl AgentRuntime {
         thread_ctx: Option<ThreadContextSnapshot>,
         resolved_plan: Option<ResolvedRunPlan>,
     ) -> Result<AgentRunResult, AgentLoopError> {
+        // Scope the host durable message sink (if late-bound) as an ambient
+        // task-local for the whole run, so the per-run background plugin can
+        // deliver `send_message`'s durable routes. No-op when unset.
+        #[cfg(feature = "background")]
+        if let Some(durable_sink) = self.durable_message_sink.get() {
+            return crate::extensions::background::scope_durable_message_sink(
+                durable_sink.clone(),
+                self.run_inner_body(activation, sink, thread_ctx, resolved_plan),
+            )
+            .await;
+        }
+        self.run_inner_body(activation, sink, thread_ctx, resolved_plan)
+            .await
+    }
+
+    async fn run_inner_body(
+        &self,
+        activation: RunActivation,
+        sink: Arc<dyn EventSink>,
+        thread_ctx: Option<ThreadContextSnapshot>,
+        resolved_plan: Option<ResolvedRunPlan>,
+    ) -> Result<AgentRunResult, AgentLoopError> {
         activation
             .validate()
             .map_err(|error| AgentLoopError::InvalidActivation(error.to_string()))?;

--- a/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/runner.rs
@@ -246,12 +246,19 @@ impl AgentRuntime {
         // task-local for the whole run, so the per-run background plugin can
         // deliver `send_message`'s durable routes. No-op when unset.
         #[cfg(feature = "background")]
-        if let Some(durable_sink) = self.durable_message_sink.get() {
-            return crate::extensions::background::scope_durable_message_sink(
-                durable_sink.clone(),
-                self.run_inner_body(activation, sink, thread_ctx, resolved_plan),
-            )
-            .await;
+        {
+            let durable_sink = self
+                .durable_message_sink
+                .read()
+                .expect("durable message sink lock poisoned")
+                .clone();
+            if let Some(durable_sink) = durable_sink {
+                return crate::extensions::background::scope_durable_message_sink(
+                    durable_sink,
+                    self.run_inner_body(activation, sink, thread_ctx, resolved_plan),
+                )
+                .await;
+            }
         }
         self.run_inner_body(activation, sink, thread_ctx, resolved_plan)
             .await

--- a/crates/awaken-runtime/src/runtime/agent_runtime/tests.rs
+++ b/crates/awaken-runtime/src/runtime/agent_runtime/tests.rs
@@ -38,6 +38,45 @@ fn new_creates_runtime() {
     assert!(rt.registry_handle().is_none());
 }
 
+/// Issue #4 regression: `set_durable_message_sink` is last-write-wins (not a
+/// first-call-wins `OnceLock`), so a runtime reused by a new mailbox repoints
+/// the sink instead of dangling on the original `Weak<Mailbox>`.
+#[cfg(feature = "background")]
+#[tokio::test]
+async fn set_durable_message_sink_rebinds_last_write_wins() {
+    use crate::extensions::background::{DurableMessageRequest, DurableMessageSink};
+
+    struct TaggedSink(&'static str);
+    #[async_trait::async_trait]
+    impl DurableMessageSink for TaggedSink {
+        async fn send_agent_message(
+            &self,
+            _request: DurableMessageRequest,
+        ) -> Result<String, String> {
+            Ok(self.0.to_string())
+        }
+    }
+
+    let rt = make_runtime();
+    assert!(rt.durable_message_sink_for_test().is_none());
+
+    rt.set_durable_message_sink(Arc::new(TaggedSink("first")));
+    rt.set_durable_message_sink(Arc::new(TaggedSink("second")));
+
+    let bound = rt.durable_message_sink_for_test().expect("a sink is bound");
+    let tag = bound
+        .send_agent_message(DurableMessageRequest {
+            message_id: "m".into(),
+            recipient_thread_id: "t".into(),
+            recipient_agent_id: None,
+            sender_agent_id: "s".into(),
+            message: "hi".into(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(tag, "second", "the second bind replaced the first");
+}
+
 #[test]
 fn resolver_returns_ref() {
     let rt = make_runtime();

--- a/crates/awaken-server-contract/src/contract/store_traits_tests.rs
+++ b/crates/awaken-server-contract/src/contract/store_traits_tests.rs
@@ -453,6 +453,7 @@ async fn thread_store_save_and_load_messages() {
             run_id: Some("run-1".to_string()),
             step_index: Some(0),
             compaction: None,
+            sender_agent_id: None,
         }),
     ];
     store.save_messages("t-1", &msgs).await.unwrap();
@@ -474,6 +475,7 @@ async fn thread_store_default_message_query_filters_and_orders() {
         run_id: Some("run-1".to_string()),
         step_index: Some(0),
         compaction: None,
+        sender_agent_id: None,
     };
     let msgs = vec![
         Message::user("input"),

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -329,6 +329,12 @@ impl ServerState {
         resolver: Arc<dyn AgentResolver>,
         config: ServerConfig,
     ) -> Self {
+        // Late-bind the mailbox-backed durable message sink onto the runtime so
+        // `send_message`'s durable routes deliver. Idempotent (OnceLock); breaks
+        // no cycle (sink holds a Weak<Mailbox>).
+        runtime.set_durable_message_sink(Arc::new(
+            crate::durable_message_sink::MailboxDurableMessageSink::new(&mailbox),
+        ));
         Self::from_modules(
             RunModuleState::new(runtime, mailbox, store, resolver),
             config,

--- a/crates/awaken-server/src/app.rs
+++ b/crates/awaken-server/src/app.rs
@@ -330,8 +330,9 @@ impl ServerState {
         config: ServerConfig,
     ) -> Self {
         // Late-bind the mailbox-backed durable message sink onto the runtime so
-        // `send_message`'s durable routes deliver. Idempotent (OnceLock); breaks
-        // no cycle (sink holds a Weak<Mailbox>).
+        // `send_message`'s durable routes deliver. Last-write-wins, so a runtime
+        // reused by a new mailbox repoints the sink; breaks no cycle (the sink
+        // holds a Weak<Mailbox>).
         runtime.set_durable_message_sink(Arc::new(
             crate::durable_message_sink::MailboxDurableMessageSink::new(&mailbox),
         ));

--- a/crates/awaken-server/src/durable_message_sink.rs
+++ b/crates/awaken-server/src/durable_message_sink.rs
@@ -11,10 +11,7 @@
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
-use awaken_runtime::RunActivation;
 use awaken_runtime::extensions::background::{DurableMessageRequest, DurableMessageSink};
-use awaken_server_contract::contract::message::Message;
-use awaken_server_contract::contract::storage::RunRequestOrigin;
 
 use crate::mailbox::Mailbox;
 
@@ -39,21 +36,14 @@ impl DurableMessageSink for MailboxDurableMessageSink {
             .upgrade()
             .ok_or_else(|| "mailbox has been dropped".to_string())?;
 
-        let message = Message::user(&request.message);
-        let mut activation = RunActivation::new(request.recipient_thread_id, vec![message])
-            .with_origin(RunRequestOrigin::Internal)
-            // The sender-side message id is the dedup key for at-least-once
-            // redelivery: a redelivered message reuses the same dispatch id.
-            .with_dispatch_id_hint(request.message_id);
-        if let Some(agent_id) = request.recipient_agent_id {
-            activation = activation.with_agent_id(agent_id);
-        }
-
-        let result = mailbox
-            .submit_background(activation)
+        // All the durable semantics — idempotent redelivery keyed on
+        // `message_id`, id-addressed recipient message, sender attribution — live
+        // in `Mailbox::submit_durable_message`, which owns the run store. This
+        // sink is just the trait adapter.
+        mailbox
+            .submit_durable_message(request)
             .await
-            .map_err(|error| error.to_string())?;
-        Ok(result.dispatch_id)
+            .map_err(|error| error.to_string())
     }
 }
 
@@ -62,6 +52,7 @@ mod tests {
     use super::*;
     use crate::mailbox::MailboxConfig;
     use awaken_runtime::AgentRuntime;
+    use awaken_server_contract::contract::storage::ThreadStore;
     use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
 
     struct StubResolver;
@@ -76,54 +67,107 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn maps_request_to_mailbox_dispatch() {
+    /// Build a mailbox over an in-memory store, returning the store handle so a
+    /// test can inspect the committed recipient log.
+    fn mailbox_with_store() -> (Arc<Mailbox>, Arc<InMemoryStore>) {
         let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let store = Arc::new(InMemoryStore::new());
         let mailbox = Arc::new(Mailbox::new(
             runtime,
             Arc::new(InMemoryMailboxStore::new()),
-            Arc::new(InMemoryStore::new()),
+            store.clone(),
             "test".to_string(),
             MailboxConfig::default(),
         ));
+        (mailbox, store)
+    }
+
+    fn request(message_id: &str) -> DurableMessageRequest {
+        DurableMessageRequest {
+            message_id: message_id.into(),
+            recipient_thread_id: "thread-2".into(),
+            recipient_agent_id: None,
+            sender_agent_id: "sender-agent".into(),
+            message: "hello".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_request_to_mailbox_dispatch() {
+        let (mailbox, _store) = mailbox_with_store();
         let sink = MailboxDurableMessageSink::new(&mailbox);
 
-        let result = sink
-            .send_agent_message(DurableMessageRequest {
-                message_id: "m1".into(),
-                recipient_thread_id: "thread-2".into(),
-                recipient_agent_id: Some("reviewer".into()),
-                sender_agent_id: "sender".into(),
-                message: "hello".into(),
-            })
-            .await;
+        let result = sink.send_agent_message(request("m1")).await;
 
         assert!(result.is_ok(), "sink delivers via the mailbox: {result:?}");
         assert!(!result.unwrap().is_empty(), "returns a dispatch id");
     }
 
+    /// Issue #2 regression: the committed recipient message is id-addressed by
+    /// the sender-side `message_id` and carries `sender_agent_id`, instead of
+    /// being an anonymous user message with a fresh id.
+    #[tokio::test]
+    async fn committed_message_is_id_addressed_and_attributes_sender() {
+        let (mailbox, store) = mailbox_with_store();
+        let sink = MailboxDurableMessageSink::new(&mailbox);
+
+        sink.send_agent_message(request("m1")).await.unwrap();
+
+        let committed = store
+            .load_committed_messages("thread-2")
+            .await
+            .unwrap()
+            .unwrap_or_default();
+        assert_eq!(committed.len(), 1, "exactly one recipient message");
+        assert_eq!(
+            committed[0].id.as_deref(),
+            Some("m1"),
+            "recipient message is id-addressed by the sender message_id"
+        );
+        assert_eq!(
+            committed[0]
+                .metadata
+                .as_ref()
+                .and_then(|m| m.sender_agent_id.as_deref()),
+            Some("sender-agent"),
+            "sender identity is preserved, not dropped"
+        );
+    }
+
+    /// Issue #1 regression: redelivering the same `message_id` (at-least-once
+    /// replay) returns the original dispatch id and does NOT append a duplicate
+    /// recipient message.
+    #[tokio::test]
+    async fn redelivery_is_idempotent_no_duplicate_append() {
+        let (mailbox, store) = mailbox_with_store();
+        let sink = MailboxDurableMessageSink::new(&mailbox);
+
+        let first = sink.send_agent_message(request("m1")).await.unwrap();
+        let second = sink.send_agent_message(request("m1")).await.unwrap();
+
+        assert_eq!(first, second, "redelivery reuses the same dispatch id");
+        let committed = store
+            .load_committed_messages("thread-2")
+            .await
+            .unwrap()
+            .unwrap_or_default();
+        assert_eq!(
+            committed
+                .iter()
+                .filter(|m| m.id.as_deref() == Some("m1"))
+                .count(),
+            1,
+            "redelivered message_id appended exactly once"
+        );
+    }
+
     #[tokio::test]
     async fn errors_when_mailbox_dropped() {
-        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
-        let mailbox = Arc::new(Mailbox::new(
-            runtime,
-            Arc::new(InMemoryMailboxStore::new()),
-            Arc::new(InMemoryStore::new()),
-            "test".to_string(),
-            MailboxConfig::default(),
-        ));
+        let (mailbox, _store) = mailbox_with_store();
         let sink = MailboxDurableMessageSink::new(&mailbox);
         drop(mailbox);
 
-        let result = sink
-            .send_agent_message(DurableMessageRequest {
-                message_id: "m1".into(),
-                recipient_thread_id: "t".into(),
-                recipient_agent_id: None,
-                sender_agent_id: "s".into(),
-                message: "m".into(),
-            })
-            .await;
+        let result = sink.send_agent_message(request("m1")).await;
         assert!(
             result.is_err(),
             "a dropped mailbox surfaces an error, not a panic"

--- a/crates/awaken-server/src/durable_message_sink.rs
+++ b/crates/awaken-server/src/durable_message_sink.rs
@@ -1,0 +1,132 @@
+//! Host implementation of the runtime's `DurableMessageSink`: delivers durable
+//! cross-thread `send_message` messages by enqueuing a background run on the
+//! recipient thread via the [`Mailbox`].
+//!
+//! This is the only new type needed to wire `send_message` end-to-end — it
+//! implements the existing `DurableMessageSink` trait and reuses the existing
+//! `Mailbox::submit_background` path. It holds a `Weak<Mailbox>` to avoid the
+//! `runtime → sink → mailbox → runtime` reference cycle (the mailbox runs on
+//! the runtime as its dispatch executor).
+
+use std::sync::{Arc, Weak};
+
+use async_trait::async_trait;
+use awaken_runtime::RunActivation;
+use awaken_runtime::extensions::background::{DurableMessageRequest, DurableMessageSink};
+use awaken_server_contract::contract::message::Message;
+use awaken_server_contract::contract::storage::RunRequestOrigin;
+
+use crate::mailbox::Mailbox;
+
+/// Maps a [`DurableMessageRequest`] to a mailbox background dispatch.
+pub struct MailboxDurableMessageSink {
+    mailbox: Weak<Mailbox>,
+}
+
+impl MailboxDurableMessageSink {
+    pub fn new(mailbox: &Arc<Mailbox>) -> Self {
+        Self {
+            mailbox: Arc::downgrade(mailbox),
+        }
+    }
+}
+
+#[async_trait]
+impl DurableMessageSink for MailboxDurableMessageSink {
+    async fn send_agent_message(&self, request: DurableMessageRequest) -> Result<String, String> {
+        let mailbox = self
+            .mailbox
+            .upgrade()
+            .ok_or_else(|| "mailbox has been dropped".to_string())?;
+
+        let message = Message::user(&request.message);
+        let mut activation = RunActivation::new(request.recipient_thread_id, vec![message])
+            .with_origin(RunRequestOrigin::Internal)
+            // The sender-side message id is the dedup key for at-least-once
+            // redelivery: a redelivered message reuses the same dispatch id.
+            .with_dispatch_id_hint(request.message_id);
+        if let Some(agent_id) = request.recipient_agent_id {
+            activation = activation.with_agent_id(agent_id);
+        }
+
+        let result = mailbox
+            .submit_background(activation)
+            .await
+            .map_err(|error| error.to_string())?;
+        Ok(result.dispatch_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mailbox::MailboxConfig;
+    use awaken_runtime::AgentRuntime;
+    use awaken_stores::{InMemoryMailboxStore, InMemoryStore};
+
+    struct StubResolver;
+    impl awaken_runtime::AgentResolver for StubResolver {
+        fn resolve(
+            &self,
+            agent_id: &str,
+        ) -> Result<awaken_runtime::ResolvedAgent, awaken_runtime::RuntimeError> {
+            Err(awaken_runtime::RuntimeError::AgentNotFound {
+                agent_id: agent_id.to_string(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_request_to_mailbox_dispatch() {
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let mailbox = Arc::new(Mailbox::new(
+            runtime,
+            Arc::new(InMemoryMailboxStore::new()),
+            Arc::new(InMemoryStore::new()),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+        let sink = MailboxDurableMessageSink::new(&mailbox);
+
+        let result = sink
+            .send_agent_message(DurableMessageRequest {
+                message_id: "m1".into(),
+                recipient_thread_id: "thread-2".into(),
+                recipient_agent_id: Some("reviewer".into()),
+                sender_agent_id: "sender".into(),
+                message: "hello".into(),
+            })
+            .await;
+
+        assert!(result.is_ok(), "sink delivers via the mailbox: {result:?}");
+        assert!(!result.unwrap().is_empty(), "returns a dispatch id");
+    }
+
+    #[tokio::test]
+    async fn errors_when_mailbox_dropped() {
+        let runtime = Arc::new(AgentRuntime::new(Arc::new(StubResolver)));
+        let mailbox = Arc::new(Mailbox::new(
+            runtime,
+            Arc::new(InMemoryMailboxStore::new()),
+            Arc::new(InMemoryStore::new()),
+            "test".to_string(),
+            MailboxConfig::default(),
+        ));
+        let sink = MailboxDurableMessageSink::new(&mailbox);
+        drop(mailbox);
+
+        let result = sink
+            .send_agent_message(DurableMessageRequest {
+                message_id: "m1".into(),
+                recipient_thread_id: "t".into(),
+                recipient_agent_id: None,
+                sender_agent_id: "s".into(),
+                message: "m".into(),
+            })
+            .await;
+        assert!(
+            result.is_err(),
+            "a dropped mailbox surfaces an error, not a panic"
+        );
+    }
+}

--- a/crates/awaken-server/src/lib.rs
+++ b/crates/awaken-server/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod admin_routes;
 pub mod app;
 pub(crate) mod auth;
 pub mod config_routes;
+pub mod durable_message_sink;
 pub mod error;
 pub mod eval_limits;
 pub mod eval_router;

--- a/crates/awaken-server/src/mailbox/submit.rs
+++ b/crates/awaken-server/src/mailbox/submit.rs
@@ -304,6 +304,69 @@ impl Mailbox {
         })
     }
 
+    /// Deliver a durable cross-thread `send_message` (the runtime's
+    /// `DurableMessageSink`) by enqueuing a background run on the recipient
+    /// thread, keyed for **idempotent redelivery** on the sender-side
+    /// `message_id`.
+    ///
+    /// Delivery is at-least-once, so the same `message_id` can arrive more than
+    /// once (a crash between sink delivery and the outbox-remove commit triggers
+    /// a replay). Two properties make that safe at the recipient:
+    ///
+    /// - The run id is **derived deterministically** from `message_id`, so a
+    ///   redelivery resolves to the same run rather than spawning a fresh one
+    ///   every time.
+    /// - A pre-check short-circuits once that run exists, returning the original
+    ///   dispatch id **without re-appending** the recipient message — so a
+    ///   redelivered message is not duplicated in the committed thread log.
+    ///
+    /// The committed message is id-addressed by `message_id` and carries the
+    /// `sender_agent_id` in its metadata, so the recipient can attribute and
+    /// (independently) deduplicate it.
+    ///
+    /// Residual window: two *concurrent* deliveries of the same `message_id` can
+    /// both miss the pre-check before either commits. This matches the mailbox's
+    /// existing at-least-once contract; the durable dispatcher drains the outbox
+    /// sequentially, so this only arises under cross-process replay races.
+    #[tracing::instrument(skip(self, request), fields(message_id = %request.message_id))]
+    pub async fn submit_durable_message(
+        self: &Arc<Self>,
+        request: awaken_runtime::extensions::background::DurableMessageRequest,
+    ) -> Result<String, MailboxError> {
+        // Deterministic, collision-free run id: the sender-side message id is a
+        // UUID, so this is unique per message and stable across redeliveries.
+        let run_id = format!("durable-msg-{}", request.message_id);
+
+        if let Some(existing) = self.run_store.load_run(&run_id).await? {
+            // Already delivered for this message_id — idempotent no-op. Return
+            // the original dispatch id (falling back to the run id if a dispatch
+            // id was never recorded) so the sink reports success and the outbox
+            // entry is cleared.
+            return Ok(existing.dispatch_id.unwrap_or(run_id));
+        }
+
+        let message = Message::user(&request.message)
+            // id-address the recipient message by the sender-side message_id so
+            // the committed log is dedup-keyed (A-G3) and the recipient can match
+            // redeliveries.
+            .with_id(request.message_id.clone())
+            .with_metadata(awaken_server_contract::contract::message::MessageMetadata {
+                sender_agent_id: Some(request.sender_agent_id),
+                ..Default::default()
+            });
+
+        let mut activation = RunActivation::new(request.recipient_thread_id, vec![message])
+            .with_origin(awaken_server_contract::contract::storage::RunRequestOrigin::Internal)
+            .with_run_id_hint(run_id)
+            .with_dispatch_id_hint(request.message_id);
+        if let Some(agent_id) = request.recipient_agent_id {
+            activation = activation.with_agent_id(agent_id);
+        }
+
+        let result = self.submit_background(activation).await?;
+        Ok(result.dispatch_id)
+    }
+
     /// Try to steer the currently active run first, then fall back to the
     /// durable mailbox queue when live delivery is unavailable.
     ///

--- a/crates/awaken-server/src/query.rs
+++ b/crates/awaken-server/src/query.rs
@@ -418,6 +418,7 @@ mod tests {
                     run_id: Some("run-1".to_string()),
                     step_index: Some(0),
                     compaction: None,
+                    sender_agent_id: None,
                 },
             ),
             Message::assistant("other").with_metadata(
@@ -425,6 +426,7 @@ mod tests {
                     run_id: Some("run-2".to_string()),
                     step_index: Some(0),
                     compaction: None,
+                    sender_agent_id: None,
                 },
             ),
             Message::assistant("new").with_metadata(
@@ -432,6 +434,7 @@ mod tests {
                     run_id: Some("run-1".to_string()),
                     step_index: Some(1),
                     compaction: None,
+                    sender_agent_id: None,
                 },
             ),
         ];

--- a/crates/awaken-server/tests/config_backends.rs
+++ b/crates/awaken-server/tests/config_backends.rs
@@ -973,6 +973,7 @@ async fn nats_buffered_store_thread_routes_round_trip_via_http() {
         run_id: Some("nats-run-1".to_string()),
         step_index: Some(0),
         compaction: None,
+        sender_agent_id: None,
     };
     store
         .save_messages(

--- a/crates/awaken-server/tests/http_api.rs
+++ b/crates/awaken-server/tests/http_api.rs
@@ -950,11 +950,13 @@ mod integration {
             run_id: Some("run-1".to_string()),
             step_index: Some(0),
             compaction: None,
+            sender_agent_id: None,
         };
         let run2 = awaken_server_contract::contract::message::MessageMetadata {
             run_id: Some("run-2".to_string()),
             step_index: Some(0),
             compaction: None,
+            sender_agent_id: None,
         };
         let messages = vec![
             Message::user("input"),

--- a/crates/awaken-stores/tests/file_store.rs
+++ b/crates/awaken-stores/tests/file_store.rs
@@ -317,6 +317,7 @@ async fn list_message_records_query_filters_visibility_run_and_order() {
         run_id: Some("run-1".to_string()),
         step_index: Some(0),
         compaction: None,
+        sender_agent_id: None,
     };
     store
         .save_messages(

--- a/crates/awaken-stores/tests/memory_store.rs
+++ b/crates/awaken-stores/tests/memory_store.rs
@@ -163,6 +163,7 @@ async fn list_message_records_query_filters_visibility_run_and_order() {
         run_id: Some("run-1".to_string()),
         step_index: Some(0),
         compaction: None,
+        sender_agent_id: None,
     };
     store
         .save_messages(

--- a/crates/awaken-stores/tests/thread_store_conformance.rs
+++ b/crates/awaken-stores/tests/thread_store_conformance.rs
@@ -543,6 +543,7 @@ pub async fn list_message_records_query_filters_and_orders<S: ThreadRunStore>(st
         run_id: Some("run-1".to_string()),
         step_index: Some(0),
         compaction: None,
+        sender_agent_id: None,
     };
     let messages = vec![
         Message::user("input"),


### PR DESCRIPTION
Wires `send_message`'s durable routes end-to-end so they actually deliver — closing the "not wired into a live host" follow-up from #276 (now merged).

## What

#276 gave `send_message` a committed outbox + `MessageDispatchHook` that needs a host `DurableMessageSink`. This connects it with the **minimum new surface**, reusing existing mechanisms:

- **Runtime — ambient sink seam (no new injection interface).** Reuses the existing `tokio::task_local!` mechanism in `extensions/background/execution_context.rs`: a `CURRENT_DURABLE_MESSAGE_SINK` task-local + `scope_/current_durable_message_sink` (both `pub(crate)`). `AgentRuntime::run_inner` scopes it for the whole run; the per-run background plugin auto-creation in `backend/local.rs` reads it and uses `with_messaging` when present. The only **new public runtime API** is `AgentRuntime::set_durable_message_sink` — the same optional-host-capability pattern as the existing `set_run_resolver`/`with_*` wiring.
- **Server — one new type, `MailboxDurableMessageSink`.** Implements the existing `DurableMessageSink` trait by mapping `DurableMessageRequest` → `RunActivation` → the existing `Mailbox::submit_background`. Holds a `Weak<Mailbox>` to avoid the `runtime → sink → mailbox → runtime` Arc cycle. `App::new` late-binds it onto the runtime (after the mailbox exists — resolves the chicken-and-egg).

No wrapper executor, no new trait, no change to `RunDispatchExecutor`, no change to the per-store single-manager invariant (manager stays per-run; only the sink is global).

## Delivery

The sender-side `message_id` (outbox entry id) is passed as the mailbox `dispatch_id_hint`, so an at-least-once redelivery reuses the same dispatch id (dedup). Origin = `Internal`. Without a sink, child still works and durable dead-letters (unchanged from #276).

## Tests

`cargo test -p awaken-runtime --features "a2a background"` (1453) + `cargo test -p awaken-server` (1050) green; `cargo check --workspace --all-features` clean.
- runtime: the ambient sink seam round-trips (visible inside the scope, gone outside)
- server: `MailboxDurableMessageSink` maps a request to a mailbox dispatch and returns a dispatch id; a dropped mailbox surfaces an error (no panic)
- (the runtime dispatcher closed-loop + retry/dead-letter tests landed in #276)

## Follow-up

Dead-letter recovery (replay/cleanup/metrics surface for `FailedDurableMessageKey`) now has real traffic to act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
