### PR TITLE
🚀 chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 Development work lands here before the next versioned release.
 
+## [0.6.0] - 2026-06-09
+
+The 0.6.0 design overhaul (ADR-0037) splits the contract crates into narrower
+runtime and server/store surfaces, renames the checkpoint vocabulary to
+`ThreadCommit` / `ThreadCommitOutcome`, and routes every durable runtime write
+through a `CommitCoordinator`. Root execution moves from `RunRequest` to an
+owned `RunActivation` boundary resolved through a typed async `Resolver` and
+`BackendProfile`; `ModelBindingSpec` merges into a unified `ModelSpec` carrying
+intrinsic capabilities and pricing; and skill/tool visibility becomes
+declarative metadata rather than pluggable code. Server embedding moves to
+`ServerState` with explicit admin/eval/trace exposure gates, and agent tool
+catalogs gain glob `allowed_tool_patterns` / `excluded_tool_patterns`. This is
+a breaking release; see the 0.5 -> 0.6 migration guide in the docs.
+
 ### Changed
 
 - **BREAKING — contract crates split into runtime and server/store surfaces.**
@@ -200,7 +214,7 @@ Development work lands here before the next versioned release.
   never read the state map directly (absent ≠ Visible). No run-start visibility
   seed: visibility resolves from live metadata + explicit runtime overrides. No
   deprecated shims — these surfaces had no in-tree consumers and the crates are
-  pre-1.0 (`0.5.1-dev`).
+  pre-1.0 (`0.6.0`).
 
 - **AgentSpec catalog fields** — `allowed_tools` / `excluded_tools` are now
   strict literal-id lists, and two new fields `allowed_tool_patterns` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "awaken-examples",
  "clap",
@@ -267,7 +267,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awaken"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-ext-generative-ui",
@@ -290,14 +290,14 @@ dependencies = [
 
 [[package]]
 name = "awaken-agent"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "awaken",
 ]
 
 [[package]]
 name = "awaken-contract"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "awaken-runtime-contract",
  "awaken-server-contract",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-doctest"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-eval"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-eval",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-examples"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-deferred-tools"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-generative-ui"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-mcp"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-observability"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-permission"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-reminder"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-skills"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-ext-deferred-tools",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-protocol-a2a"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-protocol-a2a",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime-contract"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-tool-pattern",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server-contract"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-trait",
  "awaken-runtime-contract",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-stores"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-tool-pattern"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "glob-match",
  "regex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.6.0"
