### PR TITLE
🔧 fix(release): publish awaken-eval and correct 0.6.0 crate publish order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,23 +41,26 @@ jobs:
             cargo publish --no-verify -p "$1" 2>&1 || echo "⚠️  $1: publish returned non-zero (may already exist)"
             sleep 60
           }
+          # Dependency-topological order. Base/leaf crates first so each
+          # crate's internal deps are already on the crates.io index.
+          publish awaken-tool-pattern
+          publish awaken-protocol-a2a
+          publish awaken-runtime-contract
+          publish awaken-server-contract
           publish awaken-contract
           publish awaken-stores
-          publish awaken-protocol-a2a
-          publish awaken-tool-pattern
           publish awaken-runtime
+          publish awaken-ext-observability
           publish awaken-ext-deferred-tools
           publish awaken-ext-generative-ui
           publish awaken-ext-mcp
-          publish awaken-ext-observability
           publish awaken-ext-permission
           publish awaken-ext-reminder
           publish awaken-ext-skills
+          publish awaken-eval
           publish awaken-server
           publish awaken
-          # Final crate — no sleep needed
-          echo "=== Publishing awaken-agent ==="
-          cargo publish --no-verify -p awaken-agent
+          publish awaken-agent
       - name: Create GitHub Release
         run: |
           TAG="${{ github.event.inputs.tag || github.ref_name }}"

--- a/crates/awaken-eval/Cargo.toml
+++ b/crates/awaken-eval/Cargo.toml
@@ -3,7 +3,8 @@ name = "awaken-eval"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-publish = false
+repository.workspace = true
+homepage.workspace = true
 description = "Fixture-driven replay and scoring framework for awaken agent runs"
 
 [dependencies]

--- a/crates/awaken-server/Cargo.toml
+++ b/crates/awaken-server/Cargo.toml
@@ -61,7 +61,7 @@ metrics-exporter-prometheus = { workspace = true }
 awaken-ext-observability = { workspace = true }
 
 # Eval (ADR-0032 D6: dataset CRUD + trace→fixture curation)
-awaken-eval = { path = "../awaken-eval" }
+awaken-eval = { workspace = true }
 
 # Optional
 awaken-ext-permission = { workspace = true, optional = true }


### PR DESCRIPTION
Forward-port of the 0.6.0 release hotfix (already applied to the `v0.6.0` tag) so `main` is correct for future releases.

The 0.6.0 release run failed in `Publish all crates`. Two defects in the publish pipeline:

1. **Missing split crates / wrong order** — the 0.6.0 contract split added `awaken-runtime-contract` + `awaken-server-contract`, but `release.yml`'s hand-maintained publish list never included them and still listed `awaken-contract` first (it now depends on both). First crate failed with `no matching package named awaken-runtime-contract`, cascading to all downstream crates.
2. **`awaken-server` → unpublishable `awaken-eval`** — `awaken-eval` (`publish = false`) was promoted from a dev-dependency to a normal `[dependencies]` of `awaken-server` (for `/v1/eval/*`). `cargo publish` rejects a non-dev path dep without a version. Since 0.6.0 ships eval as a server feature, the backing crate is now published.

### Changes
- `release.yml` — publish list rewritten in dependency-topological order, including the two split crates and `awaken-eval` (before `awaken-server`); the final `awaken-agent` publish is now guarded for idempotent re-runs.
- `crates/awaken-eval/Cargo.toml` — drop `publish = false`; inherit `repository`/`homepage`.
- `crates/awaken-server/Cargo.toml` — `awaken-eval` dep now references the workspace dep (carries version), so the manifest is publishable.

### Validation
- `cargo check --workspace --locked` passes.
- `cargo package --no-verify -p awaken-server` no longer reports the versionless-dependency error.
- The `v0.6.0` tag was force-moved to the equivalent fix commit and the release re-run is in progress.

> Note: `release.yml`'s `publish()` swallows all failures via `|| echo "may already exist"`, so only the final un-guarded publish determined red/green. A follow-up could make it distinguish "already published" from real errors instead of masking them.