+version = "0.6.1-dev"
 dependencies = [
  "awaken-examples",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ai-sdk-starter-agent"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "awaken-examples",
  "clap",
@@ -267,7 +267,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awaken"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-ext-generative-ui",
@@ -290,14 +290,14 @@ dependencies = [
 
 [[package]]
 name = "awaken-agent"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "awaken",
 ]
 
 [[package]]
 name = "awaken-contract"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "awaken-runtime-contract",
  "awaken-server-contract",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-doctest"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-eval"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-eval",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-examples"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-contract",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-deferred-tools"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-generative-ui"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-mcp"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-observability"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-permission"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-reminder"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-runtime",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-ext-skills"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-ext-deferred-tools",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-protocol-a2a"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-protocol-a2a",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-runtime-contract"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-tool-pattern",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-server-contract"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awaken-runtime-contract",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-stores"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "awaken-tool-pattern"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "glob-match",
  "regex",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "copilotkit-starter-agent"
-version = "0.5.1-dev"
+version = "0.6.0"
 dependencies = [
  "awaken-examples",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1-dev"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
@@ -36,22 +36,22 @@ keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-awaken-contract = { version = "0.6.0", path = "crates/awaken-contract" }
-awaken-runtime-contract = { version = "0.6.0", path = "crates/awaken-runtime-contract" }
-awaken-server-contract = { version = "0.6.0", path = "crates/awaken-server-contract" }
-awaken-protocol-a2a = { version = "0.6.0", path = "crates/awaken-protocol-a2a" }
-awaken-stores = { version = "0.6.0", path = "crates/awaken-stores" }
-awaken-runtime = { version = "0.6.0", path = "crates/awaken-runtime" }
-awaken-eval = { version = "0.6.0", path = "crates/awaken-eval" }
-awaken-ext-permission = { version = "0.6.0", path = "crates/awaken-ext-permission" }
-awaken-ext-observability = { version = "0.6.0", path = "crates/awaken-ext-observability" }
-awaken-ext-mcp = { version = "0.6.0", path = "crates/awaken-ext-mcp" }
-awaken-ext-skills = { version = "0.6.0", path = "crates/awaken-ext-skills" }
-awaken-ext-reminder = { version = "0.6.0", path = "crates/awaken-ext-reminder" }
-awaken-ext-generative-ui = { version = "0.6.0", path = "crates/awaken-ext-generative-ui" }
-awaken-ext-deferred-tools = { version = "0.6.0", path = "crates/awaken-ext-deferred-tools" }
-awaken-tool-pattern = { version = "0.6.0", path = "crates/awaken-tool-pattern" }
-awaken-server = { version = "0.6.0", path = "crates/awaken-server" }
+awaken-contract = { version = "0.6.1-dev", path = "crates/awaken-contract" }
+awaken-runtime-contract = { version = "0.6.1-dev", path = "crates/awaken-runtime-contract" }
+awaken-server-contract = { version = "0.6.1-dev", path = "crates/awaken-server-contract" }
+awaken-protocol-a2a = { version = "0.6.1-dev", path = "crates/awaken-protocol-a2a" }
+awaken-stores = { version = "0.6.1-dev", path = "crates/awaken-stores" }
+awaken-runtime = { version = "0.6.1-dev", path = "crates/awaken-runtime" }
+awaken-eval = { version = "0.6.1-dev", path = "crates/awaken-eval" }
+awaken-ext-permission = { version = "0.6.1-dev", path = "crates/awaken-ext-permission" }
+awaken-ext-observability = { version = "0.6.1-dev", path = "crates/awaken-ext-observability" }
+awaken-ext-mcp = { version = "0.6.1-dev", path = "crates/awaken-ext-mcp" }
+awaken-ext-skills = { version = "0.6.1-dev", path = "crates/awaken-ext-skills" }
+awaken-ext-reminder = { version = "0.6.1-dev", path = "crates/awaken-ext-reminder" }
+awaken-ext-generative-ui = { version = "0.6.1-dev", path = "crates/awaken-ext-generative-ui" }
+awaken-ext-deferred-tools = { version = "0.6.1-dev", path = "crates/awaken-ext-deferred-tools" }
+awaken-tool-pattern = { version = "0.6.1-dev", path = "crates/awaken-tool-pattern" }
+awaken-server = { version = "0.6.1-dev", path = "crates/awaken-server" }
 glob-match = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1-dev"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AwakenWorks/awaken"
@@ -36,22 +36,22 @@ keywords = ["ai-agent", "llm", "agent-framework", "tool-use", "multi-agent"]
 rust-version = "1.93"
 
 [workspace.dependencies]
-awaken-contract = { version = "0.5.1-dev", path = "crates/awaken-contract" }
-awaken-runtime-contract = { version = "0.5.1-dev", path = "crates/awaken-runtime-contract" }
-awaken-server-contract = { version = "0.5.1-dev", path = "crates/awaken-server-contract" }
-awaken-protocol-a2a = { version = "0.5.1-dev", path = "crates/awaken-protocol-a2a" }
-awaken-stores = { version = "0.5.1-dev", path = "crates/awaken-stores" }
-awaken-runtime = { version = "0.5.1-dev", path = "crates/awaken-runtime" }
-awaken-eval = { version = "0.5.1-dev", path = "crates/awaken-eval" }
-awaken-ext-permission = { version = "0.5.1-dev", path = "crates/awaken-ext-permission" }
-awaken-ext-observability = { version = "0.5.1-dev", path = "crates/awaken-ext-observability" }
-awaken-ext-mcp = { version = "0.5.1-dev", path = "crates/awaken-ext-mcp" }
-awaken-ext-skills = { version = "0.5.1-dev", path = "crates/awaken-ext-skills" }
-awaken-ext-reminder = { version = "0.5.1-dev", path = "crates/awaken-ext-reminder" }
-awaken-ext-generative-ui = { version = "0.5.1-dev", path = "crates/awaken-ext-generative-ui" }
-awaken-ext-deferred-tools = { version = "0.5.1-dev", path = "crates/awaken-ext-deferred-tools" }
-awaken-tool-pattern = { version = "0.5.1-dev", path = "crates/awaken-tool-pattern" }
-awaken-server = { version = "0.5.1-dev", path = "crates/awaken-server" }
+awaken-contract = { version = "0.6.0", path = "crates/awaken-contract" }
+awaken-runtime-contract = { version = "0.6.0", path = "crates/awaken-runtime-contract" }
+awaken-server-contract = { version = "0.6.0", path = "crates/awaken-server-contract" }
+awaken-protocol-a2a = { version = "0.6.0", path = "crates/awaken-protocol-a2a" }
+awaken-stores = { version = "0.6.0", path = "crates/awaken-stores" }
+awaken-runtime = { version = "0.6.0", path = "crates/awaken-runtime" }
+awaken-eval = { version = "0.6.0", path = "crates/awaken-eval" }
+awaken-ext-permission = { version = "0.6.0", path = "crates/awaken-ext-permission" }
+awaken-ext-observability = { version = "0.6.0", path = "crates/awaken-ext-observability" }
+awaken-ext-mcp = { version = "0.6.0", path = "crates/awaken-ext-mcp" }
+awaken-ext-skills = { version = "0.6.0", path = "crates/awaken-ext-skills" }
+awaken-ext-reminder = { version = "0.6.0", path = "crates/awaken-ext-reminder" }
+awaken-ext-generative-ui = { version = "0.6.0", path = "crates/awaken-ext-generative-ui" }
+awaken-ext-deferred-tools = { version = "0.6.0", path = "crates/awaken-ext-deferred-tools" }
+awaken-tool-pattern = { version = "0.6.0", path = "crates/awaken-tool-pattern" }
+awaken-server = { version = "0.6.0", path = "crates/awaken-server" }
 glob-match = "0.2"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/awaken-agent/Cargo.toml
+++ b/crates/awaken-agent/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 doctest = false
 
 [dependencies]
-awaken_core = { package = "awaken", version = "0.5.1-dev", path = "../awaken", default-features = false }
+awaken_core = { package = "awaken", version = "0.6.0", path = "../awaken", default-features = false }
 
 [features]
 default = ["full"]

--- a/crates/awaken-agent/Cargo.toml
+++ b/crates/awaken-agent/Cargo.toml
@@ -17,7 +17,7 @@ doc = false
 doctest = false
 
 [dependencies]
-awaken_core = { package = "awaken", version = "0.6.0", path = "../awaken", default-features = false }
+awaken_core = { package = "awaken", version = "0.6.1-dev", path = "../awaken", default-features = false }
 
 [features]
 default = ["full"]

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -139,7 +139,7 @@ test = true
 harness = false
 
 [dev-dependencies]
-awaken = { package = "awaken", version = "0.6.0", path = "../awaken", features = ["full"] }
+awaken = { package = "awaken", version = "0.6.1-dev", path = "../awaken", features = ["full"] }
 awaken-contract = { path = "../awaken-contract" }
 awaken-runtime = { path = "../awaken-runtime" }
 awaken-server = { path = "../awaken-server" }

--- a/crates/awaken-doctest/Cargo.toml
+++ b/crates/awaken-doctest/Cargo.toml
@@ -139,7 +139,7 @@ test = true
 harness = false
 
 [dev-dependencies]
-awaken = { package = "awaken", version = "0.5.1-dev", path = "../awaken", features = ["full"] }
+awaken = { package = "awaken", version = "0.6.0", path = "../awaken", features = ["full"] }
 awaken-contract = { path = "../awaken-contract" }
 awaken-runtime = { path = "../awaken-runtime" }
 awaken-server = { path = "../awaken-server" }


### PR DESCRIPTION
## Release 0.6.0

Cuts the **0.6.0** release — the design overhaul tracked in ADR-0037. This bundles the release commit (tag target) and the post-release `0.6.1-dev` bump, following the established v0.5.0 procedure.

### Commits
- `🚀 chore(release): 0.6.0` — tag this commit as `v0.6.0`
- `🔖 chore(release): bump to 0.6.1-dev` — restore dev version

### Release commit changes (5 files)
- **CHANGELOG.md** — `[Unreleased]` → `## [0.6.0] - 2026-06-09` with a headline summary; fresh empty `[Unreleased]`
- **Cargo.toml** — workspace version + 16 internal dependency pins → `0.6.0`
- **crates/awaken-agent/Cargo.toml**, **crates/awaken-doctest/Cargo.toml** — `awaken` dependency pin → `0.6.0`
- **Cargo.lock** — regenerated

READMEs use the versionless `changelog-current` badge and `git =` install snippet, so no README changes were needed.

### Validation
- `cargo check --workspace --locked` passes at `0.6.0` (lockfile consistent, versions resolve)
- lefthook commit hooks pass

### Why 0.6.0 (not 0.5.1)
The `[Unreleased]` section is almost entirely **BREAKING** changes (contract crate split, `Checkpoint`→`ThreadCommit`, `RunActivation`, unified `ModelSpec`, declarative visibility). Under SemVer for 0.x that is a minor bump, and ADR-0037 is titled "0.6.0 Design Overhaul" — the prior `0.5.1-dev` tag was stale.

### Release steps after merge
1. Merge to `main`
2. `git tag v0.6.0 <release-commit>` and `git push origin v0.6.0`
3. `release.yml` runs `cargo test --workspace --locked` (rejects `-dev`) then publishes crates in dependency order to crates.io

> ⚠️ Recommend a full `cargo test --workspace --locked` before tagging — a mid-publish failure leaves some crates published and is hard to roll back.